### PR TITLE
YTDB-562: Enable BTreeLinkBagConcurrencySingleBasedLinkBagTestIT

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/sbtree/BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/sbtree/BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.java
@@ -28,7 +28,6 @@ import java.util.concurrent.Future;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -80,8 +79,6 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
     youTrackDB.close();
   }
 
-  @Ignore("YTDB-510: Disabled until LinkBag is SI-aware. updateOppositeLinks loads linked "
-      + "entities that may not exist in the reader's snapshot, causing RecordNotFoundException.")
   @Test
   public void testConcurrency() throws Exception {
     try (var session = (DatabaseSessionEmbedded) youTrackDB.open(
@@ -121,7 +118,7 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
 
         latch.countDown();
 
-        Thread.sleep(30 * 60_000);
+        Thread.sleep(60_000);
         cont = false;
 
         for (var future : addFutures) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/sbtree/BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/sbtree/BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -118,7 +119,7 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
 
         latch.countDown();
 
-        Thread.sleep(60_000);
+        TimeUnit.SECONDS.sleep(60);
         cont = false;
 
         for (var future : addFutures) {


### PR DESCRIPTION
## Motivation

The `BTreeLinkBagConcurrencySingleBasedLinkBagTestIT` was disabled via `@Ignore` (YTDB-510) because `updateOppositeLinks` could load linked entities not yet visible in the reader's snapshot, causing `RecordNotFoundException`. Snapshot isolation for LinkBag is now correctly implemented, so the test can be re-enabled.

## Summary
- Remove `@Ignore` annotation from `testConcurrency()`
- Reduce stress duration from 30 minutes to 60 seconds (sufficient for CI coverage)

## Test plan
- [x] Ran the test 3 times locally (30s, 30s, 60s durations) with 5 adder + 5 deleter threads — all passed
- [ ] CI passes