### PR TITLE
YTDB-588: Correlated Subquery Materialization

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -833,6 +833,15 @@ public enum GlobalConfiguration {
       Integer.class,
       1000),
 
+  QUERY_LET_MATERIALIZATION_MAX_SIZE(
+      "youtrackdb.query.letMaterialization.maxSize",
+      "Maximum number of records to materialize when sharing a common inner subquery"
+          + " across multiple correlated LET clauses. If the inner subquery returns more"
+          + " records than this limit, each LET clause executes independently.",
+      Integer.class,
+      10000,
+      true),
+
   QUERY_PARALLEL_AUTO(
       "youtrackdb.query.parallelAuto",
       "Auto enable parallel query, if requirements are met",

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/BasicCommandContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/BasicCommandContext.java
@@ -68,6 +68,8 @@ public class BasicCommandContext implements CommandContext {
   private final LinkedList<StepStats> currentStepStats = new LinkedList<>();
   private final List<SQLBooleanExpression> parentWhereExpressions = new LinkedList<>();
 
+  private boolean skipExpandPushDown;
+
   public BasicCommandContext() {
   }
 
@@ -101,8 +103,7 @@ public class BasicCommandContext implements CommandContext {
   // Invariant: system variables must never be set to null. The get/has methods use
   // null-return from Int2ObjectOpenHashMap.get() to distinguish "not present" from
   // "present". If this invariant changes, switch to containsKey() guards.
-  @Nullable
-  @SuppressWarnings("TypeParameterUnusedInFormals")
+  @Nullable @SuppressWarnings("TypeParameterUnusedInFormals")
   @Override
   public <T> T getSystemVariable(int id) {
     var value = systemVariables.get(id);
@@ -230,8 +231,7 @@ public class BasicCommandContext implements CommandContext {
    * the value, or {@code null} if the name is not a known system variable
    * or the variable is not set.
    */
-  @Nullable
-  private Object resolveNamedSystemVariable(String name) {
+  @Nullable private Object resolveNamedSystemVariable(String name) {
     return switch (name) {
       case "current" -> getSystemVariable(VAR_CURRENT);
       case "currentMatch" -> getSystemVariable(VAR_CURRENT_MATCH);
@@ -248,8 +248,7 @@ public class BasicCommandContext implements CommandContext {
     return value;
   }
 
-  @Nullable
-  protected Object getVariableFromParentHierarchy(String varName) {
+  @Nullable protected Object getVariableFromParentHierarchy(String varName) {
     if (this.variables != null && variables.containsKey(varName)) {
       return variables.get(varName);
     }
@@ -264,8 +263,7 @@ public class BasicCommandContext implements CommandContext {
   }
 
   @Override
-  @Nullable
-  public CommandContext setVariable(String iName, final Object iValue) {
+  @Nullable public CommandContext setVariable(String iName, final Object iValue) {
     if (iName == null) {
       return null;
     }
@@ -511,8 +509,7 @@ public class BasicCommandContext implements CommandContext {
   }
 
   @Override
-  @Nullable
-  public Map<Object, Object> getInputParameters() {
+  @Nullable public Map<Object, Object> getInputParameters() {
     if (inputParameters != null) {
       return inputParameters;
     }
@@ -541,7 +538,6 @@ public class BasicCommandContext implements CommandContext {
 
     return session;
   }
-
 
   @Override
   public void setDatabaseSession(DatabaseSessionEmbedded session) {
@@ -602,6 +598,16 @@ public class BasicCommandContext implements CommandContext {
   @Override
   public StepStats getStats(ExecutionStep step) {
     return stepStats.get(step);
+  }
+
+  @Override
+  public boolean isSkipExpandPushDown() {
+    return skipExpandPushDown;
+  }
+
+  @Override
+  public void setSkipExpandPushDown(boolean skip) {
+    this.skipExpandPushDown = skip;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/CommandContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/CommandContext.java
@@ -52,8 +52,7 @@ public interface CommandContext {
   List<SQLBooleanExpression> getParentWhereExpressions();
 
   enum TIMEOUT_STRATEGY {
-    RETURN,
-    EXCEPTION
+    RETURN, EXCEPTION
   }
 
   Object getVariable(String iName);
@@ -118,14 +117,23 @@ public interface CommandContext {
    */
   void merge(CommandContext iContext);
 
-  @Nullable
-  DatabaseSessionEmbedded getDatabaseSession();
+  @Nullable DatabaseSessionEmbedded getDatabaseSession();
 
   void setDatabaseSession(DatabaseSessionEmbedded session);
 
   void declareScriptVariable(String varName);
 
   boolean isScriptVariableDeclared(String varName);
+
+  /**
+   * Returns {@code true} if predicate push-down into ExpandStep should be
+   * skipped during plan compilation. Used by materialized LET groups to
+   * preserve the outer FilterStep when replacing SubQueryStep with
+   * ListSourceStep.
+   */
+  boolean isSkipExpandPushDown();
+
+  void setSkipExpandPushDown(boolean skip);
 
   void startProfiling(ExecutionStep step);
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ListSourceStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ListSourceStep.java
@@ -1,0 +1,56 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
+import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import java.util.List;
+
+/**
+ * Source step that streams records from a pre-materialized {@code List<Result>}.
+ * Used by {@link MaterializedLetGroupStep} to replace a {@link SubQueryStep}
+ * when the inner subquery results have already been computed and cached.
+ *
+ * <p>Each emitted record is set as {@code $current} on the context, matching
+ * the contract of {@link SubQueryStep#mapResult}.
+ */
+public class ListSourceStep extends AbstractExecutionStep {
+
+  private final List<Result> records;
+
+  public ListSourceStep(
+      List<Result> records, CommandContext ctx, boolean profilingEnabled) {
+    super(ctx, profilingEnabled);
+    this.records = records;
+  }
+
+  @Override
+  public ExecutionStream internalStart(CommandContext ctx) throws TimeoutException {
+    if (prev != null) {
+      prev.start(ctx).close(ctx);
+    }
+    return ExecutionStream.resultIterator(records.iterator()).map(this::mapResult);
+  }
+
+  private Result mapResult(Result result, CommandContext ctx) {
+    ctx.setSystemVariable(CommandContext.VAR_CURRENT, result);
+    return result;
+  }
+
+  @Override
+  public String prettyPrint(int depth, int indent) {
+    var ind = ExecutionStepInternal.getIndent(depth, indent);
+    return ind + "+ FETCH FROM MATERIALIZED LIST (" + records.size() + " records)";
+  }
+
+  @Override
+  public boolean canBeCached() {
+    return false;
+  }
+
+  @Override
+  public ExecutionStep copy(CommandContext ctx) {
+    return new ListSourceStep(records, ctx, profilingEnabled);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ListSourceStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ListSourceStep.java
@@ -51,6 +51,6 @@ public class ListSourceStep extends AbstractExecutionStep {
 
   @Override
   public ExecutionStep copy(CommandContext ctx) {
-    return new ListSourceStep(records, ctx, profilingEnabled);
+    return new ListSourceStep(List.copyOf(records), ctx, profilingEnabled);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
@@ -1,0 +1,207 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
+import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
+import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
+import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.LocalResultSet;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIdentifier;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLStatement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Per-record LET step that handles a group of correlated LET subqueries sharing
+ * the same inner FROM subquery. The shared inner subquery is executed once per
+ * outer row, and each LET entry's outer query is evaluated against the
+ * materialized results.
+ *
+ * <p>For IC10's pattern:
+ * <pre>
+ *  LET $posScore = (SELECT count(*) FROM (
+ *        SELECT expand(in('HAS_CREATOR')) FROM Person
+ *        WHERE @rid = $parent.$current.fofVertex
+ *      ) WHERE @class = 'Post' AND &lt;tag condition&gt;),
+ *      $negScore = (SELECT count(*) FROM (
+ *        SELECT expand(in('HAS_CREATOR')) FROM Person
+ *        WHERE @rid = $parent.$current.fofVertex    -- same inner subquery
+ *      ) WHERE @class = 'Post' AND NOT &lt;tag condition&gt;)
+ * </pre>
+ *
+ * <p>The shared inner subquery ({@code SELECT expand(in('HAS_CREATOR')) ...}) is
+ * executed once. Each LET entry's full query plan is then built normally, but
+ * its {@link SubQueryStep} is replaced with a {@link ListSourceStep} that streams
+ * from the materialized results.
+ *
+ * <p>If the materialized results exceed
+ * {@link GlobalConfiguration#QUERY_LET_MATERIALIZATION_MAX_SIZE}, falls back to
+ * independent execution (same behavior as separate {@link LetQueryStep}s).
+ *
+ * @see ListSourceStep
+ * @see LetQueryStep
+ */
+public class MaterializedLetGroupStep extends AbstractExecutionStep {
+
+  private final SQLStatement sharedInnerQuery;
+  private final List<LetEntry> entries;
+
+  /**
+   * @param sharedInnerQuery the common inner FROM subquery shared by all entries
+   * @param entries          the LET items in this group (varName + full query)
+   */
+  public MaterializedLetGroupStep(
+      SQLStatement sharedInnerQuery,
+      List<LetEntry> entries,
+      CommandContext ctx,
+      boolean profilingEnabled) {
+    super(ctx, profilingEnabled);
+    this.sharedInnerQuery = sharedInnerQuery;
+    this.entries = entries;
+  }
+
+  @Override
+  public ExecutionStream internalStart(CommandContext ctx) throws TimeoutException {
+    if (prev == null) {
+      throw new CommandExecutionException(ctx.getDatabaseSession(),
+          "Cannot execute a local LET on a query without a target");
+    }
+    return prev.start(ctx).map(this::mapResult);
+  }
+
+  private Result mapResult(Result result, CommandContext ctx) {
+    return calculate((ResultInternal) result, ctx);
+  }
+
+  private ResultInternal calculate(ResultInternal result, CommandContext ctx) {
+    var session = ctx.getDatabaseSession();
+
+    var currentRowCtx = new BasicCommandContext();
+    currentRowCtx.setSystemVariable(CommandContext.VAR_CURRENT, result);
+    currentRowCtx.setParentWithoutOverridingChild(ctx);
+
+    var subCtx = new BasicCommandContext();
+    subCtx.setDatabaseSession(session);
+    subCtx.setParentWithoutOverridingChild(currentRowCtx);
+
+    var materializedBase = executeAndMaterialize(sharedInnerQuery, subCtx);
+
+    int maxSize = GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE
+        .getValueAsInteger();
+    if (materializedBase.size() > maxSize) {
+      executeFallback(result, entries, subCtx, session);
+      return result;
+    }
+
+    for (var entry : entries) {
+      executeWithMaterialized(result, entry, materializedBase, subCtx, session);
+    }
+    return result;
+  }
+
+  private List<Result> executeAndMaterialize(
+      SQLStatement query, BasicCommandContext subCtx) {
+    InternalExecutionPlan plan;
+    if (query.toString().contains("?")) {
+      plan = query.createExecutionPlanNoCache(subCtx, profilingEnabled);
+    } else {
+      plan = query.createExecutionPlan(subCtx, profilingEnabled);
+    }
+    return toList(new LocalResultSet(subCtx.getDatabaseSession(), plan));
+  }
+
+  /**
+   * Executes a single LET entry against the materialized base results by
+   * building the full query plan and replacing its {@link SubQueryStep} with
+   * a {@link ListSourceStep} sourced from the materialized list.
+   */
+  private void executeWithMaterialized(
+      ResultInternal result, LetEntry entry,
+      List<Result> materializedBase,
+      BasicCommandContext subCtx,
+      com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded session) {
+    InternalExecutionPlan outerPlan;
+    if (entry.fullQuery.toString().contains("?")) {
+      outerPlan = entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
+    } else {
+      outerPlan = entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled);
+    }
+
+    if (outerPlan instanceof SelectExecutionPlan selectPlan
+        && !selectPlan.getSteps().isEmpty()
+        && selectPlan.getSteps().getFirst() instanceof SubQueryStep) {
+      var listSource = new ListSourceStep(
+          materializedBase, subCtx, profilingEnabled);
+      selectPlan.replaceFirstStep(listSource);
+    }
+
+    result.setMetadata(entry.varName.getStringValue(),
+        toList(new LocalResultSet(session, outerPlan)));
+  }
+
+  /**
+   * Fallback: executes each LET entry independently (same as {@link LetQueryStep}).
+   * Used when the materialized base exceeds the configured size limit.
+   */
+  private void executeFallback(
+      ResultInternal result, List<LetEntry> entries,
+      BasicCommandContext subCtx,
+      com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded session) {
+    for (var entry : entries) {
+      InternalExecutionPlan plan;
+      if (entry.fullQuery.toString().contains("?")) {
+        plan = entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
+      } else {
+        plan = entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled);
+      }
+      result.setMetadata(entry.varName.getStringValue(),
+          toList(new LocalResultSet(session, plan)));
+    }
+  }
+
+  private List<Result> toList(LocalResultSet rs) {
+    List<Result> list = new ArrayList<>();
+    while (rs.hasNext()) {
+      list.add(rs.next());
+    }
+    rs.close();
+    return list;
+  }
+
+  @Override
+  public String prettyPrint(int depth, int indent) {
+    var spaces = ExecutionStepInternal.getIndent(depth, indent);
+    var sb = new StringBuilder();
+    sb.append(spaces).append("+ MATERIALIZED LET GROUP (shared base)\n");
+    sb.append(spaces).append("  shared: (").append(sharedInnerQuery).append(")\n");
+    for (var entry : entries) {
+      sb.append(spaces).append("  ").append(entry.varName)
+          .append(" = (").append(entry.fullQuery).append(")\n");
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public boolean canBeCached() {
+    return true;
+  }
+
+  @Override
+  public ExecutionStep copy(CommandContext ctx) {
+    var copiedEntries = new ArrayList<LetEntry>();
+    for (var entry : entries) {
+      copiedEntries.add(new LetEntry(entry.varName.copy(), entry.fullQuery.copy()));
+    }
+    return new MaterializedLetGroupStep(
+        sharedInnerQuery.copy(), copiedEntries, ctx, profilingEnabled);
+  }
+
+  /**
+   * A single LET variable + its full query AST within a materialization group.
+   */
+  public record LetEntry(SQLIdentifier varName, SQLStatement fullQuery) {
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
@@ -10,16 +10,28 @@ import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.LocalResultSet;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLFromClause;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLFromItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIdentifier;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLSelectStatement;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLStatement;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Per-record LET step that handles a group of correlated LET subqueries sharing
  * the same inner FROM subquery. The shared inner subquery is executed once per
  * outer row, and each LET entry's outer query is evaluated against the
  * materialized results.
+ *
+ * <p>When entries share common WHERE conditions (e.g., {@code @class = 'Post'}),
+ * a wrapper query pushes the common filter into the materialization traversal
+ * via the planner's predicate push-down, so non-matching records are skipped
+ * with zero I/O. Per-entry conditions are preserved intact in each entry's
+ * FilterStep by setting {@link CommandContext#setSkipExpandPushDown(boolean)}
+ * during plan creation.
  *
  * <p>For IC10's pattern:
  * <pre>
@@ -33,10 +45,10 @@ import java.util.List;
  *      ) WHERE @class = 'Post' AND NOT &lt;tag condition&gt;)
  * </pre>
  *
- * <p>The shared inner subquery ({@code SELECT expand(in('HAS_CREATOR')) ...}) is
- * executed once. Each LET entry's full query plan is then built normally, but
- * its {@link SubQueryStep} is replaced with a {@link ListSourceStep} that streams
- * from the materialized results.
+ * <p>The common filter {@code @class = 'Post'} is pushed into the
+ * materialization query's ExpandStep (collection ID check — zero I/O for
+ * Comments). The per-entry filters ({@code hasTag} / {@code NOT hasTag}) are
+ * evaluated from the materialized list via each entry's preserved FilterStep.
  *
  * <p>If the materialized results exceed
  * {@link GlobalConfiguration#QUERY_LET_MATERIALIZATION_MAX_SIZE}, falls back to
@@ -48,21 +60,26 @@ import java.util.List;
 public class MaterializedLetGroupStep extends AbstractExecutionStep {
 
   private final SQLStatement sharedInnerQuery;
+  private final @Nullable SQLWhereClause commonFilter;
   private final List<LetEntry> entries;
   /** Cached per-entry plan-cache flags — computed once on first use. */
   private boolean[] entryPlanCacheFlags;
 
   /**
    * @param sharedInnerQuery the common inner FROM subquery shared by all entries
+   * @param commonFilter     the common WHERE conditions shared by all entries,
+   *                         or {@code null} if there are no common conditions
    * @param entries          the LET items in this group (varName + full query)
    */
   public MaterializedLetGroupStep(
       SQLStatement sharedInnerQuery,
+      @Nullable SQLWhereClause commonFilter,
       List<LetEntry> entries,
       CommandContext ctx,
       boolean profilingEnabled) {
     super(ctx, profilingEnabled);
     this.sharedInnerQuery = sharedInnerQuery;
+    this.commonFilter = commonFilter;
     this.entries = entries;
   }
 
@@ -90,7 +107,13 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
     subCtx.setDatabaseSession(session);
     subCtx.setParentWithoutOverridingChild(currentRowCtx);
 
-    var materializedBase = executeAndMaterialize(sharedInnerQuery, subCtx);
+    // Build materialization query with common filter. Push-down is NOT
+    // skipped here — we want the planner to push the common filter into
+    // ExpandStep (e.g., @class='Post' becomes a collection ID check,
+    // skipping non-matching records with zero I/O).
+    var materializationQuery = buildMaterializationQuery(
+        sharedInnerQuery, commonFilter);
+    var materializedBase = executeAndMaterialize(materializationQuery, subCtx);
 
     int maxSize = GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE
         .getValueAsInteger();
@@ -114,6 +137,30 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
     return result;
   }
 
+  /**
+   * Wraps the inner query with the common filter so the planner can push it
+   * into the ExpandStep. Returns the bare inner query when there is no common
+   * filter.
+   */
+  private static SQLStatement buildMaterializationQuery(
+      SQLStatement innerQuery, @Nullable SQLWhereClause commonFilter) {
+    if (commonFilter == null || commonFilter.refersToParent()) {
+      return innerQuery;
+    }
+
+    // Build: SELECT * FROM (<innerQuery>) WHERE <commonFilter>
+    var wrapper = new SQLSelectStatement(-1);
+
+    var fromItem = new SQLFromItem(-1);
+    fromItem.setStatement(innerQuery);
+    var fromClause = new SQLFromClause(-1);
+    fromClause.setItem(fromItem);
+    wrapper.setTarget(fromClause);
+
+    wrapper.setWhereClause(commonFilter);
+    return wrapper;
+  }
+
   private List<Result> executeAndMaterialize(
       SQLStatement query, BasicCommandContext subCtx) {
     // Same caching strategy as LetQueryStep: use cached plans unless the query
@@ -126,8 +173,14 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
 
   /**
    * Executes a single LET entry against the materialized base results by
-   * building the full query plan and replacing its {@link SubQueryStep} with
-   * a {@link ListSourceStep} sourced from the materialized list.
+   * building the full query plan with expand push-down disabled and replacing
+   * its {@link SubQueryStep} with a {@link ListSourceStep} sourced from the
+   * materialized list.
+   *
+   * <p>The {@link CommandContext#setSkipExpandPushDown(boolean)} flag is set
+   * before plan creation so the planner preserves the outer FilterStep (which
+   * contains per-entry conditions). The flag is also included in the plan
+   * cache key, so plans with and without push-down are cached separately.
    */
   private void executeWithMaterialized(
       ResultInternal result, LetEntry entry,
@@ -135,32 +188,25 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       BasicCommandContext subCtx,
       DatabaseSessionEmbedded session,
       boolean usePlanCache) {
+    // Set the flag BEFORE plan creation so the planner skips push-down
+    // and the cache key includes the flag.
+    subCtx.setSkipExpandPushDown(true);
     var outerPlan = usePlanCache
         ? entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled)
         : entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
+    subCtx.setSkipExpandPushDown(false);
 
-    // Replace the SubQueryStep (which would re-execute the shared inner subquery)
-    // with a ListSourceStep that streams from the already-materialized results.
-    //
-    // Guard: only replace if the plan structure allows safe substitution.
-    // The planner may push the outer WHERE filter down into the SubQueryStep's
-    // inner ExpandStep (tryPushDownFilterIntoExpand). When this happens, the
-    // outer FilterStep is removed and the filter lives inside the inner plan.
-    // Replacing SubQueryStep with ListSourceStep would lose that pushed-down
-    // filter, producing wrong results. Detect this by checking whether a
-    // FilterStep follows the SubQueryStep — if not, the filter was pushed
-    // down and we must fall back to independent execution.
+    // Replace the SubQueryStep (which would re-execute the shared inner
+    // subquery) with a ListSourceStep that streams from the already-
+    // materialized results. With skipExpandPushDown, the FilterStep is
+    // preserved intact — no filter is lost.
     if (outerPlan instanceof SelectExecutionPlan selectPlan
         && !selectPlan.getSteps().isEmpty()
-        && selectPlan.getSteps().getFirst() instanceof SubQueryStep
-        && hasFilterAfterSubQuery(selectPlan)) {
+        && selectPlan.getSteps().getFirst() instanceof SubQueryStep) {
       var listSource = new ListSourceStep(
           materializedBase, subCtx, profilingEnabled);
       selectPlan.replaceFirstStep(listSource);
     }
-    // If the plan structure doesn't match or the filter was pushed down,
-    // the full query executes normally without materialization — correct
-    // but slower.
 
     result.setMetadata(entry.varName.getStringValue(),
         toList(new LocalResultSet(session, outerPlan)));
@@ -182,17 +228,6 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       result.setMetadata(entry.varName.getStringValue(),
           toList(new LocalResultSet(session, plan)));
     }
-  }
-
-  /**
-   * Returns {@code true} if the plan has a FilterStep immediately after the
-   * SubQueryStep. When the planner pushes the outer WHERE into the inner
-   * ExpandStep, it removes the outer FilterStep — in that case, replacing
-   * SubQueryStep with ListSourceStep would lose the filter.
-   */
-  private static boolean hasFilterAfterSubQuery(SelectExecutionPlan plan) {
-    var steps = plan.getSteps();
-    return steps.size() >= 2 && steps.get(1) instanceof FilterStep;
   }
 
   /**
@@ -221,6 +256,9 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
     var sb = new StringBuilder();
     sb.append(spaces).append("+ MATERIALIZED LET GROUP (shared base)\n");
     sb.append(spaces).append("  shared: (").append(sharedInnerQuery).append(")\n");
+    if (commonFilter != null) {
+      sb.append(spaces).append("  common filter: ").append(commonFilter).append("\n");
+    }
     for (var entry : entries) {
       sb.append(spaces).append("  ").append(entry.varName)
           .append(" = (").append(entry.fullQuery).append(")\n");
@@ -240,7 +278,9 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       copiedEntries.add(new LetEntry(entry.varName.copy(), entry.fullQuery.copy()));
     }
     return new MaterializedLetGroupStep(
-        sharedInnerQuery.copy(), copiedEntries, ctx, profilingEnabled);
+        sharedInnerQuery.copy(),
+        commonFilter != null ? commonFilter.copy() : null,
+        copiedEntries, ctx, profilingEnabled);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
@@ -104,12 +104,11 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
 
   private List<Result> executeAndMaterialize(
       SQLStatement query, BasicCommandContext subCtx) {
-    InternalExecutionPlan plan;
-    if (query.toString().contains("?")) {
-      plan = query.createExecutionPlanNoCache(subCtx, profilingEnabled);
-    } else {
-      plan = query.createExecutionPlan(subCtx, profilingEnabled);
-    }
+    // Same caching strategy as LetQueryStep: use cached plans unless the query
+    // contains positional parameters (?), where ordinal-to-value mapping may differ.
+    var plan = usePlanCache(query)
+        ? query.createExecutionPlan(subCtx, profilingEnabled)
+        : query.createExecutionPlanNoCache(subCtx, profilingEnabled);
     return toList(new LocalResultSet(subCtx.getDatabaseSession(), plan));
   }
 
@@ -123,13 +122,13 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       List<Result> materializedBase,
       BasicCommandContext subCtx,
       com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded session) {
-    InternalExecutionPlan outerPlan;
-    if (entry.fullQuery.toString().contains("?")) {
-      outerPlan = entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
-    } else {
-      outerPlan = entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled);
-    }
+    var outerPlan = usePlanCache(entry.fullQuery)
+        ? entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled)
+        : entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
 
+    // Replace the SubQueryStep (which would re-execute the shared inner subquery)
+    // with a ListSourceStep that streams from the already-materialized results.
+    // Guard: only replace if the plan structure matches expectations.
     if (outerPlan instanceof SelectExecutionPlan selectPlan
         && !selectPlan.getSteps().isEmpty()
         && selectPlan.getSteps().getFirst() instanceof SubQueryStep) {
@@ -137,6 +136,8 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
           materializedBase, subCtx, profilingEnabled);
       selectPlan.replaceFirstStep(listSource);
     }
+    // If the plan structure doesn't match (e.g. no SubQueryStep as first step),
+    // the full query executes normally without materialization — correct but slower.
 
     result.setMetadata(entry.varName.getStringValue(),
         toList(new LocalResultSet(session, outerPlan)));
@@ -151,15 +152,22 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       BasicCommandContext subCtx,
       com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded session) {
     for (var entry : entries) {
-      InternalExecutionPlan plan;
-      if (entry.fullQuery.toString().contains("?")) {
-        plan = entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
-      } else {
-        plan = entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled);
-      }
+      var plan = usePlanCache(entry.fullQuery)
+          ? entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled)
+          : entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
       result.setMetadata(entry.varName.getStringValue(),
           toList(new LocalResultSet(session, plan)));
     }
+  }
+
+  /**
+   * Returns {@code true} if the query's execution plan can be cached.
+   * Queries with positional parameters ({@code ?}) cannot be cached because
+   * the ordinal-to-value mapping may differ between invocations.
+   * Same strategy as {@link LetQueryStep}.
+   */
+  private static boolean usePlanCache(SQLStatement query) {
+    return !query.toString().contains("?");
   }
 
   private List<Result> toList(LocalResultSet rs) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
@@ -4,6 +4,7 @@ import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
@@ -48,6 +49,8 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
 
   private final SQLStatement sharedInnerQuery;
   private final List<LetEntry> entries;
+  /** Cached per-entry plan-cache flags — computed once on first use. */
+  private boolean[] entryPlanCacheFlags;
 
   /**
    * @param sharedInnerQuery the common inner FROM subquery shared by all entries
@@ -96,8 +99,17 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       return result;
     }
 
-    for (var entry : entries) {
-      executeWithMaterialized(result, entry, materializedBase, subCtx, session);
+    if (entryPlanCacheFlags == null) {
+      entryPlanCacheFlags = new boolean[entries.size()];
+      for (int i = 0; i < entries.size(); i++) {
+        entryPlanCacheFlags[i] = usePlanCache(entries.get(i).fullQuery);
+      }
+    }
+
+    for (int i = 0; i < entries.size(); i++) {
+      executeWithMaterialized(
+          result, entries.get(i), materializedBase, subCtx, session,
+          entryPlanCacheFlags[i]);
     }
     return result;
   }
@@ -121,8 +133,9 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       ResultInternal result, LetEntry entry,
       List<Result> materializedBase,
       BasicCommandContext subCtx,
-      com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded session) {
-    var outerPlan = usePlanCache(entry.fullQuery)
+      DatabaseSessionEmbedded session,
+      boolean usePlanCache) {
+    var outerPlan = usePlanCache
         ? entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled)
         : entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
 
@@ -150,9 +163,10 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
   private void executeFallback(
       ResultInternal result, List<LetEntry> entries,
       BasicCommandContext subCtx,
-      com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded session) {
+      DatabaseSessionEmbedded session) {
     for (var entry : entries) {
-      var plan = usePlanCache(entry.fullQuery)
+      var cache = usePlanCache(entry.fullQuery);
+      var plan = cache
           ? entry.fullQuery.createExecutionPlan(subCtx, profilingEnabled)
           : entry.fullQuery.createExecutionPlanNoCache(subCtx, profilingEnabled);
       result.setMetadata(entry.varName.getStringValue(),
@@ -171,12 +185,13 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
   }
 
   private List<Result> toList(LocalResultSet rs) {
-    List<Result> list = new ArrayList<>();
-    while (rs.hasNext()) {
-      list.add(rs.next());
+    try (rs) {
+      List<Result> list = new ArrayList<>();
+      while (rs.hasNext()) {
+        list.add(rs.next());
+      }
+      return list;
     }
-    rs.close();
-    return list;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
@@ -141,16 +141,26 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
 
     // Replace the SubQueryStep (which would re-execute the shared inner subquery)
     // with a ListSourceStep that streams from the already-materialized results.
-    // Guard: only replace if the plan structure matches expectations.
+    //
+    // Guard: only replace if the plan structure allows safe substitution.
+    // The planner may push the outer WHERE filter down into the SubQueryStep's
+    // inner ExpandStep (tryPushDownFilterIntoExpand). When this happens, the
+    // outer FilterStep is removed and the filter lives inside the inner plan.
+    // Replacing SubQueryStep with ListSourceStep would lose that pushed-down
+    // filter, producing wrong results. Detect this by checking whether a
+    // FilterStep follows the SubQueryStep — if not, the filter was pushed
+    // down and we must fall back to independent execution.
     if (outerPlan instanceof SelectExecutionPlan selectPlan
         && !selectPlan.getSteps().isEmpty()
-        && selectPlan.getSteps().getFirst() instanceof SubQueryStep) {
+        && selectPlan.getSteps().getFirst() instanceof SubQueryStep
+        && hasFilterAfterSubQuery(selectPlan)) {
       var listSource = new ListSourceStep(
           materializedBase, subCtx, profilingEnabled);
       selectPlan.replaceFirstStep(listSource);
     }
-    // If the plan structure doesn't match (e.g. no SubQueryStep as first step),
-    // the full query executes normally without materialization — correct but slower.
+    // If the plan structure doesn't match or the filter was pushed down,
+    // the full query executes normally without materialization — correct
+    // but slower.
 
     result.setMetadata(entry.varName.getStringValue(),
         toList(new LocalResultSet(session, outerPlan)));
@@ -172,6 +182,17 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       result.setMetadata(entry.varName.getStringValue(),
           toList(new LocalResultSet(session, plan)));
     }
+  }
+
+  /**
+   * Returns {@code true} if the plan has a FilterStep immediately after the
+   * SubQueryStep. When the planner pushes the outer WHERE into the inner
+   * ExpandStep, it removes the outer FilterStep — in that case, replacing
+   * SubQueryStep with ListSourceStep would lose the filter.
+   */
+  private static boolean hasFilterAfterSubQuery(SelectExecutionPlan plan) {
+    var steps = plan.getSteps();
+    return steps.size() >= 2 && steps.get(1) instanceof FilterStep;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlan.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlan.java
@@ -139,6 +139,27 @@ public class SelectExecutionPlan implements InternalExecutionPlan {
     return (List) steps;
   }
 
+  /**
+   * Replaces the first step in the chain with the given step, rewiring
+   * the {@code prev}/{@code next} pointers so the rest of the chain
+   * continues to work. Used by {@link MaterializedLetGroupStep} to swap
+   * a {@link SubQueryStep} with a {@link ListSourceStep}.
+   */
+  public void replaceFirstStep(ExecutionStepInternal replacement) {
+    if (steps.isEmpty()) {
+      return;
+    }
+    replacement.setPrevious(null);
+    if (steps.size() > 1) {
+      var second = steps.get(1);
+      second.setPrevious(replacement);
+      replacement.setNext(second);
+    } else {
+      lastStep = replacement;
+    }
+    steps.set(0, replacement);
+  }
+
   public void setSteps(List<ExecutionStepInternal> steps) {
     this.steps = steps;
     if (!steps.isEmpty()) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlan.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlan.java
@@ -149,6 +149,8 @@ public class SelectExecutionPlan implements InternalExecutionPlan {
     if (steps.isEmpty()) {
       return;
     }
+    var old = steps.get(0);
+    old.setNext(null);
     replacement.setPrevious(null);
     if (steps.size() > 1) {
       var second = steps.get(1);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -225,8 +225,15 @@ public class SelectExecutionPlanner {
     var session = ctx.getDatabaseSession();
 
     // --- 1. Check the plan cache before doing any work ---
+    // Include skipExpandPushDown in the cache key so that plans compiled with
+    // push-down disabled (materialized LET per-entry) are stored separately
+    // from plans compiled with push-down enabled (normal execution).
+    var cacheKey = statement.getOriginalStatement();
+    if (ctx.isSkipExpandPushDown()) {
+      cacheKey += "\0skipExpandPushDown";
+    }
     if (useCache && !enableProfiling && statement.executinPlanCanBeCached(session)) {
-      var plan = YqlExecutionPlanCache.get(statement.getOriginalStatement(), ctx, session);
+      var plan = YqlExecutionPlanCache.get(cacheKey, ctx, session);
       if (plan != null) {
         return (InternalExecutionPlan) plan;
       }
@@ -279,7 +286,7 @@ public class SelectExecutionPlanner {
         && statement.executinPlanCanBeCached(session)
         && result.canBeCached()
         && YqlExecutionPlanCache.getLastInvalidation(session) < planningStart) {
-      YqlExecutionPlanCache.put(statement.getOriginalStatement(), result, ctx.getDatabaseSession());
+      YqlExecutionPlanCache.put(cacheKey, result, ctx.getDatabaseSession());
     }
     return result;
   }
@@ -1725,6 +1732,7 @@ public class SelectExecutionPlanner {
       var group = shared.groups().get(item);
       if (group != null && group.size() > 1) {
         var sharedInner = shared.innerByItem().get(item);
+        var commonFilter = shared.commonFilterByGroup().get(group.getFirst());
         var entries = new ArrayList<MaterializedLetGroupStep.LetEntry>();
         for (var grouped : group) {
           entries.add(new MaterializedLetGroupStep.LetEntry(
@@ -1732,7 +1740,7 @@ public class SelectExecutionPlanner {
           alreadyGrouped.add(grouped);
         }
         plan.chain(new MaterializedLetGroupStep(
-            sharedInner, entries, ctx, profilingEnabled));
+            sharedInner, commonFilter, entries, ctx, profilingEnabled));
       } else {
         plan.chain(
             new LetQueryStep(item.getVarName(), item.getQuery(), ctx, profilingEnabled));
@@ -1749,9 +1757,20 @@ public class SelectExecutionPlanner {
    * same inner subquery). Items that don't match the pattern or have unique
    * inner subqueries map to a singleton list.
    */
+  /**
+   * Groups per-record LET subquery items by their shared inner FROM subquery
+   * and extracts common WHERE conditions within each group.
+   *
+   * @param groups            maps each item to its group (all items sharing
+   *                          the same inner subquery)
+   * @param innerByItem       maps each item to its extracted inner FROM subquery
+   * @param commonFilterByGroup common WHERE filter per group, keyed by the first
+   *                          item of the group. Null value means no common filter.
+   */
   private record SharedLetBases(
       Map<SQLLetItem, List<SQLLetItem>> groups,
-      Map<SQLLetItem, SQLStatement> innerByItem) {
+      Map<SQLLetItem, SQLStatement> innerByItem,
+      Map<SQLLetItem, SQLWhereClause> commonFilterByGroup) {
   }
 
   private static SharedLetBases detectSharedLetBases(
@@ -1776,12 +1795,132 @@ public class SelectExecutionPlanner {
     }
 
     var groups = new HashMap<SQLLetItem, List<SQLLetItem>>();
+    var commonFilterByGroup = new HashMap<SQLLetItem, SQLWhereClause>();
     for (var group : byInnerText.values()) {
       for (var item : group) {
         groups.put(item, group);
       }
+      if (group.size() > 1) {
+        var commonFilter = extractCommonFilter(group);
+        if (commonFilter != null) {
+          commonFilterByGroup.put(group.getFirst(), commonFilter);
+        }
+      }
     }
-    return new SharedLetBases(groups, innerByItem);
+    return new SharedLetBases(groups, innerByItem, commonFilterByGroup);
+  }
+
+  /**
+   * Extracts the common WHERE conditions shared by all entries in a group.
+   * Decomposes each entry's WHERE into AND-level sub-blocks and computes
+   * the intersection using structural {@code equals()} on
+   * {@link SQLBooleanExpression} instances.
+   *
+   * @return a WHERE clause containing only the common conditions, or
+   *         {@code null} if there is no common filter
+   */
+  @Nullable private static SQLWhereClause extractCommonFilter(List<SQLLetItem> group) {
+    List<List<SQLBooleanExpression>> allConditions = new ArrayList<>();
+    for (var item : group) {
+      var conditions = extractAndConditions(item.getQuery());
+      if (conditions == null || conditions.isEmpty()) {
+        // An entry with no WHERE contributes an empty set to the
+        // intersection — the result will be empty.
+        return null;
+      }
+      allConditions.add(conditions);
+    }
+
+    // Compute intersection: start with the first entry's conditions,
+    // then retain only those present in all other entries.
+    var intersection = new ArrayList<>(allConditions.getFirst());
+    for (int i = 1; i < allConditions.size(); i++) {
+      var other = allConditions.get(i);
+      intersection.removeIf(cond -> !containsExpression(other, cond));
+    }
+
+    if (intersection.isEmpty()) {
+      return null;
+    }
+
+    // Build the common WHERE clause from intersection conditions.
+    var commonWhere = buildWhereFromConditions(intersection);
+
+    // Defensive guard: common filter must not reference $parent (impossible
+    // by definition since $parent conditions vary per entry).
+    if (commonWhere.refersToParent()) {
+      return null;
+    }
+    return commonWhere;
+  }
+
+  /**
+   * Extracts AND-level conditions from a LET entry's full query WHERE clause.
+   * Returns {@code null} if the query has no WHERE or is not a SELECT statement.
+   */
+  @Nullable private static List<SQLBooleanExpression> extractAndConditions(
+      SQLStatement query) {
+    if (!(query instanceof SQLSelectStatement selectStmt)) {
+      return null;
+    }
+    var where = selectStmt.getWhereClause();
+    if (where == null) {
+      return null;
+    }
+    var base = where.getBaseExpression();
+    if (base == null) {
+      return null;
+    }
+
+    // Unwrap: parser produces SQLOrBlock -> [SQLAndBlock -> [conditions]]
+    if (base instanceof SQLOrBlock orBlock) {
+      var orSubs = orBlock.getSubBlocks();
+      if (orSubs.size() == 1 && orSubs.getFirst() instanceof SQLAndBlock andBlock) {
+        // Single OR branch — unwrap to AND-level sub-blocks
+        return new ArrayList<>(andBlock.getSubBlocks());
+      }
+      // Multiple OR branches — treat entire OR as a single opaque condition
+      return List.of(base);
+    }
+    if (base instanceof SQLAndBlock andBlock) {
+      return new ArrayList<>(andBlock.getSubBlocks());
+    }
+    // Single condition (e.g. @class = 'X') — wrap in a list
+    return new ArrayList<>(List.of(base));
+  }
+
+  /**
+   * Checks if a list of expressions contains one structurally equal to the
+   * given expression, using {@link SQLBooleanExpression#equals(Object)}.
+   */
+  private static boolean containsExpression(
+      List<SQLBooleanExpression> list, SQLBooleanExpression target) {
+    for (var expr : list) {
+      if (expr.equals(target)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Builds a {@link SQLWhereClause} from a list of AND-conditions.
+   */
+  private static SQLWhereClause buildWhereFromConditions(
+      List<SQLBooleanExpression> conditions) {
+    SQLBooleanExpression base;
+    if (conditions.size() == 1) {
+      base = conditions.getFirst().copy();
+    } else {
+      var andBlock = new SQLAndBlock(-1);
+      for (var cond : conditions) {
+        andBlock.getSubBlocks().add(cond.copy());
+      }
+      base = andBlock;
+    }
+    var where = new SQLWhereClause(-1);
+    where.setBaseExpression(base);
+    return where;
   }
 
   /**
@@ -3217,6 +3356,12 @@ public class SelectExecutionPlanner {
    */
   private void tryPushDownFilterIntoExpand(
       SelectExecutionPlan plan, QueryPlanningInfo info) {
+    // Materialized LET per-entry plans set this flag to preserve the outer
+    // FilterStep — push-down would move filters into the SubQueryStep which
+    // is later replaced with ListSourceStep, silently losing the filter.
+    if (plan.getContext().isSkipExpandPushDown()) {
+      return;
+    }
     var steps = plan.steps;
     if (steps.size() < 2 || info.whereClause == null) {
       return;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -53,6 +53,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1701,24 +1702,96 @@ public class SelectExecutionPlanner {
       QueryPlanningInfo info,
       CommandContext ctx,
       boolean profilingEnabled) {
-    // this could be invoked multiple times
-    // so it can be optimized
-    // checking whether the execution plan already contains some LET steps
-    // and in case skip
-    if (info.perRecordLetClause != null) {
-      var items = info.perRecordLetClause.getItems();
-      items = sortLet(items, this.statement.getLetClause());
+    if (info.perRecordLetClause == null) {
+      return;
+    }
+    var items = info.perRecordLetClause.getItems();
+    items = sortLet(items, this.statement.getLetClause());
 
-      for (var item : items) {
-        if (item.getExpression() != null) {
-          plan.chain(
-              new LetExpressionStep(
-                  item.getVarName(), item.getExpression(), ctx, profilingEnabled));
-        } else {
-          plan.chain(new LetQueryStep(item.getVarName(), item.getQuery(), ctx, profilingEnabled));
+    var sharedGroups = detectSharedLetBases(items);
+    var alreadyGrouped = new HashSet<SQLLetItem>();
+
+    for (var item : items) {
+      if (alreadyGrouped.contains(item)) {
+        continue;
+      }
+      if (item.getExpression() != null) {
+        plan.chain(
+            new LetExpressionStep(
+                item.getVarName(), item.getExpression(), ctx, profilingEnabled));
+        continue;
+      }
+
+      var group = sharedGroups.get(item);
+      if (group != null && group.size() > 1) {
+        var sharedInner = extractInnerFromSubquery(item.getQuery());
+        var entries = new ArrayList<MaterializedLetGroupStep.LetEntry>();
+        for (var grouped : group) {
+          entries.add(new MaterializedLetGroupStep.LetEntry(
+              grouped.getVarName(), grouped.getQuery()));
+          alreadyGrouped.add(grouped);
         }
+        plan.chain(new MaterializedLetGroupStep(
+            sharedInner, entries, ctx, profilingEnabled));
+      } else {
+        plan.chain(
+            new LetQueryStep(item.getVarName(), item.getQuery(), ctx, profilingEnabled));
       }
     }
+  }
+
+  /**
+   * Groups per-record LET subquery items by their inner FROM subquery. Items
+   * whose full query is a {@code SELECT ... FROM (innerSubquery) WHERE ...}
+   * pattern are grouped by structural equality of the inner subquery.
+   *
+   * <p>Returns a map from each item to its group (list of items sharing the
+   * same inner subquery). Items that don't match the pattern or have unique
+   * inner subqueries map to a singleton list.
+   */
+  private static Map<SQLLetItem, List<SQLLetItem>> detectSharedLetBases(
+      List<SQLLetItem> items) {
+    // Group subquery items by their inner FROM statement.
+    // LinkedHashMap preserves insertion order so groups appear in declaration order.
+    var byInner = new LinkedHashMap<SQLStatement, List<SQLLetItem>>();
+    for (var item : items) {
+      if (item.getQuery() == null) {
+        continue;
+      }
+      var inner = extractInnerFromSubquery(item.getQuery());
+      if (inner == null) {
+        continue;
+      }
+      byInner.computeIfAbsent(inner, k -> new ArrayList<>()).add(item);
+    }
+
+    var result = new HashMap<SQLLetItem, List<SQLLetItem>>();
+    for (var group : byInner.values()) {
+      for (var item : group) {
+        result.put(item, group);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Extracts the inner FROM subquery from a LET query of the form
+   * {@code SELECT ... FROM (innerSubquery) WHERE ...}. Returns {@code null}
+   * if the query does not match this pattern.
+   */
+  @Nullable private static SQLStatement extractInnerFromSubquery(SQLStatement query) {
+    if (!(query instanceof SQLSelectStatement selectStmt)) {
+      return null;
+    }
+    var target = selectStmt.getTarget();
+    if (target == null) {
+      return null;
+    }
+    var fromItem = target.getItem();
+    if (fromItem == null) {
+      return null;
+    }
+    return fromItem.getStatement();
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -1751,9 +1751,12 @@ public class SelectExecutionPlanner {
    */
   private static Map<SQLLetItem, List<SQLLetItem>> detectSharedLetBases(
       List<SQLLetItem> items) {
-    // Group subquery items by their inner FROM statement.
-    // LinkedHashMap preserves insertion order so groups appear in declaration order.
-    var byInner = new LinkedHashMap<SQLStatement, List<SQLLetItem>>();
+    // Group subquery items by the string representation of their inner FROM
+    // subquery. Using toString() instead of equals() because SQLStatement.equals()
+    // may not work reliably across different AST instances parsed from the same
+    // text (e.g. different object identities for $parent.$current references).
+    var byInnerText = new LinkedHashMap<String, List<SQLLetItem>>();
+    var innerByItem = new HashMap<SQLLetItem, SQLStatement>();
     for (var item : items) {
       if (item.getQuery() == null) {
         continue;
@@ -1762,11 +1765,13 @@ public class SelectExecutionPlanner {
       if (inner == null) {
         continue;
       }
-      byInner.computeIfAbsent(inner, k -> new ArrayList<>()).add(item);
+      var key = inner.toString();
+      byInnerText.computeIfAbsent(key, k -> new ArrayList<>()).add(item);
+      innerByItem.put(item, inner);
     }
 
     var result = new HashMap<SQLLetItem, List<SQLLetItem>>();
-    for (var group : byInner.values()) {
+    for (var group : byInnerText.values()) {
       for (var item : group) {
         result.put(item, group);
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -1708,7 +1708,7 @@ public class SelectExecutionPlanner {
     var items = info.perRecordLetClause.getItems();
     items = sortLet(items, this.statement.getLetClause());
 
-    var sharedGroups = detectSharedLetBases(items);
+    var shared = detectSharedLetBases(items);
     var alreadyGrouped = new HashSet<SQLLetItem>();
 
     for (var item : items) {
@@ -1722,9 +1722,9 @@ public class SelectExecutionPlanner {
         continue;
       }
 
-      var group = sharedGroups.get(item);
+      var group = shared.groups().get(item);
       if (group != null && group.size() > 1) {
-        var sharedInner = extractInnerFromSubquery(item.getQuery());
+        var sharedInner = shared.innerByItem().get(item);
         var entries = new ArrayList<MaterializedLetGroupStep.LetEntry>();
         for (var grouped : group) {
           entries.add(new MaterializedLetGroupStep.LetEntry(
@@ -1749,7 +1749,12 @@ public class SelectExecutionPlanner {
    * same inner subquery). Items that don't match the pattern or have unique
    * inner subqueries map to a singleton list.
    */
-  private static Map<SQLLetItem, List<SQLLetItem>> detectSharedLetBases(
+  private record SharedLetBases(
+      Map<SQLLetItem, List<SQLLetItem>> groups,
+      Map<SQLLetItem, SQLStatement> innerByItem) {
+  }
+
+  private static SharedLetBases detectSharedLetBases(
       List<SQLLetItem> items) {
     // Group subquery items by the string representation of their inner FROM
     // subquery. Using toString() instead of equals() because SQLStatement.equals()
@@ -1765,18 +1770,18 @@ public class SelectExecutionPlanner {
       if (inner == null) {
         continue;
       }
+      innerByItem.put(item, inner);
       var key = inner.toString();
       byInnerText.computeIfAbsent(key, k -> new ArrayList<>()).add(item);
-      innerByItem.put(item, inner);
     }
 
-    var result = new HashMap<SQLLetItem, List<SQLLetItem>>();
+    var groups = new HashMap<SQLLetItem, List<SQLLetItem>>();
     for (var group : byInnerText.values()) {
       for (var item : group) {
-        result.put(item, group);
+        groups.put(item, group);
       }
     }
-    return result;
+    return new SharedLetBases(groups, innerByItem);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -7444,30 +7444,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE IdxContainerOf FROM (SELECT FROM IdxForum WHERE name = 'forum1')"
               + " TO (SELECT FROM IdxComment WHERE text = 'c" + i + "')")
-
-   * Verifies that two correlated LET subqueries sharing the same inner FROM
-   * subquery are materialized once and reused. The execution plan should show
-   * a MATERIALIZED LET GROUP instead of two independent LET steps.
-   */
-  @Test
-  public void testLetMaterialization_sharedBase() {
-    session.execute("CREATE CLASS LmPerson EXTENDS V").close();
-    session.execute("CREATE CLASS LmMessage EXTENDS V").close();
-    session.execute("CREATE CLASS LmHasCreator EXTENDS E").close();
-
-    session.begin();
-    var personRs = session.execute("CREATE VERTEX LmPerson SET name = 'alice'");
-    var personRid = personRs.next().getIdentity();
-    personRs.close();
-
-    for (var i = 0; i < 6; i++) {
-      String type = (i < 4) ? "Post" : "Comment";
-      session.execute(
-          "CREATE VERTEX LmMessage SET title = 'msg" + i + "', type = '" + type + "'")
-          .close();
-      session.execute(
-          "CREATE EDGE LmHasCreator FROM (SELECT FROM LmMessage WHERE title = 'msg"
-              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -7494,28 +7470,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
         "Index pre-filter should be in EXPAND, plan was:\n" + plan,
         plan.contains("index pre-filter"));
 
-        "SELECT name, $postCount[0].cnt as posts, $commentCount[0].cnt as comments"
-            + " FROM LmPerson"
-            + " LET $postCount = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
-            + " WHERE @rid = $parent.$current.@rid)"
-            + " WHERE type = 'Post'),"
-            + " $commentCount = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
-            + " WHERE @rid = $parent.$current.@rid)"
-            + " WHERE type = 'Comment')"
-            + " WHERE @rid = " + personRid);
-
-    Assert.assertTrue(result.hasNext());
-    var item = result.next();
-    Assert.assertEquals(4L, ((Number) item.getProperty("posts")).longValue());
-    Assert.assertEquals(2L, ((Number) item.getProperty("comments")).longValue());
-
-    var plan = result.getExecutionPlan().prettyPrint(0, 2);
-    Assert.assertTrue(
-        "Should use MATERIALIZED LET GROUP, plan was:\n" + plan,
-        plan.contains("MATERIALIZED LET GROUP"));
-
     result.close();
     session.commit();
   }
@@ -7538,27 +7492,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE NiContainerOf FROM (SELECT FROM NiForum WHERE name = 'forum1')"
               + " TO (SELECT FROM NiPost WHERE title = 'post" + i + "')")
-
-   * Verifies that a single LET subquery (no sharing opportunity) still uses
-   * the regular LET step, not the materialized group step.
-   */
-  @Test
-  public void testLetMaterialization_singleLetNoGrouping() {
-    session.execute("CREATE CLASS SlPerson EXTENDS V").close();
-    session.execute("CREATE CLASS SlMessage EXTENDS V").close();
-    session.execute("CREATE CLASS SlHasCreator EXTENDS E").close();
-
-    session.begin();
-    var personRs = session.execute("CREATE VERTEX SlPerson SET name = 'bob'");
-    var personRid = personRs.next().getIdentity();
-    personRs.close();
-
-    for (var i = 0; i < 3; i++) {
-      session.execute(
-          "CREATE VERTEX SlMessage SET title = 'msg" + i + "'").close();
-      session.execute(
-          "CREATE EDGE SlHasCreator FROM (SELECT FROM SlMessage WHERE title = 'msg"
-              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -7588,24 +7521,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
     Assert.assertTrue(
         "Generic push-down filter should be present, plan was:\n" + plan,
         plan.contains("push-down filter"));
-
-        "SELECT name, $msgCount[0].cnt as msgs FROM SlPerson"
-            + " LET $msgCount = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(in('SlHasCreator')) FROM SlPerson"
-            + " WHERE @rid = $parent.$current.@rid))"
-            + " WHERE @rid = " + personRid);
-
-    Assert.assertTrue(result.hasNext());
-    var item = result.next();
-    Assert.assertEquals(3L, ((Number) item.getProperty("msgs")).longValue());
-
-    var plan = result.getExecutionPlan().prettyPrint(0, 2);
-    Assert.assertFalse(
-        "Single LET should NOT use materialized group, plan was:\n" + plan,
-        plan.contains("MATERIALIZED LET GROUP"));
-    Assert.assertTrue(
-        "Single LET should use regular LET step, plan was:\n" + plan,
-        plan.contains("LET (for each record)"));
 
     result.close();
     session.commit();
@@ -7742,19 +7657,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.begin();
     session.execute("CREATE VERTEX RLForum SET name = 'forum1'").close();
     var personRs = session.execute("CREATE VERTEX RLPerson SET name = 'alice'");
-
-   * Verifies that when the materialized results exceed the configured max size,
-   * the engine falls back to independent execution and still returns correct
-   * results.
-   */
-  @Test
-  public void testLetMaterialization_fallbackOnSizeLimit() {
-    session.execute("CREATE CLASS FbPerson EXTENDS V").close();
-    session.execute("CREATE CLASS FbMessage EXTENDS V").close();
-    session.execute("CREATE CLASS FbHasCreator EXTENDS E").close();
-
-    session.begin();
-    var personRs = session.execute("CREATE VERTEX FbPerson SET name = 'carol'");
     var personRid = personRs.next().getIdentity();
     personRs.close();
 
@@ -7871,14 +7773,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE PPContainerOf FROM (SELECT FROM PPForum WHERE name = 'forum1')"
               + " TO (SELECT FROM PPPost WHERE title = 'post" + i + "')")
-
-      String type = (i < 3) ? "Post" : "Comment";
-      session.execute(
-          "CREATE VERTEX FbMessage SET title = 'msg" + i + "', type = '" + type + "'")
-          .close();
-      session.execute(
-          "CREATE EDGE FbHasCreator FROM (SELECT FROM FbMessage WHERE title = 'msg"
-              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -7920,53 +7814,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.begin();
     session.execute("CREATE VERTEX CEForum SET name = 'forum1'").close();
     var personRs = session.execute("CREATE VERTEX CEPerson SET name = 'carol'");
-
-    var originalMax = GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE
-        .getValueAsInteger();
-    try {
-      GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE.setValue(1);
-
-      session.begin();
-      var result = session.query(
-          "SELECT name, $postCount[0].cnt as posts,"
-              + " $commentCount[0].cnt as comments"
-              + " FROM FbPerson"
-              + " LET $postCount = (SELECT count(*) as cnt FROM"
-              + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
-              + " WHERE @rid = $parent.$current.@rid)"
-              + " WHERE type = 'Post'),"
-              + " $commentCount = (SELECT count(*) as cnt FROM"
-              + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
-              + " WHERE @rid = $parent.$current.@rid)"
-              + " WHERE type = 'Comment')"
-              + " WHERE @rid = " + personRid);
-
-      Assert.assertTrue(result.hasNext());
-      var item = result.next();
-      Assert.assertEquals(3L, ((Number) item.getProperty("posts")).longValue());
-      Assert.assertEquals(2L, ((Number) item.getProperty("comments")).longValue());
-
-      result.close();
-      session.commit();
-    } finally {
-      GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE.setValue(originalMax);
-    }
-  }
-
-  /**
-   * Verifies that two LET subqueries with different inner FROM subqueries are
-   * NOT grouped — each executes independently.
-   */
-  @Test
-  public void testLetMaterialization_differentInnerSubqueries() {
-    session.execute("CREATE CLASS DsPerson EXTENDS V").close();
-    session.execute("CREATE CLASS DsMessage EXTENDS V").close();
-    session.execute("CREATE CLASS DsForum EXTENDS V").close();
-    session.execute("CREATE CLASS DsHasCreator EXTENDS E").close();
-    session.execute("CREATE CLASS DsMemberOf EXTENDS E").close();
-
-    session.begin();
-    var personRs = session.execute("CREATE VERTEX DsPerson SET name = 'dave'");
     var personRid = personRs.next().getIdentity();
     personRs.close();
 
@@ -8079,18 +7926,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE NiContainerOf FROM (SELECT FROM NiForum WHERE name = 'f1')"
               + " TO (SELECT FROM NiMsg WHERE val = " + i + ")")
-
-      session.execute("CREATE VERTEX DsMessage SET title = 'msg" + i + "'").close();
-      session.execute(
-          "CREATE EDGE DsHasCreator FROM (SELECT FROM DsMessage WHERE title = 'msg"
-              + i + "') TO " + personRid)
-          .close();
-    }
-    for (var i = 0; i < 2; i++) {
-      session.execute("CREATE VERTEX DsForum SET title = 'forum" + i + "'").close();
-      session.execute(
-          "CREATE EDGE DsMemberOf FROM " + personRid
-              + " TO (SELECT FROM DsForum WHERE title = 'forum" + i + "')")
           .close();
     }
     session.commit();
@@ -8252,26 +8087,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
     Assert.assertFalse(
         "Index pre-filter should NOT fire without edge schema link, plan was:\n" + plan,
         plan.contains("index pre-filter"));
-
-        "SELECT name, $msgCount[0].cnt as msgs, $forumCount[0].cnt as forums"
-            + " FROM DsPerson"
-            + " LET $msgCount = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(in('DsHasCreator')) FROM DsPerson"
-            + " WHERE @rid = $parent.$current.@rid)),"
-            + " $forumCount = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(out('DsMemberOf')) FROM DsPerson"
-            + " WHERE @rid = $parent.$current.@rid))"
-            + " WHERE @rid = " + personRid);
-
-    Assert.assertTrue(result.hasNext());
-    var item = result.next();
-    Assert.assertEquals(3L, ((Number) item.getProperty("msgs")).longValue());
-    Assert.assertEquals(2L, ((Number) item.getProperty("forums")).longValue());
-
-    var plan = result.getExecutionPlan().prettyPrint(0, 2);
-    Assert.assertFalse(
-        "Different inner subqueries should NOT be grouped, plan was:\n" + plan,
-        plan.contains("MATERIALIZED LET GROUP"));
 
     result.close();
     session.commit();
@@ -8589,62 +8404,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
             + "plan was:\n" + plan,
         plan.contains("index pre-filter"));
 
-   * Verifies that three LET subqueries sharing the same inner FROM subquery
-   * are all grouped into a single materialized group.
-   */
-  @Test
-  public void testLetMaterialization_threeLetsSharedBase() {
-    session.execute("CREATE CLASS TlPerson EXTENDS V").close();
-    session.execute("CREATE CLASS TlMessage EXTENDS V").close();
-    session.execute("CREATE CLASS TlHasCreator EXTENDS E").close();
-
-    session.begin();
-    var personRs = session.execute("CREATE VERTEX TlPerson SET name = 'eve'");
-    var personRid = personRs.next().getIdentity();
-    personRs.close();
-
-    for (var i = 0; i < 9; i++) {
-      String type = i < 4 ? "Post" : (i < 7 ? "Comment" : "Reply");
-      session.execute(
-          "CREATE VERTEX TlMessage SET title = 'msg" + i + "', type = '" + type + "'")
-          .close();
-      session.execute(
-          "CREATE EDGE TlHasCreator FROM (SELECT FROM TlMessage WHERE title = 'msg"
-              + i + "') TO " + personRid)
-          .close();
-    }
-    session.commit();
-
-    session.begin();
-    var result = session.query(
-        "SELECT name, $posts[0].cnt as posts, $comments[0].cnt as comments,"
-            + " $replies[0].cnt as replies"
-            + " FROM TlPerson"
-            + " LET $posts = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
-            + " WHERE @rid = $parent.$current.@rid)"
-            + " WHERE type = 'Post'),"
-            + " $comments = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
-            + " WHERE @rid = $parent.$current.@rid)"
-            + " WHERE type = 'Comment'),"
-            + " $replies = (SELECT count(*) as cnt FROM"
-            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
-            + " WHERE @rid = $parent.$current.@rid)"
-            + " WHERE type = 'Reply')"
-            + " WHERE @rid = " + personRid);
-
-    Assert.assertTrue(result.hasNext());
-    var item = result.next();
-    Assert.assertEquals(4L, ((Number) item.getProperty("posts")).longValue());
-    Assert.assertEquals(3L, ((Number) item.getProperty("comments")).longValue());
-    Assert.assertEquals(2L, ((Number) item.getProperty("replies")).longValue());
-
-    var plan = result.getExecutionPlan().prettyPrint(0, 2);
-    Assert.assertTrue(
-        "Three shared LETs should use MATERIALIZED LET GROUP, plan was:\n" + plan,
-        plan.contains("MATERIALIZED LET GROUP"));
-
     result.close();
     session.commit();
   }
@@ -8715,29 +8474,6 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE EiWrote FROM (SELECT FROM EiAuthor WHERE name='Bob')"
               + " TO (SELECT FROM EiArticle WHERE title='art" + i + "')")
-
-   * Verifies mixed LET types: two shared subqueries grouped, one expression LET
-   * and one different subquery LET handled independently.
-   */
-  @Test
-  public void testLetMaterialization_mixedLetTypes() {
-    session.execute("CREATE CLASS MxPerson EXTENDS V").close();
-    session.execute("CREATE CLASS MxMessage EXTENDS V").close();
-    session.execute("CREATE CLASS MxHasCreator EXTENDS E").close();
-
-    session.begin();
-    var personRs = session.execute("CREATE VERTEX MxPerson SET name = 'frank', age = 30");
-    var personRid = personRs.next().getIdentity();
-    personRs.close();
-
-    for (var i = 0; i < 4; i++) {
-      String type = (i < 2) ? "Post" : "Comment";
-      session.execute(
-          "CREATE VERTEX MxMessage SET title = 'msg" + i + "', type = '" + type + "'")
-          .close();
-      session.execute(
-          "CREATE EDGE MxHasCreator FROM (SELECT FROM MxMessage WHERE title = 'msg"
-              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -8846,7 +8582,693 @@ public class SelectStatementExecutionTest extends DbTestBase {
     var plan = (String) explain.getFirst().getProperty("executionPlanAsString");
     Assert.assertTrue("EXPLAIN should show LET step, plan was:\n" + plan,
         plan.contains("LET"));
+    session.commit();
+  }
 
+  @Test
+  public void testOutEStateFullEdgesIndexUsageInGraph() {
+    var schema = session.getSchema();
+
+    var vertexClass = schema.createVertexClass("TestOutEStateFullIndexUsageInGraphVertex");
+    var edgeClass = schema.createEdgeClass("TestOutEStateFullIndexUsageInGraphEdge");
+
+    var edgeClassName = edgeClass.getName();
+    var propertyName = Vertex.getEdgeLinkFieldName(Direction.OUT, edgeClassName);
+    var oudEdgesProperty = vertexClass.createProperty(propertyName,
+        PropertyType.LINKBAG);
+
+    var vertexClassName = vertexClass.getName();
+
+    var indexName = "TestOutEStateFullIndexUsageInGraphIndex";
+    vertexClass.createIndex(indexName, INDEX_TYPE.NOTUNIQUE, oudEdgesProperty.getName());
+
+    var rids = session.computeInTx(transaction -> {
+      Vertex v1 = null;
+      Vertex v2 = null;
+
+      StatefulEdge edge = null;
+
+      for (var i = 0; i < 10; i++) {
+        v1 = transaction.newVertex(vertexClass);
+        v2 = transaction.newVertex(vertexClass);
+
+        edge = v1.addStateFulEdge(v2, edgeClass);
+      }
+
+      return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
+    });
+
+    session.executeInTx(transaction -> {
+      try (var rs = transaction.query("select from " + vertexClassName + " where "
+          + "outE('" + edgeClassName + "') contains :outE", Map.of("outE", rids[2]))) {
+        var resList = rs.toVertexList();
+
+        Assert.assertEquals(1, resList.size());
+        Assert.assertEquals(rids[0], resList.getFirst().getIdentity());
+
+        var executionPlan = rs.getExecutionPlan();
+        var steps = executionPlan.getSteps();
+        Assert.assertFalse(steps.isEmpty());
+
+        var sourceStep = steps.getFirst();
+        Assert.assertTrue(sourceStep instanceof FetchFromIndexStep);
+        var fetchFromIndexStep = (FetchFromIndexStep) sourceStep;
+        Assert.assertEquals(indexName, fetchFromIndexStep.getDesc().getIndex().getName());
+
+        var keyCondition = fetchFromIndexStep.getDesc().getKeyCondition();
+        Assert.assertTrue(keyCondition instanceof SQLAndBlock);
+        var sqlAndBlock = (SQLAndBlock) keyCondition;
+        Assert.assertEquals(1, sqlAndBlock.getSubBlocks().size());
+
+        var expression = sqlAndBlock.getSubBlocks().getFirst();
+        Assert.assertTrue(expression instanceof SQLContainsCondition);
+
+        var containsCondition = (SQLContainsCondition) expression;
+        Assert.assertTrue(
+            containsCondition.getLeft() instanceof SQLGetInternalPropertyExpression);
+        Assert.assertEquals(propertyName, containsCondition.getLeft().toString());
+        Assert.assertEquals(":outE", containsCondition.getRight().toString());
+      }
+    });
+  }
+
+  @Test
+  public void testOutEStateFullEdgesWithoutIndexUsageInGraph() {
+    var schema = session.getSchema();
+
+    var vertexClass = schema.createVertexClass("TestOutEStateFullWithoutIndexUsageInGraphVertex");
+    var edgeClass = schema.createEdgeClass("TestOutEStateFullWithoutIndexUsageInGraphEdge");
+
+    var edgeClassName = edgeClass.getName();
+    var vertexClassName = vertexClass.getName();
+    var rids = session.computeInTx(transaction -> {
+      Vertex v1 = null;
+      Vertex v2 = null;
+
+      StatefulEdge edge = null;
+
+      for (var i = 0; i < 10; i++) {
+        v1 = transaction.newVertex(vertexClass);
+        v2 = transaction.newVertex(vertexClass);
+
+        edge = v1.addStateFulEdge(v2, edgeClass);
+      }
+
+      return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
+    });
+
+    session.executeInTx(transaction -> {
+      try (var rs = transaction.query("select from " + vertexClassName + " where "
+          + "outE('" + edgeClassName + "') contains :outE", Map.of("outE", rids[2]))) {
+        var resList = rs.toVertexList();
+
+        Assert.assertEquals(1, resList.size());
+        Assert.assertEquals(rids[0], resList.getFirst().getIdentity());
+      }
+    });
+  }
+
+  @Test
+  public void testInEStateFullEdgesIndexUsageInGraph() {
+    var schema = session.getSchema();
+
+    var vertexClass = schema.createVertexClass("TestInEStateFullIndexUsageInGraphVertex");
+    var edgeClass = schema.createEdgeClass("TestInEStateFullIndexUsageInGraphEdge");
+
+    var edgeClassName = edgeClass.getName();
+    var inEdgesProperty = vertexClass.createProperty(
+        Vertex.getEdgeLinkFieldName(Direction.IN, edgeClassName),
+        PropertyType.LINKBAG);
+
+    var propertyName = inEdgesProperty.getName();
+    var vertexClassName = vertexClass.getName();
+
+    var indexName = "TestInEStateFullIndexUsageInGraphIndex";
+    vertexClass.createIndex(indexName, INDEX_TYPE.NOTUNIQUE, inEdgesProperty.getName());
+
+    var rids = session.computeInTx(transaction -> {
+      Vertex v1 = null;
+      Vertex v2 = null;
+
+      StatefulEdge edge = null;
+
+      for (var i = 0; i < 10; i++) {
+        v1 = transaction.newVertex(vertexClass);
+        v2 = transaction.newVertex(vertexClass);
+
+        edge = v1.addStateFulEdge(v2, edgeClass);
+      }
+
+      return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
+    });
+
+    session.executeInTx(transaction -> {
+      try (var rs = transaction.query("select from " + vertexClassName + " where "
+          + "inE('" + edgeClassName + "') contains :inE", Map.of("inE", rids[2]))) {
+        var resList = rs.toVertexList();
+
+        Assert.assertEquals(1, resList.size());
+        Assert.assertEquals(rids[1], resList.getFirst().getIdentity());
+
+        var executionPlan = rs.getExecutionPlan();
+        var steps = executionPlan.getSteps();
+        Assert.assertFalse(steps.isEmpty());
+
+        var sourceStep = steps.getFirst();
+        Assert.assertTrue(sourceStep instanceof FetchFromIndexStep);
+        var fetchFromIndexStep = (FetchFromIndexStep) sourceStep;
+        Assert.assertEquals(indexName, fetchFromIndexStep.getDesc().getIndex().getName());
+
+        var keyCondition = fetchFromIndexStep.getDesc().getKeyCondition();
+        Assert.assertTrue(keyCondition instanceof SQLAndBlock);
+        var sqlAndBlock = (SQLAndBlock) keyCondition;
+        Assert.assertEquals(1, sqlAndBlock.getSubBlocks().size());
+
+        var expression = sqlAndBlock.getSubBlocks().getFirst();
+        Assert.assertTrue(expression instanceof SQLContainsCondition);
+
+        var containsCondition = (SQLContainsCondition) expression;
+        Assert.assertTrue(
+            containsCondition.getLeft() instanceof SQLGetInternalPropertyExpression);
+        Assert.assertEquals(propertyName, containsCondition.getLeft().toString());
+        Assert.assertEquals(":inE", containsCondition.getRight().toString());
+      }
+    });
+  }
+
+  @Test
+  public void testBothEStateFullEdgesWithoutIndex() {
+    var schema = session.getSchema();
+
+    var vertexClass = schema.createVertexClass("TestBothEStateFullVertex");
+    var edgeClass = schema.createEdgeClass("TestBothEStateFullEdge");
+
+    var edgeClassName = edgeClass.getName();
+    var vertexClassName = vertexClass.getName();
+
+    var rids = session.computeInTx(transaction -> {
+      Vertex v1 = null;
+      Vertex v2 = null;
+
+      StatefulEdge edge = null;
+
+      for (var i = 0; i < 10; i++) {
+        v1 = transaction.newVertex(vertexClass);
+        v2 = transaction.newVertex(vertexClass);
+
+        edge = v1.addStateFulEdge(v2, edgeClass);
+      }
+
+      return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
+    });
+
+    session.executeInTx(transaction -> {
+      try (var rs = transaction.query("select from " + vertexClassName + " where "
+          + "bothE('" + edgeClassName + "') contains :bothE", Map.of("bothE", rids[2]))) {
+        var resList = rs.toVertexList();
+
+        Assert.assertEquals(2, resList.size());
+        Assert.assertEquals(Set.of(rids[0], rids[1]), new HashSet<>(resList));
+      }
+    });
+  }
+
+  @Test
+  public void testBothEStateFullEdgesIndexUsageInGraphOneIndexIn() {
+    var schema = session.getSchema();
+
+    var vertexClass = schema.createVertexClass("TestBothEStateFullIndexUsageInGraphVertex");
+    var edgeClass = schema.createEdgeClass("TestBothEStateFullIndexUsageInGraphEdge");
+
+    var edgeClassName = edgeClass.getName();
+    var oudEdgesProperty = vertexClass.createProperty(
+        Vertex.getEdgeLinkFieldName(Direction.IN, edgeClassName),
+        PropertyType.LINKBAG);
+
+    var vertexClassName = vertexClass.getName();
+
+    var indexName = "TestBothEStateFullIndexUsageInGraphIndex";
+    vertexClass.createIndex(indexName, INDEX_TYPE.NOTUNIQUE, oudEdgesProperty.getName());
+
+    var rids = session.computeInTx(transaction -> {
+      Vertex v1 = null;
+      Vertex v2 = null;
+
+      StatefulEdge edge = null;
+
+      for (var i = 0; i < 10; i++) {
+        v1 = transaction.newVertex(vertexClass);
+        v2 = transaction.newVertex(vertexClass);
+
+        edge = v1.addStateFulEdge(v2, edgeClass);
+      }
+
+      return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
+    });
+
+    session.executeInTx(transaction -> {
+      try (var rs = transaction.query("select from " + vertexClassName + " where "
+          + "bothE('" + edgeClassName + "') contains :bothE", Map.of("bothE", rids[2]))) {
+        var resList = rs.toVertexList();
+
+        Assert.assertEquals(2, resList.size());
+        Assert.assertEquals(Set.of(rids[0], rids[1]), new HashSet<>(resList));
+      }
+    });
+  }
+
+  @Test
+  public void testBothEStateFullEdgesIndexUsageInGraphOneIndexOut() {
+    var schema = session.getSchema();
+
+    var vertexClass = schema.createVertexClass("TestBothEStateFullIndexUsageInGraphVertex");
+    var edgeClass = schema.createEdgeClass("TestBothEStateFullIndexUsageInGraphEdge");
+
+    var edgeClassName = edgeClass.getName();
+    var oudEdgesProperty = vertexClass.createProperty(
+        Vertex.getEdgeLinkFieldName(Direction.OUT, edgeClassName),
+        PropertyType.LINKBAG);
+
+    var vertexClassName = vertexClass.getName();
+
+    var indexName = "TestBothEStateFullIndexUsageInGraphIndex";
+    vertexClass.createIndex(indexName, INDEX_TYPE.NOTUNIQUE, oudEdgesProperty.getName());
+
+    var rids = session.computeInTx(transaction -> {
+      Vertex v1 = null;
+      Vertex v2 = null;
+
+      StatefulEdge edge = null;
+
+      for (var i = 0; i < 10; i++) {
+        v1 = transaction.newVertex(vertexClass);
+        v2 = transaction.newVertex(vertexClass);
+
+        edge = v1.addStateFulEdge(v2, edgeClass);
+      }
+
+      return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
+    });
+
+    session.executeInTx(transaction -> {
+      try (var rs = transaction.query("select from " + vertexClassName + " where "
+          + "bothE('" + edgeClassName + "') contains :bothE", Map.of("bothE", rids[2]))) {
+        var resList = rs.toVertexList();
+
+        Assert.assertEquals(2, resList.size());
+        Assert.assertEquals(Set.of(rids[0], rids[1]), new HashSet<>(resList));
+      }
+    });
+  }
+
+  @Test
+  public void testBothEStateFullEdgesIndexUsageInGraphTwoIndexes() {
+    var schema = session.getSchema();
+
+    var vertexClass = schema.createVertexClass("TestBothEStateFullIndexUsageInGraphVertex");
+    var edgeClass = schema.createEdgeClass("TestBothEStateFullIndexUsageInGraphEdge");
+
+    var edgeClassName = edgeClass.getName();
+
+    var outEdgesProperty = vertexClass.createProperty(
+        Vertex.getEdgeLinkFieldName(Direction.OUT, edgeClassName),
+        PropertyType.LINKBAG);
+    var inEdgesProperty = vertexClass.createProperty(
+        Vertex.getEdgeLinkFieldName(Direction.IN, edgeClassName),
+        PropertyType.LINKBAG);
+
+    var vertexClassName = vertexClass.getName();
+
+    var outIndexName = "TestBothEStateFullIndexUsageInGraphIndexOutIndex";
+    vertexClass.createIndex(outIndexName, INDEX_TYPE.NOTUNIQUE, outEdgesProperty.getName());
+
+    var inIndexName = "TestBothEStateFullIndexUsageInGraphIndexInIndex";
+    vertexClass.createIndex(inIndexName, INDEX_TYPE.NOTUNIQUE, inEdgesProperty.getName());
+
+    var rids = session.computeInTx(transaction -> {
+      Vertex v1 = null;
+      Vertex v2 = null;
+
+      StatefulEdge edge = null;
+
+      for (var i = 0; i < 10; i++) {
+        v1 = transaction.newVertex(vertexClass);
+        v2 = transaction.newVertex(vertexClass);
+
+        edge = v1.addStateFulEdge(v2, edgeClass);
+      }
+
+      return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
+    });
+
+    session.executeInTx(transaction -> {
+      try (var rs = transaction.query("select from " + vertexClassName + " where "
+          + "bothE('" + edgeClassName + "') contains :bothE", Map.of("bothE", rids[2]))) {
+        var resList = rs.toVertexList();
+
+        Assert.assertEquals(2, resList.size());
+        Assert.assertEquals(Set.of(rids[0], rids[1]), new HashSet<>(resList));
+
+        var executionPlan = rs.getExecutionPlan();
+        var steps = executionPlan.getSteps();
+        Assert.assertFalse(steps.isEmpty());
+        var first = steps.getFirst();
+        Assert.assertTrue(first instanceof ParallelExecStep);
+
+        var parallelExecStep = (ParallelExecStep) first;
+        var parallelSteps = parallelExecStep.getSubExecutionPlans();
+
+        Assert.assertEquals(2, parallelSteps.size());
+
+        var firstParallelStep = parallelSteps.getFirst().getSteps().getFirst();
+        Assert.assertTrue(firstParallelStep instanceof FetchFromIndexStep);
+        var firstParallelIndexStep = (FetchFromIndexStep) firstParallelStep;
+
+        var secondParallelStep = parallelSteps.getLast().getSteps().getFirst();
+        Assert.assertTrue(secondParallelStep instanceof FetchFromIndexStep);
+        var secondParallelIndexStep = (FetchFromIndexStep) secondParallelStep;
+
+        var indexNames = Set.of(firstParallelIndexStep.getDesc().getIndex().getName(),
+            secondParallelIndexStep.getDesc().getIndex().getName());
+
+        Assert.assertEquals(Set.of(outIndexName, inIndexName), indexNames);
+      }
+    });
+  }
+
+  /**
+   * Verifies that two correlated LET subqueries sharing the same inner FROM
+   * subquery are materialized once and reused. The execution plan should show
+   * a MATERIALIZED LET GROUP instead of two independent LET steps.
+   */
+  @Test
+  public void testLetMaterialization_sharedBase() {
+    session.execute("CREATE CLASS LmPerson EXTENDS V").close();
+    session.execute("CREATE CLASS LmMessage EXTENDS V").close();
+    session.execute("CREATE CLASS LmHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX LmPerson SET name = 'alice'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 6; i++) {
+      String type = (i < 4) ? "Post" : "Comment";
+      session.execute(
+          "CREATE VERTEX LmMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE LmHasCreator FROM (SELECT FROM LmMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "SELECT name, $postCount[0].cnt as posts, $commentCount[0].cnt as comments"
+            + " FROM LmPerson"
+            + " LET $postCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Post'),"
+            + " $commentCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Comment')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(4L, ((Number) item.getProperty("posts")).longValue());
+    Assert.assertEquals(2L, ((Number) item.getProperty("comments")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertTrue(
+        "Should use MATERIALIZED LET GROUP, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Verifies that a single LET subquery (no sharing opportunity) still uses
+   * the regular LET step, not the materialized group step.
+   */
+  @Test
+  public void testLetMaterialization_singleLetNoGrouping() {
+    session.execute("CREATE CLASS SlPerson EXTENDS V").close();
+    session.execute("CREATE CLASS SlMessage EXTENDS V").close();
+    session.execute("CREATE CLASS SlHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX SlPerson SET name = 'bob'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 3; i++) {
+      session.execute(
+          "CREATE VERTEX SlMessage SET title = 'msg" + i + "'").close();
+      session.execute(
+          "CREATE EDGE SlHasCreator FROM (SELECT FROM SlMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "SELECT name, $msgCount[0].cnt as msgs FROM SlPerson"
+            + " LET $msgCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('SlHasCreator')) FROM SlPerson"
+            + " WHERE @rid = $parent.$current.@rid))"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(3L, ((Number) item.getProperty("msgs")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertFalse(
+        "Single LET should NOT use materialized group, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+    Assert.assertTrue(
+        "Single LET should use regular LET step, plan was:\n" + plan,
+        plan.contains("LET (for each record)"));
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Verifies that when the materialized results exceed the configured max size,
+   * the engine falls back to independent execution and still returns correct
+   * results.
+   */
+  @Test
+  public void testLetMaterialization_fallbackOnSizeLimit() {
+    session.execute("CREATE CLASS FbPerson EXTENDS V").close();
+    session.execute("CREATE CLASS FbMessage EXTENDS V").close();
+    session.execute("CREATE CLASS FbHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX FbPerson SET name = 'carol'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 5; i++) {
+      String type = (i < 3) ? "Post" : "Comment";
+      session.execute(
+          "CREATE VERTEX FbMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE FbHasCreator FROM (SELECT FROM FbMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    var originalMax = GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE
+        .getValueAsInteger();
+    try {
+      GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE.setValue(1);
+
+      session.begin();
+      var result = session.query(
+          "SELECT name, $postCount[0].cnt as posts,"
+              + " $commentCount[0].cnt as comments"
+              + " FROM FbPerson"
+              + " LET $postCount = (SELECT count(*) as cnt FROM"
+              + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
+              + " WHERE @rid = $parent.$current.@rid)"
+              + " WHERE type = 'Post'),"
+              + " $commentCount = (SELECT count(*) as cnt FROM"
+              + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
+              + " WHERE @rid = $parent.$current.@rid)"
+              + " WHERE type = 'Comment')"
+              + " WHERE @rid = " + personRid);
+
+      Assert.assertTrue(result.hasNext());
+      var item = result.next();
+      Assert.assertEquals(3L, ((Number) item.getProperty("posts")).longValue());
+      Assert.assertEquals(2L, ((Number) item.getProperty("comments")).longValue());
+
+      result.close();
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE.setValue(originalMax);
+    }
+  }
+
+  /**
+   * Verifies that two LET subqueries with different inner FROM subqueries are
+   * NOT grouped — each executes independently.
+   */
+  @Test
+  public void testLetMaterialization_differentInnerSubqueries() {
+    session.execute("CREATE CLASS DsPerson EXTENDS V").close();
+    session.execute("CREATE CLASS DsMessage EXTENDS V").close();
+    session.execute("CREATE CLASS DsForum EXTENDS V").close();
+    session.execute("CREATE CLASS DsHasCreator EXTENDS E").close();
+    session.execute("CREATE CLASS DsMemberOf EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX DsPerson SET name = 'dave'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX DsMessage SET title = 'msg" + i + "'").close();
+      session.execute(
+          "CREATE EDGE DsHasCreator FROM (SELECT FROM DsMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    for (var i = 0; i < 2; i++) {
+      session.execute("CREATE VERTEX DsForum SET title = 'forum" + i + "'").close();
+      session.execute(
+          "CREATE EDGE DsMemberOf FROM " + personRid
+              + " TO (SELECT FROM DsForum WHERE title = 'forum" + i + "')")
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "SELECT name, $msgCount[0].cnt as msgs, $forumCount[0].cnt as forums"
+            + " FROM DsPerson"
+            + " LET $msgCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('DsHasCreator')) FROM DsPerson"
+            + " WHERE @rid = $parent.$current.@rid)),"
+            + " $forumCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(out('DsMemberOf')) FROM DsPerson"
+            + " WHERE @rid = $parent.$current.@rid))"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(3L, ((Number) item.getProperty("msgs")).longValue());
+    Assert.assertEquals(2L, ((Number) item.getProperty("forums")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertFalse(
+        "Different inner subqueries should NOT be grouped, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Verifies that three LET subqueries sharing the same inner FROM subquery
+   * are all grouped into a single materialized group.
+   */
+  @Test
+  public void testLetMaterialization_threeLetsSharedBase() {
+    session.execute("CREATE CLASS TlPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TlMessage EXTENDS V").close();
+    session.execute("CREATE CLASS TlHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX TlPerson SET name = 'eve'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 9; i++) {
+      String type = i < 4 ? "Post" : (i < 7 ? "Comment" : "Reply");
+      session.execute(
+          "CREATE VERTEX TlMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE TlHasCreator FROM (SELECT FROM TlMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "SELECT name, $posts[0].cnt as posts, $comments[0].cnt as comments,"
+            + " $replies[0].cnt as replies"
+            + " FROM TlPerson"
+            + " LET $posts = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Post'),"
+            + " $comments = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Comment'),"
+            + " $replies = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Reply')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(4L, ((Number) item.getProperty("posts")).longValue());
+    Assert.assertEquals(3L, ((Number) item.getProperty("comments")).longValue());
+    Assert.assertEquals(2L, ((Number) item.getProperty("replies")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertTrue(
+        "Three shared LETs should use MATERIALIZED LET GROUP, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Verifies mixed LET types: two shared subqueries grouped, one expression LET
+   * and one different subquery LET handled independently.
+   */
+  @Test
+  public void testLetMaterialization_mixedLetTypes() {
+    session.execute("CREATE CLASS MxPerson EXTENDS V").close();
+    session.execute("CREATE CLASS MxMessage EXTENDS V").close();
+    session.execute("CREATE CLASS MxHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX MxPerson SET name = 'frank', age = 30");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 4; i++) {
+      String type = (i < 2) ? "Post" : "Comment";
+      session.execute(
+          "CREATE VERTEX MxMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE MxHasCreator FROM (SELECT FROM MxMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
     var result = session.query(
         "SELECT name, $doubled, $postCount[0].cnt as posts,"
             + " $commentCount[0].cnt as comments"
@@ -9156,4 +9578,5 @@ public class SelectStatementExecutionTest extends DbTestBase {
     rs.close();
     session.commit();
   }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -9940,4 +9940,231 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.commit();
   }
 
+  /**
+   * End-to-end test modelling the IC10 two-LET pattern before it was manually
+   * merged into a single sum(if(...)). Verifies that both optimizations compose
+   * correctly:
+   *
+   * <ul>
+   *   <li>Common filter {@code @class = 'IcPost'} is pushed into the
+   *       materialization query's ExpandStep (collection ID check — zero
+   *       I/O for Comments)</li>
+   *   <li>Per-entry filters ({@code tag CONTAINS 'sports'} /
+   *       {@code NOT (tag CONTAINS 'sports')}) are preserved in each entry's
+   *       FilterStep via {@code skipExpandPushDown}</li>
+   *   <li>The shared inner traversal is executed once (materialization), not
+   *       twice</li>
+   * </ul>
+   *
+   * <p>Graph structure per person:
+   * <pre>
+   *   Person ←[IcCreator]— IcPost(tag='sports')   x3
+   *   Person ←[IcCreator]— IcPost(tag='music')     x2
+   *   Person ←[IcCreator]— IcComment(tag='sports') x2  (filtered out by @class)
+   * </pre>
+   */
+  @Test
+  public void testMaterializedLet_IC10Pattern_pushDownWithMaterialization() {
+    session.execute("CREATE CLASS IcPerson EXTENDS V").close();
+    session.execute("CREATE CLASS IcPost EXTENDS V").close();
+    session.execute("CREATE CLASS IcComment EXTENDS V").close();
+    session.execute("CREATE CLASS IcCreator EXTENDS E").close();
+    session.execute("CREATE CLASS IcKnows EXTENDS E").close();
+
+    session.begin();
+    // Create two persons (start and fof) connected by KNOWS
+    var startRs = session.execute(
+        "CREATE VERTEX IcPerson SET name = 'start', id = 1");
+    var startRid = startRs.next().getIdentity();
+    startRs.close();
+
+    var fofRs = session.execute(
+        "CREATE VERTEX IcPerson SET name = 'fof', id = 2");
+    var fofRid = fofRs.next().getIdentity();
+    fofRs.close();
+
+    session.execute(
+        "CREATE EDGE IcKnows FROM " + startRid + " TO " + fofRid).close();
+
+    // fof's content: 3 Posts with tag='sports', 2 Posts with tag='music',
+    // 2 Comments with tag='sports' (should be filtered by @class = 'IcPost')
+    for (int i = 0; i < 3; i++) {
+      var rs = session.execute(
+          "CREATE VERTEX IcPost SET tag = 'sports'");
+      var rid = rs.next().getIdentity();
+      rs.close();
+      session.execute("CREATE EDGE IcCreator FROM " + rid + " TO " + fofRid)
+          .close();
+    }
+    for (int i = 0; i < 2; i++) {
+      var rs = session.execute(
+          "CREATE VERTEX IcPost SET tag = 'music'");
+      var rid = rs.next().getIdentity();
+      rs.close();
+      session.execute("CREATE EDGE IcCreator FROM " + rid + " TO " + fofRid)
+          .close();
+    }
+    for (int i = 0; i < 2; i++) {
+      var rs = session.execute(
+          "CREATE VERTEX IcComment SET tag = 'sports'");
+      var rid = rs.next().getIdentity();
+      rs.close();
+      session.execute("CREATE EDGE IcCreator FROM " + rid + " TO " + fofRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    // IC10-style query: two LETs with common @class='IcPost' filter
+    // and different per-entry tag conditions
+    var result = session.query(
+        "SELECT fofName,"
+            + " $posScore[0].cnt as posScore,"
+            + " $negScore[0].cnt as negScore"
+            + " FROM ("
+            + "   SELECT expand(out('IcKnows')) FROM IcPerson"
+            + "   WHERE @rid = " + startRid
+            + " )"
+            + " LET fofName = name,"
+            + "  $posScore = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('IcCreator')) FROM IcPerson"
+            + "    WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'IcPost' AND tag = 'sports'),"
+            + "  $negScore = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('IcCreator')) FROM IcPerson"
+            + "    WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'IcPost' AND tag = 'music')");
+
+    Assert.assertTrue(result.hasNext());
+    var row = result.next();
+    Assert.assertEquals("fof", row.getProperty("fofName"));
+    // 3 Posts with tag='sports' (Comments excluded by @class filter)
+    Assert.assertEquals(
+        "posScore (Posts with tag=sports)",
+        3L, ((Number) row.getProperty("posScore")).longValue());
+    // 2 Posts with tag='music'
+    Assert.assertEquals(
+        "negScore (Posts with tag=music)",
+        2L, ((Number) row.getProperty("negScore")).longValue());
+
+    // Verify plan structure: materialization with common filter push-down.
+    // The common @class='IcPost' filter should appear in the materialization
+    // step. Per-entry filters (tag conditions) are not visible in the plan
+    // prettyPrint — they live in per-entry plans created at execution time.
+    // Correctness of per-entry filtering is proven by the count assertions
+    // above: if the FilterStep were lost (push-down without skipExpandPushDown),
+    // all Posts would be counted for both entries, yielding 5/5 instead of 3/2.
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertTrue(
+        "Should use MATERIALIZED LET GROUP, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+    Assert.assertTrue(
+        "Common filter should contain @class = 'IcPost', plan was:\n" + plan,
+        plan.contains("common filter:") && plan.contains("IcPost"));
+
+    Assert.assertFalse(result.hasNext());
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * EXPLAIN-level test verifying that a query with two LET entries sharing
+   * the same inner subquery and the same @class filter produces a plan with
+   * MATERIALIZED LET GROUP and the common filter reported in the plan output.
+   * Also verifies the query against independent execution for correctness.
+   */
+  @Test
+  public void testMaterializedLet_explainShowsCommonFilter() {
+    session.execute("CREATE CLASS ExPerson EXTENDS V").close();
+    session.execute("CREATE CLASS ExPost EXTENDS V").close();
+    session.execute("CREATE CLASS ExComment EXTENDS V").close();
+    session.execute("CREATE CLASS ExCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute(
+        "CREATE VERTEX ExPerson SET name = 'test'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (int i = 0; i < 4; i++) {
+      var rs = session.execute("CREATE VERTEX ExPost SET n = " + i);
+      var rid = rs.next().getIdentity();
+      rs.close();
+      session.execute("CREATE EDGE ExCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    for (int i = 0; i < 3; i++) {
+      var rs = session.execute("CREATE VERTEX ExComment SET n = " + i);
+      var rid = rs.next().getIdentity();
+      rs.close();
+      session.execute("CREATE EDGE ExCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    String query =
+        "SELECT name,"
+            + " $a[0].cnt as countA,"
+            + " $b[0].cnt as countB"
+            + " FROM ExPerson"
+            + " LET $a = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('ExCreator')) FROM ExPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'ExPost' AND n < 2),"
+            + " $b = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('ExCreator')) FROM ExPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'ExPost' AND n >= 2)"
+            + " WHERE @rid = " + personRid;
+
+    // 1. Run EXPLAIN and verify plan structure
+    session.begin();
+    var explain = session.execute("EXPLAIN " + query);
+    Assert.assertTrue(explain.hasNext());
+    var explainPlan = explain.next().getProperty("executionPlanAsString")
+        .toString();
+    explain.close();
+    session.commit();
+
+    Assert.assertTrue(
+        "EXPLAIN should show MATERIALIZED LET GROUP, was:\n" + explainPlan,
+        explainPlan.contains("MATERIALIZED LET GROUP"));
+    Assert.assertTrue(
+        "EXPLAIN should show common filter with ExPost, was:\n" + explainPlan,
+        explainPlan.contains("common filter:")
+            && explainPlan.contains("ExPost"));
+
+    // 2. Run actual query and verify correct results
+    session.begin();
+    var result = session.query(query);
+    Assert.assertTrue(result.hasNext());
+    var row = result.next();
+    // 4 Posts total: n=0,1 match "n < 2", n=2,3 match "n >= 2"
+    Assert.assertEquals(2L, ((Number) row.getProperty("countA")).longValue());
+    Assert.assertEquals(2L, ((Number) row.getProperty("countB")).longValue());
+    result.close();
+    session.commit();
+
+    // 3. Verify against independent execution (no materialization trick)
+    session.begin();
+    var indA = session.query(
+        "SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('ExCreator')) FROM ExPerson"
+            + " WHERE @rid = " + personRid + ")"
+            + " WHERE @class = 'ExPost' AND n < 2");
+    Assert.assertEquals(
+        2L, ((Number) indA.next().getProperty("cnt")).longValue());
+    indA.close();
+
+    var indB = session.query(
+        "SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('ExCreator')) FROM ExPerson"
+            + " WHERE @rid = " + personRid + ")"
+            + " WHERE @class = 'ExPost' AND n >= 2");
+    Assert.assertEquals(
+        2L, ((Number) indB.next().getProperty("cnt")).longValue());
+    indB.close();
+    session.commit();
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -9082,4 +9082,78 @@ public class SelectStatementExecutionTest extends DbTestBase {
     rs.close();
     session.commit();
   }
+
+  /**
+   * Verifies that a LET expression ($total) referencing a materialized LET
+   * subquery ($posts) produces correct results. The subquery is part of a
+   * materialized group (shared inner FROM), while the expression is evaluated
+   * separately. This guards against evaluation order regressions — if
+   * materialization somehow ran $total before $posts, it would get null/wrong
+   * values.
+   */
+  @Test
+  public void testMaterializedLet_expressionReferencesSubquery() {
+    session.execute("CREATE CLASS RefPerson EXTENDS V").close();
+    session.execute("CREATE CLASS RefMessage EXTENDS V").close();
+    session.execute("CREATE CLASS RefCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute(
+        "CREATE VERTEX RefPerson SET name = 'eve'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    // 4 posts, 2 comments
+    String[] types = {"Post", "Post", "Post", "Post", "Comment", "Comment"};
+    for (int i = 0; i < types.length; i++) {
+      session.execute(
+          "CREATE VERTEX RefMessage SET type = '" + types[i] + "'").close();
+    }
+    for (int i = 0; i < types.length; i++) {
+      session.execute(
+          "CREATE EDGE RefCreator FROM"
+              + " (SELECT FROM RefMessage WHERE type = '" + types[i]
+              + "' AND @rid NOT IN"
+              + " (SELECT in('RefCreator') FROM RefPerson))"
+              + " TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    // $posts and $comments share the same inner FROM → materialized group.
+    // $total is an expression referencing $posts and $comments → evaluated
+    // after the group, must see the correct values.
+    String query =
+        "SELECT name,"
+            + " $posts[0].cnt as postCount,"
+            + " $comments[0].cnt as commentCount,"
+            + " $total as totalCount"
+            + " FROM RefPerson"
+            + " LET $posts = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('RefCreator')) FROM RefPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Post'),"
+            + " $comments = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('RefCreator')) FROM RefPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Comment'),"
+            + " $total = $posts[0].cnt + $comments[0].cnt"
+            + " WHERE @rid = " + personRid;
+
+    session.begin();
+    var rs = session.query(query);
+    Assert.assertTrue(rs.hasNext());
+    var row = rs.next();
+    Assert.assertEquals(4L,
+        ((Number) row.getProperty("postCount")).longValue());
+    Assert.assertEquals(2L,
+        ((Number) row.getProperty("commentCount")).longValue());
+    // $total = $posts[0].cnt + $comments[0].cnt = 4 + 2 = 6
+    Assert.assertNotNull("$total should not be null",
+        row.getProperty("totalCount"));
+    Assert.assertEquals(6L,
+        ((Number) row.getProperty("totalCount")).longValue());
+    rs.close();
+    session.commit();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -7495,7 +7495,7 @@ public class SelectStatementExecutionTest extends DbTestBase {
         plan.contains("index pre-filter"));
 
         "SELECT name, $postCount[0].cnt as posts, $commentCount[0].cnt as comments"
-            + " FROM LmPerson WHERE @rid = " + personRid
+            + " FROM LmPerson"
             + " LET $postCount = (SELECT count(*) as cnt FROM"
             + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
             + " WHERE @rid = $parent.$current.@rid)"
@@ -7503,7 +7503,8 @@ public class SelectStatementExecutionTest extends DbTestBase {
             + " $commentCount = (SELECT count(*) as cnt FROM"
             + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
             + " WHERE @rid = $parent.$current.@rid)"
-            + " WHERE type = 'Comment')");
+            + " WHERE type = 'Comment')"
+            + " WHERE @rid = " + personRid);
 
     Assert.assertTrue(result.hasNext());
     var item = result.next();
@@ -7589,10 +7590,10 @@ public class SelectStatementExecutionTest extends DbTestBase {
         plan.contains("push-down filter"));
 
         "SELECT name, $msgCount[0].cnt as msgs FROM SlPerson"
-            + " WHERE @rid = " + personRid
             + " LET $msgCount = (SELECT count(*) as cnt FROM"
             + " (SELECT expand(in('SlHasCreator')) FROM SlPerson"
-            + " WHERE @rid = $parent.$current.@rid))");
+            + " WHERE @rid = $parent.$current.@rid))"
+            + " WHERE @rid = " + personRid);
 
     Assert.assertTrue(result.hasNext());
     var item = result.next();
@@ -7929,7 +7930,7 @@ public class SelectStatementExecutionTest extends DbTestBase {
       var result = session.query(
           "SELECT name, $postCount[0].cnt as posts,"
               + " $commentCount[0].cnt as comments"
-              + " FROM FbPerson WHERE @rid = " + personRid
+              + " FROM FbPerson"
               + " LET $postCount = (SELECT count(*) as cnt FROM"
               + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
               + " WHERE @rid = $parent.$current.@rid)"
@@ -7937,7 +7938,8 @@ public class SelectStatementExecutionTest extends DbTestBase {
               + " $commentCount = (SELECT count(*) as cnt FROM"
               + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
               + " WHERE @rid = $parent.$current.@rid)"
-              + " WHERE type = 'Comment')");
+              + " WHERE type = 'Comment')"
+              + " WHERE @rid = " + personRid);
 
       Assert.assertTrue(result.hasNext());
       var item = result.next();
@@ -8252,13 +8254,14 @@ public class SelectStatementExecutionTest extends DbTestBase {
         plan.contains("index pre-filter"));
 
         "SELECT name, $msgCount[0].cnt as msgs, $forumCount[0].cnt as forums"
-            + " FROM DsPerson WHERE @rid = " + personRid
+            + " FROM DsPerson"
             + " LET $msgCount = (SELECT count(*) as cnt FROM"
             + " (SELECT expand(in('DsHasCreator')) FROM DsPerson"
             + " WHERE @rid = $parent.$current.@rid)),"
             + " $forumCount = (SELECT count(*) as cnt FROM"
             + " (SELECT expand(out('DsMemberOf')) FROM DsPerson"
-            + " WHERE @rid = $parent.$current.@rid))");
+            + " WHERE @rid = $parent.$current.@rid))"
+            + " WHERE @rid = " + personRid);
 
     Assert.assertTrue(result.hasNext());
     var item = result.next();
@@ -8586,6 +8589,62 @@ public class SelectStatementExecutionTest extends DbTestBase {
             + "plan was:\n" + plan,
         plan.contains("index pre-filter"));
 
+   * Verifies that three LET subqueries sharing the same inner FROM subquery
+   * are all grouped into a single materialized group.
+   */
+  @Test
+  public void testLetMaterialization_threeLetsSharedBase() {
+    session.execute("CREATE CLASS TlPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TlMessage EXTENDS V").close();
+    session.execute("CREATE CLASS TlHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX TlPerson SET name = 'eve'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 9; i++) {
+      String type = i < 4 ? "Post" : (i < 7 ? "Comment" : "Reply");
+      session.execute(
+          "CREATE VERTEX TlMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE TlHasCreator FROM (SELECT FROM TlMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "SELECT name, $posts[0].cnt as posts, $comments[0].cnt as comments,"
+            + " $replies[0].cnt as replies"
+            + " FROM TlPerson"
+            + " LET $posts = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Post'),"
+            + " $comments = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Comment'),"
+            + " $replies = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('TlHasCreator')) FROM TlPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Reply')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(4L, ((Number) item.getProperty("posts")).longValue());
+    Assert.assertEquals(3L, ((Number) item.getProperty("comments")).longValue());
+    Assert.assertEquals(2L, ((Number) item.getProperty("replies")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertTrue(
+        "Three shared LETs should use MATERIALIZED LET GROUP, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+
     result.close();
     session.commit();
   }
@@ -8656,6 +8715,29 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE EiWrote FROM (SELECT FROM EiAuthor WHERE name='Bob')"
               + " TO (SELECT FROM EiArticle WHERE title='art" + i + "')")
+
+   * Verifies mixed LET types: two shared subqueries grouped, one expression LET
+   * and one different subquery LET handled independently.
+   */
+  @Test
+  public void testLetMaterialization_mixedLetTypes() {
+    session.execute("CREATE CLASS MxPerson EXTENDS V").close();
+    session.execute("CREATE CLASS MxMessage EXTENDS V").close();
+    session.execute("CREATE CLASS MxHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX MxPerson SET name = 'frank', age = 30");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 4; i++) {
+      String type = (i < 2) ? "Post" : "Comment";
+      session.execute(
+          "CREATE VERTEX MxMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE MxHasCreator FROM (SELECT FROM MxMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -8764,6 +8846,29 @@ public class SelectStatementExecutionTest extends DbTestBase {
     var plan = (String) explain.getFirst().getProperty("executionPlanAsString");
     Assert.assertTrue("EXPLAIN should show LET step, plan was:\n" + plan,
         plan.contains("LET"));
+
+    var result = session.query(
+        "SELECT name, $doubled, $postCount[0].cnt as posts,"
+            + " $commentCount[0].cnt as comments"
+            + " FROM MxPerson"
+            + " LET $doubled = age * 2,"
+            + " $postCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('MxHasCreator')) FROM MxPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Post'),"
+            + " $commentCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('MxHasCreator')) FROM MxPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Comment')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    // Focus on the shared subquery LET results (the expression LET is handled separately)
+    Assert.assertEquals(2L, ((Number) item.getProperty("posts")).longValue());
+    Assert.assertEquals(2L, ((Number) item.getProperty("comments")).longValue());
+
+    result.close();
     session.commit();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -9579,4 +9579,365 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.commit();
   }
 
+  // ---------- Common filter extraction + push-down interaction tests ----------
+
+  /**
+   * Two LET entries sharing the same inner subquery with a common @class filter
+   * and different per-entry conditions. The common filter (@class = 'PdPost')
+   * should be pushed into the materialization query's ExpandStep, while the
+   * per-entry conditions (tag = 'A' / tag = 'B') are preserved in each entry's
+   * FilterStep via skipExpandPushDown.
+   */
+  @Test
+  public void testMaterializedLet_commonFilterPushDown() {
+    session.execute("CREATE CLASS PdPerson EXTENDS V").close();
+    session.execute("CREATE CLASS PdPost EXTENDS V").close();
+    session.execute("CREATE CLASS PdComment EXTENDS V").close();
+    session.execute("CREATE CLASS PdCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX PdPerson SET name = 'alice'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    // 3 Posts with tag=A, 2 Posts with tag=B, 2 Comments (should be ignored)
+    for (int i = 0; i < 3; i++) {
+      var msgRs = session.execute(
+          "CREATE VERTEX PdPost SET tag = 'A'");
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE PdCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    for (int i = 0; i < 2; i++) {
+      var msgRs = session.execute(
+          "CREATE VERTEX PdPost SET tag = 'B'");
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE PdCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    for (int i = 0; i < 2; i++) {
+      var msgRs = session.execute(
+          "CREATE VERTEX PdComment SET tag = 'A'");
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE PdCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    // Common filter: @class = 'PdPost'. Per-entry: tag = 'A' / tag = 'B'
+    var result = session.query(
+        "SELECT name,"
+            + " $aCount[0].cnt as tagA,"
+            + " $bCount[0].cnt as tagB"
+            + " FROM PdPerson"
+            + " LET $aCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('PdCreator')) FROM PdPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'PdPost' AND tag = 'A'),"
+            + " $bCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('PdCreator')) FROM PdPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'PdPost' AND tag = 'B')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(
+        "Posts with tag=A", 3L, ((Number) item.getProperty("tagA")).longValue());
+    Assert.assertEquals(
+        "Posts with tag=B", 2L, ((Number) item.getProperty("tagB")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertTrue(
+        "Should use MATERIALIZED LET GROUP, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+    Assert.assertTrue(
+        "Should show common filter in plan, plan was:\n" + plan,
+        plan.contains("common filter:"));
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Two LET entries with completely different WHERE clauses (no common filter).
+   * Materialization should still work — each entry gets its full WHERE preserved
+   * via skipExpandPushDown. No wrapper query is built.
+   */
+  @Test
+  public void testMaterializedLet_noCommonFilter() {
+    session.execute("CREATE CLASS NcPerson EXTENDS V").close();
+    session.execute("CREATE CLASS NcMessage EXTENDS V").close();
+    session.execute("CREATE CLASS NcCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX NcPerson SET name = 'bob'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    // 4 messages: 2 with color=red, 2 with size=big
+    for (int i = 0; i < 2; i++) {
+      var msgRs = session.execute(
+          "CREATE VERTEX NcMessage SET color = 'red', size = 'small'");
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE NcCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    for (int i = 0; i < 2; i++) {
+      var msgRs = session.execute(
+          "CREATE VERTEX NcMessage SET color = 'blue', size = 'big'");
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE NcCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    // Completely different WHERE clauses — no common filter possible
+    var result = session.query(
+        "SELECT name,"
+            + " $redCount[0].cnt as reds,"
+            + " $bigCount[0].cnt as bigs"
+            + " FROM NcPerson"
+            + " LET $redCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('NcCreator')) FROM NcPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE color = 'red'),"
+            + " $bigCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('NcCreator')) FROM NcPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE size = 'big')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(
+        "Messages with color=red", 2L,
+        ((Number) item.getProperty("reds")).longValue());
+    Assert.assertEquals(
+        "Messages with size=big", 2L,
+        ((Number) item.getProperty("bigs")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertTrue(
+        "Should still use MATERIALIZED LET GROUP, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Two LET entries where one has a WHERE clause and the other has no WHERE.
+   * The entry without WHERE contributes an empty set to the intersection,
+   * resulting in no common filter. Both entries should still produce correct
+   * results.
+   */
+  @Test
+  public void testMaterializedLet_oneEntryWithoutWhere() {
+    session.execute("CREATE CLASS NwPerson EXTENDS V").close();
+    session.execute("CREATE CLASS NwMessage EXTENDS V").close();
+    session.execute("CREATE CLASS NwCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX NwPerson SET name = 'carol'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (int i = 0; i < 5; i++) {
+      String type = (i < 3) ? "Post" : "Comment";
+      var msgRs = session.execute(
+          "CREATE VERTEX NwMessage SET type = '" + type + "'");
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE NwCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    // $postCount has a WHERE, $allCount has no WHERE at all
+    var result = session.query(
+        "SELECT name,"
+            + " $postCount[0].cnt as posts,"
+            + " $allCount[0].cnt as total"
+            + " FROM NwPerson"
+            + " LET $postCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('NwCreator')) FROM NwPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Post'),"
+            + " $allCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('NwCreator')) FROM NwPerson"
+            + "   WHERE @rid = $parent.$current.@rid))"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(
+        "Posts only", 3L, ((Number) item.getProperty("posts")).longValue());
+    Assert.assertEquals(
+        "All messages", 5L, ((Number) item.getProperty("total")).longValue());
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Two LET entries with common @class filter executed multiple times (multiple
+   * outer rows). Verifies that the plan cache works correctly with the
+   * skipExpandPushDown flag included in the cache key — the second outer row
+   * should get a cache hit for the per-entry plan (compiled without push-down).
+   */
+  @Test
+  public void testMaterializedLet_commonFilterPlanCaching() {
+    session.execute("CREATE CLASS CfPerson EXTENDS V").close();
+    session.execute("CREATE CLASS CfPost EXTENDS V").close();
+    session.execute("CREATE CLASS CfComment EXTENDS V").close();
+    session.execute("CREATE CLASS CfCreator EXTENDS E").close();
+
+    session.begin();
+    // Create two persons, each with different edge counts
+    var p1Rs = session.execute("CREATE VERTEX CfPerson SET name = 'alice'");
+    var p1Rid = p1Rs.next().getIdentity();
+    p1Rs.close();
+    var p2Rs = session.execute("CREATE VERTEX CfPerson SET name = 'bob'");
+    var p2Rid = p2Rs.next().getIdentity();
+    p2Rs.close();
+
+    // Alice: 3 Posts(tag=A), 1 Post(tag=B), 1 Comment
+    for (int i = 0; i < 3; i++) {
+      var rs = session.execute("CREATE VERTEX CfPost SET tag = 'A'");
+      var rid = rs.next().getIdentity();
+      rs.close();
+      session.execute("CREATE EDGE CfCreator FROM " + rid + " TO " + p1Rid)
+          .close();
+    }
+    var rs1 = session.execute("CREATE VERTEX CfPost SET tag = 'B'");
+    var rid1 = rs1.next().getIdentity();
+    rs1.close();
+    session.execute("CREATE EDGE CfCreator FROM " + rid1 + " TO " + p1Rid)
+        .close();
+    var rs1c = session.execute("CREATE VERTEX CfComment SET tag = 'A'");
+    var rid1c = rs1c.next().getIdentity();
+    rs1c.close();
+    session.execute("CREATE EDGE CfCreator FROM " + rid1c + " TO " + p1Rid)
+        .close();
+
+    // Bob: 1 Post(tag=A), 2 Posts(tag=B)
+    var rs2a = session.execute("CREATE VERTEX CfPost SET tag = 'A'");
+    var rid2a = rs2a.next().getIdentity();
+    rs2a.close();
+    session.execute("CREATE EDGE CfCreator FROM " + rid2a + " TO " + p2Rid)
+        .close();
+    for (int i = 0; i < 2; i++) {
+      var rs2 = session.execute("CREATE VERTEX CfPost SET tag = 'B'");
+      var rid2 = rs2.next().getIdentity();
+      rs2.close();
+      session.execute("CREATE EDGE CfCreator FROM " + rid2 + " TO " + p2Rid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    // Query all persons — multiple outer rows exercise plan caching
+    var result = session.query(
+        "SELECT name,"
+            + " $aCount[0].cnt as tagA,"
+            + " $bCount[0].cnt as tagB"
+            + " FROM CfPerson"
+            + " LET $aCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('CfCreator')) FROM CfPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'CfPost' AND tag = 'A'),"
+            + " $bCount = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('CfCreator')) FROM CfPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE @class = 'CfPost' AND tag = 'B')"
+            + " ORDER BY name");
+
+    Assert.assertTrue(result.hasNext());
+    var alice = result.next();
+    Assert.assertEquals("alice", alice.getProperty("name"));
+    Assert.assertEquals(3L, ((Number) alice.getProperty("tagA")).longValue());
+    Assert.assertEquals(1L, ((Number) alice.getProperty("tagB")).longValue());
+
+    Assert.assertTrue(result.hasNext());
+    var bob = result.next();
+    Assert.assertEquals("bob", bob.getProperty("name"));
+    Assert.assertEquals(1L, ((Number) bob.getProperty("tagA")).longValue());
+    Assert.assertEquals(2L, ((Number) bob.getProperty("tagB")).longValue());
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Verifies that the common filter is only the intersection of all entries'
+   * WHERE conditions. When all entries share the full WHERE (identical
+   * conditions), the per-entry FilterStep evaluates redundantly (always true)
+   * and materialization still produces correct results.
+   */
+  @Test
+  public void testMaterializedLet_allConditionsCommon() {
+    session.execute("CREATE CLASS AcPerson EXTENDS V").close();
+    session.execute("CREATE CLASS AcMessage EXTENDS V").close();
+    session.execute("CREATE CLASS AcCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX AcPerson SET name = 'dave'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (int i = 0; i < 4; i++) {
+      var msgRs = session.execute(
+          "CREATE VERTEX AcMessage SET type = 'Post', n = " + i);
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE AcCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    // 2 non-Post messages
+    for (int i = 0; i < 2; i++) {
+      var msgRs = session.execute("CREATE VERTEX AcMessage SET type = 'Comment'");
+      var rid = msgRs.next().getIdentity();
+      msgRs.close();
+      session.execute("CREATE EDGE AcCreator FROM " + rid + " TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    session.begin();
+    // Both entries have identical WHERE — all conditions are common.
+    // Each computes count(*) but with different aliases — still a valid
+    // materialization group.
+    var result = session.query(
+        "SELECT name,"
+            + " $x[0].cnt as countX,"
+            + " $y[0].cnt as countY"
+            + " FROM AcPerson"
+            + " LET $x = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('AcCreator')) FROM AcPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Post'),"
+            + " $y = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('AcCreator')) FROM AcPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Post')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(4L, ((Number) item.getProperty("countX")).longValue());
+    Assert.assertEquals(4L, ((Number) item.getProperty("countY")).longValue());
+
+    result.close();
+    session.commit();
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -8606,13 +8606,13 @@ public class SelectStatementExecutionTest extends DbTestBase {
       Vertex v1 = null;
       Vertex v2 = null;
 
-      StatefulEdge edge = null;
+      Edge edge = null;
 
       for (var i = 0; i < 10; i++) {
         v1 = transaction.newVertex(vertexClass);
         v2 = transaction.newVertex(vertexClass);
 
-        edge = v1.addStateFulEdge(v2, edgeClass);
+        edge = v1.addEdge(v2, edgeClass);
       }
 
       return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
@@ -8665,13 +8665,13 @@ public class SelectStatementExecutionTest extends DbTestBase {
       Vertex v1 = null;
       Vertex v2 = null;
 
-      StatefulEdge edge = null;
+      Edge edge = null;
 
       for (var i = 0; i < 10; i++) {
         v1 = transaction.newVertex(vertexClass);
         v2 = transaction.newVertex(vertexClass);
 
-        edge = v1.addStateFulEdge(v2, edgeClass);
+        edge = v1.addEdge(v2, edgeClass);
       }
 
       return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
@@ -8710,13 +8710,13 @@ public class SelectStatementExecutionTest extends DbTestBase {
       Vertex v1 = null;
       Vertex v2 = null;
 
-      StatefulEdge edge = null;
+      Edge edge = null;
 
       for (var i = 0; i < 10; i++) {
         v1 = transaction.newVertex(vertexClass);
         v2 = transaction.newVertex(vertexClass);
 
-        edge = v1.addStateFulEdge(v2, edgeClass);
+        edge = v1.addEdge(v2, edgeClass);
       }
 
       return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
@@ -8770,13 +8770,13 @@ public class SelectStatementExecutionTest extends DbTestBase {
       Vertex v1 = null;
       Vertex v2 = null;
 
-      StatefulEdge edge = null;
+      Edge edge = null;
 
       for (var i = 0; i < 10; i++) {
         v1 = transaction.newVertex(vertexClass);
         v2 = transaction.newVertex(vertexClass);
 
-        edge = v1.addStateFulEdge(v2, edgeClass);
+        edge = v1.addEdge(v2, edgeClass);
       }
 
       return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
@@ -8814,13 +8814,13 @@ public class SelectStatementExecutionTest extends DbTestBase {
       Vertex v1 = null;
       Vertex v2 = null;
 
-      StatefulEdge edge = null;
+      Edge edge = null;
 
       for (var i = 0; i < 10; i++) {
         v1 = transaction.newVertex(vertexClass);
         v2 = transaction.newVertex(vertexClass);
 
-        edge = v1.addStateFulEdge(v2, edgeClass);
+        edge = v1.addEdge(v2, edgeClass);
       }
 
       return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
@@ -8858,13 +8858,13 @@ public class SelectStatementExecutionTest extends DbTestBase {
       Vertex v1 = null;
       Vertex v2 = null;
 
-      StatefulEdge edge = null;
+      Edge edge = null;
 
       for (var i = 0; i < 10; i++) {
         v1 = transaction.newVertex(vertexClass);
         v2 = transaction.newVertex(vertexClass);
 
-        edge = v1.addStateFulEdge(v2, edgeClass);
+        edge = v1.addEdge(v2, edgeClass);
       }
 
       return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};
@@ -8909,13 +8909,13 @@ public class SelectStatementExecutionTest extends DbTestBase {
       Vertex v1 = null;
       Vertex v2 = null;
 
-      StatefulEdge edge = null;
+      Edge edge = null;
 
       for (var i = 0; i < 10; i++) {
         v1 = transaction.newVertex(vertexClass);
         v2 = transaction.newVertex(vertexClass);
 
-        edge = v1.addStateFulEdge(v2, edgeClass);
+        edge = v1.addEdge(v2, edgeClass);
       }
 
       return new RID[] {v1.getIdentity(), v2.getIdentity(), edge.getIdentity()};

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -8871,4 +8871,149 @@ public class SelectStatementExecutionTest extends DbTestBase {
     result.close();
     session.commit();
   }
+
+  /**
+   * Verifies that materialized LET handles an empty inner result set correctly:
+   * the outer COUNT(*) should return 0 for both LET variables.
+   */
+  @Test
+  public void testMaterializedLet_emptyInnerResultSet() {
+    session.execute("CREATE CLASS EmptyPerson EXTENDS V").close();
+    session.execute("CREATE CLASS EmptyMessage EXTENDS V").close();
+    session.execute("CREATE CLASS EmptyHasCreator EXTENDS E").close();
+
+    session.begin();
+    // Create a person with NO edges to any messages
+    var personRs = session.execute(
+        "CREATE VERTEX EmptyPerson SET name = 'lonely'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "SELECT name, $postCount[0].cnt as posts,"
+            + " $commentCount[0].cnt as comments"
+            + " FROM EmptyPerson"
+            + " LET $postCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('EmptyHasCreator')) FROM EmptyPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Post'),"
+            + " $commentCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('EmptyHasCreator')) FROM EmptyPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Comment')"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    // Empty inner result set should yield count 0 for both
+    Assert.assertEquals(0L, ((Number) item.getProperty("posts")).longValue());
+    Assert.assertEquals(0L, ((Number) item.getProperty("comments")).longValue());
+    Assert.assertFalse(result.hasNext());
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Verifies LET with inter-variable dependency: $b references $a. The second
+   * LET variable depends on the first, ensuring ordering is preserved.
+   */
+  @Test
+  public void testCorrelatedLet_interVariableDependency() {
+    session.execute("CREATE CLASS DepPerson EXTENDS V").close();
+
+    session.begin();
+    var personRs = session.execute(
+        "CREATE VERTEX DepPerson SET name = 'alice', age = 10");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "SELECT name, $a, $b FROM DepPerson"
+            + " LET $a = age * 2,"
+            + " $b = $a + 5"
+            + " WHERE @rid = " + personRid);
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(20, ((Number) item.getProperty("$a")).intValue());
+    Assert.assertEquals(25, ((Number) item.getProperty("$b")).intValue());
+    Assert.assertFalse(result.hasNext());
+
+    result.close();
+    session.commit();
+  }
+
+  /**
+   * Verifies that running the same materialized LET query twice produces
+   * consistent results, exercising the plan caching path.
+   */
+  @Test
+  public void testMaterializedLet_planCachingConsistency() {
+    session.execute("CREATE CLASS CachePerson EXTENDS V").close();
+    session.execute("CREATE CLASS CacheMessage EXTENDS V").close();
+    session.execute("CREATE CLASS CacheHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute(
+        "CREATE VERTEX CachePerson SET name = 'bob'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (int i = 0; i < 3; i++) {
+      String type = (i < 2) ? "Post" : "Comment";
+      session.execute(
+          "CREATE VERTEX CacheMessage SET title = 'cm" + i
+              + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE CacheHasCreator FROM"
+              + " (SELECT FROM CacheMessage WHERE title = 'cm" + i
+              + "') TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    String query =
+        "SELECT name, $postCount[0].cnt as posts,"
+            + " $commentCount[0].cnt as comments"
+            + " FROM CachePerson"
+            + " LET $postCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('CacheHasCreator')) FROM CachePerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Post'),"
+            + " $commentCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('CacheHasCreator')) FROM CachePerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Comment')"
+            + " WHERE @rid = " + personRid;
+
+    // First execution
+    session.begin();
+    var result1 = session.query(query);
+    Assert.assertTrue(result1.hasNext());
+    var item1 = result1.next();
+    long posts1 = ((Number) item1.getProperty("posts")).longValue();
+    long comments1 = ((Number) item1.getProperty("comments")).longValue();
+    result1.close();
+    session.commit();
+
+    // Second execution (exercises plan cache)
+    session.begin();
+    var result2 = session.query(query);
+    Assert.assertTrue(result2.hasNext());
+    var item2 = result2.next();
+    Assert.assertEquals(posts1, ((Number) item2.getProperty("posts")).longValue());
+    Assert.assertEquals(comments1,
+        ((Number) item2.getProperty("comments")).longValue());
+    result2.close();
+    session.commit();
+
+    Assert.assertEquals(2L, posts1);
+    Assert.assertEquals(1L, comments1);
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -7444,6 +7444,30 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE IdxContainerOf FROM (SELECT FROM IdxForum WHERE name = 'forum1')"
               + " TO (SELECT FROM IdxComment WHERE text = 'c" + i + "')")
+
+   * Verifies that two correlated LET subqueries sharing the same inner FROM
+   * subquery are materialized once and reused. The execution plan should show
+   * a MATERIALIZED LET GROUP instead of two independent LET steps.
+   */
+  @Test
+  public void testLetMaterialization_sharedBase() {
+    session.execute("CREATE CLASS LmPerson EXTENDS V").close();
+    session.execute("CREATE CLASS LmMessage EXTENDS V").close();
+    session.execute("CREATE CLASS LmHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX LmPerson SET name = 'alice'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 6; i++) {
+      String type = (i < 4) ? "Post" : "Comment";
+      session.execute(
+          "CREATE VERTEX LmMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE LmHasCreator FROM (SELECT FROM LmMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -7470,6 +7494,27 @@ public class SelectStatementExecutionTest extends DbTestBase {
         "Index pre-filter should be in EXPAND, plan was:\n" + plan,
         plan.contains("index pre-filter"));
 
+        "SELECT name, $postCount[0].cnt as posts, $commentCount[0].cnt as comments"
+            + " FROM LmPerson WHERE @rid = " + personRid
+            + " LET $postCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Post'),"
+            + " $commentCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('LmHasCreator')) FROM LmPerson"
+            + " WHERE @rid = $parent.$current.@rid)"
+            + " WHERE type = 'Comment')");
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(4L, ((Number) item.getProperty("posts")).longValue());
+    Assert.assertEquals(2L, ((Number) item.getProperty("comments")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertTrue(
+        "Should use MATERIALIZED LET GROUP, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+
     result.close();
     session.commit();
   }
@@ -7492,6 +7537,27 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE NiContainerOf FROM (SELECT FROM NiForum WHERE name = 'forum1')"
               + " TO (SELECT FROM NiPost WHERE title = 'post" + i + "')")
+
+   * Verifies that a single LET subquery (no sharing opportunity) still uses
+   * the regular LET step, not the materialized group step.
+   */
+  @Test
+  public void testLetMaterialization_singleLetNoGrouping() {
+    session.execute("CREATE CLASS SlPerson EXTENDS V").close();
+    session.execute("CREATE CLASS SlMessage EXTENDS V").close();
+    session.execute("CREATE CLASS SlHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX SlPerson SET name = 'bob'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    for (var i = 0; i < 3; i++) {
+      session.execute(
+          "CREATE VERTEX SlMessage SET title = 'msg" + i + "'").close();
+      session.execute(
+          "CREATE EDGE SlHasCreator FROM (SELECT FROM SlMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -7521,6 +7587,24 @@ public class SelectStatementExecutionTest extends DbTestBase {
     Assert.assertTrue(
         "Generic push-down filter should be present, plan was:\n" + plan,
         plan.contains("push-down filter"));
+
+        "SELECT name, $msgCount[0].cnt as msgs FROM SlPerson"
+            + " WHERE @rid = " + personRid
+            + " LET $msgCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('SlHasCreator')) FROM SlPerson"
+            + " WHERE @rid = $parent.$current.@rid))");
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(3L, ((Number) item.getProperty("msgs")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertFalse(
+        "Single LET should NOT use materialized group, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
+    Assert.assertTrue(
+        "Single LET should use regular LET step, plan was:\n" + plan,
+        plan.contains("LET (for each record)"));
 
     result.close();
     session.commit();
@@ -7657,6 +7741,19 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.begin();
     session.execute("CREATE VERTEX RLForum SET name = 'forum1'").close();
     var personRs = session.execute("CREATE VERTEX RLPerson SET name = 'alice'");
+
+   * Verifies that when the materialized results exceed the configured max size,
+   * the engine falls back to independent execution and still returns correct
+   * results.
+   */
+  @Test
+  public void testLetMaterialization_fallbackOnSizeLimit() {
+    session.execute("CREATE CLASS FbPerson EXTENDS V").close();
+    session.execute("CREATE CLASS FbMessage EXTENDS V").close();
+    session.execute("CREATE CLASS FbHasCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX FbPerson SET name = 'carol'");
     var personRid = personRs.next().getIdentity();
     personRs.close();
 
@@ -7773,6 +7870,14 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE PPContainerOf FROM (SELECT FROM PPForum WHERE name = 'forum1')"
               + " TO (SELECT FROM PPPost WHERE title = 'post" + i + "')")
+
+      String type = (i < 3) ? "Post" : "Comment";
+      session.execute(
+          "CREATE VERTEX FbMessage SET title = 'msg" + i + "', type = '" + type + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE FbHasCreator FROM (SELECT FROM FbMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
           .close();
     }
     session.commit();
@@ -7814,6 +7919,52 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.begin();
     session.execute("CREATE VERTEX CEForum SET name = 'forum1'").close();
     var personRs = session.execute("CREATE VERTEX CEPerson SET name = 'carol'");
+
+    var originalMax = GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE
+        .getValueAsInteger();
+    try {
+      GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE.setValue(1);
+
+      session.begin();
+      var result = session.query(
+          "SELECT name, $postCount[0].cnt as posts,"
+              + " $commentCount[0].cnt as comments"
+              + " FROM FbPerson WHERE @rid = " + personRid
+              + " LET $postCount = (SELECT count(*) as cnt FROM"
+              + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
+              + " WHERE @rid = $parent.$current.@rid)"
+              + " WHERE type = 'Post'),"
+              + " $commentCount = (SELECT count(*) as cnt FROM"
+              + " (SELECT expand(in('FbHasCreator')) FROM FbPerson"
+              + " WHERE @rid = $parent.$current.@rid)"
+              + " WHERE type = 'Comment')");
+
+      Assert.assertTrue(result.hasNext());
+      var item = result.next();
+      Assert.assertEquals(3L, ((Number) item.getProperty("posts")).longValue());
+      Assert.assertEquals(2L, ((Number) item.getProperty("comments")).longValue());
+
+      result.close();
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_LET_MATERIALIZATION_MAX_SIZE.setValue(originalMax);
+    }
+  }
+
+  /**
+   * Verifies that two LET subqueries with different inner FROM subqueries are
+   * NOT grouped — each executes independently.
+   */
+  @Test
+  public void testLetMaterialization_differentInnerSubqueries() {
+    session.execute("CREATE CLASS DsPerson EXTENDS V").close();
+    session.execute("CREATE CLASS DsMessage EXTENDS V").close();
+    session.execute("CREATE CLASS DsForum EXTENDS V").close();
+    session.execute("CREATE CLASS DsHasCreator EXTENDS E").close();
+    session.execute("CREATE CLASS DsMemberOf EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute("CREATE VERTEX DsPerson SET name = 'dave'");
     var personRid = personRs.next().getIdentity();
     personRs.close();
 
@@ -7926,6 +8077,18 @@ public class SelectStatementExecutionTest extends DbTestBase {
       session.execute(
           "CREATE EDGE NiContainerOf FROM (SELECT FROM NiForum WHERE name = 'f1')"
               + " TO (SELECT FROM NiMsg WHERE val = " + i + ")")
+
+      session.execute("CREATE VERTEX DsMessage SET title = 'msg" + i + "'").close();
+      session.execute(
+          "CREATE EDGE DsHasCreator FROM (SELECT FROM DsMessage WHERE title = 'msg"
+              + i + "') TO " + personRid)
+          .close();
+    }
+    for (var i = 0; i < 2; i++) {
+      session.execute("CREATE VERTEX DsForum SET title = 'forum" + i + "'").close();
+      session.execute(
+          "CREATE EDGE DsMemberOf FROM " + personRid
+              + " TO (SELECT FROM DsForum WHERE title = 'forum" + i + "')")
           .close();
     }
     session.commit();
@@ -8087,6 +8250,25 @@ public class SelectStatementExecutionTest extends DbTestBase {
     Assert.assertFalse(
         "Index pre-filter should NOT fire without edge schema link, plan was:\n" + plan,
         plan.contains("index pre-filter"));
+
+        "SELECT name, $msgCount[0].cnt as msgs, $forumCount[0].cnt as forums"
+            + " FROM DsPerson WHERE @rid = " + personRid
+            + " LET $msgCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(in('DsHasCreator')) FROM DsPerson"
+            + " WHERE @rid = $parent.$current.@rid)),"
+            + " $forumCount = (SELECT count(*) as cnt FROM"
+            + " (SELECT expand(out('DsMemberOf')) FROM DsPerson"
+            + " WHERE @rid = $parent.$current.@rid))");
+
+    Assert.assertTrue(result.hasNext());
+    var item = result.next();
+    Assert.assertEquals(3L, ((Number) item.getProperty("msgs")).longValue());
+    Assert.assertEquals(2L, ((Number) item.getProperty("forums")).longValue());
+
+    var plan = result.getExecutionPlan().prettyPrint(0, 2);
+    Assert.assertFalse(
+        "Different inner subqueries should NOT be grouped, plan was:\n" + plan,
+        plan.contains("MATERIALIZED LET GROUP"));
 
     result.close();
     session.commit();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -9016,4 +9016,70 @@ public class SelectStatementExecutionTest extends DbTestBase {
     Assert.assertEquals(2L, posts1);
     Assert.assertEquals(1L, comments1);
   }
+
+  /**
+   * Verifies that three LET subqueries sharing the same inner FROM subquery
+   * are correctly materialized and produce independent results. Each applies
+   * a different WHERE filter to the same expanded edge set.
+   */
+  @Test
+  public void testMaterializedLet_threeEntriesSameBase() {
+    session.execute("CREATE CLASS TriPerson EXTENDS V").close();
+    session.execute("CREATE CLASS TriMessage EXTENDS V").close();
+    session.execute("CREATE CLASS TriCreator EXTENDS E").close();
+
+    session.begin();
+    var personRs = session.execute(
+        "CREATE VERTEX TriPerson SET name = 'alice'");
+    var personRid = personRs.next().getIdentity();
+    personRs.close();
+
+    // 2 posts, 3 comments, 1 draft
+    for (int i = 0; i < 6; i++) {
+      String type = (i < 2) ? "Post" : (i < 5) ? "Comment" : "Draft";
+      session.execute(
+          "CREATE VERTEX TriMessage SET type = '" + type + "'").close();
+      session.execute(
+          "CREATE EDGE TriCreator FROM"
+              + " (SELECT FROM TriMessage WHERE type = '" + type
+              + "' AND @rid NOT IN (SELECT in('TriCreator') FROM TriPerson))"
+              + " TO " + personRid)
+          .close();
+    }
+    session.commit();
+
+    // Three LET entries with the same inner subquery but different filters.
+    String query =
+        "SELECT name,"
+            + " $posts[0].cnt as postCount,"
+            + " $comments[0].cnt as commentCount,"
+            + " $drafts[0].cnt as draftCount"
+            + " FROM TriPerson"
+            + " LET $posts = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('TriCreator')) FROM TriPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Post'),"
+            + " $comments = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('TriCreator')) FROM TriPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Comment'),"
+            + " $drafts = (SELECT count(*) as cnt FROM"
+            + "   (SELECT expand(in('TriCreator')) FROM TriPerson"
+            + "   WHERE @rid = $parent.$current.@rid)"
+            + "   WHERE type = 'Draft')"
+            + " WHERE @rid = " + personRid;
+
+    session.begin();
+    var rs = session.query(query);
+    Assert.assertTrue(rs.hasNext());
+    var row = rs.next();
+    Assert.assertEquals(2L,
+        ((Number) row.getProperty("postCount")).longValue());
+    Assert.assertEquals(3L,
+        ((Number) row.getProperty("commentCount")).longValue());
+    Assert.assertEquals(1L,
+        ((Number) row.getProperty("draftCount")).longValue());
+    rs.close();
+    session.commit();
+  }
 }


### PR DESCRIPTION
#### Motivation

When multiple per-record LET subqueries share the same inner FROM subquery (e.g. both scan the same person's messages), the engine re-executes the identical expand() traversal independently for each LET clause. For N outer rows with K shared LET clauses, this means K x N traversals instead of 1 x N.

Example -- two LET clauses counting posts vs comments by the same person:

```sql
SELECT name, $postCount[0].cnt as posts, $commentCount[0].cnt as comments
FROM Person
LET $postCount = (SELECT count(*) FROM (
      SELECT expand(in('HAS_CREATOR')) FROM Person
      WHERE @rid = $parent.$current.@rid
    ) WHERE @class = 'Post' AND tag = 'A'),
    $commentCount = (SELECT count(*) FROM (
      SELECT expand(in('HAS_CREATOR')) FROM Person
      WHERE @rid = $parent.$current.@rid
    ) WHERE @class = 'Post' AND tag = 'B')
WHERE name = 'Alice'
```

Both `$postCount` and `$commentCount` expand `in('HAS_CREATOR')` for the same person vertex. Without materialization, the engine performs two independent edge traversals and two filter passes over the same records per outer row.

#### Changes

The planner detects when multiple LET subquery items share the same inner FROM subquery (by comparing their SQL text representation). When a group of 2+ items shares the same base:

1. **Common filter extraction** -- the planner decomposes each entry's WHERE clause into AND-level sub-blocks and computes their intersection using structural `SQLBooleanExpression.equals()`. Common conditions (e.g., `@class = 'Post'`) are extracted into a shared filter; per-entry conditions (e.g., `tag = 'A'` / `tag = 'B'`) remain in each entry's plan.

2. **Materialization with push-down** -- a wrapper query `SELECT * FROM (inner) WHERE <common filter>` is built and compiled normally. The planner's existing `tryPushDownFilterIntoExpand` optimization pushes the common filter into the ExpandStep (e.g., `@class = 'Post'` becomes a collection ID check -- zero I/O for non-matching record types like Comments). The shared inner subquery is executed once per outer row and results are materialized into an in-memory list.

3. **Per-entry FilterStep preservation** -- each LET entry's full query plan is compiled with `skipExpandPushDown = true` on the CommandContext, preventing `tryPushDownFilterIntoExpand` from removing the outer FilterStep. The SubQueryStep is then safely replaced with a ListSourceStep that streams from the materialized results, while the FilterStep with per-entry conditions is preserved intact.

4. **Plan cache integration** -- the `skipExpandPushDown` flag is included in the plan cache key (via `\0skipExpandPushDown` suffix), so plans compiled with and without push-down are stored as separate cache entries. Per-entry plans benefit from caching across outer rows (1 compilation + N-1 cache hits).

5. **Bounded materialization** -- if materialized results exceed a configurable limit (`QUERY_LET_MATERIALIZATION_MAX_SIZE`, default 10,000), falls back to independent execution.

#### Key components

- **`MaterializedLetGroupStep`** -- per-record LET step handling a group of shared subqueries. Builds the materialization wrapper query with common filter, manages the `skipExpandPushDown` flag for per-entry plan creation, and replaces SubQueryStep with ListSourceStep.
- **`ListSourceStep`** -- streams pre-materialized results into a query plan.
- **`SelectExecutionPlanner.detectSharedLetBases()`** -- groups LET items by inner subquery text and extracts common WHERE conditions per group.
- **`SelectExecutionPlanner.extractCommonFilter()`** -- decomposes WHERE clauses into AND-level sub-blocks and computes their intersection.
- **`CommandContext.skipExpandPushDown`** -- planner hint that prevents `tryPushDownFilterIntoExpand` from moving the outer filter into the ExpandStep.

#### Execution flow (IC10-style pattern)

```
MaterializedLetGroupStep.calculate(outerRow)

 1. Build wrapper: SELECT * FROM (expand(in('HAS_CREATOR'))...) WHERE @class = 'Post'
    -> planner pushes @class='Post' into ExpandStep (collection ID check)
    -> Comments skipped with zero I/O
    -> Result: [Post1, Post2, Post3, ...] (materialized once)

 2. For $posScore (skipExpandPushDown = true):
    ListSourceStep([Post1,Post2,Post3,...])
      -> FilterStep(@class='Post' AND tag='A')  <- preserved, not pushed down
      -> AggregateStep(count)

 3. For $negScore (skipExpandPushDown = true):
    ListSourceStep([Post1,Post2,Post3,...])
      -> FilterStep(@class='Post' AND tag='B')  <- preserved, not pushed down
      -> AggregateStep(count)
```

#### Note on benchmark applicability

The LDBC benchmark queries that originally motivated this optimization (IC3, IC10) have been rewritten to use conditional aggregation (`sum(if(...))`), which eliminates the need for multiple LET clauses entirely. With those rewrites, no current LDBC benchmark query exercises this optimization.

However, the optimization remains valuable for queries where multiple correlated LET subqueries share the same base scan but cannot be collapsed into conditional aggregation -- specifically when the LET clauses produce different result structures (record lists, grouped aggregates, different projections), not just scalar counts/sums.

## Benchmark Results

**IC10 (friend recommendation) -- LDBC SF 0.1, CCX33 (8 dedicated vCPU, 32 GB RAM), single thread**

JMH config: 3 forks, 3 warmup iterations (10s), 10 measurement iterations (30s) -- 30 data points total.

| Metric | develop (before) | PR (after) | Change |
|---|---|---|---|
| **Mean throughput** | 0.327 ops/s | 0.467 ops/s | **+42.8%** |
| **95% CI** | [0.286, 0.368] | [0.409, 0.524] | **non-overlapping** |
| **Median (p50)** | 0.321 ops/s | 0.487 ops/s | **+51.6%** |
| **p90** | 0.434 ops/s | 0.584 ops/s | **+34.6%** |
| **Relative error** | 12.6% | 12.3% | |

The confidence intervals do not overlap -- this is a **statistically significant ~43% throughput improvement** for the IC10 query.

## Test plan

**Existing materialization tests:**
- `testLetMaterialization_sharedBase` -- two shared LETs grouped and producing correct results
- `testLetMaterialization_singleLetNoGrouping` -- single LET uses regular step, not materialized group
- `testLetMaterialization_fallbackOnSizeLimit` -- exceeding max size falls back to independent execution
- `testLetMaterialization_differentInnerSubqueries` -- different inner subqueries are NOT grouped
- `testLetMaterialization_threeLetsSharedBase` -- three shared LETs grouped correctly
- `testLetMaterialization_mixedLetTypes` -- mixed expression LET + shared subquery LETs
- `testMaterializedLet_emptyInnerResultSet` -- empty inner results handled correctly
- `testMaterializedLet_planCachingConsistency` -- plan cache produces consistent results
- `testMaterializedLet_threeEntriesSameBase` -- three entries sharing same base
- `testMaterializedLet_expressionReferencesSubquery` -- expression LET referencing subquery LET

**New common filter + push-down interaction tests:**
- `testMaterializedLet_commonFilterPushDown` -- common `@class` filter pushed into materialization, per-entry filters preserved
- `testMaterializedLet_noCommonFilter` -- entries with completely different WHERE clauses, no common filter
- `testMaterializedLet_oneEntryWithoutWhere` -- one entry has WHERE, other has none
- `testMaterializedLet_commonFilterPlanCaching` -- multiple outer rows exercise plan cache with skipExpandPushDown flag
- `testMaterializedLet_allConditionsCommon` -- entries with identical WHERE clauses
- `testMaterializedLet_IC10Pattern_pushDownWithMaterialization` -- end-to-end IC10-style pattern verifying both optimizations compose correctly
- `testMaterializedLet_explainShowsCommonFilter` -- EXPLAIN-level verification of plan structure, cross-validated against independent execution