### PR TITLE
YTDB-556: Fix snapshot isolation race on ARM in AtomicOperationsManager

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArray.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArray.java
@@ -38,13 +38,26 @@ public final class CASObjectArray<T> {
     Objects.requireNonNull(value);
     Objects.requireNonNull(placeholder);
 
-    final var size = this.size.get();
-
-    if (size <= index) {
-      //noinspection StatementWithEmptyBody
-      while (add(placeholder) < index) {
-        // repeat till we will not create place for the element
+    if (this.size.get() <= index) {
+      // Expand the array to accommodate the target index. Fill gap slots
+      // [currentSize, index) with placeholders, then write the actual value
+      // at the target index directly via add(value). This eliminates the
+      // window where a concurrent reader (e.g., the snapshot scan in
+      // AtomicOperationsTable) could observe a NOT_STARTED placeholder at the
+      // target slot before the overwrite — a race that can violate snapshot
+      // isolation on ARM's relaxed memory model.
+      while (this.size.get() < index) {
+        add(placeholder);
       }
+      // size >= index now. If size == index, the target slot is the next to
+      // be allocated — write the actual value directly, no placeholder window.
+      if (this.size.get() == index) {
+        add(value);
+        return;
+      }
+      // size > index: the target slot was already expanded past (by a
+      // concurrent add() or by the gap-filling loop overshooting due to
+      // contention). Fall through to overwrite the placeholder.
     }
 
     final var containerIndex = 31 - Integer.numberOfLeadingZeros(index + 1);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -20,6 +20,7 @@
 
 package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations;
 
+import com.jetbrains.youtrackdb.internal.common.concur.lock.ScalableRWLock;
 import com.jetbrains.youtrackdb.internal.common.function.TxConsumer;
 import com.jetbrains.youtrackdb.internal.common.function.TxFunction;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
@@ -37,7 +38,6 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.W
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.Callable;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -62,7 +62,7 @@ public class AtomicOperationsManager {
   private final WriteCache writeCache;
 
   private final AtomicOperationIdGen idGen;
-  private final ReentrantLock segmentLock = new ReentrantLock();
+  private final ScalableRWLock segmentLock = new ScalableRWLock();
 
   private final OperationsFreezer writeOperationsFreezer = new OperationsFreezer();
   private final AtomicOperationsTable atomicOperationsTable;
@@ -79,7 +79,22 @@ public class AtomicOperationsManager {
   }
 
   public AtomicOperation startAtomicOperation() {
-    var snapshot = atomicOperationsTable.snapshotAtomicOperationTableState(idGen.getLastId());
+    // Read lastId under segmentLock to guarantee that all operations with
+    // commitTs <= lastId have already been registered in the operations table
+    // (via startOperation). Without this lock, a concurrent writer thread could
+    // have called idGen.nextId() (volatile write) but not yet called
+    // startOperation(), causing the snapshot scan to miss the in-progress
+    // operation. The reader would then treat the writer's commitTs as visible
+    // (below the snapshot boundary), violating snapshot isolation when the
+    // writer commits between two reads within the same transaction.
+    final long lastId;
+    segmentLock.sharedLock();
+    try {
+      lastId = idGen.getLastId();
+    } finally {
+      segmentLock.sharedUnlock();
+    }
+    var snapshot = atomicOperationsTable.snapshotAtomicOperationTableState(lastId);
     return new AtomicOperationBinaryTracking(readCache, writeCache, storage.getId(),
         snapshot, storage.getSharedSnapshotIndex(), storage.getVisibilityIndex(),
         storage.getSnapshotIndexSize());
@@ -97,13 +112,13 @@ public class AtomicOperationsManager {
     // violate Snapshot Isolation's assumption that all TXs below minActiveTs
     // are completed.
     final long commitTs;
-    segmentLock.lock();
+    segmentLock.exclusiveLock();
     try {
       commitTs = idGen.nextId();
       activeSegment = writeAheadLog.activeSegment();
       atomicOperationsTable.startOperation(commitTs, activeSegment);
     } finally {
-      segmentLock.unlock();
+      segmentLock.exclusiveUnlock();
     }
 
     atomicOperation.startToApplyOperations(commitTs);
@@ -166,7 +181,8 @@ public class AtomicOperationsManager {
               "Exception during execution of component operation inside component "
                   + component.getLockName()
                   + " in storage "
-                  + storage.getName(), component.getLockName(), storage.getName()),
+                  + storage.getName(),
+              component.getLockName(), storage.getName()),
           e, storage.getName());
     }
   }
@@ -185,7 +201,8 @@ public class AtomicOperationsManager {
               "Exception during execution of component operation inside component "
                   + component.getLockName()
                   + " in storage "
-                  + storage.getName(), component.getLockName(), storage.getName()),
+                  + storage.getName(),
+              component.getLockName(), storage.getName()),
           e, storage.getName());
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
@@ -1,0 +1,118 @@
+package com.jetbrains.youtrackdb.internal.common.concur.collection;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.vmlens.api.AllInterleavingsBuilder;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Multi-threaded tests for {@link CASObjectArray} using VMLens for systematic
+ * interleaving exploration. These tests verify that concurrent set() and get()
+ * operations do not expose placeholder values to readers.
+ *
+ * <p>The original bug: {@code set(index, value, placeholder)} first expanded
+ * the array with {@code add(placeholder)} at the target index, then overwrote
+ * it with {@code container.set(index, value)}. A concurrent reader calling
+ * {@code get(index)} between these two steps would observe the placeholder
+ * instead of the actual value. On ARM's relaxed memory model, this race was
+ * wide enough to cause snapshot isolation violations in
+ * {@code AtomicOperationsTable}.
+ */
+public class CASObjectArrayMTTest {
+
+  private static final int MAX_ITERATIONS = 100;
+
+  /**
+   * Verifies that a concurrent reader never observes the placeholder value
+   * at the target index during a set() call that expands the array.
+   *
+   * <p>Thread 1 calls {@code set(2, ACTUAL, PLACEHOLDER)} which must expand
+   * the array from size 0 to size 3. Thread 2 reads index 2 as soon as it
+   * becomes available (size > 2). The read must never return PLACEHOLDER.
+   */
+  @Test
+  public void setWithExpansionShouldNeverExposePlaceholderToReader() throws Exception {
+    final int PLACEHOLDER = -1;
+    final int ACTUAL = 42;
+    final int TARGET_INDEX = 2;
+
+    try (var allInterleavings = new AllInterleavingsBuilder()
+        .withMaximumIterations(MAX_ITERATIONS)
+        .build("setWithExpansionShouldNeverExposePlaceholderToReader")) {
+      while (allInterleavings.hasNext()) {
+        var array = new CASObjectArray<Integer>();
+
+        var readValue = new int[] {0};
+
+        var writer = new Thread(() -> {
+          array.set(TARGET_INDEX, ACTUAL, PLACEHOLDER);
+        });
+
+        var reader = new Thread(() -> {
+          // Spin until the target index is accessible
+          while (array.size() <= TARGET_INDEX) {
+            Thread.yield();
+          }
+          readValue[0] = array.get(TARGET_INDEX);
+        });
+
+        writer.start();
+        reader.start();
+        writer.join();
+        reader.join();
+
+        // The reader must see the actual value, never the placeholder.
+        assertNotEquals(PLACEHOLDER, readValue[0],
+            "Reader observed placeholder at target index during set() expansion");
+      }
+    }
+  }
+
+  /**
+   * Verifies that gap-filling slots below the target index correctly receive
+   * placeholder values, while the target index receives the actual value.
+   *
+   * <p>Thread 1 calls {@code set(3, ACTUAL, PLACEHOLDER)}. Thread 2 reads
+   * all indices [0, 3] once they become available. Gap indices must have
+   * the placeholder, and the target index must have the actual value.
+   */
+  @Test
+  public void setWithGapsShouldFillPlaceholdersAndSetActualAtTarget() throws Exception {
+    final int PLACEHOLDER = -1;
+    final int ACTUAL = 99;
+    final int TARGET_INDEX = 3;
+
+    try (var allInterleavings = new AllInterleavingsBuilder()
+        .withMaximumIterations(MAX_ITERATIONS)
+        .build("setWithGapsShouldFillPlaceholdersAndSetActualAtTarget")) {
+      while (allInterleavings.hasNext()) {
+        var array = new CASObjectArray<Integer>();
+
+        var readValues = new int[TARGET_INDEX + 1];
+
+        var writer = new Thread(() -> {
+          array.set(TARGET_INDEX, ACTUAL, PLACEHOLDER);
+        });
+
+        var reader = new Thread(() -> {
+          // Wait until the full expansion is done
+          while (array.size() <= TARGET_INDEX) {
+            Thread.yield();
+          }
+          for (int i = 0; i <= TARGET_INDEX; i++) {
+            readValues[i] = array.get(i);
+          }
+        });
+
+        writer.start();
+        reader.start();
+        writer.join();
+        reader.join();
+
+        // Target index must have the actual value
+        assertNotEquals(PLACEHOLDER, readValues[TARGET_INDEX],
+            "Target index should have actual value, not placeholder");
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
@@ -1,6 +1,6 @@
 package com.jetbrains.youtrackdb.internal.common.concur.collection;
 
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.vmlens.api.AllInterleavingsBuilder;
 import org.junit.jupiter.api.Test;
@@ -62,8 +62,8 @@ public class CASObjectArrayMTTest {
         reader.join();
 
         // The reader must see the actual value, never the placeholder.
-        assertNotEquals(PLACEHOLDER, readValue[0],
-            "Reader observed placeholder at target index during set() expansion");
+        assertEquals(ACTUAL, readValue[0],
+            "Reader should observe actual value, not placeholder or default");
       }
     }
   }
@@ -110,7 +110,7 @@ public class CASObjectArrayMTTest {
         reader.join();
 
         // Target index must have the actual value
-        assertNotEquals(PLACEHOLDER, readValues[TARGET_INDEX],
+        assertEquals(ACTUAL, readValues[TARGET_INDEX],
             "Target index should have actual value, not placeholder");
       }
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentOpExceptionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManagerComponentOpExceptionTest.java
@@ -1,0 +1,111 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.core.exception.CommonDurableComponentException;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AtomicOperationIdGen;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurableComponent;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WriteAheadLog;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link AtomicOperationsManager#executeInsideComponentOperation} and
+ * {@link AtomicOperationsManager#calculateInsideComponentOperation} correctly propagate
+ * componentName and dbName in the wrapping {@link CommonDurableComponentException}
+ * when the delegate throws.
+ */
+public class AtomicOperationsManagerComponentOpExceptionTest {
+
+  private static final String STORAGE_NAME = "testStorage";
+  private static final String COMPONENT_LOCK_NAME = "testComponent";
+
+  private AtomicOperationsManager manager;
+  private AtomicOperation operation;
+  private DurableComponent component;
+
+  @Before
+  public void setUp() {
+    var storage = mock(AbstractStorage.class);
+    when(storage.getName()).thenReturn(STORAGE_NAME);
+    when(storage.getWALInstance()).thenReturn(mock(WriteAheadLog.class));
+    when(storage.getReadCache()).thenReturn(mock(ReadCache.class));
+    when(storage.getWriteCache()).thenReturn(mock(WriteCache.class));
+    when(storage.getIdGen()).thenReturn(mock(AtomicOperationIdGen.class));
+
+    var table = mock(AtomicOperationsTable.class);
+    manager = new AtomicOperationsManager(storage, table);
+
+    operation = mock(AtomicOperation.class);
+    // Pretend the lock is already held so acquireExclusiveLockTillOperationComplete
+    // skips the actual locking.
+    when(operation.containsInLockedObjects(anyString())).thenReturn(true);
+
+    component = mock(DurableComponent.class);
+    when(component.getLockName()).thenReturn(COMPONENT_LOCK_NAME);
+  }
+
+  /**
+   * When executeInsideComponentOperation's consumer throws, the wrapping
+   * CommonDurableComponentException must have dbName=storageName and
+   * componentName=componentLockName (not swapped).
+   */
+  @Test
+  public void testExecuteInsideComponentOperationSetsCorrectExceptionFields() {
+    try {
+      manager.executeInsideComponentOperation(
+          operation,
+          component,
+          op -> {
+            throw new RuntimeException("test failure");
+          });
+      fail("Expected exception to be thrown");
+    } catch (CommonDurableComponentException e) {
+      assertExceptionFieldsCorrect(e);
+    }
+  }
+
+  /**
+   * When calculateInsideComponentOperation's function throws, the wrapping
+   * CommonDurableComponentException must have dbName=storageName and
+   * componentName=componentLockName (not swapped).
+   */
+  @Test
+  public void testCalculateInsideComponentOperationSetsCorrectExceptionFields() {
+    try {
+      manager.calculateInsideComponentOperation(
+          operation,
+          component,
+          op -> {
+            throw new RuntimeException("test failure");
+          });
+      fail("Expected exception to be thrown");
+    } catch (CommonDurableComponentException e) {
+      assertExceptionFieldsCorrect(e);
+    }
+  }
+
+  /**
+   * Verifies that the exception carries the correct dbName and componentName fields.
+   * Both values must be distinct (STORAGE_NAME != COMPONENT_LOCK_NAME) so that
+   * a parameter-swap mutation is detectable.
+   */
+  private static void assertExceptionFieldsCorrect(CommonDurableComponentException e) {
+    assertEquals(STORAGE_NAME, e.getDbName());
+    // getMessage() includes both DB Name and Component Name labels
+    assertTrue(
+        "Exception message should contain Component Name=\"" + COMPONENT_LOCK_NAME + "\"",
+        e.getMessage().contains("Component Name=\"" + COMPONENT_LOCK_NAME + "\""));
+    assertTrue(
+        "Exception message should contain DB Name=\"" + STORAGE_NAME + "\"",
+        e.getMessage().contains("DB Name=\"" + STORAGE_NAME + "\""));
+  }
+}


### PR DESCRIPTION
## Summary

- Fix two cooperating races in snapshot creation that violated repeatable reads on ARM's relaxed memory model
- Upgrade `segmentLock` from `ReentrantLock` to `ScalableRWLock` (shared lock for readers, exclusive for writers) to avoid serializing snapshot creation
- Eliminate placeholder window in `CASObjectArray.set()` by writing the actual value directly at the target index during expansion
- Add VMLens concurrent regression test for `CASObjectArray`

## Motivation

CI failure on Linux ARM (JDK 21, Oracle): https://github.com/JetBrains/youtrackdb/runs/67068264662

`testSIRandomTimingStressMultiThread` failed with a snapshot isolation violation — two reads of the same record within a single transaction returned different values. Reproduced consistently on ARM (~1.5% failure rate in baseline).

**Root cause**: `startAtomicOperation()` called `idGen.getLastId()` without holding `segmentLock`. A concurrent writer that had called `nextId()` but not yet `startOperation()` made the reader see a `lastId` including the writer's commitTs, while the snapshot scan found no corresponding IN_PROGRESS entry. A secondary race in `CASObjectArray.set()` (placeholder visible before actual value) contributed.

**Verified**: 0 failures in 1000 runs on Hetzner ARM (cax31), compared to ~15 expected failures at baseline rate.

## Test plan

- [x] Full core test suite passes locally (x86, disk storage)
- [x] 1000 iterations of `testSIRandomTimingStressMultiThread` on ARM — 0 failures
- [x] New `CASObjectArrayMTTest` (VMLens) passes
- [ ] CI pipeline (all platforms)