### PR TITLE
Add Claude Code Action for automated Qodana fix PRs

### DIFF
--- a/.github/workflows/ci-cd-diagram.md
+++ b/.github/workflows/ci-cd-diagram.md
@@ -142,8 +142,12 @@ new findings using Claude Code Action (`anthropics/claude-code-action@v1`):
 
 1. **Manage fix PRs** - Finds existing fix PRs for the source PR, detects stale ones invalidated
    by force-pushes (gap detection), and closes them
-2. **Filter SARIF** - Filters Qodana's SARIF output to only new findings in files changed since
-   the last processed commit (incremental processing)
+2. **Filter SARIF** - Compares the baseline report (`.github/workflows/qodana.sarif.json`) with
+   the generated one to identify new findings. Filtering scope depends on PR commit count:
+   - **Single-commit PR**: fixes all new findings from the baseline comparison (the entire PR is
+     one change set, so all new findings are attributable to it)
+   - **Multi-commit PR**: fixes only new findings in files changed since the last processed commit
+     (incremental processing to avoid re-processing earlier commits)
 3. **Claude Code** - Invokes Claude to apply minimal fixes to source files (no git operations)
 4. **Create fix PR** - Pushes fixes to a branch named
    `{YTDB-NNN-}qodana-claude-fix-pr{N}-{sha7}` and creates a PR targeting the source branch

--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -49,6 +49,7 @@ jobs:
           github.event_name == 'pull_request' &&
           !contains(github.head_ref, 'qodana-claude-fix-')
         id: pr-management
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |
@@ -173,6 +174,7 @@ jobs:
           github.event_name == 'pull_request' &&
           steps.pr-management.outputs.has_new_commits == 'true'
         id: filter-sarif
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -262,6 +264,7 @@ jobs:
           steps.pr-management.outputs.has_new_commits == 'true' &&
           steps.filter-sarif.outputs.has_findings == 'true'
         id: fix-findings
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -286,6 +289,7 @@ jobs:
           steps.filter-sarif.outputs.has_findings == 'true' &&
           steps.fix-findings.outcome == 'success'
         id: push-fixes
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -339,6 +343,7 @@ jobs:
           always() && !cancelled() &&
           github.event_name == 'pull_request' &&
           steps.push-fixes.outputs.has_fixes == 'true'
+        continue-on-error: true
         uses: actions/github-script@v8
         env:
           FIX_BRANCH: ${{ steps.push-fixes.outputs.fix_branch }}
@@ -395,6 +400,7 @@ jobs:
 
       - name: Job summary
         if: always() && !cancelled() && github.event_name == 'pull_request'
+        continue-on-error: true
         shell: bash
         env:
           HAS_NEW_COMMITS: ${{ steps.pr-management.outputs.has_new_commits }}

--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -16,6 +16,7 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -78,6 +78,7 @@ jobs:
               page++;
             }
             core.info(`PR has ${commits.length} commits`);
+            core.setOutput('commit_count', String(commits.length));
 
             // Find open fix PRs for this source PR
             const searchPattern = `qodana-claude-fix-pr${prNumber}-`;
@@ -182,6 +183,13 @@ jobs:
           SARIF_FILE="${{ runner.temp }}/qodana/results/qodana.sarif.json"
           FILTERED_FILE="${{ runner.temp }}/filtered-findings.json"
 
+          # Default to 0 (treated as multi-commit) if pr-management failed
+          COMMIT_COUNT="${{ steps.pr-management.outputs.commit_count }}"
+          if ! [[ "${COMMIT_COUNT:-0}" =~ ^[0-9]+$ ]]; then
+            COMMIT_COUNT=0
+          fi
+          COMMIT_COUNT="${COMMIT_COUNT:-0}"
+
           if [[ ! -f "$SARIF_FILE" ]]; then
             echo "SARIF file not found at $SARIF_FILE"
             echo "has_findings=false" >> "$GITHUB_OUTPUT"
@@ -189,42 +197,68 @@ jobs:
             exit 0
           fi
 
-          # Determine diff base
-          LAST_SHA="${{ steps.pr-management.outputs.last_processed_sha }}"
-          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          echo "=== Baseline Comparison ==="
+          echo "Baseline report: .github/workflows/qodana.sarif.json"
+          echo "Generated report: $SARIF_FILE"
+          echo "PR commit count: $COMMIT_COUNT"
+          echo ""
 
