### PR TITLE
Refactored record version as frontend transaction id

### DIFF
--- a/client/src/main/java/com/jetbrains/youtrackdb/internal/client/remote/StorageCollectionRemote.java
+++ b/client/src/main/java/com/jetbrains/youtrackdb/internal/client/remote/StorageCollectionRemote.java
@@ -78,7 +78,7 @@ public class StorageCollectionRemote implements StorageCollection {
   @Override
   public PhysicalPosition createRecord(
       byte[] content,
-      int recordVersion,
+      long recordVersion,
       byte recordType,
       PhysicalPosition allocatedPosition,
       AtomicOperation atomicOperation) {
@@ -94,14 +94,14 @@ public class StorageCollectionRemote implements StorageCollection {
   public void updateRecord(
       long collectionPosition,
       byte[] content,
-      int recordVersion,
+      long recordVersion,
       byte recordType,
       AtomicOperation atomicOperation) {
     throw new UnsupportedOperationException("updateRecord");
   }
 
   @Override
-  public void updateRecordVersion(long collectionPosition, int recordVersion,
+  public void updateRecordVersion(long collectionPosition, long recordVersion,
       AtomicOperation atomicOperation) {
     throw new UnsupportedOperationException("updateRecordVersion");
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/api/exception/ConcurrentModificationException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/exception/ConcurrentModificationException.java
@@ -36,8 +36,8 @@ public class ConcurrentModificationException extends NeedRetryException
   private static final long serialVersionUID = 1L;
 
   private RID rid;
-  private int databaseVersion = 0;
-  private int recordVersion = 0;
+  private long databaseVersion = 0;
+  private long recordVersion = 0;
   private int recordOperation;
 
   public ConcurrentModificationException(ConcurrentModificationException exception) {
@@ -55,8 +55,8 @@ public class ConcurrentModificationException extends NeedRetryException
 
   public ConcurrentModificationException(
       String dbName, final RID iRID,
-      final int iDatabaseVersion,
-      final int iRecordVersion,
+      final long iDatabaseVersion,
+      final long iRecordVersion,
       final int iRecordOperation) {
     super(dbName,
         makeMessage(iRecordOperation, iRID, iDatabaseVersion, iRecordVersion),
@@ -88,11 +88,11 @@ public class ConcurrentModificationException extends NeedRetryException
     return Objects.hash(rid, databaseVersion, recordVersion, recordOperation);
   }
 
-  public int getEnhancedDatabaseVersion() {
+  public long getEnhancedDatabaseVersion() {
     return databaseVersion;
   }
 
-  public int getEnhancedRecordVersion() {
+  public long getEnhancedRecordVersion() {
     return recordVersion;
   }
 
@@ -101,7 +101,7 @@ public class ConcurrentModificationException extends NeedRetryException
   }
 
   private static String makeMessage(
-      int recordOperation, RID rid, int databaseVersion, int recordVersion) {
+      int recordOperation, RID rid, long databaseVersion, long recordVersion) {
     final var operation = RecordOperation.getName(recordOperation);
 
     final var sb =

--- a/core/src/main/java/com/jetbrains/youtrackdb/api/record/DBRecord.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/record/DBRecord.java
@@ -60,12 +60,13 @@ public interface DBRecord extends Identifiable, Element {
 
   /**
    * Returns the current version number of the record. When the record is created has version = 0.
-   * At every change the storage increment the version number. Version number is used by Optimistic
-   * transactions to check if the record is changed in the meanwhile of the transaction.
+   * At every change, the storage assigns the frontend transaction ID as a new version number.
+   * Version number is used by Optimistic transactions to check if the record is changed in the
+   * meanwhile of the transaction.
    *
    * @return The version number. 0 if it's a brand new record.
    */
-  int getVersion();
+  long getVersion();
 
   /**
    * Checks if the record is dirty, namely if it was changed in memory.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/RecordAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/RecordAbstract.java
@@ -54,7 +54,7 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
 
   @Nonnull
   protected final RecordIdInternal recordId;
-  protected int recordVersion = 0;
+  protected long recordVersion = 0;
 
   protected byte[] source;
   protected int size;
@@ -269,15 +269,15 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
   }
 
   @Override
-  public final int getVersion() {
+  public final long getVersion() {
     return recordVersion;
   }
 
-  public final int getVersionNoLoad() {
+  public final long getVersionNoLoad() {
     return recordVersion;
   }
 
-  public final void setVersion(final int iVersion) {
+  public final void setVersion(final long iVersion) {
     recordVersion = iVersion;
   }
 
@@ -386,7 +386,7 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
 
 
   public RecordAbstract fill(
-      final int version, final byte[] buffer, boolean dirty) {
+      final long version, final byte[] buffer, boolean dirty) {
     var session = getSession();
     if (this.dirty > 0) {
       throw new DatabaseException(session.getDatabaseName(), "Cannot call fill() on dirty records");

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/RecordVersionHelper.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/RecordVersionHelper.java
@@ -27,60 +27,44 @@ import com.jetbrains.youtrackdb.internal.core.serialization.BinaryProtocol;
  */
 public class RecordVersionHelper {
 
-  public static final int SERIALIZED_SIZE = BinaryProtocol.SIZE_INT;
+  public static final int SERIALIZED_SIZE = BinaryProtocol.SIZE_LONG;
 
   protected RecordVersionHelper() {
   }
 
-  public static int increment(final int version) {
-    if (isTombstone(version)) {
-      throw new IllegalStateException("Record was deleted and cannot be updated.");
-    }
-
-    return version + 1;
-  }
-
-  public static int decrement(final int version) {
-    if (isTombstone(version)) {
-      throw new IllegalStateException("Record was deleted and cannot be updated.");
-    }
-
-    return version - 1;
-  }
-
-  public static boolean isValid(final int version) {
+  public static boolean isValid(final long version) {
     return version > -1;
   }
 
-  public static boolean isTombstone(final int version) {
+  public static boolean isTombstone(final long version) {
     return version < 0;
   }
 
-  public static byte[] toStream(final int version) {
-    return BinaryProtocol.int2bytes(version);
+  public static byte[] toStream(final long version) {
+    return BinaryProtocol.long2bytes(version);
   }
 
-  public static int fromStream(final byte[] stream) {
-    return BinaryProtocol.bytes2int(stream);
+  public static long fromStream(final byte[] stream) {
+    return BinaryProtocol.bytes2long(stream);
   }
 
-  public static int reset() {
+  public static long reset() {
     return 0;
   }
 
-  public static int disable() {
+  public static long disable() {
     return -1;
   }
 
-  public static int compareTo(final int v1, final int v2) {
-    final int myVersion;
+  public static int compareTo(final long v1, final long v2) {
+    final long myVersion;
     if (isTombstone(v1)) {
       myVersion = -v1;
     } else {
       myVersion = v1;
     }
 
-    final int otherVersion;
+    final long otherVersion;
     if (isTombstone(v2)) {
       otherVersion = -v2;
     } else {
@@ -98,11 +82,11 @@ public class RecordVersionHelper {
     return 1;
   }
 
-  public static String toString(final int version) {
+  public static String toString(final long version) {
     return String.valueOf(version);
   }
 
-  public static int fromString(final String string) {
-    return Integer.parseInt(string);
+  public static long fromString(final String string) {
+    return Long.parseLong(string);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3435,7 +3435,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
   @Override
   public final RecordAbstract fill(
-      final int version, final byte[] buffer, final boolean dirty) {
+      final long version, final byte[] buffer, final boolean dirty) {
     var session = getSession();
     if (this.dirty > 0) {
       throw new DatabaseException(session.getDatabaseName(),

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/string/JSONSerializerJackson.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/string/JSONSerializerJackson.java
@@ -388,7 +388,7 @@ public class JSONSerializerJackson {
     Map<String, String> fieldTypes = new HashMap<>();
     var entityType = EntityType.PUBLIC;
     Boolean embeddedFlag = null;
-    Integer recordVersion = null;
+    Long recordVersion = null;
 
     var fieldsCount = 0;
 
@@ -501,7 +501,7 @@ public class JSONSerializerJackson {
               throw new SerializationException(session,
                   "Expected field value integer");
             }
-            recordVersion = jsonParser.getIntValue();
+            recordVersion = jsonParser.getLongValue();
             token = jsonParser.nextToken();
           }
           default -> throw new SerializationException(session,
@@ -1338,7 +1338,7 @@ public class JSONSerializerJackson {
       @Nullable String className,
       Map<String, String> fieldTypes,
       boolean isEmbedded,
-      @Nullable Integer recordVersion,
+      @Nullable Long recordVersion,
       @Nullable EntityType entityType
   ) {
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/PhysicalPosition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/PhysicalPosition.java
@@ -30,13 +30,13 @@ import java.io.ObjectOutput;
 public class PhysicalPosition implements SerializableStream, Externalizable {
 
   private static final int binarySize =
-      BinaryProtocol.SIZE_LONG
-          + BinaryProtocol.SIZE_BYTE
-          + BinaryProtocol.SIZE_INT
-          + BinaryProtocol.SIZE_INT;
+      BinaryProtocol.SIZE_LONG // collectionPosition
+          + BinaryProtocol.SIZE_BYTE // recordType
+          + BinaryProtocol.SIZE_LONG // recordVersion
+          + BinaryProtocol.SIZE_INT; // recordSize
   public long collectionPosition;
   public byte recordType;
-  public int recordVersion = 0;
+  public long recordVersion = 0;
   public int recordSize;
 
   public PhysicalPosition() {
@@ -50,7 +50,7 @@ public class PhysicalPosition implements SerializableStream, Externalizable {
     recordType = iRecordType;
   }
 
-  public PhysicalPosition(final long iCollectionPosition, final int iVersion) {
+  public PhysicalPosition(final long iCollectionPosition, final long iVersion) {
     collectionPosition = iCollectionPosition;
     recordVersion = iVersion;
   }
@@ -92,7 +92,7 @@ public class PhysicalPosition implements SerializableStream, Externalizable {
     recordSize = BinaryProtocol.bytes2int(iStream, pos);
     pos += BinaryProtocol.SIZE_INT;
 
-    recordVersion = BinaryProtocol.bytes2int(iStream, pos);
+    recordVersion = BinaryProtocol.bytes2long(iStream, pos);
 
     return this;
   }
@@ -111,7 +111,7 @@ public class PhysicalPosition implements SerializableStream, Externalizable {
     BinaryProtocol.int2bytes(recordSize, buffer, pos);
     pos += BinaryProtocol.SIZE_INT;
 
-    BinaryProtocol.int2bytes(recordVersion, buffer, pos);
+    BinaryProtocol.long2bytes(recordVersion, buffer, pos);
     return buffer;
   }
 
@@ -131,7 +131,7 @@ public class PhysicalPosition implements SerializableStream, Externalizable {
   public int hashCode() {
     var result = (int) (31 * collectionPosition);
     result = 31 * result + (int) recordType;
-    result = 31 * result + recordVersion;
+    result = 31 * result + (int) recordVersion;
     result = 31 * result + recordSize;
     return result;
   }
@@ -141,7 +141,7 @@ public class PhysicalPosition implements SerializableStream, Externalizable {
     out.writeLong(collectionPosition);
     out.writeByte(recordType);
     out.writeInt(recordSize);
-    out.writeInt(recordVersion);
+    out.writeLong(recordVersion);
   }
 
   @Override
@@ -149,6 +149,6 @@ public class PhysicalPosition implements SerializableStream, Externalizable {
     collectionPosition = in.readLong();
     recordType = in.readByte();
     recordSize = in.readInt();
-    recordVersion = in.readInt();
+    recordVersion = in.readLong();
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawBuffer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawBuffer.java
@@ -22,7 +22,7 @@ package com.jetbrains.youtrackdb.internal.core.storage;
 import java.util.Arrays;
 import java.util.Objects;
 
-public record RawBuffer(byte[] buffer, int version, byte recordType) {
+public record RawBuffer(byte[] buffer, long version, byte recordType) {
 
   @Override
   public boolean equals(Object o) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RecordMetadata.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RecordMetadata.java
@@ -28,9 +28,9 @@ import com.jetbrains.youtrackdb.api.record.RID;
 public final class RecordMetadata {
 
   private final RID recordId;
-  private final int recordVersion;
+  private final long recordVersion;
 
-  public RecordMetadata(RID recordId, int recordVersion) {
+  public RecordMetadata(RID recordId, long recordVersion) {
     this.recordId = recordId;
     this.recordVersion = recordVersion;
   }
@@ -39,7 +39,7 @@ public final class RecordMetadata {
     return recordId;
   }
 
-  public int getVersion() {
+  public long getVersion() {
     return recordVersion;
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageCollection.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageCollection.java
@@ -77,7 +77,7 @@ public interface StorageCollection {
    */
   PhysicalPosition createRecord(
       byte[] content,
-      int recordVersion,
+      long recordVersion,
       byte recordType,
       PhysicalPosition allocatedPosition,
       AtomicOperation atomicOperation);
@@ -87,12 +87,12 @@ public interface StorageCollection {
   void updateRecord(
       long collectionPosition,
       byte[] content,
-      int recordVersion,
+      long recordVersion,
       byte recordType,
       AtomicOperation atomicOperation);
 
   void updateRecordVersion(long collectionPosition,
-      int recordVersion,
+      long recordVersion,
       AtomicOperation atomicOperation);
 
   @Nonnull

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
@@ -86,7 +86,7 @@ public final class CollectionPage extends DurablePage {
   }
 
   public int appendRecord(
-      final int recordVersion,
+      final long recordVersion,
       final byte[] record,
       final int requestedPosition,
       final IntSet bookedRecordPositions) {
@@ -262,7 +262,7 @@ public final class CollectionPage extends DurablePage {
   }
 
   private boolean insertIntoRequestedSlot(
-      final int recordVersion,
+      final long recordVersion,
       final int freePosition,
       final int entrySize,
       final int requestedPosition,
@@ -336,7 +336,7 @@ public final class CollectionPage extends DurablePage {
 
   @Nullable
   private RawPairIntegerBoolean findFirstEmptySlot(
-      int recordVersion,
+      long recordVersion,
       int entryPosition,
       int indexesLength,
       int entrySize,
@@ -401,7 +401,7 @@ public final class CollectionPage extends DurablePage {
     return new RawPairIntegerBoolean(entryIndex, allocatedFromFreeList);
   }
 
-  private int appendEntry(int recordVersion, int freePosition, int indexesLength, int entrySize) {
+  private int appendEntry(long recordVersion, int freePosition, int indexesLength, int entrySize) {
     int entryIndex;
     entryIndex = indexesLength;
 
@@ -441,7 +441,7 @@ public final class CollectionPage extends DurablePage {
     return oldRecord;
   }
 
-  public int getRecordVersion(int position) {
+  public long getRecordVersion(int position) {
     var indexesLength = getPageIndexesLength();
     if (position >= indexesLength) {
       return -1;
@@ -837,16 +837,16 @@ public final class CollectionPage extends DurablePage {
     return getPointerValuePositionAt(computePointerPosition(position));
   }
 
-  public void setVersionAt(int entryIndexPosition, int version) {
-    setIntValue(entryIndexPosition + IntegerSerializer.INT_SIZE, version);
+  public void setVersionAt(int entryIndexPosition, long version) {
+    setLongValue(entryIndexPosition + IntegerSerializer.INT_SIZE, version);
   }
 
-  public int getVersionAt(int entryIndexPosition) {
-    return getIntValue(entryIndexPosition + IntegerSerializer.INT_SIZE);
+  public long getVersionAt(int entryIndexPosition) {
+    return getLongValue(entryIndexPosition + IntegerSerializer.INT_SIZE);
   }
 
-  public void updateVersionAt(int entryIndexPosition, int version) {
-    setIntValue(entryIndexPosition + IntegerSerializer.INT_SIZE, version);
+  public void updateVersionAt(int entryIndexPosition, long version) {
+    setLongValue(entryIndexPosition + IntegerSerializer.INT_SIZE, version);
   }
 
   public static int computePointerPosition(int position) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
@@ -336,7 +336,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
   @Override
   public PhysicalPosition createRecord(
       final byte[] content,
-      final int recordVersion,
+      final long recordVersion,
       final byte recordType,
       final PhysicalPosition allocatedPosition,
       final AtomicOperation atomicOperation) {
@@ -423,7 +423,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
       final byte[] content,
       final int len,
       final byte recordType,
-      final int recordVersion,
+      final long recordVersion,
       final long nextRecordPointer,
       final AtomicOperation atomicOperation,
       final Int2ObjectFunction<CollectionPage> pageSupplier,
@@ -659,7 +659,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
       final AtomicOperation atomicOperation)
       throws IOException {
 
-    var recordVersion = 0;
+    var recordVersion = 0L;
 
     final List<byte[]> recordChunks = new ArrayList<>(2);
     var contentSize = 0;
@@ -814,7 +814,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
   public void updateRecord(
       final long collectionPosition,
       final byte[] content,
-      final int recordVersion,
+      final long recordVersion,
       final byte recordType,
       final AtomicOperation atomicOperation) {
     executeInsideComponentOperation(
@@ -936,7 +936,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
   }
 
   @Override
-  public void updateRecordVersion(long collectionPosition, int recordVersion,
+  public void updateRecordVersion(long collectionPosition, long recordVersion,
       AtomicOperation atomicOperation) {
     executeInsideComponentOperation(
         atomicOperation,
@@ -1346,7 +1346,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
   }
 
   private static PhysicalPosition createPhysicalPosition(
-      final byte recordType, final long collectionPosition, final int version) {
+      final byte recordType, final long collectionPosition, final long version) {
     final var physicalPosition = new PhysicalPosition();
     physicalPosition.recordType = recordType;
     physicalPosition.recordSize = -1;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DeepLinkedDocumentSaveTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DeepLinkedDocumentSaveTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransaction;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
@@ -16,7 +17,7 @@ public class DeepLinkedDocumentSaveTest extends DbTestBase {
 
     session.getMetadata().getSchema().createClass("Test");
 
-    session.begin();
+    FrontendTransaction tx = session.begin();
     var doc = (EntityImpl) session.newEntity("Test");
     docs.add(doc);
     for (var i = 0; i < 3000; i++) {
@@ -29,7 +30,7 @@ public class DeepLinkedDocumentSaveTest extends DbTestBase {
     assertEquals(3001, session.countClass("Test"));
 
     for (var d : docs) {
-      assertEquals(1, d.getVersion());
+      assertEquals(tx.getId(), d.getVersion());
     }
   }
 }

--- a/server/src/main/java/com/jetbrains/youtrackdb/internal/server/network/protocol/http/command/get/ServerCommandGetDocument.java
+++ b/server/src/main/java/com/jetbrains/youtrackdb/internal/server/network/protocol/http/command/get/ServerCommandGetDocument.java
@@ -69,7 +69,7 @@ public class ServerCommandGetDocument extends ServerCommandAuthenticatedDbAbstra
               HttpUtils.HEADER_ETAG + rec.getVersion());
         } else {
           final var ifNoneMatch = iRequest.getHeader("If-None-Match");
-          if (ifNoneMatch != null && Integer.toString(rec.getVersion()).equals(ifNoneMatch)) {
+          if (ifNoneMatch != null && Long.toString(rec.getVersion()).equals(ifNoneMatch)) {
             // SAME CONTENT, DON'T SEND BACK RECORD
             iResponse.send(
                 HttpUtils.STATUS_OK_NOMODIFIED_CODE,

--- a/tests/src/test/java/com/jetbrains/youtrackdb/auto/FrontendTransactionImplTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/auto/FrontendTransactionImplTest.java
@@ -81,12 +81,12 @@ public class FrontendTransactionImplTest extends BaseDBTest {
       var record2 = session2.load(record.getIdentity());
 
       final RID rid2 = record2.getIdentity();
-      final int version2 = record2.getVersion();
+      final long version2 = record2.getVersion();
       final var rec2 = (RecordAbstract) record2;
       rec2.fill(version2, "This is the second version".getBytes(), true);
 
       final RID rid1 = record1.getIdentity();
-      final int version1 = record1.getVersion();
+      final long version1 = record1.getVersion();
       final var rec1 = (RecordAbstract) record1;
       rec1.fill(version1, "This is the third version".getBytes(), true);
 

--- a/tests/src/test/java/com/jetbrains/youtrackdb/auto/TransactionConsistencyTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/auto/TransactionConsistencyTest.java
@@ -61,8 +61,8 @@ public class TransactionConsistencyTest extends BaseDBTest {
     RID vDocA_Rid = vDocA_db1.getIdentity().copy();
     RID vDocB_Rid = vDocB_db1.getIdentity().copy();
 
-    var vDocA_version = -1;
-    var vDocB_version = -1;
+    var vDocA_version = -1L;
+    var vDocB_version = -1L;
 
     database2 = acquireSession();
     database2.begin();


### PR DESCRIPTION
To support snapshot isolation, to be able to associate records with transactions, an incremented-based version, was refactored to use the frontend transaction ID.