### PR TITLE
Rework Phase 4: 2 git-tracked artifacts, untracked workflow files

### DIFF
--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -1,34 +1,33 @@
 # Commit Message Conventions — Workflow
 
 Extends the project's base commit conventions (see `CLAUDE.md` §Git
-Conventions). These additional conventions apply during Phase 3 execution
-and enable reliable session resume by making commit types identifiable
-in `git log`.
+Conventions). These conventions apply during Phase 3 execution and enable
+reliable session resume by making commit types identifiable in `git log`.
+
+Only **code changes** are committed during execution. Workflow working files
+(step files, review files, plan file) are never committed — they persist on
+disk between sessions. See `conventions.md` §1.2 for the tracking model.
 
 ---
 
 ## Commit type prefixes
 
-All commits follow the base `YTDB-NNN:` prefix rule. The **second part**
-of the message (after the YTDB prefix) uses these conventions:
-
 | Commit type | Message pattern | Example |
 |---|---|---|
-| **Step implementation** | Imperative summary of the change | `YTDB-605: Add histogram header to leaf page` |
-| **Review fix** | `Review fix:` prefix | `YTDB-605: Review fix: extract validation to helper method` |
-| **Episode** | `Write Track N episode` or `Write Step N episode` | `YTDB-605: Write Step 3 episode and mark complete` |
-| **Step file update** | Describes the metadata change | `YTDB-605: Mark Track 1 Phase A complete` |
+| **Step implementation** | Imperative summary of the change | `Add histogram header to leaf page` |
+| **Review fix** | `Review fix:` prefix | `Review fix: extract validation to helper method` |
 
 ## How these are used on resume
 
-When Phase B resumes and detects orphan commits (code committed but no
-episode), it scans `git log --oneline {base_commit}..HEAD` and uses
-these patterns:
+When Phase B resumes and detects orphan commits (code committed but episode
+not written to the step file on disk), it scans
+`git log --oneline {base_commit}..HEAD` and uses these patterns:
 
-1. **Episode commits** — contain `Write ... episode` → used to find the
-   boundary of the last completed step.
-2. **Review fix commits** — contain `Review fix:` → indicate the code
-   review loop already ran. Resume from episode production (sub-step 5).
-3. **Implementation commits** — anything else that's not a step
-   file/episode update → code review loop has not run. Resume from code
-   review (sub-step 4).
+1. **Review fix commits** — contain `Review fix:` → indicate the code
+   review loop already ran for that step. Resume from episode production.
+2. **Implementation commits** — anything else → code review loop has not
+   run. Resume from code review.
+
+The step file on disk is the source of truth for which steps are complete
+(have episodes). Any code commits beyond the last completed step's work
+are orphans for the next `[ ]` step.

--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -14,8 +14,7 @@ These subsections extend the plan file structure defined in
 ### After track completion (user-approved)
 
 The track episode is written to the plan file **only after the user
-approves** the track results (see workflow.md §Track Completion Protocol).
-The episode and `[x]` marker are committed together in a single commit:
+approves** the track results (see workflow.md §Track Completion Protocol):
 
 ```markdown
 - [x] Track 2: <title>
@@ -169,9 +168,9 @@ steps), **Key files** (always), **Critical context** (rare).
 Step failed fields: **What was attempted**, **Why it failed**, **Impact on
 remaining steps**, **Key files**.
 
-Episodes are immutable once committed. Code is committed first, then the
-episode is written and committed as a **separate episode commit**. Episode
-length is proportional to cross-track impact.
+Episodes are immutable once written. Code is committed first, then the
+episode is written to the step file on disk. Episode length is proportional
+to cross-track impact.
 
 **Full format, rules, and examples:**
 [`episode-format-reference.md`](episode-format-reference.md)
@@ -180,21 +179,10 @@ length is proportional to cross-track impact.
 
 ## 2.3 Commit Message Format
 
-Follow the project's commit message conventions (see `CLAUDE.md`). If the
-branch name contains a YTDB issue number, the `prepare-commit-msg` hook
-auto-prepends the prefix.
-
-```
-YTDB-NNN: <imperative summary, under 50 chars>
-
-<detailed explanation of WHY this change was made — motivation, context,
-trade-offs. Not a restatement of the diff.>
-```
-
-Omit the `YTDB-NNN:` prefix when the branch has no associated issue.
-
-**"Why" over "what"** in commit messages. The diff shows what changed; the
-message explains why.
+Follow the project's commit message conventions (see `CLAUDE.md`). Only
+**code changes** are committed — workflow working files are never committed
+(see `conventions.md` §1.2). For commit type prefixes used during execution,
+see [`commit-conventions.md`](commit-conventions.md).
 
 ---
 
@@ -264,11 +252,11 @@ There are two plan-related directories — don't confuse them:
 
 | | Global `~/.claude/plans/` | Project `docs/adr/<dir-name>/` |
 |---|---|---|
-| **Purpose** | Claude Code session artifacts | Durable project plans (lightweight ADRs) |
-| **Names** | Auto-generated (`synthetic-orbiting-gizmo.md`) | `implementation-plan.md` + `tracks/track-N.md` |
-| **Version-controlled** | No | Yes |
-| **Survives context clearing** | Exists on disk but not reliably linked | Yes — referenced by path in prompts |
-| **After feature is complete** | Can be deleted | Keep as decision record |
+| **Purpose** | Claude Code session artifacts | Working files during execution; final artifacts after Phase 4 |
+| **Names** | Auto-generated | Working: `implementation-plan.md`, `tracks/track-N.md`; Final: `design-final.md`, `adr.md` |
+| **Version-controlled** | No | Only Phase 4 artifacts (`design-final.md`, `adr.md`) |
+| **Survives context clearing** | Exists on disk but not reliably linked | Yes — on disk, referenced by path |
+| **After feature is complete** | Can be deleted | Working files deleted with branch; artifacts kept |
 
 Claude may internally use plan mode during execution — that's fine.
 But insights must be captured in the **project's track episodes** (plan

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -31,13 +31,12 @@ defaulting to the current git branch name.
 
 ```
 docs/adr/<dir-name>/
