### PR TITLE
Add plan corrections for deferred code review findings

### DIFF
--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -185,7 +185,7 @@ parallel. After all complete, findings are deduplicated, severity-assigned
 Max 3 iterations per level.
 
 - **Step-level:** see `step-implementation.md` §Per-Step Workflow (sub-step 4)
-- **Track-level:** see `track-code-review.md`
+- **Track-level:** see `track-code-review.md` (includes track completion)
 
 ---
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -1,8 +1,16 @@
-# Track Execution — Phase C: Track-Level Code Review
+# Track Execution — Phase C: Code Review + Track Completion
 
 After all steps are committed, spawn **ten sub-agents in parallel** to review
 the full track diff. These are deliberately sub-agents — fresh eyes catch
 systematic issues that you (as the implementer) are blind to.
+
+After the review loop completes and any deferred findings are processed,
+this phase continues directly into track completion: compiling the track
+episode, presenting results to the user, and marking the track `[x]` upon
+approval. Merging code review and track completion into a single session
+ensures the agent has full context of which findings were fixed, which were
+deferred (and where), and what plan corrections were made — all of which
+feed into an accurate track episode.
 
 **Five dimensional code review agents** (each reviews code from its own
 perspective):
@@ -166,7 +174,7 @@ Iterate on the synthesized findings:
    The iteration count is shared across all review dimensions (not
    independent counters).
 3. If blockers persist after 3 iterations, note them — they'll be presented
-   to the user during track review (workflow.md §Track Completion Protocol)
+   to the user during track completion (below).
 4. When all reviews pass (or max iterations reached), mark
    `Track-level code review` as `[x]` in the step file's Progress section.
    Commit this update.
@@ -199,20 +207,60 @@ If no findings were deferred, skip this section.
 
 ---
 
-## Phase C Completion
+## Track Completion
 
-After all track-level reviews pass (or max iterations reached):
+After the review loop completes and any plan corrections are committed,
+proceed directly to track completion **in the same session**.
 
-1. **Verify `Track-level code review` is marked `[x]`** and committed.
-2. **Inform the user** that Phase C is complete:
-   - Review outcomes across all code and test quality dimensions
-     (passed / passed with noted findings)
-   - Any unresolved findings to present during track completion
-   - Instruct: "Clear session and re-run `/execute-tracks` to complete
-     the track (write track episode, present results)."
-3. **End the session.** Do not proceed to track completion in the same
-   session.
+1. **Compile the track episode** from all step episodes in the step file.
+   The track episode is a strategic summary — what was built, key
+   discoveries, plan deviations with cross-track impact. If findings were
+   deferred to other tracks, mention the plan corrections and which
+   tracks were affected.
 
-The next session detects all phases `[x]` and enters the Track Completion
-Protocol (workflow.md): compiles the track episode, writes it to the plan
-file, marks the track `[x]`, and presents results to the user for approval.
+2. **Present track results to the user** (do NOT write to plan file yet):
+   - Track episode (compiled but not yet persisted)
+   - All step episodes from the step file
+   - Git log of track commits
+   - Any unresolved track-level code review findings
+   - Plan corrections made (if any) — which findings were deferred and
+     where
+
+3. **Wait for user response:**
+   - **Approved** — proceed to step 4.
+   - **Fixes needed** — apply the user's specific fixes as additional
+     commits. Re-run track-level code review if fixes are substantial.
+     Re-compile the track episode if fixes changed outcomes.
+     Present updated results and wait again.
+   - **Fundamental rework** — trigger ESCALATE (see workflow.md
+     §Inline Replanning).
+
+4. **Write the track episode and mark `[x]`** in the plan file (single
+   commit, only after user approval):
+
+   ```markdown
+   - [x] Track N: <title>
+     > <description>
+     >
+     > **Track episode:**
+     > <strategic summary — length proportional to cross-track impact>
+     >
+     > **Step file:** `tracks/track-N.md` (M steps, K failed)
+   ```
+
+5. **Session ends.** Strategy refresh happens next session.
+
+**Why deferred write:** Writing the track episode and marking `[x]` before
+user approval creates a state that cannot be reliably resumed — if the
+session ends between marking `[x]` and receiving approval, the next session
+detects the track as complete (State A: strategy refresh needed) and skips
+user review entirely. By deferring the plan file write, an interrupted
+session simply re-enters track completion on resume (all phases `[x]` in
+the step file, track still `[ ]` in the plan file).
+
+**Why merge with code review:** Phase C's code review and track completion
+have no perspective conflict — unlike Phase B→C (where implementation
+context biases code review), here the reviewer mindset naturally feeds into
+the track episode. More importantly, Phase C may produce plan corrections
+(deferred findings → new or updated tracks), and the track episode must
+accurately reflect these. A separate session would lose this context.

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -173,6 +173,32 @@ Iterate on the synthesized findings:
 
 ---
 