-          if [[ -n "$LAST_SHA" ]]; then
-            # Resolve short SHA to full commit SHA
-            FULL_SHA=$(git rev-parse --verify "${LAST_SHA}^{commit}" 2>/dev/null || true)
-            if [[ -n "$FULL_SHA" ]]; then
-              DIFF_BASE="$FULL_SHA"
-              echo "Using last processed commit as diff base: $DIFF_BASE"
+          # The Qodana scan uses --baseline to compare the baseline report
+          # (.github/workflows/qodana.sarif.json) with the generated one.
+          # Findings marked baselineState=="new" are issues present in the
+          # generated report but absent from the baseline — i.e. truly new issues.
+
+          ALLOWED_SEVERITIES='["Critical","High","Moderate"]'
+
+          # Log findings with null baselineState (defensive: Qodana should always
+          # set this field when --baseline is used, but we track nulls for debugging)
+          NULL_BASELINE_COUNT=$(jq '[.runs[]?.results[]? | select(.baselineState == null)] | length' "$SARIF_FILE")
+          if [[ "$NULL_BASELINE_COUNT" -gt 0 ]]; then
+            echo "WARNING: $NULL_BASELINE_COUNT finding(s) have null baselineState (included as new)"
+          fi
+
+          # Determine changed-file filter: null means "all files" (single-commit),
+          # a JSON array means "restrict to these files" (multi-commit).
+          if [[ "$COMMIT_COUNT" -eq 1 ]]; then
+            echo "Single-commit PR: fixing ALL new findings from baseline comparison"
+            echo "(no changed-file filtering applied)"
+            CHANGED_FILES_JSON='null'
+          else
+            echo "Multi-commit PR: fixing only new findings in recently changed files"
+
+            LAST_SHA="${{ steps.pr-management.outputs.last_processed_sha }}"
+            BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+            if [[ -n "$LAST_SHA" ]]; then
+              FULL_SHA=$(git rev-parse --verify "${LAST_SHA}^{commit}" 2>/dev/null || true)
+              if [[ -n "$FULL_SHA" ]]; then
+                DIFF_BASE="$FULL_SHA"
+                echo "Using last processed commit as diff base: $DIFF_BASE"
+              else
+                DIFF_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
+                echo "Last processed SHA not in history, using merge-base: $DIFF_BASE"
+              fi
             else
               DIFF_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
-              echo "Last processed SHA not in history, using merge-base: $DIFF_BASE"
+              echo "No last processed SHA, using merge-base: $DIFF_BASE"
             fi
-          else
-            DIFF_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
-            echo "No last processed SHA, using merge-base: $DIFF_BASE"
+
+            CHANGED_FILES=$(git diff --name-only "$DIFF_BASE" HEAD)
+            if [[ -z "$CHANGED_FILES" ]]; then
+              echo "No changed files found"
+              echo "has_findings=false" >> "$GITHUB_OUTPUT"
+              echo "finding_count=0" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            echo "Changed files:"
+            echo "$CHANGED_FILES"
+
+            CHANGED_FILES_JSON=$(echo "$CHANGED_FILES" | jq -R -s 'split("\n") | map(select(length > 0))')
           fi
 
