### PR TITLE
Register Gremlin graphs during plugin startup

### DIFF
--- a/server/src/main/java/com/jetbrains/youtrackdb/internal/server/plugin/gremlin/YTDBGraphManager.java
+++ b/server/src/main/java/com/jetbrains/youtrackdb/internal/server/plugin/gremlin/YTDBGraphManager.java
@@ -1,7 +1,6 @@
 package com.jetbrains.youtrackdb.internal.server.plugin.gremlin;
 
 import com.jetbrains.youtrackdb.api.SessionListener;
-import com.jetbrains.youtrackdb.api.YouTrackDB.ConfigurationParameters;
 import com.jetbrains.youtrackdb.api.record.RID;
 import com.jetbrains.youtrackdb.api.transaction.Transaction;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
@@ -18,7 +17,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.script.Bindings;
 import javax.script.SimpleBindings;
-import org.apache.commons.configuration2.BaseConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.server.GraphManager;
@@ -46,7 +44,7 @@ public class YTDBGraphManager implements GraphManager {
 
   @Override
   public Set<String> getGraphNames() {
-    return youTrackDBServer.listDatabases();
+    return registeredGraphs.keySet();
   }
 
   @Override
@@ -81,18 +79,11 @@ public class YTDBGraphManager implements GraphManager {
 
     var graphName = traversalSourceName.substring(TRAVERSAL_SOURCE_PREFIX.length());
     var graph = getGraph(graphName);
-    if (graph != null) {
-      return graph.traversal();
+    if (graph == null) {
+      return null;
     }
 
-    // Lazy-load graph if it exists in the database but hasn't been registered yet
-    if (getGraphNames().contains(graphName)) {
-      var config = new BaseConfiguration();
-      config.setProperty(ConfigurationParameters.CONFIG_DB_NAME, graphName);
-      return openGraph(graphName, name -> newGraphProxyInstance(graphName, config)).traversal();
-    }
-
-    return null;
+    return graph.traversal();
   }
 
   @Override


### PR DESCRIPTION
  ### Summary
  - register every existing non-system database with `YTDBGraphManager` when `GremlinServerPlugin` starts, so graphs exist before remote queries hit them