+## Plan Corrections from Deferred Findings
+
+During synthesis and the review loop, some findings may be **out of scope
+for the current track** — the issue is real but fixing it here would expand
+the track beyond its goals. After all in-scope fixes are applied and the
+review loop completes, process any deferred findings by updating the
+implementation plan:
+
+1. **Categorize** — for each finding you chose not to fix in the current
+   track, decide where the work belongs:
+   - An **existing future track** — if it fits that track's purpose, add
+     the item to that track's description. Update the scope indicator if
+     the addition meaningfully changes the expected step count.
+   - A **new separate track** — if no existing track covers the work, add
+     a new track to the plan's checklist with a description, scope
+     indicator, and dependency notation (typically depends on the current
+     track). Follow the same format as other tracks in the plan.
+
+2. **Commit plan changes** — commit the updated `implementation-plan.md`
+   as a separate commit. Reference the finding IDs in the commit message
+   so the plan correction is traceable to the review that motivated it.
+
+If no findings were deferred, skip this section.
+
+---
+
 ## Phase C Completion
 
 After all track-level reviews pass (or max iterations reached):

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -8,11 +8,11 @@ each executed in a **separate session**:
 1. **Phase A: Review + Decomposition** — this document (current session)
 2. **Phase B: Step Implementation** — see
    [`step-implementation.md`](step-implementation.md) (next session)
-3. **Phase C: Track-Level Code Review** — see
+3. **Phase C: Code Review + Track Completion** — see
    [`track-code-review.md`](track-code-review.md) (session after Phase B)
 
-After Phase C, the next session runs the Track Completion Protocol
-(see workflow.md) for user review.
+Phase C includes both the track-level code review and track completion
+(episode compilation, plan corrections, user approval) in a single session.
 
 ---
 

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -24,13 +24,19 @@ The overall workflow has four stages:
 Within Phase 3, each track goes through three sub-phases:
 - **Phase A**: Review + Decomposition (`track-review.md`)
 - **Phase B**: Step Implementation (`step-implementation.md`)
-- **Phase C**: Track-Level Code Review (`track-code-review.md`)
+- **Phase C**: Code Review + Track Completion (`track-code-review.md`)
 
 **Each session handles exactly one sub-phase of one track.** After completing
 a sub-phase, the session ends and the user re-runs `/execute-tracks` to
 start the next sub-phase with fresh context. This prevents context
 dilution — review context doesn't clutter implementation, and implementation
 context doesn't bias the code review.
+
+Phase C includes both the track-level code review and track completion
+(episode compilation, user approval, plan file update) in a single session.
+This ensures the agent retains full context of which findings were fixed,
+which were deferred to other tracks, and what plan corrections were made —
+all of which feed into an accurate track episode.
 
 Between sessions, the step file's **Progress** section and step episodes
 bridge context. The user clears the session and re-runs `/execute-tracks`
@@ -50,8 +56,7 @@ flowchart TD
     READ -->|"Track just completed\n(no strategy refresh yet)"| SR["Strategy Refresh\n(CONTINUE / ADJUST / ESCALATE)"]
     READ -->|"Fresh start"| PA["Phase A: Review +\nDecomposition"]
     READ -->|"Phase A done,\nsteps incomplete"| PB["Phase B: Step\nImplementation"]
