### PR TITLE
YTDB-570: Add comprehensive JavaDoc to V2 collection classes

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/CollectionPositionMapV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/CollectionPositionMapV2.java
@@ -34,10 +34,83 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.ArrayUtils;
 
+/**
+ * Maps logical <em>collection positions</em> (monotonically increasing {@code long} values) to
+ * physical record locations ({@link CollectionPositionMapBucket.PositionEntry}) on the data pages
+ * of a {@link PaginatedCollectionV2}.
+ *
+ * <h2>File Layout</h2>
+ *
+ * <p>The position map is stored in a single file with extension {@value
+ * CollectionPositionMap#DEF_EXTENSION}. The file is organized as a sequence of fixed-size pages
+ * managed by the disk cache. Page 0 is a {@link MapEntryPoint} that holds the count of bucket
+ * pages currently in use. Pages 1..N are {@link CollectionPositionMapBucket} pages, each holding
+ * up to {@link CollectionPositionMapBucket#MAX_ENTRIES} position entries.
+ *
+ * <pre>{@code
+ *  .cpm file layout:
+ *  +-------------------------------+
+ *  | Page 0: MapEntryPoint         |
+ *  |   fileSize (int) = N          |  <-- number of bucket pages in use
+ *  +-------------------------------+
+ *  | Page 1: CollectionPositionMapBucket  |
+ *  |   entry[0] .. entry[MAX-1]    |
+ *  +-------------------------------+
+ *  | Page 2: CollectionPositionMapBucket  |
+ *  |   entry[0] .. entry[MAX-1]    |
+ *  +-------------------------------+
+ *  |           ...                 |
+ *  +-------------------------------+
+ *  | Page N: CollectionPositionMapBucket  |
+ *  |   entry[0] .. entry[K]        |  <-- last page may be partially filled
+ *  +-------------------------------+
+ * }</pre>
+ *
+ * <h2>Position-to-Page Mapping</h2>
+ *
+ * <p>A collection position {@code P} maps to:
+ * <ul>
+ *   <li><b>Bucket page index</b>: {@code P / MAX_ENTRIES + 1} (the {@code +1} accounts for
+ *       the entry-point page at index 0)</li>
+ *   <li><b>Entry index within the bucket</b>: {@code P % MAX_ENTRIES}</li>
+ * </ul>
+ *
+ * <pre>{@code
+ *  Collection position space:
+ *
+ *  Position:  0  1  2 ... MAX-1  MAX  MAX+1 ... 2*MAX-1  2*MAX ...
+ *             |------Page 1------|  |-------Page 2------|  |--Page 3--...
+ *
+ *  Example (MAX_ENTRIES = 378):
+ *    position 0   -> page 1, index 0
+ *    position 377 -> page 1, index 377
+ *    position 378 -> page 2, index 0
+ *    position 756 -> page 3, index 0
+ * }</pre>
+ *
+ * <h2>Entry Lifecycle</h2>
+ *
+ * <p>Each entry in a bucket has one of four statuses:
+ * <ul>
+ *   <li>{@link CollectionPositionMapBucket#NOT_EXISTENT} - never allocated (implicit, beyond
+ *       current size)</li>
+ *   <li>{@link CollectionPositionMapBucket#ALLOCATED} - slot reserved but no data written yet</li>
+ *   <li>{@link CollectionPositionMapBucket#FILLED} - contains a valid position entry pointing to
+ *       a data page</li>
+ *   <li>{@link CollectionPositionMapBucket#REMOVED} - tombstone (deletion version stored for MVCC
+ *       visibility checks)</li>
+ * </ul>
+ *
+ * @see PaginatedCollectionV2
+ * @see CollectionPositionMapBucket
+ * @see MapEntryPoint
+ */
 public final class CollectionPositionMapV2 extends CollectionPositionMap {
 
+  /** Internal file ID assigned by the disk cache when the .cpm file is opened/created. */
   private long fileId;
 
+  /** Package-private constructor; instances are created by {@link PaginatedCollectionV2}. */
   CollectionPositionMapV2(
       final AbstractStorage storage,
       final String name,
@@ -46,19 +119,27 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     super(storage, name, extension, lockName);
   }
 
+  /** Opens an existing position-map file by name through the disk cache. */
   public void open(final AtomicOperation atomicOperation) throws IOException {
     fileId = openFile(atomicOperation, getFullName());
   }
 
+  /**
+   * Creates a new position-map file and initializes its entry point (page 0) with a file size
+   * of zero. If the physical file already has pages (e.g., leftover from a partial previous
+   * creation), the existing page 0 is reused and reset.
+   */
   public void create(final AtomicOperation atomicOperation) throws IOException {
     fileId = addFile(atomicOperation, getFullName());
 
     if (getFilledUpTo(atomicOperation, fileId) == 0) {
+      // Fresh file -- append the entry-point page.
       try (final var cacheEntry = addPage(atomicOperation, fileId)) {
         final var mapEntryPoint = new MapEntryPoint(cacheEntry);
         mapEntryPoint.setFileSize(0);
       }
     } else {
+      // File already has pages -- reset the entry point.
       try (final var cacheEntry = loadPageForWrite(atomicOperation, fileId, 0, false)) {
         final var mapEntryPoint = new MapEntryPoint(cacheEntry);
         mapEntryPoint.setFileSize(0);
@@ -90,6 +171,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     setName(newName);
   }
 
+  /**
+   * Reads the logical page count (number of bucket pages in use) from the entry-point page.
+   * This value does <em>not</em> include the entry-point page itself.
+   */
   private long getLastPage(final AtomicOperation atomicOperation) throws IOException {
     long lastPage;
     try (final var entryPointEntry = loadPageForRead(atomicOperation, fileId, 0)) {
@@ -99,6 +184,18 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     return lastPage;
   }
 
+  /**
+   * Allocates a new collection position and returns its global index. The allocation proceeds
+   * by finding the last bucket page that has room (or creating a new one if the current last
+   * bucket is full), then calling {@link CollectionPositionMapBucket#allocate()} to reserve a
+   * slot with status {@link CollectionPositionMapBucket#ALLOCATED}.
+   *
+   * <p>The returned global collection position is computed as:
+   * {@code localIndex + (bucketPageIndex - 1) * MAX_ENTRIES}.
+   *
+   * @param atomicOperation the current atomic operation context
+   * @return the newly allocated global collection position
+   */
   public long allocate(final AtomicOperation atomicOperation) throws IOException {
     CacheEntry cacheEntry;
     var clear = false;
@@ -112,16 +209,20 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
       assert lastPage <= filledUpTo - 1;
 
       if (lastPage == 0) {
+        // No bucket pages exist yet -- create the first one.
         if (lastPage == filledUpTo - 1) {
+          // Physical file has no pages beyond the entry point -- append a new one.
           cacheEntry = addPage(atomicOperation, fileId);
           filledUpTo++;
         } else {
+          // Reuse an existing-but-unclaimed page (recovery scenario).
           cacheEntry = loadPageForWrite(atomicOperation, fileId, lastPage + 1, false);
         }
         mapEntryPoint.setFileSize(lastPage + 1);
 
         clear = true;
       } else {
+        // Load the current last bucket page to check if it has room.
         cacheEntry = loadPageForWrite(atomicOperation, fileId, lastPage, true);
       }
 
@@ -132,6 +233,7 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
         }
 
         if (bucket.isFull()) {
+          // Current last bucket page is full -- allocate a new bucket page.
           cacheEntry.close();
 
           assert lastPage <= filledUpTo - 1;
@@ -147,6 +249,7 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
           bucket = new CollectionPositionMapBucket(cacheEntry);
           bucket.init();
         }
+        // Reserve a slot in the bucket and convert to a global collection position.
         final long index = bucket.allocate();
         return index
             + (long) (cacheEntry.getPageIndex() - 1) * CollectionPositionMapBucket.MAX_ENTRIES;
@@ -156,6 +259,15 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * Updates the position entry for the given collection position. Transitions the entry from
+   * ALLOCATED to FILLED if it was previously allocated, or replaces the current entry if already
+   * FILLED.
+   *
+   * @param collectionPosition the global collection position to update
+   * @param entry              the new position entry (page index, record offset, version)
+   * @param atomicOperation    the current atomic operation context
+   */
   public void update(
       final long collectionPosition,
       final CollectionPositionMapBucket.PositionEntry entry,
@@ -171,6 +283,12 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * Updates only the record version of the entry at the given collection position, leaving
+   * the page index and record offset unchanged. Used when the record content has not moved
+   * but the version stamp needs to be updated (e.g., during
+   * {@link PaginatedCollectionV2#updateRecordVersion}).
+   */
   public void updateVersion(
       final long collectionPosition, final long recordVersion,
       final AtomicOperation atomicOperation)
@@ -185,10 +303,15 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * Loads the bucket page that contains the entry for the given collection position, for
+   * writing. Throws if the position is beyond the current range of allocated bucket pages.
+   */
   private CacheEntry loadBucketPageForWrite(
       final long collectionPosition,
       final AtomicOperation atomicOperation) throws IOException {
 
+    // +1 because page 0 is the entry-point page, bucket pages start at index 1.
     final var pageIndex = collectionPosition / CollectionPositionMapBucket.MAX_ENTRIES + 1;
 
     final var lastPage = getLastPage(atomicOperation);
@@ -202,6 +325,14 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     return loadPageForWrite(atomicOperation, fileId, pageIndex, true);
   }
 
+  /**
+   * Retrieves the position entry for the given collection position, or {@code null} if the
+   * position does not exist or is not in FILLED status.
+   *
+   * @param collectionPosition the global collection position to look up
+   * @param atomicOperation    the current atomic operation context
+   * @return the position entry, or {@code null} if not found / not filled
+   */
   @Nullable
   public CollectionPositionMapBucket.PositionEntry get(
       final long collectionPosition, final AtomicOperation atomicOperation) throws IOException {
@@ -220,6 +351,16 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * Retrieves the position entry together with its status byte for the given collection position.
+   * Unlike {@link #get}, this method returns entries in any status (FILLED, REMOVED, ALLOCATED),
+   * which is needed by the MVCC read path to detect tombstones and invisible versions.
+   *
+   * @param collectionPosition the global collection position to look up
+   * @param atomicOperation    the current atomic operation context
+   * @return an {@link CollectionPositionMapBucket.EntryWithStatus} containing the status and
+   *         (for FILLED/REMOVED) the position entry; never {@code null}
+   */
   @Nonnull
   public CollectionPositionMapBucket.EntryWithStatus getWithStatus(
       final long collectionPosition, final AtomicOperation atomicOperation) throws IOException {
@@ -239,6 +380,14 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * Marks the entry at the given collection position as REMOVED (tombstone) and stores the
+   * {@code deletionVersion} so MVCC readers can determine deletion visibility.
+   *
+   * @param collectionPosition the global collection position to mark as removed
+   * @param deletionVersion    the commitTs of the deleting transaction
+   * @param atomicOperation    the current atomic operation context
+   */
   public void remove(final long collectionPosition, final long deletionVersion,
       final AtomicOperation atomicOperation)
       throws IOException {
@@ -253,6 +402,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * Returns up to {@code limit} FILLED positions that are {@code >= collectionPosition},
+   * scanning forward through bucket pages.
+   */
   long[] ceilingPositions(
       long collectionPosition,
       AtomicOperation atomicOperation,
@@ -262,6 +415,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
         LONG_ARRAY_RESULT_BUILDER);
   }
 
+  /**
+   * Returns up to {@code limit} FILLED positions that are strictly {@code > collectionPosition},
+   * scanning forward through bucket pages.
+   */
   long[] higherPositions(
       long collectionPosition,
       AtomicOperation atomicOperation,
@@ -276,6 +433,11 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
         LONG_ARRAY_RESULT_BUILDER);
   }
 
+  /**
+   * Returns all FILLED position entries strictly greater than {@code collectionPosition},
+   * including their physical page locations and record versions. Used by
+   * {@link PaginatedCollectionV2#nextPage} for page-based browsing.
+   */
   CollectionPositionEntry[] higherPositionsEntries(
       long collectionPosition,
       AtomicOperation atomicOperation
@@ -356,6 +518,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     return result;
   }
 
+  /**
+   * Returns up to {@code limit} FILLED positions strictly less than {@code collectionPosition},
+   * scanning backward through bucket pages. Results are in ascending order.
+   */
   long[] lowerPositions(
       long collectionPosition,
       AtomicOperation atomicOperation,
@@ -370,6 +536,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
         LONG_ARRAY_RESULT_BUILDER, false);
   }
 
+  /**
+   * Returns all FILLED position entries strictly less than {@code collectionPosition},
+   * in <em>descending</em> order (highest position first). Used for backward page browsing.
+   */
   CollectionPositionEntry[] lowerPositionsEntriesReversed(
       long collectionPosition,
       AtomicOperation atomicOperation
@@ -383,6 +553,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
         COL_POS_ENTRY_ARRAY_RESULT_BUILDER, true);
   }
 
+  /**
+   * Returns up to {@code limit} FILLED positions that are {@code <= collectionPosition},
+   * scanning backward through bucket pages. Results are in ascending order.
+   */
   long[] floorPositions(
       long collectionPosition,
       AtomicOperation atomicOperation,
@@ -467,6 +641,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     return result;
   }
 
+  /**
+   * Scans forward through all bucket pages to find the first FILLED position, or returns
+   * {@link RID#COLLECTION_POS_INVALID} if the map is empty.
+   */
   long getFirstPosition(final AtomicOperation atomicOperation) throws IOException {
     final var lastPage = getLastPage(atomicOperation);
 
@@ -488,6 +666,11 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     return RID.COLLECTION_POS_INVALID;
   }
 
+  /**
+   * Returns the raw status byte ({@link CollectionPositionMapBucket#NOT_EXISTENT},
+   * {@link CollectionPositionMapBucket#ALLOCATED}, {@link CollectionPositionMapBucket#FILLED},
+   * or {@link CollectionPositionMapBucket#REMOVED}) for the given collection position.
+   */
   public byte getStatus(final long collectionPosition, final AtomicOperation atomicOperation)
       throws IOException {
     final var pageIndex =
@@ -507,6 +690,10 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * Scans backward through all bucket pages to find the last FILLED position, or returns
+   * {@link RID#COLLECTION_POS_INVALID} if the map is empty.
+   */
   public long getLastPosition(final AtomicOperation atomicOperation) throws IOException {
     final var lastPage = getLastPage(atomicOperation);
 
@@ -572,11 +759,24 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
     }
   }
 
+  /**
+   * A snapshot of a position map entry enriched with the global collection position. Used as a
+   * transfer object when iterating position entries for page-based browsing (see
+   * {@link #higherPositionsEntries} and {@link #lowerPositionsEntriesReversed}).
+   *
+   * <p>Unlike {@link CollectionPositionMapBucket.PositionEntry} (which stores the page index and
+   * record offset), this class additionally carries the global {@link #position} so that
+   * callers don't need to recompute it from the bucket page index and local entry index.
+   */
   public static final class CollectionPositionEntry {
 
+    /** Global collection position (the logical record ID within this collection). */
     private final long position;
+    /** Data-file page index where the record's entry-point chunk is stored. */
     private final long page;
+    /** Slot offset within the data page. */
     private final int offset;
+    /** Record version (commitTs of the writing transaction). */
     private final long recordVersion;
 
     CollectionPositionEntry(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMap.java
@@ -7,13 +7,84 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.
 import java.io.IOException;
 import javax.annotation.Nonnull;
 
+/**
+ * A two-level free-space map that tracks the maximum free space available on each data page of a
+ * {@link PaginatedCollectionV2}, enabling efficient O(log N) lookup for a page with enough room
+ * to store a record chunk.
+ *
+ * <h2>Architecture</h2>
+ *
+ * <p>The free-space map is stored in a single file with extension {@value #DEF_EXTENSION}. The
+ * file contains a hierarchy of {@link FreeSpaceMapPage} pages organized in a two-level structure:
+ *
+ * <pre>{@code
+ *  .fsm file layout:
+ *
+ *  Page 0 (first level):
+ *  +-----------------------------------------------------+
+ *  |  Segment tree over second-level pages                |
+ *  |  Each cell = max(free space across all data pages    |
+ *  |              tracked by the corresponding            |
+ *  |              second-level page)                      |
+ *  +-----------------------------------------------------+
+ *
+ *  Pages 1..K (second level):
+ *  +-----------------------------------------------------+
+ *  |  Segment tree over individual data pages             |
+ *  |  Each leaf cell = normalized free space of one       |
+ *  |                   data page                          |
+ *  +-----------------------------------------------------+
+ *
+ *  Lookup flow for findFreePage(requiredSize):
+ *
+ *  1. Normalize requiredSize:
+ *        normalizedSize = requiredSize / NORMALIZATION_INTERVAL + 1
+ *
+ *  2. Search first-level page (page 0) for a second-level page
+ *     whose max free space >= normalizedSize
+ *        -> returns secondLevelPageIndex (local index within page 0's tree)
+ *
+ *  3. Search the second-level page for a data page whose
+ *     normalized free space >= normalizedSize
+ *        -> returns localDataPageIndex
+ *
+ *  4. Global data page index =
+ *        localDataPageIndex + secondLevelPageIndex * CELLS_PER_PAGE
+ * }</pre>
+ *
+ * <h2>Normalization</h2>
+ *
+ * <p>Free space values are <em>normalized</em> to fit in a single byte (0..255) by dividing
+ * the actual free space in bytes by {@link #NORMALIZATION_INTERVAL}. This quantization trades
+ * precision for compact storage: each cell in the segment tree occupies only 1 byte. The
+ * normalization interval is {@code floor(MAX_PAGE_SIZE_BYTES / 256)}, ensuring that a full
+ * page maps to a value of ~255.
+ *
+ * <h2>Update Flow</h2>
+ *
+ * <p>When a record is written to or deleted from a data page, the collection calls
+ * {@link #updatePageFreeSpace(AtomicOperation, int, int)} with the page's new maximum record
+ * size. The normalized value is propagated through the second-level segment tree (updating the
+ * leaf and its ancestors), and the new maximum for that second-level page is then propagated
+ * up to the first-level tree.
+ *
+ * @see FreeSpaceMapPage
+ * @see PaginatedCollectionV2
+ */
 public final class FreeSpaceMap extends DurableComponent {
 
+  /** File extension for free-space map files. */
   public static final String DEF_EXTENSION = ".fsm";
 
+  /**
+   * Normalization divisor that converts raw free-space bytes to a 0..255 range. Computed as
+   * {@code floor(MAX_PAGE_SIZE_BYTES / 256)}. For the default 8 KB page size (8192 bytes),
+   * this equals 32, so each unit represents ~32 bytes of free space.
+   */
   static final int NORMALIZATION_INTERVAL =
       (int) Math.floor(DurablePage.MAX_PAGE_SIZE_BYTES / 256.0);
 
+  /** Internal file ID assigned by the disk cache when the .fsm file is opened/created. */
   private long fileId;
 
   public FreeSpaceMap(
@@ -44,12 +115,29 @@ public final class FreeSpaceMap extends DurableComponent {
     }
   }
 
+  /**
+   * Finds a data page with at least {@code requiredSize} bytes of free space.
+   *
+   * <p>The search is a two-step process:
+   * <ol>
+   *   <li>Search the <b>first-level</b> page (page 0) to find which second-level page
+   *       contains a data page with enough free space.</li>
+   *   <li>Search the identified <b>second-level</b> page to find the specific data page.</li>
+   * </ol>
+   *
+   * @param requiredSize    minimum free space required (in raw bytes)
+   * @param atomicOperation the current atomic operation context
+   * @return the data-file page index of a suitable page, or {@code -1} if no page qualifies
+   */
   public int findFreePage(final int requiredSize, AtomicOperation atomicOperation)
       throws IOException {
+    // Normalize the required size to the same scale used by the segment tree cells.
+    // The +1 ensures we round up, so we never return a page with slightly less space than needed.
     final var normalizedSize = requiredSize / NORMALIZATION_INTERVAL + 1;
 
     final int localSecondLevelPageIndex;
 
+    // Step 1: search the first-level page for a second-level page with enough max free space.
     try (final var firstLevelEntry = loadPageForRead(atomicOperation, fileId, 0)) {
       final var page = new FreeSpaceMapPage(firstLevelEntry);
       localSecondLevelPageIndex = page.findPage(normalizedSize);
@@ -58,15 +146,37 @@ public final class FreeSpaceMap extends DurableComponent {
       }
     }
 
+    // Step 2: search within the identified second-level page for the actual data page.
+    // Second-level pages start at file page index 1 (page 0 is the first level).
     final var secondLevelPageIndex = localSecondLevelPageIndex + 1;
     try (final var leafEntry =
         loadPageForRead(atomicOperation, fileId, secondLevelPageIndex)) {
       final var page = new FreeSpaceMapPage(leafEntry);
+      // Convert the local leaf index to a global data-page index.
       return page.findPage(normalizedSize)
           + localSecondLevelPageIndex * FreeSpaceMapPage.CELLS_PER_PAGE;
     }
   }
 
+  /**
+   * Updates the free-space tracking for a specific data page. Called by
+   * {@link PaginatedCollectionV2} after writing or deleting a record on the data page.
+   *
+   * <p>The update propagates through both levels of the tree:
+   * <ol>
+   *   <li>Normalize {@code freeSpace} to a 0..255 byte value.</li>
+   *   <li>Update the leaf in the second-level page, which returns the new max for that
+   *       second-level page.</li>
+   *   <li>Propagate the new max up to the corresponding cell in the first-level page.</li>
+   * </ol>
+   *
+   * <p>If the second-level page does not yet exist (the data file grew beyond what the FSM
+   * currently tracks), new pages are appended and initialized before the update.
+   *
+   * @param atomicOperation the current atomic operation context
+   * @param pageIndex       the data-file page index whose free space changed
+   * @param freeSpace       the new maximum record size (in raw bytes) that fits on the page
+   */
   public void updatePageFreeSpace(
       final AtomicOperation atomicOperation, final int pageIndex, final int freeSpace)
       throws IOException {
@@ -75,10 +185,11 @@ public final class FreeSpaceMap extends DurableComponent {
     assert freeSpace < DurablePage.MAX_PAGE_SIZE_BYTES;
 
     final var normalizedSpace = freeSpace / NORMALIZATION_INTERVAL;
+    // +1 because page 0 of the FSM file is the first-level page.
     final var secondLevelPageIndex = 1 + pageIndex / FreeSpaceMapPage.CELLS_PER_PAGE;
 
+    // Ensure all required pages exist (the FSM file may need to grow).
     final var filledUpTo = getFilledUpTo(atomicOperation, fileId);
-
     for (var i = 0; i < secondLevelPageIndex - filledUpTo + 1; i++) {
       try (final var cacheEntry = addPage(atomicOperation, fileId)) {
         final var page = new FreeSpaceMapPage(cacheEntry);
@@ -86,6 +197,7 @@ public final class FreeSpaceMap extends DurableComponent {
       }
     }
 
+    // Update the second-level page's segment tree and get the new page-wide maximum.
     final int maxFreeSpaceSecondLevel;
     final var localSecondLevelPageIndex = pageIndex % FreeSpaceMapPage.CELLS_PER_PAGE;
     try (final var leafEntry =
@@ -96,6 +208,7 @@ public final class FreeSpaceMap extends DurableComponent {
           page.updatePageMaxFreeSpace(localSecondLevelPageIndex, normalizedSpace);
     }
 
+    // Propagate the new second-level maximum up to the first-level page.
     try (final var firstLevelCacheEntry =
         loadPageForWrite(atomicOperation, fileId, 0, true)) {
       final var page = new FreeSpaceMapPage(firstLevelCacheEntry);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMapPage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMapPage.java
@@ -3,20 +3,95 @@ package com.jetbrains.youtrackdb.internal.core.storage.collection.v2;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurablePage;
 
+/**
+ * A single page of a {@link FreeSpaceMap}, implementing a <em>max-heap segment tree</em> packed
+ * into a flat byte array. Each cell stores a single byte (0..255) representing a normalized
+ * free-space value. The tree supports two operations:
+ * <ul>
+ *   <li>{@link #findPage(int)} - find a leaf whose value is {@code >= requiredSize} (O(log N))</li>
+ *   <li>{@link #updatePageMaxFreeSpace(int, int)} - update a leaf and propagate the max up to
+ *       the root (O(log N))</li>
+ * </ul>
+ *
+ * <h2>Segment Tree Layout</h2>
+ *
+ * <p>The tree is stored in a level-order (BFS) layout within the page's usable area (bytes
+ * {@link DurablePage#NEXT_FREE_POSITION} through {@link DurablePage#MAX_PAGE_SIZE_BYTES}).
+ * Internal nodes store the maximum of their two children. Leaf nodes store the normalized
+ * free-space value for one data page.
+ *
+ * <pre>{@code
+ *  Page byte layout (level-order segment tree):
+ *
+ *  Offset NEXT_FREE_POSITION:
+ *  +--------+--------+--------+--------+--------+--------+-----+
+ *  | root   | L2[0]  | L2[1]  | L3[0]  | L3[1]  | L3[2]  | ... |
+ *  | (L1)   |        |        |        |        |        |     |
+ *  +--------+--------+--------+--------+--------+--------+-----+
+ *  |<-- internal nodes ---------------------------------->|
+ *                                            +--------+--------+-----+
+ *                                            | leaf0  | leaf1  | ... |
+ *                                            +--------+--------+-----+
+ *                                            |<-- CELLS_PER_PAGE leaves -->|
+ *
+ *  Level 1 (root):   1 node   -> max of everything
+ *  Level 2:          2 nodes  -> max of left/right halves
+ *  Level 3:          4 nodes
+ *  ...
+ *  Level LEVELS:     CELLS_PER_PAGE leaves (each = one data page's normalized free space)
+ *
+ *  Node at level L, index I is stored at byte offset:
+ *    NEXT_FREE_POSITION + ((1 << (L-1)) - 1 + I) * CELL_SIZE
+ *
+ *  For the default 8 KB page size (MAX_PAGE_SIZE_BYTES = 8192, NEXT_FREE_POSITION = 28):
+ *    - Total usable bytes = 8164
+ *    - LEVELS = 12 (tree depth)
+ *    - Internal nodes = 2^11 - 1 = 2047
+ *    - CELLS_PER_PAGE = 8164 - 2047 = 6117 (leaves / tracked data pages)
+ * }</pre>
+ *
+ * <h2>Search Algorithm ({@link #findPage})</h2>
+ *
+ * <p>Starting at the root (level 1), descend through the tree by always preferring the left
+ * child if its value is {@code >= requiredSize}; otherwise take the right child. This greedily
+ * finds the leftmost (lowest-index) leaf that satisfies the requirement.
+ *
+ * <h2>Update Algorithm ({@link #updatePageMaxFreeSpace})</h2>
+ *
+ * <p>Set the leaf value, then walk up to the root, recalculating each parent as the max of its
+ * two children. Returns the root value (the global maximum for this page).
+ *
+ * @see FreeSpaceMap
+ */
 public final class FreeSpaceMapPage extends DurablePage {
 
+  /** Size of each cell in bytes. Each cell holds a single unsigned byte (0..255). */
   private static final int CELL_SIZE = 1;
+
+  /**
+   * Number of leaf cells (data pages tracked) per FSM page. This equals the total usable
+   * cells minus the internal (non-leaf) nodes of the segment tree.
+   */
   static final int CELLS_PER_PAGE;
+
+  /** Depth of the segment tree (number of levels, root = level 1, leaves = level LEVELS). */
   private static final int LEVELS;
+
+  /** Byte offset within the page where the leaf nodes begin. */
   private static final int LEAVES_START_OFFSET;
 
   static {
+    // Maximum number of 1-byte cells that could fit in the full page.
     final var pageCells = MAX_PAGE_SIZE_BYTES / CELL_SIZE;
 
+    // Tree depth: floor(log2(pageCells)). The tree is as deep as possible while fitting
+    // all nodes into the usable page area.
     LEVELS = Integer.SIZE - Integer.numberOfLeadingZeros(pageCells) - 1;
 
+    // Total cells that fit in the usable area (after the DurablePage header).
     final var totalCells = (MAX_PAGE_SIZE_BYTES - NEXT_FREE_POSITION) / CELL_SIZE;
-    // amount of leaves in a tree
+    // Internal nodes at levels 1..(LEVELS-1) = 2^(LEVELS-1) - 1.
+    // Leaves = totalCells - internalNodes.
     CELLS_PER_PAGE = totalCells - ((1 << (LEVELS - 1)) - 1);
 
     LEAVES_START_OFFSET = nodeOffset(LEVELS, 0);
@@ -26,19 +101,44 @@ public final class FreeSpaceMapPage extends DurablePage {
     super(cacheEntry);
   }
 
+  /** Zeroes out the entire usable area, resetting all segment-tree nodes to 0. */
   public void init() {
     final var zeros = new byte[MAX_PAGE_SIZE_BYTES - NEXT_FREE_POSITION];
     setBinaryValue(NEXT_FREE_POSITION, zeros);
   }
 
+  /**
+   * Searches the segment tree for the leftmost leaf whose value is {@code >= requiredSize}.
+   *
+   * <p>Algorithm: start at the root. At each level, prefer the left child if it satisfies the
+   * requirement; otherwise descend into the right child. This greedily finds the lowest-index
+   * qualifying leaf in O(LEVELS) time.
+   *
+   * <pre>{@code
+   *  Example (LEVELS=4, requiredSize=50):
+   *
+   *          [120]           <- root: max=120 >= 50, proceed
+   *         /     \
+   *      [80]     [120]      <- left=80 >= 50, go left
+   *      / \       / \
+   *   [40] [80]  [90][120]   <- left=40 < 50, go right (80 >= 50)
+   *              ...
+   *         [80]             <- leaf found at this index
+   * }</pre>
+   *
+   * @param requiredSize the minimum normalized free-space value needed
+   * @return the leaf index (0-based) of a qualifying page, or {@code -1} if none qualifies
+   */
   public int findPage(int requiredSize) {
     var nodeIndex = 0;
 
+    // Check the root first: if the global maximum is too small, no leaf can satisfy.
     final var maxValue = 0xFF & getByteValue(nodeOffset(1, 0));
     if (maxValue == 0 || maxValue < requiredSize) {
       return -1;
     }
 
+    // Descend through the tree levels, choosing left or right child.
     for (var level = 2; level <= LEVELS; level++) {
       final var leftNodeIndex = nodeIndex << 1;
       if (leftNodeIndex >= CELLS_PER_PAGE) {
@@ -48,8 +148,10 @@ public final class FreeSpaceMapPage extends DurablePage {
 
       final var leftMax = 0xFF & getByteValue(leftNodeOffset);
       if (leftMax >= requiredSize) {
+        // Left child satisfies -- prefer lower indices for locality.
         nodeIndex <<= 1;
       } else {
+        // Left child insufficient -- the right child must satisfy (guaranteed by parent).
         final var rightNodeIndex = (nodeIndex << 1) + 1;
 
         if (rightNodeIndex >= CELLS_PER_PAGE) {
@@ -64,6 +166,30 @@ public final class FreeSpaceMapPage extends DurablePage {
     return nodeIndex;
   }
 
+  /**
+   * Updates the normalized free-space value for the leaf at {@code pageIndex} and propagates
+   * the change up to the root, recalculating each ancestor as the max of its two children.
+   *
+   * <pre>{@code
+   *  Example: update leaf[3] from 40 to 90
+   *
+   *  Before:                    After:
+   *        [80]                       [90]       <- root updated
+   *       /    \                     /    \
+   *    [80]    [60]              [90]    [60]     <- parent updated
+   *    / \     / \               / \     / \
+   *  [50][80][40][60]          [50][80][90][60]   <- leaf updated
+   *              ^                      ^
+   *         pageIndex=3            pageIndex=3
+   * }</pre>
+   *
+   * <p>If the leaf already holds the requested value, the method short-circuits and returns the
+   * current root value without writing anything.
+   *
+   * @param pageIndex the 0-based leaf index to update
+   * @param freeSpace the new normalized free-space value (0..255)
+   * @return the new root value (global maximum) after the update
+   */
   public int updatePageMaxFreeSpace(final int pageIndex, final int freeSpace) {
     assert freeSpace < (1 << (CELL_SIZE * 8));
     assert pageIndex >= 0;
@@ -72,6 +198,7 @@ public final class FreeSpaceMapPage extends DurablePage {
       throw new IllegalArgumentException("Page index " + pageIndex + " exceeds tree capacity");
     }
 
+    // Start at the leaf level and walk upward to the root.
     var nodeOffset = LEAVES_START_OFFSET + pageIndex * CELL_SIZE;
     var nodeIndex = pageIndex;
     var nodeValue = freeSpace;
@@ -79,41 +206,56 @@ public final class FreeSpaceMapPage extends DurablePage {
     for (var level = LEVELS; level > 0; level--) {
       final var prevValue = 0xFF & getByteValue(nodeOffset);
       if (prevValue == nodeValue) {
+        // Value unchanged at this level -- the ancestors won't change either.
         return 0xFF & getByteValue(nodeOffset(1, 0));
       }
 
       setByteValue(nodeOffset, (byte) nodeValue);
       if (level == 1) {
+        // Reached the root -- return the new root value.
         return nodeValue;
       }
 
+      // Determine the sibling index (left <-> right).
       final int siblingIndex;
-
       if ((nodeIndex & 1) == 0) {
         siblingIndex = nodeIndex + 1;
       } else {
         siblingIndex = nodeIndex - 1;
       }
 
+      // Read the sibling's value. If the sibling is beyond the page boundary (can happen
+      // for the rightmost node at a level), use the current node's value as the sibling.
       final var siblingOffset = nodeOffset(level, siblingIndex);
       final int siblingValue;
-
       if (siblingOffset + 2 <= MAX_PAGE_SIZE_BYTES) {
         siblingValue = 0xFF & getByteValue(siblingOffset);
       } else {
         siblingValue = nodeValue;
       }
 
+      // The parent's value is the max of the two children.
       nodeValue = Math.max(nodeValue, siblingValue);
       nodeIndex = nodeIndex >> 1;
       nodeOffset = nodeOffset(level - 1, nodeIndex);
     }
 
-    // unreachable
+    // unreachable -- the loop always returns when level == 1
     assert false;
     return 0;
   }
 
+  /**
+   * Computes the byte offset within the page for the node at the given level and index.
+   *
+   * <p>The formula uses the level-order (BFS) layout where level {@code L} starts at
+   * offset {@code NEXT_FREE_POSITION + (2^(L-1) - 1) * CELL_SIZE}, and node index {@code I}
+   * within that level is at an additional offset of {@code I * CELL_SIZE}.
+   *
+   * @param nodeLevel the tree level (1 = root, LEVELS = leaves)
+   * @param nodeIndex the 0-based index within the level
+   * @return the byte offset within the page
+   */
   private static int nodeOffset(int nodeLevel, int nodeIndex) {
     return NEXT_FREE_POSITION + ((1 << (nodeLevel - 1)) - 1 + nodeIndex) * CELL_SIZE;
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/MapEntryPoint.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/MapEntryPoint.java
@@ -3,18 +3,41 @@ package com.jetbrains.youtrackdb.internal.core.storage.collection.v2;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurablePage;
 
+/**
+ * Page 0 of a {@link CollectionPositionMapV2}'s file ({@code .cpm}), serving as the entry point
+ * that tracks how many bucket pages are currently in use.
+ *
+ * <h2>Page Layout</h2>
+ *
+ * <pre>{@code
+ *  Byte offset (relative to NEXT_FREE_POSITION):
+ *  +-------------------+
+ *  | FILE_SIZE (4B)    |
+ *  | = bucket page cnt |
+ *  +-------------------+
+ *
+ *  FILE_SIZE stores the number of CollectionPositionMapBucket pages (pages 1..N) that
+ *  are currently in use. Page 0 (this entry point) is not counted. A value of 0 means
+ *  no positions have been allocated yet.
+ * }</pre>
+ *
+ * @see CollectionPositionMapV2
+ */
 final class MapEntryPoint extends DurablePage {
 
+  /** Byte offset for the file-size field (number of bucket pages in use). */
   private static final int FILE_SIZE_OFFSET = NEXT_FREE_POSITION;
 
   MapEntryPoint(CacheEntry cacheEntry) {
     super(cacheEntry);
   }
 
+  /** Returns the number of bucket pages currently in use (pages 1..N). */
   int getFileSize() {
     return getIntValue(FILE_SIZE_OFFSET);
   }
 
+  /** Sets the number of bucket pages currently in use. */
   void setFileSize(int size) {
     setIntValue(FILE_SIZE_OFFSET, size);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionStateV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionStateV2.java
@@ -25,14 +25,37 @@ import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurablePage;
 
 /**
- * A durable page that stores the state metadata for a v2 paginated collection.
+ * Page 0 of a {@link PaginatedCollectionV2}'s data file ({@code .pcl}), storing collection-level
+ * metadata. This page is always the first page in the data file and is never used for record
+ * storage.
  *
- * @since 20.08.13
+ * <h2>Page Layout</h2>
+ *
+ * <pre>{@code
+ *  Byte offset (relative to NEXT_FREE_POSITION):
+ *  +-------------------+-------------------+-------------------+
+ *  | RECORDS_SIZE (4B) |    SIZE (4B)      |  FILE_SIZE (4B)   |
+ *  |   (reserved)      |   (reserved)      | = data page count |
+ *  +-------------------+-------------------+-------------------+
+ *
+ *  FILE_SIZE tracks how many data pages (pages 1..N) have been allocated in the data file.
+ *  Page 0 itself is not counted. This counter is used by
+ *  PaginatedCollectionV2#allocateNewPage() to determine whether to append a new page or
+ *  reuse an existing one.
+ * }</pre>
+ *
+ * <p>The {@code RECORDS_SIZE} and {@code SIZE} fields are reserved for future use and are
+ * currently unused by V2 collections.
+ *
+ * @see PaginatedCollectionV2
  */
 public final class PaginatedCollectionStateV2 extends DurablePage {
 
+  /** Byte offset for the records-size field (reserved, currently unused). */
   private static final int RECORDS_SIZE_OFFSET = NEXT_FREE_POSITION;
+  /** Byte offset for the size field (reserved, currently unused). */
   private static final int SIZE_OFFSET = RECORDS_SIZE_OFFSET + IntegerSerializer.INT_SIZE;
+  /** Byte offset for the file-size field (number of allocated data pages). */
   private static final int FILE_SIZE_OFFSET = SIZE_OFFSET + IntegerSerializer.INT_SIZE;
   private static final int APPROXIMATE_RECORDS_COUNT_OFFSET =
       FILE_SIZE_OFFSET + IntegerSerializer.INT_SIZE;
@@ -41,10 +64,18 @@ public final class PaginatedCollectionStateV2 extends DurablePage {
     super(cacheEntry);
   }
 
+  /**
+   * Sets the number of data pages currently allocated in the collection's data file.
+   * Does not count page 0 (this state page itself).
+   */
   public void setFileSize(int size) {
     setIntValue(FILE_SIZE_OFFSET, size);
   }
 
+  /**
+   * Returns the number of data pages currently allocated in the collection's data file.
+   * Does not count page 0 (this state page itself).
+   */
   public int getFileSize() {
     return getIntValue(FILE_SIZE_OFFSET);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
@@ -59,39 +59,182 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * Version 2 implementation of a paginated collection that stores records across multiple pages.
+ * Version 2 implementation of a paginated record collection for the YouTrackDB storage engine.
  *
- * @since 10/7/13
+ * <p>A "collection" is the physical storage unit that holds records belonging to a database class
+ * (vertex type, edge type, or document type). Each collection manages its own data pages, position
+ * map, and free-space index. Records are identified by a <em>collection position</em> (a
+ * monotonically increasing {@code long}), which, combined with the collection {@link #id}, forms
+ * the full Record ID (RID) of the form {@code #collectionId:collectionPosition}.
+ *
+ * <h2>Architecture Overview</h2>
+ *
+ * <p>A {@code PaginatedCollectionV2} is composed of three on-disk components, each stored as a
+ * separate file managed through the disk-cache layer ({@link
+ * com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache ReadCache} /
+ * {@link com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache WriteCache}):
+ *
+ * <pre>{@code
+ *  PaginatedCollectionV2
+ *  |
+ *  |-- Data file  (.pcl)           -- CollectionPage pages holding serialized record chunks
+ *  |     page 0: PaginatedCollectionStateV2 (collection metadata / file-size counter)
+ *  |     page 1..N: CollectionPage instances with record entries
+ *  |
+ *  |-- Position map  (.cpm)        -- CollectionPositionMapV2
+ *  |     page 0: MapEntryPoint (stores the count of bucket pages)
+ *  |     page 1..M: CollectionPositionMapBucket pages
+ *  |       Each bucket holds up to MAX_ENTRIES position entries:
+ *  |         [status: 1B][pageIndex: 8B][recordPosition: 4B][recordVersion: 8B]
+ *  |
+ *  |-- Free-space map  (.fsm)      -- FreeSpaceMap (two-level segment tree)
+ *        page 0: first-level summary (max free space per second-level page)
+ *        page 1..K: second-level leaves (max free space per data page)
+ * }</pre>
+ *
+ * <h2>Record Storage Layout</h2>
+ *
+ * <p>A record is serialized into an "entry" consisting of a metadata header followed by the raw
+ * content bytes. The entry is then split into one or more <em>chunks</em> that are stored across
+ * {@link CollectionPage} pages. Chunks form a singly-linked list via embedded page pointers,
+ * enabling records larger than a single page to be stored.
+ *
+ * <pre>{@code
+ *  Entry layout (logical):
+ *  +------------+-------------+---------------------+-----------------------+
+ *  | recordType | contentSize | collectionPosition  |    actual content     |
+ *  |   (1 B)    |   (4 B)    |       (8 B)          |      (N bytes)        |
+ *  +------------+-------------+---------------------+-----------------------+
+ *  |<---------- METADATA_SIZE = 13 B -------------->|
+ *
+ *  Chunk layout on a CollectionPage (per page slot):
+ *  +------------------+------------------+-----------------+
+ *  |   entry data     | firstRecordFlag  | nextPagePointer |
+ *  |   (variable)     |     (1 B)        |     (8 B)       |
+ *  +------------------+------------------+-----------------+
+ *
+ *  Multi-chunk record (written tail-first, read head-first):
+ *
+ *  CollectionPage A (entry point)       CollectionPage B (tail)
+ *  +---------------------------------+  +---------------------------+
+ *  | metadata + content[0..P] | 1 |ptr--->| content[P+1..N] | 0 | -1 |
+ *  +---------------------------------+  +---------------------------+
+ *         ^                                    (nextPagePointer = -1
+ *         |                                     means end of chain)
+ *    Position map entry
+ *    points here
+ * }</pre>
+ *
+ * <p>The serialization writes chunks in <strong>reverse order</strong> (tail chunk first, head
+ * chunk last). This means the entry-point chunk -- the one the position map points to -- is
+ * always the last chunk written, which simplifies crash recovery: if the write is interrupted
+ * before the entry point is written, the position map still points to the old (valid) data.
+ *
+ * <h2>MVCC and Snapshot Isolation</h2>
+ *
+ * <p>Records use multi-version concurrency control (MVCC) for snapshot isolation:
+ * <ul>
+ *   <li>Each record version is stamped with the writing transaction's {@code commitTs}.</li>
+ *   <li>Before overwriting or deleting a record, the previous version's position entry is saved
+ *       to a <em>snapshot index</em> (keyed by {@link SnapshotKey}) so concurrent readers can
+ *       still access the old version.</li>
+ *   <li>A <em>visibility index</em> (keyed by {@link VisibilityKey}) tracks when snapshot entries
+ *       can be garbage-collected once all older transactions complete.</li>
+ *   <li>Reads check version visibility via {@link
+ *       com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsTable.AtomicOperationsSnapshot
+ *       AtomicOperationsSnapshot} and fall back to historical entries when the current version
+ *       is not yet visible.</li>
+ * </ul>
+ *
+ * <h2>Concurrency</h2>
+ *
+ * <p>Read operations acquire a shared lock; write operations acquire an exclusive lock. All
+ * structural mutations run inside an {@link AtomicOperation} for crash-safe atomicity via
+ * write-ahead logging (WAL).
+ *
+ * @see CollectionPositionMapV2
+ * @see FreeSpaceMap
+ * @see CollectionPage
+ * @see PaginatedCollectionStateV2
  */
 public final class PaginatedCollectionV2 extends PaginatedCollection {
 
-  // max chunk size - next page pointer - first record flag
+  /**
+   * Maximum entry data that can fit in a single chunk on a {@link CollectionPage}. Derived from
+   * {@link CollectionPage#MAX_RECORD_SIZE} minus the per-chunk overhead of the first-record flag
+   * (1 byte) and the next-page pointer (8 bytes).
+   */
   private static final int MAX_ENTRY_SIZE =
       CollectionPage.MAX_RECORD_SIZE - ByteSerializer.BYTE_SIZE - LongSerializer.LONG_SIZE;
 
+  /**
+   * Minimum chunk size: just the first-record flag (1 byte) + next-page pointer (8 bytes),
+   * with no entry data. Used as a lower bound when requesting a page from the free-space map.
+   */
   private static final int MIN_ENTRY_SIZE = ByteSerializer.BYTE_SIZE + LongSerializer.LONG_SIZE;
 
+  /** Page index of the collection state page within the data file (.pcl). Always page 0. */
   private static final int STATE_ENTRY_INDEX = 0;
+
+  /** On-disk binary format version for this collection implementation. */
   private static final int BINARY_VERSION = 3;
 
-  /// Size of the per-record metadata header that precedes the actual record content. Layout:
-  /// {@code [recordType: 1B][contentSize: 4B][collectionPosition: 8B]}.
+  /**
+   * Size of the per-record metadata header that precedes the actual record content.
+   *
+   * <pre>{@code
+   * Layout: [recordType: 1B][contentSize: 4B][collectionPosition: 8B] = 13 bytes
+   * }</pre>
+   */
   private static final int METADATA_SIZE =
       ByteSerializer.BYTE_SIZE + IntegerSerializer.INT_SIZE + LongSerializer.LONG_SIZE;
 
+  /**
+   * Bit offset used to pack a page index and a record position into a single {@code long}
+   * page pointer. The page index occupies bits [16..63] and the record position occupies
+   * bits [0..15].
+   *
+   * @see #createPagePointer(long, int)
+   * @see #getPageIndex(long)
+   * @see #getRecordPosition(long)
+   */
   private static final int PAGE_INDEX_OFFSET = 16;
+
+  /** Bitmask to extract the 16-bit record position from a packed page pointer. */
   private static final int RECORD_POSITION_MASK = 0xFFFF;
 
+  /** Whether this collection stores internal system data (e.g., schema metadata). */
   private final boolean systemCollection;
+
+  /**
+   * Maps logical collection positions to physical locations (page index + offset) in the data
+   * file. Also tracks record status (ALLOCATED, FILLED, REMOVED) and version.
+   */
   private final CollectionPositionMapV2 collectionPositionMap;
+
+  /**
+   * Two-level segment tree that tracks the maximum free space available on each data page,
+   * enabling O(log N) lookup for a page with enough room for a new record chunk.
+   */
   private final FreeSpaceMap freeSpaceMap;
+
+  /** Human-readable storage name, used in exception messages and logging. */
   private final String storageName;
 
+  /** Per-collection rate meters for create/read/update/delete/conflict operations. */
   private StorageCollection.Meters meters = Meters.NOOP;
 
+  /**
+   * Numeric identifier for this collection, assigned during {@link #configure}. Forms the
+   * "collection ID" part of a Record ID ({@code #id:collectionPosition}).
+   */
   private volatile int id;
   private volatile long approximateRecordsCount;
+
+  /** Internal file ID assigned by the disk cache when the data file (.pcl) is opened/created. */
   private long fileId;
+
+  /** Strategy for resolving concurrent-modification conflicts on records in this collection. */
   private RecordConflictStrategy recordConflictStrategy;
 
   public PaginatedCollectionV2(
@@ -424,18 +567,31 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     return createPhysicalPosition(recordType, collectionPosition, newRecordVersion);
   }
 
+  /**
+   * Finds or allocates a data page with at least {@code entrySize} bytes of free space.
+   *
+   * <p>First consults the {@link FreeSpaceMap} for an existing page with enough room. If no
+   * suitable page is found, a brand-new page is allocated from the data file and initialized.
+   *
+   * @param atomicOperation the current atomic operation context
+   * @param entrySize       minimum free space required on the page (bytes)
+   * @return a {@link CollectionPage} with enough room for the entry, never {@code null}
+   */
   private CollectionPage findNewPageToWrite(
       final AtomicOperation atomicOperation, final int entrySize) {
     final CollectionPage page;
     try {
+      // Ask the FSM for an existing page that can accommodate the chunk.
       final var nextPageToWrite = findNextFreePageIndexToWrite(entrySize, atomicOperation);
 
       final CacheEntry cacheEntry;
       boolean isNew;
       if (nextPageToWrite >= 0) {
+        // Found an existing page with enough free space.
         cacheEntry = loadPageForWrite(atomicOperation, fileId, nextPageToWrite, true);
         isNew = false;
       } else {
+        // No existing page fits -- grow the data file by one page.
         cacheEntry = allocateNewPage(atomicOperation);
         isNew = true;
       }
@@ -649,8 +805,22 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     return new RawPairObjectInteger<>(chunk, written);
   }
 
+  /**
+   * Queries the {@link FreeSpaceMap} for an existing data page that can hold a chunk of the
+   * given size.
+   *
+   * <p>If no page has enough room for the full chunk, and the entry is large (more than half
+   * of {@link #MAX_ENTRY_SIZE}), a second attempt is made with half the chunk size. This
+   * allows large records to be split across more chunks rather than immediately allocating a
+   * new page, improving space utilization.
+   *
+   * @param bytesToWrite    the entry bytes remaining to write (clamped to {@link #MAX_ENTRY_SIZE})
+   * @param atomicOperation the current atomic operation context
+   * @return the data-file page index of a suitable page, or {@code -1} if none found
+   */
   private int findNextFreePageIndexToWrite(int bytesToWrite, AtomicOperation atomicOperation)
       throws IOException {
+    // Clamp to the maximum entry data per chunk -- larger entries will be split.
     if (bytesToWrite > MAX_ENTRY_SIZE) {
       bytesToWrite = MAX_ENTRY_SIZE;
     }
@@ -662,6 +832,8 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     var chunkSize = calculateChunkSize(bytesToWrite);
     var pageIndex = freeSpaceMap.findFreePage(chunkSize, atomicOperation);
 
+    // Fallback: for large entries, try to find a page that can hold at least half.
+    // This trades off more chunks for better page utilization.
     if (pageIndex < 0 && bytesToWrite > MAX_ENTRY_SIZE / 2) {
       final var halfChunkSize = calculateChunkSize(bytesToWrite / 2);
       if (halfChunkSize > 0) {
@@ -1026,6 +1198,12 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
         });
   }
 
+  /**
+   * Deletes a record while preserving its previous version for MVCC readers. First saves the
+   * current position entry to the snapshot index via {@link #keepPreviousRecordVersion}, then
+   * marks the position map entry as REMOVED (tombstone) with the current transaction's commitTs
+   * as the deletion version.
+   */
   private void deleteRecordWithPreservingPreviousVersion(AtomicOperation atomicOperation,
       long collectionPosition,
       PositionEntry positionEntry) throws IOException {
@@ -1033,6 +1211,8 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     var recordVersion = atomicOperation.getCommitTs();
     keepPreviousRecordVersion(collectionPosition, recordVersion, atomicOperation, positionEntry);
 
+    // Mark as REMOVED in the position map. The deletion version (commitTs) is stored so
+    // readers can determine whether the deletion is visible to their snapshot.
     collectionPositionMap.remove(collectionPosition, recordVersion, atomicOperation);
 
     decrementApproximateRecordsCount(atomicOperation);
@@ -1089,6 +1269,12 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
         recordType, atomicOperation, positionEntry);
   }
 
+  /**
+   * Updates a record with new content while preserving the old version for MVCC readers. The
+   * update always writes the new content to fresh page slot(s) (it does <em>not</em> overwrite
+   * in place), then updates the position map to point to the new location. If the new content
+   * happens to land on the same page/offset (unlikely in practice), only the version is updated.
+   */
   private void updateRecordWithPreservingPreviousVersion(long collectionPosition, byte[] content,
       byte recordType, AtomicOperation atomicOperation,
       PositionEntry positionEntry) throws IOException {
@@ -1135,6 +1321,29 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     }
   }
 
+  /**
+   * Saves the current version of a record to the snapshot index before it is overwritten or
+   * deleted, enabling MVCC snapshot isolation for concurrent readers.
+   *
+   * <p>If the old version equals the new version (i.e., the same transaction is overwriting its
+   * own write), the snapshot is skipped because no other transaction could have seen that version.
+   *
+   * <p>Two index entries are created:
+   * <ol>
+   *   <li><b>Snapshot entry</b> ({@link SnapshotKey} -> {@link PositionEntry}): maps the old
+   *       {@code (collectionId, collectionPosition, oldVersion)} triple to the physical page
+   *       location of the old record. This allows readers with a snapshot older than
+   *       {@code newRecordVersion} to find and read the previous version.</li>
+   *   <li><b>Visibility entry</b> ({@link VisibilityKey} -> {@link SnapshotKey}): keyed by
+   *       {@code newRecordVersion}, enables garbage collection of the snapshot entry once all
+   *       transactions that could see the old version have completed.</li>
+   * </ol>
+   *
+   * @param collectionPosition logical position of the record being modified
+   * @param newRecordVersion   the commitTs of the modifying transaction
+   * @param atomicOperation    the current atomic operation context
+   * @param positionEntry      the current physical location of the record to preserve
+   */
   private void keepPreviousRecordVersion(long collectionPosition, long newRecordVersion,
       AtomicOperation atomicOperation, PositionEntry positionEntry) throws IOException {
     try (final var cacheEntry = loadPageForRead(atomicOperation, fileId,
@@ -1142,16 +1351,17 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
       final var localPage = new CollectionPage(cacheEntry);
       var oldRecordVersion = localPage.getRecordVersion(positionEntry.getRecordPosition());
       if (oldRecordVersion == newRecordVersion) {
-        //we overwrite our own version, no need to preserve it
+        // Same transaction overwriting its own write -- no need to preserve, because
+        // no other transaction could have seen this version.
         return;
       }
 
+      // Store the old version's physical location in the snapshot index.
       var snapshotKey = new SnapshotKey(id, collectionPosition, oldRecordVersion);
       atomicOperation.putSnapshotEntry(snapshotKey, positionEntry);
 
-      // The snapshotKey should be kept until the presence of active transactions
-      // started before the new record version is added - recordVersion
-      // Transaction keeps the state when it was started in atomicOperationTableState
+      // Register a visibility entry so the snapshot can be garbage-collected once all
+      // transactions that started before newRecordVersion have completed.
       var visibilityKey = new VisibilityKey(newRecordVersion, id, collectionPosition);
       atomicOperation.putVisibilityEntry(visibilityKey, snapshotKey);
     }
@@ -1531,6 +1741,11 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     }
   }
 
+  /**
+   * Shared initialization logic called by both {@link #configure} overloads. Validates the
+   * collection name, optionally sets the record conflict strategy, registers per-collection
+   * metrics, and stores the numeric collection ID.
+   */
   private void init(final int id, final String name, final String conflictStrategy)
       throws IOException {
     FileUtils.checkValidName(name);
@@ -1581,6 +1796,15 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     return physicalPosition;
   }
 
+  /**
+   * Reassembles a multi-chunk record into a single contiguous byte array by concatenating the
+   * data portions of each chunk (stripping the trailing first-record flag and next-page pointer
+   * from each). If the record fits in a single chunk, the original array is returned as-is.
+   *
+   * @param recordChunks list of raw chunk byte arrays in read order (head to tail)
+   * @param contentSize  total data bytes across all chunks (excluding per-chunk overhead)
+   * @return a single byte array containing the full entry (metadata + content)
+   */
   private static byte[] convertRecordChunksToSingleChunk(
       final List<byte[]> recordChunks, final int contentSize) {
     final byte[] fullContent;
@@ -1603,18 +1827,49 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     return fullContent;
   }
 
+  /**
+   * Packs a page index and a record position into a single {@code long} pointer.
+   *
+   * <pre>{@code
+   * Bit layout of the packed pointer:
+   *  63                 16  15              0
+   *  +--------------------+-----------------+
+   *  |    pageIndex       | recordPosition  |
+   *  +--------------------+-----------------+
+   * }</pre>
+   *
+   * @see #getPageIndex(long)
+   * @see #getRecordPosition(long)
+   */
   private static long createPagePointer(final long pageIndex, final int pagePosition) {
     return pageIndex << PAGE_INDEX_OFFSET | pagePosition;
   }
 
+  /** Extracts the 16-bit record position from a packed page pointer. */
   private static int getRecordPosition(final long nextPagePointer) {
     return (int) (nextPagePointer & RECORD_POSITION_MASK);
   }
 
+  /** Extracts the page index (bits 16..63) from a packed page pointer. */
   private static long getPageIndex(final long nextPagePointer) {
     return nextPagePointer >>> PAGE_INDEX_OFFSET;
   }
 
+  /**
+   * Allocates a new data page in the collection's data file and increments the file-size counter
+   * stored on the state page (page 0).
+   *
+   * <p>The collection tracks its own "logical" file size in
+   * {@link PaginatedCollectionStateV2#getFileSize()}, which may be less than the physical file
+   * size reported by the cache ({@code filledUpTo}). If the logical size equals the physical
+   * size minus 1 (accounting for page 0 being the state page), a truly new page is appended to
+   * the file. Otherwise, the next page after the current logical end is reused (it already
+   * exists on disk but was not yet claimed by this collection). This can happen after a crash
+   * where pages were physically allocated but the state counter was not yet updated.
+   *
+   * @param atomicOperation the current atomic operation context
+   * @return a {@link CacheEntry} for the newly allocated page (caller must close it)
+   */
   private CacheEntry allocateNewPage(AtomicOperation atomicOperation) throws IOException {
     CacheEntry cacheEntry;
     try (final var stateCacheEntry =
@@ -1624,10 +1879,11 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
       final var filledUpTo = getFilledUpTo(atomicOperation, fileId);
 
       if (fileSize == filledUpTo - 1) {
+        // Logical end matches physical end -- must physically append a new page.
         cacheEntry = addPage(atomicOperation, fileId);
       } else {
+        // Physical file has pages beyond the logical end -- reuse the next one.
         assert fileSize < filledUpTo - 1;
-
         cacheEntry = loadPageForWrite(atomicOperation, fileId, fileSize + 1, false);
       }
 
@@ -1636,6 +1892,11 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     return cacheEntry;
   }
 
+  /**
+   * Initializes page 0 of the data file as the collection state page. If the file is empty,
+   * a new page is appended; otherwise the existing page 0 is loaded. The file-size counter is
+   * reset to 0, meaning no data pages are currently allocated (page 0 itself is not counted).
+   */
   private void initCollectionState(final AtomicOperation atomicOperation) throws IOException {
     final CacheEntry stateEntry;
     if (getFilledUpTo(atomicOperation, fileId) == 0) {


### PR DESCRIPTION
## Motivation

The V2 paginated collection subsystem (`PaginatedCollectionV2`, `CollectionPositionMapV2`, `FreeSpaceMap`, `FreeSpaceMapPage`, `PaginatedCollectionStateV2`, `MapEntryPoint`) lacked documentation, making it difficult for developers to understand the storage architecture, page layouts, MVCC mechanism, and the free-space map segment tree without reverse-engineering the code.

## Summary

- Add class-level JavaDoc with ASCII architecture diagrams to all 6 classes in the `collection.v2` package
- Document the three-file structure (`.pcl` data file, `.cpm` position map, `.fsm` free-space map) and their relationships
- Add ASCII diagrams for record entry layout, multi-chunk serialization, page pointer bit packing, segment tree structure, and page layouts
- Add inline comments to key methods explaining MVCC snapshot isolation, version visibility, historical entry lookup, and space allocation strategies
- Document all fields with their purpose and invariants

## Test plan

- [x] `./mvnw -pl gremlin-annotations,core clean compile -q` passes (no syntax errors in JavaDoc)
- [x] `LocalPaginatedCollectionV2TestIT`, `CollectionPositionMapV2Test`, `FreeSpaceMapTestIT`, `FreeSpaceMapPageTest` all pass
- [ ] Verify documentation renders correctly in IDE