+  ## Working files (untracked — on disk only, deleted with the branch)
   implementation-plan.md          <- strategic: goals, architecture, tracks,
                                      track-level episodic summaries
   design.md                       <- design-level: class diagrams, workflow
                                      diagrams, complex/opaque part explanations
                                      (created in Phase 1, never modified after)
-  design-final.md                 <- post-implementation design document reflecting
-                                     what was actually built (created in Phase 4)
   tracks/
     track-1.md                    <- tactical: decomposed steps, step episodes
     track-2.md
@@ -46,7 +45,17 @@ docs/adr/<dir-name>/
     structural.md
     track-1-technical.md
     ...
+
+  ## Final artifacts (committed in Phase 4 — the only tracked files)
+  design-final.md                 <- post-implementation design reflecting
+                                     what was actually built
+  adr.md                          <- architecture decision record with actual
+                                     outcomes, aggregated from all episodes
 ```
+
+Working files persist on disk between sessions and are never committed.
+The user deletes them alongside the branch after the PR is merged.
+Only the two Phase 4 artifacts are committed to git.
 
 ### Plan file content (`implementation-plan.md`)
 
@@ -76,8 +85,8 @@ docs/adr/<dir-name>/
   > **Scope:** ~N steps covering X, Y, Z
   > **Depends on:** Track 1 (when applicable)
 
-## Final Design Document
-- [ ] Phase 4: Final design document (`design-final.md`)
+## Final Artifacts
+- [ ] Phase 4: Final artifacts (`design-final.md`, `adr.md`)
 ```
 
 **Planning rule:** If a track would need more than ~5-7 steps or internal

--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -117,8 +117,9 @@ sections:
    crash recovery, performance-critical paths, or non-obvious invariants, it MUST
    have a dedicated section. Omitting these is a structural review finding.
 7. **Frozen after Phase 1** — the original `design.md` is never modified after
-   planning. A separate `design-final.md` is produced in Phase 4 to capture the
-   actual implemented design. Both are kept for planned-vs-actual comparison.
+   planning. Phase 4 produces `design-final.md` (actual design) and `adr.md`
+   (architecture decisions with actual outcomes) — the only git-tracked
+   workflow artifacts.
 
 ## Structure
 

--- a/.claude/workflow/episode-format-reference.md
+++ b/.claude/workflow/episode-format-reference.md
@@ -42,7 +42,7 @@ after it commits the code changes and completes the code review cycle.
   adapt remaining steps within the track and across tracks.
 - Keep each field concise but complete. A reviewer should understand the
   full step outcome from the episode alone, without reading the diff.
-- Episodes are immutable once committed. If later work reveals an episode
+- Episodes are immutable once written. If later work reveals an episode
   was wrong, add a correction note to the later step's episode, don't edit
   the original.
 
@@ -116,13 +116,12 @@ line; a step that uncovered a concurrency bug needs a full explanation.
 
 ---
 
-## Commit and episode ordering
+## Code commit and episode ordering
 
 Code changes are committed first (including any code review fix commits).
-After all code is committed, the episode is written to the step file and
-committed as a **separate episode commit**. This avoids the chicken-and-egg
-problem of needing the episode before the commit while needing the
-implementation to produce the episode.
+After all code is committed, the episode is written to the step file on
+disk. Episodes are never committed — they are working files that persist
+between sessions and are aggregated into the ADR during Phase 4.
 
 ---
 

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -17,8 +17,8 @@ session. Phase 1 is preceded by Phase 0 (Research) in the same session.
   [`implementation-review.md`](implementation-review.md) — two-step review:
   (1) consistency review (design doc ↔ code ↔ plan), (2) structural review.
 - **Phase 3 (Execution):** See [`workflow.md`](workflow.md).
