### PR TITLE
Replace synchronized with AtomicReference in DatabasePoolImpl

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImpl.java
@@ -27,10 +27,13 @@ import com.jetbrains.youtrackdb.internal.common.concur.resource.ResourcePool;
 import com.jetbrains.youtrackdb.internal.common.concur.resource.ResourcePoolListener;
 import com.jetbrains.youtrackdb.internal.core.exception.AcquireTimeoutException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 public class DatabasePoolImpl implements DatabasePoolInternal {
 
-  private volatile ResourcePool<Void, DatabaseSessionEmbedded> pool;
+  private final AtomicReference<ResourcePool<Void, DatabaseSessionEmbedded>> pool =
+      new AtomicReference<>();
   private final YouTrackDBInternal factory;
   private final YouTrackDBConfigImpl config;
   private final String databaseName;
@@ -38,42 +41,14 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
 
   private volatile long lastCloseTime = System.currentTimeMillis();
 
-
   public DatabasePoolImpl(
       YouTrackDBInternal factory,
       String database,
       String user,
       String password,
       YouTrackDBConfigImpl config) {
-    var max = config.getConfiguration().getValueAsInteger(DB_POOL_MAX);
-    var min = config.getConfiguration().getValueAsInteger(DB_POOL_MIN);
-    this.factory = factory;
-    this.config = config;
-    this.databaseName = database;
-    this.userName = user;
-
-    pool =
-        new ResourcePool<>(
-            min,
-            max,
-            new ResourcePoolListener<>() {
-              @Override
-              public DatabaseSessionEmbedded createNewResource(
-                  Void iKey, Object... iAdditionalArgs) {
-                return factory.poolOpen(database, user, password, DatabasePoolImpl.this);
-              }
-
-              @Override
-              public boolean reuseResource(
-                  Void iKey, Object[] iAdditionalArgs, DatabaseSessionEmbedded iValue) {
-                var polledSession = (PooledSession) iValue;
-                if (polledSession.isBackendClosed()) {
-                  return false;
-                }
-                polledSession.reuse();
-                return true;
-              }
-            });
+    this(factory, database, user, config,
+        pool -> factory.poolOpen(database, user, password, pool));
   }
 
   public DatabasePoolImpl(
@@ -81,7 +56,23 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
       String database,
       String user,
       YouTrackDBConfigImpl config) {
+    this(factory, database, user, config,
+        pool -> {
+          if (factory instanceof YouTrackDBInternalEmbedded embedded) {
+            return embedded.poolOpenNoAuthenticate(database, user, pool);
+          } else {
+            throw new UnsupportedOperationException(
+                "Opening database without password is not supported");
+          }
+        });
+  }
 
+  private DatabasePoolImpl(
+      YouTrackDBInternal factory,
+      String database,
+      String user,
+      YouTrackDBConfigImpl config,
+      Function<DatabasePoolInternal, DatabaseSessionEmbedded> sessionFactory) {
     var max = config.getConfiguration().getValueAsInteger(DB_POOL_MAX);
     var min = config.getConfiguration().getValueAsInteger(DB_POOL_MIN);
     this.factory = factory;
@@ -89,7 +80,7 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
     this.databaseName = database;
     this.userName = user;
 
-    pool =
+    pool.set(
         new ResourcePool<>(
             min,
             max,
@@ -97,13 +88,7 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
               @Override
               public DatabaseSessionEmbedded createNewResource(
                   Void iKey, Object... iAdditionalArgs) {
-                if (factory instanceof YouTrackDBInternalEmbedded embedded) {
-                  return embedded.poolOpenNoAuthenticate(database, user,
-                      DatabasePoolImpl.this);
-                } else {
-                  throw new UnsupportedOperationException(
-                      "Opening database without password is not supported");
-                }
+                return sessionFactory.apply(DatabasePoolImpl.this);
               }
 
               @Override
@@ -113,20 +98,15 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
                 if (pooledSession.isBackendClosed()) {
                   return false;
                 }
-
                 pooledSession.reuse();
                 return true;
               }
-            });
+            }));
   }