-          # Get changed files
-          CHANGED_FILES=$(git diff --name-only "$DIFF_BASE" HEAD)
-          if [[ -z "$CHANGED_FILES" ]]; then
-            echo "No changed files found"
-            echo "has_findings=false" >> "$GITHUB_OUTPUT"
-            echo "finding_count=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-
-          # Build jq filter array from changed files
-          CHANGED_FILES_JSON=$(echo "$CHANGED_FILES" | jq -R -s 'split("\n") | map(select(length > 0))')
-
-          # Filter SARIF: keep only new Critical/High/Moderate findings in changed files
-          ALLOWED_SEVERITIES='["Critical","High","Moderate"]'
+          # Unified jq filter: when $changed is null, all files pass;
+          # when $changed is an array, only matching files pass.
           jq --argjson changed "$CHANGED_FILES_JSON" \
              --argjson severities "$ALLOWED_SEVERITIES" '
             [
@@ -235,7 +269,7 @@ jobs:
               | .locations[]?
               | .physicalLocation.artifactLocation.uri as $uri
               | select($uri != null)
-              | select($changed | any(. as $f | $uri == $f or ($uri | endswith("/" + $f))))
+              | select($changed == null or ($changed | any(. as $f | $uri == $f or ($uri | endswith("/" + $f)))))
               | {
                   ruleId: $result.ruleId,
                   level: $result.level,
@@ -251,6 +285,8 @@ jobs:
           ' "$SARIF_FILE" > "$FILTERED_FILE"
 
           COUNT=$(jq 'length' "$FILTERED_FILE")
+          echo ""
+          echo "=== Results ==="
           echo "Filtered findings: $COUNT"
 
           if [[ "$COUNT" -eq 0 ]]; then
@@ -411,7 +447,13 @@ jobs:
           HAS_FIXES: ${{ steps.push-fixes.outputs.has_fixes }}
           FIX_BRANCH: ${{ steps.push-fixes.outputs.fix_branch }}
           FINDING_COUNT: ${{ steps.filter-sarif.outputs.finding_count }}
+          COMMIT_COUNT: ${{ steps.pr-management.outputs.commit_count }}
         run: |
+          COMMIT_COUNT="${COMMIT_COUNT:-0}"
+          if ! [[ "$COMMIT_COUNT" =~ ^[0-9]+$ ]]; then
+            COMMIT_COUNT=0
+          fi
+
           {
             echo "## Qodana Claude Fix Summary"
             echo ""
@@ -419,12 +461,21 @@ jobs:
             if [[ "$HAS_NEW_COMMITS" != "true" ]]; then
               echo "No new commits to process (fix PR already exists for current HEAD)."
             elif [[ "$HAS_FINDINGS" != "true" ]]; then
-              echo "No new Qodana findings in changed files."
+              if [[ "$COMMIT_COUNT" -eq 1 ]]; then
+                echo "No new Qodana findings compared to baseline (single-commit PR, all files checked)."
+              else
+                echo "No new Qodana findings in changed files (multi-commit PR)."
+              fi
             elif [[ "$HAS_FIXES" != "true" ]]; then
               echo "Claude Code did not produce any fixes."
             else
               echo "Created fix branch: \`${FIX_BRANCH}\`"
               echo ""
               echo "Findings processed: **${FINDING_COUNT}**"
+              if [[ "$COMMIT_COUNT" -eq 1 ]]; then
+                echo "Mode: single-commit PR (all new findings from baseline comparison)"
+              else
+                echo "Mode: multi-commit PR (new findings in changed files only)"
+              fi
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -223,11 +223,14 @@ jobs:
           # Build jq filter array from changed files
           CHANGED_FILES_JSON=$(echo "$CHANGED_FILES" | jq -R -s 'split("\n") | map(select(length > 0))')
 
-          # Filter SARIF: keep only new findings in changed files, simplify output
-          jq --argjson changed "$CHANGED_FILES_JSON" '
+          # Filter SARIF: keep only new Critical/High/Moderate findings in changed files
+          ALLOWED_SEVERITIES='["Critical","High","Moderate"]'
+          jq --argjson changed "$CHANGED_FILES_JSON" \
+             --argjson severities "$ALLOWED_SEVERITIES" '
             [
               .runs[]?.results[]?
               | select(.baselineState == "new" or .baselineState == null)
+              | select(.properties.qodanaSeverity as $sev | $severities | index($sev))
               | . as $result
               | .locations[]?
               | .physicalLocation.artifactLocation.uri as $uri
@@ -242,7 +245,7 @@ jobs:
                   startColumn: .physicalLocation.region.startColumn,
                   snippet: .physicalLocation.region.snippet.text,
                   context: .physicalLocation.contextRegion.snippet.text,
-                  severity: ($result.properties.ideaSeverity // $result.level)
+                  severity: $result.properties.qodanaSeverity
                 }
             ]
           ' "$SARIF_FILE" > "$FILTERED_FILE"

--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -1,12 +1,6 @@
 name: Qodana
 on:
   workflow_dispatch:
-    inputs:
-      cleanup:
-        description: 'Apply Qodana cleanup fixes'
-        required: false
-        type: boolean
-        default: false
   pull_request:
   push:
     branches:
@@ -22,8 +16,6 @@ jobs:
       contents: write
       pull-requests: write
       checks: write
-    env:
-      RUN_CLEANUP: ${{ github.event_name == 'workflow_dispatch' && inputs.cleanup == true }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -34,96 +26,395 @@ jobs:
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2025.3
         with:
-          args: --linter, jetbrains/qodana-jvm:${{ env.QODANA_VERSION }}, --baseline, .github/workflows/qodana.sarif.json${{ env.RUN_CLEANUP == 'true' && ', --cleanup' || '' }}
+          args: --linter, jetbrains/qodana-jvm:${{ env.QODANA_VERSION }}, --baseline, .github/workflows/qodana.sarif.json
           pr-mode: 'true'
           push-fixes: none
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
 
-      - name: Extract issue number from branch name
-        if: env.RUN_CLEANUP == 'true'
-        id: extract-issue
+      - name: Upload Qodana SARIF
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qodana-sarif
+          path: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+          retention-days: 30
+
+      # ── Claude Code: Automated Qodana Fix PR ──────────────────────────
+
+      - name: Manage existing fix PRs
+        if: >-
+          always() && !cancelled() &&
+          github.event_name == 'pull_request' &&
+          !contains(github.head_ref, 'qodana-claude-fix-')
+        id: pr-management
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const sourceBranch = context.payload.pull_request.head.ref;
+            const headSha = context.payload.pull_request.head.sha;
+            const headSha7 = headSha.substring(0, 7);
+
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('source_branch', sourceBranch);
+            core.setOutput('head_sha7', headSha7);
+
+            // Get all commits in this PR
+            const commits = [];
+            let page = 1;
+            while (true) {
+              const resp = await github.rest.pulls.listCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                per_page: 100,
+                page
+              });
+              commits.push(...resp.data.map(c => c.sha));
+              if (resp.data.length < 100) break;
+              page++;
+            }
+            core.info(`PR has ${commits.length} commits`);
+
+            // Find open fix PRs for this source PR
+            const searchPattern = `qodana-claude-fix-pr${prNumber}-`;
+            const allPRs = [];
+            let prPage = 1;
+            while (true) {
+              const resp = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                per_page: 100,
+                page: prPage
+              });
+              allPRs.push(...resp.data);
+              if (resp.data.length < 100) break;
+              prPage++;
+            }
+
+            const fixPRs = allPRs
+              .filter(pr => pr.head.ref.includes(searchPattern))
+              .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+
+            core.info(`Found ${fixPRs.length} open fix PRs`);
+
+            // Gap detection: walk fix PRs in order, close from first gap onward
+            let gapFound = false;
+            let lastValidSha7 = '';
+
+            for (const fixPR of fixPRs) {
+              const branchName = fixPR.head.ref;
+              const shaMatch = branchName.match(/-([0-9a-f]{7})$/);
+              if (!shaMatch) {
+                core.warning(`Fix PR #${fixPR.number} branch "${branchName}" has no SHA suffix`);
+                continue;
+              }
+              const fixSha7 = shaMatch[1];
+
+              if (!gapFound) {
+                // Check if this SHA is in current PR commits
+                const found = commits.some(c => c.startsWith(fixSha7));
+                if (!found) {
+                  gapFound = true;
+                  core.info(`Gap detected at fix PR #${fixPR.number} (SHA ${fixSha7} not in PR)`);
+                } else {
+                  lastValidSha7 = fixSha7;
+                }
+              }
+
+              if (gapFound) {
+                core.info(`Closing stale fix PR #${fixPR.number} (branch: ${branchName})`);
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: fixPR.number,
+                  body: `Closing: source PR #${prNumber} was force-pushed, invalidating this fix PR.`
+                });
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: fixPR.number,
+                  state: 'closed'
+                });
+                try {
+                  await github.rest.git.deleteRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `heads/${branchName}`
+                  });
+                } catch (e) {
+                  core.warning(`Failed to delete branch ${branchName}: ${e.message}`);
+                }
+              }
+            }
+
+            // Check if a fix PR already exists for this exact HEAD
+            const alreadyExists = fixPRs.some(pr => {
+              const m = pr.head.ref.match(/-([0-9a-f]{7})$/);
+              return m && m[1] === headSha7 && !gapFound;
+            });
+
+            if (alreadyExists) {
+              core.info(`Fix PR already exists for HEAD ${headSha7}, skipping`);
+              core.setOutput('has_new_commits', 'false');
+              core.setOutput('last_processed_sha', headSha7);
+              return;
+            }
+
+            core.setOutput('has_new_commits', 'true');
+            core.setOutput('last_processed_sha', lastValidSha7);
+
+      - name: Filter SARIF findings
+        if: >-
+          always() && !cancelled() &&
+          github.event_name == 'pull_request' &&
+          steps.pr-management.outputs.has_new_commits == 'true'
+        id: filter-sarif
         shell: bash
         run: |
           set -euo pipefail
 