-- **Phase 4 (Final Design Document):** See [`workflow.md`](workflow.md)
-  §Final Design Document.
+- **Phase 4 (Final Artifacts):** See [`workflow.md`](workflow.md)
+  §Final Artifacts.
 
 ```mermaid
 flowchart TD
@@ -26,7 +26,7 @@ flowchart TD
     P1["Phase 1: Planning\nTracks + architecture notes\n+ design document"]
     P2["/review-plan\nPhase 2: Implementation Review\n1. Consistency review (interactive)\n2. Structural review (automatic)"]
     P3["/execute-tracks\nPhase 3: Execution\n(see workflow.md)\nIncludes replanning via ESCALATE"]
-    P4["Phase 4: Final Design Document\nPost-implementation design\nCompare planned vs actual"]
+    P4["Phase 4: Final Artifacts\ndesign-final.md + adr.md\n(only tracked files)"]
     DONE((Done))
 
     P0 -->|"user: create the plan"| P1
@@ -222,7 +222,8 @@ for complex/opaque parts (concurrency, crash recovery, performance paths).
 
 Required content: (1) Mermaid class diagrams, (2) Mermaid workflow/sequence
 diagrams, (3) dedicated paragraphs for complex parts. All diagrams paired
-with prose. Frozen after Phase 1 — `design-final.md` is produced in Phase 4.
+with prose. Frozen after Phase 1 — `design-final.md` and `adr.md` are
+produced in Phase 4 as the only git-tracked workflow artifacts.
 
 **Full rules, examples, and structure:**
 [`design-document-rules.md`](design-document-rules.md)

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -1,112 +1,125 @@
-Read and follow the workflow for Phase 4 (Final Design Document).
+Read and follow the workflow for Phase 4 (Final Artifacts).
 
 **Step 1 — Read workflow documents.**
 
 Read these before doing anything else:
-1. `.claude/workflow/conventions.md` — shared formats, glossary, plan file structure
-2. `.claude/workflow/design-document-rules.md` — design document rules and structure
-3. `.claude/workflow/workflow.md` — §Final Design Document (Phase 4) for the
-   purpose and process
+1. `.claude/workflow/conventions.md` — shared formats, plan file structure
+2. `.claude/workflow/design-document-rules.md` — design document rules
+3. `.claude/workflow/workflow.md` — §Final Artifacts (Phase 4)
 
-**Step 2 — Read the implementation plan and original design document.**
+**Step 2 — Read all workflow working files and the implemented code.**
 
 Plan directory name: if "$ARGUMENTS" is non-empty, use it as the directory
 name. Otherwise, default to the current git branch name
 (`git branch --show-current`).
 
 Read:
-- `docs/adr/<dir-name>/implementation-plan.md` — the full plan with all track
-  episodes (these document what was discovered and what deviated from the plan)
-- `docs/adr/<dir-name>/design.md` — the original design document from Phase 1
-  (this is the "planned" design — do NOT modify it)
-- `docs/adr/<dir-name>/tracks/track-*.md` — all track step files. These contain
-  detailed step episodes documenting what was actually implemented, what failed,
-  and what design deviations occurred. This is the richest source of context for
-  understanding why the final design differs from the planned design.
+- `docs/adr/<dir-name>/implementation-plan.md` — full plan with track episodes
+- `docs/adr/<dir-name>/design.md` — original design document (do NOT modify)
+- `docs/adr/<dir-name>/tracks/track-*.md` — all step files with step episodes
 
-**Step 2.5 — Mark Phase 4 as in progress.**
+Using the plan's Architecture Notes and track episodes as a guide, read the
+actual implemented code: all classes, interfaces, and components mentioned
+in the plan, plus any that emerged during execution.
 
-In `docs/adr/<dir-name>/implementation-plan.md`, update the `## Final Design
-Document` section to mark Phase 4 as in progress:
+**Step 3 — Produce the two final artifacts.**
 
-```markdown
-## Final Design Document
-- [>] Phase 4: Final design document (`design-final.md`)
-```
-
-Commit this change with a message like: `Mark Phase 4 (final design document) as in progress`.
-
-Skip this step if Phase 4 is already marked `[>]` (resuming an interrupted session).
-
-**Step 3 — Read the implemented code.**
-
-Using the implementation plan's Architecture Notes (Component Map, Decision
-Records) and track episodes as a guide, read the actual implemented code:
-- All classes, interfaces, and components mentioned in the plan
-- Any new classes/interfaces that emerged during execution (mentioned in track
-  episodes or step files)
-- Key method signatures and relationships between components
-
-Build a complete picture of what was actually built, not what was planned.
-
-**Step 4 — Produce the final design document.**
+### Artifact 1: Final Design Document (`design-final.md`)
 
 Write `docs/adr/<dir-name>/design-final.md` reflecting the **actual
-implementation**. Follow the same structure as the original `design.md` but
-based on the real code:
+implementation**. Same structure as `design.md` but based on real code:
 
 ```
 # <Feature Name> — Final Design
 
 ## Overview
-<Brief summary of what was actually built — the real design as implemented,
-not the planned design. Note any high-level deviations from the original plan.>
+<What was actually built. Note high-level deviations from the original plan.>
 
 ## Class Design
-<Mermaid classDiagram(s) showing the classes/interfaces as they actually exist
-in the codebase. Pair each diagram with prose explaining responsibilities and
-any deviations from the planned design.>
+<Mermaid classDiagram(s) of actual classes/interfaces. Pair with prose.>
 
 ## Workflow
-<Mermaid sequenceDiagram(s) and/or flowchart(s) showing the actual runtime
-behavior. Pair each diagram with prose explaining the flow and any differences
-from the planned flow.>
+<Mermaid sequenceDiagram(s)/flowchart(s) of actual runtime behavior.
+Pair with prose.>
 
