### PR TITLE
Add manual JMH benchmark comparison workflow

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -1,0 +1,362 @@
+name: LDBC JMH Benchmark Compare
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_prebuilt_db:
+        description: >
+          Use pre-built DB from S3 (fast, ~2 min setup).
+          When false, loads from CSV (~21 min per run).
+        required: false
+        type: boolean
+        default: true
+      queries:
+        description: >
+          Comma-separated query IDs to benchmark (e.g. IS1,IC2,IC13).
+          Leave empty to run the full suite.
+        required: false
+        type: string
+        default: ''
+
+# Prevent duplicate runs for the same branch; different branches run in parallel
+# on separate ephemeral runners provisioned by TestFlows.
+concurrency:
+  group: jmh-compare-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LDBC_SCALE_FACTOR: '1'
+
+jobs:
+  compare:
+    runs-on:
+      - self-hosted
+      - type-ccx33
+      - image-x86-system-ubuntu-24.04
+    timeout-minutes: 1200
+
+    steps:
+      # ── Setup ────────────────────────────────────────────────────────────
+      - name: Checkout (full history for fork-point detection)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Install tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq zstd python3-pip > /dev/null 2>&1
+          pip install --break-system-packages boto3 -q
+
+      - name: Resolve commits
+        id: commits
+        run: |
+          set -euo pipefail
+
+          HEAD_SHA=$(git rev-parse HEAD)
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+          # Ensure we have the develop branch ref for merge-base
+          git fetch origin develop:refs/remotes/origin/develop --no-tags
+
+          FORK_POINT=$(git merge-base HEAD origin/develop)
+
+          if [ "$HEAD_SHA" = "$FORK_POINT" ]; then
+            echo "::error::Fork-point equals HEAD — nothing to compare."
+            exit 1
+          fi
+
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "head_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "fork_point=$FORK_POINT" >> "$GITHUB_OUTPUT"
+          echo "fork_short=$(git rev-parse --short $FORK_POINT)" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          echo "Branch:     $BRANCH"
+          echo "HEAD:       $HEAD_SHA"
+          echo "Fork-point: $FORK_POINT"
+
+      - name: Build JMH filter from query list
+        id: filter
+        run: |
+          set -euo pipefail
+          QUERIES="${{ inputs.queries }}"
+          if [ -n "$QUERIES" ]; then
+            # Convert "IS1,IC2,IC13" → ".*is1_.*|.*ic2_.*|.*ic13_.*"
+            JMH_FILTER=$(echo "$QUERIES" \
+              | tr '[:upper:]' '[:lower:]' \
+              | tr ',' '\n' \
+              | sed 's/.*/.*&_.*/' \
+              | paste -sd'|')
+            echo "jmh_filter=$JMH_FILTER" >> "$GITHUB_OUTPUT"
+            echo "Filter: $JMH_FILTER"
+          else
+            echo "jmh_filter=" >> "$GITHUB_OUTPUT"
+            echo "Filter: (all benchmarks)"
+          fi
+
+      - name: Save helper scripts
+        run: |
+          # Copy comparison script to /tmp/ so it survives git checkouts
+          cp jmh-ldbc/jmh-compare.py /tmp/jmh-compare-${{ github.run_id }}.py
+
+      # ── Download data (once) ─────────────────────────────────────────────
+      - name: Download pre-built database from S3
+        if: inputs.use_prebuilt_db == true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
+          S3_ENDPOINT: ${{ secrets.HETZNER_S3_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          python3 - << 'PYEOF'
+          import boto3, os
+          s3 = boto3.client('s3',
+              endpoint_url=os.environ['S3_ENDPOINT'],
+              aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+              aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
+          print('Downloading pre-built SF 1 database from S3...')
+          s3.download_file('bench-cache', 'ldbc/ldbc-sf1-bench-db.tar.zst',
+              '/tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst')
+          print('Downloaded.')
+          PYEOF
+          zstd -d "/tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst" \
+               -o "/tmp/ldbc-bench-db-${{ github.run_id }}.tar"
+          rm -f "/tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst"
+
+      - name: Download LDBC CSV dataset from S3
+        if: inputs.use_prebuilt_db == false
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
+          S3_ENDPOINT: ${{ secrets.HETZNER_S3_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          python3 - << 'PYEOF'
+          import boto3, os
+          s3 = boto3.client('s3',
+              endpoint_url=os.environ['S3_ENDPOINT'],
+              aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+              aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
+          print('Downloading SF 1 CSV dataset from S3...')
+          s3.download_file('bench-cache', 'ldbc/ldbc-sf1-composite-merged-fk.tar.zst',
+              '/tmp/ldbc-csv-${{ github.run_id }}.tar.zst')
+          print('Downloaded.')
+          PYEOF
+          zstd -d "/tmp/ldbc-csv-${{ github.run_id }}.tar.zst" \
+               -o "/tmp/ldbc-csv-${{ github.run_id }}.tar"
+          rm -f "/tmp/ldbc-csv-${{ github.run_id }}.tar.zst"
+
+      # ── Base run (fork-point) ────────────────────────────────────────────
+      - name: 'Base: checkout fork-point'
+        run: git checkout ${{ steps.commits.outputs.fork_point }}
+
+      - name: 'Base: compile'
+        run: |
+          chmod +x mvnw
+          ./mvnw -pl jmh-ldbc -am clean compile -DskipTests \
+            -Dspotless.check.skip=true -q
+
+      - name: 'Base: extract pre-built database'
+        if: inputs.use_prebuilt_db == true
+        run: |
+          mkdir -p jmh-ldbc/target/ldbc-bench-db
+          tar xf "/tmp/ldbc-bench-db-${{ github.run_id }}.tar" \
+            -C jmh-ldbc/target/ldbc-bench-db
+
+      - name: 'Base: extract CSV dataset'
+        if: inputs.use_prebuilt_db == false
+        run: |
+          mkdir -p jmh-ldbc/target/ldbc-dataset/sf1
+          tar xf "/tmp/ldbc-csv-${{ github.run_id }}.tar" \
+            -C jmh-ldbc/target/ldbc-dataset/sf1
+
+      - name: 'Base: load database from CSV'
+        if: inputs.use_prebuilt_db == false
+        run: |
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1"
+
+      - name: 'Base: warm OS page cache'
+        env:
+          JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+        run: |
+          FILTER_ARG=""
+          if [ -n "$JMH_FILTER" ]; then
+            FILTER_ARG="$JMH_FILTER "
+          fi
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="${FILTER_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1"
+
+      - name: 'Base: run benchmarks'
+        env:
+          JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+        run: |
+          FILTER_ARG=""
+          if [ -n "$JMH_FILTER" ]; then
+            FILTER_ARG="$JMH_FILTER "
+          fi
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="${FILTER_ARG}-rf json -rff /tmp/jmh-base-${{ github.run_id }}.json" \
+            2>&1 | tee /tmp/jmh-base-log-${{ github.run_id }}.txt
+
+      # ── Head run (branch tip) ────────────────────────────────────────────
+      - name: 'Head: checkout branch tip'
+        run: git checkout ${{ steps.commits.outputs.head_sha }}
+
+      - name: 'Head: compile'
+        run: |
+          chmod +x mvnw
+          ./mvnw -pl jmh-ldbc -am clean compile -DskipTests \
+            -Dspotless.check.skip=true -q
+
+      - name: 'Head: extract pre-built database'
+        if: inputs.use_prebuilt_db == true
+        run: |
+          mkdir -p jmh-ldbc/target/ldbc-bench-db
+          tar xf "/tmp/ldbc-bench-db-${{ github.run_id }}.tar" \
+            -C jmh-ldbc/target/ldbc-bench-db
+
+      - name: 'Head: extract CSV dataset'
+        if: inputs.use_prebuilt_db == false
+        run: |
+          mkdir -p jmh-ldbc/target/ldbc-dataset/sf1
+          tar xf "/tmp/ldbc-csv-${{ github.run_id }}.tar" \
+            -C jmh-ldbc/target/ldbc-dataset/sf1
+
+      - name: 'Head: load database from CSV'
+        if: inputs.use_prebuilt_db == false
+        run: |
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1"
+
+      - name: 'Head: warm OS page cache'
+        env:
+          JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+        run: |
+          FILTER_ARG=""
+          if [ -n "$JMH_FILTER" ]; then
+            FILTER_ARG="$JMH_FILTER "
+          fi
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="${FILTER_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1"
+
+      - name: 'Head: run benchmarks'
+        env:
+          JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
+        run: |
+          FILTER_ARG=""
+          if [ -n "$JMH_FILTER" ]; then
+            FILTER_ARG="$JMH_FILTER "
+          fi
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="${FILTER_ARG}-rf json -rff /tmp/jmh-head-${{ github.run_id }}.json" \
+            2>&1 | tee /tmp/jmh-head-log-${{ github.run_id }}.txt
+
+      # ── Compare & publish ────────────────────────────────────────────────
+      - name: Compare results
+        run: |
+          python3 "/tmp/jmh-compare-${{ github.run_id }}.py" \
+            --base "/tmp/jmh-base-${{ github.run_id }}.json" \
+            --head "/tmp/jmh-head-${{ github.run_id }}.json" \
+            --base-sha "${{ steps.commits.outputs.fork_point }}" \
+            --head-sha "${{ steps.commits.outputs.head_sha }}" \
+            --output "/tmp/jmh-comparison-${{ github.run_id }}.md"
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: jmh-compare-${{ steps.commits.outputs.head_short }}-vs-${{ steps.commits.outputs.fork_short }}-${{ github.run_id }}
+          path: |
+            /tmp/jmh-base-${{ github.run_id }}.json
+            /tmp/jmh-head-${{ github.run_id }}.json
+            /tmp/jmh-comparison-${{ github.run_id }}.md
+            /tmp/jmh-base-log-${{ github.run_id }}.txt
+            /tmp/jmh-head-log-${{ github.run_id }}.txt
+          retention-days: 90
+
+      - name: Post comparison to open PRs
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync(
+              '/tmp/jmh-comparison-${{ github.run_id }}.md', 'utf8');
+            const branch = '${{ steps.commits.outputs.branch }}';
+
+            // Find open PRs whose head branch matches this branch
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open',
+            });
+
+            if (prs.length === 0) {
+              console.log(`No open PRs found for branch: ${branch}`);
+              return;
+            }
+
+            const HEADER = '<!-- jmh-ldbc-compare -->';
+            const fullBody = `${HEADER}\n${body}`;
+
+            for (const pr of prs) {
+              // Look for an existing benchmark comment to update
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+              });
+
+              const existing = comments.find(c => c.body.startsWith(HEADER));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: fullBody,
+                });
+                console.log(`Updated benchmark comment on PR #${pr.number}`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: fullBody,
+                });
+                console.log(`Created benchmark comment on PR #${pr.number}`);
+              }
+            }
+
+      # ── Cleanup temp files ──────────────────────────────────────────────
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -f /tmp/ldbc-bench-db-${{ github.run_id }}.tar \
+                /tmp/ldbc-csv-${{ github.run_id }}.tar \
+                /tmp/jmh-compare-${{ github.run_id }}.py \
+                /tmp/jmh-base-${{ github.run_id }}.json \
+                /tmp/jmh-head-${{ github.run_id }}.json \
+                /tmp/jmh-comparison-${{ github.run_id }}.md \
+                /tmp/jmh-base-log-${{ github.run_id }}.txt \
+                /tmp/jmh-head-log-${{ github.run_id }}.txt

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Compare two JMH JSON result files and produce a markdown comparison table.
+
+Usage:
+    python3 jmh-compare.py \
+        --base base-results.json --head head-results.json \
+        --base-sha abc1234 --head-sha def5678 \
+        --output comparison.md
+"""
+
+import argparse
+import json
+import sys
+
+
+def parse_jmh_results(data):
+    """Parse JMH JSON into dict keyed by (query, suite)."""
+    results = {}
+    for entry in data:
+        benchmark_full = entry["benchmark"]
+        parts = benchmark_full.rsplit(".", 2)
+        class_name = parts[-2]
+        method_name = parts[-1]
+
+        if "SingleThread" in class_name:
+            suite = "SingleThread"
+        elif "MultiThread" in class_name:
+            suite = "MultiThread"
+        else:
+            suite = class_name
+
+        primary = entry.get("primaryMetric", {})
+        score = primary.get("score", 0)
+        score_error = primary.get("scoreError", 0)
+
+        results[(method_name, suite)] = {
+            "query": method_name,
+            "suite": suite,
+            "score": score,
+            "score_error": score_error,
+        }
+    return results
+
+
+def compute_scalability(results):
+    """Compute MT/ST throughput ratio per query."""
+    st = {k[0]: v for k, v in results.items() if k[1] == "SingleThread"}
+    mt = {k[0]: v for k, v in results.items() if k[1] == "MultiThread"}
+
+    scalability = {}
+    for query in st:
+        if query in mt and st[query]["score"] > 0:
+            scalability[query] = {
+                "ratio": mt[query]["score"] / st[query]["score"],
+                "st_score": st[query]["score"],
+                "mt_score": mt[query]["score"],
+            }
+    return scalability
+
+
+def fmt_score(score):
+    """Format throughput score with appropriate precision."""
+    if score >= 1000:
+        return f"{score:,.0f}"
+    elif score >= 1:
+        return f"{score:.1f}"
+    else:
+        return f"{score:.3f}"
+
+
+def fmt_error(score, error):
+    """Format score error as a percentage of score."""
+    if score == 0:
+        return "N/A"
+    return f"\u00b1{error / score * 100:.1f}%"
+
+
+def fmt_delta(base_val, head_val):
+    """Format percentage change from base to head."""
+    if base_val == 0:
+        return "N/A"
+    delta = (head_val - base_val) / base_val * 100
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{delta:.1f}%"
+
+
+def delta_icon(base_val, head_val, threshold_pct=5.0):
+    """Return an icon indicating regression/improvement/neutral."""
+    if base_val == 0:
+        return ""
+    delta = (head_val - base_val) / base_val * 100
+    if delta <= -threshold_pct:
+        return " :red_circle:"
+    elif delta >= threshold_pct:
+        return " :green_circle:"
+    return ""
+
+
+def build_suite_table(base, head, suite):
+    """Build markdown table rows for a single suite (ST or MT)."""
+    queries = sorted(set(
+        k[0] for k in list(base.keys()) + list(head.keys()) if k[1] == suite
+    ))
+    if not queries:
+        return []
+
+    rows = []
+    for query in queries:
+        b = base.get((query, suite))
+        h = head.get((query, suite))
+
+        if b and h:
+            delta = fmt_delta(b["score"], h["score"])
+            icon = delta_icon(b["score"], h["score"])
+            rows.append(
+                f"| {query} "
+                f"| {fmt_score(b['score'])} "
+                f"| {fmt_error(b['score'], b['score_error'])} "
+                f"| {fmt_score(h['score'])} "
+                f"| {fmt_error(h['score'], h['score_error'])} "
+                f"| {delta}{icon} |"
+            )
+        elif b:
+            rows.append(
+                f"| {query} "
+                f"| {fmt_score(b['score'])} "
+                f"| {fmt_error(b['score'], b['score_error'])} "
+                f"| \u2014 | \u2014 | removed |"
+            )
+        else:
+            rows.append(
+                f"| {query} "
+                f"| \u2014 | \u2014 "
+                f"| {fmt_score(h['score'])} "
+                f"| {fmt_error(h['score'], h['score_error'])} "
+                f"| new |"
+            )
+    return rows
+
+
+def count_changes(base, head, threshold_pct=5.0):
+    """Count regressions and improvements across all suites."""
+    regressions = 0
+    improvements = 0
+    for key in set(base.keys()) | set(head.keys()):
+        b = base.get(key)
+        h = head.get(key)
+        if b and h and b["score"] > 0:
+            delta = (h["score"] - b["score"]) / b["score"] * 100
+            if delta <= -threshold_pct:
+                regressions += 1
+            elif delta >= threshold_pct:
+                improvements += 1
+    return regressions, improvements
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare two JMH result files")
+    parser.add_argument("--base", required=True, help="Base (fork-point) results JSON")
+    parser.add_argument("--head", required=True, help="Head (branch tip) results JSON")
+    parser.add_argument("--base-sha", required=True, help="Base commit SHA")
+    parser.add_argument("--head-sha", required=True, help="Head commit SHA")
+    parser.add_argument("--output", default="-", help="Output file (- for stdout)")
+    args = parser.parse_args()
+
+    with open(args.base) as f:
+        base_data = json.load(f)
+    with open(args.head) as f:
+        head_data = json.load(f)
+
+    base = parse_jmh_results(base_data)
+    head = parse_jmh_results(head_data)
+
+    base_scal = compute_scalability(base)
+    head_scal = compute_scalability(head)
+
+    regressions, improvements = count_changes(base, head)
+
+    lines = []
+    lines.append("## JMH LDBC Benchmark Comparison")
+    lines.append("")
+    lines.append(
+        f"**Base:** `{args.base_sha[:10]}` (fork-point with develop) "
+        f"| **Head:** `{args.head_sha[:10]}`"
+    )
+    if regressions > 0 or improvements > 0:
+        parts = []
+        if regressions > 0:
+            parts.append(f":red_circle: {regressions} regression(s)")
+        if improvements > 0:
+            parts.append(f":green_circle: {improvements} improvement(s)")
+        lines.append(f"**Summary:** {', '.join(parts)} (>\u00b15% threshold)")
+    lines.append("")
+
+    for suite, label in [("SingleThread", "Single-Thread"),
+                         ("MultiThread", "Multi-Thread")]:
+        rows = build_suite_table(base, head, suite)
+        if not rows:
+            continue
+        lines.append(f"### {label} Results")
+        lines.append("")
+        lines.append(
+            "| Benchmark | Base ops/s | Base err | Head ops/s | Head err | \u0394% |"
+        )
+        lines.append(
+            "|-----------|-----------|---------|-----------|---------|-----|"
+        )
+        lines.extend(rows)
+        lines.append("")
+
+    # Scalability table
+    all_queries = sorted(set(list(base_scal.keys()) + list(head_scal.keys())))
+    if all_queries:
+        lines.append("### Scalability (MT/ST ratio)")
+        lines.append("")
+        lines.append("| Benchmark | Base ratio | Head ratio | \u0394% |")
+        lines.append("|-----------|-----------|-----------|-----|")
+
+        for query in all_queries:
+            b = base_scal.get(query)
+            h = head_scal.get(query)
+            if b and h:
+                delta = fmt_delta(b["ratio"], h["ratio"])
+                lines.append(
+                    f"| {query} | {b['ratio']:.2f}x | {h['ratio']:.2f}x | {delta} |"
+                )
+            elif b:
+                lines.append(f"| {query} | {b['ratio']:.2f}x | \u2014 | removed |")
+            else:
+                lines.append(f"| {query} | \u2014 | {h['ratio']:.2f}x | new |")
+        lines.append("")
+
+    output = "\n".join(lines)
+
+    if args.output == "-":
+        print(output)
+    else:
+        with open(args.output, "w") as f:
+            f.write(output)
+        print(f"Comparison written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -10,7 +10,6 @@ Usage:
 
 import argparse
 import json
-import sys
 
 
 def parse_jmh_results(data):
@@ -18,9 +17,10 @@ def parse_jmh_results(data):
     results = {}
     for entry in data:
         benchmark_full = entry["benchmark"]
-        parts = benchmark_full.rsplit(".", 2)
-        class_name = parts[-2]
-        method_name = parts[-1]
+        if "." not in benchmark_full:
+            continue
+        class_name_full, method_name = benchmark_full.rsplit(".", 1)
+        class_name = class_name_full.rsplit(".", 1)[-1]
 
         if "SingleThread" in class_name:
             suite = "SingleThread"
@@ -98,9 +98,9 @@ def delta_icon(base_val, head_val, threshold_pct=5.0):
 
 def build_suite_table(base, head, suite):
     """Build markdown table rows for a single suite (ST or MT)."""
-    queries = sorted(set(
-        k[0] for k in list(base.keys()) + list(head.keys()) if k[1] == suite
-    ))
+    queries = sorted({
+        k[0] for k in (base.keys() | head.keys()) if k[1] == suite
+    })
     if not queries:
         return []
 
@@ -142,7 +142,7 @@ def count_changes(base, head, threshold_pct=5.0):
     """Count regressions and improvements across all suites."""
     regressions = 0
     improvements = 0
-    for key in set(base.keys()) | set(head.keys()):
+    for key in base.keys() | head.keys():
         b = base.get(key)
         h = head.get(key)
         if b and h and b["score"] > 0:
@@ -209,7 +209,7 @@ def main():
         lines.append("")
 
     # Scalability table
-    all_queries = sorted(set(list(base_scal.keys()) + list(head_scal.keys())))
+    all_queries = sorted(base_scal.keys() | head_scal.keys())
     if all_queries:
         lines.append("### Scalability (MT/ST ratio)")
         lines.append("")


### PR DESCRIPTION
## Motivation

Currently JMH benchmarks run nightly on develop only, with no easy way to compare benchmark results between a feature branch and its fork-point. This makes it hard to detect performance regressions or improvements introduced by a branch before merging.

## Summary

- **New workflow** `.github/workflows/ldbc-jmh-compare.yml` — manual-only (`workflow_dispatch`) that:
  - Runs on a CCX33 self-hosted runner via TestFlows (no server provisioning)
  - Finds the fork-point with `develop` via `git merge-base`
  - Runs the full JMH LDBC suite (or a filtered subset) at both the fork-point and branch HEAD
  - Each run builds its own database (prebuilt from S3 or fresh from CSV)
  - Compares throughput, error, and MT/ST scalability side-by-side
  - Posts results as a sticky PR comment on any open PRs for the branch

- **New script** `jmh-ldbc/jmh-compare.py` — parses two JMH JSON result files and generates a markdown comparison with:
  - Single-thread and multi-thread result tables (ops/s, error %, Δ%)
  - Scalability ratio table (MT/ST)
  - Regression/improvement summary with ±5% threshold icons

### Workflow inputs
| Input | Default | Description |
|-------|---------|-------------|
| `use_prebuilt_db` | `true` | Pre-built DB (~2 min) vs CSV loading (~21 min/run) |
| `queries` | _(empty = all)_ | Comma-separated query IDs, e.g. `IS1,IC2,IC13` |

## Test plan
- [ ] Trigger workflow manually on this branch — verify it fails with "fork-point equals HEAD" (since this branch has no code changes beyond the workflow itself)
- [ ] Trigger on a branch with actual code changes — verify both base and head benchmarks complete and comparison is posted to PR
- [ ] Test with query filter (e.g. `IS1,IS2`) — verify only filtered queries appear in results
- [ ] Test with `use_prebuilt_db=false` — verify CSV loading works for both runs