-          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-          BRANCH_NAME_LOWER="${BRANCH_NAME,,}"
+          SARIF_FILE="${{ runner.temp }}/qodana/results/qodana.sarif.json"
+          FILTERED_FILE="${{ runner.temp }}/filtered-findings.json"
 
-          # Pattern: ytdb + optional non-alphanumeric + digits (case-insensitive)
-          if [[ $BRANCH_NAME_LOWER =~ ^(ytdb)([^a-zA-Z0-9]?)([0-9]+) ]]; then
-            ISSUE_PREFIX="YTDB-${BASH_REMATCH[3]}"
-            echo "issue_prefix=${ISSUE_PREFIX}" >> "$GITHUB_OUTPUT"
-            echo "has_issue=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_issue=false" >> "$GITHUB_OUTPUT"
+          if [[ ! -f "$SARIF_FILE" ]]; then
+            echo "SARIF file not found at $SARIF_FILE"
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+            echo "finding_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      - name: Push cleanup fixes branch
-        if: env.RUN_CLEANUP == 'true'
+          # Determine diff base
+          LAST_SHA="${{ steps.pr-management.outputs.last_processed_sha }}"
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+
+          if [[ -n "$LAST_SHA" ]]; then
+            # Resolve short SHA to full commit SHA
+            FULL_SHA=$(git rev-parse --verify "${LAST_SHA}^{commit}" 2>/dev/null || true)
+            if [[ -n "$FULL_SHA" ]]; then
+              DIFF_BASE="$FULL_SHA"
+              echo "Using last processed commit as diff base: $DIFF_BASE"
+            else
+              DIFF_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
+              echo "Last processed SHA not in history, using merge-base: $DIFF_BASE"
+            fi
+          else
+            DIFF_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
+            echo "No last processed SHA, using merge-base: $DIFF_BASE"
+          fi
+
+          # Get changed files
+          CHANGED_FILES=$(git diff --name-only "$DIFF_BASE" HEAD)
+          if [[ -z "$CHANGED_FILES" ]]; then
+            echo "No changed files found"
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+            echo "finding_count=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # Build jq filter array from changed files
+          CHANGED_FILES_JSON=$(echo "$CHANGED_FILES" | jq -R -s 'split("\n") | map(select(length > 0))')
+
+          # Filter SARIF: keep only new findings in changed files, simplify output
+          jq --argjson changed "$CHANGED_FILES_JSON" '
+            [
+              .runs[]?.results[]?
+              | select(.baselineState == "new" or .baselineState == null)
+              | . as $result
+              | .locations[]?
+              | .physicalLocation.artifactLocation.uri as $uri
+              | select($uri != null)
+              | select($changed | any(. as $f | $uri == $f or ($uri | endswith("/" + $f))))
+              | {
+                  ruleId: $result.ruleId,
+                  level: $result.level,
+                  message: $result.message.text,
+                  file: $uri,
+                  startLine: .physicalLocation.region.startLine,
+                  startColumn: .physicalLocation.region.startColumn,
+                  snippet: .physicalLocation.region.snippet.text,
+                  context: .physicalLocation.contextRegion.snippet.text,
+                  severity: ($result.properties.ideaSeverity // $result.level)
+                }
+            ]
+          ' "$SARIF_FILE" > "$FILTERED_FILE"
+
+          COUNT=$(jq 'length' "$FILTERED_FILE")
+          echo "Filtered findings: $COUNT"
+
+          if [[ "$COUNT" -eq 0 ]]; then
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_findings=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "finding_count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Fix findings with Claude Code
+        if: >-
+          always() && !cancelled() &&
+          github.event_name == 'pull_request' &&
+          steps.pr-management.outputs.has_new_commits == 'true' &&
+          steps.filter-sarif.outputs.has_findings == 'true'
+        id: fix-findings
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are a code quality assistant. Read the findings file at
+            ${{ runner.temp }}/filtered-findings.json and fix each static analysis
+            finding by editing the source files.
+
+            RULES:
+            1. Apply minimal fixes - do not change code logic or behavior
+            2. Do NOT modify files under core/.../sql/parser/ (generated code)
+            3. Do NOT create git commits, branches, or PRs - only edit source files
+            4. Skip findings that cannot be safely fixed without behavior changes
+            5. Code style: 2-space indent, 100 char lines, always use braces
+          claude_args: "--max-turns 30 --disallowedTools Bash,WebSearch,WebFetch"
+
+      - name: Create fix branch and push
+        if: >-
+          always() && !cancelled() &&
+          github.event_name == 'pull_request' &&
+          steps.pr-management.outputs.has_new_commits == 'true' &&
+          steps.filter-sarif.outputs.has_findings == 'true' &&
+          steps.fix-findings.outcome == 'success'
         id: push-fixes
         shell: bash
         run: |
-          set -uo pipefail
+          set -euo pipefail
 
-          # Check if there are changes to commit
+          # Check if Claude made any changes
           if git diff --quiet && git diff --staged --quiet; then
             echo "No changes to commit"
             echo "has_fixes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          set -e
-
           git config user.name "qodana-bot[bot]"
           git config user.email "qodana-bot[bot]@users.noreply.github.com"
 
-          SOURCE_BRANCH="${{ github.head_ref || github.ref_name }}"
-          # Generate unique suffix using short SHA and run number
-          UNIQUE_SUFFIX="${GITHUB_SHA:0:7}-${GITHUB_RUN_NUMBER}"
+          SOURCE_BRANCH="${{ steps.pr-management.outputs.source_branch }}"
+          HEAD_SHA7="${{ steps.pr-management.outputs.head_sha7 }}"
+          PR_NUMBER="${{ steps.pr-management.outputs.pr_number }}"
 
-          # Build branch name with issue prefix if available
-          if [[ "${{ steps.extract-issue.outputs.has_issue }}" == "true" ]]; then
-            CLEANUP_BRANCH="${{ steps.extract-issue.outputs.issue_prefix }}-qodana-fixes-${UNIQUE_SUFFIX}"
-            COMMIT_MSG="${{ steps.extract-issue.outputs.issue_prefix }}: Apply Qodana cleanup fixes"
-          else
-            # Sanitize branch name to avoid special character issues
-            SANITIZED_SOURCE=$(echo "$SOURCE_BRANCH" | tr -cd '[:alnum:]-_/')
-            CLEANUP_BRANCH="qodana-fixes-${SANITIZED_SOURCE}-${UNIQUE_SUFFIX}"
-            COMMIT_MSG="Apply Qodana cleanup fixes"
+          # Extract issue prefix from source branch
+          BRANCH_LOWER="${SOURCE_BRANCH,,}"
+          HAS_ISSUE="false"
+          ISSUE_PREFIX=""
+
+          if [[ $BRANCH_LOWER =~ ^(ytdb)([^a-zA-Z0-9]?)([0-9]+) ]]; then
+            ISSUE_PREFIX="YTDB-${BASH_REMATCH[3]}"
+            HAS_ISSUE="true"
           fi
 
-          git checkout -b "$CLEANUP_BRANCH"
-          git add -A
+          # Build branch name
+          if [[ "$HAS_ISSUE" == "true" ]]; then
+            FIX_BRANCH="${ISSUE_PREFIX}-qodana-claude-fix-pr${PR_NUMBER}-${HEAD_SHA7}"
+            COMMIT_MSG="${ISSUE_PREFIX}: Fix Qodana findings (automated)"
+          else
+            FIX_BRANCH="qodana-claude-fix-pr${PR_NUMBER}-${HEAD_SHA7}"
+            COMMIT_MSG="Fix Qodana findings (automated)"
+          fi
+
+          git checkout -b "$FIX_BRANCH"
+          git add -u
           git commit -m "$COMMIT_MSG"
-          git push -u origin "$CLEANUP_BRANCH" --force-with-lease
+          git push -u origin "$FIX_BRANCH" --force-with-lease
 
-          echo "cleanup_branch=$CLEANUP_BRANCH" >> "$GITHUB_OUTPUT"
-          echo "source_branch=$SOURCE_BRANCH" >> "$GITHUB_OUTPUT"
           echo "has_fixes=true" >> "$GITHUB_OUTPUT"
+          echo "fix_branch=$FIX_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "source_branch=$SOURCE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "has_issue=$HAS_ISSUE" >> "$GITHUB_OUTPUT"
+          echo "issue_prefix=$ISSUE_PREFIX" >> "$GITHUB_OUTPUT"
 
-      - name: Output fixes info
-        if: env.RUN_CLEANUP == 'true' && steps.push-fixes.outputs.has_fixes == 'true'
+      - name: Create fix PR
+        if: >-
+          always() && !cancelled() &&
+          github.event_name == 'pull_request' &&
+          steps.push-fixes.outputs.has_fixes == 'true'
+        uses: actions/github-script@v8
+        env:
+          FIX_BRANCH: ${{ steps.push-fixes.outputs.fix_branch }}
+          SOURCE_BRANCH: ${{ steps.push-fixes.outputs.source_branch }}
+          HAS_ISSUE: ${{ steps.push-fixes.outputs.has_issue }}
+          ISSUE_PREFIX: ${{ steps.push-fixes.outputs.issue_prefix }}
+          PR_NUMBER: ${{ steps.pr-management.outputs.pr_number }}
+          FINDING_COUNT: ${{ steps.filter-sarif.outputs.finding_count }}
+        with:
+          script: |
+            const fixBranch = process.env.FIX_BRANCH;
+            const sourceBranch = process.env.SOURCE_BRANCH;
+            const hasIssue = process.env.HAS_ISSUE === 'true';
+            const issuePrefix = process.env.ISSUE_PREFIX;
+            const prNumber = process.env.PR_NUMBER;
+            const findingCount = process.env.FINDING_COUNT;
+
+            const title = hasIssue
+              ? `${issuePrefix}: Fix Qodana findings from PR #${prNumber}`
+              : `Fix Qodana findings from PR #${prNumber}`;
+
+            const body = [
+              `## Automated Qodana Fix`,
+              ``,
+              `This PR fixes **${findingCount}** static analysis finding(s) detected by Qodana on PR #${prNumber}.`,
+              ``,
+              `### Review checklist`,
+              `- [ ] Fixes are minimal and do not change behavior`,
+              `- [ ] No generated code was modified`,
+              `- [ ] Code style is consistent with the project`,
+              ``,
+              `> Generated automatically by Claude Code from Qodana SARIF output.`
+            ].join('\n');
+
+            try {
+              const { data: pr } = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                head: fixBranch,
+                base: sourceBranch
+              });
+              core.info(`Created fix PR #${pr.number}: ${pr.html_url}`);
+              core.setOutput('fix_pr_url', pr.html_url);
+              core.setOutput('fix_pr_number', String(pr.number));
+            } catch (err) {
+              if (err.status === 422) {
+                core.info(`Fix PR already exists for branch ${fixBranch}`);
+              } else {
+                throw err;
+              }
+            }
+
+      - name: Job summary
+        if: always() && !cancelled() && github.event_name == 'pull_request'
         shell: bash