-## <Complex Topic 1>
-<How this complex part was actually implemented, why it differs from the plan
-(if it does), gotchas discovered during implementation.>
-
-## <Complex Topic 2>
-<How this complex part was actually implemented, why it differs from the plan
-(if it does), gotchas discovered during implementation.>
+## <Complex Topic>
+<How this was actually implemented, why it differs from the plan (if it does),
+gotchas discovered.>
 ```
 
 Rules:
-- **All diagrams must be Mermaid** — `classDiagram`, `sequenceDiagram`,
-  `flowchart`, or `stateDiagram` as appropriate.
-- **Reflect reality, not the plan** — if the implementation diverged from the
-  original design, the final document shows what was built. Use track episodes
-  to understand why deviations occurred.
-- **Pair every diagram with prose** — explain what the diagram shows and, where
-  relevant, how it differs from the original design.
-- **Keep diagrams focused** — same sizing rules as the original: class diagrams
-  ≤ ~12 classes, sequence diagrams ≤ ~8 participants.
-- **Complex parts are mandatory** — same rule as the original design document:
-  concurrency, crash recovery, performance-critical paths, non-obvious
-  invariants must have dedicated sections.
-- **Do NOT modify `design.md`** — the original stays untouched for comparison.
+- All diagrams must be Mermaid. Reflect reality, not the plan.
+- Pair every diagram with prose.
+- Keep diagrams focused (class ≤ ~12, sequence ≤ ~8 participants).
+- Complex parts (concurrency, crash recovery, performance paths) are mandatory.
+- Do NOT modify `design.md`.
 
-**Step 5 — Commit and mark Phase 4 complete.**
+### Artifact 2: ADR (`adr.md`)
 
-1. Commit `design-final.md` with a message explaining this is the
-   post-implementation design document.
+Write `docs/adr/<dir-name>/adr.md` — a post-implementation Architecture
+Decision Record derived from `implementation-plan.md`, adjusted for actual
+outcomes using insights from all episodic memories.
 
-2. Update the `## Final Design Document` section in
-   `docs/adr/<dir-name>/implementation-plan.md` to mark Phase 4 as complete:
+**Episodic memory aggregation:** Scan **all step episodes first** (they
+contain ground-truth details — "What was discovered", "What was done",
+"What changed from the plan"), then cross-reference with **track episodes**
+(which add strategic framing). Both levels must be aggregated — track
+episodes are summaries that may omit step-level details important for
+future work. Every discovery and plan deviation from either level should
+be evaluated for inclusion in the ADR.
 
-   ```markdown
-   ## Final Design Document
-   - [x] Phase 4: Final design document (`design-final.md`)
-   ```
+```
+# <Feature Name> — Architecture Decision Record
 
-3. Commit the plan file update.
+## Summary
+<What problem it solves, what was built.>
+
+## Goals
+<Adjusted for actual outcomes. Note descoped or changed goals.>
+
+## Constraints
+<Note relaxed constraints or new ones discovered.>
+
+## Architecture Notes
+
+### Component Map
+<Updated Mermaid diagram + bullet list reflecting actual topology.>
+
+### Decision Records
+<All decisions from the plan, updated for actual outcomes:
+- Implemented as planned → note it
+- Modified during execution → update rationale, note what changed and why
+- New decisions that emerged → add with rationale
+Retain D1, D2, ... numbering; append new decisions at the end.>
+
+### Invariants & Contracts (if applicable)
+### Integration Points (if applicable)
+### Non-Goals (if applicable)
+
+## Key Discoveries
+<Synthesized from both track episodes AND step episodes — important things
+learned during implementation that weren't known at planning time. Step
+episodes are the primary source (ground truth); track episodes provide
+strategic framing. Include discoveries that would affect future work in
+the same area, even if they seem minor at the step level.>
+```
+
+Rules:
+- No track details — captures decisions and outcomes, not execution process.
+- Aggregate from both episode levels — do not rely on track episodes alone,
+  as they may omit step-level details.
+- Retain original decision numbering for traceability.
+
+**Step 4 — Commit and complete.**
+
+Stage and commit both artifacts in a single commit:
+
+```
+Add final workflow artifacts
+
+Post-implementation artifacts:
+- design-final.md: actual design reflecting implemented code
+- adr.md: architecture decision record with actual outcomes
+```
+
+Inform the user that Phase 4 is complete and the workflow is done.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -15,7 +15,6 @@ commit for Phase C's track-level code review:
 1. Run `git rev-parse HEAD` to get the current SHA.
 2. Write it to the step file's `## Base commit` section (creating the
    section if it doesn't exist).
-3. Commit this update to the step file.
 
 This only needs to happen once per track — skip if `## Base commit` already
 has a SHA (e.g., when resuming Phase B after a mid-phase checkpoint).
@@ -27,28 +26,24 @@ has a SHA (e.g., when resuming Phase B after a mid-phase checkpoint).
 When resuming Phase B (mid-phase checkpoint or session restart), the next
 `[ ]` step may have been **partially completed** in the previous session —
 code committed but episode not yet written. This happens when a session ends
-between sub-step 3 (code commit) and sub-step 5 (episode commit), e.g., due
+between sub-step 3 (code commit) and sub-step 7 (episode writing), e.g., due
 to high context consumption or an unexpected session termination.
 
 **Detection:** After identifying the next `[ ]` step, check for orphan
-commits — implementation commits that exist after the last episoded step
-but have no corresponding episode in the step file:
+commits — code commits that exist but have no corresponding episode in
+the step file on disk:
 
