### PR TITLE
Remove Hetzner location pinning from CI workflows

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -69,7 +69,7 @@ jobs:
     name: Linux ${{ matrix.arch }} - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
-    runs-on: [ self-hosted, in-nbg1, '${{ matrix.arch == ''x86'' && ''type-cpx42'' || ''type-cax31'' }}',
+    runs-on: [ self-hosted, '${{ matrix.arch == ''x86'' && ''type-cpx42'' || ''type-cax31'' }}',
                'image-${{ matrix.arch == ''x86'' && ''x86-system'' || ''arm-system'' }}-ubuntu-24.04',
                volume-cache ]
     strategy:

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -70,8 +70,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
     runs-on: [ self-hosted, '${{ matrix.arch == ''x86'' && ''type-cpx42'' || ''type-cax31'' }}',
-               'image-${{ matrix.arch == ''x86'' && ''x86-system'' || ''arm-system'' }}-ubuntu-24.04',
-               volume-cache ]
+               'image-${{ matrix.arch == ''x86'' && ''x86-system'' || ''arm-system'' }}-ubuntu-24.04' ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -155,7 +155,6 @@ jobs:
       - self-hosted
       - "${{ matrix.arch == 'x86' && 'type-cpx42' || 'type-cax31' }}"
       - "image-${{ matrix.arch == 'x86' && 'x86-system' || 'arm-system' }}-ubuntu-24.04"
-      - volume-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -153,7 +153,6 @@ jobs:
     if: needs.detect-changes.outputs.should_build == 'true'
     runs-on:
       - self-hosted
-      - in-nbg1
       - "${{ matrix.arch == 'x86' && 'type-cpx42' || 'type-cax31' }}"
       - "image-${{ matrix.arch == 'x86' && 'x86-system' || 'arm-system' }}-ubuntu-24.04"
       - volume-cache

--- a/.github/workflows/testflows-orchestrator/scripts/setup.sh
+++ b/.github/workflows/testflows-orchestrator/scripts/setup.sh
@@ -3,40 +3,6 @@ set -euxo pipefail
 
 trap 'echo "Setup failed at line $LINENO"' ERR
 
-# Set default cache directory
-if [ -z "${CACHE_DIR:-}" ]; then
-    CACHE_DIR="/mnt/cache"
-fi
-
-# Setup APT package cache if volume is available (must be done before any apt-get commands)
-{
-    if [ -d "$CACHE_DIR" ]; then
-        echo "Setting up APT package cache"
-        APT_CACHE_DIR="$CACHE_DIR/apt/archives"
-        mkdir -p "$APT_CACHE_DIR"
-
-        # Configure APT to use the cache directory
-        cat > /etc/apt/apt.conf.d/00-cache-config <<EOF
-Dir::Cache::Archives "$APT_CACHE_DIR";
-EOF
-
-        # Also cache the package lists
-        APT_LISTS_DIR="$CACHE_DIR/apt/lists"
-        mkdir -p "$APT_LISTS_DIR"
-
-        # Bind mount the lists directory for faster apt-get update
-        if ! mountpoint -q /var/lib/apt/lists; then
-            mount --bind "$APT_LISTS_DIR" /var/lib/apt/lists
-        fi
-
-        echo "APT cache configured:"
-        echo "  - Package archives: $APT_CACHE_DIR"
-        echo "  - Package lists: $APT_LISTS_DIR"
-    else
-        echo "No cache volume available, using default APT cache"
-    fi
-}
-
 # Initial package list update
 apt-get update
 
@@ -91,50 +57,19 @@ apt-get update
     echo "Install Docker Engine"
     apt-get -y install ca-certificates curl gnupg
 
-    # Setup cache directory if it exists
-    if [ -d "$CACHE_DIR" ]; then
-        CACHE_DIR_DOCKER="$CACHE_DIR/docker"
-        mkdir -p "$CACHE_DIR_DOCKER"
-        echo "Using cache directory: $CACHE_DIR_DOCKER"
-    else
-        CACHE_DIR_DOCKER=""
-        echo "No cache directory available, proceeding without caching"
-    fi
-
     echo "Add Docker's official GPG key"
     install -m 0755 -d /etc/apt/keyrings
     DOCKER_GPG_PATH="/etc/apt/keyrings/docker.asc"
-
-    DOCKER_GPG_CACHE="$CACHE_DIR_DOCKER/docker.asc"
-    if [ -n "$CACHE_DIR_DOCKER" ] && [ -f "$DOCKER_GPG_CACHE" ]; then
-        echo "Using cached Docker GPG key"
-        cp "$DOCKER_GPG_CACHE" "$DOCKER_GPG_PATH"
-    else
-        echo "Downloading Docker GPG key"
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o "$DOCKER_GPG_PATH"
-        if [ -n "$CACHE_DIR_DOCKER" ]; then
-            cp "$DOCKER_GPG_PATH" "$DOCKER_GPG_CACHE"
-        fi
-    fi
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o "$DOCKER_GPG_PATH"
     chmod a+r "$DOCKER_GPG_PATH"
 
     echo "Set up Docker's repository"
-    DOCKER_LIST_PATH="/etc/apt/sources.list.d/docker.list"
-    if [ -n "$CACHE_DIR_DOCKER" ] && [ -f "$CACHE_DIR_DOCKER/docker.list" ]; then
-        echo "Using cached Docker repository list"
-        cp "$CACHE_DIR_DOCKER/docker.list" "$DOCKER_LIST_PATH"
-    else
-        echo "Creating Docker repository list"
-        ARCH=$(dpkg --print-architecture)
-        # shellcheck source=/dev/null
-        . /etc/os-release
-        CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
-        echo "deb [arch=$ARCH signed-by=$DOCKER_GPG_PATH] https://download.docker.com/linux/ubuntu $CODENAME stable" | \
-        tee "$DOCKER_LIST_PATH" > /dev/null
-        if [ -n "$CACHE_DIR_DOCKER" ]; then
-            cp "$DOCKER_LIST_PATH" "$CACHE_DIR_DOCKER/docker.list"
-        fi
-    fi
+    ARCH=$(dpkg --print-architecture)
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    CODENAME="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
+    echo "deb [arch=$ARCH signed-by=$DOCKER_GPG_PATH] https://download.docker.com/linux/ubuntu $CODENAME stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
 
     echo "Install Docker Engine and containerd"
     apt-get -y update
@@ -150,40 +85,16 @@ apt-get update
 {
     echo "Install Node.js LTS"
 
-    # Setup cache directory if it exists
-    if [ -d "$CACHE_DIR" ]; then
-        CACHE_DIR_NODE="$CACHE_DIR/node"
-        mkdir -p "$CACHE_DIR_NODE"
-        echo "Using cache directory: $CACHE_DIR_NODE"
-    else
-        CACHE_DIR_NODE=""
-        echo "No cache directory available, proceeding without caching"
-    fi
-
     echo "Add NodeSource GPG key"
     install -m 0755 -d /etc/apt/keyrings
     NODE_GPG_PATH="/etc/apt/keyrings/nodesource.gpg"
-
-    NODE_GPG_CACHE="${CACHE_DIR_NODE}/nodesource.gpg"
-    if [ -n "$CACHE_DIR_NODE" ] && [ -f "$NODE_GPG_CACHE" ]; then
-        echo "Using cached NodeSource GPG key"
-        cp "$NODE_GPG_CACHE" "$NODE_GPG_PATH"
-    else
-        echo "Downloading NodeSource GPG key"
-        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o "$NODE_GPG_PATH"
-        if [ -n "$CACHE_DIR_NODE" ]; then
-            cp "$NODE_GPG_PATH" "$NODE_GPG_CACHE"
-        fi
-    fi
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o "$NODE_GPG_PATH"
     chmod a+r "$NODE_GPG_PATH"
 
     echo "Set up NodeSource repository"
     NODE_MAJOR=22
-    NODE_LIST_PATH="/etc/apt/sources.list.d/nodesource.list"
-
-    # Always recreate the repo list to ensure correct GPG path (don't cache this file)
     echo "deb [signed-by=$NODE_GPG_PATH] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | \
-    tee "$NODE_LIST_PATH" > /dev/null
+    tee /etc/apt/sources.list.d/nodesource.list > /dev/null
 
     echo "Install Node.js"
     apt-get -y update
@@ -191,56 +102,4 @@ apt-get update
 
     echo "Node.js version: $(node --version)"
     echo "npm version: $(npm --version)"
-}
-{
-    echo "Setup build tool caches"
-
-    if [ -d "$CACHE_DIR" ]; then
-        # Verify ubuntu user exists before operating on home directory
-        if ! id ubuntu &>/dev/null; then
-            echo "ERROR: ubuntu user does not exist. Run the user setup block first."
-            exit 1
-        fi
-
-        UBUNTU_HOME="/home/ubuntu"
-
-        # Maven cache setup
-        MAVEN_CACHE="$CACHE_DIR/maven"
-        mkdir -p "$MAVEN_CACHE" "${UBUNTU_HOME}/.m2/repository"
-
-        # Bind mount Maven cache
-        if ! grep -qF "$MAVEN_CACHE ${UBUNTU_HOME}/.m2/repository" /etc/fstab; then
-            echo "$MAVEN_CACHE ${UBUNTU_HOME}/.m2/repository none bind 0 0" >> /etc/fstab
-        fi
-        if ! mountpoint -q "${UBUNTU_HOME}/.m2/repository"; then
-            mount --bind "$MAVEN_CACHE" "${UBUNTU_HOME}/.m2/repository"
-        fi
-
-        # Set Maven cache ownership for ubuntu user (non-recursive to avoid slow operation on large caches)
-        chown ubuntu:ubuntu "${UBUNTU_HOME}/.m2"
-        chown ubuntu:ubuntu "${UBUNTU_HOME}/.m2/repository"
-        chown ubuntu:ubuntu "$MAVEN_CACHE"
-
-        # npm cache setup
-        NPM_CACHE="$CACHE_DIR/npm"
-        mkdir -p "$NPM_CACHE" "${UBUNTU_HOME}/.npm"
-
-        # Bind mount npm cache
-        if ! grep -qF "$NPM_CACHE ${UBUNTU_HOME}/.npm" /etc/fstab; then
-            echo "$NPM_CACHE ${UBUNTU_HOME}/.npm none bind 0 0" >> /etc/fstab
-        fi
-        if ! mountpoint -q "${UBUNTU_HOME}/.npm"; then
-            mount --bind "$NPM_CACHE" "${UBUNTU_HOME}/.npm"
-        fi
-
-        # Set npm cache ownership for ubuntu user
-        chown ubuntu:ubuntu "${UBUNTU_HOME}/.npm"
-        chown ubuntu:ubuntu "$NPM_CACHE"
-
-        echo "Build tool caches mounted from volume:"
-        echo "  - $MAVEN_CACHE → ${UBUNTU_HOME}/.m2/repository"
-        echo "  - $NPM_CACHE → ${UBUNTU_HOME}/.npm"
-    else
-        echo "No cache volume available, proceeding without build tool caching"
-    fi
 }

--- a/.github/workflows/testflows-orchestrator/scripts/startup-arm64.sh
+++ b/.github/workflows/testflows-orchestrator/scripts/startup-arm64.sh
@@ -16,40 +16,10 @@ ACTIONS_RUNNER_SHA256="f5863a211241436186723159a111f352f25d5d22711639761ea24c98c
 ACTIONS_RUNNER_ARCH="arm64"
 ACTIONS_RUNNER_FILE="actions-runner-linux-${ACTIONS_RUNNER_ARCH}-${ACTIONS_RUNNER_VERSION}.tar.gz"
 ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v${ACTIONS_RUNNER_VERSION}/${ACTIONS_RUNNER_FILE}"
-CACHE_DIR="${CACHE_DIR:-/mnt/cache}"
-CACHE_DIR_GITHUB="${CACHE_DIR}/github"
 
-download_and_verify() {
-    echo "Downloading actions runner package from GitHub..."
-    curl -o "${ACTIONS_RUNNER_FILE}" -L "${ACTIONS_RUNNER_URL}"
-    echo "${ACTIONS_RUNNER_SHA256}  ${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c
-}
-
-# Try to use cache volume if available
-if [ -d "${CACHE_DIR}" ]; then
-    if [ -f "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" ]; then
-        echo "Found runner package in cache, verifying checksum..."
-        if echo "${ACTIONS_RUNNER_SHA256}  ${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c; then
-            echo "Checksum verified, copying from cache..."
-            cp "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" .
-        else
-            echo "Cache file checksum mismatch"
-            download_and_verify
-            # Save to cache for future use
-            mkdir -p "${CACHE_DIR_GITHUB}"
-            cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
-        fi
-    else
-        echo "Runner package not found in cache"
-        download_and_verify
-        # Save to cache for future use
-        mkdir -p "${CACHE_DIR_GITHUB}"
-        cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
-    fi
-else
-    echo "Cache directory not available, downloading directly..."
-    download_and_verify
-fi
+echo "Downloading actions runner package from GitHub..."
+curl -o "${ACTIONS_RUNNER_FILE}" -L "${ACTIONS_RUNNER_URL}"
+echo "${ACTIONS_RUNNER_SHA256}  ${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c
 
 tar xzf "./${ACTIONS_RUNNER_FILE}"
 

--- a/.github/workflows/testflows-orchestrator/scripts/startup-x64.sh
+++ b/.github/workflows/testflows-orchestrator/scripts/startup-x64.sh
@@ -16,40 +16,10 @@ ACTIONS_RUNNER_SHA256="5fcc01bd546ba5c3f1291c2803658ebd3cedb3836489eda3be357d41b
 ACTIONS_RUNNER_ARCH="x64"
 ACTIONS_RUNNER_FILE="actions-runner-linux-${ACTIONS_RUNNER_ARCH}-${ACTIONS_RUNNER_VERSION}.tar.gz"
 ACTIONS_RUNNER_URL="https://github.com/actions/runner/releases/download/v${ACTIONS_RUNNER_VERSION}/${ACTIONS_RUNNER_FILE}"
-CACHE_DIR="${CACHE_DIR:-/mnt/cache}"
-CACHE_DIR_GITHUB="${CACHE_DIR}/github"
 
-download_and_verify() {
-    echo "Downloading actionsrunner package from GitHub..."
-    curl -o "${ACTIONS_RUNNER_FILE}" -L "${ACTIONS_RUNNER_URL}"
-    echo "${ACTIONS_RUNNER_SHA256}  ${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c
-}
-
-# Try to use cache volume if available
-if [ -d "${CACHE_DIR}" ]; then
-    if [ -f "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" ]; then
-        echo "Found runner package in cache, verifying checksum..."
-        if echo "${ACTIONS_RUNNER_SHA256}  ${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c; then
-            echo "Checksum verified, copying from cache..."
-            cp "${CACHE_DIR_GITHUB}/${ACTIONS_RUNNER_FILE}" .
-        else
-            echo "Cache file checksum mismatch"
-            download_and_verify
-            # Save to cache for future use
-            mkdir -p "${CACHE_DIR_GITHUB}"
-            cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
-        fi
-    else
-        echo "Runner package not found in cache"
-        download_and_verify
-        # Save to cache for future use
-        mkdir -p "${CACHE_DIR_GITHUB}"
-        cp "${ACTIONS_RUNNER_FILE}" "${CACHE_DIR_GITHUB}/"
-    fi
-else
-    echo "Cache directory not available, downloading directly..."
-    download_and_verify
-fi
+echo "Downloading actions runner package from GitHub..."
+curl -o "${ACTIONS_RUNNER_FILE}" -L "${ACTIONS_RUNNER_URL}"
+echo "${ACTIONS_RUNNER_SHA256}  ${ACTIONS_RUNNER_FILE}" | shasum -a 256 -c
 
 tar xzf "./${ACTIONS_RUNNER_FILE}"
 


### PR DESCRIPTION
## Summary
- Remove `in-nbg1` label from self-hosted runner selectors in `maven-pipeline.yml` and `maven-integration-tests-pipeline.yml`
- Without a location label, the testflows orchestrator lets Hetzner auto-select any EU datacenter with available capacity
- Prevents CI stalls when ARM (cax31) servers are sold out in a single datacenter (currently happening in nbg1)

## Motivation
ARM server capacity in Hetzner's nbg1 datacenter is currently exhausted, causing all ARM CI jobs to queue indefinitely. The orchestrator was pinned to nbg1 via the `in-nbg1` label. Other EU locations (e.g. fsn1) have available capacity. Since we don't care about which EU location runs CI, removing the pin lets the orchestrator dynamically pick any available location.

Also cleaned up 24 orphaned cache volumes stuck in nbg1.

## Test plan
- [x] Verified fsn1 has ARM capacity (test server created and deleted successfully)
- [ ] Merge and confirm queued ARM jobs get provisioned in an available location