-    READ -->|"All steps done,\ncode review incomplete"| PC["Phase C: Track-Level\nCode Review"]
-    READ -->|"All phases done,\nplan not updated"| TC["Track Completion\nProtocol"]
+    READ -->|"All steps done,\ncode review incomplete\nor track not marked [x]"| PC["Phase C: Code Review\n+ Track Completion"]
     READ -->|"All tracks done,\nPhase 4 not complete"| P4["Phase 4: Final\nDesign Document"]
 
     SR -->|CONTINUE / ADJUST| PA
@@ -62,9 +67,9 @@ flowchart TD
 
     PA --> END_A["Session ends\n(Phase A complete)"]
     PB --> END_B["Session ends\n(Phase B complete)"]
-    PC --> END_C["Session ends\n(Phase C complete)"]
 
-    TC --> PRESENT["Present track results\nUser reviews"]
+    PC --> REVIEW["Code review\n+ plan corrections"]
+    REVIEW --> PRESENT["Present track results\nUser reviews"]
     PRESENT -->|Approved| END_TRACK["Session ends\n(track complete)"]
     PRESENT -->|"Fixes needed"| FIX["Apply fixes"] --> PRESENT
     PRESENT -->|"Fundamental rework"| REPLAN
@@ -73,7 +78,6 @@ flowchart TD
 
     END_A -->|"Next session"| START
     END_B -->|"Next session"| START