-1. Find the last `[x]` step's episode commit (or the base commit if no
-   steps are complete) by scanning `git log --oneline {base_commit}..HEAD`.
-2. If there are commits after that point that are NOT step file/episode
-   updates (i.e., they are code implementation or review fix commits):
+1. Count the `[x]` steps in the step file. Scan
+   `git log --oneline {base_commit}..HEAD` for code commits.
+2. If there are more code commits than accounted for by completed steps:
    - The previous session committed code for this step but didn't write
      the episode.
    - **Resume from the appropriate sub-step** by checking commit messages
      (see `commit-conventions.md` for the patterns):
      - If any orphan commit message contains `Review fix:` → the code
-       review loop already ran. Skip directly to episode production
-       (sub-step 5).
-     - If no `Review fix:` commits exist → run the code review loop
-       (sub-step 4).
-   - Write the episode, mark the step `[x]`, update the Progress count,
-     and commit the episode.
+       review loop already ran. Skip directly to episode production.
+     - If no `Review fix:` commits exist → run the code review loop.
+   - Write the episode, mark the step `[x]`, update the Progress count.
    - Then proceed to the next `[ ]` step normally.
 3. If no orphan commits exist: implement the step from scratch.
 
@@ -73,7 +68,7 @@ before they compound. Batching these activities across steps loses all
 three benefits.
 
 **Prohibited patterns:**
-- Starting Step N+1 code before Step N's episode is committed
+- Starting Step N+1 code before Step N's episode is written
 - Batching code reviews across multiple steps
 - Batching episodes across multiple steps ("retroactive" episodes)
 - Running tests in the background and continuing to the next step
@@ -168,10 +163,9 @@ completion**, before moving to the next step:
 
    Mark the step as `[x]`. Update the **Progress** section's `Step
    implementation` count (e.g., `(3/5 complete)`). If this is the last step,
-   mark `Step implementation` as `[x]`. Commit the episode as a **separate
-   episode commit**.
+   mark `Step implementation` as `[x]`.
 
-   After the episode commit: if the context level was `warning` or
+   After writing the episode: if the context level was `warning` or
    `critical`, do NOT start the next step. Save all work and ask the user
    for a session refresh (see workflow.md §Context Consumption Check).
 
@@ -195,9 +189,7 @@ The episode includes:
 - **Critical context** — anything essential that doesn't fit above (use
   sparingly)
 
-Write the episode to the step file and commit it as a separate episode commit.
-See `conventions-execution.md` §2.2 (Commit and episode ordering) for the
-rationale behind separate episode commits.
+Write the episode to the step file on disk.
 
 ---
 
@@ -209,7 +201,7 @@ architectural problems, coverage cannot be met):
 
 1. Revert any uncommitted changes (`git checkout -- .`)
 2. Produce a **failed episode** (see conventions-execution.md §2.2)
-3. Write the failed episode to the step file and commit it
+3. Write the failed episode to the step file on disk
 4. Decide: **retry** with a different approach, or **split** the step into
    smaller pieces that can succeed independently
 
@@ -288,7 +280,7 @@ and track-level escalation rules.
 If you've completed 5+ steps and more remain, suggest ending the session
 to shed accumulated context:
 
-- Ensure all episodes are written and committed
+- Ensure all episodes are written to the step file on disk
 - Update the **Progress** section's `Step implementation` count
 - Inform the user: "Completed N of M steps. Suggest clearing session and
   re-running `/execute-tracks` to resume with fresh context."
@@ -305,7 +297,6 @@ in the same session is usually better.
 After the last step's episode is committed:
 
 1. **Mark `Step implementation` as `[x]`** in the Progress section.
-   Commit the step file update.
 2. **Inform the user** that Phase B is complete:
    - How many steps were implemented (including any failed/retried)
    - Key discoveries from step episodes

--- a/.claude/workflow/strategy-refresh.md
+++ b/.claude/workflow/strategy-refresh.md
@@ -48,12 +48,12 @@ completed or skipped a track (State A in workflow.md §Startup Protocol).
    - **ESCALATE** — accumulated discoveries have fundamentally changed the
      picture. Enter inline replanning (see `inline-replanning.md`).
 
-5. **Write the `**Strategy refresh:**` line** to the plan file under the
-   completed track's block (see conventions-execution.md §After strategy
-   refresh for format). For CONTINUE, a one-liner suffices. For ADJUST,
-   include a brief summary of what was adjusted. ESCALATE does not write a
-   strategy refresh line — it triggers replanning which restructures the
-   plan directly.
+5. **Write the `**Strategy refresh:**` line** to the plan file on disk
+   under the completed track's block (see conventions-execution.md §After
+   strategy refresh for format). For CONTINUE, a one-liner suffices. For
+   ADJUST, include a brief summary of what was adjusted. ESCALATE does not
+   write a strategy refresh line — it triggers replanning which restructures
+   the plan directly.
 
 6. **Proceed** to Phase A of the next track in the same session.
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -23,8 +23,7 @@ diff. There is no cross-step interaction to catch.
 1. Mark `Track-level code review` as `[x]` in the step file's Progress
    section with a note: `(skipped — single-step track, fully reviewed
    in Phase B)`.
-2. Commit the step file update.
-3. Skip directly to **Track Completion** (below) in the same session.
+2. Skip directly to **Track Completion** (below) in the same session.
 
 ---
 
@@ -141,10 +140,8 @@ Iterate on the synthesized findings:
 1. If any findings need fixes:
    - Apply fixes as **additional commits** (never amend prior commits)
    - Run tests to verify fixes don't break anything
-   - **Update the Progress section** to record the completed iteration
-     (e.g., `- [ ] Track-level code review (1/3 iterations)`) and commit
-     this update together with the fix commits. This ensures the iteration
-     count survives session interruptions.
+   - **Update the Progress section** on disk to record the completed
+     iteration (e.g., `- [ ] Track-level code review (1/3 iterations)`).
    - Spawn **fresh sub-agents** to verify (gate check) — only re-run the
      review dimension(s) that had open findings. For example, if only
      crash-safety code findings and test-completeness findings remain,
@@ -168,7 +165,6 @@ Iterate on the synthesized findings:
    to the user during track completion (below).
 4. When all reviews pass (or max iterations reached), mark
    `Track-level code review` as `[x]` in the step file's Progress section.
-   Commit this update.
 
 ---
 
@@ -190,9 +186,8 @@ implementation plan:
      indicator, and dependency notation (typically depends on the current
      track). Follow the same format as other tracks in the plan.
 
-2. **Commit plan changes** — commit the updated `implementation-plan.md`
-   as a separate commit. Reference the finding IDs in the commit message
-   so the plan correction is traceable to the review that motivated it.
+2. **Save plan changes** — update `implementation-plan.md` on disk.
+   Note the finding IDs that motivated each plan correction.
 
 If no findings were deferred, skip this section.
 
@@ -226,8 +221,8 @@ proceed directly to track completion **in the same session**.
    - **Fundamental rework** — trigger ESCALATE (see workflow.md
      §Inline Replanning).
 
-4. **Write the track episode and mark `[x]`** in the plan file (single
-   commit, only after user approval):
+4. **Write the track episode and mark `[x]`** in the plan file on disk
+   (only after user approval):
 
    ```markdown
    - [x] Track N: <title>
