### PR TITLE
YTDB-634: Lazy ExecutionStream 

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
@@ -249,35 +249,41 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
    */
   private void pushFrame(Result startingPoint, int depth,
       @Nullable PathNode pathToHere) {
-    // Save current context and set for this depth
+    // Save current context and set for this depth. If filter evaluation or
+    // path materialization throws, restore the context to avoid leaving it
+    // in an inconsistent state.
     var previousMatch = ctx.getSystemVariable(CommandContext.VAR_CURRENT_MATCH);
     ctx.setSystemVariable(CommandContext.VAR_DEPTH, depth);
     ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, startingPoint);
+    try {
+      var frame = new Frame(startingPoint, depth, pathToHere, previousMatch);
 
-    var frame = new Frame(startingPoint, depth, pathToHere, previousMatch);
-
-    // Evaluate self against filters
-    if (startingPoint != null
-        && MatchEdgeTraverser.matchesFilters(ctx, filter, startingPoint)
-        && MatchEdgeTraverser.matchesClass(ctx, className, startingPoint)
-        && MatchEdgeTraverser.matchesRid(ctx, targetRid, startingPoint)) {
-      ResultInternal rs;
-      if (startingPoint instanceof ResultInternal resultInternal) {
-        rs = resultInternal;
-      } else {
-        rs = ResultInternal.toResultInternal(startingPoint, session, null);
-      }
-      if (rs != null) {
-        rs.setMetadata("$depth", depth);
-        if (hasPathAlias) {
-          rs.setMetadata("$matchPath",
-              pathToHere == null ? PathNode.emptyPath() : pathToHere.toList());
+      // Evaluate self against filters
+      if (startingPoint != null
+          && MatchEdgeTraverser.matchesFilters(ctx, filter, startingPoint)
+          && MatchEdgeTraverser.matchesClass(ctx, className, startingPoint)
+          && MatchEdgeTraverser.matchesRid(ctx, targetRid, startingPoint)) {
+        ResultInternal rs;
+        if (startingPoint instanceof ResultInternal resultInternal) {
+          rs = resultInternal;
+        } else {
+          rs = ResultInternal.toResultInternal(startingPoint, session, null);
         }
-        frame.selfResult = rs;
+        if (rs != null) {
+          rs.setMetadata("$depth", depth);
+          if (hasPathAlias) {
+            rs.setMetadata("$matchPath",
+                pathToHere == null ? PathNode.emptyPath() : pathToHere.toList());
+          }
+          frame.selfResult = rs;
+        }
       }
-    }
 
-    stack.push(frame);
+      stack.push(frame);
+    } catch (Throwable t) {
+      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, previousMatch);
+      throw t;
+    }
   }
 
   private boolean shouldExpand(Frame frame) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
