### PR TITLE
YTDB: Fix Grafana JMH dashboard and add regression alerting

### DIFF
--- a/jmh-ldbc/grafana/dashboards/ldbc-jmh.json
+++ b/jmh-ldbc/grafana/dashboards/ldbc-jmh.json
@@ -48,7 +48,7 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])",
+          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])",
           "refId": "A"
         }
       ]
@@ -83,7 +83,7 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])",
+          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])",
           "refId": "A"
         }
       ]
@@ -127,116 +127,125 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"scalability\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"ratio\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])",
+          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"scalability\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"ratio\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])",
           "refId": "A"
         }
       ]
     },
     {
-      "title": "Latest vs Previous Run (Single-Thread)",
-      "description": "Delta table comparing the last two runs",
+      "title": "Run-over-Run History (Single-Thread)",
+      "description": "Last 14 nightly runs with run-over-run percentage change. Green = improvement, red = regression.",
       "type": "table",
-      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 30 },
-      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": [
-          {
-            "matcher": { "id": "byName", "options": "delta_pct" },
-            "properties": [
-              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
-              { "id": "thresholds", "value": { "mode": "absolute", "steps": [
-                { "color": "red", "value": null },
-                { "color": "yellow", "value": -5 },
-                { "color": "green", "value": 0 }
-              ]}}
-            ]
-          }
-        ]
-      },
-      "options": {
-        "showHeader": true,
-        "sortBy": [{ "displayName": "query", "desc": false }]
-      },
-      "targets": [
-        {
-          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "latest = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -30d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> last()\n  |> set(key: \"run\", value: \"latest\")\n\nprevious = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -30d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"], desc: true)\n  |> limit(n: 2)\n  |> last()\n  |> set(key: \"run\", value: \"previous\")\n\nunion(tables: [latest, previous])\n  |> pivot(rowKey: [\"query\"], columnKey: [\"run\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({\n      query: r.query,\n      latest: r.latest,\n      previous: r.previous,\n      delta_pct: if r.previous > 0.0 then (r.latest - r.previous) / r.previous * 100.0 else 0.0\n  }))",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "Latest vs Previous Run (Multi-Thread)",
-      "description": "Delta table comparing the last two runs",
-      "type": "table",
-      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 30 },
-      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": [
-          {
-            "matcher": { "id": "byName", "options": "delta_pct" },
-            "properties": [
-              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
-              { "id": "thresholds", "value": { "mode": "absolute", "steps": [
-                { "color": "red", "value": null },
-                { "color": "yellow", "value": -5 },
-                { "color": "green", "value": 0 }
-              ]}}
-            ]
-          }
-        ]
-      },
-      "options": {
-        "showHeader": true,
-        "sortBy": [{ "displayName": "query", "desc": false }]
-      },
-      "targets": [
-        {
-          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "latest = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -30d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> last()\n  |> set(key: \"run\", value: \"latest\")\n\nprevious = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -30d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"], desc: true)\n  |> limit(n: 2)\n  |> last()\n  |> set(key: \"run\", value: \"previous\")\n\nunion(tables: [latest, previous])\n  |> pivot(rowKey: [\"query\"], columnKey: [\"run\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({\n      query: r.query,\n      latest: r.latest,\n      previous: r.previous,\n      delta_pct: if r.previous > 0.0 then (r.latest - r.previous) / r.previous * 100.0 else 0.0\n  }))",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "title": "Per-Query Detail: ${query}",
-      "description": "Score with error band for the selected query",
-      "type": "timeseries",
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 42 },
+      "gridPos": { "h": 16, "w": 12, "x": 0, "y": 30 },
       "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": {
-            "axisBorderShow": false,
-            "axisLabel": "ops/s",
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "always"
-          },
-          "unit": "ops",
-          "links": [
-            {
-              "title": "View commit",
-              "url": "https://github.com/JetBrains/youtrackdb/commit/${__data.fields.commit_sha}",
-              "targetBlank": true
-            }
-          ]
+          "custom": { "align": "auto" }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "delta_pct" },
+            "properties": [
+              { "id": "displayName", "value": "\u0394%" },
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [
+                { "color": "red", "value": null },
+                { "color": "yellow", "value": -5 },
+                { "color": "green", "value": 0 }
+              ]}}
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "score" },
+            "properties": [
+              { "id": "displayName", "value": "Score (ops/s)" },
+              { "id": "unit", "value": "ops" },
+              { "id": "decimals", "value": 1 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "_time" },
+            "properties": [
+              { "id": "displayName", "value": "Run Date" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "query" },
+            "properties": [
+              { "id": "displayName", "value": "Query" }
+            ]
+          }
+        ]
       },
       "options": {
-        "legend": { "calcs": ["lastNotNull", "min", "max", "mean"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Query", "desc": false }, { "displayName": "Run Date", "desc": true }]
       },
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.query == \"${query}\")\n  |> filter(fn: (r) => r.suite =~ /${suite}/)\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\" or r._field == \"score_error\")\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> map(fn: (r) => ({\n      r with\n      _value: r.score,\n      score_low: r.score - r.score_error,\n      score_high: r.score + r.score_error\n  }))",
+          "query": "base = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -90d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> tail(n: 15)\n\nscores = base\n  |> tail(n: 14)\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\ndiffs = base\n  |> difference(columns: [\"_value\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\njoin(tables: {s: scores, d: diffs}, on: [\"_time\", \"query\"])\n  |> map(fn: (r) => ({\n      _time: r._time,\n      query: r.query,\n      score: r._value_s,\n      delta_pct: if (r._value_s - r._value_d) > 0.0 then r._value_d / (r._value_s - r._value_d) * 100.0 else 0.0\n  }))\n  |> sort(columns: [\"query\", \"_time\"], desc: false)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Run-over-Run History (Multi-Thread)",
+      "description": "Last 14 nightly runs with run-over-run percentage change. Green = improvement, red = regression.",
+      "type": "table",
+      "gridPos": { "h": 16, "w": 12, "x": 12, "y": 30 },
+      "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "delta_pct" },
+            "properties": [
+              { "id": "displayName", "value": "\u0394%" },
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [
+                { "color": "red", "value": null },
+                { "color": "yellow", "value": -5 },
+                { "color": "green", "value": 0 }
+              ]}}
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "score" },
+            "properties": [
+              { "id": "displayName", "value": "Score (ops/s)" },
+              { "id": "unit", "value": "ops" },
+              { "id": "decimals", "value": 1 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "_time" },
+            "properties": [
+              { "id": "displayName", "value": "Run Date" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "query" },
+            "properties": [
+              { "id": "displayName", "value": "Query" }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Query", "desc": false }, { "displayName": "Run Date", "desc": true }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+          "query": "base = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -90d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> tail(n: 15)\n\nscores = base\n  |> tail(n: 14)\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\ndiffs = base\n  |> difference(columns: [\"_value\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\njoin(tables: {s: scores, d: diffs}, on: [\"_time\", \"query\"])\n  |> map(fn: (r) => ({\n      _time: r._time,\n      query: r.query,\n      score: r._value_s,\n      delta_pct: if (r._value_s - r._value_d) > 0.0 then r._value_d / (r._value_s - r._value_d) * 100.0 else 0.0\n  }))\n  |> sort(columns: [\"query\", \"_time\"], desc: false)",
           "refId": "A"
         }
       ]
@@ -257,26 +266,49 @@
       {
         "current": { "selected": false, "text": "develop", "value": "develop" },
         "name": "branch",
+        "label": "Branch",
         "type": "custom",
         "query": "develop,main,.*",
+        "options": [
+          { "selected": true, "text": "develop", "value": "develop" },
+          { "selected": false, "text": "main", "value": "main" },
+          { "selected": false, "text": ".*", "value": ".*" }
+        ],
         "includeAll": false,
         "multi": false
       },
-      {
-        "name": "suite",
-        "type": "custom",
-        "query": "SingleThread,MultiThread,.*",
-        "current": { "selected": false, "text": ".*", "value": ".*" },
-        "includeAll": false,
-        "multi": false
-      },
-      {
+{
         "name": "query",
+        "label": "Query",
         "type": "custom",
         "query": "is1_personProfile,is2_personPosts,is3_personFriends,is4_messageContent,is5_messageCreator,is6_messageForum,is7_messageReplies,ic1_transitiveFriends,ic2_recentFriendMessages,ic3_friendsInCountries,ic4_newTopics,ic5_newGroups,ic6_tagCoOccurrence,ic7_recentLikers,ic8_recentReplies,ic9_recentFofMessages,ic10_friendRecommendation,ic11_jobReferral,ic12_expertSearch,ic13_shortestPath",
-        "current": { "selected": false, "text": "is1_personProfile", "value": "is1_personProfile" },
-        "includeAll": false,
-        "multi": false
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "options": [
+          { "selected": true, "text": "All", "value": "$__all" },
+          { "selected": false, "text": "is1_personProfile", "value": "is1_personProfile" },
+          { "selected": false, "text": "is2_personPosts", "value": "is2_personPosts" },
+          { "selected": false, "text": "is3_personFriends", "value": "is3_personFriends" },
+          { "selected": false, "text": "is4_messageContent", "value": "is4_messageContent" },
+          { "selected": false, "text": "is5_messageCreator", "value": "is5_messageCreator" },
+          { "selected": false, "text": "is6_messageForum", "value": "is6_messageForum" },
+          { "selected": false, "text": "is7_messageReplies", "value": "is7_messageReplies" },
+          { "selected": false, "text": "ic1_transitiveFriends", "value": "ic1_transitiveFriends" },
+          { "selected": false, "text": "ic2_recentFriendMessages", "value": "ic2_recentFriendMessages" },
+          { "selected": false, "text": "ic3_friendsInCountries", "value": "ic3_friendsInCountries" },
+          { "selected": false, "text": "ic4_newTopics", "value": "ic4_newTopics" },
+          { "selected": false, "text": "ic5_newGroups", "value": "ic5_newGroups" },
+          { "selected": false, "text": "ic6_tagCoOccurrence", "value": "ic6_tagCoOccurrence" },
+          { "selected": false, "text": "ic7_recentLikers", "value": "ic7_recentLikers" },
+          { "selected": false, "text": "ic8_recentReplies", "value": "ic8_recentReplies" },
+          { "selected": false, "text": "ic9_recentFofMessages", "value": "ic9_recentFofMessages" },
+          { "selected": false, "text": "ic10_friendRecommendation", "value": "ic10_friendRecommendation" },
+          { "selected": false, "text": "ic11_jobReferral", "value": "ic11_jobReferral" },
+          { "selected": false, "text": "ic12_expertSearch", "value": "ic12_expertSearch" },
+          { "selected": false, "text": "ic13_shortestPath", "value": "ic13_shortestPath" }
+        ],
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true
       }
     ]
   },

--- a/jmh-ldbc/grafana/docker-compose.yml
+++ b/jmh-ldbc/grafana/docker-compose.yml
@@ -45,6 +45,8 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - INFLUXDB_ADMIN_TOKEN=${INFLUXDB_ADMIN_TOKEN}
+      - ZULIP_API_KEY=${ZULIP_API_KEY}
     depends_on:
       - influxdb
 

--- a/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
+++ b/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
@@ -1,0 +1,283 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: jmh-benchmark-regressions
+    folder: JMH Alerts
+    interval: 1h
+    rules:
+      # ── Run-over-run regression (>10% drop vs previous nightly) ──
+      - uid: jmh-run-over-run-regression
+        title: "JMH run-over-run regression (>10% drop)"
+        condition: C
+        for: 0s
+        annotations:
+          summary: >-
+            Benchmark {{ $labels.query }} ({{ $labels.suite }}) dropped
+            {{ printf "%.1f" $values.B.Value }}% vs the previous run.
+          description: >-
+            The latest nightly benchmark score is more than 10% below
+            the previous run. Check the dashboard for details.
+          dashboard_url: https://bench.youtrackdb.io
+        labels:
+          severity: warning
+        noDataState: OK
+        execErrState: OK
+        data:
+          # Query B: compute delta_pct per query+suite in Flux
+          - refId: B
+            relativeTimeRange:
+              from: 7776000  # 90 days in seconds
+              to: 0
+            datasourceUid: "P951FEA4DE68E13C5"
+            model:
+              refId: B
+              datasource:
+                type: influxdb
+                uid: "P951FEA4DE68E13C5"
+              query: |
+                // Noise suppression: exclude benchmarks where score_error > 10% of score
+                noise = from(bucket: "jmh-benchmarks")
+                  |> range(start: -30d)
+                  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
+                  |> filter(fn: (r) => r.branch == "develop")
+                  |> filter(fn: (r) => r._field == "score" or r._field == "score_error")
+                  |> group(columns: ["query", "suite"])
+                  |> sort(columns: ["_time"], desc: true)
+                  |> limit(n: 2)
+                  |> first()
+                  |> group(columns: ["query", "suite"])
+                  |> pivot(rowKey: ["query", "suite"], columnKey: ["_field"], valueColumn: "_value")
+                  |> filter(fn: (r) => r.score > 0.0 and r.score_error / r.score <= 0.10)
+                  |> keep(columns: ["query", "suite"])
+                  |> group()
+
+                base = from(bucket: "jmh-benchmarks")
+                  |> range(start: -30d)
+                  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
+                  |> filter(fn: (r) => r.branch == "develop")
+                  |> filter(fn: (r) => r._field == "score")
+                  |> group(columns: ["query", "suite"])
+                  |> sort(columns: ["_time"], desc: true)
+                  |> limit(n: 2)
+
+                latest = base
+                  |> first()
+                  |> keep(columns: ["_value", "query", "suite"])
+                  |> group()
+
+                previous = base
+                  |> last()
+                  |> keep(columns: ["_value", "query", "suite"])
+                  |> group()
+
+                delta = join(tables: {l: latest, p: previous}, on: ["query", "suite"])
+                  |> map(fn: (r) => ({
+                    _time: now(),
+                    query: r.query,
+                    suite: r.suite,
+                    _value: if r._value_p > 0.0
+                      then (r._value_l - r._value_p) / r._value_p * 100.0
+                      else 0.0,
+                  }))
+
+                // Keep only non-noisy benchmarks
+                join(tables: {d: delta, n: noise}, on: ["query", "suite"])
+                  |> map(fn: (r) => ({
+                    _time: r._time,
+                    query: r.query,
+                    suite: r.suite,
+                    _value: r._value_d,
+                  }))
+                  |> group(columns: ["query", "suite"])
+          # Reduce: extract the single value from each series
+          - refId: A
+            relativeTimeRange:
+              from: 7776000
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: A
+              type: reduce
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    type: last
+              expression: B
+              reducer: last
+              settings:
+                mode: ""
+          # Threshold: fire if delta_pct < -10 (more than 10% regression)
+          - refId: C
+            relativeTimeRange:
+              from: 7776000
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params:
+                      - -10
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    type: last
+              expression: A
+
+      # ── Below 14-run rolling average (>5% drop) ──
+      - uid: jmh-below-rolling-average
+        title: "JMH below 14-run average (>5% drop)"
+        condition: C
+        for: 0s
+        annotations:
+          summary: >-
+            Benchmark {{ $labels.query }} ({{ $labels.suite }}) is
+            {{ printf "%.1f" $values.B.Value }}% below the 14-run average.
+          description: >-
+            The latest nightly benchmark score is more than 5% below
+            the 14-run rolling average. This may indicate a gradual
+            regression. Check the dashboard for details.
+          dashboard_url: https://bench.youtrackdb.io
+        labels:
+          severity: warning
+        noDataState: OK
+        execErrState: OK
+        data:
+          # Query B: compute delta_pct (latest vs 14-run avg) per query+suite
+          - refId: B
+            relativeTimeRange:
+              from: 7776000
+              to: 0
+            datasourceUid: "P951FEA4DE68E13C5"
+            model:
+              refId: B
+              datasource:
+                type: influxdb
+                uid: "P951FEA4DE68E13C5"
+              query: |
+                // Noise suppression: exclude benchmarks where score_error > 10% of score
+                noise = from(bucket: "jmh-benchmarks")
+                  |> range(start: -90d)
+                  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
+                  |> filter(fn: (r) => r.branch == "develop")
+                  |> filter(fn: (r) => r._field == "score" or r._field == "score_error")
+                  |> group(columns: ["query", "suite"])
+                  |> sort(columns: ["_time"], desc: true)
+                  |> limit(n: 2)
+                  |> first()
+                  |> group(columns: ["query", "suite"])
+                  |> pivot(rowKey: ["query", "suite"], columnKey: ["_field"], valueColumn: "_value")
+                  |> filter(fn: (r) => r.score > 0.0 and r.score_error / r.score <= 0.10)
+                  |> keep(columns: ["query", "suite"])
+                  |> group()
+
+                base = from(bucket: "jmh-benchmarks")
+                  |> range(start: -90d)
+                  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
+                  |> filter(fn: (r) => r.branch == "develop")
+                  |> filter(fn: (r) => r._field == "score")
+                  |> group(columns: ["query", "suite"])
+                  |> sort(columns: ["_time"], desc: true)
+                  |> limit(n: 15)
+
+                latest = base
+                  |> first()
+                  |> keep(columns: ["_value", "query", "suite"])
+                  |> group()
+
+                avg14 = base
+                  |> tail(n: 14)
+                  |> mean()
+                  |> keep(columns: ["_value", "query", "suite"])
+                  |> group()
+
+                delta = join(tables: {l: latest, a: avg14}, on: ["query", "suite"])
+                  |> map(fn: (r) => ({
+                    _time: now(),
+                    query: r.query,
+                    suite: r.suite,
+                    _value: if r._value_a > 0.0
+                      then (r._value_l - r._value_a) / r._value_a * 100.0
+                      else 0.0,
+                  }))
+
+                // Keep only non-noisy benchmarks
+                join(tables: {d: delta, n: noise}, on: ["query", "suite"])
+                  |> map(fn: (r) => ({
+                    _time: r._time,
+                    query: r.query,
+                    suite: r.suite,
+                    _value: r._value_d,
+                  }))
+                  |> group(columns: ["query", "suite"])
+          # Reduce: extract the single value from each series
+          - refId: A
+            relativeTimeRange:
+              from: 7776000
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: A
+              type: reduce
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    type: last
+              expression: B
+              reducer: last
+              settings:
+                mode: ""
+          # Threshold: fire if delta_pct < -5 (more than 5% below average)
+          - refId: C
+            relativeTimeRange:
+              from: 7776000
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params:
+                      - -5
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    type: last
+              expression: A

--- a/jmh-ldbc/grafana/provisioning/alerting/contact-points.yaml
+++ b/jmh-ldbc/grafana/provisioning/alerting/contact-points.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: zulip-jmh-bench
+    receivers:
+      - uid: zulip-jmh-bench-webhook
+        type: webhook
+        settings:
+          url: >-
+            https://youtrackdb.zulipchat.com/api/v1/external/grafana?api_key=${ZULIP_API_KEY}&stream=ytdb&topic=jmh-ldbc-bench
+          httpMethod: POST

--- a/jmh-ldbc/grafana/provisioning/alerting/notification-policies.yaml
+++ b/jmh-ldbc/grafana/provisioning/alerting/notification-policies.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: zulip-jmh-bench
+    group_by:
+      - alertname
+      - suite
+    group_wait: 1m
+    group_interval: 10m
+    repeat_interval: 24h

--- a/jmh-ldbc/jmh-regression-alert.py
+++ b/jmh-ldbc/jmh-regression-alert.py
@@ -4,6 +4,7 @@
 import argparse
 import json
 import sys
+import urllib.parse
 import urllib.request
 import urllib.error
 import base64
@@ -249,9 +250,6 @@ def send_zulip_message(content, zulip_url, api_key, bot_email, stream, topic):
         print(f"Zulip API error: {e.code} - {body_text}", file=sys.stderr)
         sys.exit(1)
 
-
-# Need urllib.parse for urlencode
-import urllib.parse
 
 
 def main():

--- a/jmh-ldbc/jmh-regression-alert.py
+++ b/jmh-ldbc/jmh-regression-alert.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Check JMH results for performance regressions and alert via Zulip."""
+
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.error
+import base64
+
+
+def parse_latest_results(data):
+    """Parse JMH JSON into {(query, suite): {score, score_error}} dict."""
+    results = {}
+    for entry in data:
+        parts = entry["benchmark"].rsplit(".", 2)
+        class_name = parts[-2]
+        method_name = parts[-1]
+
+        if "SingleThread" in class_name:
+            suite = "SingleThread"
+        elif "MultiThread" in class_name:
+            suite = "MultiThread"
+        else:
+            suite = class_name
+
+        primary = entry.get("primaryMetric", {})
+        score = primary.get("score", 0)
+        score_error = primary.get("scoreError", 0)
+
+        results[(method_name, suite)] = {
+            "score": score,
+            "score_error": score_error,
+        }
+    return results
+
+
+def query_influxdb(url, token, org, bucket, suite, branch, limit):
+    """Query InfluxDB for the last N scores per query (excluding the latest push)."""
+    # Get historical data: last `limit` runs before the most recent
+    flux = f'''
+from(bucket: "{bucket}")
+  |> range(start: -90d)
+  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
+  |> filter(fn: (r) => r.suite == "{suite}")
+  |> filter(fn: (r) => r.branch == "{branch}")
+  |> filter(fn: (r) => r._field == "score")
+  |> group(columns: ["query"])
+  |> sort(columns: ["_time"], desc: true)
+  |> limit(n: {limit})
+  |> sort(columns: ["_time"])
+  |> keep(columns: ["_time", "_value", "query"])
+'''
+    query_url = f"{url.rstrip('/')}/api/v2/query?org={org}"
+    body = json.dumps({"query": flux, "type": "flux"}).encode("utf-8")
+    req = urllib.request.Request(
+        query_url,
+        data=body,
+        headers={
+            "Authorization": f"Token {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/csv",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            csv_data = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")
+        print(f"InfluxDB query failed: {e.code} - {body_text}", file=sys.stderr)
+        return {}
+
+    return parse_influx_csv(csv_data)
+
+
+def parse_influx_csv(csv_data):
+    """Parse InfluxDB CSV response into {query: [scores_oldest_first]} dict.
+
+    InfluxDB annotated CSV format:
+      ,result,table,_time,_value,query
+      ,_result,0,2026-03-21T03:48:00Z,56216.45,is1_personProfile
+    """
+    history = {}
+    header_cols = None
+    value_idx = None
+    query_idx = None
+
+    for line in csv_data.strip().splitlines():
+        # Skip annotation rows
+        if line.startswith("#"):
+            continue
+        # Skip empty lines
+        if not line.strip():
+            continue
+
+        parts = [p.strip() for p in line.split(",")]
+
+        # Detect header row (contains column names)
+        if "_value" in parts and "query" in parts:
+            header_cols = parts
+            value_idx = parts.index("_value")
+            query_idx = parts.index("query")
+            continue
+
+        # Parse data rows
+        if value_idx is not None and query_idx is not None and len(parts) > max(
+            value_idx, query_idx
+        ):
+            try:
+                value = float(parts[value_idx])
+                query = parts[query_idx].strip()
+                if query:
+                    history.setdefault(query, []).append(value)
+            except (ValueError, IndexError):
+                continue
+
+    return history
+
+
+def check_regressions(latest, history, run_over_run_pct, avg_pct, noise_threshold):
+    """Check for regressions. Returns list of regression dicts."""
+    regressions = []
+
+    for (query, suite), data in latest.items():
+        score = data["score"]
+        score_error = data["score_error"]
+
+        # Skip noisy benchmarks (score_error > noise_threshold% of score)
+        if score > 0 and (score_error / score) > (noise_threshold / 100.0):
+            continue
+
+        hist = history.get(suite, {}).get(query, [])
+        if not hist:
+            continue
+
+        # Run-over-run check: compare with the most recent historical run
+        prev_score = hist[-1]
+        if prev_score > 0:
+            ror_delta = (score - prev_score) / prev_score * 100.0
+            if ror_delta < -run_over_run_pct:
+                regressions.append({
+                    "query": query,
+                    "suite": suite,
+                    "type": "run-over-run",
+                    "score": score,
+                    "baseline": prev_score,
+                    "delta_pct": ror_delta,
+                    "threshold": -run_over_run_pct,
+                })
+
+        # vs 14-run average check
+        if len(hist) >= 3:  # need at least 3 data points for meaningful average
+            avg = sum(hist) / len(hist)
+            if avg > 0:
+                avg_delta = (score - avg) / avg * 100.0
+                if avg_delta < -avg_pct:
+                    regressions.append({
+                        "query": query,
+                        "suite": suite,
+                        "type": f"vs {len(hist)}-run avg",
+                        "score": score,
+                        "baseline": avg,
+                        "delta_pct": avg_delta,
+                        "threshold": -avg_pct,
+                    })
+
+    return regressions
+
+
+def format_zulip_message(regressions, branch, commit_sha, dashboard_url):
+    """Format regressions into a Zulip markdown message."""
+    lines = [
+        ":warning: **JMH Benchmark Regression Detected**",
+        "",
+        f"**Branch:** `{branch}` | "
+        f"**Commit:** [{commit_sha[:8]}]"
+        f"(https://github.com/JetBrains/youtrackdb/commit/{commit_sha})",
+        "",
+    ]
+
+    # Group by type
+    ror = [r for r in regressions if r["type"] == "run-over-run"]
+    avg = [r for r in regressions if r["type"] != "run-over-run"]
+
+    if ror:
+        lines.append("### Run-over-run regressions (>10% drop vs previous)")
+        lines.append("")
+        lines.append("| Query | Suite | Score | Previous | \u0394% |")
+        lines.append("|---|---|---|---|---|")
+        for r in sorted(ror, key=lambda x: x["delta_pct"]):
+            lines.append(
+                f"| `{r['query']}` | {r['suite']} | "
+                f"{r['score']:.1f} | {r['baseline']:.1f} | "
+                f"**{r['delta_pct']:+.1f}%** |"
+            )
+        lines.append("")
+
+    if avg:
+        lines.append("### Below rolling average (>5% drop vs 14-run avg)")
+        lines.append("")
+        lines.append("| Query | Suite | Score | Avg | \u0394% |")
+        lines.append("|---|---|---|---|---|")
+        for r in sorted(avg, key=lambda x: x["delta_pct"]):
+            lines.append(
+                f"| `{r['query']}` | {r['suite']} | "
+                f"{r['score']:.1f} | {r['baseline']:.1f} | "
+                f"**{r['delta_pct']:+.1f}%** |"
+            )
+        lines.append("")
+
+    lines.append(f":bar_chart: [Dashboard]({dashboard_url})")
+
+    return "\n".join(lines)
+
+
+def send_zulip_message(content, zulip_url, api_key, bot_email, stream, topic):
+    """Send a message to Zulip via the API."""
+    url = f"{zulip_url.rstrip('/')}/api/v1/messages"
+    params = urllib.parse.urlencode({
+        "type": "stream",
+        "to": stream,
+        "topic": topic,
+        "content": content,
+    }).encode("utf-8")
+
+    credentials = base64.b64encode(
+        f"{bot_email}:{api_key}".encode("utf-8")
+    ).decode("utf-8")
+
+    req = urllib.request.Request(
+        url,
+        data=params,
+        headers={
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+            if result.get("result") == "success":
+                print(f"Zulip message sent (id={result.get('id')})")
+            else:
+                print(f"Zulip response: {result}", file=sys.stderr)
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace")
+        print(f"Zulip API error: {e.code} - {body_text}", file=sys.stderr)
+        sys.exit(1)
+
+
+# Need urllib.parse for urlencode
+import urllib.parse
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check JMH results for regressions and alert via Zulip"
+    )
+    parser.add_argument("--input", required=True, help="JMH JSON results file")
+    parser.add_argument("--influxdb-url", required=True, help="InfluxDB URL")
+    parser.add_argument("--influxdb-token", required=True, help="InfluxDB read token")
+    parser.add_argument("--influxdb-org", default="youtrackdb", help="InfluxDB org")
+    parser.add_argument(
+        "--influxdb-bucket", default="jmh-benchmarks", help="InfluxDB bucket"
+    )
+    parser.add_argument("--branch", required=True, help="Git branch name")
+    parser.add_argument("--commit-sha", required=True, help="Git commit SHA")
+    parser.add_argument(
+        "--run-over-run-threshold",
+        type=float,
+        default=10.0,
+        help="Run-over-run regression threshold in %% (default: 10)",
+    )
+    parser.add_argument(
+        "--avg-threshold",
+        type=float,
+        default=5.0,
+        help="Rolling average regression threshold in %% (default: 5)",
+    )
+    parser.add_argument(
+        "--history-size",
+        type=int,
+        default=14,
+        help="Number of historical runs to average (default: 14)",
+    )
+    parser.add_argument(
+        "--noise-threshold",
+        type=float,
+        default=10.0,
+        help="Skip benchmarks with score_error > N%% of score (default: 10)",
+    )
+    parser.add_argument(
+        "--zulip-url",
+        default="https://youtrackdb.zulipchat.com",
+        help="Zulip organization URL",
+    )
+    parser.add_argument("--zulip-api-key", required=True, help="Zulip bot API key")
+    parser.add_argument(
+        "--zulip-bot-email",
+        default="ci-status-bot@youtrackdb.zulipchat.com",
+        help="Zulip bot email",
+    )
+    parser.add_argument("--zulip-stream", default="ytdb", help="Zulip stream")
+    parser.add_argument(
+        "--zulip-topic", default="jmh-ldbc-bench", help="Zulip topic"
+    )
+    parser.add_argument(
+        "--dashboard-url",
+        default="https://bench.youtrackdb.io",
+        help="Grafana dashboard URL",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print message without sending"
+    )
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    latest = parse_latest_results(data)
+    print(f"Parsed {len(latest)} benchmark results from current run")
+
+    # Query historical data per suite
+    history = {}
+    for suite in ("SingleThread", "MultiThread"):
+        hist = query_influxdb(
+            args.influxdb_url,
+            args.influxdb_token,
+            args.influxdb_org,
+            args.influxdb_bucket,
+            suite,
+            args.branch,
+            args.history_size,
+        )
+        history[suite] = hist
+        total_points = sum(len(v) for v in hist.values())
+        print(f"Fetched {total_points} historical data points for {suite}")
+
+    regressions = check_regressions(
+        latest,
+        history,
+        args.run_over_run_threshold,
+        args.avg_threshold,
+        args.noise_threshold,
+    )
+
+    if not regressions:
+        print("No regressions detected. All clear.")
+        return
+
+    print(f"Detected {len(regressions)} regression(s)!")
+    message = format_zulip_message(
+        regressions, args.branch, args.commit_sha, args.dashboard_url
+    )
+
+    if args.dry_run:
+        print("\n--- Zulip message (dry run) ---")
+        print(message)
+        return
+
+    send_zulip_message(
+        message,
+        args.zulip_url,
+        args.zulip_api_key,
+        args.zulip_bot_email,
+        args.zulip_stream,
+        args.zulip_topic,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Fix dashboard legends**: Flux queries now use `|> keep()` to strip InfluxDB metadata columns, so legends show meaningful query names (e.g., `is1_personProfile`) instead of `_value {_start=..., _stop=...}`
- **Fix query filter dropdown**: Made the Query variable multi-select with proper `options` arrays and wired `${query:regex}` filter into all panels
- **Replace 2-run delta tables with 14-run history**: Tables now show the last 14 nightly runs with run-over-run Δ% for each benchmark
- **Add Grafana alerting to Zulip**: Two provisioned alert rules (run-over-run >10% drop, vs 14-run avg >5% drop) with noise suppression (skip benchmarks where score_error >10% of score). Notifications go to `ytdb` / `jmh-ldbc-bench` via Zulip's Grafana webhook integration.

## Changes

| File | What |
|---|---|
| `jmh-ldbc/grafana/dashboards/ldbc-jmh.json` | Dashboard fixes: legends, query filter, 14-run history tables |
| `jmh-ldbc/grafana/docker-compose.yml` | Pass `ZULIP_API_KEY` env to Grafana container |
| `jmh-ldbc/grafana/provisioning/alerting/*.yaml` | Contact point, notification policy, and alert rules |
| `jmh-ldbc/jmh-regression-alert.py` | Standalone CLI tool for manual regression checks |

## Test plan

- [x] Dashboard deployed to bench.youtrackdb.io and verified: legends show query names, Query dropdown filters all panels
- [x] Grafana alerting provisioned and verified: both rules show `inactive` state (no current regressions)
- [x] `jmh-regression-alert.py` tested with dry-run against real InfluxDB data — correctly detects regressions and formats Zulip messages
- [ ] Verify Zulip notification delivery on next nightly run that triggers a regression