@@ -245,9 +240,9 @@ proceed directly to track completion **in the same session**.
 user approval creates a state that cannot be reliably resumed — if the
 session ends between marking `[x]` and receiving approval, the next session
 detects the track as complete (State A: strategy refresh needed) and skips
-user review entirely. By deferring the plan file write, an interrupted
-session simply re-enters track completion on resume (all phases `[x]` in
-the step file, track still `[ ]` in the plan file).
+user review entirely. By deferring the write, an interrupted session simply
+re-enters track completion on resume (all phases `[x]` in the step file,
+track still `[ ]` in the plan file).
 
 **Why merge with code review:** Phase C's code review and track completion
 have no perspective conflict — unlike Phase B→C (where implementation

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -33,9 +33,8 @@ Phase C includes both the track-level code review and track completion
    - Update the **Reviews completed** section in the step file (create the
      step file early with just the Progress and Reviews sections if it
      doesn't exist yet)
-   - **Commit the review file and step file update together.** This ensures
-     partial review progress survives session interruptions — the next
-     session can skip completed reviews and only re-run missing ones.
+   - These files persist on disk between sessions — the next session can
+     skip completed reviews and only re-run missing ones.
    - **Context consumption check** (mandatory after each review, except
      after the last action of the phase): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
@@ -48,7 +47,7 @@ Phase C includes both the track-level code review and track completion
 3. **Decompose scope indicators** into concrete steps
 4. **Write the step file** to `docs/adr/<dir-name>/tracks/track-N.md` with
    all steps as `[ ]` items. Mark `Review + decomposition` as `[x]` in the
-   Progress section. Commit the step file.
+   Progress section.
 
 ### Complexity Assessment and Which Reviews to Run
 
@@ -135,7 +134,7 @@ different aspects, based on what is actually needed.
 
 After writing the step file with all decomposed steps:
 
-1. **Verify the step file** is committed with:
+1. **Verify the step file** on disk has:
    - `Review + decomposition` marked `[x]` in Progress
    - All reviews recorded in Reviews completed
    - All steps listed as `[ ]` items

--- a/.claude/workflow/track-skip.md
+++ b/.claude/workflow/track-skip.md
@@ -16,8 +16,8 @@ A track can be skipped (`[~]`) in two situations:
    agent always presents the rationale and waits for the user to confirm.
    Even when a review sub-agent recommends `skip`, the user decides.
 
-2. **Write a skip record** to the plan file and mark the track `[~]`
-   (single commit):
+2. **Write a skip record** to the plan file on disk and mark the track
+   `[~]`:
 
    ```markdown
    - [~] Track N: <title>
@@ -31,12 +31,10 @@ A track can be skipped (`[~]`) in two situations:
    It must include enough context for strategy refresh to assess downstream
    impact.
 
-3. **Delete the step file** (`tracks/track-N.md`) if one exists (e.g.,
-   Phase A created it before the skip was decided). Include the deletion
-   in the same commit.
+3. **Delete the step file** (`tracks/track-N.md`) from disk if one exists
+   (e.g., Phase A created it before the skip was decided).
 
-4. **Delete review files** (`reviews/track-N-*.md`) if any exist. Include
-   in the same commit.
+4. **Delete review files** (`reviews/track-N-*.md`) from disk if any exist.
 
 5. **Strategy refresh** treats `[~]` tracks the same as `[x]` tracks for
    State A detection (see workflow.md §Startup Protocol). A skipped track's
@@ -53,9 +51,8 @@ A track can be skipped (`[~]`) in two situations:
 If the skip is decided during Phase A (review sub-agent recommends it and
 user confirms):
 
-- Write the `[~]` marker and skip record to the plan file
-- Delete any partially-created step file and review files
-- Commit everything together
+- Write the `[~]` marker and skip record to the plan file on disk
+- Delete any partially-created step file and review files from disk
 - The session continues: if strategy refresh was already done, proceed to
   the next `[ ]` track's Phase A. If no more tracks remain, proceed to
   Phase 4 detection.
@@ -66,7 +63,6 @@ user confirms):
 
 If the user says "skip Track N" at session start:
 
-- Write the `[~]` marker and skip record (user provides the reason)
-- Delete any step file and review files for that track
-- Commit
+- Write the `[~]` marker and skip record on disk (user provides the reason)
+- Delete any step file and review files for that track from disk
 - Continue with normal startup protocol for the next track

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -20,7 +20,7 @@ The overall workflow has five stages:
   (1) consistency review (design doc ↔ code ↔ plan, interactive),
   (2) structural review (plan-internal quality, automatic)
 - **Phase 3 (Execution)**: `/execute-tracks` — implement and review tracks
-- **Phase 4 (Final Design Document)**: produce post-implementation design document (prompt: `prompts/create-final-design.md`)
+- **Phase 4 (Final Artifacts)**: produce `design-final.md` and `adr.md` (prompt: `prompts/create-final-design.md`)
 
 Within Phase 3, each track goes through three sub-phases:
 - **Phase A**: Review + Decomposition (`track-review.md`)
@@ -58,7 +58,7 @@ flowchart TD
     READ -->|"Fresh start"| PA["Phase A: Review +\nDecomposition"]
     READ -->|"Phase A done,\nsteps incomplete"| PB["Phase B: Step\nImplementation"]
     READ -->|"All steps done,\ncode review incomplete\nor track not marked [x]"| PC["Phase C: Code Review\n+ Track Completion"]
-    READ -->|"All tracks done,\nPhase 4 not complete"| P4["Phase 4: Final\nDesign Document"]
+    READ -->|"All tracks done,\nPhase 4 not complete"| P4["Phase 4: Final\nArtifacts"]
 
     SR -->|CONTINUE / ADJUST| PA
     SR -->|ESCALATE| REPLAN["Inline Replanning"]
@@ -111,7 +111,7 @@ perspective on cross-track impact.
    | Last completed/skipped track (`[x]` or `[~]`) has no `**Strategy refresh:**` line | — | **State A**: strategy refresh first |
    | All `[x]`/`[~]` tracks have `**Strategy refresh:**`; next track is `[ ]` | No step file | **State B**: fresh start (Phase A) |
    | A track is `[ ]` | Step file exists | **State C**: mid-track resume |
-   | All tracks `[x]` or `[~]`; Phase 4 is `[ ]` or `[>]` | — | **State D**: Phase 4 (final design document) |
+   | All tracks `[x]` or `[~]`; Phase 4 is `[ ]` or `[>]` | — | **State D**: Phase 4 (final artifacts) |
    | All tracks `[x]` or `[~]`; Phase 4 is `[x]` | — | **Done** |
 
    **State C sub-states** (from step file Progress section):
@@ -126,12 +126,12 @@ perspective on cross-track impact.
 
    Each resume handles exactly **one phase** — end session after that phase.
 
-   **State D** (Phase 4 — final design document):
+   **State D** (Phase 4 — final artifacts):
 
    | Phase 4 marker | Resume action |
    |---|---|
    | `[ ]` | Start Phase 4: mark `[>]`, follow `prompts/create-final-design.md` |
-   | `[>]` | Resume Phase 4: check if `design-final.md` exists. If yes, review and complete. If no, restart from Step 3 of `create-final-design.md` |
+   | `[>]` | Resume Phase 4: check which artifacts exist. If both exist, review and complete. Otherwise, restart from Step 3 of `create-final-design.md` |
 
 4. **Inform the user** of the auto-resume decision:
    - Which track you're working on and why
@@ -196,17 +196,18 @@ Continue to the next step. No user notification needed.
 Phase boundaries are **mandatory** session boundaries. Each session handles
 exactly one phase:
 
-- **After Phase A (review + decomposition)** — step file is written and
-  committed with all steps as `[ ]` and `Review + decomposition` marked
-  `[x]`. Session ends. Next session starts Phase B.
+- **After Phase A (review + decomposition)** — step file is written to disk
+  with all steps as `[ ]` and `Review + decomposition` marked `[x]`. Session
+  ends. Next session starts Phase B.
 
 - **After Phase B (step implementation)** — all steps are implemented,
-  tested, committed, and have episodes. `Step implementation` is marked
-  `[x]`. Session ends. Next session starts Phase C.
+  tested, and committed. Episodes are written to the step file on disk.
+  `Step implementation` is marked `[x]`. Session ends. Next session starts
+  Phase C.
 
 - **After Phase C (code review + track completion)** — review is complete,
-  plan corrections committed (if any), user approved track results, track
-  episode written and track marked `[x]` (single commit after approval).
+  plan corrections saved (if any), user approved track results, track
+  episode written and track marked `[x]` in the plan file on disk.
   Session ends. Strategy refresh happens in the next session. If session
   is interrupted before user approval, the next session re-enters Phase C
   at the track completion stage (all phases `[x]` in step file, track
@@ -259,10 +260,9 @@ yet.
 1. **Do NOT start the next unit of work.** No next step (Phase B), no
    next review iteration (Phase C), no further decomposition (Phase A).
 2. **Save all work:**
-   - Ensure all progress is written to the step/review files and committed
-   - Update the **Progress** section in the step file to reflect current
-     state
-   - Commit the step file update
+   - Ensure all code changes are committed
+   - Ensure all progress is written to the step/review files on disk
+   - Update the **Progress** section in the step file on disk
 3. **Ask the user for a session refresh:**
    - Inform them of current progress and what remains
    - Instruct: "Context window is running low. Please clear the session
@@ -274,10 +274,8 @@ work when context consumption is at `warning` level or above.
 ### What to do before ending a session
 
 - Ensure all code changes are committed
-- Ensure all step episodes are written to the step file and committed
-- Update the **Progress** section in the step file to reflect the
-  current phase completion state
-- Commit the step file update
+- Ensure all step episodes are written to the step file on disk
+- Update the **Progress** section in the step file on disk
 - Inform the user of the session state so the next `/execute-tracks`
   auto-resumes correctly
 
@@ -366,25 +364,25 @@ Completion.
 
 ---
 
-## Final Design Document (Phase 4)
+## Final Artifacts (Phase 4)
 
-After all tracks are complete, a separate session produces `design-final.md`
-reflecting what was actually built. The original `design.md` is never
-modified — both are kept for planned-vs-actual comparison.
+After all tracks are complete, a separate session produces two artifacts
+that are the **only workflow files committed to git**:
 
-**Tracking in the plan file:** The `## Final Design Document` section in
+1. **`design-final.md`** — post-implementation design reflecting what was
+   actually built (the original `design.md` stays unmodified on disk)
+2. **`adr.md`** — architecture decision record with actual outcomes,
+   aggregating discoveries from both track and step episodic memories
+
+**Tracking in the plan file:** The `## Final Artifacts` section in
 `implementation-plan.md` tracks Phase 4 progress:
 
 ```markdown
-## Final Design Document
-- [ ] Phase 4: Final design document (`design-final.md`)   ← not started
-- [>] Phase 4: Final design document (`design-final.md`)   ← in progress
-- [x] Phase 4: Final design document (`design-final.md`)   ← complete
+## Final Artifacts
+- [ ] Phase 4: Final artifacts (`design-final.md`, `adr.md`)   ← not started
+- [>] Phase 4: Final artifacts (`design-final.md`, `adr.md`)   ← in progress
+- [x] Phase 4: Final artifacts (`design-final.md`, `adr.md`)   ← complete
 ```
-
-The marker transitions are:
-1. `[ ]` → `[>]` when the session begins Phase 4 (before reading code)
-2. `[>]` → `[x]` when `design-final.md` is committed
 
 **Full instructions:** [`prompts/create-final-design.md`](prompts/create-final-design.md)
 
@@ -407,7 +405,7 @@ For other workflow components, see:
 - **`research.md`** — Phase 0 (research: interactive exploration before planning)
 - **`planning.md`** — Phase 1 (planning)
 - **`implementation-review.md`** — Phase 2 (implementation review: consistency + structural)
-- **`prompts/create-final-design.md`** — Phase 4 (final design document)
+- **`prompts/create-final-design.md`** — Phase 4 (final artifacts: `design-final.md`, `adr.md`)
 
 On-demand reference documents (loaded only when their specific situation arises):
 - **`strategy-refresh.md`** — full strategy refresh protocol (State A)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,8 +174,12 @@ Tests configure YouTrackDB-specific system properties in `<argLine>`:
 - **No merge commits** (enforced by CI - `block-merge-commits.yml`)
 - PR title auto-prefixed with YTDB issue number from branch name
 - Target branch: `develop`
+- **1 PR = 1 squashed commit** — all branch commits are squashed on merge
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
+
+### Workflow Artifacts
+- Some squashed commits include `docs/adr/<dir-name>/design-final.md` and `docs/adr/<dir-name>/adr.md` — post-implementation workflow artifacts documenting the final design and architectural decisions. These are the only workflow files tracked by git; all intermediate files (implementation plan, step files, reviews) exist only on the branch during development.
 
 ## Key Entry Points
 


### PR DESCRIPTION
## Summary
- Phase 4 now produces 2 final artifacts: `design-final.md` (actual design) and `adr.md` (architecture decision record with actual outcomes)
- All intermediate workflow files (implementation-plan.md, design.md, tracks/, reviews/) are working files that persist on disk only — never committed to git
- ADR aggregates discoveries from both track-level and step-level episodic memories to avoid losing important facts
- Removed YTDB-NNN issue prefixes from commit conventions (issue prefixes live on PR titles only, 1 PR = 1 squashed commit)
- Added "Workflow Artifacts" section to CLAUDE.md documenting that some squashed commits include these 2 artifact files

## Test plan
- [ ] Verify workflow docs are internally consistent (no remaining references to committing workflow files)
- [ ] Verify Phase 4 prompt produces both artifacts correctly
- [ ] Verify CLAUDE.md documents the artifact presence in squashed commits