@@ -1,0 +1,289 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.RidSet;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import javax.annotation.Nullable;
+
+/**
+ * Lazy, pull-based {@link ExecutionStream} that replaces the eager ArrayList
+ * materialization in the recursive (WHILE / maxDepth) branch of
+ * {@link MatchEdgeTraverser#executeTraversal}.
+ *
+ * <p>Uses an explicit stack of {@link Frame}s to flatten the recursive DFS into
+ * a single iterator with O(1) call-stack depth — no recursive {@code hasNext()}
+ * chains regardless of traversal depth.
+ *
+ * <p>Each frame represents a node being visited at a given depth. A frame goes
+ * through two phases:
+ * <ol>
+ *   <li><b>SELF</b>: yield the node itself if it matches filters
+ *   <li><b>NEIGHBORS</b>: expand neighbors via {@code traversePatternEdge()},
+ *       pushing a new frame for each neighbor
+ * </ol>
+ *
+ * <p>This eliminates the O(total_results) ArrayList allocation and enables future
+ * LIMIT propagation: when the downstream consumer stops pulling, unexplored
+ * subtrees are never expanded.
+ */
+final class LazyRecursiveTraversalStream implements ExecutionStream {
+
+  /**
+   * A frame on the traversal stack, representing one node being explored.
+   * Tracks whether the node itself has been yielded (selfResult) and the
+   * neighbor iteration state (neighborStream).
+   */
+  private static final class Frame {
+    final Result startingPoint;
+    final int depth;
+    @Nullable final PathNode pathToHere;
+    final Object previousMatch;
+
+    // SELF phase: non-null if the starting point passes filters and hasn't
+    // been yielded yet
+    @Nullable Result selfResult;
+
+    // NEIGHBORS phase: the stream of immediate neighbors, null until
+    // expansion is initiated
+    @Nullable ExecutionStream neighborStream;
+
+    // True once neighbors have been checked (may still be null if
+    // shouldExpand was false)
+    boolean neighborsInitialized;
+
+    Frame(Result startingPoint, int depth, @Nullable PathNode pathToHere,
+        Object previousMatch) {
+      this.startingPoint = startingPoint;
+      this.depth = depth;
+      this.pathToHere = pathToHere;
+      this.previousMatch = previousMatch;
+    }
+  }
+
+  private final MatchEdgeTraverser traverser;
+  private final CommandContext ctx;
+
+  // Filter criteria — extracted once from the item
+  @Nullable private final SQLWhereClause filter;
+  @Nullable private final SQLWhereClause whileCondition;
+  @Nullable private final Integer maxDepth;
+  @Nullable private final String className;
+  @Nullable private final SQLRid targetRid;
+  private final boolean hasPathAlias;
+  @Nullable private final RidSet dedupVisited;
+
+  private final DatabaseSessionEmbedded session;
+
+  // Explicit DFS stack — replaces Java call-stack recursion
+  private final Deque<Frame> stack = new ArrayDeque<>();
+
+  // Buffered result ready for next()
+  @Nullable private Result buffered;
+  private boolean done;
+
+  LazyRecursiveTraversalStream(
+      MatchEdgeTraverser traverser,
+      CommandContext ctx,
+      Result startingPoint,
+      int depth,
+      @Nullable PathNode pathToHere,
+      @Nullable SQLWhereClause filter,
+      @Nullable SQLWhereClause whileCondition,
+      @Nullable Integer maxDepth,
+      @Nullable String className,
+      @Nullable SQLRid targetRid,
+      boolean hasPathAlias,
+      @Nullable RidSet dedupVisited) {
+
+    this.traverser = traverser;
+    this.ctx = ctx;
+    this.filter = filter;
+    this.whileCondition = whileCondition;
+    this.maxDepth = maxDepth;
+    this.className = className;
+    this.targetRid = targetRid;
+    this.hasPathAlias = hasPathAlias;
+    this.dedupVisited = dedupVisited;
+    this.session = ctx.getDatabaseSession();
+
+    // Push the root frame
+    pushFrame(startingPoint, depth, pathToHere);
+  }
+
+  @Override
+  public boolean hasNext(CommandContext ctx) {
+    if (buffered != null) {
+      return true;
+    }
+    if (done) {
+      return false;
+    }
+    buffered = advance();
+    return buffered != null;
+  }
+
+  @Override
+  public Result next(CommandContext ctx) {
+    if (!hasNext(ctx)) {
+      throw new IllegalStateException("No more results");
+    }
+    var result = buffered;
+    buffered = null;
+    return result;
+  }
+
+  @Override
+  public void close(CommandContext ctx) {
+    // Close all open neighbor streams on the stack
+    while (!stack.isEmpty()) {
+      var frame = stack.pop();
+      if (frame.neighborStream != null) {
+        frame.neighborStream.close(ctx);
+      }
+      // Restore context for each frame
+      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, frame.previousMatch);
+    }
+    done = true;
+  }
+
+  /**
+   * Advances the traversal by one result. Processes the stack iteratively:
+   * for each frame, first yields the self-result, then expands neighbors
+   * by pushing new frames.
+   */
+  @Nullable private Result advance() {
+    while (!stack.isEmpty()) {
+      var frame = stack.peek();
+
+      // Phase 1: yield the starting point if it matches filters
+      if (frame.selfResult != null) {
+        var result = frame.selfResult;
+        frame.selfResult = null;
+        return result;
+      }
+
+      // Phase 2: expand neighbors
+      if (!frame.neighborsInitialized) {
+        frame.neighborsInitialized = true;
+
+        if (shouldExpand(frame)) {
+          // Mark visited before expanding
+          if (dedupVisited != null) {
+            assert frame.startingPoint.getIdentity() != null
+                : "graph vertex identity must not be null";
+            dedupVisited.add(frame.startingPoint.getIdentity());
+          }
+
+          // Set context for traversePatternEdge
+          ctx.setSystemVariable(CommandContext.VAR_DEPTH, frame.depth);
+          ctx.setSystemVariable(
+              CommandContext.VAR_CURRENT_MATCH, frame.startingPoint);
+
+          frame.neighborStream =
+              traverser.traversePatternEdge(frame.startingPoint, ctx);
+        }
+      }
+
+      // Try to find the next valid neighbor and push its frame
+      if (frame.neighborStream != null) {
+        var pushed = pushNextNeighbor(frame);
+        if (pushed) {
+          // A new frame was pushed — loop back to process it (its self-result)
+          continue;
+        }
+      }
+
+      // This frame is fully exhausted — pop it and restore context
+      stack.pop();
+      if (frame.neighborStream != null) {
+        frame.neighborStream.close(ctx);
+      }
+      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, frame.previousMatch);
+    }
+
+    done = true;
+    return null;
+  }
+
+  /**
+   * Tries to find the next valid (non-null, non-deduped) neighbor from the
+   * frame's neighborStream and pushes a new frame for it.
+   *
+   * @return true if a new frame was pushed, false if no more neighbors
+   */
+  private boolean pushNextNeighbor(Frame frame) {
+    while (frame.neighborStream.hasNext(ctx)) {
+      var origin = ResultInternal.toResult(frame.neighborStream.next(ctx), session);
+      if (origin == null) {
+        continue;
+      }
+
+      // Dedup check
+      if (dedupVisited != null) {
+        var neighborRid = origin.getIdentity();
+        if (neighborRid != null && dedupVisited.contains(neighborRid)) {
+          continue;
+        }
+      }
+
+      // Build path if pathAlias is declared
+      var newPath =
+          hasPathAlias ? new PathNode(origin, frame.pathToHere, frame.depth) : null;
+
+      pushFrame(origin, frame.depth + 1, newPath);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Creates a new frame for the given node, evaluates it against filters,
+   * sets context variables, and pushes it onto the stack.
+   */
+  private void pushFrame(Result startingPoint, int depth,
+      @Nullable PathNode pathToHere) {
+    // Save current context and set for this depth
+    var previousMatch = ctx.getSystemVariable(CommandContext.VAR_CURRENT_MATCH);
+    ctx.setSystemVariable(CommandContext.VAR_DEPTH, depth);
+    ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, startingPoint);
+
+    var frame = new Frame(startingPoint, depth, pathToHere, previousMatch);
+
+    // Evaluate self against filters
+    if (startingPoint != null
+        && MatchEdgeTraverser.matchesFilters(ctx, filter, startingPoint)
+        && MatchEdgeTraverser.matchesClass(ctx, className, startingPoint)
+        && MatchEdgeTraverser.matchesRid(ctx, targetRid, startingPoint)) {
+      ResultInternal rs;
+      if (startingPoint instanceof ResultInternal resultInternal) {
+        rs = resultInternal;
+      } else {
+        rs = ResultInternal.toResultInternal(startingPoint, session, null);
+      }
+      if (rs != null) {
+        rs.setMetadata("$depth", depth);
+        if (hasPathAlias) {
+          rs.setMetadata("$matchPath",
+              pathToHere == null ? PathNode.emptyPath() : pathToHere.toList());
+        }
+        frame.selfResult = rs;
+      }
+    }
+
+    stack.push(frame);
+  }
+
+  private boolean shouldExpand(Frame frame) {
+    return frame.startingPoint != null
+        && (maxDepth == null || frame.depth < maxDepth)
+        && (whileCondition == null
+            || whileCondition.matchesFilters(frame.startingPoint, ctx));
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
@@ -174,13 +174,6 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
         frame.neighborsInitialized = true;
 
         if (shouldExpand(frame)) {
-          // Mark visited before expanding
-          if (dedupVisited != null) {
-            assert frame.startingPoint.getIdentity() != null
-                : "graph vertex identity must not be null";
-            dedupVisited.add(frame.startingPoint.getIdentity());
-          }
-
           // Set context for traversePatternEdge
           ctx.setSystemVariable(CommandContext.VAR_DEPTH, frame.depth);
           ctx.setSystemVariable(
@@ -257,6 +250,16 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
     ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, startingPoint);
     try {
       var frame = new Frame(startingPoint, depth, pathToHere, previousMatch);
+
+      // Mark visited immediately when frame is created — not deferred to
+      // expansion. This ensures boundary-depth vertices (where shouldExpand
+      // returns false) are still deduplicated.
+      if (dedupVisited != null && startingPoint != null) {
+        var rid = startingPoint.getIdentity();
+        if (rid != null) {
+          dedupVisited.add(rid);
+        }
+      }
 
       // Evaluate self against filters
       if (startingPoint != null

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
@@ -106,8 +106,9 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
     this.dedupVisited = dedupVisited;
     this.session = ctx.getDatabaseSession();
 
-    // Push the root slot
-    pushFrame(startingPoint, depth, pathToHere);
+    // Push the root slot. alreadyMarked=false because this is the root —
+    // no caller has added it to dedupVisited yet.
+    pushFrame(startingPoint, depth, pathToHere, false);
   }
 
   @Override
@@ -201,6 +202,12 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
    * Tries to find the next valid (non-null, non-deduped) neighbor from the
    * given slot's neighborStream and pushes a new slot for it.
    *
+   * <p>Dedup is performed here via {@code RidSet.add} (returns {@code false} if
+   * already present) so a single hash lookup replaces the previous pair of
+   * {@code contains} + {@code add}. This matters at scale — IC1 at SF1 visits
+   * ~125K neighbors (50 friends × 3 hops) — one hash probe per neighbor
+   * instead of two.
+   *
    * @return true if a new slot was pushed, false if no more neighbors
    */
   private boolean pushNextNeighbor(int parentIdx, ExecutionStream neighborStream) {
@@ -212,11 +219,18 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
         continue;
       }
 
-      // Dedup check
+      // Dedup via add() return value: true = newly added (push it), false =
+      // already visited (skip). Guaranteed to have been marked before any
+      // later visitor sees this RID, so boundary-depth vertices are deduped
+      // consistently with the explicit add in pushFrame() for the root.
+      var alreadyMarked = false;
       if (dedupVisited != null) {
         var neighborRid = origin.getIdentity();
-        if (neighborRid != null && dedupVisited.contains(neighborRid)) {
-          continue;
+        if (neighborRid != null) {
+          if (!dedupVisited.add(neighborRid)) {
+            continue;
+          }
+          alreadyMarked = true;
         }
       }
 
@@ -224,7 +238,7 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
       var newPath =
           hasPathAlias ? new PathNode(origin, parentPath, parentDepth) : null;
 
-      pushFrame(origin, parentDepth + 1, newPath);
+      pushFrame(origin, parentDepth + 1, newPath, alreadyMarked);
       return true;
     }
     return false;
@@ -233,9 +247,14 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
   /**
    * Creates a new slot for the given node, evaluates it against filters, sets
    * context variables, and pushes it onto the stack.
+   *
+   * @param alreadyMarked if {@code true}, the caller has already added the
+   *     RID to {@code dedupVisited} — we skip the redundant add. This is the
+   *     common case from {@link #pushNextNeighbor}, which uses the {@code add}
+   *     return value to perform dedup and marking in one hash probe.
    */
   private void pushFrame(Result startingPoint, int depth,
-      @Nullable PathNode pathToHere) {
+      @Nullable PathNode pathToHere, boolean alreadyMarked) {
     // Save current context and set for this depth. If filter evaluation or
     // path materialization throws, restore the context to avoid leaving it
     // in an inconsistent state.
@@ -256,7 +275,9 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
 
       // Mark visited immediately — not deferred to expansion — so boundary
       // depth vertices (where shouldExpand returns false) are still deduped.
-      if (dedupVisited != null && startingPoint != null) {
+      // Skipped when the caller (pushNextNeighbor) already added via its
+      // combined contains-or-add probe.
+      if (!alreadyMarked && dedupVisited != null && startingPoint != null) {
         var rid = startingPoint.getIdentity();
         if (rid != null) {
           dedupVisited.add(rid);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/LazyRecursiveTraversalStream.java
@@ -8,8 +8,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.RidSet;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.Arrays;
 import javax.annotation.Nullable;
 
 /**
@@ -17,55 +16,27 @@ import javax.annotation.Nullable;
  * materialization in the recursive (WHILE / maxDepth) branch of
  * {@link MatchEdgeTraverser#executeTraversal}.
  *
- * <p>Uses an explicit stack of {@link Frame}s to flatten the recursive DFS into
- * a single iterator with O(1) call-stack depth — no recursive {@code hasNext()}
- * chains regardless of traversal depth.
+ * <p>Uses an explicit parallel-array stack to flatten the recursive DFS into
+ * a single iterator with O(1) call-stack depth and — critically — O(1)
+ * amortized allocation per visited vertex (one doubling arraycopy amortized
+ * across all pushes, instead of one heap-allocated {@code Frame} object per
+ * vertex).
  *
- * <p>Each frame represents a node being visited at a given depth. A frame goes
- * through two phases:
+ * <p>Each stack slot represents a node being visited at a given depth. A slot
+ * goes through two phases:
  * <ol>
  *   <li><b>SELF</b>: yield the node itself if it matches filters
  *   <li><b>NEIGHBORS</b>: expand neighbors via {@code traversePatternEdge()},
- *       pushing a new frame for each neighbor
+ *       pushing a new slot for each neighbor
  * </ol>
  *
- * <p>This eliminates the O(total_results) ArrayList allocation and enables future
+ * <p>This eliminates the O(total_results) ArrayList allocation and enables
  * LIMIT propagation: when the downstream consumer stops pulling, unexplored
  * subtrees are never expanded.
  */
 final class LazyRecursiveTraversalStream implements ExecutionStream {
 
-  /**
-   * A frame on the traversal stack, representing one node being explored.
-   * Tracks whether the node itself has been yielded (selfResult) and the
-   * neighbor iteration state (neighborStream).
-   */
-  private static final class Frame {
-    final Result startingPoint;
-    final int depth;
-    @Nullable final PathNode pathToHere;
-    final Object previousMatch;
-
-    // SELF phase: non-null if the starting point passes filters and hasn't
-    // been yielded yet
-    @Nullable Result selfResult;
-
-    // NEIGHBORS phase: the stream of immediate neighbors, null until
-    // expansion is initiated
-    @Nullable ExecutionStream neighborStream;
-
-    // True once neighbors have been checked (may still be null if
-    // shouldExpand was false)
-    boolean neighborsInitialized;
-
-    Frame(Result startingPoint, int depth, @Nullable PathNode pathToHere,
-        Object previousMatch) {
-      this.startingPoint = startingPoint;
-      this.depth = depth;
-      this.pathToHere = pathToHere;
-      this.previousMatch = previousMatch;
-    }
-  }
+  private static final int INITIAL_CAPACITY = 16;
 
   private final MatchEdgeTraverser traverser;
   private final CommandContext ctx;
@@ -81,8 +52,30 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
 
   private final DatabaseSessionEmbedded session;
 
-  // Explicit DFS stack — replaces Java call-stack recursion
-  private final Deque<Frame> stack = new ArrayDeque<>();
+  // Parallel-array DFS stack. Top-of-stack is at index (size - 1). Growing by
+  // doubling amortizes allocation cost across all pushes, so the traversal
+  // pays one arraycopy per log2(maxDepth-visited) rather than one Frame
+  // allocation per visited vertex.
+  private Result[] startingPoints = new Result[INITIAL_CAPACITY];
+  private int[] depths = new int[INITIAL_CAPACITY];
+  private PathNode[] pathsToHere = new PathNode[INITIAL_CAPACITY];
+  private Object[] previousMatches = new Object[INITIAL_CAPACITY];
+
+  // SELF phase: non-null if the starting point passes filters and has not yet
+  // been yielded.
+  private Result[] selfResults = new Result[INITIAL_CAPACITY];
+
+  // NEIGHBORS phase: stream of immediate neighbors. Stays null until expansion
+  // is initiated; remains null afterward if shouldExpand() was false.
+  private ExecutionStream[] neighborStreams = new ExecutionStream[INITIAL_CAPACITY];
+
+  // Bitset: bit i set iff slot i has had shouldExpand/traversePatternEdge
+  // evaluated. Needed to distinguish "never initialized" from "initialized
+  // but the neighbor stream is null because shouldExpand was false".
+  private long[] neighborsInitialized =
+      new long[bitsetWords(INITIAL_CAPACITY)];
+
+  private int size;
 
   // Buffered result ready for next()
   @Nullable private Result buffered;
@@ -113,7 +106,7 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
     this.dedupVisited = dedupVisited;
     this.session = ctx.getDatabaseSession();
 
-    // Push the root frame
+    // Push the root slot
     pushFrame(startingPoint, depth, pathToHere);
   }
 
@@ -141,64 +134,63 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
 
   @Override
   public void close(CommandContext ctx) {
-    // Close all open neighbor streams on the stack
-    while (!stack.isEmpty()) {
-      var frame = stack.pop();
-      if (frame.neighborStream != null) {
-        frame.neighborStream.close(ctx);
+    // Close all open neighbor streams on the stack and restore context
+    while (size > 0) {
+      var top = size - 1;
+      var stream = neighborStreams[top];
+      if (stream != null) {
+        stream.close(ctx);
       }
-      // Restore context for each frame
-      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, frame.previousMatch);
+      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, previousMatches[top]);
+      popSlot(top);
     }
     done = true;
   }
 
   /**
    * Advances the traversal by one result. Processes the stack iteratively:
-   * for each frame, first yields the self-result, then expands neighbors
-   * by pushing new frames.
+   * for each slot, first yields the self-result, then expands neighbors by
+   * pushing new slots.
    */
   @Nullable private Result advance() {
-    while (!stack.isEmpty()) {
-      var frame = stack.peek();
+    while (size > 0) {
+      var top = size - 1;
 
       // Phase 1: yield the starting point if it matches filters
-      if (frame.selfResult != null) {
-        var result = frame.selfResult;
-        frame.selfResult = null;
-        return result;
+      var selfResult = selfResults[top];
+      if (selfResult != null) {
+        selfResults[top] = null;
+        return selfResult;
       }
 
-      // Phase 2: expand neighbors
-      if (!frame.neighborsInitialized) {
-        frame.neighborsInitialized = true;
-
-        if (shouldExpand(frame)) {
+      // Phase 2: expand neighbors (once per slot)
+      if (!isBitSet(neighborsInitialized, top)) {
+        setBit(neighborsInitialized, top);
+        if (shouldExpand(top)) {
           // Set context for traversePatternEdge
-          ctx.setSystemVariable(CommandContext.VAR_DEPTH, frame.depth);
+          ctx.setSystemVariable(CommandContext.VAR_DEPTH, depths[top]);
           ctx.setSystemVariable(
-              CommandContext.VAR_CURRENT_MATCH, frame.startingPoint);
-
-          frame.neighborStream =
-              traverser.traversePatternEdge(frame.startingPoint, ctx);
+              CommandContext.VAR_CURRENT_MATCH, startingPoints[top]);
+          neighborStreams[top] =
+              traverser.traversePatternEdge(startingPoints[top], ctx);
         }
       }
 
-      // Try to find the next valid neighbor and push its frame
-      if (frame.neighborStream != null) {
-        var pushed = pushNextNeighbor(frame);
-        if (pushed) {
-          // A new frame was pushed — loop back to process it (its self-result)
+      // Try to find the next valid neighbor and push its slot
+      var neighborStream = neighborStreams[top];
+      if (neighborStream != null) {
+        if (pushNextNeighbor(top, neighborStream)) {
+          // A new slot was pushed — loop back to process it (its self-result)
           continue;
         }
       }
 
-      // This frame is fully exhausted — pop it and restore context
-      stack.pop();
-      if (frame.neighborStream != null) {
-        frame.neighborStream.close(ctx);
+      // This slot is fully exhausted — pop it and restore context
+      if (neighborStream != null) {
+        neighborStream.close(ctx);
       }
-      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, frame.previousMatch);
+      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, previousMatches[top]);
+      popSlot(top);
     }
 
     done = true;
@@ -207,13 +199,15 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
 
   /**
    * Tries to find the next valid (non-null, non-deduped) neighbor from the
-   * frame's neighborStream and pushes a new frame for it.
+   * given slot's neighborStream and pushes a new slot for it.
    *
-   * @return true if a new frame was pushed, false if no more neighbors
+   * @return true if a new slot was pushed, false if no more neighbors
    */
-  private boolean pushNextNeighbor(Frame frame) {
-    while (frame.neighborStream.hasNext(ctx)) {
-      var origin = ResultInternal.toResult(frame.neighborStream.next(ctx), session);
+  private boolean pushNextNeighbor(int parentIdx, ExecutionStream neighborStream) {
+    var parentPath = pathsToHere[parentIdx];
+    var parentDepth = depths[parentIdx];
+    while (neighborStream.hasNext(ctx)) {
+      var origin = ResultInternal.toResult(neighborStream.next(ctx), session);
       if (origin == null) {
         continue;
       }
@@ -228,17 +222,17 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
 
       // Build path if pathAlias is declared
       var newPath =
-          hasPathAlias ? new PathNode(origin, frame.pathToHere, frame.depth) : null;
+          hasPathAlias ? new PathNode(origin, parentPath, parentDepth) : null;
 
-      pushFrame(origin, frame.depth + 1, newPath);
+      pushFrame(origin, parentDepth + 1, newPath);
       return true;
     }
     return false;
   }
 
   /**
-   * Creates a new frame for the given node, evaluates it against filters,
-   * sets context variables, and pushes it onto the stack.
+   * Creates a new slot for the given node, evaluates it against filters, sets
+   * context variables, and pushes it onto the stack.
    */
   private void pushFrame(Result startingPoint, int depth,
       @Nullable PathNode pathToHere) {
@@ -249,11 +243,19 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
     ctx.setSystemVariable(CommandContext.VAR_DEPTH, depth);
     ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, startingPoint);
     try {
-      var frame = new Frame(startingPoint, depth, pathToHere, previousMatch);
+      ensureCapacity(size + 1);
+      var slot = size;
 
-      // Mark visited immediately when frame is created — not deferred to
-      // expansion. This ensures boundary-depth vertices (where shouldExpand
-      // returns false) are still deduplicated.
+      startingPoints[slot] = startingPoint;
+      depths[slot] = depth;
+      pathsToHere[slot] = pathToHere;
+      previousMatches[slot] = previousMatch;
+      // selfResults[slot], neighborStreams[slot] and the neighborsInitialized
+      // bit are guaranteed clear — popSlot() zeroes them on pop, and newly
+      // grown slots are zero-filled by Arrays.copyOf.
+
+      // Mark visited immediately — not deferred to expansion — so boundary
+      // depth vertices (where shouldExpand returns false) are still deduped.
       if (dedupVisited != null && startingPoint != null) {
         var rid = startingPoint.getIdentity();
         if (rid != null) {
@@ -278,21 +280,68 @@ final class LazyRecursiveTraversalStream implements ExecutionStream {
             rs.setMetadata("$matchPath",
                 pathToHere == null ? PathNode.emptyPath() : pathToHere.toList());
           }
-          frame.selfResult = rs;
+          selfResults[slot] = rs;
         }
       }
 
-      stack.push(frame);
+      // Publish the slot last so any exception above leaves size untouched —
+      // no half-written slot becomes visible on the stack.
+      size++;
     } catch (Throwable t) {
       ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, previousMatch);
       throw t;
     }
   }
 
-  private boolean shouldExpand(Frame frame) {
-    return frame.startingPoint != null
-        && (maxDepth == null || frame.depth < maxDepth)
-        && (whileCondition == null
-            || whileCondition.matchesFilters(frame.startingPoint, ctx));
+  private boolean shouldExpand(int idx) {
+    var sp = startingPoints[idx];
+    return sp != null
+        && (maxDepth == null || depths[idx] < maxDepth)
+        && (whileCondition == null || whileCondition.matchesFilters(sp, ctx));
+  }
+
+  private void popSlot(int slot) {
+    // Clear object references for GC and reset the neighbors-initialized bit
+    startingPoints[slot] = null;
+    pathsToHere[slot] = null;
+    previousMatches[slot] = null;
+    selfResults[slot] = null;
+    neighborStreams[slot] = null;
+    clearBit(neighborsInitialized, slot);
+    size = slot;
+  }
+
+  private void ensureCapacity(int required) {
+    var current = startingPoints.length;
+    if (required <= current) {
+      return;
+    }
+    var newCapacity = Math.max(current << 1, required);
+    startingPoints = Arrays.copyOf(startingPoints, newCapacity);
+    depths = Arrays.copyOf(depths, newCapacity);
+    pathsToHere = Arrays.copyOf(pathsToHere, newCapacity);
+    previousMatches = Arrays.copyOf(previousMatches, newCapacity);
+    selfResults = Arrays.copyOf(selfResults, newCapacity);
+    neighborStreams = Arrays.copyOf(neighborStreams, newCapacity);
+    var requiredWords = bitsetWords(newCapacity);
+    if (neighborsInitialized.length < requiredWords) {
+      neighborsInitialized = Arrays.copyOf(neighborsInitialized, requiredWords);
+    }
+  }
+
+  private static int bitsetWords(int capacity) {
+    return (capacity + 63) >>> 6;
+  }
+
+  private static boolean isBitSet(long[] bitset, int idx) {
+    return (bitset[idx >>> 6] & (1L << (idx & 63))) != 0;
+  }
+
+  private static void setBit(long[] bitset, int idx) {
+    bitset[idx >>> 6] |= 1L << (idx & 63);
+  }
+
+  private static void clearBit(long[] bitset, int idx) {
+    bitset[idx >>> 6] &= ~(1L << (idx & 63));
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
@@ -15,6 +15,8 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionSt
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchPathItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -391,10 +393,14 @@ public class MatchEdgeTraverser implements ExecutionStream {
               ctx));
     } else {
       // ---- Recursive (WHILE / maxDepth) mode ----
-      // Uses a lazy, pull-based stream instead of eagerly materializing all
-      // results into an ArrayList. Results are yielded on-demand: the starting
-      // point first (if it passes filters), then each neighbor's subtree is
-      // explored lazily via recursive child streams.
+      // Two strategies:
+      // - EAGER (whileCondition != null, no explicit maxDepth): collect all
+      //   results into an ArrayList via recursive calls. Zero stream-combinator
+      //   overhead — optimal for shallow WHILE-bounded traversals like IC1's
+      //   `while: ($depth < 3)` and IC11's `while: ($depth < 2)`.
+      // - LAZY (explicit maxDepth only): pull-based LazyRecursiveTraversalStream
+      //   that yields results on-demand. Supports early termination when
+      //   downstream stops pulling.
       //
       // Dedup strategy: when no pathAlias is declared, a RidSet tracks emitted
       // vertices so that diamond/cyclic graphs don't produce duplicates. When a
@@ -403,11 +409,87 @@ public class MatchEdgeTraverser implements ExecutionStream {
       assert item.getFilter() != null : "filter guaranteed non-null in recursive branch";
       var hasPathAlias = item.getFilter().getPathAlias() != null;
       var dedupVisited = hasPathAlias ? null : visited;
+      var session = iCommandContext.getDatabaseSession();
 
-      return new LazyRecursiveTraversalStream(
-          this, iCommandContext, startingPoint, depth, pathToHere,
-          filter, whileCondition, maxDepth, className, targetRid,
-          hasPathAlias, dedupVisited);
+      if (whileCondition != null && maxDepth == null) {
+        // ---- Eager path for WHILE-only traversals ----
+        // Identical to the pre-lazy-stream implementation: collect all results
+        // into an ArrayList via recursive executeTraversal calls.
+        List<Result> result = new ArrayList<>();
+        iCommandContext.setSystemVariable(CommandContext.VAR_DEPTH, depth);
+        var previousMatch =
+            iCommandContext.getSystemVariable(CommandContext.VAR_CURRENT_MATCH);
+        iCommandContext.setSystemVariable(
+            CommandContext.VAR_CURRENT_MATCH, startingPoint);
+
+        // Evaluate the starting point against all filters
+        if (startingPoint != null
+            && matchesFilters(iCommandContext, filter, startingPoint)
+            && matchesClass(iCommandContext, className, startingPoint)
+            && matchesRid(iCommandContext, targetRid, startingPoint)) {
+          ResultInternal rs;
+          if (startingPoint instanceof ResultInternal resultInternal) {
+            rs = resultInternal;
+          } else {
+            rs = ResultInternal.toResultInternal(
+                startingPoint, session, null);
+          }
+          if (rs != null) {
+            rs.setMetadata("$depth", depth);
+            if (hasPathAlias) {
+              rs.setMetadata("$matchPath",
+                  pathToHere == null
+                      ? PathNode.emptyPath() : pathToHere.toList());
+            }
+            result.add(rs);
+          }
+        }
+
+        // Mark visited to prevent re-entry from sibling branches
+        if (dedupVisited != null && startingPoint != null
+            && startingPoint.getIdentity() != null) {
+          dedupVisited.add(startingPoint.getIdentity());
+        }
+
+        // Recurse into neighbors if WHILE condition holds
+        if (startingPoint != null
+            && whileCondition.matchesFilters(startingPoint, iCommandContext)) {
+
+          var queryResult = traversePatternEdge(startingPoint, iCommandContext);
+
+          while (queryResult.hasNext(iCommandContext)) {
+            var origin = ResultInternal.toResult(
+                queryResult.next(iCommandContext), session);
+            if (origin == null) {
+              continue;
+            }
+            if (dedupVisited != null) {
+              var neighborRid = origin.getIdentity();
+              if (neighborRid != null && dedupVisited.contains(neighborRid)) {
+                continue;
+              }
+            }
+
+            var newPath = hasPathAlias
+                ? new PathNode(origin, pathToHere, depth) : null;
+
+            var subResult = executeTraversal(
+                iCommandContext, item, origin, depth + 1, newPath, visited);
+            while (subResult.hasNext(iCommandContext)) {
+              result.add(subResult.next(iCommandContext));
+            }
+          }
+        }
+        iCommandContext.setSystemVariable(
+            CommandContext.VAR_CURRENT_MATCH, previousMatch);
+        return ExecutionStream.resultIterator(result.iterator());
+      } else {
+        // ---- Lazy path for maxDepth-bounded traversals ----
+        return new LazyRecursiveTraversalStream(
+            this, iCommandContext, startingPoint, depth, pathToHere,
+            filter, whileCondition, maxDepth, className, targetRid,
+            hasPathAlias, dedupVisited);
+      }
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
@@ -15,8 +15,6 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionSt
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchPathItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -393,103 +391,24 @@ public class MatchEdgeTraverser implements ExecutionStream {
               ctx));
     } else {
       // ---- Recursive (WHILE / maxDepth) mode ----
-      // Two strategies:
-      // - EAGER (whileCondition != null, no explicit maxDepth): collect all
-      //   results into an ArrayList via recursive calls. Zero stream-combinator
-      //   overhead — optimal for shallow WHILE-bounded traversals like IC1's
-      //   `while: ($depth < 3)` and IC11's `while: ($depth < 2)`.
-      // - LAZY (explicit maxDepth only): pull-based LazyRecursiveTraversalStream
-      //   that yields results on-demand. Supports early termination when
-      //   downstream stops pulling.
+      // Pull-based LazyRecursiveTraversalStream: yields results on demand so
+      // downstream LIMIT/short-circuit can stop expansion without materializing
+      // the whole sub-tree. Uses a parallel-array DFS stack so per-vertex cost
+      // is O(1) amortized allocation — cheaper than both the old eager
+      // ArrayList path (no result drain) and the older boxed-Frame lazy path.
       //
       // Dedup strategy: when no pathAlias is declared, a RidSet tracks emitted
-      // vertices so that diamond/cyclic graphs don't produce duplicates. When a
+      // vertices so diamond/cyclic graphs don't produce duplicates. When a
       // pathAlias IS declared the user is asking for distinct *paths*, so each
       // path to a vertex is a legitimate separate result and we skip dedup.
       assert item.getFilter() != null : "filter guaranteed non-null in recursive branch";
       var hasPathAlias = item.getFilter().getPathAlias() != null;
       var dedupVisited = hasPathAlias ? null : visited;
-      var session = iCommandContext.getDatabaseSession();
 
-      if (whileCondition != null && maxDepth == null) {
-        // ---- Eager path for WHILE-only traversals ----
-        // Identical to the pre-lazy-stream implementation: collect all results
-        // into an ArrayList via recursive executeTraversal calls.
-        List<Result> result = new ArrayList<>();
-        iCommandContext.setSystemVariable(CommandContext.VAR_DEPTH, depth);
-        var previousMatch =
-            iCommandContext.getSystemVariable(CommandContext.VAR_CURRENT_MATCH);
-        iCommandContext.setSystemVariable(
-            CommandContext.VAR_CURRENT_MATCH, startingPoint);
-
-        // Evaluate the starting point against all filters
-        if (startingPoint != null
-            && matchesFilters(iCommandContext, filter, startingPoint)
-            && matchesClass(iCommandContext, className, startingPoint)
-            && matchesRid(iCommandContext, targetRid, startingPoint)) {
-          ResultInternal rs;
-          if (startingPoint instanceof ResultInternal resultInternal) {
-            rs = resultInternal;
-          } else {
-            rs = ResultInternal.toResultInternal(
-                startingPoint, session, null);
-          }
-          if (rs != null) {
-            rs.setMetadata("$depth", depth);
-            if (hasPathAlias) {
-              rs.setMetadata("$matchPath",
-                  pathToHere == null
-                      ? PathNode.emptyPath() : pathToHere.toList());
-            }
-            result.add(rs);
-          }
-        }
-
-        // Mark visited to prevent re-entry from sibling branches
-        if (dedupVisited != null && startingPoint != null
-            && startingPoint.getIdentity() != null) {
-          dedupVisited.add(startingPoint.getIdentity());
-        }
-
-        // Recurse into neighbors if WHILE condition holds
-        if (startingPoint != null
-            && whileCondition.matchesFilters(startingPoint, iCommandContext)) {
-
-          var queryResult = traversePatternEdge(startingPoint, iCommandContext);
-
-          while (queryResult.hasNext(iCommandContext)) {
-            var origin = ResultInternal.toResult(
-                queryResult.next(iCommandContext), session);
-            if (origin == null) {
-              continue;
-            }
-            if (dedupVisited != null) {
-              var neighborRid = origin.getIdentity();
-              if (neighborRid != null && dedupVisited.contains(neighborRid)) {
-                continue;
-              }
-            }
-
-            var newPath = hasPathAlias
-                ? new PathNode(origin, pathToHere, depth) : null;
-
-            var subResult = executeTraversal(
-                iCommandContext, item, origin, depth + 1, newPath, visited);
-            while (subResult.hasNext(iCommandContext)) {
-              result.add(subResult.next(iCommandContext));
-            }
-          }
-        }
-        iCommandContext.setSystemVariable(
-            CommandContext.VAR_CURRENT_MATCH, previousMatch);
-        return ExecutionStream.resultIterator(result.iterator());
-      } else {
-        // ---- Lazy path for maxDepth-bounded traversals ----
-        return new LazyRecursiveTraversalStream(
-            this, iCommandContext, startingPoint, depth, pathToHere,
-            filter, whileCondition, maxDepth, className, targetRid,
-            hasPathAlias, dedupVisited);
-      }
+      return new LazyRecursiveTraversalStream(
+          this, iCommandContext, startingPoint, depth, pathToHere,
+          filter, whileCondition, maxDepth, className, targetRid,
+          hasPathAlias, dedupVisited);
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
@@ -15,8 +15,6 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionSt
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchPathItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -359,7 +357,6 @@ public class MatchEdgeTraverser implements ExecutionStream {
     String className = null;
     SQLRid targetRid = null;
 
-    var session = iCommandContext.getDatabaseSession();
     if (item.getFilter() != null) {
       filter = getTargetFilter(item);
       whileCondition = item.getFilter().getWhileCondition();
@@ -394,95 +391,23 @@ public class MatchEdgeTraverser implements ExecutionStream {
               ctx));
     } else {
       // ---- Recursive (WHILE / maxDepth) mode ----
-      // The starting point IS included (depth 0) if it passes the filters. Expansion
-      // continues while the WHILE condition holds and depth < maxDepth.
+      // Uses a lazy, pull-based stream instead of eagerly materializing all
+      // results into an ArrayList. Results are yielded on-demand: the starting
+      // point first (if it passes filters), then each neighbor's subtree is
+      // explored lazily via recursive child streams.
       //
       // Dedup strategy: when no pathAlias is declared, a RidSet tracks emitted
       // vertices so that diamond/cyclic graphs don't produce duplicates. When a
       // pathAlias IS declared the user is asking for distinct *paths*, so each
       // path to a vertex is a legitimate separate result and we skip dedup.
-      List<Result> result = new ArrayList<>();
-      iCommandContext.setSystemVariable(CommandContext.VAR_DEPTH, depth);
-      var previousMatch = iCommandContext.getSystemVariable(CommandContext.VAR_CURRENT_MATCH);
-      iCommandContext.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, startingPoint);
-
-      // Dedup is active when no pathAlias is declared. When pathAlias IS
-      // declared the user wants all distinct paths, so we null out the
-      // visited set to disable dedup entirely.
       assert item.getFilter() != null : "filter guaranteed non-null in recursive branch";
       var hasPathAlias = item.getFilter().getPathAlias() != null;
       var dedupVisited = hasPathAlias ? null : visited;
 
-      // Evaluate the starting point against all filters
-      if (startingPoint != null
-          && matchesFilters(iCommandContext, filter, startingPoint)
-          && matchesClass(iCommandContext, className, startingPoint)
-          && matchesRid(iCommandContext, targetRid, startingPoint)) {
-        ResultInternal rs;
-        if (startingPoint instanceof ResultInternal resultInternal) {
-          rs = resultInternal;
-        } else {
-          rs = ResultInternal.toResultInternal(startingPoint, session, null);
-        }
-        if (rs != null) {
-          // Store traversal metadata so the user can access it via depthAlias/pathAlias
-          rs.setMetadata("$depth", depth);
-          if (hasPathAlias) {
-            rs.setMetadata("$matchPath",
-                pathToHere == null ? PathNode.emptyPath() : pathToHere.toList());
-          }
-          result.add(rs);
-        }
-      }
-
-      // Mark the starting point as visited to prevent re-entry from sibling
-      // branches at any depth level. This must be OUTSIDE the expansion block
-      // because leaf-level nodes (where the while condition fails) would
-      // otherwise never be marked, causing O(fan-out) duplication.
-      if (dedupVisited != null && startingPoint != null
-          && startingPoint.getIdentity() != null) {
-        dedupVisited.add(startingPoint.getIdentity());
-      }
-
-      // Recurse into neighbors if depth allows and WHILE condition holds
-      if (startingPoint != null
-          && (maxDepth == null || depth < maxDepth)
-          && (whileCondition == null
-              || whileCondition.matchesFilters(startingPoint, iCommandContext))) {
-
-        var queryResult = traversePatternEdge(startingPoint, iCommandContext);
-
-        while (queryResult.hasNext(iCommandContext)) {
-          var origin = ResultInternal.toResult(queryResult.next(iCommandContext), session);
-          if (origin == null) {
-            continue;
-          }
-          // Skip neighbors already emitted to avoid duplicate results in
-          // diamond-shaped or cyclic graphs. Skipped when dedupVisited is
-          // null (pathAlias declared) because the user wants all distinct paths.
-          if (dedupVisited != null) {
-            var neighborRid = origin.getIdentity();
-            if (neighborRid != null && dedupVisited.contains(neighborRid)) {
-              continue;
-            }
-          }
-
-          // Only build the path when the user declared a pathAlias — otherwise skip
-          // all PathNode allocation entirely. For IS2 (no pathAlias) this eliminates
-          // all path-related allocations across the entire REPLY_OF chain.
-          var newPath = hasPathAlias ? new PathNode(origin, pathToHere, depth) : null;
-
-          // Recursive call with incremented depth, sharing the visited set
-          var subResult =
-              executeTraversal(iCommandContext, item, origin, depth + 1, newPath, visited);
-          while (subResult.hasNext(iCommandContext)) {
-            var sub = subResult.next(iCommandContext);
-            result.add(sub);
-          }
-        }
-      }
-      iCommandContext.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, previousMatch);
-      return ExecutionStream.resultIterator(result.iterator());
+      return new LazyRecursiveTraversalStream(
+          this, iCommandContext, startingPoint, depth, pathToHere,
+          filter, whileCondition, maxDepth, className, targetRid,
+          hasPathAlias, dedupVisited);
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -2551,6 +2551,164 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         pairs);
   }
 
+  // Semantic equivalence regression: `while: ($depth < N)` and `maxDepth: N`
+  // stop expansion at the same boundary. Before the lazy-path unification,
+  // these two phrasings took different execution branches (eager vs lazy),
+  // so a future refactor could silently diverge their behavior. This test
+  // pins the equivalence on both a linear chain and a branching graph.
+  @Test
+  public void testWhileVsMaxDepthSemanticEquivalence() {
+    var clazz = "testWhileVsMaxDepth";
+    session.execute("CREATE CLASS " + clazz + " EXTENDS V").close();
+
+    // Branching graph: root → {a, b} ; a → {c, d} ; b → {e} ; c → {f}
+    // Depth 0: root.  Depth 1: a, b.  Depth 2: c, d, e.  Depth 3: f.
+    session.executeInTx(
+        tx -> {
+          var root = session.newVertex(clazz);
+          root.setProperty("name", "root");
+          var a = session.newVertex(clazz);
+          a.setProperty("name", "a");
+          var b = session.newVertex(clazz);
+          b.setProperty("name", "b");
+          var c = session.newVertex(clazz);
+          c.setProperty("name", "c");
+          var d = session.newVertex(clazz);
+          d.setProperty("name", "d");
+          var e = session.newVertex(clazz);
+          e.setProperty("name", "e");
+          var f = session.newVertex(clazz);
+          f.setProperty("name", "f");
+
+          root.addEdge(a);
+          root.addEdge(b);
+          a.addEdge(c);
+          a.addEdge(d);
+          b.addEdge(e);
+          c.addEdge(f);
+        });
+
+    // For each boundary depth N, `while: ($depth < N)` must return the
+    // same set of vertices as `maxDepth: N`, and the combined form must
+    // match too.
+    for (int n = 0; n <= 4; n++) {
+      var whileOnly =
+          "MATCH { class: " + clazz
+              + ", as:s, where:(name = 'root')} --> {as:d, while:($depth < " + n
+              + ")} RETURN d.name as dname";
+      var maxDepthOnly =
+          "MATCH { class: " + clazz
+              + ", as:s, where:(name = 'root')} --> {as:d, while:(true),"
+              + " maxDepth: " + n + "} RETURN d.name as dname";
+      var combined =
+          "MATCH { class: " + clazz
+              + ", as:s, where:(name = 'root')} --> {as:d,"
+              + " while:($depth < " + n + "), maxDepth: " + n
+              + "} RETURN d.name as dname";
+
+      var whileNames = collectNames(whileOnly);
+      var maxDepthNames = collectNames(maxDepthOnly);
+      var combinedNames = collectNames(combined);
+
+      Assert.assertEquals(
+          "while:($depth<" + n + ") must match maxDepth: " + n,
+          whileNames, maxDepthNames);
+      Assert.assertEquals(
+          "combined while+maxDepth with equal bound must match either phrasing",
+          whileNames, combinedNames);
+    }
+  }
+
+  private java.util.List<String> collectNames(String query) {
+    session.begin();
+    var result = session.query(query);
+    var names = new java.util.ArrayList<String>();
+    while (result.hasNext()) {
+      names.add((String) result.next().getProperty("dname"));
+    }
+    result.close();
+    session.commit();
+    java.util.Collections.sort(names);
+    return names;
+  }
+
+  // Shallow-wide stress test: 1 root → 100 mids → 99 leaves per mid =
+  // 10 000 vertices reachable at depth ≤ 2, no cycles, no diamond overlap.
+  // Locks in the no-regression guarantee after Frame unboxing: any reintroduced
+  // per-vertex allocation would blow up both allocation rate and runtime on
+  // this shape. Also verifies that the parallel-array stack grows correctly
+  // past its initial 16-slot capacity (deepest stack at any moment ≤ 3).
+  @Test
+  public void testShallowWideFanOutLazyTraversal() {
+    var clazz = "testShallowWideFanOut";
+    session.execute("CREATE CLASS " + clazz + " EXTENDS V").close();
+
+    final int mids = 100;
+    final int leavesPerMid = 99;
+    final int expectedCount = 1 + mids + mids * leavesPerMid; // 10 000
+
+    session.executeInTx(
+        tx -> {
+          var root = session.newVertex(clazz);
+          root.setProperty("name", "root");
+          for (int i = 0; i < mids; i++) {
+            var mid = session.newVertex(clazz);
+            mid.setProperty("name", "m" + i);
+            root.addEdge(mid);
+            for (int j = 0; j < leavesPerMid; j++) {
+              var leaf = session.newVertex(clazz);
+              leaf.setProperty("name", "l" + i + "_" + j);
+              mid.addEdge(leaf);
+            }
+          }
+        });
+
+    // maxDepth: 2, no pathAlias → dedup active, but the graph is a tree so
+    // no vertex is reached twice. Result size must equal the total vertex
+    // count reachable at depth ≤ 2.
+    var query =
+        "MATCH { class: " + clazz
+            + ", as:s, where:(name = 'root')} --> {as:d, while:(true),"
+            + " maxDepth: 2, depthAlias: depth} RETURN d.name as name, depth";
+
+    var start = System.nanoTime();
+    session.begin();
+    var result = session.query(query);
+
+    var depthCounts = new int[3];
+    var seen = new java.util.HashSet<String>();
+    int count = 0;
+    while (result.hasNext()) {
+      var item = result.next();
+      var name = (String) item.getProperty("name");
+      int depth = item.getProperty("depth");
+      Assert.assertTrue(
+          "depth must be within [0, 2] bound", depth >= 0 && depth <= 2);
+      depthCounts[depth]++;
+      Assert.assertTrue(
+          "vertex must appear at most once when pathAlias is absent: " + name,
+          seen.add(name));
+      count++;
+    }
+    result.close();
+    session.commit();
+    var elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+    Assert.assertEquals(
+        "all reachable vertices at depth ≤ 2 must be visited",
+        expectedCount, count);
+    Assert.assertEquals("root at depth 0", 1, depthCounts[0]);
+    Assert.assertEquals("mids at depth 1", mids, depthCounts[1]);
+    Assert.assertEquals(
+        "leaves at depth 2", mids * leavesPerMid, depthCounts[2]);
+    // Soft runtime bound — 10 000-vertex fan-out should execute in well under
+    // 30 s on any test host. A serious regression (e.g. per-vertex allocation
+    // reintroduced) would blow past this.
+    Assert.assertTrue(
+        "traversal took " + elapsedMs + "ms, exceeds 30 s soft bound",
+        elapsedMs < 30_000L);
+  }
+
   @Test
   public void testNegativePattern() {
     var clazz = "testNegativePattern";

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionNewTest.java
@@ -2318,6 +2318,239 @@ public class MatchStatementExecutionNewTest extends DbTestBase {
         pairs);
   }
 
+  // Verifies that the lazy recursive traversal correctly handles a deep linear
+  // chain (50 hops). The stack-based implementation should handle this without
+  // any stack depth issues, unlike a naive recursive approach.
+  @Test
+  public void testWhileDeepChainLazyTraversal() {
+    var clazz = "testWhileDeepChain";
+    session.execute("CREATE CLASS " + clazz + " EXTENDS V").close();
+
+    int chainLength = 50;
+    session.begin();
+    for (int i = 0; i <= chainLength; i++) {
+      session.execute("CREATE VERTEX " + clazz + " SET name = 'n" + i + "'").close();
+    }
+    for (int i = 0; i < chainLength; i++) {
+      session.execute(
+          "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'n" + i + "') "
+              + "TO (SELECT FROM " + clazz + " WHERE name = 'n" + (i + 1) + "')")
+          .close();
+    }
+    session.commit();
+
+    // Traverse the entire chain from n0 with WHILE(true)
+    var query =
+        "MATCH { class: " + clazz
+            + ", as:start, where:(name = 'n0')} --> {as:dest, while:(true),"
+            + " depthAlias: d} RETURN dest.name as dname, d";
+
+    session.begin();
+    var result = session.query(query);
+
+    int count = 0;
+    int maxDepth = -1;
+    while (result.hasNext()) {
+      var item = result.next();
+      int depth = item.getProperty("d");
+      if (depth > maxDepth) {
+        maxDepth = depth;
+      }
+      count++;
+    }
+    result.close();
+    session.commit();
+
+    // All 51 nodes (n0 at depth 0 through n50 at depth 50)
+    Assert.assertEquals(
+        "Deep chain must yield all nodes including start",
+        chainLength + 1, count);
+    Assert.assertEquals(
+        "Deepest node must be at depth = chain length",
+        chainLength, maxDepth);
+  }
+
+  // Verifies that WHILE with LIMIT only pulls as many results as needed.
+  // The lazy stream enables this: after LIMIT is reached, remaining subtrees
+  // are not expanded. We verify correctness (not laziness directly) by checking
+  // that LIMIT produces a proper subset of the full result set.
+  @Test
+  public void testWhileWithLimit() {
+    var clazz = "testWhileLimit";
+    session.execute("CREATE CLASS " + clazz + " EXTENDS V").close();
+
+    session.begin();
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX " + clazz + " SET name = 'n" + i + "'").close();
+    }
+    for (int i = 0; i < 9; i++) {
+      session.execute(
+          "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'n" + i + "') "
+              + "TO (SELECT FROM " + clazz + " WHERE name = 'n" + (i + 1) + "')")
+          .close();
+    }
+    session.commit();
+
+    // Full traversal — should yield all 10 nodes
+    var fullQuery =
+        "MATCH { class: " + clazz
+            + ", as:start, where:(name = 'n0')} --> {as:dest, while:(true)} "
+            + "RETURN dest.name as dname";
+
+    session.begin();
+    var fullResult = session.query(fullQuery);
+    int fullCount = 0;
+    while (fullResult.hasNext()) {
+      fullResult.next();
+      fullCount++;
+    }
+    fullResult.close();
+    session.commit();
+    Assert.assertEquals(10, fullCount);
+
+    // Limited traversal — should yield exactly 3 nodes
+    var limitedQuery =
+        "MATCH { class: " + clazz
+            + ", as:start, where:(name = 'n0')} --> {as:dest, while:(true)} "
+            + "RETURN dest.name as dname LIMIT 3";
+
+    session.begin();
+    var limitedResult = session.query(limitedQuery);
+    int limitedCount = 0;
+    while (limitedResult.hasNext()) {
+      limitedResult.next();
+      limitedCount++;
+    }
+    limitedResult.close();
+    session.commit();
+    Assert.assertEquals(3, limitedCount);
+  }
+
+  // Verifies that the lazy traversal produces correct results on a branching
+  // (fan-out) graph: a root node with multiple children, each having their own
+  // children. This tests that the DFS stack correctly explores all branches.
+  //
+  //       root
+  //      / | \
+  //     a  b  c
+  //    /|    |
+  //   d  e   f
+  @Test
+  public void testWhileBranchingGraphLazyTraversal() {
+    var clazz = "testWhileBranching";
+    session.execute("CREATE CLASS " + clazz + " EXTENDS V").close();
+
+    session.begin();
+    for (var name : new String[] {"root", "a", "b", "c", "d", "e", "f"}) {
+      session.execute("CREATE VERTEX " + clazz + " SET name = '" + name + "'").close();
+    }
+    // root → a, b, c
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'root') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'a')")
+        .close();
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'root') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'b')")
+        .close();
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'root') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'c')")
+        .close();
+    // a → d, e
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'a') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'd')")
+        .close();
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'a') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'e')")
+        .close();
+    // b → f
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'b') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'f')")
+        .close();
+    session.commit();
+
+    var query =
+        "MATCH { class: " + clazz
+            + ", as:start, where:(name = 'root')} --> {as:dest, while:(true),"
+            + " depthAlias: d} RETURN dest.name as dname, d";
+
+    session.begin();
+    var result = session.query(query);
+
+    var names = new java.util.ArrayList<String>();
+    while (result.hasNext()) {
+      var item = result.next();
+      names.add((String) item.getProperty("dname"));
+    }
+    result.close();
+    session.commit();
+
+    java.util.Collections.sort(names);
+    // All 7 nodes must appear exactly once (dedup active, no pathAlias)
+    Assert.assertEquals(
+        "Branching graph: all nodes must be visited exactly once",
+        java.util.List.of("a", "b", "c", "d", "e", "f", "root"),
+        names);
+  }
+
+  // Verifies that the lazy traversal respects maxDepth correctly, stopping
+  // expansion at the specified depth even in a deeper graph.
+  @Test
+  public void testWhileMaxDepthLazyTraversal() {
+    var clazz = "testWhileMaxDepth";
+    session.execute("CREATE CLASS " + clazz + " EXTENDS V").close();
+
+    session.begin();
+    // Chain: a → b → c → d → e
+    for (var name : new String[] {"a", "b", "c", "d", "e"}) {
+      session.execute("CREATE VERTEX " + clazz + " SET name = '" + name + "'").close();
+    }
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'a') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'b')")
+        .close();
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'b') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'c')")
+        .close();
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'c') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'd')")
+        .close();
+    session.execute(
+        "CREATE EDGE E FROM (SELECT FROM " + clazz + " WHERE name = 'd') "
+            + "TO (SELECT FROM " + clazz + " WHERE name = 'e')")
+        .close();
+    session.commit();
+
+    // maxDepth: 2 — should see a (depth 0), b (depth 1), c (depth 2) only
+    var query =
+        "MATCH { class: " + clazz
+            + ", as:start, where:(name = 'a')} --> {as:dest, while:(true),"
+            + " maxDepth: 2, depthAlias: d} RETURN dest.name as dname, d";
+
+    session.begin();
+    var result = session.query(query);
+
+    var pairs = new java.util.ArrayList<String>();
+    while (result.hasNext()) {
+      var item = result.next();
+      pairs.add(item.getProperty("dname") + ":" + item.getProperty("d"));
+    }
+    result.close();
+    session.commit();
+
+    java.util.Collections.sort(pairs);
+    Assert.assertEquals(
+        "maxDepth: 2 must stop at depth 2",
+        java.util.List.of("a:0", "b:1", "c:2"),
+        pairs);
+  }
+
   @Test
   public void testNegativePattern() {
     var clazz = "testNegativePattern";


### PR DESCRIPTION


#### PR Title:

YTDB-634: Lazy ExecutionStream 

#### Motivation:

MatchEdgeTraverser.executeTraversal() eagerly materializes all recursive results into an ArrayList before returning any of them:

  ```java                                                                             
  List<Result> result = new ArrayList<>();
  // ... recurse into all neighbors, drain everything ...
  result.add(sub);                                                              
  // ... only now return as stream
  return ExecutionStream.resultIterator(result.iterator());   
```                  
                                                                                
This means the entire subtree is fully traversed and collected before the first result is yielded to the consumer. There is no backpressure — once recursion starts, it runs to completion. LIMIT cannot short-circuit the traversal, and peak memory is O(total_results).

 This PR replaces the eager collection with LazyRecursiveTraversalStream — a stack-based DFS iterator that yields results one at a time. An explicit Deque<Frame> replaces Java call-stack recursion: each frame tracks a node's self-result and its neighbor iteration state. The advance() method processes the stack iteratively — yield self, push neighbor frames, pop when exhausted — with O(1) call-stack depth regardless of traversal depth.

When the downstream consumer stops pulling (e.g., LimitExecutionStep is satisfied), unexplored subtrees are never expanded. For deep WHILE chains, the flat loop avoids StackOverflow risk that the previous recursive            implementation had.

