### PR TITLE
Fix char-to-int promotion bug in BTreeTestIT key perturbation

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
@@ -874,9 +874,15 @@ public class BTreeTestIT {
       final var fromKeyIndex = random.nextInt(keys.length);
       var fromKey = keys[fromKeyIndex];
 
-      if (random.nextBoolean()) {
+      // Occasionally perturb the key to test iteration with keys not in the map.
+      // Guard: keys shorter than 2 chars cannot be meaningfully shortened.
+      // Cast to (char) to avoid int promotion — without the cast, char arithmetic
+      // produces an int that gets appended as its decimal representation (e.g.
+      // "99998" + 48 instead of "99998" + '0'), which corrupts the key.
+      if (random.nextBoolean() && fromKey.length() >= 2) {
         fromKey =
-            fromKey.substring(0, fromKey.length() - 2) + (fromKey.charAt(fromKey.length() - 1) - 1);
+            fromKey.substring(0, fromKey.length() - 2)
+                + (char) (fromKey.charAt(fromKey.length() - 1) - 1);
       }
 
       final Iterator<RawPair<String, RID>> indexIterator;
@@ -928,8 +934,12 @@ public class BTreeTestIT {
     for (var i = 0; i < 100; i++) {
       var toKeyIndex = random.nextInt(keys.length);
       var toKey = keys[toKeyIndex];
-      if (random.nextBoolean()) {
-        toKey = toKey.substring(0, toKey.length() - 2) + (toKey.charAt(toKey.length() - 1) + 1);
+      // See comment in assertIterateMajorEntries for why the (char) cast and
+      // length guard are necessary.
+      if (random.nextBoolean() && toKey.length() >= 2) {
+        toKey =
+            toKey.substring(0, toKey.length() - 2)
+                + (char) (toKey.charAt(toKey.length() - 1) + 1);
       }
 
       final Iterator<RawPair<String, RID>> indexIterator;
@@ -984,13 +994,18 @@ public class BTreeTestIT {
       var fromKey = keys[fromKeyIndex];
       var toKey = keys[toKeyIndex];
 
-      if (random.nextBoolean()) {
+      // See comment in assertIterateMajorEntries for why the (char) cast and
+      // length guard are necessary.
+      if (random.nextBoolean() && fromKey.length() >= 2) {
         fromKey =
-            fromKey.substring(0, fromKey.length() - 2) + (fromKey.charAt(fromKey.length() - 1) - 1);
+            fromKey.substring(0, fromKey.length() - 2)
+                + (char) (fromKey.charAt(fromKey.length() - 1) - 1);
       }
 
-      if (random.nextBoolean()) {
-        toKey = toKey.substring(0, toKey.length() - 2) + (toKey.charAt(toKey.length() - 1) + 1);
+      if (random.nextBoolean() && toKey.length() >= 2) {
+        toKey =
+            toKey.substring(0, toKey.length() - 2)
+                + (char) (toKey.charAt(toKey.length() - 1) + 1);
       }
 
       if (fromKey.compareTo(toKey) > 0) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
@@ -874,15 +874,8 @@ public class BTreeTestIT {
       final var fromKeyIndex = random.nextInt(keys.length);
       var fromKey = keys[fromKeyIndex];
 
-      // Occasionally perturb the key to test iteration with keys not in the map.
-      // Guard: keys shorter than 2 chars cannot be meaningfully shortened.
-      // Cast to (char) to avoid int promotion — without the cast, char arithmetic
-      // produces an int that gets appended as its decimal representation (e.g.
-      // "99998" + 48 instead of "99998" + '0'), which corrupts the key.
       if (random.nextBoolean() && fromKey.length() >= 2) {
-        fromKey =
-            fromKey.substring(0, fromKey.length() - 2)
-                + (char) (fromKey.charAt(fromKey.length() - 1) - 1);
+        fromKey = perturbKey(fromKey, -1);
       }
 
       final Iterator<RawPair<String, RID>> indexIterator;
@@ -934,12 +927,8 @@ public class BTreeTestIT {
     for (var i = 0; i < 100; i++) {
       var toKeyIndex = random.nextInt(keys.length);
       var toKey = keys[toKeyIndex];
-      // See comment in assertIterateMajorEntries for why the (char) cast and
-      // length guard are necessary.
       if (random.nextBoolean() && toKey.length() >= 2) {
-        toKey =
-            toKey.substring(0, toKey.length() - 2)
-                + (char) (toKey.charAt(toKey.length() - 1) + 1);
+        toKey = perturbKey(toKey, +1);
       }
 
       final Iterator<RawPair<String, RID>> indexIterator;
@@ -994,18 +983,12 @@ public class BTreeTestIT {
       var fromKey = keys[fromKeyIndex];
       var toKey = keys[toKeyIndex];
 
-      // See comment in assertIterateMajorEntries for why the (char) cast and
-      // length guard are necessary.
       if (random.nextBoolean() && fromKey.length() >= 2) {
-        fromKey =
-            fromKey.substring(0, fromKey.length() - 2)
-                + (char) (fromKey.charAt(fromKey.length() - 1) - 1);
+        fromKey = perturbKey(fromKey, -1);
       }
 
       if (random.nextBoolean() && toKey.length() >= 2) {
-        toKey =
-            toKey.substring(0, toKey.length() - 2)
-                + (char) (toKey.charAt(toKey.length() - 1) + 1);
+        toKey = perturbKey(toKey, +1);
       }
 
       if (fromKey.compareTo(toKey) > 0) {
@@ -1072,6 +1055,24 @@ public class BTreeTestIT {
         Assert.assertTrue(indexIterator.hasNext());
       }
     }
+  }
+
+  /**
+   * Perturbs a key by dropping the second-to-last character and shifting the last
+   * character by {@code delta}. The result is one character shorter than the original
+   * and is very likely not present in the map, which lets the iteration tests exercise
+   * keys that fall between actual B-tree entries.
+   *
+   * <p>The cast to {@code (char)} is critical: without it, Java promotes the
+   * {@code char + int} arithmetic to {@code int}, and string concatenation appends the
+   * decimal representation (e.g. {@code "99998" + 48} instead of {@code "99998" + '0'}).
+   *
+   * @param key   the original key (must have {@code length >= 2})
+   * @param delta the amount to shift the last character (typically {@code -1} or {@code +1})
+   */
+  private static String perturbKey(String key, int delta) {
+    return key.substring(0, key.length() - 2)
+        + (char) (key.charAt(key.length() - 1) + delta);
   }
 
   static final class RollbackException extends BaseException implements HighLevelException {


### PR DESCRIPTION
## Summary
- Fix Java char-to-int promotion bug in `BTreeTestIT` key perturbation logic that caused `IllegalArgumentException: fromKey > toKey` in the Small Cache IT CI job
- Cast char arithmetic results to `(char)` at all 4 affected locations in `assertIterateMajorEntries`, `assertIterateMinorEntries`, and `assertIterateBetweenEntries`
- Add `length >= 2` guard to prevent `StringIndexOutOfBoundsException` on single-character keys

## Motivation
The [Small Cache IT job on develop](https://github.com/JetBrains/youtrackdb/actions/runs/23636672073) failed with:
```
BTreeTestIT.testIterateEntriesMajor -- IllegalArgumentException: fromKey > toKey
```
The expression `(fromKey.charAt(fromKey.length() - 1) - 1)` produces an `int` due to Java's char-to-int promotion. When concatenated with a String, the decimal representation is appended (e.g. `"99998" + 48` = `"9999848"`) instead of the character (`"999980"`). With `KEYS_COUNT=10000` (small-cache profile), the corrupted key can exceed `lastKey()`, causing `descendingMap().subMap()` to throw.

## Test plan
- [x] `BTreeTestIT#testIterateEntriesMajor` passes with small-cache params (`keysCount=10000, bufferSize=4`)
- [x] `BTreeTestIT#testIterateEntriesMinor` passes with small-cache params
- [x] `BTreeTestIT#testIterateEntriesBetween` passes with small-cache params
- [x] Spotless formatting check passes
- [ ] CI Small Cache IT job passes