-
 
   @Override
   public DatabaseSessionEmbedded acquire() throws AcquireTimeoutException {
-    ResourcePool<Void, DatabaseSessionEmbedded> p;
-    synchronized (this) {
-      p = pool;
-    }
+    var p = pool.get();
     if (p != null) {
       return p.getResource(
           null, config.getConfiguration().getValueAsLong(DB_POOL_ACQUIRE_TIMEOUT));
@@ -136,12 +116,8 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
   }
 
   @Override
-  public synchronized void close() {
-    ResourcePool<Void, DatabaseSessionEmbedded> p;
-    synchronized (this) {
-      p = pool;
-      pool = null;
-    }
+  public void close() {
+    var p = pool.getAndSet(null);
     if (p != null) {
       for (var res : p.getAllResources()) {
         ((PooledSession) res).realClose();
@@ -153,12 +129,9 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
 
   @Override
   public void release(DatabaseSessionEmbedded database) {
-    ResourcePool<Void, DatabaseSessionEmbedded> p;
-    synchronized (this) {
-      p = pool;
-    }
+    var p = pool.get();
     if (p != null) {
-      pool.returnResource(database);
+      p.returnResource(database);
     } else {
       throw new DatabaseException(database.getDatabaseName(), "The pool is closed");
     }
@@ -167,15 +140,20 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
 
   @Override
   public boolean isUnused() {
-    if (pool == null) {
+    var p = pool.get();
+    if (p == null) {
       return true;
     } else {
-      return pool.getResourcesOutCount() == 0;
+      return p.getResourcesOutCount() == 0;
     }
   }
 
   public int getAvailableResources() {
-    return pool.getAvailableResources();
+    var p = pool.get();
+    if (p == null) {
+      throw new DatabaseException("The pool is closed");
+    }
+    return p.getAvailableResources();
   }
 
   @Override
@@ -200,6 +178,6 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
 
   @Override
   public boolean isClosed() {
-    return pool == null;
+    return pool.get() == null;
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImpl.java
@@ -75,6 +75,10 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
       Function<DatabasePoolInternal, DatabaseSessionEmbedded> sessionFactory) {
     var max = config.getConfiguration().getValueAsInteger(DB_POOL_MAX);
     var min = config.getConfiguration().getValueAsInteger(DB_POOL_MIN);
+    assert min >= 0 : "DB_POOL_MIN must be non-negative: " + min;
+    assert max > 0 : "DB_POOL_MAX must be positive: " + max;
+    assert min <= max : "DB_POOL_MIN (" + min + ") must be <= DB_POOL_MAX (" + max + ")";
+
     this.factory = factory;
     this.config = config;
     this.databaseName = database;
@@ -102,6 +106,8 @@ public class DatabasePoolImpl implements DatabasePoolInternal {
                 return true;
               }
             }));
+
+    assert pool.get() != null : "Pool must be initialized after construction";
   }
 
   @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImplTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImplTest.java
@@ -11,6 +11,7 @@ import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
 import com.jetbrains.youtrackdb.api.YourTracks;
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.common.concur.lock.ThreadInterruptedException;
 import com.jetbrains.youtrackdb.internal.core.config.YouTrackDBConfig;
 import com.jetbrains.youtrackdb.internal.core.exception.AcquireTimeoutException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
@@ -448,18 +449,30 @@ public class DatabasePoolImplTest {
   // via a CyclicBarrier to maximize the chance of overlapping acquire()
   // and close() calls. Uses max=8 so that close()'s semaphore drain does
   // not block threads mid-acquire indefinitely.
-  // Two kinds of DatabaseException are expected during the race:
-  //   1. "The pool is closed" — from acquire()/release() when the pool
-  //      AtomicReference is already null.
-  //   2. "Database '...' is closed" — from session operations (e.g.
-  //      getMetadata()) when pool.close() has already called realClose()
-  //      on the underlying session while a worker still holds a reference.
-  // Any other DatabaseException is flagged as unexpected.
+  //
+  // Expected exceptions during the race:
+  //   1. DatabaseException("The pool is closed") — acquire()/release()
+  //      when the pool AtomicReference is already null.
+  //   2. DatabaseException("Database '...' is closed") — session operations
+  //      (e.g. getMetadata()) when pool.close() has already called
+  //      realClose() on the underlying session.
+  //   3. AcquireTimeoutException — threads blocked on the semaphore after
+  //      close() drained all permits. A short DB_POOL_ACQUIRE_TIMEOUT
+  //      (5 seconds) ensures these threads unblock promptly rather than
+  //      waiting the default 60 seconds, which would exceed the test
+  //      timeout on slow CI runners (e.g. ARM).
+  //   4. ThreadInterruptedException — surefire may interrupt threads when
+  //      forkedProcessExitTimeoutInSeconds fires on overloaded runners.
   @Test
   public void closeDuringConcurrentAcquireDoesNotHang() throws Exception {
     var config = new BaseConfiguration();
     config.setProperty(GlobalConfiguration.CREATE_DEFAULT_USERS.getKey(), false);
     config.setProperty(GlobalConfiguration.DB_POOL_MAX.getKey(), 8);
+    // Keep acquire timeout short so threads blocked on the semaphore after
+    // close() drains permits unblock within a few seconds. The default
+    // 60 s exceeds the test's done.await() timeout on slow ARM runners.
+    config.setProperty(
+        GlobalConfiguration.DB_POOL_ACQUIRE_TIMEOUT.getKey(), 5_000);
 
     var youTrackDb = createYouTrackDB(config);
     try {
@@ -496,6 +509,14 @@ public class DatabasePoolImplTest {
                 && !msg.startsWith("Database '")) {
               firstUnexpected.compareAndSet(null, e);
             }
+          } catch (AcquireTimeoutException e) {
+            // Threads blocked on sem.tryAcquire() when close() drained
+            // all permits will get this after DB_POOL_ACQUIRE_TIMEOUT.
+            // This is expected and not a bug.
+          } catch (ThreadInterruptedException e) {
+            // Surefire may interrupt threads when
+            // forkedProcessExitTimeoutInSeconds fires on slow runners.
+            // This is not a pool bug.
           } catch (Exception e) {
             firstUnexpected.compareAndSet(null, e);
           } finally {
@@ -508,6 +529,8 @@ public class DatabasePoolImplTest {
       barrier.await(10, TimeUnit.SECONDS);
       pool.close();
 
+      // 30 s is well above the 5 s acquire timeout × 4 threads,
+      // providing ample margin for slow CI runners.
       assertTrue("Threads did not finish (possible deadlock)",
           done.await(30, TimeUnit.SECONDS));
       assertTrue("Pool must be closed after close() was called",

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImplTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImplTest.java
@@ -126,7 +126,9 @@ public class DatabasePoolImplTest {
         pool.release(session);
         fail("Expected DatabaseException");
       } catch (DatabaseException e) {
-        // expected
+        assertTrue("Expected 'The pool is closed' prefix, got: "
+            + e.getMessage(),
+            e.getMessage().startsWith("The pool is closed"));
       }
       assertEquals("lastCloseTime must not update when pool is closed",
           timeBeforeRelease, pool.getLastCloseTime());
@@ -445,9 +447,14 @@ public class DatabasePoolImplTest {
   // sessions does not deadlock. Workers and the main thread start together
   // via a CyclicBarrier to maximize the chance of overlapping acquire()
   // and close() calls. Uses max=8 so that close()'s semaphore drain does
-  // not block threads mid-acquire indefinitely. Only DatabaseExceptions
-  // with "The pool is closed" are accepted as expected; other
-  // DatabaseExceptions are flagged.
+  // not block threads mid-acquire indefinitely.
+  // Two kinds of DatabaseException are expected during the race:
+  //   1. "The pool is closed" — from acquire()/release() when the pool
+  //      AtomicReference is already null.
+  //   2. "Database '...' is closed" — from session operations (e.g.
+  //      getMetadata()) when pool.close() has already called realClose()
+  //      on the underlying session while a worker still holds a reference.
+  // Any other DatabaseException is flagged as unexpected.
   @Test
   public void closeDuringConcurrentAcquireDoesNotHang() throws Exception {
     var config = new BaseConfiguration();
@@ -479,10 +486,14 @@ public class DatabasePoolImplTest {
               }
             }
           } catch (DatabaseException e) {
-            // Only "pool is closed" exceptions are expected from both
-            // acquire() (pool null) and session.close() -> release()
-            // (pool null). Any other DatabaseException is unexpected.
-            if (!e.getMessage().startsWith("The pool is closed")) {
+            // "The pool is closed" — acquire()/release() after pool nulled.
+            // "Database '...' is closed" — session operations after
+            // pool.close() called realClose() on the underlying session
+            // (race between close() and a worker using an already-acquired
+            // session).
+            String msg = e.getMessage();
+            if (!msg.startsWith("The pool is closed")
+                && !msg.startsWith("Database '")) {
               firstUnexpected.compareAndSet(null, e);
             }
           } catch (Exception e) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImplTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabasePoolImplTest.java
@@ -1,0 +1,553 @@
+package com.jetbrains.youtrackdb.internal.core.db;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
+import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.config.YouTrackDBConfig;
+import com.jetbrains.youtrackdb.internal.core.exception.AcquireTimeoutException;
+import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.configuration2.BaseConfiguration;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests for {@link DatabasePoolImpl} covering lifecycle, error paths,
+ * and concurrent access after the synchronized-to-AtomicReference migration.
+ */
+public class DatabasePoolImplTest {
+
+  private static final String PASSWORD = "adminpwd";
+
+  private YouTrackDBImpl createYouTrackDB() {
+    var config = new BaseConfiguration();
+    config.setProperty(GlobalConfiguration.CREATE_DEFAULT_USERS.getKey(), false);
+
+    return (YouTrackDBImpl) YourTracks.instance(
+        DbTestBase.getBaseDirectoryPathStr(getClass()), config);
+  }
+
+  private YouTrackDBImpl createYouTrackDB(BaseConfiguration config) {
+    return (YouTrackDBImpl) YourTracks.instance(
+        DbTestBase.getBaseDirectoryPathStr(getClass()), config);
+  }
+
+  private void createDatabase(YouTrackDBImpl youTrackDb, String dbName) {
+    youTrackDb.createIfNotExists(dbName, DatabaseType.MEMORY,
+        new LocalUserCredential("admin", PASSWORD, PredefinedLocalRole.ADMIN));
+  }
+
+  private DatabasePoolImpl createPool(YouTrackDBImpl youTrackDb, String dbName) {
+    return new DatabasePoolImpl(
+        youTrackDb.internal, dbName, "admin", PASSWORD,
+        (YouTrackDBConfigImpl) YouTrackDBConfig.defaultConfig());
+  }
+
+  private DatabasePoolImpl createPool(
+      YouTrackDBImpl youTrackDb, String dbName, BaseConfiguration config) {
+    var poolConfig = YouTrackDBConfig.builder()
+        .fromApacheConfiguration(config).build();
+    return new DatabasePoolImpl(
+        youTrackDb.internal, dbName, "admin", PASSWORD,
+        (YouTrackDBConfigImpl) poolConfig);
+  }
+
+  // Verifies that acquire() on a closed pool throws DatabaseException, not NPE.
+  @Test
+  public void acquireOnClosedPoolThrowsDatabaseException() {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testAcquireClosed");
+      var pool = createPool(youTrackDb, "testAcquireClosed");
+      pool.close();
+
+      try {
+        pool.acquire();
+        fail("Expected DatabaseException");
+      } catch (DatabaseException e) {
+        assertEquals("The pool is closed", e.getMessage());
+      }
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that release() on a closed pool throws DatabaseException.
+  // Regression test for the bug where release() used the field `pool` instead
+  // of the local snapshot `p`, which could NPE under concurrent close().
+  @Test
+  public void releaseOnClosedPoolThrowsDatabaseException() {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testReleaseClosed");
+      var pool = createPool(youTrackDb, "testReleaseClosed");
+      var session = pool.acquire();
+      pool.close();
+
+      try {
+        pool.release(session);
+        fail("Expected DatabaseException");
+      } catch (DatabaseException e) {
+        // release() uses the two-arg constructor which appends DB Name
+        assertTrue("Expected 'The pool is closed' prefix, got: "
+            + e.getMessage(),
+            e.getMessage().startsWith("The pool is closed"));
+      }
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that lastCloseTime is NOT updated when release() throws on a
+  // closed pool. If lastCloseTime were updated on failed releases, eviction
+  // logic would believe the pool is recently active when it is actually closed.
+  @Test
+  public void releaseOnClosedPoolDoesNotUpdateLastCloseTime() {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testReleaseClosedTime");
+      var pool = createPool(youTrackDb, "testReleaseClosedTime");
+      var session = pool.acquire();
+      pool.close();
+
+      long timeBeforeRelease = pool.getLastCloseTime();
+      try {
+        pool.release(session);
+        fail("Expected DatabaseException");
+      } catch (DatabaseException e) {
+        // expected
+      }
+      assertEquals("lastCloseTime must not update when pool is closed",
+          timeBeforeRelease, pool.getLastCloseTime());
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that getAvailableResources() on a closed pool throws
+  // DatabaseException instead of NPE.
+  @Test
+  public void getAvailableResourcesOnClosedPoolThrowsDatabaseException() {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testAvailClosed");
+      var pool = createPool(youTrackDb, "testAvailClosed");
+      pool.close();
+
+      try {
+        pool.getAvailableResources();
+        fail("Expected DatabaseException");
+      } catch (DatabaseException e) {
+        assertEquals("The pool is closed", e.getMessage());
+      }
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that close() is idempotent — calling it twice does not throw.
+  @Test
+  public void doubleCloseIsIdempotent() {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testDoubleClose");
+      var pool = createPool(youTrackDb, "testDoubleClose");
+
+      pool.close();
+      assertTrue("Pool should be closed after first close", pool.isClosed());
+
+      pool.close();
+      assertTrue("Pool should remain closed after second close",
+          pool.isClosed());
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies isClosed(), isUnused(), and getAvailableResources() state
+  // transitions through the pool lifecycle.
+  @Test
+  public void poolStateTransitions() {
+    var config = new BaseConfiguration();
+    config.setProperty(GlobalConfiguration.CREATE_DEFAULT_USERS.getKey(), false);
+    config.setProperty(GlobalConfiguration.DB_POOL_MAX.getKey(), 2);
+
+    var youTrackDb = createYouTrackDB(config);
+    try {
+      createDatabase(youTrackDb, "testStateTransitions");
+      var pool = createPool(youTrackDb, "testStateTransitions", config);
+
+      assertFalse(pool.isClosed());
+      assertTrue(pool.isUnused());
+      int initialAvailable = pool.getAvailableResources();
+      assertEquals(2, initialAvailable);
+
+      var session = pool.acquire();
+      assertFalse(pool.isUnused());
+      assertEquals(initialAvailable - 1, pool.getAvailableResources());
+
+      session.close();
+      assertTrue(pool.isUnused());
+      assertEquals(initialAvailable, pool.getAvailableResources());
+
+      pool.close();
+      assertTrue(pool.isClosed());
+      // A closed pool reports as unused so callers checking isUnused()
+      // for eviction don't need a separate isClosed() guard.
+      assertTrue(pool.isUnused());
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that the no-password constructor with a non-embedded factory
+  // throws UnsupportedOperationException. The ResourcePool pre-allocates min
+  // resources during construction (DB_POOL_MIN defaults to 1), so the
+  // exception is thrown at construction time when createNewResource triggers
+  // the session factory lambda.
+  @Test
+  public void noPasswordConstructorWithNonEmbeddedFactoryThrows() {
+    // Mock is not an instance of YouTrackDBInternalEmbedded, triggering the
+    // UnsupportedOperationException path in the session factory lambda.
+    var nonEmbeddedFactory = Mockito.mock(YouTrackDBInternal.class);
+
+    try {
+      new DatabasePoolImpl(
+          nonEmbeddedFactory, "testNoPassNonEmbedded", "admin",
+          (YouTrackDBConfigImpl) YouTrackDBConfig.defaultConfig());
+      fail("Expected UnsupportedOperationException");
+    } catch (UnsupportedOperationException e) {
+      assertEquals("Opening database without password is not supported",
+          e.getMessage());
+    }
+  }
+
+  // Verifies the no-password constructor works with an embedded factory,
+  // exercising the poolOpenNoAuthenticate path. Confirms the session is
+  // usable and that closing it returns the resource to the pool.
+  @Test
+  public void noPasswordConstructorWithEmbeddedFactory() {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testNoPassEmbedded");
+      var pool = new DatabasePoolImpl(
+          youTrackDb.internal, "testNoPassEmbedded", "admin",
+          (YouTrackDBConfigImpl) YouTrackDBConfig.defaultConfig());
+
+      try {
+        assertFalse(pool.isClosed());
+        int availableBefore = pool.getAvailableResources();
+
+        var session = pool.acquire();
+        assertFalse(session.isClosed());
+        assertEquals("testNoPassEmbedded", session.getDatabaseName());
+        assertEquals(availableBefore - 1, pool.getAvailableResources());
+
+        session.close();
+        assertEquals("Session close should return resource to pool",
+            availableBefore, pool.getAvailableResources());
+        assertTrue(pool.isUnused());
+      } finally {
+        pool.close();
+      }
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that acquiring from an exhausted pool throws
+  // AcquireTimeoutException after the configured timeout, and that the
+  // timeout does not corrupt pool state.
+  @Test
+  public void acquireOnExhaustedPoolThrowsAcquireTimeoutException() {
+    var config = new BaseConfiguration();
+    config.setProperty(GlobalConfiguration.CREATE_DEFAULT_USERS.getKey(), false);
+    config.setProperty(GlobalConfiguration.DB_POOL_MAX.getKey(), 1);
+    // 500 ms: short enough for a fast test, long enough to avoid
+    // flakiness on loaded CI agents
+    config.setProperty(
+        GlobalConfiguration.DB_POOL_ACQUIRE_TIMEOUT.getKey(), 500);
+
+    var youTrackDb = createYouTrackDB(config);
+    try {
+      createDatabase(youTrackDb, "testExhaustedPool");
+      var pool = createPool(youTrackDb, "testExhaustedPool", config);
+
+      var session = pool.acquire();
+      try {
+        pool.acquire();
+        fail("Expected AcquireTimeoutException");
+      } catch (AcquireTimeoutException e) {
+        // Timeout must not close the pool or corrupt state
+        assertFalse("Pool must remain open after acquire timeout",
+            pool.isClosed());
+        assertEquals("All permits still held by the first session",
+            0, pool.getAvailableResources());
+      } finally {
+        session.close();
+        pool.close();
+      }
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that with DB_POOL_MIN=0, no resources are pre-allocated at
+  // construction time and the first acquire() lazily creates a session.
+  // This exercises a different code path in ResourcePool than min>=1.
+  @Test
+  public void poolWithMinZeroLazilyCreatesResources() {
+    var config = new BaseConfiguration();
+    config.setProperty(GlobalConfiguration.CREATE_DEFAULT_USERS.getKey(), false);
+    config.setProperty(GlobalConfiguration.DB_POOL_MIN.getKey(), 0);
+    config.setProperty(GlobalConfiguration.DB_POOL_MAX.getKey(), 2);
+
+    var youTrackDb = createYouTrackDB(config);
+    try {
+      createDatabase(youTrackDb, "testMinZero");
+      var pool = createPool(youTrackDb, "testMinZero", config);
+
+      try {
+        // With min=0, no resources are created upfront; all max permits
+        // available
+        assertEquals(2, pool.getAvailableResources());
+
+        var session = pool.acquire();
+        assertFalse(session.isClosed());
+        assertEquals(1, pool.getAvailableResources());
+
+        session.close();
+        assertEquals(2, pool.getAvailableResources());
+        assertTrue(pool.isUnused());
+      } finally {
+        pool.close();
+      }
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that lastCloseTime advances after a session is released,
+  // and that the volatile write is visible from a different thread.
+  // lastCloseTime drives pool eviction decisions.
+  @Test
+  public void lastCloseTimeUpdatesAfterRelease() throws Exception {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testLastCloseTime");
+      var pool = createPool(youTrackDb, "testLastCloseTime");
+
+      // Capture a strict lower bound right before the release.
+      // Acquire and release happen on a separate thread (pooled sessions
+      // are thread-local, so both must happen on the same thread).
+      // The CountDownLatch establishes happens-before between the
+      // volatile write in release() (before countDown) and the read below.
+      long beforeRelease = System.currentTimeMillis();
+
+      var released = new CountDownLatch(1);
+      var releaseThread = new Thread(() -> {
+        var session = pool.acquire();
+        session.close();
+        released.countDown();
+      });
+      releaseThread.start();
+
+      assertTrue("Release thread timed out",
+          released.await(10, TimeUnit.SECONDS));
+      releaseThread.join(10_000);
+
+      long after = pool.getLastCloseTime();
+      assertTrue("lastCloseTime must be >= the pre-release timestamp;"
+          + " beforeRelease=" + beforeRelease + " after=" + after,
+          after >= beforeRelease);
+
+      pool.close();
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that multiple threads can concurrently acquire and release
+  // sessions without corruption. Uses pool max=2 with 8 threads to force
+  // heavy semaphore contention and exercise the ConcurrentLinkedQueue
+  // poll loop under concurrent access.
+  @Test
+  public void concurrentAcquireAndRelease() throws Exception {
+    var config = new BaseConfiguration();
+    config.setProperty(GlobalConfiguration.CREATE_DEFAULT_USERS.getKey(), false);
+    config.setProperty(GlobalConfiguration.DB_POOL_MAX.getKey(), 2);
+
+    var youTrackDb = createYouTrackDB(config);
+    try {
+      createDatabase(youTrackDb, "testConcurrentPool");
+      var pool = createPool(youTrackDb, "testConcurrentPool", config);
+
+      int poolMax = config.getInt(GlobalConfiguration.DB_POOL_MAX.getKey());
+      // 8 threads vs 2 pool slots forces 6 threads to block at any time,
+      // maximising semaphore contention
+      int threadCount = 8;
+      int iterations = 50;
+      var barrier = new CyclicBarrier(threadCount);
+      var done = new CountDownLatch(threadCount);
+      var firstError = new AtomicReference<Throwable>();
+
+      for (int t = 0; t < threadCount; t++) {
+        new Thread(() -> {
+          try {
+            barrier.await(10, TimeUnit.SECONDS);
+            for (int i = 0; i < iterations; i++) {
+              var session = pool.acquire();
+              try {
+                session.getMetadata();
+              } finally {
+                session.close();
+              }
+            }
+          } catch (Exception e) {
+            firstError.compareAndSet(null, e);
+          } finally {
+            done.countDown();
+          }
+        }).start();
+      }
+
+      assertTrue("Timed out waiting for threads",
+          done.await(60, TimeUnit.SECONDS));
+      if (firstError.get() != null) {
+        throw new AssertionError(
+            "Worker thread failed", firstError.get());
+      }
+
+      // Verify pool state is fully consistent after concurrent workload
+      assertTrue("Pool should be unused after all sessions released",
+          pool.isUnused());
+      assertEquals("All semaphore permits should be restored",
+          poolMax, pool.getAvailableResources());
+
+      pool.close();
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that closing a pool while threads are actively acquiring
+  // sessions does not deadlock. Workers and the main thread start together
+  // via a CyclicBarrier to maximize the chance of overlapping acquire()
+  // and close() calls. Uses max=8 so that close()'s semaphore drain does
+  // not block threads mid-acquire indefinitely. Only DatabaseExceptions
+  // with "The pool is closed" are accepted as expected; other
+  // DatabaseExceptions are flagged.
+  @Test
+  public void closeDuringConcurrentAcquireDoesNotHang() throws Exception {
+    var config = new BaseConfiguration();
+    config.setProperty(GlobalConfiguration.CREATE_DEFAULT_USERS.getKey(), false);
+    config.setProperty(GlobalConfiguration.DB_POOL_MAX.getKey(), 8);
+
+    var youTrackDb = createYouTrackDB(config);
+    try {
+      createDatabase(youTrackDb, "testCloseDuringAcquire");
+      var pool = createPool(youTrackDb, "testCloseDuringAcquire", config);
+
+      int threadCount = 4;
+      // +1 for the main thread so all start simultaneously
+      var barrier = new CyclicBarrier(threadCount + 1);
+      var done = new CountDownLatch(threadCount);
+      var firstUnexpected = new AtomicReference<Throwable>();
+
+      for (int t = 0; t < threadCount; t++) {
+        new Thread(() -> {
+          try {
+            barrier.await(10, TimeUnit.SECONDS);
+            // Enough iterations to likely overlap with close()
+            for (int i = 0; i < 200; i++) {
+              var session = pool.acquire();
+              try {
+                session.getMetadata();
+              } finally {
+                session.close();
+              }
+            }
+          } catch (DatabaseException e) {
+            // Only "pool is closed" exceptions are expected from both
+            // acquire() (pool null) and session.close() -> release()
+            // (pool null). Any other DatabaseException is unexpected.
+            if (!e.getMessage().startsWith("The pool is closed")) {
+              firstUnexpected.compareAndSet(null, e);
+            }
+          } catch (Exception e) {
+            firstUnexpected.compareAndSet(null, e);
+          } finally {
+            done.countDown();
+          }
+        }).start();
+      }
+
+      // Main thread also waits on barrier, then immediately closes
+      barrier.await(10, TimeUnit.SECONDS);
+      pool.close();
+
+      assertTrue("Threads did not finish (possible deadlock)",
+          done.await(30, TimeUnit.SECONDS));
+      assertTrue("Pool must be closed after close() was called",
+          pool.isClosed());
+      if (firstUnexpected.get() != null) {
+        throw new AssertionError(
+            "Unexpected exception in worker thread",
+            firstUnexpected.get());
+      }
+    } finally {
+      youTrackDb.close();
+    }
+  }
+
+  // Verifies that concurrent close() calls are safe: exactly one thread
+  // performs the actual cleanup via getAndSet(null), others see null and
+  // no-op.
+  @Test
+  public void concurrentCloseIsIdempotent() throws Exception {
+    var youTrackDb = createYouTrackDB();
+    try {
+      createDatabase(youTrackDb, "testConcurrentClose");
+      var pool = createPool(youTrackDb, "testConcurrentClose");
+
+      int threadCount = 8;
+      var barrier = new CyclicBarrier(threadCount);
+      var done = new CountDownLatch(threadCount);
+      var firstError = new AtomicReference<Throwable>();
+
+      for (int t = 0; t < threadCount; t++) {
+        new Thread(() -> {
+          try {
+            barrier.await(10, TimeUnit.SECONDS);
+            pool.close();
+          } catch (Exception e) {
+            firstError.compareAndSet(null, e);
+          } finally {
+            done.countDown();
+          }
+        }).start();
+      }
+
+      assertTrue("Timed out waiting for threads",
+          done.await(30, TimeUnit.SECONDS));
+      if (firstError.get() != null) {
+        throw new AssertionError(
+            "Thread failed during concurrent close", firstError.get());
+      }
+      assertTrue(pool.isClosed());
+    } finally {
+      youTrackDb.close();
+    }
+  }
+}


### PR DESCRIPTION
#### Motivation:

`DatabasePoolImpl` used `synchronized` blocks to protect reads and writes to
the `pool` field. Since only a single reference is being guarded with no
compound invariant, `AtomicReference` is a better fit — it eliminates lock
contention on the acquire/release/close hot paths and simplifies the code.

The old `close()` method was both `synchronized` on the method **and**
contained a redundant nested `synchronized(this)` block (reentrant lock).
`AtomicReference.getAndSet(null)` replaces both with a single atomic
operation.

This change also fixes a latent bug in `release()`: the old code read the
field `pool` directly instead of the local snapshot `p` after the null check.
If `close()` raced in between, `pool` would be `null` and `release()` would
throw `NullPointerException` instead of the expected `DatabaseException`.

Additionally, the two public constructors had substantial duplication —
both extracted `min`/`max` from config, assigned the same fields, and created
a `ResourcePool` with nearly identical listeners. This is now extracted into
a private constructor that accepts a `Function<DatabasePoolInternal,
DatabaseSessionEmbedded>` session factory.

## Summary

- Replace `volatile ResourcePool pool` with `final AtomicReference<ResourcePool>`
- Replace `synchronized` blocks with `pool.get()` / `pool.getAndSet(null)`
- Fix `release()` bug: use local snapshot `p` instead of field `pool`
- Add null guard to `getAvailableResources()` (throws `DatabaseException` vs NPE)
- Extract constructor duplication via private constructor + `Function` parameter
- Add `DatabasePoolImplTest` (14 tests): lifecycle, error paths, constructors,
  acquire timeout, `lastCloseTime` volatile visibility, concurrent acquire/release/close

## Test plan

- [x] `./mvnw -pl core test -Dtest=DatabasePoolImplTest` — 14 tests pass
- [ ] Full core unit test suite: `./mvnw -pl core clean test`
- [ ] Integration tests: `./mvnw -pl core clean verify -P ci-integration-tests`