-    END_C -->|"Next session"| START
     END_TRACK -->|"Next session"| START
     END_P4 -->|"All done"| DONE["Workflow complete"]
 ```
@@ -116,8 +120,8 @@ perspective on cross-track impact.
    | `Review + decomposition` is `[ ]` | Re-run only missing reviews, then decompose |
    | `Review + decomposition` is `[x]`, steps partially complete | Resume from next `[ ]` step (see step-implementation.md §Phase B Resume for orphan commit recovery) |
    | Steps contain `[!]` (failed) entries | Check if a retry `[ ]` step follows — if yes, resume from retry. If no retry step, present failed episode to user |
-   | All steps `[x]`, code review `[ ]` or partial | Run Phase C from current iteration |
-   | All phases `[x]` | Track completion — compile episode, present to user for approval |
+   | All steps `[x]`, code review `[ ]` or partial | Run Phase C from current iteration (includes track completion after review) |
+   | All steps `[x]`, code review `[x]`, track still `[ ]` in plan | Resume track completion — compile episode, present to user for approval |
 
    Each resume handles exactly **one phase** — end session after that phase.
 
@@ -197,15 +201,13 @@ exactly one phase:
   tested, committed, and have episodes. `Step implementation` is marked
   `[x]`. Session ends. Next session starts Phase C.
 
-- **After Phase C (track-level code review)** — review is complete,
-  `Track-level code review` is marked `[x]`. Session ends. Next session
-  writes the track episode and presents results to the user.
-
-- **After track completion** — user approved, track episode written and
-  track marked `[x]` (single commit after approval). Session ends. Strategy
-  refresh happens in the next session. If session is interrupted before
-  user approval, the next session re-enters the Track Completion Protocol
-  (all phases `[x]` in step file, track still `[ ]` in plan file).
+- **After Phase C (code review + track completion)** — review is complete,
+  plan corrections committed (if any), user approved track results, track
+  episode written and track marked `[x]` (single commit after approval).
+  Session ends. Strategy refresh happens in the next session. If session
+  is interrupted before user approval, the next session re-enters Phase C
+  at the track completion stage (all phases `[x]` in step file, track
+  still `[ ]` in plan file).
 
 - **Mid-Phase B checkpoint** — if you've completed 5+ steps and the track
   has more steps remaining, suggest ending the session. The step file with
@@ -291,9 +293,9 @@ User interaction points:
 |---|---|---|
 | **Session start** | Auto-resume decision (which track, which phase) | Confirm or override |
 | **Strategy refresh** | Assessment report (CONTINUE / ADJUST / ESCALATE) | Accept or override |
-| **Phase complete** | Phase summary, what was done, next phase | User clears session, re-runs `/execute-tracks` |
+| **Phase A/B complete** | Phase summary, what was done, next phase | User clears session, re-runs `/execute-tracks` |
 | **Cross-track impact** | Which tracks affected, what broke, recommendation | Continue, pause, or escalate |
-| **Track complete** | Track episode, step episodes, git log of commits | Approve, request fixes, or rework |
+| **Track complete (end of Phase C)** | Track episode, step episodes, git log of commits, plan corrections | Approve, request fixes, or rework |
 | **Step failure (2nd attempt)** | What failed twice, what was tried, options | Retry differently, adjust, or escalate |
 | **Design decision needed** | Alternatives with trade-offs, recommendation | Choose an alternative or provide guidance |
 
@@ -343,48 +345,11 @@ propose → review → iterate cycle.
 
 ## Track Completion Protocol
 
-After track-level code review passes (or max iterations):
+Track completion is part of Phase C — it runs in the same session as the
+track-level code review, after the review loop and any plan corrections.
 
-1. **Compile the track episode** from all step episodes in the step file.
-   The track episode is a strategic summary — what was built, key
-   discoveries, plan deviations with cross-track impact.
-
-2. **Present track results to the user** (do NOT write to plan file yet):
-   - Track episode (compiled but not yet persisted)
-   - All step episodes from the step file
-   - Git log of track commits
-   - Any unresolved track-level code review findings
-
-3. **Wait for user response:**
-   - **Approved** — proceed to step 4.
-   - **Fixes needed** — apply the user's specific fixes as additional
-     commits. Re-run track-level code review if fixes are substantial.
-     Re-compile the track episode if fixes changed outcomes.
-     Present updated results and wait again.
-   - **Fundamental rework** — trigger ESCALATE.
-
-4. **Write the track episode and mark `[x]`** in the plan file (single
-   commit, only after user approval):
-
-   ```markdown
-   - [x] Track N: <title>
-     > <description>
-     >
-     > **Track episode:**
-     > <strategic summary — length proportional to cross-track impact>
-     >
-     > **Step file:** `tracks/track-N.md` (M steps, K failed)
-   ```
-
-5. **Session ends.** Strategy refresh happens next session.
-
-**Why deferred write:** Writing the track episode and marking `[x]` before
-user approval creates a state that cannot be reliably resumed — if the
-session ends between marking `[x]` and receiving approval, the next session
-detects the track as complete (State A: strategy refresh needed) and skips
-user review entirely. By deferring the plan file write, an interrupted
-session simply re-enters the Track Completion Protocol on resume (all
-phases `[x]` in the step file, track still `[ ]` in the plan file).
+**Full protocol:** [`track-code-review.md`](track-code-review.md) §Track
+Completion.
 
 ---
 
@@ -425,7 +390,7 @@ For other workflow components, see:
   resume (review fix, episode, step file updates)
 - **`track-review.md`** — Phase A: review + decomposition
 - **`step-implementation.md`** — Phase B: step implementation
-- **`track-code-review.md`** — Phase C: track-level code review
+- **`track-code-review.md`** — Phase C: code review + track completion
 - **`planning.md`** — Phase 1 (planning)
 - **`implementation-review.md`** — Phase 2 (implementation review: consistency + structural)
 - **`prompts/create-final-design.md`** — Phase 4 (final design document)


### PR DESCRIPTION
## Summary
- During Phase C (track-level code review), dimensional review agents may find issues that are real but out of scope for the current track
- Previously these findings had no defined handling — they could be silently dropped
- Adds a "Plan Corrections from Deferred Findings" section to `track-code-review.md` that instructs the main agent to update `implementation-plan.md` by adding deferred items to existing future tracks or creating new tracks

## Test plan
- [ ] Verify the new section integrates correctly in the Phase C flow (between review loop and Phase C Completion)
- [ ] Confirm no changes needed in review prompts or conventions — sub-agents produce findings as before, the main agent handles categorization