+        env:
+          HAS_NEW_COMMITS: ${{ steps.pr-management.outputs.has_new_commits }}
+          HAS_FINDINGS: ${{ steps.filter-sarif.outputs.has_findings }}
+          HAS_FIXES: ${{ steps.push-fixes.outputs.has_fixes }}
+          FIX_BRANCH: ${{ steps.push-fixes.outputs.fix_branch }}
+          FINDING_COUNT: ${{ steps.filter-sarif.outputs.finding_count }}
         run: |
-          set -euo pipefail
-
-          CLEANUP_BRANCH="${{ steps.push-fixes.outputs.cleanup_branch }}"
-          SOURCE_BRANCH="${{ steps.push-fixes.outputs.source_branch }}"
-
-          COMPARE_URL="https://github.com/${{ github.repository }}/compare/${SOURCE_BRANCH}...${CLEANUP_BRANCH}"
-          PR_CREATE_URL="https://github.com/${{ github.repository }}/compare/${SOURCE_BRANCH}...${CLEANUP_BRANCH}?expand=1"
-
-          # Output to job summary
           {
-            echo "## 🤖 Qodana Cleanup Fixes Available"
+            echo "## Qodana Claude Fix Summary"
             echo ""
-            echo "**Branch with fixes:** [\`$CLEANUP_BRANCH\`]($COMPARE_URL)"
-            echo ""
-            echo "**Options:**"
-            echo "1. [Create a PR]($PR_CREATE_URL) to merge fixes into \`$SOURCE_BRANCH\`"
-            echo "2. Cherry-pick commits: \`git cherry-pick origin/$CLEANUP_BRANCH\`"
-            echo "3. Rebase locally: \`git rebase origin/$CLEANUP_BRANCH\`"
-            echo ""
-            echo "⚠️ Please review the changes before merging - automated fixes may not always be correct."
+
+            if [[ "$HAS_NEW_COMMITS" != "true" ]]; then
+              echo "No new commits to process (fix PR already exists for current HEAD)."
+            elif [[ "$HAS_FINDINGS" != "true" ]]; then
+              echo "No new Qodana findings in changed files."
+            elif [[ "$HAS_FIXES" != "true" ]]; then
+              echo "Claude Code did not produce any fixes."
+            else
+              echo "Created fix branch: \`${FIX_BRANCH}\`"
+              echo ""
+              echo "Findings processed: **${FINDING_COUNT}**"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
#### PR Title:

Add Claude Code Action for automated Qodana fix PRs

#### Motivation:

The repository uses JetBrains Qodana for static analysis with zero-tolerance for critical/high/moderate issues. When Qodana finds issues on a PR, developers must fix them manually. The previous cleanup-based approach (Qodana's built-in `--cleanup` flag) produced broken code and was not usable in practice. This change automates fix generation using Claude Code Action, which reads the SARIF output, identifies findings in changed code, and creates a fix PR targeting the source branch.

#### Changes:

**File: `.github/workflows/qodana-scan.yml`**

- **Removed** the manual cleanup flow: `cleanup` workflow_dispatch input, `RUN_CLEANUP` env var, `--cleanup` Qodana arg, and the 3 cleanup steps (Extract issue number, Push cleanup fixes branch, Output fixes info)
- **Added 6 new steps** to the existing `qodana` job (all gated to run only on `pull_request` events, all with `continue-on-error: true` so they never block the PR check):
  1. **Manage existing fix PRs** (`actions/github-script@v8`) - Finds open fix PRs for the source PR, detects stale ones invalidated by force-pushes using gap detection on commit SHAs, closes them, and determines the last processed commit for incremental processing. Outputs `commit_count` to enable single vs multi-commit filtering.
  2. **Filter SARIF findings** (bash + jq) - Compares the baseline report (`.github/workflows/qodana.sarif.json`) with the generated one via Qodana's `--baseline` flag. Filters to only `baselineState: "new"` findings with **Critical, High, or Moderate** `qodanaSeverity`. Filtering scope depends on PR commit count:
     - **Single-commit PR**: fixes ALL new findings from the baseline comparison (no changed-file filtering — the entire PR is one change set)
     - **Multi-commit PR**: fixes only new findings in files changed since the last processed commit (incremental processing)
     - Uses a unified jq filter with a `null` sentinel for "all files" to eliminate code duplication between the two paths
     - Validates `COMMIT_COUNT` with regex and defaults to `0` (multi-commit, the conservative path) if `pr-management` failed
     - Logs a warning when findings have `null` `baselineState` for debugging
  3. **Fix findings with Claude Code** (`anthropics/claude-code-action@v1`) - Invokes Claude to apply minimal source file edits; Bash/WebSearch/WebFetch tools are disallowed to prevent unintended side effects
  4. **Create fix branch and push** - Stages only modified tracked files (`git add -u`), creates a branch named `{YTDB-NNN-}qodana-claude-fix-pr{N}-{sha7}`, commits and pushes
  5. **Create fix PR** (`actions/github-script@v8`) - Creates a PR targeting the source branch with finding count, review checklist, and 422 "already exists" error handling
  6. **Job summary** - Writes a markdown summary to `$GITHUB_STEP_SUMMARY` showing the mode used (single-commit vs multi-commit) and finding count

**Security hardening** (based on code review):
- All `actions/github-script` steps use `process.env.*` instead of `${{ }}` interpolation in JS to prevent script injection via branch names
- All bash steps use `env:` block instead of inline `${{ }}` in conditionals
- Fix PRs from `qodana-claude-fix-*` branches are excluded from the Claude pipeline to prevent recursive triggers
- Claude Code step has an `id` and the push step is gated on `steps.fix-findings.outcome == 'success'` to avoid committing partial fixes
- `pulls.list` API call is paginated to handle repos with 100+ open PRs
- SARIF file matching uses path-boundary checks (`$uri == $f or endswith("/" + $f)`) to prevent false positives
- Short SHA resolution uses `git rev-parse` instead of `git log | grep`
- All Claude fix steps use `continue-on-error: true` to ensure they never fail the Qodana job (needed for bootstrap when workflow differs from default branch)

**File: `.github/workflows/ci-cd-diagram.md`**
- Updated Mermaid diagram: replaced "Optional: Push cleanup fixes" with the 3-step Claude fix pipeline (Filter SARIF -> Claude Code Action -> Create Fix PR)
- Updated qodana-scan.yml description to document the new automated fix flow with commit-count-based filtering
- Updated workflow summary table

**New required secret:** `ANTHROPIC_API_KEY` (for Claude Code Action)