### PR TITLE
YTDB-627: Replace ConcurrentHashMap with primitive ConcurrentLongIntHashMap in LockFreeReadCache

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -220,6 +220,10 @@ public class ConcurrentLongIntHashMap<V> {
   /**
    * A single segment of the hash map. Holds parallel arrays for keys and values, guarded by a
    * {@link StampedLock}. Uses open addressing with linear probing.
+   *
+   * <p><b>Write ordering convention:</b> when inserting a new entry, the value is written before the
+   * key fields (fileId, pageIndex). A concurrent optimistic reader that sees a non-null value at a
+   * slot will find valid key fields because the write lock ensures ordering via stamp validation.
    */
   private static final class Section<V> {
     private static final float FILL_FACTOR = 0.66f;
@@ -235,7 +239,7 @@ public class ConcurrentLongIntHashMap<V> {
     /** Number of logically present entries. */
     private volatile int size;
 
-    /** Number of occupied buckets (entries + tombstones). Drives resize threshold. */
+    /** Number of occupied buckets. Drives resize threshold. */
     private int usedBuckets;
 
     /** Current array length (always a power of two). */
@@ -276,7 +280,6 @@ public class ConcurrentLongIntHashMap<V> {
         int idx = (bucket + i) & bucketMask;
         V val = vals[idx];
         if (val == null) {
-          // Empty slot — key is not present
           break;
         }
         if (fIds[idx] == fileId && pIdxs[idx] == pageIndex) {
@@ -316,35 +319,46 @@ public class ConcurrentLongIntHashMap<V> {
       return null;
     }
 
+    /**
+     * Probe for a key under write lock. Returns the index where the key was found (non-negative),
+     * or a negative value encoding the first empty slot: {@code ~firstEmptySlot}. Callers decode
+     * the empty slot index with {@code ~returnValue}.
+     */
+    private int probeForKey(long fileId, int pageIndex, int hashMix) {
+      int bucketMask = capacity - 1;
+      int bucket = hashMix & bucketMask;
+      int firstEmpty = -1;
+
+      for (int i = 0; i < capacity; i++) {
+        int idx = (bucket + i) & bucketMask;
+        V val = values[idx];
+        if (val == null) {
+          if (firstEmpty == -1) {
+            firstEmpty = idx;
+          }
+          break;
+        }
+        if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+          return idx;
+        }
+      }
+
+      assert firstEmpty >= 0 : "No empty slot found; resize threshold should prevent full table";
+      return ~firstEmpty;
+    }
+
     V put(long fileId, int pageIndex, V value, int hashMix) {
       long stamp = lock.writeLock();
       try {
-        int bucketMask = capacity - 1;
-        int bucket = hashMix & bucketMask;
-
-        // Probe for existing key or first empty slot
-        int firstEmpty = -1;
-        for (int i = 0; i < capacity; i++) {
-          int idx = (bucket + i) & bucketMask;
-          V val = values[idx];
-          if (val == null) {
-            if (firstEmpty == -1) {
-              firstEmpty = idx;
-            }
-            break;
-          }
-          if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
-            // Key found — replace value
-            V prev = values[idx];
-            // Write ordering: value before keys (A2 review decision).
-            // On the read path, a reader that sees the new value also sees valid keys.
-            // If the reader sees the old value, it's still consistent with the old keys.
-            values[idx] = value;
-            return prev;
-          }
+        int probeResult = probeForKey(fileId, pageIndex, hashMix);
+        if (probeResult >= 0) {
+          // Key found — replace value (write ordering: value before keys, see Section Javadoc)
+          V prev = values[probeResult];
+          values[probeResult] = value;
+          return prev;
         }
 
-        insertAt(firstEmpty, fileId, pageIndex, value);
+        insertAt(~probeResult, fileId, pageIndex, value, hashMix);
         return null;
       } finally {
         lock.unlockWrite(stamp);
@@ -354,26 +368,12 @@ public class ConcurrentLongIntHashMap<V> {
     V putIfAbsent(long fileId, int pageIndex, V value, int hashMix) {
       long stamp = lock.writeLock();
       try {
-        int bucketMask = capacity - 1;
-        int bucket = hashMix & bucketMask;
-
-        int firstEmpty = -1;
-        for (int i = 0; i < capacity; i++) {
-          int idx = (bucket + i) & bucketMask;
-          V val = values[idx];
-          if (val == null) {
-            if (firstEmpty == -1) {
-              firstEmpty = idx;
-            }
-            break;
-          }
-          if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
-            // Key exists — return current value, don't replace
-            return val;
-          }
+        int probeResult = probeForKey(fileId, pageIndex, hashMix);
+        if (probeResult >= 0) {
+          return values[probeResult];
         }
 
-        insertAt(firstEmpty, fileId, pageIndex, value);
+        insertAt(~probeResult, fileId, pageIndex, value, hashMix);
         return null;
       } finally {
         lock.unlockWrite(stamp);
@@ -384,32 +384,18 @@ public class ConcurrentLongIntHashMap<V> {
         long fileId, int pageIndex, LongIntFunction<V> mappingFunction, int hashMix) {
       long stamp = lock.writeLock();
       try {
-        int bucketMask = capacity - 1;
-        int bucket = hashMix & bucketMask;
-
-        int firstEmpty = -1;
-        for (int i = 0; i < capacity; i++) {
-          int idx = (bucket + i) & bucketMask;
-          V val = values[idx];
-          if (val == null) {
-            if (firstEmpty == -1) {
-              firstEmpty = idx;
-            }
-            break;
-          }
-          if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
-            return val;
-          }
+        int probeResult = probeForKey(fileId, pageIndex, hashMix);
+        if (probeResult >= 0) {
+          return values[probeResult];
         }
 
-        // Key absent — compute the value
         V newValue = mappingFunction.apply(fileId, pageIndex);
         if (newValue == null) {
           throw new IllegalArgumentException(
               "computeIfAbsent mapping function must not return null");
         }
 
-        insertAt(firstEmpty, fileId, pageIndex, newValue);
+        insertAt(~probeResult, fileId, pageIndex, newValue, hashMix);
         return newValue;
       } finally {
         lock.unlockWrite(stamp);
@@ -420,17 +406,14 @@ public class ConcurrentLongIntHashMap<V> {
      * Insert a new entry at the given slot index. Handles resize if needed. Must be called under
      * write lock.
      */
-    private void insertAt(int slotIdx, long fileId, int pageIndex, V value) {
-      // Check if resize is needed before inserting
+    private void insertAt(int slotIdx, long fileId, int pageIndex, V value, int hashMix) {
       if (usedBuckets >= resizeThreshold) {
-        rehash(capacity * 2);
+        rehash();
         // Recalculate slot after resize — arrays have changed
-        slotIdx = findEmptySlot(fileId, pageIndex);
+        slotIdx = findEmptySlot(hashMix);
       }
 
-      // Write ordering: value first, then key fields (A2 review decision).
-      // A concurrent optimistic reader that sees the value will also see valid keys
-      // because the write lock ensures ordering via the stamp validation.
+      // Value first, then key fields (see Section Javadoc for write ordering rationale)
       values[slotIdx] = value;
       fileIds[slotIdx] = fileId;
       pageIndices[slotIdx] = pageIndex;
@@ -439,10 +422,10 @@ public class ConcurrentLongIntHashMap<V> {
       size++;
     }
 
-    /** Find an empty slot for the given key. Must be called under write lock after resize. */
-    private int findEmptySlot(long fileId, int pageIndex) {
+    /** Find an empty slot starting from the hash bucket. Must be called under write lock. */
+    private int findEmptySlot(int hashMix) {
       int bucketMask = capacity - 1;
-      int bucket = (int) hash(fileId, pageIndex) & bucketMask;
+      int bucket = hashMix & bucketMask;
 
       for (int i = 0; i < capacity; i++) {
         int idx = (bucket + i) & bucketMask;
@@ -451,14 +434,16 @@ public class ConcurrentLongIntHashMap<V> {
         }
       }
 
-      // Should never happen — resize ensures there's always room
       throw new IllegalStateException("No empty slot found after resize");
     }
 
     /** Double the capacity and re-insert all entries. Must be called under write lock. */
     @SuppressWarnings("unchecked")
-    private void rehash(int newCapacity) {
-      newCapacity = alignToPowerOfTwo(newCapacity);
+    private void rehash() {
+      if (capacity >= (1 << 30)) {
+        throw new IllegalStateException("Maximum section capacity reached (2^30)");
+      }
+      int newCapacity = capacity * 2;
 
       long[] oldFileIds = fileIds;
       int[] oldPageIndices = pageIndices;
@@ -470,7 +455,7 @@ public class ConcurrentLongIntHashMap<V> {
       pageIndices = new int[newCapacity];
       values = (V[]) new Object[newCapacity];
       resizeThreshold = (int) (newCapacity * FILL_FACTOR);
-      usedBuckets = size; // Rehash eliminates tombstones
+      usedBuckets = size;
 
       int bucketMask = newCapacity - 1;
       for (int i = 0; i < oldCapacity; i++) {
@@ -480,12 +465,10 @@ public class ConcurrentLongIntHashMap<V> {
           int pIdx = oldPageIndices[i];
           int bucket = (int) hash(fId, pIdx) & bucketMask;
 
-          // Find empty slot in new arrays
           while (values[bucket] != null) {
             bucket = (bucket + 1) & bucketMask;
           }
 
-          // Write ordering: value first, then keys
           values[bucket] = val;
           fileIds[bucket] = fId;
           pageIndices[bucket] = pIdx;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -756,11 +756,15 @@ public class ConcurrentLongIntHashMap<V> {
         }
       }
 
-      // Swap all at once — section remains consistent even if OOM occurred above
-      capacity = newCapacity;
+      // Swap arrays BEFORE capacity — an optimistic reader that snapshots the new capacity
+      // but old arrays would use a mask larger than the array length, causing AIOOBE.
+      // By writing arrays first, a reader that sees the old capacity uses a smaller mask
+      // against larger arrays (safe), while a reader that sees the new capacity uses the
+      // correct mask against the new arrays (also safe).
       fileIds = newFileIds;
       pageIndices = newPageIndices;
       values = newValues;
+      capacity = newCapacity;
       resizeThreshold = (int) (newCapacity * FILL_FACTOR);
       usedBuckets = size;
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -124,6 +124,50 @@ public class ConcurrentLongIntHashMap<V> {
     return size() == 0;
   }
 
+  /**
+   * Associates the value with the given composite key. If the key is already present, the previous
+   * value is replaced.
+   *
+   * @return the previous value, or {@code null} if absent
+   * @throws IllegalArgumentException if value is null
+   */
+  public V put(long fileId, int pageIndex, V value) {
+    if (value == null) {
+      throw new IllegalArgumentException("Null values are not allowed");
+    }
+    long hash = hash(fileId, pageIndex);
+    int sectionIdx = sectionIndex(hash);
+    return sections[sectionIdx].put(fileId, pageIndex, value, (int) hash);
+  }
+
+  /**
+   * Associates the value with the given composite key only if the key is not already present.
+   *
+   * @return the existing value if present, or {@code null} if the new value was inserted
+   * @throws IllegalArgumentException if value is null
+   */
+  public V putIfAbsent(long fileId, int pageIndex, V value) {
+    if (value == null) {
+      throw new IllegalArgumentException("Null values are not allowed");
+    }
+    long hash = hash(fileId, pageIndex);
+    int sectionIdx = sectionIndex(hash);
+    return sections[sectionIdx].putIfAbsent(fileId, pageIndex, value, (int) hash);
+  }
+
+  /**
+   * If the key is absent, computes a value using the mapping function and inserts it. If the key is
+   * present, returns the existing value without calling the function.
+   *
+   * @return the existing or newly computed value
+   * @throws IllegalArgumentException if the mapping function returns null
+   */
+  public V computeIfAbsent(long fileId, int pageIndex, LongIntFunction<V> mappingFunction) {
+    long hash = hash(fileId, pageIndex);
+    int sectionIdx = sectionIndex(hash);
+    return sections[sectionIdx].computeIfAbsent(fileId, pageIndex, mappingFunction, (int) hash);
+  }
+
   /** Returns the total capacity (sum of all section capacities). */
   public long capacity() {
     long total = 0;
@@ -178,6 +222,8 @@ public class ConcurrentLongIntHashMap<V> {
    * {@link StampedLock}. Uses open addressing with linear probing.
    */
   private static final class Section<V> {
+    private static final float FILL_FACTOR = 0.66f;
+
     private final StampedLock lock = new StampedLock();
 
     // Parallel arrays — same index across all three stores one logical entry.
@@ -189,8 +235,14 @@ public class ConcurrentLongIntHashMap<V> {
     /** Number of logically present entries. */
     private volatile int size;
 
+    /** Number of occupied buckets (entries + tombstones). Drives resize threshold. */
+    private int usedBuckets;
+
     /** Current array length (always a power of two). */
     private int capacity;
+
+    /** Resize when usedBuckets exceeds this. */
+    private int resizeThreshold;
 
     @SuppressWarnings("unchecked")
     Section(int capacity) {
@@ -199,6 +251,8 @@ public class ConcurrentLongIntHashMap<V> {
       this.pageIndices = new int[this.capacity];
       this.values = (V[]) new Object[this.capacity];
       this.size = 0;
+      this.usedBuckets = 0;
+      this.resizeThreshold = (int) (this.capacity * FILL_FACTOR);
     }
 
     V get(long fileId, int pageIndex, int hashMix) {
@@ -260,6 +314,183 @@ public class ConcurrentLongIntHashMap<V> {
         }
       }
       return null;
+    }
+
+    V put(long fileId, int pageIndex, V value, int hashMix) {
+      long stamp = lock.writeLock();
+      try {
+        int bucketMask = capacity - 1;
+        int bucket = hashMix & bucketMask;
+
+        // Probe for existing key or first empty slot
+        int firstEmpty = -1;
+        for (int i = 0; i < capacity; i++) {
+          int idx = (bucket + i) & bucketMask;
+          V val = values[idx];
+          if (val == null) {
+            if (firstEmpty == -1) {
+              firstEmpty = idx;
+            }
+            break;
+          }
+          if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+            // Key found — replace value
+            V prev = values[idx];
+            // Write ordering: value before keys (A2 review decision).
+            // On the read path, a reader that sees the new value also sees valid keys.
+            // If the reader sees the old value, it's still consistent with the old keys.
+            values[idx] = value;
+            return prev;
+          }
+        }
+
+        insertAt(firstEmpty, fileId, pageIndex, value);
+        return null;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    V putIfAbsent(long fileId, int pageIndex, V value, int hashMix) {
+      long stamp = lock.writeLock();
+      try {
+        int bucketMask = capacity - 1;
+        int bucket = hashMix & bucketMask;
+
+        int firstEmpty = -1;
+        for (int i = 0; i < capacity; i++) {
+          int idx = (bucket + i) & bucketMask;
+          V val = values[idx];
+          if (val == null) {
+            if (firstEmpty == -1) {
+              firstEmpty = idx;
+            }
+            break;
+          }
+          if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+            // Key exists — return current value, don't replace
+            return val;
+          }
+        }
+
+        insertAt(firstEmpty, fileId, pageIndex, value);
+        return null;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    V computeIfAbsent(
+        long fileId, int pageIndex, LongIntFunction<V> mappingFunction, int hashMix) {
+      long stamp = lock.writeLock();
+      try {
+        int bucketMask = capacity - 1;
+        int bucket = hashMix & bucketMask;
+
+        int firstEmpty = -1;
+        for (int i = 0; i < capacity; i++) {
+          int idx = (bucket + i) & bucketMask;
+          V val = values[idx];
+          if (val == null) {
+            if (firstEmpty == -1) {
+              firstEmpty = idx;
+            }
+            break;
+          }
+          if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+            return val;
+          }
+        }
+
+        // Key absent — compute the value
+        V newValue = mappingFunction.apply(fileId, pageIndex);
+        if (newValue == null) {
+          throw new IllegalArgumentException(
+              "computeIfAbsent mapping function must not return null");
+        }
+
+        insertAt(firstEmpty, fileId, pageIndex, newValue);
+        return newValue;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    /**
+     * Insert a new entry at the given slot index. Handles resize if needed. Must be called under
+     * write lock.
+     */
+    private void insertAt(int slotIdx, long fileId, int pageIndex, V value) {
+      // Check if resize is needed before inserting
+      if (usedBuckets >= resizeThreshold) {
+        rehash(capacity * 2);
+        // Recalculate slot after resize — arrays have changed
+        slotIdx = findEmptySlot(fileId, pageIndex);
+      }
+
+      // Write ordering: value first, then key fields (A2 review decision).
+      // A concurrent optimistic reader that sees the value will also see valid keys
+      // because the write lock ensures ordering via the stamp validation.
+      values[slotIdx] = value;
+      fileIds[slotIdx] = fileId;
+      pageIndices[slotIdx] = pageIndex;
+
+      usedBuckets++;
+      size++;
+    }
+
+    /** Find an empty slot for the given key. Must be called under write lock after resize. */
+    private int findEmptySlot(long fileId, int pageIndex) {
+      int bucketMask = capacity - 1;
+      int bucket = (int) hash(fileId, pageIndex) & bucketMask;
+
+      for (int i = 0; i < capacity; i++) {
+        int idx = (bucket + i) & bucketMask;
+        if (values[idx] == null) {
+          return idx;
+        }
+      }
+
+      // Should never happen — resize ensures there's always room
+      throw new IllegalStateException("No empty slot found after resize");
+    }
+
+    /** Double the capacity and re-insert all entries. Must be called under write lock. */
+    @SuppressWarnings("unchecked")
+    private void rehash(int newCapacity) {
+      newCapacity = alignToPowerOfTwo(newCapacity);
+
+      long[] oldFileIds = fileIds;
+      int[] oldPageIndices = pageIndices;
+      V[] oldValues = values;
+      int oldCapacity = capacity;
+
+      capacity = newCapacity;
+      fileIds = new long[newCapacity];
+      pageIndices = new int[newCapacity];
+      values = (V[]) new Object[newCapacity];
+      resizeThreshold = (int) (newCapacity * FILL_FACTOR);
+      usedBuckets = size; // Rehash eliminates tombstones
+
+      int bucketMask = newCapacity - 1;
+      for (int i = 0; i < oldCapacity; i++) {
+        V val = oldValues[i];
+        if (val != null) {
+          long fId = oldFileIds[i];
+          int pIdx = oldPageIndices[i];
+          int bucket = (int) hash(fId, pIdx) & bucketMask;
+
+          // Find empty slot in new arrays
+          while (values[bucket] != null) {
+            bucket = (bucket + 1) & bucketMask;
+          }
+
+          // Write ordering: value first, then keys
+          values[bucket] = val;
+          fileIds[bucket] = fId;
+          pageIndices[bucket] = pIdx;
+        }
+      }
     }
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -538,8 +538,8 @@ public class ConcurrentLongIntHashMap<V> {
 
     /**
      * Remove all entries with the given fileId. Sweeps the entire section linearly under write
-     * lock, collecting removed values into the provided list. After the sweep, if the tombstone
-     * ratio is too high, performs a same-capacity rehash to compact the section.
+     * lock, collecting removed values into the provided list. After the sweep, always performs a
+     * same-capacity rehash to compact the section and restore probe chain integrity.
      */
     void removeByFileId(long fileId, List<V> removedEntries) {
       long stamp = lock.writeLock();
@@ -561,10 +561,8 @@ public class ConcurrentLongIntHashMap<V> {
         size -= removed;
         usedBuckets -= removed;
 
-        // After bulk removal, compact if tombstone ratio exceeds threshold.
         // Since we used simple nullification (not backward-sweep per entry), there may be
-        // gaps in probe chains. A same-capacity rehash eliminates all gaps.
-        // Always rehash after removeByFileId to restore probe chain integrity.
+        // gaps in probe chains. A same-capacity rehash restores probe chain integrity.
         rehashSameCapacity();
       } finally {
         lock.unlockWrite(stamp);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -21,6 +21,8 @@
  */
 package com.jetbrains.youtrackdb.internal.common.collection;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.locks.StampedLock;
 
 /**
@@ -213,6 +215,27 @@ public class ConcurrentLongIntHashMap<V> {
     long hash = hash(fileId, pageIndex);
     int sectionIdx = sectionIndex(hash);
     return sections[sectionIdx].remove(fileId, pageIndex, expected, (int) hash);
+  }
+
+  /**
+   * Removes all entries with the given fileId across all sections.
+   *
+   * <p>Each section is swept linearly under its write lock: matching entries are collected into a
+   * list and the section's arrays are compacted (same-capacity rehash if needed). The returned list
+   * is safe to iterate outside any lock — callers can perform post-removal processing (e.g.,
+   * freeze, eviction callbacks) without holding segment locks.
+   *
+   * <p>Cross-section removal is not collectively atomic, matching the per-entry atomicity of
+   * individual {@code remove()} calls.
+   *
+   * @return a list of removed values (may be empty, never null)
+   */
+  public List<V> removeByFileId(long fileId) {
+    var result = new ArrayList<V>();
+    for (Section<V> section : sections) {
+      section.removeByFileId(fileId, result);
+    }
+    return result;
   }
 
   /** Returns the total capacity (sum of all section capacities). */
@@ -510,6 +533,74 @@ public class ConcurrentLongIntHashMap<V> {
         return true;
       } finally {
         lock.unlockWrite(stamp);
+      }
+    }
+
+    /**
+     * Remove all entries with the given fileId. Sweeps the entire section linearly under write
+     * lock, collecting removed values into the provided list. After the sweep, if the tombstone
+     * ratio is too high, performs a same-capacity rehash to compact the section.
+     */
+    void removeByFileId(long fileId, List<V> removedEntries) {
+      long stamp = lock.writeLock();
+      try {
+        int removed = 0;
+        for (int i = 0; i < capacity; i++) {
+          V val = values[i];
+          if (val != null && fileIds[i] == fileId) {
+            removedEntries.add(val);
+            values[i] = null;
+            removed++;
+          }
+        }
+
+        if (removed == 0) {
+          return;
+        }
+
+        size -= removed;
+        usedBuckets -= removed;
+
+        // After bulk removal, compact if tombstone ratio exceeds threshold.
+        // Since we used simple nullification (not backward-sweep per entry), there may be
+        // gaps in probe chains. A same-capacity rehash eliminates all gaps.
+        // Always rehash after removeByFileId to restore probe chain integrity.
+        rehashSameCapacity();
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    /**
+     * Rehash at the same capacity — re-insert all live entries into fresh arrays. Eliminates any
+     * gaps left by bulk removal. Must be called under write lock.
+     */
+    @SuppressWarnings("unchecked")
+    private void rehashSameCapacity() {
+      long[] oldFileIds = fileIds;
+      int[] oldPageIndices = pageIndices;
+      V[] oldValues = values;
+
+      fileIds = new long[capacity];
+      pageIndices = new int[capacity];
+      values = (V[]) new Object[capacity];
+
+      int bucketMask = capacity - 1;
+      for (int i = 0; i < capacity; i++) {
+        V val = oldValues[i];
+        if (val != null) {
+          long fId = oldFileIds[i];
+          int pIdx = oldPageIndices[i];
+          int bucket = (int) hash(fId, pIdx) & bucketMask;
+
+          while (values[bucket] != null) {
+            bucket = (bucket + 1) & bucketMask;
+          }
+
+          values[bucket] = val;
+          fileIds[bucket] = fId;
+          pageIndices[bucket] = pIdx;
+        }
       }
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -287,6 +287,16 @@ public class ConcurrentLongIntHashMap<V> {
   // ---- Hashing ----
 
   /**
+   * Computes an int hash for the frequency sketch (TinyLFU admission filter). Uses
+   * {@code Long.hashCode(fileId) * 31 + pageIndex} — intentionally independent from the map's
+   * internal murmur hash to avoid correlation with bucket position (the murmur hash lower bits
+   * determine the bucket, so reusing them for frequency counting would cluster sketch counters).
+   */
+  public static int hashForFrequencySketch(long fileId, int pageIndex) {
+    return Long.hashCode(fileId) * 31 + pageIndex;
+  }
+
+  /**
    * Mixes both key fields into a 64-bit hash using a Murmur3-style finalizer.
    *
    * <p>The pageIndex is spread into the upper bits of a long before combining with fileId,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -238,6 +238,39 @@ public class ConcurrentLongIntHashMap<V> {
     return result;
   }
 
+  /** Removes all entries from all sections. */
+  public void clear() {
+    for (Section<V> s : sections) {
+      s.clear();
+    }
+  }
+
+  /** Iterates all entries, passing (fileId, pageIndex, value) to the consumer. */
+  public void forEach(LongIntObjConsumer<V> consumer) {
+    for (Section<V> s : sections) {
+      s.forEach(consumer);
+    }
+  }
+
+  /** Iterates all values, passing each to the consumer. */
+  public void forEachValue(java.util.function.Consumer<V> consumer) {
+    for (Section<V> s : sections) {
+      s.forEachValue(consumer);
+    }
+  }
+
+  /**
+   * Shrinks the internal capacity to fit the current number of entries (respecting the fill
+   * factor). Each section independently shrinks to the smallest power-of-two capacity that can hold
+   * its current entries. Available but not called automatically — the cache has a stable working set
+   * size.
+   */
+  public void shrink() {
+    for (Section<V> s : sections) {
+      s.shrink();
+    }
+  }
+
   /** Returns the total capacity (sum of all section capacities). */
   public long capacity() {
     long total = 0;
@@ -718,6 +751,96 @@ public class ConcurrentLongIntHashMap<V> {
           fileIds[bucket] = fId;
           pageIndices[bucket] = pIdx;
         }
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    void clear() {
+      long stamp = lock.writeLock();
+      try {
+        fileIds = new long[capacity];
+        pageIndices = new int[capacity];
+        values = (V[]) new Object[capacity];
+        size = 0;
+        usedBuckets = 0;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    void forEach(LongIntObjConsumer<V> consumer) {
+      long stamp = lock.readLock();
+      try {
+        for (int i = 0; i < capacity; i++) {
+          V val = values[i];
+          if (val != null) {
+            consumer.accept(fileIds[i], pageIndices[i], val);
+          }
+        }
+      } finally {
+        lock.unlockRead(stamp);
+      }
+    }
+
+    void forEachValue(java.util.function.Consumer<V> consumer) {
+      long stamp = lock.readLock();
+      try {
+        for (int i = 0; i < capacity; i++) {
+          V val = values[i];
+          if (val != null) {
+            consumer.accept(val);
+          }
+        }
+      } finally {
+        lock.unlockRead(stamp);
+      }
+    }
+
+    /**
+     * Shrink capacity to fit current entries. Must hold write lock during the rehash. The minimum
+     * capacity is 2 (matching the constructor floor).
+     */
+    @SuppressWarnings("unchecked")
+    void shrink() {
+      long stamp = lock.writeLock();
+      try {
+        int newCapacity = alignToPowerOfTwo((int) Math.ceil(size / FILL_FACTOR));
+        newCapacity = Math.max(2, newCapacity);
+        if (newCapacity >= capacity) {
+          return; // No shrinking needed
+        }
+
+        long[] oldFileIds = fileIds;
+        int[] oldPageIndices = pageIndices;
+        V[] oldValues = values;
+        int oldCapacity = capacity;
+
+        capacity = newCapacity;
+        fileIds = new long[newCapacity];
+        pageIndices = new int[newCapacity];
+        values = (V[]) new Object[newCapacity];
+        resizeThreshold = (int) (newCapacity * FILL_FACTOR);
+        usedBuckets = size;
+
+        int bucketMask = newCapacity - 1;
+        for (int i = 0; i < oldCapacity; i++) {
+          V val = oldValues[i];
+          if (val != null) {
+            long fId = oldFileIds[i];
+            int pIdx = oldPageIndices[i];
+            int bucket = (int) hash(fId, pIdx) & bucketMask;
+
+            while (values[bucket] != null) {
+              bucket = (bucket + 1) & bucketMask;
+            }
+
+            values[bucket] = val;
+            fileIds[bucket] = fId;
+            pageIndices[bucket] = pIdx;
+          }
+        }
+      } finally {
+        lock.unlockWrite(stamp);
       }
     }
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -168,6 +168,53 @@ public class ConcurrentLongIntHashMap<V> {
     return sections[sectionIdx].computeIfAbsent(fileId, pageIndex, mappingFunction, (int) hash);
   }
 
+  /**
+   * Computes a new mapping for the given key. The remapping function receives the caller-supplied
+   * fileId and pageIndex, plus the current value (or {@code null} if absent).
+   *
+   * <p><b>Semantics:</b>
+   *
+   * <ul>
+   *   <li>Key absent, function returns null → no-op (key stays absent)
+   *   <li>Key absent, function returns non-null → insert
+   *   <li>Key present, function returns null → removal
+   *   <li>Key present, function returns non-null → replace
+   * </ul>
+   *
+   * <p><b>Warning:</b> The remapping function is called while holding the section's write lock. It
+   * must be fast, non-blocking, and must not call back into this map (StampedLock is not reentrant).
+   *
+   * @return the new value associated with the key, or {@code null} if removed/absent
+   */
+  public V compute(long fileId, int pageIndex, LongIntKeyValueFunction<V> remappingFunction) {
+    long hash = hash(fileId, pageIndex);
+    int sectionIdx = sectionIndex(hash);
+    return sections[sectionIdx].compute(fileId, pageIndex, remappingFunction, (int) hash);
+  }
+
+  /**
+   * Removes the entry for the given composite key.
+   *
+   * @return the removed value, or {@code null} if absent
+   */
+  public V remove(long fileId, int pageIndex) {
+    long hash = hash(fileId, pageIndex);
+    int sectionIdx = sectionIndex(hash);
+    return sections[sectionIdx].remove(fileId, pageIndex, (int) hash);
+  }
+
+  /**
+   * Removes the entry for the given composite key only if it is currently mapped to the specified
+   * value. Uses reference equality ({@code ==}), not {@code equals()}.
+   *
+   * @return {@code true} if the entry was removed
+   */
+  public boolean remove(long fileId, int pageIndex, V expected) {
+    long hash = hash(fileId, pageIndex);
+    int sectionIdx = sectionIndex(hash);
+    return sections[sectionIdx].remove(fileId, pageIndex, expected, (int) hash);
+  }
+
   /** Returns the total capacity (sum of all section capacities). */
   public long capacity() {
     long total = 0;
@@ -400,6 +447,117 @@ public class ConcurrentLongIntHashMap<V> {
       } finally {
         lock.unlockWrite(stamp);
       }
+    }
+
+    V compute(
+        long fileId, int pageIndex, LongIntKeyValueFunction<V> remappingFunction, int hashMix) {
+      long stamp = lock.writeLock();
+      try {
+        int probeResult = probeForKey(fileId, pageIndex, hashMix);
+
+        if (probeResult >= 0) {
+          // Key present — call function with current value
+          V newValue = remappingFunction.apply(fileId, pageIndex, values[probeResult]);
+          if (newValue != null) {
+            values[probeResult] = newValue;
+            return newValue;
+          }
+          // Function returned null on present key → removal
+          removeAt(probeResult);
+          return null;
+        }
+
+        // Key absent — call function with null
+        V newValue = remappingFunction.apply(fileId, pageIndex, null);
+        if (newValue == null) {
+          // Function returned null on absent key → no-op
+          return null;
+        }
+        insertAt(~probeResult, fileId, pageIndex, newValue, hashMix);
+        return newValue;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    V remove(long fileId, int pageIndex, int hashMix) {
+      long stamp = lock.writeLock();
+      try {
+        int probeResult = probeForKey(fileId, pageIndex, hashMix);
+        if (probeResult < 0) {
+          return null;
+        }
+        V prev = values[probeResult];
+        removeAt(probeResult);
+        return prev;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    boolean remove(long fileId, int pageIndex, V expected, int hashMix) {
+      long stamp = lock.writeLock();
+      try {
+        int probeResult = probeForKey(fileId, pageIndex, hashMix);
+        if (probeResult < 0) {
+          return false;
+        }
+        // Reference equality, not equals() (T7 review decision)
+        if (values[probeResult] != expected) {
+          return false;
+        }
+        removeAt(probeResult);
+        return true;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    /**
+     * Remove the entry at the given slot and perform backward-sweep tombstone cleanup. This avoids
+     * leaving tombstones in the probe chain: after nullifying the slot, any entries that were
+     * displaced past this slot during insertion are shifted backward to fill the gap. Must be called
+     * under write lock.
+     */
+    private void removeAt(int slotIdx) {
+      values[slotIdx] = null;
+      size--;
+
+      // Backward-sweep cleanup: move entries that were displaced past the removed slot
+      // back toward their ideal bucket position.
+      int bucketMask = capacity - 1;
+      int nextIdx = (slotIdx + 1) & bucketMask;
+      while (values[nextIdx] != null) {
+        int idealBucket = (int) hash(fileIds[nextIdx], pageIndices[nextIdx]) & bucketMask;
+
+        // Check if the entry at nextIdx belongs in the gap we created.
+        // It needs to be moved if its ideal bucket is at or before the empty slot
+        // (accounting for wrap-around).
+        if (isBetween(idealBucket, slotIdx, nextIdx, bucketMask)) {
+          // Move the entry to the empty slot
+          fileIds[slotIdx] = fileIds[nextIdx];
+          pageIndices[slotIdx] = pageIndices[nextIdx];
+          values[slotIdx] = values[nextIdx];
+          values[nextIdx] = null;
+          slotIdx = nextIdx;
+        }
+        nextIdx = (nextIdx + 1) & bucketMask;
+      }
+
+      // No tombstones created — usedBuckets decreases with size
+      usedBuckets--;
+    }
+
+    /**
+     * Returns true if {@code idealBucket} is in the range (emptySlot, currentIdx] when considering
+     * wrap-around. This means the entry at currentIdx needs to be moved to emptySlot because its
+     * ideal position is at or before the gap.
+     */
+    private static boolean isBetween(int idealBucket, int emptySlot, int currentIdx, int mask) {
+      // The entry needs moving if its ideal position is "behind" or at the empty slot
+      // relative to its current position. In a circular buffer, this means:
+      // distance(idealBucket → currentIdx) >= distance(emptySlot → currentIdx)
+      return ((currentIdx - idealBucket) & mask) >= ((currentIdx - emptySlot) & mask);
     }
 
     /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -24,6 +24,7 @@ package com.jetbrains.youtrackdb.internal.common.collection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.StampedLock;
+import java.util.function.Consumer;
 
 /**
  * Concurrent hash map with composite {@code (long fileId, int pageIndex)} key and generic value.
@@ -161,6 +162,9 @@ public class ConcurrentLongIntHashMap<V> {
    * If the key is absent, computes a value using the mapping function and inserts it. If the key is
    * present, returns the existing value without calling the function.
    *
+   * <p><b>Warning:</b> The mapping function is called while holding the section's write lock. It
+   * must be fast, non-blocking, and must not call back into this map (StampedLock is not reentrant).
+   *
    * @return the existing or newly computed value
    * @throws IllegalArgumentException if the mapping function returns null
    */
@@ -253,7 +257,7 @@ public class ConcurrentLongIntHashMap<V> {
   }
 
   /** Iterates all values, passing each to the consumer. */
-  public void forEachValue(java.util.function.Consumer<V> consumer) {
+  public void forEachValue(Consumer<V> consumer) {
     for (Section<V> s : sections) {
       s.forEachValue(consumer);
     }
@@ -602,37 +606,9 @@ public class ConcurrentLongIntHashMap<V> {
       }
     }
 
-    /**
-     * Rehash at the same capacity — re-insert all live entries into fresh arrays. Eliminates any
-     * gaps left by bulk removal. Must be called under write lock.
-     */
-    @SuppressWarnings("unchecked")
+    /** Same-capacity rehash to compact gaps from bulk removal. Must be called under write lock. */
     private void rehashSameCapacity() {
-      long[] oldFileIds = fileIds;
-      int[] oldPageIndices = pageIndices;
-      V[] oldValues = values;
-
-      fileIds = new long[capacity];
-      pageIndices = new int[capacity];
-      values = (V[]) new Object[capacity];
-
-      int bucketMask = capacity - 1;
-      for (int i = 0; i < capacity; i++) {
-        V val = oldValues[i];
-        if (val != null) {
-          long fId = oldFileIds[i];
-          int pIdx = oldPageIndices[i];
-          int bucket = (int) hash(fId, pIdx) & bucketMask;
-
-          while (values[bucket] != null) {
-            bucket = (bucket + 1) & bucketMask;
-          }
-
-          values[bucket] = val;
-          fileIds[bucket] = fId;
-          pageIndices[bucket] = pIdx;
-        }
-      }
+      rehashTo(capacity);
     }
 
     /**
@@ -716,13 +692,19 @@ public class ConcurrentLongIntHashMap<V> {
     }
 
     /** Double the capacity and re-insert all entries. Must be called under write lock. */
-    @SuppressWarnings("unchecked")
     private void rehash() {
       if (capacity >= (1 << 30)) {
         throw new IllegalStateException("Maximum section capacity reached (2^30)");
       }
-      int newCapacity = capacity * 2;
+      rehashTo(capacity * 2);
+    }
 
+    /**
+     * Re-insert all live entries into fresh arrays of the given capacity. Updates capacity,
+     * resizeThreshold, and usedBuckets. Must be called under write lock.
+     */
+    @SuppressWarnings("unchecked")
+    private void rehashTo(int newCapacity) {
       long[] oldFileIds = fileIds;
       int[] oldPageIndices = pageIndices;
       V[] oldValues = values;
@@ -782,7 +764,7 @@ public class ConcurrentLongIntHashMap<V> {
       }
     }
 
-    void forEachValue(java.util.function.Consumer<V> consumer) {
+    void forEachValue(Consumer<V> consumer) {
       long stamp = lock.readLock();
       try {
         for (int i = 0; i < capacity; i++) {
@@ -797,48 +779,19 @@ public class ConcurrentLongIntHashMap<V> {
     }
 
     /**
-     * Shrink capacity to fit current entries. Must hold write lock during the rehash. The minimum
+     * Shrink capacity to fit current entries. Acquires the write lock internally. The minimum
      * capacity is 2 (matching the constructor floor).
      */
-    @SuppressWarnings("unchecked")
     void shrink() {
       long stamp = lock.writeLock();
       try {
+        // When size == 0, yields newCapacity = 2 (minimum)
         int newCapacity = alignToPowerOfTwo((int) Math.ceil(size / FILL_FACTOR));
         newCapacity = Math.max(2, newCapacity);
         if (newCapacity >= capacity) {
-          return; // No shrinking needed
+          return;
         }
-
-        long[] oldFileIds = fileIds;
-        int[] oldPageIndices = pageIndices;
-        V[] oldValues = values;
-        int oldCapacity = capacity;
-
-        capacity = newCapacity;
-        fileIds = new long[newCapacity];
-        pageIndices = new int[newCapacity];
-        values = (V[]) new Object[newCapacity];
-        resizeThreshold = (int) (newCapacity * FILL_FACTOR);
-        usedBuckets = size;
-
-        int bucketMask = newCapacity - 1;
-        for (int i = 0; i < oldCapacity; i++) {
-          V val = oldValues[i];
-          if (val != null) {
-            long fId = oldFileIds[i];
-            int pIdx = oldPageIndices[i];
-            int bucket = (int) hash(fId, pIdx) & bucketMask;
-
-            while (values[bucket] != null) {
-              bucket = (bucket + 1) & bucketMask;
-            }
-
-            values[bucket] = val;
-            fileIds[bucket] = fId;
-            pageIndices[bucket] = pIdx;
-          }
-        }
+        rehashTo(newCapacity);
       } finally {
         lock.unlockWrite(stamp);
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -344,7 +344,7 @@ public class ConcurrentLongIntHashMap<V> {
    * Entries are only created under the section's write lock, so the small allocation is never on
    * the hot read path.
    */
-  record Entry<V>(long fileId, int pageIndex, V value) {
+  private record Entry<V>(long fileId, int pageIndex, V value) {
   }
 
   // ---- Section (inner class) ----

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -60,10 +60,10 @@ public class ConcurrentLongIntHashMap<V> {
     void accept(long fileId, int pageIndex, T value);
   }
 
-  /** Remapping function for {@link #compute}. Receives the key and the current value (or null). */
+  /** Remapping function for {@code compute}. Receives the key and the current value (or null). */
   @FunctionalInterface
-  public interface LongIntKeyValueFunction<V> {
-    V apply(long fileId, int pageIndex, V currentValue);
+  public interface LongIntKeyValueFunction<T> {
+    T apply(long fileId, int pageIndex, T currentValue);
   }
 
   // ---- Constructors ----
@@ -164,6 +164,10 @@ public class ConcurrentLongIntHashMap<V> {
     if (n <= 1) {
       return 1;
     }
+    if (n > (1 << 30)) {
+      throw new IllegalArgumentException(
+          "Cannot align to power of two: " + n + " exceeds maximum array capacity (2^30)");
+    }
     return Integer.highestOneBit(n - 1) << 1;
   }
 
@@ -182,7 +186,7 @@ public class ConcurrentLongIntHashMap<V> {
     private int[] pageIndices;
     private V[] values;
 
-    /** Number of logically present entries (not counting tombstones). */
+    /** Number of logically present entries. */
     private volatile int size;
 
     /** Current array length (always a power of two). */
@@ -198,22 +202,30 @@ public class ConcurrentLongIntHashMap<V> {
     }
 
     V get(long fileId, int pageIndex, int hashMix) {
-      int bucketMask = capacity - 1;
-      int bucket = hashMix & bucketMask;
-
-      // Optimistic read — no memory barriers other than the stamp validation
+      // Optimistic read — acquire stamp first, then snapshot all mutable fields to locals.
+      // If a concurrent resize replaces the arrays between stamp and validate, the stamp
+      // validation will fail and we fall back to the read lock.
       long stamp = lock.tryOptimisticRead();
 
-      // Probe loop under optimistic read
+      // Snapshot mutable fields to locals under the optimistic stamp
+      int cap = capacity;
+      long[] fIds = fileIds;
+      int[] pIdxs = pageIndices;
+      V[] vals = values;
+
+      int bucketMask = cap - 1;
+      int bucket = hashMix & bucketMask;
+
+      // Probe loop using local snapshots only
       V foundValue = null;
-      for (int i = 0; i < capacity; i++) {
+      for (int i = 0; i < cap; i++) {
         int idx = (bucket + i) & bucketMask;
-        V val = values[idx];
+        V val = vals[idx];
         if (val == null) {
           // Empty slot — key is not present
           break;
         }
-        if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+        if (fIds[idx] == fileId && pIdxs[idx] == pageIndex) {
           foundValue = val;
           break;
         }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -514,10 +514,10 @@ public class ConcurrentLongIntHashMap<V> {
     }
 
     /**
-     * Remove the entry at the given slot and perform backward-sweep tombstone cleanup. This avoids
-     * leaving tombstones in the probe chain: after nullifying the slot, any entries that were
-     * displaced past this slot during insertion are shifted backward to fill the gap. Must be called
-     * under write lock.
+     * Remove the entry at the given slot and perform backward-sweep compaction. After nullifying
+     * the slot, any entries that were displaced past this position during insertion are shifted
+     * backward to fill the gap. This prevents tombstones entirely — {@code usedBuckets} decreases
+     * with {@code size}. Must be called under write lock.
      */
     private void removeAt(int slotIdx) {
       values[slotIdx] = null;
@@ -549,14 +549,12 @@ public class ConcurrentLongIntHashMap<V> {
     }
 
     /**
-     * Returns true if {@code idealBucket} is in the range (emptySlot, currentIdx] when considering
-     * wrap-around. This means the entry at currentIdx needs to be moved to emptySlot because its
-     * ideal position is at or before the gap.
+     * Returns true if the entry at {@code currentIdx} was displaced past the gap at {@code
+     * emptySlot} during its original insertion, meaning it should be shifted backward to fill the
+     * gap. Equivalently: the circular distance from {@code idealBucket} to {@code currentIdx} is
+     * &gt;= the distance from {@code emptySlot} to {@code currentIdx}.
      */
     private static boolean isBetween(int idealBucket, int emptySlot, int currentIdx, int mask) {
-      // The entry needs moving if its ideal position is "behind" or at the empty slot
-      // relative to its current position. In a circular buffer, this means:
-      // distance(idealBucket → currentIdx) >= distance(emptySlot → currentIdx)
       return ((currentIdx - idealBucket) & mask) >= ((currentIdx - emptySlot) & mask);
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Original: Apache BookKeeper ConcurrentLongHashMap
+ * Adapted for composite (long fileId, int pageIndex) keys by YouTrackDB.
+ */
+package com.jetbrains.youtrackdb.internal.common.collection;
+
+import java.util.concurrent.locks.StampedLock;
+
+/**
+ * Concurrent hash map with composite {@code (long fileId, int pageIndex)} key and generic value.
+ *
+ * <p>Forked from Apache BookKeeper's {@code ConcurrentLongHashMap} and adapted for two-field keys.
+ * Uses segmented open-addressing with {@link StampedLock} per segment: {@code get()} uses
+ * optimistic reads with a single read-lock fallback; mutations use write locks.
+ *
+ * <p>Null values are disallowed — a null value slot indicates an empty bucket. Both
+ * {@code fileId=0} and {@code pageIndex=0} are valid keys.
+ *
+ * @param <V> the value type
+ */
+public class ConcurrentLongIntHashMap<V> {
+
+  /** Default number of sections (must be power-of-two). */
+  private static final int DEFAULT_SECTION_COUNT = 16;
+
+  /** Default expected number of items. */
+  private static final int DEFAULT_EXPECTED_ITEMS = 256;
+
+  private final Section<V>[] sections;
+  private final int sectionMask;
+
+  // ---- Nested functional interfaces ----
+
+  /** Mapping function that takes primitive fileId and pageIndex, avoiding boxing. */
+  @FunctionalInterface
+  public interface LongIntFunction<R> {
+    R apply(long fileId, int pageIndex);
+  }
+
+  /** Consumer that takes primitive fileId, pageIndex and a value, avoiding boxing. */
+  @FunctionalInterface
+  public interface LongIntObjConsumer<T> {
+    void accept(long fileId, int pageIndex, T value);
+  }
+
+  /** Remapping function for {@link #compute}. Receives the key and the current value (or null). */
+  @FunctionalInterface
+  public interface LongIntKeyValueFunction<V> {
+    V apply(long fileId, int pageIndex, V currentValue);
+  }
+
+  // ---- Constructors ----
+
+  public ConcurrentLongIntHashMap() {
+    this(DEFAULT_EXPECTED_ITEMS, DEFAULT_SECTION_COUNT);
+  }
+
+  public ConcurrentLongIntHashMap(int expectedItems) {
+    this(expectedItems, DEFAULT_SECTION_COUNT);
+  }
+
+  @SuppressWarnings("unchecked")
+  public ConcurrentLongIntHashMap(int expectedItems, int sectionCount) {
+    if (sectionCount <= 0 || (sectionCount & (sectionCount - 1)) != 0) {
+      throw new IllegalArgumentException(
+          "sectionCount must be a positive power of two: " + sectionCount);
+    }
+    if (expectedItems < 0) {
+      throw new IllegalArgumentException(
+          "expectedItems must be non-negative: " + expectedItems);
+    }
+
+    this.sectionMask = sectionCount - 1;
+    this.sections = new Section[sectionCount];
+
+    int perSectionCapacity = Math.max(2, alignToPowerOfTwo(expectedItems / sectionCount));
+    for (int i = 0; i < sectionCount; i++) {
+      sections[i] = new Section<>(perSectionCapacity);
+    }
+  }
+
+  // ---- Public API ----
+
+  /**
+   * Returns the value for the given composite key, or {@code null} if absent.
+   *
+   * <p>Uses an optimistic read on the segment's {@link StampedLock}. If the optimistic read is
+   * invalidated by a concurrent write, falls back to a single read-lock acquisition.
+   */
+  public V get(long fileId, int pageIndex) {
+    long hash = hash(fileId, pageIndex);
+    int sectionIdx = sectionIndex(hash);
+    return sections[sectionIdx].get(fileId, pageIndex, (int) hash);
+  }
+
+  /** Returns the total number of entries across all sections. */
+  public long size() {
+    long total = 0;
+    for (Section<V> s : sections) {
+      total += s.size;
+    }
+    return total;
+  }
+
+  /** Returns {@code true} if the map contains no entries. */
+  public boolean isEmpty() {
+    return size() == 0;
+  }
+
+  /** Returns the total capacity (sum of all section capacities). */
+  public long capacity() {
+    long total = 0;
+    for (Section<V> s : sections) {
+      total += s.capacity;
+    }
+    return total;
+  }
+
+  // ---- Hashing ----
+
+  /**
+   * Mixes both key fields into a 64-bit hash using a Murmur3-style finalizer.
+   *
+   * <p>The pageIndex is spread into the upper bits of a long before combining with fileId,
+   * ensuring that keys differing only in pageIndex still distribute well across sections and
+   * buckets.
+   */
+  static long hash(long fileId, int pageIndex) {
+    // Combine: spread pageIndex into long, XOR with fileId
+    long h = fileId ^ (((long) pageIndex) * 0x9E3779B97F4A7C15L);
+    // Murmur3 64-bit finalizer
+    h ^= h >>> 33;
+    h *= 0xFF51AFD7ED558CCDL;
+    h ^= h >>> 33;
+    h *= 0xC4CEB9FE1A85EC53L;
+    h ^= h >>> 33;
+    return h;
+  }
+
+  private int sectionIndex(long hash) {
+    return (int) (hash >>> 32) & sectionMask;
+  }
+
+  // ---- Utility ----
+
+  static int alignToPowerOfTwo(int n) {
+    if (n <= 1) {
+      return 1;
+    }
+    return Integer.highestOneBit(n - 1) << 1;
+  }
+
+  // ---- Section (inner class) ----
+
+  /**
+   * A single segment of the hash map. Holds parallel arrays for keys and values, guarded by a
+   * {@link StampedLock}. Uses open addressing with linear probing.
+   */
+  private static final class Section<V> {
+    private final StampedLock lock = new StampedLock();
+
+    // Parallel arrays — same index across all three stores one logical entry.
+    // An empty slot has values[i] == null (fileIds and pageIndices content is undefined).
+    private long[] fileIds;
+    private int[] pageIndices;
+    private V[] values;
+
+    /** Number of logically present entries (not counting tombstones). */
+    private volatile int size;
+
+    /** Current array length (always a power of two). */
+    private int capacity;
+
+    @SuppressWarnings("unchecked")
+    Section(int capacity) {
+      this.capacity = alignToPowerOfTwo(Math.max(2, capacity));
+      this.fileIds = new long[this.capacity];
+      this.pageIndices = new int[this.capacity];
+      this.values = (V[]) new Object[this.capacity];
+      this.size = 0;
+    }
+
+    V get(long fileId, int pageIndex, int hashMix) {
+      int bucketMask = capacity - 1;
+      int bucket = hashMix & bucketMask;
+
+      // Optimistic read — no memory barriers other than the stamp validation
+      long stamp = lock.tryOptimisticRead();
+
+      // Probe loop under optimistic read
+      V foundValue = null;
+      for (int i = 0; i < capacity; i++) {
+        int idx = (bucket + i) & bucketMask;
+        V val = values[idx];
+        if (val == null) {
+          // Empty slot — key is not present
+          break;
+        }
+        if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+          foundValue = val;
+          break;
+        }
+      }
+
+      if (lock.validate(stamp)) {
+        return foundValue;
+      }
+
+      // Optimistic read invalidated — fall back to read lock
+      stamp = lock.readLock();
+      try {
+        return getUnderLock(fileId, pageIndex, hashMix);
+      } finally {
+        lock.unlockRead(stamp);
+      }
+    }
+
+    /** Probe for a key under a lock (read or write). */
+    private V getUnderLock(long fileId, int pageIndex, int hashMix) {
+      int bucketMask = capacity - 1;
+      int bucket = hashMix & bucketMask;
+
+      for (int i = 0; i < capacity; i++) {
+        int idx = (bucket + i) & bucketMask;
+        V val = values[idx];
+        if (val == null) {
+          return null;
+        }
+        if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+          return val;
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -328,9 +328,10 @@ public class ConcurrentLongIntHashMap<V> {
    * A single segment of the hash map. Holds parallel arrays for keys and values, guarded by a
    * {@link StampedLock}. Uses open addressing with linear probing.
    *
-   * <p><b>Write ordering convention:</b> when inserting a new entry, the value is written before the
-   * key fields (fileId, pageIndex). A concurrent optimistic reader that sees a non-null value at a
-   * slot will find valid key fields because the write lock ensures ordering via stamp validation.
+   * <p><b>Note on write ordering:</b> within {@code insertAt}, the value is written before key
+   * fields. The write order does not matter for correctness — all writes happen under the write
+   * lock, and any concurrent optimistic reader will fail stamp validation if a write occurred,
+   * falling back to the read lock.
    */
   private static final class Section<V> {
     private static final float FILL_FACTOR = 0.66f;
@@ -343,7 +344,7 @@ public class ConcurrentLongIntHashMap<V> {
     private int[] pageIndices;
     private V[] values;
 
-    /** Number of logically present entries. */
+    /** Number of logically present entries. Volatile for lock-free reads in the outer size(). */
     private volatile int size;
 
     /** Number of occupied buckets. Drives resize threshold. */
@@ -459,7 +460,7 @@ public class ConcurrentLongIntHashMap<V> {
       try {
         int probeResult = probeForKey(fileId, pageIndex, hashMix);
         if (probeResult >= 0) {
-          // Key found — replace value (write ordering: value before keys, see Section Javadoc)
+          // Key found — replace value only (key fields are already correct)
           V prev = values[probeResult];
           values[probeResult] = value;
           return prev;
@@ -597,6 +598,9 @@ public class ConcurrentLongIntHashMap<V> {
 
         size -= removed;
         usedBuckets -= removed;
+        assert size >= 0 : "size went negative after removeByFileId: " + size;
+        assert usedBuckets >= 0
+            : "usedBuckets went negative after removeByFileId: " + usedBuckets;
 
         // Since we used simple nullification (not backward-sweep per entry), there may be
         // gaps in probe chains. A same-capacity rehash restores probe chain integrity.
@@ -620,6 +624,7 @@ public class ConcurrentLongIntHashMap<V> {
     private void removeAt(int slotIdx) {
       values[slotIdx] = null;
       size--;
+      assert size >= 0 : "size went negative: " + size;
 
       // Backward-sweep cleanup: move entries that were displaced past the removed slot
       // back toward their ideal bucket position.
@@ -644,6 +649,7 @@ public class ConcurrentLongIntHashMap<V> {
 
       // No tombstones created — usedBuckets decreases with size
       usedBuckets--;
+      assert usedBuckets >= 0 : "usedBuckets went negative: " + usedBuckets;
     }
 
     /**
@@ -667,13 +673,17 @@ public class ConcurrentLongIntHashMap<V> {
         slotIdx = findEmptySlot(hashMix);
       }
 
-      // Value first, then key fields (see Section Javadoc for write ordering rationale)
+      assert values[slotIdx] == null : "insertAt called on non-empty slot " + slotIdx;
+
+      // Write order does not matter — all under write lock (see Section Javadoc)
       values[slotIdx] = value;
       fileIds[slotIdx] = fileId;
       pageIndices[slotIdx] = pageIndex;
 
       usedBuckets++;
       size++;
+      assert usedBuckets == size
+          : "usedBuckets (" + usedBuckets + ") != size (" + size + ") — tombstone leak?";
     }
 
     /** Find an empty slot starting from the hash bucket. Must be called under write lock. */
@@ -705,17 +715,18 @@ public class ConcurrentLongIntHashMap<V> {
      */
     @SuppressWarnings("unchecked")
     private void rehashTo(int newCapacity) {
+      assert newCapacity > 0 && (newCapacity & (newCapacity - 1)) == 0
+          : "newCapacity must be a power of two: " + newCapacity;
+
       long[] oldFileIds = fileIds;
       int[] oldPageIndices = pageIndices;
       V[] oldValues = values;
       int oldCapacity = capacity;
 
-      capacity = newCapacity;
-      fileIds = new long[newCapacity];
-      pageIndices = new int[newCapacity];
-      values = (V[]) new Object[newCapacity];
-      resizeThreshold = (int) (newCapacity * FILL_FACTOR);
-      usedBuckets = size;
+      // Allocate all new arrays FIRST — if OOM occurs, old state is untouched
+      long[] newFileIds = new long[newCapacity];
+      int[] newPageIndices = new int[newCapacity];
+      V[] newValues = (V[]) new Object[newCapacity];
 
       int bucketMask = newCapacity - 1;
       for (int i = 0; i < oldCapacity; i++) {
@@ -725,15 +736,26 @@ public class ConcurrentLongIntHashMap<V> {
           int pIdx = oldPageIndices[i];
           int bucket = (int) hash(fId, pIdx) & bucketMask;
 
-          while (values[bucket] != null) {
+          while (newValues[bucket] != null) {
             bucket = (bucket + 1) & bucketMask;
           }
 
-          values[bucket] = val;
-          fileIds[bucket] = fId;
-          pageIndices[bucket] = pIdx;
+          newValues[bucket] = val;
+          newFileIds[bucket] = fId;
+          newPageIndices[bucket] = pIdx;
         }
       }
+
+      // Swap all at once — section remains consistent even if OOM occurred above
+      capacity = newCapacity;
+      fileIds = newFileIds;
+      pageIndices = newPageIndices;
+      values = newValues;
+      resizeThreshold = (int) (newCapacity * FILL_FACTOR);
+      usedBuckets = size;
+
+      assert usedBuckets == size
+          : "usedBuckets (" + usedBuckets + ") != size (" + size + ") after rehash";
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -332,27 +332,38 @@ public class ConcurrentLongIntHashMap<V> {
     return Integer.highestOneBit(n - 1) << 1;
   }
 
+  // ---- Entry record ----
+
+  /**
+   * A single entry in the hash table. Packs key fields and value onto one cache line (~36 bytes
+   * with compressed oops: 12-byte header + 8 long + 4 int + 4 padding + 8 reference), so each
+   * linear probe requires only one array access + one object dereference instead of three separate
+   * array accesses across three cache lines.
+   *
+   * <p>Immutable — mutations (value replacement, removal) write a new Entry or null to the slot.
+   * Entries are only created under the section's write lock, so the small allocation is never on
+   * the hot read path.
+   */
+  record Entry<V>(long fileId, int pageIndex, V value) {
+  }
+
   // ---- Section (inner class) ----
 
   /**
-   * A single segment of the hash map. Holds parallel arrays for keys and values, guarded by a
+   * A single segment of the hash map. Holds an array of {@link Entry} records, guarded by a
    * {@link StampedLock}. Uses open addressing with linear probing.
    *
-   * <p><b>Note on write ordering:</b> within {@code insertAt}, the value is written before key
-   * fields. The write order does not matter for correctness — all writes happen under the write
-   * lock, and any concurrent optimistic reader will fail stamp validation if a write occurred,
-   * falling back to the read lock.
+   * <p>An empty slot has {@code entries[i] == null}. All mutations happen under the write lock;
+   * optimistic readers snapshot the array reference and capacity, then validate the stamp after
+   * probing.
    */
   private static final class Section<V> {
     private static final float FILL_FACTOR = 0.66f;
 
     private final StampedLock lock = new StampedLock();
 
-    // Parallel arrays — same index across all three stores one logical entry.
-    // An empty slot has values[i] == null (fileIds and pageIndices content is undefined).
-    private long[] fileIds;
-    private int[] pageIndices;
-    private V[] values;
+    // Single array — each slot holds a complete Entry or null (empty).
+    private Entry<V>[] entries;
 
     /** Number of logically present entries. Volatile for lock-free reads in the outer size(). */
     private volatile int size;
@@ -369,39 +380,36 @@ public class ConcurrentLongIntHashMap<V> {
     @SuppressWarnings("unchecked")
     Section(int capacity) {
       this.capacity = alignToPowerOfTwo(Math.max(2, capacity));
-      this.fileIds = new long[this.capacity];
-      this.pageIndices = new int[this.capacity];
-      this.values = (V[]) new Object[this.capacity];
+      this.entries = new Entry[this.capacity];
       this.size = 0;
       this.usedBuckets = 0;
       this.resizeThreshold = (int) (this.capacity * FILL_FACTOR);
     }
 
     V get(long fileId, int pageIndex, int hashMix) {
-      // Optimistic read — acquire stamp first, then snapshot all mutable fields to locals.
-      // If a concurrent resize replaces the arrays between stamp and validate, the stamp
+      // Optimistic read — acquire stamp first, then snapshot mutable fields to locals.
+      // If a concurrent resize replaces the array between stamp and validate, the stamp
       // validation will fail and we fall back to the read lock.
       long stamp = lock.tryOptimisticRead();
 
       // Snapshot mutable fields to locals under the optimistic stamp
       int cap = capacity;
-      long[] fIds = fileIds;
-      int[] pIdxs = pageIndices;
-      V[] vals = values;
+      Entry<V>[] tbl = entries;
 
       int bucketMask = cap - 1;
       int bucket = hashMix & bucketMask;
 
-      // Probe loop using local snapshots only
+      // Probe loop using local snapshots only — one array access + one object
+      // dereference per probe, all fields on the same cache line.
       V foundValue = null;
       for (int i = 0; i < cap; i++) {
         int idx = (bucket + i) & bucketMask;
-        V val = vals[idx];
-        if (val == null) {
+        Entry<V> e = tbl[idx];
+        if (e == null) {
           break;
         }
-        if (fIds[idx] == fileId && pIdxs[idx] == pageIndex) {
-          foundValue = val;
+        if (e.fileId == fileId && e.pageIndex == pageIndex) {
+          foundValue = e.value;
           break;
         }
       }
@@ -426,12 +434,12 @@ public class ConcurrentLongIntHashMap<V> {
 
       for (int i = 0; i < capacity; i++) {
         int idx = (bucket + i) & bucketMask;
-        V val = values[idx];
-        if (val == null) {
+        Entry<V> e = entries[idx];
+        if (e == null) {
           return null;
         }
-        if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
-          return val;
+        if (e.fileId == fileId && e.pageIndex == pageIndex) {
+          return e.value;
         }
       }
       return null;
@@ -449,14 +457,14 @@ public class ConcurrentLongIntHashMap<V> {
 
       for (int i = 0; i < capacity; i++) {
         int idx = (bucket + i) & bucketMask;
-        V val = values[idx];
-        if (val == null) {
+        Entry<V> e = entries[idx];
+        if (e == null) {
           if (firstEmpty == -1) {
             firstEmpty = idx;
           }
           break;
         }
-        if (fileIds[idx] == fileId && pageIndices[idx] == pageIndex) {
+        if (e.fileId == fileId && e.pageIndex == pageIndex) {
           return idx;
         }
       }
@@ -470,9 +478,9 @@ public class ConcurrentLongIntHashMap<V> {
       try {
         int probeResult = probeForKey(fileId, pageIndex, hashMix);
         if (probeResult >= 0) {
-          // Key found — replace value only (key fields are already correct)
-          V prev = values[probeResult];
-          values[probeResult] = value;
+          // Key found — replace with new entry (records are immutable)
+          V prev = entries[probeResult].value;
+          entries[probeResult] = new Entry<>(fileId, pageIndex, value);
           return prev;
         }
 
@@ -488,7 +496,7 @@ public class ConcurrentLongIntHashMap<V> {
       try {
         int probeResult = probeForKey(fileId, pageIndex, hashMix);
         if (probeResult >= 0) {
-          return values[probeResult];
+          return entries[probeResult].value;
         }
 
         insertAt(~probeResult, fileId, pageIndex, value, hashMix);
@@ -504,7 +512,7 @@ public class ConcurrentLongIntHashMap<V> {
       try {
         int probeResult = probeForKey(fileId, pageIndex, hashMix);
         if (probeResult >= 0) {
-          return values[probeResult];
+          return entries[probeResult].value;
         }
 
         V newValue = mappingFunction.apply(fileId, pageIndex);
@@ -528,9 +536,9 @@ public class ConcurrentLongIntHashMap<V> {
 
         if (probeResult >= 0) {
           // Key present — call function with current value
-          V newValue = remappingFunction.apply(fileId, pageIndex, values[probeResult]);
+          V newValue = remappingFunction.apply(fileId, pageIndex, entries[probeResult].value);
           if (newValue != null) {
-            values[probeResult] = newValue;
+            entries[probeResult] = new Entry<>(fileId, pageIndex, newValue);
             return newValue;
           }
           // Function returned null on present key → removal
@@ -558,7 +566,7 @@ public class ConcurrentLongIntHashMap<V> {
         if (probeResult < 0) {
           return null;
         }
-        V prev = values[probeResult];
+        V prev = entries[probeResult].value;
         removeAt(probeResult);
         return prev;
       } finally {
@@ -574,7 +582,7 @@ public class ConcurrentLongIntHashMap<V> {
           return false;
         }
         // Reference equality, not equals() (T7 review decision)
-        if (values[probeResult] != expected) {
+        if (entries[probeResult].value != expected) {
           return false;
         }
         removeAt(probeResult);
@@ -594,10 +602,10 @@ public class ConcurrentLongIntHashMap<V> {
       try {
         int removed = 0;
         for (int i = 0; i < capacity; i++) {
-          V val = values[i];
-          if (val != null && fileIds[i] == fileId) {
-            removedEntries.add(val);
-            values[i] = null;
+          Entry<V> e = entries[i];
+          if (e != null && e.fileId == fileId) {
+            removedEntries.add(e.value);
+            entries[i] = null;
             removed++;
           }
         }
@@ -632,7 +640,7 @@ public class ConcurrentLongIntHashMap<V> {
      * with {@code size}. Must be called under write lock.
      */
     private void removeAt(int slotIdx) {
-      values[slotIdx] = null;
+      entries[slotIdx] = null;
       size--;
       assert size >= 0 : "size went negative: " + size;
 
@@ -640,18 +648,17 @@ public class ConcurrentLongIntHashMap<V> {
       // back toward their ideal bucket position.
       int bucketMask = capacity - 1;
       int nextIdx = (slotIdx + 1) & bucketMask;
-      while (values[nextIdx] != null) {
-        int idealBucket = (int) hash(fileIds[nextIdx], pageIndices[nextIdx]) & bucketMask;
+      while (entries[nextIdx] != null) {
+        Entry<V> e = entries[nextIdx];
+        int idealBucket = (int) hash(e.fileId, e.pageIndex) & bucketMask;
 
         // Check if the entry at nextIdx belongs in the gap we created.
         // It needs to be moved if its ideal bucket is at or before the empty slot
         // (accounting for wrap-around).
         if (isBetween(idealBucket, slotIdx, nextIdx, bucketMask)) {
-          // Move the entry to the empty slot
-          fileIds[slotIdx] = fileIds[nextIdx];
-          pageIndices[slotIdx] = pageIndices[nextIdx];
-          values[slotIdx] = values[nextIdx];
-          values[nextIdx] = null;
+          // Move the entry to the empty slot — just a reference copy, no new allocation
+          entries[slotIdx] = e;
+          entries[nextIdx] = null;
           slotIdx = nextIdx;
         }
         nextIdx = (nextIdx + 1) & bucketMask;
@@ -679,16 +686,13 @@ public class ConcurrentLongIntHashMap<V> {
     private void insertAt(int slotIdx, long fileId, int pageIndex, V value, int hashMix) {
       if (usedBuckets >= resizeThreshold) {
         rehash();
-        // Recalculate slot after resize — arrays have changed
+        // Recalculate slot after resize — array has changed
         slotIdx = findEmptySlot(hashMix);
       }
 
-      assert values[slotIdx] == null : "insertAt called on non-empty slot " + slotIdx;
+      assert entries[slotIdx] == null : "insertAt called on non-empty slot " + slotIdx;
 
-      // Write order does not matter — all under write lock (see Section Javadoc)
-      values[slotIdx] = value;
-      fileIds[slotIdx] = fileId;
-      pageIndices[slotIdx] = pageIndex;
+      entries[slotIdx] = new Entry<>(fileId, pageIndex, value);
 
       usedBuckets++;
       size++;
@@ -703,7 +707,7 @@ public class ConcurrentLongIntHashMap<V> {
 
       for (int i = 0; i < capacity; i++) {
         int idx = (bucket + i) & bucketMask;
-        if (values[idx] == null) {
+        if (entries[idx] == null) {
           return idx;
         }
       }
@@ -720,50 +724,44 @@ public class ConcurrentLongIntHashMap<V> {
     }
 
     /**
-     * Re-insert all live entries into fresh arrays of the given capacity. Updates capacity,
+     * Re-insert all live entries into a fresh array of the given capacity. Updates capacity,
      * resizeThreshold, and usedBuckets. Must be called under write lock.
+     *
+     * <p>Existing Entry records are reused (just reference-copied into the new array) — no new
+     * Entry allocations during rehash.
      */
     @SuppressWarnings("unchecked")
     private void rehashTo(int newCapacity) {
       assert newCapacity > 0 && (newCapacity & (newCapacity - 1)) == 0
           : "newCapacity must be a power of two: " + newCapacity;
 
-      long[] oldFileIds = fileIds;
-      int[] oldPageIndices = pageIndices;
-      V[] oldValues = values;
+      Entry<V>[] oldEntries = entries;
       int oldCapacity = capacity;
 
-      // Allocate all new arrays FIRST — if OOM occurs, old state is untouched
-      long[] newFileIds = new long[newCapacity];
-      int[] newPageIndices = new int[newCapacity];
-      V[] newValues = (V[]) new Object[newCapacity];
+      // Allocate new array FIRST — if OOM occurs, old state is untouched
+      Entry<V>[] newEntries = new Entry[newCapacity];
 
       int bucketMask = newCapacity - 1;
       for (int i = 0; i < oldCapacity; i++) {
-        V val = oldValues[i];
-        if (val != null) {
-          long fId = oldFileIds[i];
-          int pIdx = oldPageIndices[i];
-          int bucket = (int) hash(fId, pIdx) & bucketMask;
+        Entry<V> e = oldEntries[i];
+        if (e != null) {
+          int bucket = (int) hash(e.fileId, e.pageIndex) & bucketMask;
 
-          while (newValues[bucket] != null) {
+          while (newEntries[bucket] != null) {
             bucket = (bucket + 1) & bucketMask;
           }
 
-          newValues[bucket] = val;
-          newFileIds[bucket] = fId;
-          newPageIndices[bucket] = pIdx;
+          // Reuse existing Entry record — just a reference copy
+          newEntries[bucket] = e;
         }
       }
 
-      // Swap arrays BEFORE capacity — an optimistic reader that snapshots the new capacity
-      // but old arrays would use a mask larger than the array length, causing AIOOBE.
-      // By writing arrays first, a reader that sees the old capacity uses a smaller mask
-      // against larger arrays (safe), while a reader that sees the new capacity uses the
-      // correct mask against the new arrays (also safe).
-      fileIds = newFileIds;
-      pageIndices = newPageIndices;
-      values = newValues;
+      // Swap array BEFORE capacity — an optimistic reader that snapshots the new capacity
+      // but old array would use a mask larger than the array length, causing AIOOBE.
+      // By writing the array first, a reader that sees the old capacity uses a smaller mask
+      // against a larger array (safe), while a reader that sees the new capacity uses the
+      // correct mask against the new array (also safe).
+      entries = newEntries;
       capacity = newCapacity;
       resizeThreshold = (int) (newCapacity * FILL_FACTOR);
       usedBuckets = size;
@@ -776,9 +774,7 @@ public class ConcurrentLongIntHashMap<V> {
     void clear() {
       long stamp = lock.writeLock();
       try {
-        fileIds = new long[capacity];
-        pageIndices = new int[capacity];
-        values = (V[]) new Object[capacity];
+        entries = new Entry[capacity];
         size = 0;
         usedBuckets = 0;
       } finally {
@@ -790,9 +786,9 @@ public class ConcurrentLongIntHashMap<V> {
       long stamp = lock.readLock();
       try {
         for (int i = 0; i < capacity; i++) {
-          V val = values[i];
-          if (val != null) {
-            consumer.accept(fileIds[i], pageIndices[i], val);
+          Entry<V> e = entries[i];
+          if (e != null) {
+            consumer.accept(e.fileId, e.pageIndex, e.value);
           }
         }
       } finally {
@@ -804,9 +800,9 @@ public class ConcurrentLongIntHashMap<V> {
       long stamp = lock.readLock();
       try {
         for (int i = 0; i < capacity; i++) {
-          V val = values[i];
-          if (val != null) {
-            consumer.accept(val);
+          Entry<V> e = entries[i];
+          if (e != null) {
+            consumer.accept(e.value);
           }
         }
       } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntry.java
@@ -21,7 +21,6 @@
 package com.jetbrains.youtrackdb.internal.core.storage.cache;
 
 import com.jetbrains.youtrackdb.internal.core.storage.cache.chm.LRUList;
-import com.jetbrains.youtrackdb.internal.core.storage.cache.chm.PageKey;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.LogSequenceNumber;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WALChanges;
 import java.io.Closeable;
@@ -115,6 +114,4 @@ public interface CacheEntry extends Closeable {
   void clearAllocationFlag();
 
   boolean insideCache();
-
-  PageKey getPageKey();
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImpl.java
@@ -58,6 +58,8 @@ public class CacheEntryImpl implements CacheEntry {
 
   private final boolean insideCache;
   private final ReadCache readCache;
+  private final long fileId;
+  private final int pageIndex;
   private final PageKey pageKey;
 
   public CacheEntryImpl(
@@ -78,6 +80,8 @@ public class CacheEntryImpl implements CacheEntry {
     this.dataPointer = dataPointer;
     this.insideCache = insideCache;
     this.readCache = readCache;
+    this.fileId = fileId;
+    this.pageIndex = pageIndex;
     this.pageKey = new PageKey(fileId, pageIndex);
   }
 
@@ -108,12 +112,12 @@ public class CacheEntryImpl implements CacheEntry {
 
   @Override
   public long getFileId() {
-    return pageKey.fileId();
+    return fileId;
   }
 
   @Override
   public int getPageIndex() {
-    return pageKey.pageIndex();
+    return pageIndex;
   }
 
   @Override
@@ -313,12 +317,12 @@ public class CacheEntryImpl implements CacheEntry {
     if (!(o instanceof CacheEntryImpl that)) {
       return false;
     }
-    return this.pageKey.equals(that.pageKey);
+    return this.fileId == that.fileId && this.pageIndex == that.pageIndex;
   }
 
   @Override
   public int hashCode() {
-    return pageKey.hashCode();
+    return Long.hashCode(fileId) * 31 + pageIndex;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImpl.java
@@ -1,7 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.storage.cache;
 
 import com.jetbrains.youtrackdb.internal.core.storage.cache.chm.LRUList;
-import com.jetbrains.youtrackdb.internal.core.storage.cache.chm.PageKey;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.LogSequenceNumber;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WALChanges;
 import java.io.IOException;
@@ -60,7 +59,6 @@ public class CacheEntryImpl implements CacheEntry {
   private final ReadCache readCache;
   private final long fileId;
   private final int pageIndex;
-  private final PageKey pageKey;
 
   public CacheEntryImpl(
       final long fileId,
@@ -82,7 +80,6 @@ public class CacheEntryImpl implements CacheEntry {
     this.readCache = readCache;
     this.fileId = fileId;
     this.pageIndex = pageIndex;
-    this.pageKey = new PageKey(fileId, pageIndex);
   }
 
   @Override
@@ -326,11 +323,6 @@ public class CacheEntryImpl implements CacheEntry {
     // Long.hashCode(fileId) * 31 + pageIndex. This is intentionally different from
     // the map's internal murmur hash to avoid correlation with bucket position.
     return Long.hashCode(fileId) * 31 + pageIndex;
-  }
-
-  @Override
-  public PageKey getPageKey() {
-    return this.pageKey;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImpl.java
@@ -322,6 +322,9 @@ public class CacheEntryImpl implements CacheEntry {
 
   @Override
   public int hashCode() {
+    // Same formula as ConcurrentLongIntHashMap.hashForFrequencySketch — both use
+    // Long.hashCode(fileId) * 31 + pageIndex. This is intentionally different from
+    // the map's internal murmur hash to avoid correlation with bucket position.
     return Long.hashCode(fileId) * 31 + pageIndex;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -10,7 +10,6 @@ import com.jetbrains.youtrackdb.internal.common.profiler.metrics.CoreMetrics;
 import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricsRegistry;
 import com.jetbrains.youtrackdb.internal.common.profiler.metrics.Ratio;
 import com.jetbrains.youtrackdb.internal.common.types.ModifiableBoolean;
-import com.jetbrains.youtrackdb.internal.common.util.RawPairLongInteger;
 import com.jetbrains.youtrackdb.internal.core.YouTrackDBEnginesManager;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
@@ -28,7 +27,6 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.L
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -626,40 +624,32 @@ public final class LockFreeReadCache implements ReadCache {
   public void truncateFile(long fileId, final WriteCache writeCache) throws IOException {
     fileId = AbstractWriteCache.checkFileIdCompatibility(writeCache.getId(), fileId);
 
-    final var filledUpTo = (int) writeCache.getFilledUpTo(fileId);
     writeCache.truncateFile(fileId);
-
-    clearFile(fileId, filledUpTo, writeCache);
+    clearFile(fileId, writeCache);
   }
 
   @Override
   public void closeFile(long fileId, final boolean flush, final WriteCache writeCache) {
     fileId = AbstractWriteCache.checkFileIdCompatibility(writeCache.getId(), fileId);
-    final var filledUpTo = (int) writeCache.getFilledUpTo(fileId);
 
-    clearFile(fileId, filledUpTo, writeCache);
+    clearFile(fileId, writeCache);
     writeCache.close(fileId, flush);
   }
 
   @Override
   public void deleteFile(long fileId, final WriteCache writeCache) throws IOException {
     fileId = AbstractWriteCache.checkFileIdCompatibility(writeCache.getId(), fileId);
-    final var filledUpTo = (int) writeCache.getFilledUpTo(fileId);
 
-    clearFile(fileId, filledUpTo, writeCache);
+    clearFile(fileId, writeCache);
     writeCache.deleteFile(fileId);
   }
 
   @Override
   public void deleteStorage(final WriteCache writeCache) throws IOException {
     final var files = writeCache.files().values();
-    final List<RawPairLongInteger> filledUpTo = new ArrayList<>(1024);
-    for (final long fileId : files) {
-      filledUpTo.add(new RawPairLongInteger(fileId, (int) writeCache.getFilledUpTo(fileId)));
-    }
 
-    for (final var entry : filledUpTo) {
-      clearFile(entry.first, entry.second, writeCache);
+    for (final long fileId : files) {
+      clearFile(fileId, writeCache);
     }
 
     writeCache.delete();
@@ -668,46 +658,52 @@ public final class LockFreeReadCache implements ReadCache {
   @Override
   public void closeStorage(final WriteCache writeCache) throws IOException {
     final var files = writeCache.files().values();
-    final List<RawPairLongInteger> filledUpTo = new ArrayList<>(1024);
-    for (final long fileId : files) {
-      filledUpTo.add(new RawPairLongInteger(fileId, (int) writeCache.getFilledUpTo(fileId)));
-    }
 
-    for (final var entry : filledUpTo) {
-      clearFile(entry.first, entry.second, writeCache);
+    for (final long fileId : files) {
+      clearFile(fileId, writeCache);
     }
 
     writeCache.close();
   }
 
-  private void clearFile(final long fileId, final int filledUpTo, final WriteCache writeCache) {
+  private void clearFile(final long fileId, final WriteCache writeCache) {
     flushCurrentThreadReadBatch();
     evictionLock.lock();
     try {
       emptyBuffers();
 
-      for (var pageIndex = 0; pageIndex < filledUpTo; pageIndex++) {
-        final var cacheEntry = data.remove(fileId, pageIndex);
-        if (cacheEntry != null) {
-          if (cacheEntry.freeze()) {
-            policy.onRemove(cacheEntry);
-            cacheSize.decrementAndGet();
+      // Bulk removal: removeByFileId sweeps each segment linearly under its write
+      // lock, collecting removed entries into a list. Entries are returned after
+      // the segment lock is released, so the processing below (freeze, onRemove,
+      // checkCacheOverflow) does not run under a segment write lock — avoiding
+      // StampedLock reentrancy deadlock if callbacks re-enter the map.
+      //
+      // Precondition: clearFile assumes no concurrent doLoad for the same fileId.
+      // A concurrent doLoad could re-insert an entry for a page of this file after
+      // removeByFileId completes. This is a pre-existing race (the old per-page
+      // loop had the same gap between remove and freeze). Callers ensure this by
+      // coordinating file lifecycle at a higher level.
+      final var removedEntries = data.removeByFileId(fileId);
 
-            try {
-              writeCache.checkCacheOverflow();
-            } catch (final java.lang.InterruptedException e) {
-              throw BaseException.wrapException(
-                  new ThreadInterruptedException("Check of write cache overflow was interrupted"),
-                  e, writeCache.getStorageName());
-            }
-          } else {
-            throw new StorageException(writeCache.getStorageName(),
-                "Page with index "
-                    + cacheEntry.getPageIndex()
-                    + " for file id "
-                    + cacheEntry.getFileId()
-                    + " is used and cannot be removed");
+      for (final var cacheEntry : removedEntries) {
+        if (cacheEntry.freeze()) {
+          policy.onRemove(cacheEntry);
+          cacheSize.decrementAndGet();
+
+          try {
+            writeCache.checkCacheOverflow();
+          } catch (final java.lang.InterruptedException e) {
+            throw BaseException.wrapException(
+                new ThreadInterruptedException("Check of write cache overflow was interrupted"),
+                e, writeCache.getStorageName());
           }
+        } else {
+          throw new StorageException(writeCache.getStorageName(),
+              "Page with index "
+                  + cacheEntry.getPageIndex()
+                  + " for file id "
+                  + cacheEntry.getFileId()
+                  + " is used and cannot be removed");
         }
       }
     } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -597,7 +597,7 @@ public final class LockFreeReadCache implements ReadCache {
     try {
       emptyBuffers();
 
-      var entries = new ArrayList<CacheEntry>();
+      var entries = new ArrayList<CacheEntry>(cacheSize.get());
       data.forEachValue(entries::add);
 
       for (final var entry : entries) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -354,8 +354,7 @@ public final class LockFreeReadCache implements ReadCache {
 
   @Override
   @Nullable public PageFrame getPageFrameOptimistic(final long fileId, final long pageIndex) {
-    final var pageKey = new PageKey(fileId, (int) pageIndex);
-    final var cacheEntry = data.get(pageKey);
+    final var cacheEntry = data.get(fileId, (int) pageIndex);
 
     if (cacheEntry == null || !cacheEntry.isAlive()) {
       return null;
@@ -371,8 +370,7 @@ public final class LockFreeReadCache implements ReadCache {
 
   @Override
   public void recordOptimisticAccess(final long fileId, final long pageIndex) {
-    final var pageKey = new PageKey(fileId, (int) pageIndex);
-    final var cacheEntry = data.get(pageKey);
+    final var cacheEntry = data.get(fileId, (int) pageIndex);
 
     // Entry may have been evicted between stamp validation and this call.
     // One missed frequency bump is harmless — skip silently.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -100,9 +100,11 @@ public final class LockFreeReadCache implements ReadCache {
       this.pageFramePool = bufferPool.pageFramePool();
 
       this.maxCacheSize = (int) (maxCacheSizeInBytes / pageSize);
-      // Section count matches ConcurrentHashMap's concurrency level (N_CPU << 1).
-      // The map constructor aligns to the next power of two internally.
-      this.data = new ConcurrentLongIntHashMap<>(this.maxCacheSize, N_CPU << 1);
+      // Section count rounded up to power of two from N_CPU << 1 (matching
+      // ConcurrentHashMap's concurrency level). ConcurrentLongIntHashMap requires
+      // power-of-two section count for bit-mask section selection.
+      this.data =
+          new ConcurrentLongIntHashMap<>(this.maxCacheSize, ceilingPowerOfTwo(N_CPU << 1));
       policy = new WTinyLFUPolicy(data, new FrequencySketch(), cacheSize);
       policy.setMaxSize(this.maxCacheSize);
     } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.storage.cache.chm;
 
+import com.jetbrains.youtrackdb.internal.common.collection.ConcurrentLongIntHashMap;
 import com.jetbrains.youtrackdb.internal.common.concur.lock.ThreadInterruptedException;
 import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -61,7 +61,7 @@ public final class LockFreeReadCache implements ReadCache {
    */
   private static final int READ_BATCH_SIZE = 16;
 
-  private final ConcurrentHashMap<PageKey, CacheEntry> data;
+  private final ConcurrentLongIntHashMap<CacheEntry> data;
   private final Lock evictionLock = new ReentrantLock();
 
   private final WTinyLFUPolicy policy;
@@ -100,7 +100,9 @@ public final class LockFreeReadCache implements ReadCache {
       this.pageFramePool = bufferPool.pageFramePool();
 
       this.maxCacheSize = (int) (maxCacheSizeInBytes / pageSize);
-      this.data = new ConcurrentHashMap<>(this.maxCacheSize, 0.5f, N_CPU << 1);
+      // Section count matches ConcurrentHashMap's concurrency level (N_CPU << 1).
+      // The map constructor aligns to the next power of two internally.
+      this.data = new ConcurrentLongIntHashMap<>(this.maxCacheSize, N_CPU << 1);
       policy = new WTinyLFUPolicy(data, new FrequencySketch(), cacheSize);
       policy.setMaxSize(this.maxCacheSize);
     } finally {
@@ -177,18 +179,21 @@ public final class LockFreeReadCache implements ReadCache {
       final WriteCache writeCache,
       final boolean verifyChecksums) {
     final var fileId = AbstractWriteCache.checkFileIdCompatibility(writeCache.getId(), extFileId);
-    final var pageKey = new PageKey(fileId, pageIndex);
 
     for (;;) {
-      var cacheEntry = data.get(pageKey);
+      var cacheEntry = data.get(fileId, pageIndex);
 
       if (cacheEntry == null) {
         final var updatedEntry = new CacheEntry[1];
 
+        // The compute lambda receives (fId, pIdx, entry) but we use the outer-scope
+        // captured fileId and pageIndex — they are guaranteed identical to the lambda
+        // parameters since we pass (fileId, pageIndex) as the compute key.
         cacheEntry =
             data.compute(
-                pageKey,
-                (page, entry) -> {
+                fileId,
+                pageIndex,
+                (fId, pIdx, entry) -> {
                   if (entry == null) {
                     try {
                       final var pointer =
@@ -199,8 +204,7 @@ public final class LockFreeReadCache implements ReadCache {
                       }
 
                       updatedEntry[0] =
-                          new CacheEntryImpl(
-                              page.fileId(), page.pageIndex(), pointer, false, this);
+                          new CacheEntryImpl(fileId, pageIndex, pointer, false, this);
                       return null;
                     } catch (final IOException e) {
                       throw BaseException.wrapException(
@@ -234,7 +238,6 @@ public final class LockFreeReadCache implements ReadCache {
       final WriteCache writeCache,
       final boolean verifyChecksums) {
     final var fileId = AbstractWriteCache.checkFileIdCompatibility(writeCache.getId(), extFileId);
-    final var pageKey = new PageKey(fileId, pageIndex);
 
     var success = false;
     try {
@@ -243,7 +246,7 @@ public final class LockFreeReadCache implements ReadCache {
 
         CacheEntry cacheEntry;
 
-        cacheEntry = data.get(pageKey);
+        cacheEntry = data.get(fileId, pageIndex);
 
         if (cacheEntry != null) {
           if (cacheEntry.acquireEntry()) {
@@ -255,10 +258,14 @@ public final class LockFreeReadCache implements ReadCache {
         } else {
           final var read = new boolean[1];
 
+          // The compute lambda receives (fId, pIdx, entry) but we use the outer-scope
+          // captured fileId and pageIndex — they are guaranteed identical to the lambda
+          // parameters since we pass (fileId, pageIndex) as the compute key.
           cacheEntry =
               data.compute(
-                  pageKey,
-                  (page, entry) -> {
+                  fileId,
+                  pageIndex,
+                  (fId, pIdx, entry) -> {
                     if (entry == null) {
                       try {
                         final var pointer =
@@ -269,8 +276,7 @@ public final class LockFreeReadCache implements ReadCache {
                         }
 
                         cacheSize.incrementAndGet();
-                        return new CacheEntryImpl(
-                            page.fileId(), page.pageIndex(), pointer, true, this);
+                        return new CacheEntryImpl(fileId, pageIndex, pointer, true, this);
                       } catch (final IOException e) {
                         throw BaseException.wrapException(
                             new StorageException(writeCache.getStorageName(),
@@ -324,7 +330,8 @@ public final class LockFreeReadCache implements ReadCache {
     final CacheEntry cacheEntry = new CacheEntryImpl(fileId, pageIndex, cachePointer, true, this);
     cacheEntry.acquireEntry();
 
-    final var oldCacheEntry = data.putIfAbsent(cacheEntry.getPageKey(), cacheEntry);
+    final var oldCacheEntry =
+        data.putIfAbsent(cacheEntry.getFileId(), cacheEntry.getPageIndex(), cacheEntry);
     if (oldCacheEntry != null) {
       throw new IllegalStateException(
           "Page  " + fileId + ":" + pageIndex + " was allocated in other thread");
@@ -394,13 +401,17 @@ public final class LockFreeReadCache implements ReadCache {
         cacheEntry.clearAllocationFlag();
       }
 
+      // Virtual-lock pattern: compute() holds the segment write lock while the
+      // remapping function executes, even if the key is absent. This ensures
+      // writeCache.store() runs atomically w.r.t. concurrent map operations on
+      // the same key. If absent, remapping returns null → no-op (no insertion).
       data.compute(
-          cacheEntry.getPageKey(),
-          (page, entry) -> {
+          cacheEntry.getFileId(),
+          cacheEntry.getPageIndex(),
+          (fId, pIdx, entry) -> {
             writeCache.store(
                 cacheEntry.getFileId(), cacheEntry.getPageIndex(), cacheEntry.getCachePointer());
-            return entry; // may be absent if page in pinned pages, in such case we use map as
-            // virtual lock
+            return entry;
           });
     }
 
@@ -586,7 +597,10 @@ public final class LockFreeReadCache implements ReadCache {
     try {
       emptyBuffers();
 
-      for (final var entry : data.values()) {
+      var entries = new ArrayList<CacheEntry>();
+      data.forEachValue(entries::add);
+
+      for (final var entry : entries) {
         if (entry.freeze()) {
           policy.onRemove(entry);
         } else {
@@ -671,8 +685,7 @@ public final class LockFreeReadCache implements ReadCache {
       emptyBuffers();
 
       for (var pageIndex = 0; pageIndex < filledUpTo; pageIndex++) {
-        final var pageKey = new PageKey(fileId, pageIndex);
-        final var cacheEntry = data.remove(pageKey);
+        final var cacheEntry = data.remove(fileId, pageIndex);
         if (cacheEntry != null) {
           if (cacheEntry.freeze()) {
             policy.onRemove(cacheEntry);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/PageKey.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/PageKey.java
@@ -1,5 +1,0 @@
-package com.jetbrains.youtrackdb.internal.core.storage.cache.chm;
-
-public record PageKey(long fileId, int pageIndex) {
-
-}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/WTinyLFUPolicy.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/WTinyLFUPolicy.java
@@ -1,8 +1,9 @@
 package com.jetbrains.youtrackdb.internal.core.storage.cache.chm;
 
+import com.jetbrains.youtrackdb.internal.common.collection.ConcurrentLongIntHashMap;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -14,7 +15,7 @@ public final class WTinyLFUPolicy {
   private static final int PROBATIONARY_PERCENT = 20;
 
   private volatile int maxSize;
-  private final ConcurrentHashMap<PageKey, CacheEntry> data;
+  private final ConcurrentLongIntHashMap<CacheEntry> data;
   private final Admittor admittor;
 
   private final AtomicInteger cacheSize;
@@ -28,7 +29,7 @@ public final class WTinyLFUPolicy {
   private int maxSecondLevelSize;
 
   WTinyLFUPolicy(
-      final ConcurrentHashMap<PageKey, CacheEntry> data,
+      final ConcurrentLongIntHashMap<CacheEntry> data,
       final Admittor admittor,
       final AtomicInteger cacheSize) {
     this.data = data;
@@ -55,7 +56,9 @@ public final class WTinyLFUPolicy {
   }
 
   public void onAccess(CacheEntry cacheEntry) {
-    admittor.increment(cacheEntry.getPageKey().hashCode());
+    admittor.increment(
+        ConcurrentLongIntHashMap.hashForFrequencySketch(
+            cacheEntry.getFileId(), cacheEntry.getPageIndex()));
 
     if (!cacheEntry.isDead()) {
       if (probation.contains(cacheEntry)) {
@@ -80,7 +83,9 @@ public final class WTinyLFUPolicy {
   }
 
   void onAdd(final CacheEntry cacheEntry) {
-    admittor.increment(cacheEntry.getPageKey().hashCode());
+    admittor.increment(
+        ConcurrentLongIntHashMap.hashForFrequencySketch(
+            cacheEntry.getFileId(), cacheEntry.getPageIndex()));
 
     if (cacheEntry.isAlive()) {
       assert !eden.contains(cacheEntry);
@@ -107,8 +112,12 @@ public final class WTinyLFUPolicy {
       } else {
         final var victim = probation.peek();
 
-        final var candidateKeyHashCode = candidate.getPageKey().hashCode();
-        final var victimKeyHashCode = victim.getPageKey().hashCode();
+        final var candidateKeyHashCode =
+            ConcurrentLongIntHashMap.hashForFrequencySketch(
+                candidate.getFileId(), candidate.getPageIndex());
+        final var victimKeyHashCode =
+            ConcurrentLongIntHashMap.hashForFrequencySketch(
+                victim.getFileId(), victim.getPageIndex());
 
         final var candidateFrequency = admittor.frequency(candidateKeyHashCode);
         final var victimFrequency = admittor.frequency(victimKeyHashCode);
@@ -118,7 +127,8 @@ public final class WTinyLFUPolicy {
           probation.moveToTheTail(candidate);
 
           if (victim.freeze()) {
-            final var removed = data.remove(victim.getPageKey(), victim);
+            final var removed =
+                data.remove(victim.getFileId(), victim.getPageIndex(), victim);
             victim.makeDead();
 
             if (removed) {
@@ -131,7 +141,8 @@ public final class WTinyLFUPolicy {
           }
         } else {
           if (candidate.freeze()) {
-            final var removed = data.remove(candidate.getPageKey(), candidate);
+            final var removed =
+                data.remove(candidate.getFileId(), candidate.getPageIndex(), candidate);
             candidate.makeDead();
 
             if (removed) {
@@ -206,7 +217,10 @@ public final class WTinyLFUPolicy {
   }
 
   void assertConsistency() {
-    for (final var cacheEntry : data.values()) {
+    var allEntries = new ArrayList<CacheEntry>();
+    data.forEachValue(allEntries::add);
+
+    for (final var cacheEntry : allEntries) {
       assert eden.contains(cacheEntry)
           || protection.contains(cacheEntry)
           || probation.contains(cacheEntry);
@@ -214,17 +228,17 @@ public final class WTinyLFUPolicy {
 
     var counter = 0;
     for (final var cacheEntry : eden) {
-      assert data.get(cacheEntry.getPageKey()) == cacheEntry;
+      assert data.get(cacheEntry.getFileId(), cacheEntry.getPageIndex()) == cacheEntry;
       counter++;
     }
 
     for (final var cacheEntry : probation) {
-      assert data.get(cacheEntry.getPageKey()) == cacheEntry;
+      assert data.get(cacheEntry.getFileId(), cacheEntry.getPageIndex()) == cacheEntry;
       counter++;
     }
 
     for (final var cacheEntry : protection) {
-      assert data.get(cacheEntry.getPageKey()) == cacheEntry;
+      assert data.get(cacheEntry.getFileId(), cacheEntry.getPageIndex()) == cacheEntry;
       counter++;
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CacheEntryChanges.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CacheEntryChanges.java
@@ -3,7 +3,6 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atom
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.chm.LRUList;
-import com.jetbrains.youtrackdb.internal.core.storage.cache.chm.PageKey;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.LogSequenceNumber;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WALChanges;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WALPageChangesPortion;
@@ -212,11 +211,6 @@ public class CacheEntryChanges implements CacheEntry {
   @Override
   public void setInitialLSN(LogSequenceNumber lsn) {
     this.initialLSN = lsn;
-  }
-
-  @Override
-  public PageKey getPageKey() {
-    return delegate.getPageKey();
   }
 
   @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -275,4 +275,228 @@ public class ConcurrentLongIntHashMapConcurrentTest {
         .as("size() matches forEach entry count after rehash stress")
         .isEqualTo(entryCount.get());
   }
+
+  // ---- removeByFileId concurrent tests ----
+
+  /**
+   * removeByFileId for a target file while other threads concurrently read/write entries for
+   * different file IDs. Verifies that all target-file entries are removed and entries for other
+   * files are unaffected.
+   *
+   * <p>Setup: pre-populate the map with entries for files 0-9. One thread repeatedly calls
+   * removeByFileId(targetFileId) while other threads perform get/put on files != targetFileId. After
+   * completion, verify target-file entries are gone and other-file entries are intact.
+   */
+  @Test
+  public void removeByFileIdDoesNotAffectOtherFiles() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(1024);
+    long targetFileId = 5;
+    int pagesPerFile = 100;
+    int otherFileCount = 9; // files 0-4 and 6-9
+    int rounds = 50;
+
+    // Pre-populate all files
+    for (long fId = 0; fId < 10; fId++) {
+      for (int pIdx = 0; pIdx < pagesPerFile; pIdx++) {
+        map.put(fId, pIdx, fId + ":" + pIdx);
+      }
+    }
+
+    int totalThreads = 5; // 1 remover + 4 read/write workers on other files
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+
+    try {
+      // Remover thread — repeatedly removes and re-populates the target file
+      futures.add(
+          executor.submit(
+              () -> {
+                startBarrier.await();
+                for (int r = 0; r < rounds; r++) {
+                  var removed = map.removeByFileId(targetFileId);
+                  // Re-populate so next round has entries to remove
+                  for (int pIdx = 0; pIdx < pagesPerFile; pIdx++) {
+                    map.put(targetFileId, pIdx, targetFileId + ":" + pIdx);
+                  }
+                }
+                return null;
+              }));
+
+      // 4 worker threads on other files — get/put to verify no interference
+      for (int t = 0; t < 4; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < rounds * pagesPerFile; i++) {
+                    // Pick a file != targetFileId
+                    long fileId = rng.nextInt(otherFileCount);
+                    if (fileId >= targetFileId) {
+                      fileId++; // skip targetFileId
+                    }
+                    int pageIndex = rng.nextInt(pagesPerFile);
+                    String value = fileId + ":" + pageIndex;
+
+                    if (rng.nextBoolean()) {
+                      map.put(fileId, pageIndex, value);
+                    } else {
+                      String result = map.get(fileId, pageIndex);
+                      if (result != null) {
+                        assertThat(result)
+                            .as("get(%d, %d) returned correct value", fileId, pageIndex)
+                            .isEqualTo(value);
+                      }
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Final removeByFileId to ensure target is gone
+    map.removeByFileId(targetFileId);
+
+    // Verify: no entries for the target file remain
+    map.forEach(
+        (fileId, pageIndex, value) -> {
+          assertThat(fileId)
+              .as("no entries for target file %d should remain", targetFileId)
+              .isNotEqualTo(targetFileId);
+          assertThat(value)
+              .as("value at (%d, %d) matches canonical form", fileId, pageIndex)
+              .isEqualTo(fileId + ":" + pageIndex);
+        });
+  }
+
+  /**
+   * removeByFileId + concurrent put on the same file. One thread calls removeByFileId while another
+   * thread inserts entries for the same file. After both complete, we do a final removeByFileId and
+   * verify the map is empty for that file. This exercises the race between removal and insertion
+   * within the same section.
+   */
+  @Test
+  public void removeByFileIdWithConcurrentPutOnSameFile() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(256);
+    long fileId = 42;
+    int pagesPerFile = 200;
+    int rounds = 100;
+
+    int totalThreads = 4; // 2 removers + 2 inserters
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+
+    try {
+      // 2 remover threads
+      for (int t = 0; t < 2; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  for (int r = 0; r < rounds; r++) {
+                    map.removeByFileId(fileId);
+                  }
+                  return null;
+                }));
+      }
+
+      // 2 inserter threads
+      for (int t = 0; t < 2; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  for (int r = 0; r < rounds; r++) {
+                    for (int pIdx = 0; pIdx < pagesPerFile; pIdx++) {
+                      map.put(fileId, pIdx, fileId + ":" + pIdx);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // After all threads stop, do a final removal and verify empty for this file.
+    // Some entries may remain from the last inserter round — that's expected (R2 race).
+    map.removeByFileId(fileId);
+
+    map.forEach(
+        (fId, pageIndex, value) -> assertThat(fId)
+            .as("no entries for file %d should remain after final removeByFileId", fileId)
+            .isNotEqualTo(fileId));
+  }
+
+  /**
+   * Multiple concurrent removeByFileId for different files. Several threads each call
+   * removeByFileId for their own file ID simultaneously. Verifies each file's entries are fully
+   * removed and no cross-file interference occurs.
+   */
+  @Test
+  public void multipleConcurrentRemoveByFileIdForDifferentFiles() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(4096);
+    int fileCount = 8;
+    int pagesPerFile = 200;
+
+    // Pre-populate
+    for (long fId = 0; fId < fileCount; fId++) {
+      for (int pIdx = 0; pIdx < pagesPerFile; pIdx++) {
+        map.put(fId, pIdx, fId + ":" + pIdx);
+      }
+    }
+
+    assertThat(map.size())
+        .as("initial size")
+        .isEqualTo((long) fileCount * pagesPerFile);
+
+    var executor = Executors.newFixedThreadPool(fileCount);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(fileCount);
+
+    try {
+      // Each thread removes one file
+      for (int t = 0; t < fileCount; t++) {
+        long targetFile = t;
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var removed = map.removeByFileId(targetFile);
+                  // Every entry in the removed list must belong to the target file
+                  for (var val : removed) {
+                    assertThat(val)
+                        .as("removed value belongs to file %d", targetFile)
+                        .startsWith(targetFile + ":");
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // All files removed concurrently — map should be empty
+    assertThat(map.size()).as("map should be empty after all files removed").isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -316,10 +316,11 @@ public class ConcurrentLongIntHashMapConcurrentTest {
                 for (int r = 0; r < rounds; r++) {
                   var removed = map.removeByFileId(targetFileId);
                   // Every returned value must belong to the target file
+                  // and match the canonical fileId:pageIndex form
                   for (var val : removed) {
                     assertThat(val)
                         .as("removed value belongs to target file %d", targetFileId)
-                        .startsWith(targetFileId + ":");
+                        .matches(targetFileId + ":\\d+");
                   }
                   // Re-populate so next round has entries to remove
                   for (int pIdx = 0; pIdx < pagesPerFile; pIdx++) {
@@ -373,7 +374,7 @@ public class ConcurrentLongIntHashMapConcurrentTest {
     for (var val : finalRemoved) {
       assertThat(val)
           .as("final removal returned value belonging to target file")
-          .startsWith(targetFileId + ":");
+          .matches(targetFileId + ":\\d+");
     }
 
     // Verify: no entries for the target file remain, and count other-file entries
@@ -429,7 +430,7 @@ public class ConcurrentLongIntHashMapConcurrentTest {
                     for (var val : removed) {
                       assertThat(val)
                           .as("removed value must belong to file %d", fileId)
-                          .startsWith(fileId + ":");
+                          .matches(fileId + ":\\d+");
                     }
                   }
                   return null;
@@ -525,15 +526,15 @@ public class ConcurrentLongIntHashMapConcurrentTest {
                 () -> {
                   startBarrier.await();
                   var removed = map.removeByFileId(targetFile);
-                  // Must return exactly pagesPerFile entries, all belonging to target file
-                  assertThat(removed)
-                      .as("removeByFileId(%d) should return all entries", targetFile)
-                      .hasSize(pagesPerFile);
-                  for (var val : removed) {
-                    assertThat(val)
-                        .as("removed value belongs to file %d", targetFile)
-                        .startsWith(targetFile + ":");
+                  // Must return exactly pagesPerFile entries with exact content —
+                  // no concurrent writes, so the set is fully deterministic
+                  var expected = new ArrayList<String>(pagesPerFile);
+                  for (int pIdx = 0; pIdx < pagesPerFile; pIdx++) {
+                    expected.add(targetFile + ":" + pIdx);
                   }
+                  assertThat(removed)
+                      .as("removeByFileId(%d) should return all page values", targetFile)
+                      .containsExactlyInAnyOrderElementsOf(expected);
                   return null;
                 }));
       }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -9,7 +9,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.LockSupport;
 import org.junit.Test;
 
 /**
@@ -116,12 +115,18 @@ public class ConcurrentLongIntHashMapConcurrentTest {
                       }
                       case 11 -> {
                         // ~8% compute (slow — holds write lock to force optimistic-read
-                        // fallback for concurrent readers)
+                        // fallback for concurrent readers).
+                        // Uses busy-wait instead of LockSupport.parkNanos because Windows
+                        // timer granularity rounds parkNanos(100µs) up to ~15ms, causing
+                        // the test to exceed its 60s timeout on Windows CI runners.
                         map.compute(
                             fileId,
                             pageIndex,
                             (fId, pIdx, cur) -> {
-                              LockSupport.parkNanos(100_000); // 100µs
+                              long deadline = System.nanoTime() + 100_000; // 100µs
+                              while (System.nanoTime() < deadline) {
+                                Thread.onSpinWait();
+                              }
                               return value;
                             });
                       }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -315,6 +315,12 @@ public class ConcurrentLongIntHashMapConcurrentTest {
                 startBarrier.await();
                 for (int r = 0; r < rounds; r++) {
                   var removed = map.removeByFileId(targetFileId);
+                  // Every returned value must belong to the target file
+                  for (var val : removed) {
+                    assertThat(val)
+                        .as("removed value belongs to target file %d", targetFileId)
+                        .startsWith(targetFileId + ":");
+                  }
                   // Re-populate so next round has entries to remove
                   for (int pIdx = 0; pIdx < pagesPerFile; pIdx++) {
                     map.put(targetFileId, pIdx, targetFileId + ":" + pIdx);
@@ -363,9 +369,15 @@ public class ConcurrentLongIntHashMapConcurrentTest {
     }
 
     // Final removeByFileId to ensure target is gone
-    map.removeByFileId(targetFileId);
+    var finalRemoved = map.removeByFileId(targetFileId);
+    for (var val : finalRemoved) {
+      assertThat(val)
+          .as("final removal returned value belonging to target file")
+          .startsWith(targetFileId + ":");
+    }
 
-    // Verify: no entries for the target file remain
+    // Verify: no entries for the target file remain, and count other-file entries
+    var otherEntryCount = new AtomicLong();
     map.forEach(
         (fileId, pageIndex, value) -> {
           assertThat(fileId)
@@ -374,36 +386,51 @@ public class ConcurrentLongIntHashMapConcurrentTest {
           assertThat(value)
               .as("value at (%d, %d) matches canonical form", fileId, pageIndex)
               .isEqualTo(fileId + ":" + pageIndex);
+          otherEntryCount.incrementAndGet();
         });
+    // Workers only write canonical values for other files — all 9 files x 100 pages must survive
+    assertThat(otherEntryCount.get())
+        .as("all other-file entries must be present")
+        .isEqualTo((long) otherFileCount * pagesPerFile);
+    assertThat(map.size()).isEqualTo(otherEntryCount.get());
   }
 
   /**
-   * removeByFileId + concurrent put on the same file. One thread calls removeByFileId while another
-   * thread inserts entries for the same file. After both complete, we do a final removeByFileId and
-   * verify the map is empty for that file. This exercises the race between removal and insertion
-   * within the same section.
+   * removeByFileId + concurrent put and reads on the same file. Removers call removeByFileId while
+   * inserters add entries and readers verify value correctness — all for the same file. Uses a
+   * single section to maximize intra-section contention on the write lock. After all threads
+   * complete, a final removeByFileId verifies the map is empty for that file.
+   *
+   * <p>Readers exercise the optimistic-read-to-read-lock fallback during removeByFileId's
+   * same-capacity rehash, which replaces the section's arrays under the write lock.
    */
   @Test
   public void removeByFileIdWithConcurrentPutOnSameFile() throws Exception {
-    var map = new ConcurrentLongIntHashMap<String>(256);
+    // Single section — all operations contend on one StampedLock
+    var map = new ConcurrentLongIntHashMap<String>(256, 1);
     long fileId = 42;
     int pagesPerFile = 200;
     int rounds = 100;
 
-    int totalThreads = 4; // 2 removers + 2 inserters
+    int totalThreads = 6; // 2 removers + 2 inserters + 2 readers
     var executor = Executors.newFixedThreadPool(totalThreads);
     var futures = new ArrayList<Future<Void>>();
     var startBarrier = new CyclicBarrier(totalThreads);
 
     try {
-      // 2 remover threads
+      // 2 remover threads — validate returned values belong to correct file
       for (int t = 0; t < 2; t++) {
         futures.add(
             executor.submit(
                 () -> {
                   startBarrier.await();
                   for (int r = 0; r < rounds; r++) {
-                    map.removeByFileId(fileId);
+                    var removed = map.removeByFileId(fileId);
+                    for (var val : removed) {
+                      assertThat(val)
+                          .as("removed value must belong to file %d", fileId)
+                          .startsWith(fileId + ":");
+                    }
                   }
                   return null;
                 }));
@@ -424,6 +451,26 @@ public class ConcurrentLongIntHashMapConcurrentTest {
                 }));
       }
 
+      // 2 reader threads — verify get() returns correct or null during removal
+      for (int t = 0; t < 2; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int r = 0; r < rounds * pagesPerFile; r++) {
+                    int pIdx = rng.nextInt(pagesPerFile);
+                    String result = map.get(fileId, pIdx);
+                    if (result != null) {
+                      assertThat(result)
+                          .as("get(%d, %d) must return canonical value or null", fileId, pIdx)
+                          .isEqualTo(fileId + ":" + pIdx);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
       for (var future : futures) {
         future.get(30, TimeUnit.SECONDS);
       }
@@ -433,7 +480,8 @@ public class ConcurrentLongIntHashMapConcurrentTest {
     }
 
     // After all threads stop, do a final removal and verify empty for this file.
-    // Some entries may remain from the last inserter round — that's expected (R2 race).
+    // Some entries may remain from the last inserter round — that's expected
+    // (inserters can re-insert after the last removeByFileId call).
     map.removeByFileId(fileId);
 
     map.forEach(
@@ -477,7 +525,10 @@ public class ConcurrentLongIntHashMapConcurrentTest {
                 () -> {
                   startBarrier.await();
                   var removed = map.removeByFileId(targetFile);
-                  // Every entry in the removed list must belong to the target file
+                  // Must return exactly pagesPerFile entries, all belonging to target file
+                  assertThat(removed)
+                      .as("removeByFileId(%d) should return all entries", targetFile)
+                      .hasSize(pagesPerFile);
                   for (var val : removed) {
                     assertThat(val)
                         .as("removed value belongs to file %d", targetFile)

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -3,21 +3,22 @@ package com.jetbrains.youtrackdb.internal.common.collection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 import org.junit.Test;
 
 /**
  * Concurrent stress tests for {@link ConcurrentLongIntHashMap}.
  *
  * <p>Validates concurrency correctness under high contention: mixed operations with overlapping
- * keys, rehash during concurrent access, and optimistic-read-to-read-lock fallback. Uses raw
- * {@link ExecutorService} + {@link Future#get(long, TimeUnit)} pattern for failure detection.
+ * keys, rehash during concurrent access, and optimistic-read-to-read-lock fallback. Uses raw {@link
+ * java.util.concurrent.ExecutorService} + {@link Future#get(long, TimeUnit)} pattern for failure
+ * detection.
  */
 public class ConcurrentLongIntHashMapConcurrentTest {
 
@@ -26,210 +27,252 @@ public class ConcurrentLongIntHashMapConcurrentTest {
 
   /**
    * Mixed concurrent operations on overlapping keys. N threads perform random
-   * get/put/remove/computeIfAbsent/compute on a bounded key space (~10K keys). After all threads
-   * complete, verifies that the map is internally consistent: size matches the number of entries
-   * visible via forEach, and every entry returned by forEach is retrievable via get().
+   * get/put/putIfAbsent/remove/computeIfAbsent/compute on a bounded key space (~10K keys). After
+   * all threads complete, verifies that the map is internally consistent: size matches the number of
+   * entries visible via forEach, every entry's value matches its key's canonical form, and every
+   * entry returned by forEach is retrievable via get().
    *
-   * <p>Includes a slow-compute variant where compute lambda sleeps briefly to force readers through
-   * the read-lock fallback path (optimistic read fails due to concurrent write lock held).
+   * <p>Includes a slow-compute variant where the compute lambda parks briefly to hold the write
+   * lock, forcing concurrent readers through the read-lock fallback path (optimistic read fails due
+   * to concurrent write lock held).
    */
   @Test
   public void mixedConcurrentOperationsAreConsistent() throws Exception {
     var map = new ConcurrentLongIntHashMap<String>(1024);
-    var executor = Executors.newCachedThreadPool();
+    var executor = Executors.newFixedThreadPool(THREAD_COUNT);
     var futures = new ArrayList<Future<Void>>();
-    var errors = new AtomicBoolean(false);
+    var startBarrier = new CyclicBarrier(THREAD_COUNT);
 
     // Bounded key space: 100 files x 100 pages = 10K unique keys
     int fileCount = 100;
     int pageCount = 100;
 
-    for (int t = 0; t < THREAD_COUNT; t++) {
-      futures.add(
-          executor.submit(
-              () -> {
-                var rng = ThreadLocalRandom.current();
-                for (int i = 0; i < OPS_PER_THREAD; i++) {
-                  long fileId = rng.nextInt(fileCount);
-                  int pageIndex = rng.nextInt(pageCount);
-                  String value = fileId + ":" + pageIndex;
-                  int op = rng.nextInt(10);
+    try {
+      for (int t = 0; t < THREAD_COUNT; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < OPS_PER_THREAD; i++) {
+                    long fileId = rng.nextInt(fileCount);
+                    int pageIndex = rng.nextInt(pageCount);
+                    String value = fileId + ":" + pageIndex;
+                    int op = rng.nextInt(12);
 
-                  try {
                     switch (op) {
                       case 0, 1, 2, 3 -> {
-                        // 40% reads
-                        map.get(fileId, pageIndex);
+                        // ~33% reads — verify value correctness when present
+                        String result = map.get(fileId, pageIndex);
+                        if (result != null) {
+                          assertThat(result)
+                              .as("get(%d, %d) returned correct value", fileId, pageIndex)
+                              .isEqualTo(value);
+                        }
                       }
                       case 4, 5 -> {
-                        // 20% put
+                        // ~17% put
                         map.put(fileId, pageIndex, value);
                       }
                       case 6 -> {
-                        // 10% remove
-                        map.remove(fileId, pageIndex);
+                        // ~8% putIfAbsent
+                        String result = map.putIfAbsent(fileId, pageIndex, value);
+                        if (result != null) {
+                          assertThat(result)
+                              .as(
+                                  "putIfAbsent(%d, %d) returned correct existing value",
+                                  fileId, pageIndex)
+                              .isEqualTo(value);
+                        }
                       }
                       case 7 -> {
-                        // 10% computeIfAbsent
-                        map.computeIfAbsent(
-                            fileId, pageIndex, (fId, pIdx) -> fId + ":" + pIdx);
+                        // ~8% remove
+                        map.remove(fileId, pageIndex);
                       }
                       case 8 -> {
-                        // 10% compute (fast)
+                        // ~8% conditional remove (three-arg, reference equality)
+                        String current = map.get(fileId, pageIndex);
+                        if (current != null) {
+                          map.remove(fileId, pageIndex, current);
+                        }
+                      }
+                      case 9 -> {
+                        // ~8% computeIfAbsent
+                        String result =
+                            map.computeIfAbsent(
+                                fileId, pageIndex, (fId, pIdx) -> fId + ":" + pIdx);
+                        assertThat(result)
+                            .as(
+                                "computeIfAbsent(%d, %d) returned correct value",
+                                fileId, pageIndex)
+                            .isEqualTo(value);
+                      }
+                      case 10 -> {
+                        // ~8% compute (fast) — toggle present/absent
                         map.compute(
                             fileId,
                             pageIndex,
-                            (fId, pIdx, cur) -> cur == null ? value : null); // toggle present/absent
+                            (fId, pIdx, cur) -> cur == null ? value : null);
                       }
-                      case 9 -> {
-                        // 10% compute (slow — forces optimistic-read fallback for
-                        // concurrent readers)
+                      case 11 -> {
+                        // ~8% compute (slow — holds write lock to force optimistic-read
+                        // fallback for concurrent readers)
                         map.compute(
                             fileId,
                             pageIndex,
                             (fId, pIdx, cur) -> {
-                              try {
-                                Thread.sleep(1);
-                              } catch (InterruptedException e) {
-                                Thread.currentThread().interrupt();
-                              }
+                              LockSupport.parkNanos(100_000); // 100µs
                               return value;
                             });
                       }
                       default -> throw new AssertionError("unreachable");
                     }
-                  } catch (Exception e) {
-                    errors.set(true);
-                    throw new RuntimeException(
-                        "Operation " + op + " failed at iteration " + i, e);
                   }
-                }
-                return null;
-              }));
-    }
+                  return null;
+                }));
+      }
 
-    // Wait for all threads — propagates any exception
-    for (var future : futures) {
-      future.get(60, TimeUnit.SECONDS);
+      // Wait for all threads — propagates any exception
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
     }
-    executor.shutdown();
-
-    assertThat(errors.get())
-        .as("no unexpected exceptions during concurrent operations")
-        .isFalse();
 
     // Verify map internal consistency: size matches actual entry count,
-    // and every entry visible via forEach is retrievable via get()
-    var entryCount = new long[] {0};
+    // every value matches its key's canonical form, and every entry
+    // visible via forEach is retrievable via get()
+    var entryCount = new AtomicLong();
     map.forEach(
         (fileId, pageIndex, value) -> {
           assertThat(value).as("value at (%d, %d) is non-null", fileId, pageIndex).isNotNull();
+          assertThat(value)
+              .as("value at (%d, %d) matches canonical form", fileId, pageIndex)
+              .isEqualTo(fileId + ":" + pageIndex);
           assertThat(map.get(fileId, pageIndex))
               .as("get(%d, %d) matches forEach entry", fileId, pageIndex)
               .isSameAs(value);
-          entryCount[0]++;
+          entryCount.incrementAndGet();
         });
     assertThat(map.size())
         .as("size() matches forEach entry count")
-        .isEqualTo(entryCount[0]);
+        .isEqualTo(entryCount.get());
   }
 
   /**
    * Rehash under concurrent access. Uses a 1-section map with minimal capacity (4 slots) so that
    * rehash is triggered frequently during inserts. Writer threads insert entries, reader threads
    * continuously get entries, and remover threads remove random entries — all running concurrently.
+   * A startup barrier ensures all threads overlap during rehash events.
    *
-   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException}, no stale/corrupt values returned, and
-   * correct final state (every entry visible via forEach is retrievable via get).
+   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException}, no stale/corrupt values returned,
+   * correct final state (every entry visible via forEach is retrievable via get and matches its
+   * key's canonical form), and that rehash actually occurred (capacity grew beyond initial 4).
    */
   @Test
   public void rehashUnderConcurrentAccessIsCorrect() throws Exception {
     // Single section, capacity 4 — rehash triggers frequently
     var map = new ConcurrentLongIntHashMap<String>(4, 1);
-    var executor = Executors.newCachedThreadPool();
+    int totalThreads = 8; // 3 writers + 3 readers + 2 removers
+    var executor = Executors.newFixedThreadPool(totalThreads);
     var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
 
     // Bounded key space to keep memory reasonable (~10K unique keys)
     int keyBound = 10_000;
     int opsPerThread = 100_000;
 
-    // Track all values ever inserted — used for correctness validation of get() results
-    var insertedValues = new ConcurrentHashMap<String, String>();
-
-    // 3 writer threads — insert entries, causing frequent rehash
-    for (int t = 0; t < 3; t++) {
-      futures.add(
-          executor.submit(
-              () -> {
-                var rng = ThreadLocalRandom.current();
-                for (int i = 0; i < opsPerThread; i++) {
-                  int key = rng.nextInt(keyBound);
-                  long fileId = key / 100;
-                  int pageIndex = key % 100;
-                  String value = fileId + ":" + pageIndex;
-                  insertedValues.put(value, value);
-                  map.put(fileId, pageIndex, value);
-                }
-                return null;
-              }));
-    }
-
-    // 3 reader threads — continuous reads; verify non-null results are valid
-    for (int t = 0; t < 3; t++) {
-      futures.add(
-          executor.submit(
-              () -> {
-                var rng = ThreadLocalRandom.current();
-                for (int i = 0; i < opsPerThread; i++) {
-                  int key = rng.nextInt(keyBound);
-                  long fileId = key / 100;
-                  int pageIndex = key % 100;
-                  String result = map.get(fileId, pageIndex);
-                  if (result != null) {
-                    // Value must match the canonical form for this key
-                    assertThat(result)
-                        .as("get(%d, %d) returned a valid value", fileId, pageIndex)
-                        .isEqualTo(fileId + ":" + pageIndex);
+    try {
+      // 3 writer threads — insert entries, causing frequent rehash
+      for (int t = 0; t < 3; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int key = rng.nextInt(keyBound);
+                    long fileId = key / 100;
+                    int pageIndex = key % 100;
+                    String value = fileId + ":" + pageIndex;
+                    map.put(fileId, pageIndex, value);
                   }
-                }
-                return null;
-              }));
+                  return null;
+                }));
+      }
+
+      // 3 reader threads — continuous reads; verify non-null results are valid
+      for (int t = 0; t < 3; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int key = rng.nextInt(keyBound);
+                    long fileId = key / 100;
+                    int pageIndex = key % 100;
+                    String result = map.get(fileId, pageIndex);
+                    if (result != null) {
+                      // Value must match the canonical form for this key
+                      assertThat(result)
+                          .as("get(%d, %d) returned a valid value", fileId, pageIndex)
+                          .isEqualTo(fileId + ":" + pageIndex);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      // 2 remover threads — remove random entries to keep occupancy oscillating
+      for (int t = 0; t < 2; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int key = rng.nextInt(keyBound);
+                    long fileId = key / 100;
+                    int pageIndex = key % 100;
+                    map.remove(fileId, pageIndex);
+                  }
+                  return null;
+                }));
+      }
+
+      // Wait for all threads
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
     }
 
-    // 2 remover threads — remove random entries to keep occupancy oscillating
-    for (int t = 0; t < 2; t++) {
-      futures.add(
-          executor.submit(
-              () -> {
-                var rng = ThreadLocalRandom.current();
-                for (int i = 0; i < opsPerThread; i++) {
-                  int key = rng.nextInt(keyBound);
-                  long fileId = key / 100;
-                  int pageIndex = key % 100;
-                  map.remove(fileId, pageIndex);
-                }
-                return null;
-              }));
-    }
-
-    // Wait for all threads
-    for (var future : futures) {
-      future.get(60, TimeUnit.SECONDS);
-    }
-    executor.shutdown();
+    // Verify rehash actually occurred — capacity must have grown from initial 4
+    assertThat(map.capacity())
+        .as("capacity should have grown via rehash from initial 4")
+        .isGreaterThan(4);
 
     // Final consistency: size matches forEach count, all entries retrievable
-    var entryCount = new long[] {0};
+    // and values match their keys' canonical form
+    var entryCount = new AtomicLong();
     map.forEach(
         (fileId, pageIndex, value) -> {
           assertThat(value).isNotNull();
+          assertThat(value)
+              .as("value at (%d, %d) matches canonical form", fileId, pageIndex)
+              .isEqualTo(fileId + ":" + pageIndex);
           assertThat(map.get(fileId, pageIndex))
               .as("get(%d, %d) after all threads done", fileId, pageIndex)
               .isSameAs(value);
-          entryCount[0]++;
+          entryCount.incrementAndGet();
         });
     assertThat(map.size())
         .as("size() matches forEach entry count after rehash stress")
-        .isEqualTo(entryCount[0]);
+        .isEqualTo(entryCount.get());
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -1,0 +1,235 @@
+package com.jetbrains.youtrackdb.internal.common.collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+
+/**
+ * Concurrent stress tests for {@link ConcurrentLongIntHashMap}.
+ *
+ * <p>Validates concurrency correctness under high contention: mixed operations with overlapping
+ * keys, rehash during concurrent access, and optimistic-read-to-read-lock fallback. Uses raw
+ * {@link ExecutorService} + {@link Future#get(long, TimeUnit)} pattern for failure detection.
+ */
+public class ConcurrentLongIntHashMapConcurrentTest {
+
+  private static final int THREAD_COUNT = 8;
+  private static final int OPS_PER_THREAD = 200_000;
+
+  /**
+   * Mixed concurrent operations on overlapping keys. N threads perform random
+   * get/put/remove/computeIfAbsent/compute on a bounded key space (~10K keys). After all threads
+   * complete, verifies that the map is internally consistent: size matches the number of entries
+   * visible via forEach, and every entry returned by forEach is retrievable via get().
+   *
+   * <p>Includes a slow-compute variant where compute lambda sleeps briefly to force readers through
+   * the read-lock fallback path (optimistic read fails due to concurrent write lock held).
+   */
+  @Test
+  public void mixedConcurrentOperationsAreConsistent() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(1024);
+    var executor = Executors.newCachedThreadPool();
+    var futures = new ArrayList<Future<Void>>();
+    var errors = new AtomicBoolean(false);
+
+    // Bounded key space: 100 files x 100 pages = 10K unique keys
+    int fileCount = 100;
+    int pageCount = 100;
+
+    for (int t = 0; t < THREAD_COUNT; t++) {
+      futures.add(
+          executor.submit(
+              () -> {
+                var rng = ThreadLocalRandom.current();
+                for (int i = 0; i < OPS_PER_THREAD; i++) {
+                  long fileId = rng.nextInt(fileCount);
+                  int pageIndex = rng.nextInt(pageCount);
+                  String value = fileId + ":" + pageIndex;
+                  int op = rng.nextInt(10);
+
+                  try {
+                    switch (op) {
+                      case 0, 1, 2, 3 -> {
+                        // 40% reads
+                        map.get(fileId, pageIndex);
+                      }
+                      case 4, 5 -> {
+                        // 20% put
+                        map.put(fileId, pageIndex, value);
+                      }
+                      case 6 -> {
+                        // 10% remove
+                        map.remove(fileId, pageIndex);
+                      }
+                      case 7 -> {
+                        // 10% computeIfAbsent
+                        map.computeIfAbsent(
+                            fileId, pageIndex, (fId, pIdx) -> fId + ":" + pIdx);
+                      }
+                      case 8 -> {
+                        // 10% compute (fast)
+                        map.compute(
+                            fileId,
+                            pageIndex,
+                            (fId, pIdx, cur) -> cur == null ? value : null); // toggle present/absent
+                      }
+                      case 9 -> {
+                        // 10% compute (slow — forces optimistic-read fallback for
+                        // concurrent readers)
+                        map.compute(
+                            fileId,
+                            pageIndex,
+                            (fId, pIdx, cur) -> {
+                              try {
+                                Thread.sleep(1);
+                              } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                              }
+                              return value;
+                            });
+                      }
+                      default -> throw new AssertionError("unreachable");
+                    }
+                  } catch (Exception e) {
+                    errors.set(true);
+                    throw new RuntimeException(
+                        "Operation " + op + " failed at iteration " + i, e);
+                  }
+                }
+                return null;
+              }));
+    }
+
+    // Wait for all threads — propagates any exception
+    for (var future : futures) {
+      future.get(60, TimeUnit.SECONDS);
+    }
+    executor.shutdown();
+
+    assertThat(errors.get())
+        .as("no unexpected exceptions during concurrent operations")
+        .isFalse();
+
+    // Verify map internal consistency: size matches actual entry count,
+    // and every entry visible via forEach is retrievable via get()
+    var entryCount = new long[] {0};
+    map.forEach(
+        (fileId, pageIndex, value) -> {
+          assertThat(value).as("value at (%d, %d) is non-null", fileId, pageIndex).isNotNull();
+          assertThat(map.get(fileId, pageIndex))
+              .as("get(%d, %d) matches forEach entry", fileId, pageIndex)
+              .isSameAs(value);
+          entryCount[0]++;
+        });
+    assertThat(map.size())
+        .as("size() matches forEach entry count")
+        .isEqualTo(entryCount[0]);
+  }
+
+  /**
+   * Rehash under concurrent access. Uses a 1-section map with minimal capacity (4 slots) so that
+   * rehash is triggered frequently during inserts. Writer threads insert entries, reader threads
+   * continuously get entries, and remover threads remove random entries — all running concurrently.
+   *
+   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException}, no stale/corrupt values returned, and
+   * correct final state (every entry visible via forEach is retrievable via get).
+   */
+  @Test
+  public void rehashUnderConcurrentAccessIsCorrect() throws Exception {
+    // Single section, capacity 4 — rehash triggers frequently
+    var map = new ConcurrentLongIntHashMap<String>(4, 1);
+    var executor = Executors.newCachedThreadPool();
+    var futures = new ArrayList<Future<Void>>();
+
+    // Bounded key space to keep memory reasonable (~10K unique keys)
+    int keyBound = 10_000;
+    int opsPerThread = 100_000;
+
+    // Track all values ever inserted — used for correctness validation of get() results
+    var insertedValues = new ConcurrentHashMap<String, String>();
+
+    // 3 writer threads — insert entries, causing frequent rehash
+    for (int t = 0; t < 3; t++) {
+      futures.add(
+          executor.submit(
+              () -> {
+                var rng = ThreadLocalRandom.current();
+                for (int i = 0; i < opsPerThread; i++) {
+                  int key = rng.nextInt(keyBound);
+                  long fileId = key / 100;
+                  int pageIndex = key % 100;
+                  String value = fileId + ":" + pageIndex;
+                  insertedValues.put(value, value);
+                  map.put(fileId, pageIndex, value);
+                }
+                return null;
+              }));
+    }
+
+    // 3 reader threads — continuous reads; verify non-null results are valid
+    for (int t = 0; t < 3; t++) {
+      futures.add(
+          executor.submit(
+              () -> {
+                var rng = ThreadLocalRandom.current();
+                for (int i = 0; i < opsPerThread; i++) {
+                  int key = rng.nextInt(keyBound);
+                  long fileId = key / 100;
+                  int pageIndex = key % 100;
+                  String result = map.get(fileId, pageIndex);
+                  if (result != null) {
+                    // Value must match the canonical form for this key
+                    assertThat(result)
+                        .as("get(%d, %d) returned a valid value", fileId, pageIndex)
+                        .isEqualTo(fileId + ":" + pageIndex);
+                  }
+                }
+                return null;
+              }));
+    }
+
+    // 2 remover threads — remove random entries to keep occupancy oscillating
+    for (int t = 0; t < 2; t++) {
+      futures.add(
+          executor.submit(
+              () -> {
+                var rng = ThreadLocalRandom.current();
+                for (int i = 0; i < opsPerThread; i++) {
+                  int key = rng.nextInt(keyBound);
+                  long fileId = key / 100;
+                  int pageIndex = key % 100;
+                  map.remove(fileId, pageIndex);
+                }
+                return null;
+              }));
+    }
+
+    // Wait for all threads
+    for (var future : futures) {
+      future.get(60, TimeUnit.SECONDS);
+    }
+    executor.shutdown();
+
+    // Final consistency: size matches forEach count, all entries retrievable
+    var entryCount = new long[] {0};
+    map.forEach(
+        (fileId, pageIndex, value) -> {
+          assertThat(value).isNotNull();
+          assertThat(map.get(fileId, pageIndex))
+              .as("get(%d, %d) after all threads done", fileId, pageIndex)
+              .isSameAs(value);
+          entryCount[0]++;
+        });
+    assertThat(map.size())
+        .as("size() matches forEach entry count after rehash stress")
+        .isEqualTo(entryCount[0]);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1659,25 +1659,21 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(h1).isNotEqualTo(h2);
   }
 
-  /** Verify hashForFrequencySketch handles zero keys correctly. */
+  /** Verify hashForFrequencySketch computes a known value for zero keys. */
   @Test
   public void hashForFrequencySketchWithZeroKeys() {
-    // Should not throw and should produce a valid hash
+    // Long.hashCode(0) == 0, so result is 0 * 31 + 0 == 0
     int h = ConcurrentLongIntHashMap.hashForFrequencySketch(0L, 0);
-    // Just verify it runs — any int is valid
-    assertThat(h).isNotNull();
+    assertThat(h).isEqualTo(0);
   }
 
   /**
-   * Verify hashForFrequencySketch is independent from the map's internal hash.
-   * The internal murmur hash determines bucket placement; the frequency sketch hash
-   * must use a different algorithm to avoid correlation.
+   * Verify hashForFrequencySketch matches the documented formula
+   * (Long.hashCode(fileId) * 31 + pageIndex) and differs from the map's internal
+   * murmur hash truncated to int.
    */
   @Test
-  public void hashForFrequencySketchIsIndependentFromInternalHash() {
-    // hashForFrequencySketch uses Long.hashCode(fileId) * 31 + pageIndex
-    // The map's internal hash uses murmur3 finalizer.
-    // Verify the formula matches the documented algorithm.
+  public void hashForFrequencySketchMatchesDocumentedFormula() {
     long fileId = 123456789L;
     int pageIndex = 42;
     int expected = Long.hashCode(fileId) * 31 + pageIndex;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1141,4 +1141,187 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(map.size()).isEqualTo(1);
     assertThat(map.get(9L, 0)).isEqualTo("other");
   }
+
+  // ---- clear() ----
+
+  @Test
+  public void clearRemovesAllEntries() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    for (int i = 0; i < 50; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(50);
+
+    map.clear();
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    for (int i = 0; i < 50; i++) {
+      assertThat(map.get((long) i, i)).isNull();
+    }
+  }
+
+  @Test
+  public void clearOnEmptyMapIsNoOp() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.clear();
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void clearAllowsReinsertion() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    long initialCapacity = map.capacity();
+
+    map.put(1L, 1, "a");
+    map.put(2L, 2, "b");
+    map.clear();
+
+    map.put(3L, 3, "c");
+    assertThat(map.get(3L, 3)).isEqualTo("c");
+    assertThat(map.size()).isEqualTo(1);
+    // Capacity should not change from clear
+    assertThat(map.capacity()).isEqualTo(initialCapacity);
+  }
+
+  // ---- forEach() ----
+
+  @Test
+  public void forEachVisitsAllEntries() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "a");
+    map.put(2L, 20, "b");
+    map.put(3L, 30, "c");
+
+    var visited = new java.util.HashMap<String, String>();
+    map.forEach((fid, pid, val) -> visited.put(fid + ":" + pid, val));
+
+    assertThat(visited)
+        .containsEntry("1:10", "a")
+        .containsEntry("2:20", "b")
+        .containsEntry("3:30", "c")
+        .hasSize(3);
+  }
+
+  @Test
+  public void forEachOnEmptyMapVisitsNothing() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    int[] count = {0};
+    map.forEach((fid, pid, val) -> count[0]++);
+    assertThat(count[0]).isEqualTo(0);
+  }
+
+  // ---- forEachValue() ----
+
+  @Test
+  public void forEachValueVisitsAllValues() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "a");
+    map.put(2L, 20, "b");
+    map.put(3L, 30, "c");
+
+    var values = new java.util.ArrayList<String>();
+    map.forEachValue(values::add);
+
+    assertThat(values).containsExactlyInAnyOrder("a", "b", "c");
+  }
+
+  // ---- shrink() ----
+
+  @Test
+  public void shrinkReducesCapacity() {
+    var map = new ConcurrentLongIntHashMap<String>(1024, 1);
+    assertThat(map.capacity()).isEqualTo(1024);
+
+    // Insert only a few entries
+    map.put(1L, 1, "a");
+    map.put(2L, 2, "b");
+    map.put(3L, 3, "c");
+
+    map.shrink();
+    // Capacity should be smaller than 1024 but still hold the 3 entries
+    assertThat(map.capacity()).isLessThan(1024);
+    assertThat(map.capacity()).isGreaterThanOrEqualTo(3);
+
+    // All entries must survive shrink
+    assertThat(map.get(1L, 1)).isEqualTo("a");
+    assertThat(map.get(2L, 2)).isEqualTo("b");
+    assertThat(map.get(3L, 3)).isEqualTo("c");
+    assertThat(map.size()).isEqualTo(3);
+  }
+
+  @Test
+  public void shrinkOnEmptyMapKeepsMinimumCapacity() {
+    var map = new ConcurrentLongIntHashMap<String>(1024, 1);
+    map.shrink();
+    // Minimum capacity is 2 per section
+    assertThat(map.capacity()).isEqualTo(2);
+    // Map must still be usable
+    map.put(1L, 1, "a");
+    assertThat(map.get(1L, 1)).isEqualTo("a");
+  }
+
+  @Test
+  public void shrinkIsNoOpWhenCapacityAlreadyOptimal() {
+    // With capacity=2 (minimum) and 1 entry, ceil(1/0.66)=2 → no shrink possible
+    var map = new ConcurrentLongIntHashMap<String>(2, 1);
+    map.put(1L, 1, "a");
+    long capBefore = map.capacity();
+
+    map.shrink();
+    assertThat(map.capacity()).isEqualTo(capBefore);
+    assertThat(map.get(1L, 1)).isEqualTo("a");
+  }
+
+  // ---- Resize with many entries (entries survive) ----
+
+  @Test
+  public void resizeWithManyEntriesPreservesAll() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+
+    // Insert enough to trigger multiple resizes
+    for (int i = 0; i < 1000; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(1000);
+
+    // Verify all entries survived all resizes
+    for (int i = 0; i < 1000; i++) {
+      assertThat(map.get((long) i, i))
+          .as("Entry (%d, %d) must survive multiple resizes", (long) i, i)
+          .isEqualTo("val-" + i);
+    }
+
+    // Capacity should be power of two
+    long cap = map.capacity();
+    assertThat(cap & (cap - 1))
+        .as("Capacity must be power of two")
+        .isEqualTo(0);
+  }
+
+  // ---- Large map with many sections ----
+
+  @Test
+  public void largeMapWithManySections() {
+    var map = new ConcurrentLongIntHashMap<String>(1024, 16);
+    for (int i = 0; i < 1000; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(1000);
+
+    for (int i = 0; i < 1000; i++) {
+      assertThat(map.get((long) i, i)).isEqualTo("val-" + i);
+    }
+
+    // Remove half
+    for (int i = 0; i < 500; i++) {
+      map.remove((long) i, i);
+    }
+    assertThat(map.size()).isEqualTo(500);
+
+    // Remaining entries intact
+    for (int i = 500; i < 1000; i++) {
+      assertThat(map.get((long) i, i)).isEqualTo("val-" + i);
+    }
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1668,16 +1668,21 @@ public class ConcurrentLongIntHashMapTest {
   }
 
   /**
-   * Verify hashForFrequencySketch matches the documented formula
-   * (Long.hashCode(fileId) * 31 + pageIndex) and differs from the map's internal
-   * murmur hash truncated to int.
+   * Verify hashForFrequencySketch returns pre-computed known values — guards against
+   * accidental formula changes (a tautological re-derivation would not catch that).
    */
   @Test
-  public void hashForFrequencySketchMatchesDocumentedFormula() {
-    long fileId = 123456789L;
-    int pageIndex = 42;
-    int expected = Long.hashCode(fileId) * 31 + pageIndex;
-    assertThat(ConcurrentLongIntHashMap.hashForFrequencySketch(fileId, pageIndex))
-        .isEqualTo(expected);
+  public void hashForFrequencySketchMatchesPrecomputedValues() {
+    // Long.hashCode(1L) = 1, so 1 * 31 + 0 = 31
+    assertThat(ConcurrentLongIntHashMap.hashForFrequencySketch(1L, 0)).isEqualTo(31);
+    // Long.hashCode(1L) = 1, so 1 * 31 + 5 = 36
+    assertThat(ConcurrentLongIntHashMap.hashForFrequencySketch(1L, 5)).isEqualTo(36);
+    // Long.hashCode(123456789L) = 123456789, so 123456789 * 31 + 42 = -467806795
+    assertThat(ConcurrentLongIntHashMap.hashForFrequencySketch(123456789L, 42))
+        .isEqualTo(-467806795);
+    // Long.hashCode(Long.MAX_VALUE) = (int)(MAX ^ (MAX >>> 32)) = -2147483648 (Integer.MIN_VALUE)
+    // Integer.MIN_VALUE * 31 overflows and wraps to Integer.MIN_VALUE in int arithmetic
+    assertThat(ConcurrentLongIntHashMap.hashForFrequencySketch(Long.MAX_VALUE, 0))
+        .isEqualTo(-2147483648);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -589,4 +589,165 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(map.size()).isEqualTo(3);
   }
 
+  // ---- compute() ----
+
+  @Test
+  public void computeOnAbsentKeyWithNullReturnIsNoOp() {
+    // Absent key + null return = no-op (R1/T2 review decision)
+    var map = new ConcurrentLongIntHashMap<String>();
+    String result = map.compute(1L, 10, (fid, pid, current) -> null);
+    assertThat(result).isNull();
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.get(1L, 10)).isNull();
+  }
+
+  @Test
+  public void computeOnAbsentKeyWithNonNullReturnInserts() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    String result = map.compute(1L, 10, (fid, pid, current) -> {
+      assertThat(current).as("Current value should be null for absent key").isNull();
+      return "new-value";
+    });
+    assertThat(result).isEqualTo("new-value");
+    assertThat(map.get(1L, 10)).isEqualTo("new-value");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void computeOnPresentKeyWithNullReturnRemoves() {
+    // Present key + null return = removal (R1/T2 review decision)
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "existing");
+    String result = map.compute(1L, 10, (fid, pid, current) -> {
+      assertThat(current).isEqualTo("existing");
+      return null;
+    });
+    assertThat(result).isNull();
+    assertThat(map.get(1L, 10)).isNull();
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void computeOnPresentKeyWithNonNullReturnReplaces() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "old");
+    String result = map.compute(1L, 10, (fid, pid, current) -> "new-" + current);
+    assertThat(result).isEqualTo("new-old");
+    assertThat(map.get(1L, 10)).isEqualTo("new-old");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void computePassesCallerSuppliedKeysForAbsentKey() {
+    // R8 review decision: pass caller's fileId/pageIndex, not array contents
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.compute(42L, 99, (fid, pid, current) -> {
+      assertThat(fid).isEqualTo(42L);
+      assertThat(pid).isEqualTo(99);
+      return "value";
+    });
+    assertThat(map.get(42L, 99)).isEqualTo("value");
+  }
+
+  // ---- remove() ----
+
+  @Test
+  public void removeReturnsRemovedValue() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "hello");
+    String removed = map.remove(1L, 10);
+    assertThat(removed).isEqualTo("hello");
+    assertThat(map.get(1L, 10)).isNull();
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void removeReturnsNullForAbsentKey() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.remove(1L, 10)).isNull();
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void removeDoesNotAffectOtherEntries() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    map.put(1L, 1, "a");
+    map.put(2L, 2, "b");
+    map.put(3L, 3, "c");
+
+    map.remove(2L, 2);
+
+    assertThat(map.get(1L, 1)).isEqualTo("a");
+    assertThat(map.get(2L, 2)).isNull();
+    assertThat(map.get(3L, 3)).isEqualTo("c");
+    assertThat(map.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void getFindsEntryAfterRemovalInProbeChain() {
+    // Verify backward-sweep cleanup: after removing an entry mid-chain, subsequent
+    // entries must still be findable (no tombstone gap breaks the probe).
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    // Insert several entries that may form a probe chain in the single section
+    for (int i = 0; i < 8; i++) {
+      map.put(1L, i, "val-" + i);
+    }
+
+    // Remove entries from the middle of the chain
+    map.remove(1L, 2);
+    map.remove(1L, 4);
+
+    // All remaining entries must still be findable
+    assertThat(map.get(1L, 0)).isEqualTo("val-0");
+    assertThat(map.get(1L, 1)).isEqualTo("val-1");
+    assertThat(map.get(1L, 2)).isNull();
+    assertThat(map.get(1L, 3)).isEqualTo("val-3");
+    assertThat(map.get(1L, 4)).isNull();
+    assertThat(map.get(1L, 5)).isEqualTo("val-5");
+    assertThat(map.get(1L, 6)).isEqualTo("val-6");
+    assertThat(map.get(1L, 7)).isEqualTo("val-7");
+    assertThat(map.size()).isEqualTo(6);
+  }
+
+  // ---- Conditional remove ----
+
+  @Test
+  public void conditionalRemoveSucceedsWithSameReference() {
+    // T7 review decision: reference equality
+    var map = new ConcurrentLongIntHashMap<String>();
+    String value = "hello";
+    map.put(1L, 10, value);
+    boolean removed = map.remove(1L, 10, value);
+    assertThat(removed).isTrue();
+    assertThat(map.get(1L, 10)).isNull();
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void conditionalRemoveFailsWithDifferentReferenceEvenIfEqual() {
+    // T7: uses == not equals()
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "hello");
+    // new String creates a different reference that equals() the stored one
+    boolean removed = map.remove(1L, 10, new String("hello"));
+    assertThat(removed).isFalse();
+    assertThat(map.get(1L, 10)).isEqualTo("hello");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void conditionalRemoveReturnsFalseForAbsentKey() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.remove(1L, 10, "nothing")).isFalse();
+  }
+
+  @Test
+  public void removeAndReinsertWorks() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "first");
+    map.remove(1L, 10);
+    map.put(1L, 10, "second");
+    assertThat(map.get(1L, 10)).isEqualTo("second");
+    assertThat(map.size()).isEqualTo(1);
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1,0 +1,158 @@
+package com.jetbrains.youtrackdb.internal.common.collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ConcurrentLongIntHashMap}.
+ *
+ * <p>Tests are organized by operation, starting with constructor and get() (Step 1), followed by
+ * mutation operations in subsequent steps.
+ */
+public class ConcurrentLongIntHashMapTest {
+
+  // ---- Constructor tests ----
+
+  @Test
+  public void emptyMapHasSizeZero() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void constructorWithExpectedItems() {
+    var map = new ConcurrentLongIntHashMap<String>(1024);
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    // Capacity should be at least 1024 / 16 sections, power-of-two aligned, times 16
+    assertThat(map.capacity()).isGreaterThanOrEqualTo(1024);
+  }
+
+  @Test
+  public void constructorWithCustomSectionCount() {
+    var map = new ConcurrentLongIntHashMap<String>(256, 4);
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.capacity()).isGreaterThan(0);
+  }
+
+  @Test
+  public void constructorRejectsNonPowerOfTwoSectionCount() {
+    assertThatThrownBy(() -> new ConcurrentLongIntHashMap<String>(256, 3))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("power of two");
+  }
+
+  @Test
+  public void constructorRejectsZeroSectionCount() {
+    assertThatThrownBy(() -> new ConcurrentLongIntHashMap<String>(256, 0))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void constructorRejectsNegativeExpectedItems() {
+    assertThatThrownBy(() -> new ConcurrentLongIntHashMap<String>(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("non-negative");
+  }
+
+  // ---- get() on empty map ----
+
+  @Test
+  public void getOnEmptyMapReturnsNull() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.get(1L, 0)).isNull();
+    assertThat(map.get(0L, 0)).isNull();
+    assertThat(map.get(Long.MAX_VALUE, Integer.MAX_VALUE)).isNull();
+  }
+
+  @Test
+  public void getWithFileIdZeroOnEmptyMapReturnsNull() {
+    // fileId=0 is a valid key, not a sentinel. Must not confuse with empty slot.
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.get(0L, 0)).isNull();
+    assertThat(map.get(0L, 42)).isNull();
+  }
+
+  @Test
+  public void getWithPageIndexZeroOnEmptyMapReturnsNull() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.get(42L, 0)).isNull();
+  }
+
+  // ---- Hash distribution sanity ----
+
+  @Test
+  public void hashFunctionProducesDifferentValuesForDifferentKeys() {
+    // Verify that nearby keys produce different hashes (no trivial collisions)
+    long h1 = ConcurrentLongIntHashMap.hash(0L, 0);
+    long h2 = ConcurrentLongIntHashMap.hash(0L, 1);
+    long h3 = ConcurrentLongIntHashMap.hash(1L, 0);
+    long h4 = ConcurrentLongIntHashMap.hash(1L, 1);
+
+    assertThat(h1).isNotEqualTo(h2);
+    assertThat(h1).isNotEqualTo(h3);
+    assertThat(h1).isNotEqualTo(h4);
+    assertThat(h2).isNotEqualTo(h3);
+    assertThat(h2).isNotEqualTo(h4);
+    assertThat(h3).isNotEqualTo(h4);
+  }
+
+  @Test
+  public void hashFunctionDistributesAcrossSections() {
+    // With default 16 sections, a range of fileIds should hit multiple sections.
+    int[] sectionHits = new int[16];
+    for (int fileId = 0; fileId < 1000; fileId++) {
+      long h = ConcurrentLongIntHashMap.hash(fileId, 0);
+      int section = (int) (h >>> 32) & 15;
+      sectionHits[section]++;
+    }
+    // Each section should get at least some hits — no section should be starved.
+    for (int hits : sectionHits) {
+      assertThat(hits)
+          .as("Each section should receive some entries for a range of fileIds")
+          .isGreaterThan(0);
+    }
+  }
+
+  // ---- alignToPowerOfTwo ----
+
+  @Test
+  public void alignToPowerOfTwoBasicCases() {
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(0)).isEqualTo(1);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(1)).isEqualTo(1);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(2)).isEqualTo(2);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(3)).isEqualTo(4);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(4)).isEqualTo(4);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(5)).isEqualTo(8);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(100)).isEqualTo(128);
+  }
+
+  // ---- Capacity ----
+
+  @Test
+  public void capacityIsPowerOfTwoPerSection() {
+    // Each section's capacity must be power-of-two for the bucket mask to work.
+    var map = new ConcurrentLongIntHashMap<String>(100, 4);
+    long totalCapacity = map.capacity();
+    // Total capacity = 4 sections × per-section capacity (power of two)
+    assertThat(totalCapacity).isGreaterThanOrEqualTo(100);
+    // Per-section capacity is power of two, so total is divisible by 4
+    assertThat(totalCapacity % 4).isEqualTo(0);
+    long perSection = totalCapacity / 4;
+    assertThat(perSection & (perSection - 1))
+        .as("Per-section capacity should be a power of two")
+        .isEqualTo(0);
+  }
+
+  @Test
+  public void singleSectionMap() {
+    // Edge case: map with a single section
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    assertThat(map.capacity()).isGreaterThanOrEqualTo(16);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1632,4 +1632,56 @@ public class ConcurrentLongIntHashMapTest {
     map.forEachValue(val -> count[0]++);
     assertThat(count[0]).isEqualTo(0);
   }
+
+  // ---- hashForFrequencySketch ----
+
+  /** Verify hashForFrequencySketch is consistent (same inputs → same output). */
+  @Test
+  public void hashForFrequencySketchIsConsistent() {
+    int h1 = ConcurrentLongIntHashMap.hashForFrequencySketch(42L, 7);
+    int h2 = ConcurrentLongIntHashMap.hashForFrequencySketch(42L, 7);
+    assertThat(h1).isEqualTo(h2);
+  }
+
+  /** Verify hashForFrequencySketch differentiates keys that differ only in pageIndex. */
+  @Test
+  public void hashForFrequencySketchDiffersForDifferentPageIndex() {
+    int h1 = ConcurrentLongIntHashMap.hashForFrequencySketch(1L, 0);
+    int h2 = ConcurrentLongIntHashMap.hashForFrequencySketch(1L, 1);
+    assertThat(h1).isNotEqualTo(h2);
+  }
+
+  /** Verify hashForFrequencySketch differentiates keys that differ only in fileId. */
+  @Test
+  public void hashForFrequencySketchDiffersForDifferentFileId() {
+    int h1 = ConcurrentLongIntHashMap.hashForFrequencySketch(0L, 5);
+    int h2 = ConcurrentLongIntHashMap.hashForFrequencySketch(1L, 5);
+    assertThat(h1).isNotEqualTo(h2);
+  }
+
+  /** Verify hashForFrequencySketch handles zero keys correctly. */
+  @Test
+  public void hashForFrequencySketchWithZeroKeys() {
+    // Should not throw and should produce a valid hash
+    int h = ConcurrentLongIntHashMap.hashForFrequencySketch(0L, 0);
+    // Just verify it runs — any int is valid
+    assertThat(h).isNotNull();
+  }
+
+  /**
+   * Verify hashForFrequencySketch is independent from the map's internal hash.
+   * The internal murmur hash determines bucket placement; the frequency sketch hash
+   * must use a different algorithm to avoid correlation.
+   */
+  @Test
+  public void hashForFrequencySketchIsIndependentFromInternalHash() {
+    // hashForFrequencySketch uses Long.hashCode(fileId) * 31 + pageIndex
+    // The map's internal hash uses murmur3 finalizer.
+    // Verify the formula matches the documented algorithm.
+    long fileId = 123456789L;
+    int pageIndex = 42;
+    int expected = Long.hashCode(fileId) * 31 + pageIndex;
+    assertThat(ConcurrentLongIntHashMap.hashForFrequencySketch(fileId, pageIndex))
+        .isEqualTo(expected);
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -500,9 +500,9 @@ public class ConcurrentLongIntHashMapTest {
     map.put(2L, 2, "b");
     assertThat(map.capacity()).isEqualTo(4);
 
-    // Third insert triggers resize
+    // Third insert triggers resize: 4 → 8
     map.put(3L, 3, "c");
-    assertThat(map.capacity()).isGreaterThan(4);
+    assertThat(map.capacity()).isEqualTo(8);
 
     assertThat(map.get(1L, 1)).isEqualTo("a");
     assertThat(map.get(2L, 2)).isEqualTo("b");
@@ -556,7 +556,8 @@ public class ConcurrentLongIntHashMapTest {
             (fid, pid) -> {
               throw new RuntimeException("computation failed");
             }))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("computation failed");
 
     // Map should still be usable and the failed key should not be present
     assertThat(map.get(1L, 1)).isEqualTo("existing");
@@ -853,11 +854,10 @@ public class ConcurrentLongIntHashMapTest {
   }
 
   @Test
-  public void computeLeavesMapConsistentWhenFunctionThrows() {
+  public void computeLeavesMapConsistentWhenFunctionThrowsOnPresentKey() {
     var map = new ConcurrentLongIntHashMap<String>();
     map.put(1L, 10, "existing");
 
-    // Function throws on present key
     assertThatThrownBy(
         () -> map.compute(
             1L,
@@ -865,11 +865,17 @@ public class ConcurrentLongIntHashMapTest {
             (fid, pid, current) -> {
               throw new RuntimeException("remapping failed");
             }))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("remapping failed");
     assertThat(map.get(1L, 10)).isEqualTo("existing");
     assertThat(map.size()).isEqualTo(1);
+  }
 
-    // Function throws on absent key
+  @Test
+  public void computeLeavesMapConsistentWhenFunctionThrowsOnAbsentKey() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "existing");
+
     assertThatThrownBy(
         () -> map.compute(
             2L,
@@ -877,7 +883,8 @@ public class ConcurrentLongIntHashMapTest {
             (fid, pid, current) -> {
               throw new RuntimeException("remapping failed");
             }))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("remapping failed");
     assertThat(map.get(2L, 20)).isNull();
     assertThat(map.size()).isEqualTo(1);
   }
@@ -1239,9 +1246,8 @@ public class ConcurrentLongIntHashMapTest {
     map.put(3L, 3, "c");
 
     map.shrink();
-    // Capacity should be smaller than 1024 but still hold the 3 entries
-    assertThat(map.capacity()).isLessThan(1024);
-    assertThat(map.capacity()).isGreaterThanOrEqualTo(3);
+    // ceil(3 / 0.66) = 5, alignToPowerOfTwo(5) = 8
+    assertThat(map.capacity()).isEqualTo(8);
 
     // All entries must survive shrink
     assertThat(map.get(1L, 1)).isEqualTo("a");
@@ -1344,7 +1350,8 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(map.capacity()).isEqualTo(capacityBeforeRemoval);
 
     map.shrink();
-    assertThat(map.capacity()).isLessThan(capacityBeforeRemoval);
+    // ceil(10 / 0.66) = 16, alignToPowerOfTwo(16) = 16
+    assertThat(map.capacity()).isEqualTo(16);
 
     for (int i = 0; i < 10; i++) {
       assertThat(map.get((long) i, i))
@@ -1408,5 +1415,221 @@ public class ConcurrentLongIntHashMapTest {
     for (int i = 0; i < 200; i++) {
       assertThat(map.get((long) i, i)).isEqualTo("val-" + i);
     }
+  }
+
+  // ---- Backward-sweep compaction wraparound tests (TC1) ----
+
+  @Test
+  public void removeAtWraparoundBoundaryPreservesProbeChain() {
+    // Single section, capacity=8 so entries can wrap around the array boundary.
+    // Insert 5 entries — with linear probing some will probe-chain across the 7→0 boundary.
+    var map = new ConcurrentLongIntHashMap<String>(8, 1);
+    assertThat(map.capacity()).isEqualTo(8);
+
+    for (int i = 0; i < 5; i++) {
+      map.put(1L, i, "val-" + i);
+    }
+
+    // Remove entries one by one in forward order, verifying all remaining entries
+    // are still findable after each removal. This exercises backward-sweep compaction
+    // including the wraparound case when entries span the array boundary.
+    for (int removed = 0; removed < 5; removed++) {
+      map.remove(1L, removed);
+      for (int remaining = removed + 1; remaining < 5; remaining++) {
+        assertThat(map.get(1L, remaining))
+            .as("Entry (1, %d) must be findable after removing (1, %d)", remaining, removed)
+            .isEqualTo("val-" + remaining);
+      }
+    }
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void removeAtWraparoundWithReverseRemovalOrder() {
+    // Same setup but remove in reverse order — stresses different compaction patterns
+    var map = new ConcurrentLongIntHashMap<String>(8, 1);
+    for (int i = 0; i < 5; i++) {
+      map.put(1L, i, "val-" + i);
+    }
+
+    for (int removed = 4; removed >= 0; removed--) {
+      map.remove(1L, removed);
+      for (int remaining = 0; remaining < removed; remaining++) {
+        assertThat(map.get(1L, remaining))
+            .as("Entry (1, %d) must be findable after removing (1, %d)", remaining, removed)
+            .isEqualTo("val-" + remaining);
+      }
+    }
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void removeAtWraparoundWithInterleavedFiles() {
+    // Two files interleaved in a small single-section map — removal of one file's entries
+    // must not break probe chains for the other file's entries that may span the boundary.
+    var map = new ConcurrentLongIntHashMap<String>(8, 1);
+
+    for (int i = 0; i < 5; i++) {
+      map.put(1L, i, "f1-" + i);
+      if (i < 3) {
+        map.put(2L, i, "f2-" + i);
+      }
+    }
+    // 5 + 3 = 8 entries would trigger resize, but 5 entries leaves room
+
+    // Remove all file-1 entries one by one
+    for (int i = 0; i < 5; i++) {
+      map.remove(1L, i);
+    }
+
+    // All file-2 entries must survive
+    for (int i = 0; i < 3; i++) {
+      assertThat(map.get(2L, i))
+          .as("File-2 entry (2, %d) must survive file-1 removals", i)
+          .isEqualTo("f2-" + i);
+    }
+    assertThat(map.size()).isEqualTo(3);
+  }
+
+  // ---- removeByFileId boundary tests (TC2) ----
+
+  @Test
+  public void removeByFileIdWithHighLoadFactorPreservesAllSurvivors() {
+    // Single section, fill close to the resize threshold to maximize probe chain collisions.
+    // capacity=32, threshold=(int)(32*0.66)=21
+    var map = new ConcurrentLongIntHashMap<String>(32, 1);
+    assertThat(map.capacity()).isEqualTo(32);
+
+    // Insert 10 entries for fileId=1 and 10 for fileId=2 = 20 entries (just under threshold)
+    for (int p = 0; p < 10; p++) {
+      map.put(1L, p, "f1-" + p);
+      map.put(2L, p, "f2-" + p);
+    }
+    assertThat(map.size()).isEqualTo(20);
+    assertThat(map.capacity()).isEqualTo(32);
+
+    var removed = map.removeByFileId(1L);
+    assertThat(removed).hasSize(10);
+    assertThat(map.size()).isEqualTo(10);
+
+    // Every file-2 entry must survive the same-capacity rehash
+    for (int p = 0; p < 10; p++) {
+      assertThat(map.get(2L, p))
+          .as("Entry (2, %d) must survive removeByFileId rehash", p)
+          .isEqualTo("f2-" + p);
+    }
+  }
+
+  // ---- putIfAbsent resize test (TC3) ----
+
+  @Test
+  public void putIfAbsentTriggersResizeCorrectly() {
+    var map = new ConcurrentLongIntHashMap<String>(8, 4);
+    long initialCapacity = map.capacity();
+
+    for (int i = 0; i < 20; i++) {
+      map.putIfAbsent((long) i, i, "val-" + i);
+    }
+
+    assertThat(map.size()).isEqualTo(20);
+    assertThat(map.capacity()).isGreaterThan(initialCapacity);
+    for (int i = 0; i < 20; i++) {
+      assertThat(map.get((long) i, i)).isEqualTo("val-" + i);
+    }
+  }
+
+  // ---- compute remove then reinsert (TC4) ----
+
+  @Test
+  public void computeRemoveThenReinsertSameKey() {
+    // Verifies that backward-sweep compaction after compute-removal leaves the table
+    // in a state where the same key can be correctly re-inserted via compute.
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    for (int i = 0; i < 6; i++) {
+      map.put(1L, i, "val-" + i);
+    }
+
+    // Remove via compute returning null
+    map.compute(1L, 3, (fid, pid, cur) -> null);
+    assertThat(map.get(1L, 3)).isNull();
+    assertThat(map.size()).isEqualTo(5);
+
+    // Re-insert same key via compute
+    map.compute(
+        1L,
+        3,
+        (fid, pid, cur) -> {
+          assertThat(cur).as("Key was removed, current should be null").isNull();
+          return "reinserted";
+        });
+    assertThat(map.get(1L, 3)).isEqualTo("reinserted");
+    assertThat(map.size()).isEqualTo(6);
+
+    // All other entries must be intact
+    for (int i = 0; i < 6; i++) {
+      if (i == 3) {
+        assertThat(map.get(1L, i)).isEqualTo("reinserted");
+      } else {
+        assertThat(map.get(1L, i)).isEqualTo("val-" + i);
+      }
+    }
+  }
+
+  // ---- Extreme pageIndex values with same fileId (TC5) ----
+
+  @Test
+  public void putDistinguishesExtremePageIndexValues() {
+    // Verifies that the hash function correctly separates extreme pageIndex values
+    // when the fileId is identical.
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    map.put(1L, Integer.MAX_VALUE, "max");
+    map.put(1L, Integer.MIN_VALUE, "min");
+    map.put(1L, 0, "zero");
+    map.put(1L, -1, "neg-one");
+    map.put(1L, 1, "one");
+
+    assertThat(map.get(1L, Integer.MAX_VALUE)).isEqualTo("max");
+    assertThat(map.get(1L, Integer.MIN_VALUE)).isEqualTo("min");
+    assertThat(map.get(1L, 0)).isEqualTo("zero");
+    assertThat(map.get(1L, -1)).isEqualTo("neg-one");
+    assertThat(map.get(1L, 1)).isEqualTo("one");
+    assertThat(map.size()).isEqualTo(5);
+  }
+
+  // ---- removeByFileId with fileId=0 at high occupancy (TC6) ----
+
+  @Test
+  public void removeByFileIdZeroWithHighOccupancyOnlyRemovesActualEntries() {
+    // At high occupancy, many empty slots have fileIds[i] == 0L (Java default).
+    // The val != null guard in removeByFileId is essential — verify it works at scale.
+    var map = new ConcurrentLongIntHashMap<String>(64, 1);
+    for (int p = 0; p < 20; p++) {
+      map.put(0L, p, "f0-" + p);
+      map.put(1L, p, "f1-" + p);
+    }
+    assertThat(map.size()).isEqualTo(40);
+
+    var removed = map.removeByFileId(0L);
+    assertThat(removed).hasSize(20);
+    assertThat(map.size()).isEqualTo(20);
+
+    // All fileId=1 entries must survive
+    for (int p = 0; p < 20; p++) {
+      assertThat(map.get(1L, p)).isEqualTo("f1-" + p);
+    }
+    // All fileId=0 entries must be gone
+    for (int p = 0; p < 20; p++) {
+      assertThat(map.get(0L, p)).isNull();
+    }
+  }
+
+  // ---- forEachValue on empty map (TC7) ----
+
+  @Test
+  public void forEachValueOnEmptyMapVisitsNothing() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    int[] count = {0};
+    map.forEachValue(val -> count[0]++);
+    assertThat(count[0]).isEqualTo(0);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -305,6 +305,9 @@ public class ConcurrentLongIntHashMapTest {
     assertThatThrownBy(() -> map.put(1L, 1, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Null");
+    // Map must remain consistent after the error
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.get(1L, 1)).isNull();
   }
 
   @Test
@@ -371,6 +374,8 @@ public class ConcurrentLongIntHashMapTest {
     assertThatThrownBy(() -> map.putIfAbsent(1L, 1, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Null");
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.get(1L, 1)).isNull();
   }
 
   // ---- computeIfAbsent() ----
@@ -388,10 +393,19 @@ public class ConcurrentLongIntHashMapTest {
   public void computeIfAbsentReturnsExistingWhenPresent() {
     var map = new ConcurrentLongIntHashMap<String>();
     map.put(1L, 10, "existing");
-    String result = map.computeIfAbsent(1L, 10, (fid, pid) -> "should-not-compute");
+    int[] callCount = {0};
+    String result =
+        map.computeIfAbsent(
+            1L,
+            10,
+            (fid, pid) -> {
+              callCount[0]++;
+              return "should-not-compute";
+            });
     assertThat(result).isEqualTo("existing");
     assertThat(map.get(1L, 10)).isEqualTo("existing");
     assertThat(map.size()).isEqualTo(1);
+    assertThat(callCount[0]).as("Mapping function must not be called when key is present").isZero();
   }
 
   @Test
@@ -400,6 +414,9 @@ public class ConcurrentLongIntHashMapTest {
     assertThatThrownBy(() -> map.computeIfAbsent(1L, 10, (fid, pid) -> null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("must not return null");
+    // Map must remain consistent after the error
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.get(1L, 10)).isNull();
   }
 
   @Test
@@ -409,6 +426,142 @@ public class ConcurrentLongIntHashMapTest {
     String result = map.computeIfAbsent(0L, 0, (fid, pid) -> "fid=" + fid + ",pid=" + pid);
     assertThat(result).isEqualTo("fid=0,pid=0");
     assertThat(map.get(0L, 0)).isEqualTo("fid=0,pid=0");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  // ---- Probe chain: same fileId/different pageIndex and vice versa ----
+
+  @Test
+  public void putDistinguishesSameFileIdDifferentPageIndex() {
+    // Single section forces all keys into the same probe chain
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    map.put(42L, 0, "page-0");
+    map.put(42L, 1, "page-1");
+    map.put(42L, 2, "page-2");
+
+    assertThat(map.get(42L, 0)).isEqualTo("page-0");
+    assertThat(map.get(42L, 1)).isEqualTo("page-1");
+    assertThat(map.get(42L, 2)).isEqualTo("page-2");
+    assertThat(map.size()).isEqualTo(3);
+  }
+
+  @Test
+  public void putDistinguishesSamePageIndexDifferentFileId() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    map.put(1L, 99, "file-1");
+    map.put(2L, 99, "file-2");
+    map.put(3L, 99, "file-3");
+
+    assertThat(map.get(1L, 99)).isEqualTo("file-1");
+    assertThat(map.get(2L, 99)).isEqualTo("file-2");
+    assertThat(map.get(3L, 99)).isEqualTo("file-3");
+    assertThat(map.size()).isEqualTo(3);
+  }
+
+  @Test
+  public void putAndGetWithNegativeKeys() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(-1L, -1, "neg-neg");
+    map.put(Long.MIN_VALUE, Integer.MIN_VALUE, "min-min");
+    map.put(Long.MAX_VALUE, Integer.MAX_VALUE, "max-max");
+
+    assertThat(map.get(-1L, -1)).isEqualTo("neg-neg");
+    assertThat(map.get(Long.MIN_VALUE, Integer.MIN_VALUE)).isEqualTo("min-min");
+    assertThat(map.get(Long.MAX_VALUE, Integer.MAX_VALUE)).isEqualTo("max-max");
+    assertThat(map.size()).isEqualTo(3);
+  }
+
+  @Test
+  public void putReplaceDoesNotAffectSizeOrTriggerSpuriousResize() {
+    // Single section, capacity 4, threshold = floor(4 * 0.66) = 2
+    var map = new ConcurrentLongIntHashMap<String>(4, 1);
+    long initialCapacity = map.capacity();
+
+    map.put(1L, 1, "v1");
+    assertThat(map.size()).isEqualTo(1);
+
+    // Replace the same entry many times — size must stay 1, no resize
+    for (int i = 0; i < 50; i++) {
+      map.put(1L, 1, "v1-replaced-" + i);
+    }
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.capacity()).isEqualTo(initialCapacity);
+    assertThat(map.get(1L, 1)).isEqualTo("v1-replaced-49");
+  }
+
+  @Test
+  public void resizeTriggersAtExactThreshold() {
+    // Single section with capacity=4, threshold = (int)(4 * 0.66) = 2
+    // Inserts: usedBuckets 0→1→2, third insert sees usedBuckets=2 >= 2, triggers resize
+    var map = new ConcurrentLongIntHashMap<String>(4, 1);
+    assertThat(map.capacity()).isEqualTo(4);
+
+    map.put(1L, 1, "a");
+    map.put(2L, 2, "b");
+    assertThat(map.capacity()).isEqualTo(4);
+
+    // Third insert triggers resize
+    map.put(3L, 3, "c");
+    assertThat(map.capacity()).isGreaterThan(4);
+
+    assertThat(map.get(1L, 1)).isEqualTo("a");
+    assertThat(map.get(2L, 2)).isEqualTo("b");
+    assertThat(map.get(3L, 3)).isEqualTo("c");
+    assertThat(map.size()).isEqualTo(3);
+  }
+
+  @Test
+  public void computeIfAbsentTriggersResizeCorrectly() {
+    var map = new ConcurrentLongIntHashMap<String>(8, 4);
+    long initialCapacity = map.capacity();
+
+    for (int i = 0; i < 20; i++) {
+      final int idx = i;
+      map.computeIfAbsent((long) i, i, (fid, pid) -> "computed-" + idx);
+    }
+
+    for (int i = 0; i < 20; i++) {
+      assertThat(map.get((long) i, i))
+          .as("Entry (%d, %d) should survive resize via computeIfAbsent", (long) i, i)
+          .isEqualTo("computed-" + i);
+    }
+    assertThat(map.size()).isEqualTo(20);
+    assertThat(map.capacity()).isGreaterThan(initialCapacity);
+  }
+
+  @Test
+  public void putManyPagesForSameFile() {
+    // Realistic access pattern: one file with many pages
+    var map = new ConcurrentLongIntHashMap<String>();
+    long fileId = 42L;
+    for (int page = 0; page < 500; page++) {
+      map.put(fileId, page, "page-" + page);
+    }
+    assertThat(map.size()).isEqualTo(500);
+    for (int page = 0; page < 500; page++) {
+      assertThat(map.get(fileId, page)).isEqualTo("page-" + page);
+    }
+    assertThat(map.get(43L, 0)).isNull();
+  }
+
+  @Test
+  public void computeIfAbsentLeavesMapConsistentWhenFunctionThrows() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 1, "existing");
+
+    assertThatThrownBy(
+        () -> map.computeIfAbsent(
+            2L,
+            2,
+            (fid, pid) -> {
+              throw new RuntimeException("computation failed");
+            }))
+        .isInstanceOf(RuntimeException.class);
+
+    // Map should still be usable and the failed key should not be present
+    assertThat(map.get(1L, 1)).isEqualTo("existing");
+    assertThat(map.get(2L, 2)).isNull();
+    assertThat(map.size()).isEqualTo(1);
   }
 
   // ---- get() with populated map (deferred from Step 1) ----

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1039,4 +1039,106 @@ public class ConcurrentLongIntHashMapTest {
       }
     }
   }
+
+  @Test
+  public void removeByFileIdWithFileIdZero() {
+    // fileId=0 must not confuse empty slots (where fileIds[i] defaults to 0)
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    map.put(0L, 0, "f0-p0");
+    map.put(0L, 1, "f0-p1");
+    map.put(1L, 0, "f1-p0");
+
+    var removed = map.removeByFileId(0L);
+    assertThat(removed).containsExactlyInAnyOrder("f0-p0", "f0-p1");
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.get(0L, 0)).isNull();
+    assertThat(map.get(0L, 1)).isNull();
+    assertThat(map.get(1L, 0)).isEqualTo("f1-p0");
+  }
+
+  @Test
+  public void removeByFileIdRemoveAllThenFillToResizeThreshold() {
+    // Single section, capacity=16, resizeThreshold = (int)(16 * 0.66) = 10
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+
+    for (int i = 0; i < 10; i++) {
+      map.put(1L, i, "v" + i);
+    }
+    assertThat(map.size()).isEqualTo(10);
+
+    var removed = map.removeByFileId(1L);
+    assertThat(removed).hasSize(10);
+    assertThat(map.size()).isEqualTo(0);
+
+    // Re-fill to the same level — proves usedBuckets was correctly reset
+    for (int i = 0; i < 10; i++) {
+      map.put(2L, i, "new-" + i);
+    }
+    assertThat(map.size()).isEqualTo(10);
+    assertThat(map.capacity()).isEqualTo(16);
+    for (int i = 0; i < 10; i++) {
+      assertThat(map.get(2L, i)).isEqualTo("new-" + i);
+    }
+  }
+
+  @Test
+  public void removeByFileIdConsecutiveCallsOnDifferentFiles() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    for (int i = 0; i < 5; i++) {
+      map.put(1L, i, "f1-" + i);
+      map.put(2L, i, "f2-" + i);
+      map.put(3L, i, "f3-" + i);
+    }
+    assertThat(map.size()).isEqualTo(15);
+
+    map.removeByFileId(1L);
+    assertThat(map.size()).isEqualTo(10);
+
+    map.removeByFileId(3L);
+    assertThat(map.size()).isEqualTo(5);
+
+    for (int i = 0; i < 5; i++) {
+      assertThat(map.get(2L, i)).isEqualTo("f2-" + i);
+      assertThat(map.get(1L, i)).isNull();
+      assertThat(map.get(3L, i)).isNull();
+    }
+  }
+
+  @Test
+  public void removeByFileIdRepeatedPutRemoveCycles() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+
+    for (int cycle = 0; cycle < 10; cycle++) {
+      long fid = cycle;
+      for (int p = 0; p < 8; p++) {
+        map.put(fid, p, "c" + cycle + "-p" + p);
+      }
+      assertThat(map.size()).isEqualTo(8);
+
+      var removed = map.removeByFileId(fid);
+      assertThat(removed).hasSize(8);
+      assertThat(map.size()).isEqualTo(0);
+    }
+
+    // Capacity should not have grown (8 entries in cap-16 section)
+    assertThat(map.capacity()).isEqualTo(16);
+    map.put(100L, 0, "final");
+    assertThat(map.get(100L, 0)).isEqualTo("final");
+  }
+
+  @Test
+  public void removeByFileIdCalledTwiceForSameFile() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(5L, 0, "a");
+    map.put(5L, 1, "b");
+    map.put(9L, 0, "other");
+
+    var first = map.removeByFileId(5L);
+    assertThat(first).hasSize(2);
+
+    var second = map.removeByFileId(5L);
+    assertThat(second).isEmpty();
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.get(9L, 0)).isEqualTo("other");
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.common.collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.HashSet;
 import org.junit.Test;
 
 /**
@@ -27,15 +28,42 @@ public class ConcurrentLongIntHashMapTest {
     var map = new ConcurrentLongIntHashMap<String>(1024);
     assertThat(map.size()).isEqualTo(0);
     assertThat(map.isEmpty()).isTrue();
-    // Capacity should be at least 1024 / 16 sections, power-of-two aligned, times 16
-    assertThat(map.capacity()).isGreaterThanOrEqualTo(1024);
+    // 1024 / 16 sections = 64 per section (already power of two), x 16 = 1024
+    assertThat(map.capacity()).isEqualTo(1024);
   }
 
   @Test
   public void constructorWithCustomSectionCount() {
     var map = new ConcurrentLongIntHashMap<String>(256, 4);
     assertThat(map.size()).isEqualTo(0);
-    assertThat(map.capacity()).isGreaterThan(0);
+    // 256 / 4 = 64 per section (already power of two), x 4 = 256
+    assertThat(map.capacity()).isEqualTo(256);
+    assertThat(map.capacity() % 4).isEqualTo(0);
+    long perSection = map.capacity() / 4;
+    assertThat(perSection & (perSection - 1))
+        .as("Per-section capacity should be a power of two")
+        .isEqualTo(0);
+  }
+
+  @Test
+  public void constructorWithZeroExpectedItemsCreatesMinimalMap() {
+    // expectedItems=0 is valid — creates a map with minimum per-section capacity.
+    var map = new ConcurrentLongIntHashMap<String>(0);
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    // Each section gets Math.max(2, alignToPowerOfTwo(0/16)) = 2, so total = 2 * 16 = 32
+    assertThat(map.capacity()).isEqualTo(32);
+    // Must be usable — get should not throw
+    assertThat(map.get(1L, 1)).isNull();
+  }
+
+  @Test
+  public void constructorWithOneExpectedItem() {
+    // Smallest positive expectedItems — each section gets minimum capacity of 2.
+    var map = new ConcurrentLongIntHashMap<String>(1);
+    assertThat(map.size()).isEqualTo(0);
+    // 1 / 16 = 0, alignToPowerOfTwo(0) = 1, Math.max(2, 1) = 2, x 16 = 32
+    assertThat(map.capacity()).isEqualTo(32);
   }
 
   @Test
@@ -48,14 +76,27 @@ public class ConcurrentLongIntHashMapTest {
   @Test
   public void constructorRejectsZeroSectionCount() {
     assertThatThrownBy(() -> new ConcurrentLongIntHashMap<String>(256, 0))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("power of two");
+  }
+
+  @Test
+  public void constructorRejectsNegativeSectionCount() {
+    assertThatThrownBy(() -> new ConcurrentLongIntHashMap<String>(256, -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("power of two");
+    // -16 has the same bit pattern as a power of two in the low bits
+    assertThatThrownBy(() -> new ConcurrentLongIntHashMap<String>(256, -16))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("power of two");
   }
 
   @Test
   public void constructorRejectsNegativeExpectedItems() {
     assertThatThrownBy(() -> new ConcurrentLongIntHashMap<String>(-1))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("non-negative");
+        .hasMessageContaining("non-negative")
+        .hasMessageContaining("-1");
   }
 
   // ---- get() on empty map ----
@@ -64,7 +105,6 @@ public class ConcurrentLongIntHashMapTest {
   public void getOnEmptyMapReturnsNull() {
     var map = new ConcurrentLongIntHashMap<String>();
     assertThat(map.get(1L, 0)).isNull();
-    assertThat(map.get(0L, 0)).isNull();
     assertThat(map.get(Long.MAX_VALUE, Integer.MAX_VALUE)).isNull();
   }
 
@@ -80,6 +120,17 @@ public class ConcurrentLongIntHashMapTest {
   public void getWithPageIndexZeroOnEmptyMapReturnsNull() {
     var map = new ConcurrentLongIntHashMap<String>();
     assertThat(map.get(42L, 0)).isNull();
+  }
+
+  @Test
+  public void getWithNegativeKeyValuesOnEmptyMapReturnsNull() {
+    // Negative fileId and pageIndex must not cause ArrayIndexOutOfBoundsException
+    // in the section index calculation (uses >>> unsigned shift).
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.get(-1L, -1)).isNull();
+    assertThat(map.get(Long.MIN_VALUE, Integer.MIN_VALUE)).isNull();
+    assertThat(map.get(-1L, Integer.MIN_VALUE)).isNull();
+    assertThat(map.get(Long.MIN_VALUE, -1)).isNull();
   }
 
   // ---- Hash distribution sanity ----
@@ -101,26 +152,65 @@ public class ConcurrentLongIntHashMapTest {
   }
 
   @Test
-  public void hashFunctionDistributesAcrossSections() {
-    // With default 16 sections, a range of fileIds should hit multiple sections.
+  public void hashFunctionDistributesFileIdsAcrossSections() {
+    // With default 16 sections, a range of fileIds should distribute uniformly.
     int[] sectionHits = new int[16];
     for (int fileId = 0; fileId < 1000; fileId++) {
       long h = ConcurrentLongIntHashMap.hash(fileId, 0);
       int section = (int) (h >>> 32) & 15;
       sectionHits[section]++;
     }
-    // Each section should get at least some hits — no section should be starved.
-    for (int hits : sectionHits) {
-      assertThat(hits)
-          .as("Each section should receive some entries for a range of fileIds")
-          .isGreaterThan(0);
+    // 1000 keys / 16 sections = 62.5 expected per section.
+    // Each section should be within a reasonable range of the mean.
+    for (int i = 0; i < sectionHits.length; i++) {
+      assertThat(sectionHits[i])
+          .as("Section %d hit count should be within reasonable range", i)
+          .isBetween(30, 120);
     }
+  }
+
+  @Test
+  public void hashFunctionDistributesPageIndicesAcrossSections() {
+    // Varying only pageIndex while fixing fileId should also distribute well.
+    int[] sectionHits = new int[16];
+    for (int pageIndex = 0; pageIndex < 1000; pageIndex++) {
+      long h = ConcurrentLongIntHashMap.hash(42L, pageIndex);
+      int section = (int) (h >>> 32) & 15;
+      sectionHits[section]++;
+    }
+    for (int i = 0; i < sectionHits.length; i++) {
+      assertThat(sectionHits[i])
+          .as("Section %d hit count should be within reasonable range", i)
+          .isBetween(30, 120);
+    }
+  }
+
+  @Test
+  public void hashFunctionHandlesExtremeKeyValues() {
+    // All extreme combinations must produce distinct hashes.
+    long[] fileIds = {Long.MIN_VALUE, -1L, 0L, 1L, Long.MAX_VALUE};
+    int[] pageIndices = {Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE};
+
+    var hashes = new HashSet<Long>();
+    for (long fid : fileIds) {
+      for (int pid : pageIndices) {
+        hashes.add(ConcurrentLongIntHashMap.hash(fid, pid));
+      }
+    }
+    // 25 distinct key pairs should yield mostly distinct hashes.
+    // A few collisions are acceptable for a 64-bit hash over extreme values.
+    assertThat(hashes.size())
+        .as("At most 2 collisions among 25 extreme key pairs")
+        .isGreaterThanOrEqualTo(23);
   }
 
   // ---- alignToPowerOfTwo ----
 
   @Test
   public void alignToPowerOfTwoBasicCases() {
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(-1)).isEqualTo(1);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(-100)).isEqualTo(1);
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(Integer.MIN_VALUE)).isEqualTo(1);
     assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(0)).isEqualTo(1);
     assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(1)).isEqualTo(1);
     assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(2)).isEqualTo(2);
@@ -130,16 +220,32 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(100)).isEqualTo(128);
   }
 
+  @Test
+  public void alignToPowerOfTwoMaxValidPowerOfTwo() {
+    // 1 << 30 is the largest valid power-of-two for int arrays.
+    assertThat(ConcurrentLongIntHashMap.alignToPowerOfTwo(1 << 30)).isEqualTo(1 << 30);
+  }
+
+  @Test
+  public void alignToPowerOfTwoOverflowThrows() {
+    // Values above 2^30 cannot be rounded up without overflowing int.
+    assertThatThrownBy(() -> ConcurrentLongIntHashMap.alignToPowerOfTwo((1 << 30) + 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("exceeds maximum");
+    assertThatThrownBy(() -> ConcurrentLongIntHashMap.alignToPowerOfTwo(Integer.MAX_VALUE))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("exceeds maximum");
+  }
+
   // ---- Capacity ----
 
   @Test
   public void capacityIsPowerOfTwoPerSection() {
     // Each section's capacity must be power-of-two for the bucket mask to work.
+    // 100 / 4 = 25, alignToPowerOfTwo(25) = 32, x 4 = 128
     var map = new ConcurrentLongIntHashMap<String>(100, 4);
     long totalCapacity = map.capacity();
-    // Total capacity = 4 sections × per-section capacity (power of two)
-    assertThat(totalCapacity).isGreaterThanOrEqualTo(100);
-    // Per-section capacity is power of two, so total is divisible by 4
+    assertThat(totalCapacity).isEqualTo(128);
     assertThat(totalCapacity % 4).isEqualTo(0);
     long perSection = totalCapacity / 4;
     assertThat(perSection & (perSection - 1))
@@ -153,6 +259,6 @@ public class ConcurrentLongIntHashMapTest {
     var map = new ConcurrentLongIntHashMap<String>(16, 1);
     assertThat(map.size()).isEqualTo(0);
     assertThat(map.isEmpty()).isTrue();
-    assertThat(map.capacity()).isGreaterThanOrEqualTo(16);
+    assertThat(map.capacity()).isEqualTo(16);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -750,4 +750,160 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(map.get(1L, 10)).isEqualTo("second");
     assertThat(map.size()).isEqualTo(1);
   }
+
+  // ---- Backward-sweep edge cases ----
+
+  @Test
+  public void removeSingleEntryLeavesMapConsistentForReinsert() {
+    var map = new ConcurrentLongIntHashMap<String>(4, 1);
+    long initialCapacity = map.capacity();
+
+    map.put(1L, 1, "only");
+    assertThat(map.size()).isEqualTo(1);
+
+    map.remove(1L, 1);
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    assertThat(map.capacity()).isEqualTo(initialCapacity);
+
+    // Proves usedBuckets was correctly decremented to 0
+    map.put(2L, 2, "new");
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.capacity()).isEqualTo(initialCapacity);
+    assertThat(map.get(2L, 2)).isEqualTo("new");
+  }
+
+  @Test
+  public void removeAllEntriesOneByOneLeavesEmptyMap() {
+    // Non-sequential removal order stresses backward-sweep across the entire section
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    int count = 8;
+    for (int i = 0; i < count; i++) {
+      map.put(1L, i, "val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(count);
+
+    int[] removalOrder = {3, 0, 7, 1, 5, 2, 6, 4};
+    for (int i = 0; i < removalOrder.length; i++) {
+      map.remove(1L, removalOrder[i]);
+      assertThat(map.size()).isEqualTo(count - i - 1);
+      // All non-removed entries must still be findable
+      for (int j = i + 1; j < removalOrder.length; j++) {
+        assertThat(map.get(1L, removalOrder[j]))
+            .as(
+                "Entry (1, %d) must be findable after removing (1, %d)",
+                removalOrder[j], removalOrder[i])
+            .isEqualTo("val-" + removalOrder[j]);
+      }
+    }
+
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+
+    // Map must accept new inserts after full drain
+    map.put(99L, 99, "fresh");
+    assertThat(map.get(99L, 99)).isEqualTo("fresh");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  // ---- compute() additional edge cases ----
+
+  @Test
+  public void computeRemovalMaintainsProbeChainIntegrity() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    for (int i = 0; i < 6; i++) {
+      map.put(1L, i, "val-" + i);
+    }
+
+    // Remove entry (1, 2) via compute returning null
+    String result = map.compute(1L, 2, (fid, pid, current) -> null);
+    assertThat(result).isNull();
+    assertThat(map.size()).isEqualTo(5);
+
+    for (int i = 0; i < 6; i++) {
+      if (i == 2) {
+        assertThat(map.get(1L, i)).isNull();
+      } else {
+        assertThat(map.get(1L, i)).isEqualTo("val-" + i);
+      }
+    }
+  }
+
+  @Test
+  public void computeInsertTriggersResizeCorrectly() {
+    var map = new ConcurrentLongIntHashMap<String>(8, 4);
+    long initialCapacity = map.capacity();
+
+    for (int i = 0; i < 20; i++) {
+      final int idx = i;
+      map.compute(
+          (long) i,
+          i,
+          (fid, pid, current) -> {
+            assertThat(current).isNull();
+            return "computed-" + idx;
+          });
+    }
+
+    assertThat(map.size()).isEqualTo(20);
+    assertThat(map.capacity()).isGreaterThan(initialCapacity);
+    for (int i = 0; i < 20; i++) {
+      assertThat(map.get((long) i, i)).isEqualTo("computed-" + i);
+    }
+  }
+
+  @Test
+  public void computeLeavesMapConsistentWhenFunctionThrows() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "existing");
+
+    // Function throws on present key
+    assertThatThrownBy(
+        () -> map.compute(
+            1L,
+            10,
+            (fid, pid, current) -> {
+              throw new RuntimeException("remapping failed");
+            }))
+        .isInstanceOf(RuntimeException.class);
+    assertThat(map.get(1L, 10)).isEqualTo("existing");
+    assertThat(map.size()).isEqualTo(1);
+
+    // Function throws on absent key
+    assertThatThrownBy(
+        () -> map.compute(
+            2L,
+            20,
+            (fid, pid, current) -> {
+              throw new RuntimeException("remapping failed");
+            }))
+        .isInstanceOf(RuntimeException.class);
+    assertThat(map.get(2L, 20)).isNull();
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void computeWithZeroKeyFieldsWorksCorrectly() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    // Insert via compute on the (0, 0) key
+    map.compute(
+        0L,
+        0,
+        (fid, pid, current) -> {
+          assertThat(fid).isEqualTo(0L);
+          assertThat(pid).isEqualTo(0);
+          assertThat(current).isNull();
+          return "zero-zero";
+        });
+    assertThat(map.get(0L, 0)).isEqualTo("zero-zero");
+
+    // Replace via compute
+    map.compute(0L, 0, (fid, pid, current) -> "updated");
+    assertThat(map.get(0L, 0)).isEqualTo("updated");
+
+    // Remove via compute returning null
+    map.compute(0L, 0, (fid, pid, current) -> null);
+    assertThat(map.get(0L, 0)).isNull();
+    assertThat(map.size()).isEqualTo(0);
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -906,4 +906,137 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(map.get(0L, 0)).isNull();
     assertThat(map.size()).isEqualTo(0);
   }
+
+  // ---- removeByFileId() ----
+
+  @Test
+  public void removeByFileIdRemovesOnlyTargetFile() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    // Insert pages from 3 different files
+    for (int page = 0; page < 10; page++) {
+      map.put(1L, page, "f1-p" + page);
+      map.put(2L, page, "f2-p" + page);
+      map.put(3L, page, "f3-p" + page);
+    }
+    assertThat(map.size()).isEqualTo(30);
+
+    // Remove all pages for file 2
+    var removed = map.removeByFileId(2L);
+    assertThat(removed).hasSize(10);
+
+    // File 2 pages are gone
+    for (int page = 0; page < 10; page++) {
+      assertThat(map.get(2L, page)).isNull();
+    }
+    // File 1 and 3 pages intact
+    for (int page = 0; page < 10; page++) {
+      assertThat(map.get(1L, page)).isEqualTo("f1-p" + page);
+      assertThat(map.get(3L, page)).isEqualTo("f3-p" + page);
+    }
+    assertThat(map.size()).isEqualTo(20);
+  }
+
+  @Test
+  public void removeByFileIdReturnsCorrectValues() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(42L, 0, "a");
+    map.put(42L, 1, "b");
+    map.put(42L, 2, "c");
+    map.put(99L, 0, "other");
+
+    var removed = map.removeByFileId(42L);
+    assertThat(removed).containsExactlyInAnyOrder("a", "b", "c");
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.get(99L, 0)).isEqualTo("other");
+  }
+
+  @Test
+  public void removeByFileIdOnEmptyMap() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    var removed = map.removeByFileId(1L);
+    assertThat(removed).isEmpty();
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void removeByFileIdForNonExistentFileId() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 0, "exists");
+    var removed = map.removeByFileId(999L);
+    assertThat(removed).isEmpty();
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.get(1L, 0)).isEqualTo("exists");
+  }
+
+  @Test
+  public void removeByFileIdCompactsSection() {
+    // After removeByFileId, the section should be compacted so that
+    // remaining entries are still findable (no broken probe chains).
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    // Interleave entries from two files
+    for (int i = 0; i < 8; i++) {
+      map.put(1L, i, "f1-" + i);
+      map.put(2L, i, "f2-" + i);
+    }
+    assertThat(map.size()).isEqualTo(16);
+
+    map.removeByFileId(1L);
+    assertThat(map.size()).isEqualTo(8);
+
+    // All file-2 entries must be findable after compaction
+    for (int i = 0; i < 8; i++) {
+      assertThat(map.get(2L, i))
+          .as("Entry (2, %d) must be findable after removeByFileId(1)", i)
+          .isEqualTo("f2-" + i);
+    }
+  }
+
+  @Test
+  public void removeByFileIdAllowsReinsertionAfterRemoval() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    for (int i = 0; i < 5; i++) {
+      map.put(1L, i, "old-" + i);
+    }
+    map.removeByFileId(1L);
+    assertThat(map.size()).isEqualTo(0);
+
+    // Re-insert with same fileId — must work correctly
+    for (int i = 0; i < 5; i++) {
+      map.put(1L, i, "new-" + i);
+    }
+    for (int i = 0; i < 5; i++) {
+      assertThat(map.get(1L, i)).isEqualTo("new-" + i);
+    }
+    assertThat(map.size()).isEqualTo(5);
+  }
+
+  @Test
+  public void removeByFileIdWithManyEntriesAcrossMultipleSections() {
+    // Entries from many files spread across all 16 sections
+    var map = new ConcurrentLongIntHashMap<String>();
+    int filesCount = 10;
+    int pagesPerFile = 50;
+    for (long fid = 0; fid < filesCount; fid++) {
+      for (int page = 0; page < pagesPerFile; page++) {
+        map.put(fid, page, "f" + fid + "-p" + page);
+      }
+    }
+    assertThat(map.size()).isEqualTo(filesCount * pagesPerFile);
+
+    // Remove file 5
+    var removed = map.removeByFileId(5L);
+    assertThat(removed).hasSize(pagesPerFile);
+    assertThat(map.size()).isEqualTo((filesCount - 1) * pagesPerFile);
+
+    // Verify all other files intact
+    for (long fid = 0; fid < filesCount; fid++) {
+      for (int page = 0; page < pagesPerFile; page++) {
+        if (fid == 5) {
+          assertThat(map.get(fid, page)).isNull();
+        } else {
+          assertThat(map.get(fid, page)).isEqualTo("f" + fid + "-p" + page);
+        }
+      }
+    }
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -261,4 +261,179 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(map.isEmpty()).isTrue();
     assertThat(map.capacity()).isEqualTo(16);
   }
+
+  // ---- put() ----
+
+  @Test
+  public void putAndGetRoundtrip() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.put(1L, 10, "hello")).isNull();
+    assertThat(map.get(1L, 10)).isEqualTo("hello");
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.isEmpty()).isFalse();
+  }
+
+  @Test
+  public void putReplacesExistingValue() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "first");
+    String prev = map.put(1L, 10, "second");
+    assertThat(prev).isEqualTo("first");
+    assertThat(map.get(1L, 10)).isEqualTo("second");
+    // Size should not change on replace
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void putWithFileIdZeroAndPageIndexZero() {
+    // fileId=0 and pageIndex=0 are valid keys, not sentinels.
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(0L, 0, "zero-zero");
+    assertThat(map.get(0L, 0)).isEqualTo("zero-zero");
+    assertThat(map.size()).isEqualTo(1);
+
+    // Also put with fileId=0, different pageIndex
+    map.put(0L, 1, "zero-one");
+    assertThat(map.get(0L, 1)).isEqualTo("zero-one");
+    assertThat(map.get(0L, 0)).isEqualTo("zero-zero");
+    assertThat(map.size()).isEqualTo(2);
+  }
+
+  @Test
+  public void putRejectsNullValue() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThatThrownBy(() -> map.put(1L, 1, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Null");
+  }
+
+  @Test
+  public void putMultipleDistinctKeys() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    for (int i = 0; i < 100; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(100);
+    for (int i = 0; i < 100; i++) {
+      assertThat(map.get((long) i, i)).isEqualTo("val-" + i);
+    }
+  }
+
+  @Test
+  public void putTriggersResizeWhenCapacityExceeded() {
+    // Create a small map to easily trigger resize.
+    // 4 sections, 8 items expected => 2 per section capacity, but min 2, so each section cap=2.
+    // Fill factor 0.66, threshold = 2*0.66 = 1. So inserting 2 items in one section triggers resize.
+    var map = new ConcurrentLongIntHashMap<String>(8, 4);
+    long initialCapacity = map.capacity();
+
+    // Insert enough entries to force at least one section to resize
+    for (int i = 0; i < 20; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+
+    // All entries should survive resize
+    for (int i = 0; i < 20; i++) {
+      assertThat(map.get((long) i, i))
+          .as("Entry (%d, %d) should survive resize", (long) i, i)
+          .isEqualTo("val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(20);
+    // Capacity should have grown
+    assertThat(map.capacity()).isGreaterThan(initialCapacity);
+  }
+
+  // ---- putIfAbsent() ----
+
+  @Test
+  public void putIfAbsentInsertsWhenAbsent() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    String result = map.putIfAbsent(1L, 10, "hello");
+    assertThat(result).isNull();
+    assertThat(map.get(1L, 10)).isEqualTo("hello");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void putIfAbsentReturnsExistingWhenPresent() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "first");
+    String result = map.putIfAbsent(1L, 10, "second");
+    assertThat(result).isEqualTo("first");
+    // Value should not have changed
+    assertThat(map.get(1L, 10)).isEqualTo("first");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void putIfAbsentRejectsNullValue() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThatThrownBy(() -> map.putIfAbsent(1L, 1, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Null");
+  }
+
+  // ---- computeIfAbsent() ----
+
+  @Test
+  public void computeIfAbsentComputesWhenAbsent() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    String result = map.computeIfAbsent(1L, 10, (fid, pid) -> "computed-" + fid + "-" + pid);
+    assertThat(result).isEqualTo("computed-1-10");
+    assertThat(map.get(1L, 10)).isEqualTo("computed-1-10");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void computeIfAbsentReturnsExistingWhenPresent() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "existing");
+    String result = map.computeIfAbsent(1L, 10, (fid, pid) -> "should-not-compute");
+    assertThat(result).isEqualTo("existing");
+    assertThat(map.get(1L, 10)).isEqualTo("existing");
+    assertThat(map.size()).isEqualTo(1);
+  }
+
+  @Test
+  public void computeIfAbsentRejectsNullReturnFromFunction() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThatThrownBy(() -> map.computeIfAbsent(1L, 10, (fid, pid) -> null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not return null");
+  }
+
+  @Test
+  public void computeIfAbsentWithFileIdZero() {
+    // fileId=0 passed to the mapping function must be correct, not confused with a sentinel
+    var map = new ConcurrentLongIntHashMap<String>();
+    String result = map.computeIfAbsent(0L, 0, (fid, pid) -> "fid=" + fid + ",pid=" + pid);
+    assertThat(result).isEqualTo("fid=0,pid=0");
+    assertThat(map.get(0L, 0)).isEqualTo("fid=0,pid=0");
+  }
+
+  // ---- get() with populated map (deferred from Step 1) ----
+
+  @Test
+  public void getReturnsNullForAbsentKeyInPopulatedMap() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(1L, 10, "hello");
+    assertThat(map.get(1L, 11)).isNull();
+    assertThat(map.get(2L, 10)).isNull();
+  }
+
+  @Test
+  public void getWithFileIdZeroRetrievesCorrectly() {
+    // Now that put exists, verify fileId=0 is not confused with empty sentinel
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put(0L, 0, "zero-zero");
+    map.put(0L, 1, "zero-one");
+    map.put(1L, 0, "one-zero");
+
+    assertThat(map.get(0L, 0)).isEqualTo("zero-zero");
+    assertThat(map.get(0L, 1)).isEqualTo("zero-one");
+    assertThat(map.get(1L, 0)).isEqualTo("one-zero");
+    assertThat(map.get(0L, 2)).isNull();
+    assertThat(map.size()).isEqualTo(3);
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1324,4 +1324,89 @@ public class ConcurrentLongIntHashMapTest {
       assertThat(map.get((long) i, i)).isEqualTo("val-" + i);
     }
   }
+
+  // ---- Additional edge cases from Step 5 review ----
+
+  @Test
+  public void shrinkAfterManyInsertsAndRemovesPreservesRemainingEntries() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+
+    for (int i = 0; i < 500; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+    long capacityBeforeRemoval = map.capacity();
+
+    // Remove most entries, leaving only 10
+    for (int i = 10; i < 500; i++) {
+      map.remove((long) i, i);
+    }
+    assertThat(map.size()).isEqualTo(10);
+    assertThat(map.capacity()).isEqualTo(capacityBeforeRemoval);
+
+    map.shrink();
+    assertThat(map.capacity()).isLessThan(capacityBeforeRemoval);
+
+    for (int i = 0; i < 10; i++) {
+      assertThat(map.get((long) i, i))
+          .as("Entry (%d, %d) must survive shrink", (long) i, i)
+          .isEqualTo("val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(10);
+
+    // Map still functional after shrink
+    map.put(999L, 999, "new");
+    assertThat(map.get(999L, 999)).isEqualTo("new");
+  }
+
+  @Test
+  public void clearFollowedByShrinkReducesToMinimumCapacity() {
+    var map = new ConcurrentLongIntHashMap<String>(1024, 1);
+    for (int i = 0; i < 100; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+
+    map.clear();
+    map.shrink();
+    assertThat(map.capacity()).isEqualTo(2);
+
+    map.put(1L, 1, "a");
+    assertThat(map.get(1L, 1)).isEqualTo("a");
+  }
+
+  @Test
+  public void forEachVisitsCorrectEntriesAfterRemovals() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    for (int i = 0; i < 20; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+    for (int i = 0; i < 20; i += 2) {
+      map.remove((long) i, i);
+    }
+
+    var visited = new java.util.HashMap<String, String>();
+    map.forEach((fid, pid, val) -> visited.put(fid + ":" + pid, val));
+
+    assertThat(visited).hasSize(10);
+    for (int i = 1; i < 20; i += 2) {
+      assertThat(visited).containsEntry(i + ":" + i, "val-" + i);
+    }
+  }
+
+  @Test
+  public void shrinkThenInsertManyTriggersCorrectResize() {
+    var map = new ConcurrentLongIntHashMap<String>(1024, 1);
+    map.put(1L, 1, "a");
+    map.shrink();
+    long shrunkCapacity = map.capacity();
+
+    for (int i = 0; i < 200; i++) {
+      map.put((long) i, i, "val-" + i);
+    }
+    assertThat(map.size()).isEqualTo(200);
+    assertThat(map.capacity()).isGreaterThan(shrunkCapacity);
+
+    for (int i = 0; i < 200; i++) {
+      assertThat(map.get((long) i, i)).isEqualTo("val-" + i);
+    }
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImplTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/CacheEntryImplTest.java
@@ -1,0 +1,117 @@
+package com.jetbrains.youtrackdb.internal.core.storage.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.internal.common.collection.ConcurrentLongIntHashMap;
+import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link CacheEntryImpl} equals/hashCode contract and hash consistency
+ * with {@link ConcurrentLongIntHashMap#hashForFrequencySketch(long, int)}.
+ */
+public class CacheEntryImplTest {
+
+  private DirectMemoryAllocator allocator;
+  private ByteBufferPool pool;
+  private CachePointer pointer;
+
+  @Before
+  public void setUp() {
+    allocator = new DirectMemoryAllocator();
+    pool = new ByteBufferPool(1, allocator, 0);
+    pointer = new CachePointer(pool.acquireDirect(true, Intention.TEST), pool, 1, 0);
+    pointer.incrementReadersReferrer();
+  }
+
+  @After
+  public void tearDown() {
+    pointer.decrementReadersReferrer();
+  }
+
+  // ---- equals contract ----
+
+  /** Two entries with same fileId and pageIndex are equal. */
+  @Test
+  public void equalsSameFileIdAndPageIndex() {
+    var a = new CacheEntryImpl(5L, 10, pointer, false, null);
+    var b = new CacheEntryImpl(5L, 10, pointer, false, null);
+    assertThat(a).isEqualTo(b);
+    assertThat(b).isEqualTo(a);
+  }
+
+  /** Entries with same fileId but different pageIndex are not equal. */
+  @Test
+  public void notEqualsDifferentPageIndex() {
+    var a = new CacheEntryImpl(5L, 10, pointer, false, null);
+    var b = new CacheEntryImpl(5L, 11, pointer, false, null);
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  /** Entries with different fileId but same pageIndex are not equal. */
+  @Test
+  public void notEqualsDifferentFileId() {
+    var a = new CacheEntryImpl(5L, 10, pointer, false, null);
+    var b = new CacheEntryImpl(6L, 10, pointer, false, null);
+    assertThat(a).isNotEqualTo(b);
+  }
+
+  /** An entry is not equal to null. */
+  @Test
+  public void notEqualsNull() {
+    var a = new CacheEntryImpl(5L, 10, pointer, false, null);
+    assertThat(a).isNotEqualTo(null);
+  }
+
+  /** An entry is not equal to an object of a different type. */
+  @Test
+  public void notEqualsDifferentType() {
+    var a = new CacheEntryImpl(5L, 10, pointer, false, null);
+    assertThat(a.equals("not a cache entry")).isFalse();
+  }
+
+  /** An entry is equal to itself (reflexivity). */
+  @Test
+  public void equalsReflexive() {
+    var a = new CacheEntryImpl(5L, 10, pointer, false, null);
+    assertThat(a).isEqualTo(a);
+  }
+
+  // ---- hashCode contract ----
+
+  /** Equal entries have equal hash codes. */
+  @Test
+  public void equalEntriesHaveEqualHashCodes() {
+    var a = new CacheEntryImpl(5L, 10, pointer, false, null);
+    var b = new CacheEntryImpl(5L, 10, pointer, false, null);
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+  }
+
+  // ---- hash consistency with frequency sketch ----
+
+  /**
+   * CacheEntryImpl.hashCode() must match hashForFrequencySketch for the same (fileId,
+   * pageIndex). Both are documented as using Long.hashCode(fileId) * 31 + pageIndex.
+   * This test pins the cross-class invariant so that a formula change in either class
+   * is detected as a regression.
+   */
+  @Test
+  public void hashCodeMatchesHashForFrequencySketch() {
+    long[] fileIds = {0L, 1L, 42L, 123456789L, Long.MAX_VALUE};
+    int[] pageIndices = {0, 1, 100, Integer.MAX_VALUE};
+
+    for (long fileId : fileIds) {
+      for (int pageIndex : pageIndices) {
+        var entry = new CacheEntryImpl(fileId, pageIndex, pointer, false, null);
+        assertThat(entry.hashCode())
+            .as("hashCode mismatch for fileId=%d, pageIndex=%d", fileId, pageIndex)
+            .isEqualTo(
+                ConcurrentLongIntHashMap.hashForFrequencySketch(fileId, pageIndex));
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheConcurrentTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheConcurrentTestIT.java
@@ -38,6 +38,23 @@ import org.junit.experimental.categories.Category;
 @Category(SequentialTest.class)
 public class LockFreeReadCacheConcurrentTestIT {
 
+  private static final int PAGE_SIZE = 4 * 1024; // 4KB pages
+  // 4MB cache — forces frequent eviction with ~1024 pages capacity
+  private static final long MAX_MEMORY = 4L * 1024 * 1024;
+
+  /** Creates cache + write cache fixture for tests. */
+  private record CacheFixture(
+      LockFreeReadCache readCache, WriteCache writeCache, ByteBufferPool byteBufferPool) {
+  }
+
+  private static CacheFixture createCacheFixture() {
+    var allocator = new DirectMemoryAllocator();
+    var byteBufferPool = new ByteBufferPool(PAGE_SIZE, allocator, 256);
+    var readCache = new LockFreeReadCache(byteBufferPool, MAX_MEMORY, PAGE_SIZE);
+    var writeCache = new MockedWriteCache(byteBufferPool);
+    return new CacheFixture(readCache, writeCache, byteBufferPool);
+  }
+
   /**
    * Concurrent reads + writes with eviction on a small cache. Multiple threads call
    * loadForRead/loadForWrite on a 4MB cache (small enough to force frequent eviction). Verifies: no
@@ -46,13 +63,9 @@ public class LockFreeReadCacheConcurrentTestIT {
    */
   @Test
   public void concurrentReadsAndWritesWithEviction() throws Exception {
-    final int pageSize = 4 * 1024; // 4KB pages
-    final var allocator = new DirectMemoryAllocator();
-    final var byteBufferPool = new ByteBufferPool(pageSize, allocator, 256);
-    final long maxMemory = 4L * 1024 * 1024; // 4MB cache — forces frequent eviction
-
-    final var readCache = new LockFreeReadCache(byteBufferPool, maxMemory, pageSize);
-    final WriteCache writeCache = new MockedWriteCache(byteBufferPool);
+    final var fixture = createCacheFixture();
+    final var readCache = fixture.readCache();
+    final WriteCache writeCache = fixture.writeCache();
 
     int fileCount = 4;
     int pageLimit = 1000; // 4 files x 1000 pages = 4000 pages, but cache fits ~1024
@@ -124,7 +137,7 @@ public class LockFreeReadCacheConcurrentTestIT {
           .isGreaterThan(0);
       assertThat(readCache.getUsedMemory())
           .as("used memory within cache limit")
-          .isLessThanOrEqualTo(maxMemory);
+          .isLessThanOrEqualTo(MAX_MEMORY);
     } finally {
       readCache.clear();
     }
@@ -143,13 +156,9 @@ public class LockFreeReadCacheConcurrentTestIT {
    */
   @Test
   public void deleteFileAfterConcurrentLoad() throws Exception {
-    final int pageSize = 4 * 1024;
-    final var allocator = new DirectMemoryAllocator();
-    final var byteBufferPool = new ByteBufferPool(pageSize, allocator, 256);
-    final long maxMemory = 4L * 1024 * 1024;
-
-    final var readCache = new LockFreeReadCache(byteBufferPool, maxMemory, pageSize);
-    final WriteCache writeCache = new MockedWriteCache(byteBufferPool);
+    final var fixture = createCacheFixture();
+    final var readCache = fixture.readCache();
+    final WriteCache writeCache = fixture.writeCache();
 
     int fileCount = 4;
     int pageLimit = 500;
@@ -173,6 +182,8 @@ public class LockFreeReadCacheConcurrentTestIT {
                     int pageIndex = rng.nextInt(pageLimit);
                     var entry = readCache.loadForRead(fileId, pageIndex, writeCache, true);
                     assertThat(entry).isNotNull();
+                    assertThat(entry.getFileId()).isEqualTo(fileId);
+                    assertThat(entry.getPageIndex()).isEqualTo(pageIndex);
                     readCache.releaseFromRead(entry);
                   }
                   return null;
@@ -196,14 +207,19 @@ public class LockFreeReadCacheConcurrentTestIT {
           .isGreaterThan(0);
       assertThat(readCache.getUsedMemory())
           .as("used memory within cache limit")
-          .isLessThanOrEqualTo(maxMemory);
+          .isLessThanOrEqualTo(MAX_MEMORY);
 
-      // Delete all files one by one — exercises clearFile -> removeByFileId path
+      // Delete all files one by one — exercises clearFile -> removeByFileId path.
+      // Memory must not increase after each deletion.
+      long previousMemory = readCache.getUsedMemory();
       for (int fId = 0; fId < fileCount; fId++) {
         readCache.deleteFile(fId, writeCache);
-        assertThat(readCache.getUsedMemory())
-            .as("memory non-negative after deleting file %d", fId)
-            .isGreaterThanOrEqualTo(0);
+        long currentMemory = readCache.getUsedMemory();
+        assertThat(currentMemory)
+            .as("memory should not increase after deleting file %d", fId)
+            .isLessThanOrEqualTo(previousMemory);
+        readCache.assertConsistency();
+        previousMemory = currentMemory;
       }
 
       // After all files deleted, cache should be empty and consistent

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheConcurrentTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheConcurrentTestIT.java
@@ -1,0 +1,432 @@
+package com.jetbrains.youtrackdb.internal.core.storage.cache.chm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
+import com.jetbrains.youtrackdb.internal.common.types.ModifiableBoolean;
+import com.jetbrains.youtrackdb.internal.core.command.CommandOutputListener;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.PageDataVerificationError;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.local.BackgroundExceptionListener;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.PageIsBrokenListener;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.LogSequenceNumber;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Concurrent stress tests for {@link LockFreeReadCache} with the {@link
+ * com.jetbrains.youtrackdb.internal.common.collection.ConcurrentLongIntHashMap} backing store.
+ * Validates that the integrated cache (map + eviction policy + read/write buffers) behaves
+ * correctly under concurrent load and file deletion.
+ *
+ * <p>Uses {@link MockedWriteCache} (no disk I/O) and {@code @Category(SequentialTest.class)} to
+ * avoid CI flakiness from parallel test execution.
+ */
+@Category(SequentialTest.class)
+public class LockFreeReadCacheConcurrentTestIT {
+
+  /**
+   * Concurrent reads + writes with eviction on a small cache. Multiple threads call
+   * loadForRead/loadForWrite on a 4MB cache (small enough to force frequent eviction). Verifies: no
+   * exceptions, no data corruption, cache internal consistency after all threads complete, and that
+   * memory usage stays within bounds.
+   */
+  @Test
+  public void concurrentReadsAndWritesWithEviction() throws Exception {
+    final int pageSize = 4 * 1024; // 4KB pages
+    final var allocator = new DirectMemoryAllocator();
+    final var byteBufferPool = new ByteBufferPool(pageSize, allocator, 256);
+    final long maxMemory = 4L * 1024 * 1024; // 4MB cache — forces frequent eviction
+
+    final var readCache = new LockFreeReadCache(byteBufferPool, maxMemory, pageSize);
+    final WriteCache writeCache = new MockedWriteCache(byteBufferPool);
+
+    int fileCount = 4;
+    int pageLimit = 1000; // 4 files x 1000 pages = 4000 pages, but cache fits ~1024
+    int opsPerThread = 50_000;
+    int totalThreads = 8; // 4 readers + 4 writers
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+
+    try {
+      // 4 reader threads
+      for (int t = 0; t < 4; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int fileId = rng.nextInt(fileCount);
+                    int pageIndex = rng.nextInt(pageLimit);
+                    var cacheEntry =
+                        readCache.loadForRead(fileId, pageIndex, writeCache, true);
+                    // Loaded entry must be non-null and have valid pointer
+                    assertThat(cacheEntry).isNotNull();
+                    assertThat(cacheEntry.getCachePointer()).isNotNull();
+                    readCache.releaseFromRead(cacheEntry);
+                  }
+                  return null;
+                }));
+      }
+
+      // 4 writer threads
+      for (int t = 0; t < 4; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int fileId = rng.nextInt(fileCount);
+                    int pageIndex = rng.nextInt(pageLimit);
+                    var cacheEntry =
+                        readCache.loadForWrite(fileId, pageIndex, writeCache, true, null);
+                    assertThat(cacheEntry).isNotNull();
+                    assertThat(cacheEntry.getCachePointer()).isNotNull();
+                    readCache.releaseFromWrite(cacheEntry, writeCache, true);
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Post-run validation: cache internal consistency
+    readCache.assertSize();
+    readCache.assertConsistency();
+    assertThat(readCache.getUsedMemory())
+        .as("used memory within cache limit")
+        .isLessThanOrEqualTo(maxMemory);
+
+    // Cleanup
+    readCache.clear();
+    assertThat(readCache.getUsedMemory()).isEqualTo(0);
+  }
+
+  /**
+   * Concurrent readers on multiple files, followed by file deletion and consistency check. Runs
+   * concurrent loadForRead across multiple files to stress the cache under heavy contention, then
+   * stops readers and deletes all files one by one, verifying cache consistency at each stage.
+   *
+   * <p>deleteFile cannot be called while readers hold entries (StorageException: page is in use), so
+   * readers are stopped before deletion. The test validates: (1) concurrent load/release does not
+   * corrupt internal state, (2) deleteFile correctly clears each file's entries from the cache, (3)
+   * final state is consistent and empty.
+   */
+  @Test
+  public void deleteFileAfterConcurrentLoad() throws Exception {
+    final int pageSize = 4 * 1024;
+    final var allocator = new DirectMemoryAllocator();
+    final var byteBufferPool = new ByteBufferPool(pageSize, allocator, 256);
+    final long maxMemory = 4L * 1024 * 1024;
+
+    final var readCache = new LockFreeReadCache(byteBufferPool, maxMemory, pageSize);
+    final WriteCache writeCache = new MockedWriteCache(byteBufferPool);
+
+    int fileCount = 4;
+    int pageLimit = 500;
+    int opsPerThread = 50_000;
+
+    int readerCount = 8;
+    var executor = Executors.newFixedThreadPool(readerCount);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(readerCount);
+
+    try {
+      // Run concurrent readers to stress cache with contention + eviction
+      for (int t = 0; t < readerCount; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int fileId = rng.nextInt(fileCount);
+                    int pageIndex = rng.nextInt(pageLimit);
+                    var entry = readCache.loadForRead(fileId, pageIndex, writeCache, true);
+                    assertThat(entry).isNotNull();
+                    readCache.releaseFromRead(entry);
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Cache should be consistent after concurrent load
+    readCache.assertSize();
+    readCache.assertConsistency();
+    assertThat(readCache.getUsedMemory())
+        .as("used memory within cache limit")
+        .isLessThanOrEqualTo(maxMemory);
+
+    // Delete all files one by one — exercises clearFile -> removeByFileId path
+    for (int fId = 0; fId < fileCount; fId++) {
+      readCache.deleteFile(fId, writeCache);
+    }
+
+    // After all files deleted, cache should be empty
+    assertThat(readCache.getUsedMemory())
+        .as("cache should be empty after all files deleted")
+        .isEqualTo(0);
+    readCache.assertSize();
+  }
+
+  /** Minimal WriteCache stub — allocates from ByteBufferPool, no disk I/O. */
+  private record MockedWriteCache(ByteBufferPool byteBufferPool) implements WriteCache {
+
+    @Override
+    public CachePointer load(
+        final long fileId,
+        final long startPageIndex,
+        final ModifiableBoolean cacheHit,
+        final boolean verifyChecksums) {
+      final var pointer = byteBufferPool.acquireDirect(true, Intention.TEST);
+      final var cachePointer =
+          new CachePointer(pointer, byteBufferPool, fileId, (int) startPageIndex);
+      cachePointer.incrementReadersReferrer();
+      return cachePointer;
+    }
+
+    @Override
+    public void addPageIsBrokenListener(final PageIsBrokenListener listener) {
+    }
+
+    @Override
+    public void removePageIsBrokenListener(final PageIsBrokenListener listener) {
+    }
+
+    @Override
+    public long bookFileId(final String fileName) {
+      return 0;
+    }
+
+    @Override
+    public long loadFile(final String fileName) {
+      return 0;
+    }
+
+    @Override
+    public long addFile(final String fileName) {
+      return 0;
+    }
+
+    @Override
+    public long addFile(final String fileName, final long fileId) {
+      return 0;
+    }
+
+    @Override
+    public long fileIdByName(final String fileName) {
+      return 0;
+    }
+
+    @Override
+    public boolean checkLowDiskSpace() {
+      return false;
+    }
+
+    @Override
+    public void syncDataFiles(long segmentId) {
+    }
+
+    @Override
+    public void flushTillSegment(final long segmentId) {
+    }
+
+    @Override
+    public boolean exists(final String fileName) {
+      return false;
+    }
+
+    @Override
+    public boolean exists(final long fileId) {
+      return false;
+    }
+
+    @Override
+    public void restoreModeOn() {
+    }
+
+    @Override
+    public void restoreModeOff() {
+    }
+
+    @Override
+    public void store(
+        final long fileId, final long pageIndex, final CachePointer dataPointer) {
+    }
+
+    @Override
+    public void checkCacheOverflow() {
+    }
+
+    @Override
+    public int allocateNewPage(final long fileId) {
+      return 0;
+    }
+
+    @Override
+    public void flush(final long fileId) {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public long getFilledUpTo(final long fileId) {
+      return 0;
+    }
+
+    @Override
+    public long getExclusiveWriteCachePagesSize() {
+      return 0;
+    }
+
+    @Override
+    public void deleteFile(final long fileId) {
+    }
+
+    @Override
+    public void truncateFile(final long fileId) {
+    }
+
+    @Override
+    public void renameFile(final long fileId, final String newFileName) {
+    }
+
+    @Override
+    public long[] close() {
+      return new long[0];
+    }
+
+    @Override
+    public void close(final long fileId, final boolean flush) {
+    }
+
+    @Override
+    public PageDataVerificationError[] checkStoredPages(
+        final CommandOutputListener commandOutputListener) {
+      return new PageDataVerificationError[0];
+    }
+
+    @Override
+    public long[] delete() {
+      return new long[0];
+    }
+
+    @Override
+    public String fileNameById(final long fileId) {
+      return null;
+    }
+
+    @Override
+    public String nativeFileNameById(final long fileId) {
+      return null;
+    }
+
+    @Override
+    public int getId() {
+      return 0;
+    }
+
+    @Override
+    public Map<String, Long> files() {
+      return null;
+    }
+
+    @Override
+    public int pageSize() {
+      return 0;
+    }
+
+    @Override
+    public String restoreFileById(final long fileId) {
+      return null;
+    }
+
+    @Override
+    public void addBackgroundExceptionListener(final BackgroundExceptionListener listener) {
+    }
+
+    @Override
+    public void removeBackgroundExceptionListener(
+        final BackgroundExceptionListener listener) {
+    }
+
+    @Override
+    public Path getRootDirectory() {
+      return null;
+    }
+
+    @Override
+    public int internalFileId(final long fileId) {
+      return 0;
+    }
+
+    @Override
+    public long externalFileId(final int fileId) {
+      return 0;
+    }
+
+    @Override
+    public boolean fileIdsAreEqual(long firsId, long secondId) {
+      return false;
+    }
+
+    @Override
+    public Long getMinimalNotFlushedSegment() {
+      return null;
+    }
+
+    @Override
+    public void updateDirtyPagesTable(
+        final CachePointer pointer, final LogSequenceNumber startLSN) {
+    }
+
+    @Override
+    public void create() {
+    }
+
+    @Override
+    public void open() throws IOException {
+    }
+
+    @Override
+    public void replaceFileId(long fileId, long newFileId) {
+    }
+
+    @Override
+    public String getStorageName() {
+      return null;
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheConcurrentTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheConcurrentTestIT.java
@@ -75,8 +75,9 @@ public class LockFreeReadCacheConcurrentTestIT {
                     int pageIndex = rng.nextInt(pageLimit);
                     var cacheEntry =
                         readCache.loadForRead(fileId, pageIndex, writeCache, true);
-                    // Loaded entry must be non-null and have valid pointer
                     assertThat(cacheEntry).isNotNull();
+                    assertThat(cacheEntry.getFileId()).isEqualTo(fileId);
+                    assertThat(cacheEntry.getPageIndex()).isEqualTo(pageIndex);
                     assertThat(cacheEntry.getCachePointer()).isNotNull();
                     readCache.releaseFromRead(cacheEntry);
                   }
@@ -97,6 +98,8 @@ public class LockFreeReadCacheConcurrentTestIT {
                     var cacheEntry =
                         readCache.loadForWrite(fileId, pageIndex, writeCache, true, null);
                     assertThat(cacheEntry).isNotNull();
+                    assertThat(cacheEntry.getFileId()).isEqualTo(fileId);
+                    assertThat(cacheEntry.getPageIndex()).isEqualTo(pageIndex);
                     assertThat(cacheEntry.getCachePointer()).isNotNull();
                     readCache.releaseFromWrite(cacheEntry, writeCache, true);
                   }
@@ -113,14 +116,18 @@ public class LockFreeReadCacheConcurrentTestIT {
     }
 
     // Post-run validation: cache internal consistency
-    readCache.assertSize();
-    readCache.assertConsistency();
-    assertThat(readCache.getUsedMemory())
-        .as("used memory within cache limit")
-        .isLessThanOrEqualTo(maxMemory);
-
-    // Cleanup
-    readCache.clear();
+    try {
+      readCache.assertSize();
+      readCache.assertConsistency();
+      assertThat(readCache.getUsedMemory())
+          .as("cache should have entries after concurrent operations")
+          .isGreaterThan(0);
+      assertThat(readCache.getUsedMemory())
+          .as("used memory within cache limit")
+          .isLessThanOrEqualTo(maxMemory);
+    } finally {
+      readCache.clear();
+    }
     assertThat(readCache.getUsedMemory()).isEqualTo(0);
   }
 
@@ -181,22 +188,33 @@ public class LockFreeReadCacheConcurrentTestIT {
     }
 
     // Cache should be consistent after concurrent load
-    readCache.assertSize();
-    readCache.assertConsistency();
-    assertThat(readCache.getUsedMemory())
-        .as("used memory within cache limit")
-        .isLessThanOrEqualTo(maxMemory);
+    try {
+      readCache.assertSize();
+      readCache.assertConsistency();
+      assertThat(readCache.getUsedMemory())
+          .as("cache should have entries before deletion")
+          .isGreaterThan(0);
+      assertThat(readCache.getUsedMemory())
+          .as("used memory within cache limit")
+          .isLessThanOrEqualTo(maxMemory);
 
-    // Delete all files one by one — exercises clearFile -> removeByFileId path
-    for (int fId = 0; fId < fileCount; fId++) {
-      readCache.deleteFile(fId, writeCache);
+      // Delete all files one by one — exercises clearFile -> removeByFileId path
+      for (int fId = 0; fId < fileCount; fId++) {
+        readCache.deleteFile(fId, writeCache);
+        assertThat(readCache.getUsedMemory())
+            .as("memory non-negative after deleting file %d", fId)
+            .isGreaterThanOrEqualTo(0);
+      }
+
+      // After all files deleted, cache should be empty and consistent
+      assertThat(readCache.getUsedMemory())
+          .as("cache should be empty after all files deleted")
+          .isEqualTo(0);
+      readCache.assertSize();
+      readCache.assertConsistency();
+    } finally {
+      readCache.clear();
     }
-
-    // After all files deleted, cache should be empty
-    assertThat(readCache.getUsedMemory())
-        .as("cache should be empty after all files deleted")
-        .isEqualTo(0);
-    readCache.assertSize();
   }
 
   /** Minimal WriteCache stub — allocates from ByteBufferPool, no disk I/O. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/WTinyLFUPolicyTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/WTinyLFUPolicyTest.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.storage.cache.chm;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.jetbrains.youtrackdb.internal.common.collection.ConcurrentLongIntHashMap;
 import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
@@ -12,7 +13,6 @@ import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,7 +25,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -61,7 +61,7 @@ public class WTinyLFUPolicyTest {
     }
 
     Assert.assertArrayEquals(
-        new CacheEntry[]{cacheEntries[2], cacheEntries[1], cacheEntries[0]},
+        new CacheEntry[] {cacheEntries[2], cacheEntries[1], cacheEntries[0]},
         toArray(wTinyLFU.eden()));
 
     wTinyLFU.onAccess(cacheEntries[1]);
@@ -77,7 +77,7 @@ public class WTinyLFUPolicyTest {
     }
 
     Assert.assertArrayEquals(
-        new CacheEntry[]{cacheEntries[1], cacheEntries[2], cacheEntries[0]},
+        new CacheEntry[] {cacheEntries[1], cacheEntries[2], cacheEntries[0]},
         toArray(wTinyLFU.eden()));
 
     wTinyLFU.onAccess(cacheEntries[1]);
@@ -92,7 +92,7 @@ public class WTinyLFUPolicyTest {
       Assert.assertFalse(protectionIterator.hasNext());
     }
     Assert.assertArrayEquals(
-        new CacheEntry[]{cacheEntries[1], cacheEntries[2], cacheEntries[0]},
+        new CacheEntry[] {cacheEntries[1], cacheEntries[2], cacheEntries[0]},
         toArray(wTinyLFU.eden()));
 
     wTinyLFU.onAccess(cacheEntries[0]);
@@ -108,7 +108,7 @@ public class WTinyLFUPolicyTest {
     }
 
     Assert.assertArrayEquals(
-        new CacheEntry[]{cacheEntries[0], cacheEntries[1], cacheEntries[2]},
+        new CacheEntry[] {cacheEntries[0], cacheEntries[1], cacheEntries[2]},
         toArray(wTinyLFU.eden()));
 
     Assert.assertEquals(3, cacheSize.get());
@@ -122,7 +122,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -146,10 +146,10 @@ public class WTinyLFUPolicyTest {
     cacheSize.incrementAndGet();
     wTinyLFU.onAdd(cacheEntries[3]);
 
-    Assert.assertArrayEquals(new CacheEntry[]{cacheEntries[0]}, toArray(wTinyLFU.probation()));
+    Assert.assertArrayEquals(new CacheEntry[] {cacheEntries[0]}, toArray(wTinyLFU.probation()));
     Assert.assertFalse(wTinyLFU.protection().hasNext());
     Assert.assertArrayEquals(
-        new CacheEntry[]{cacheEntries[3], cacheEntries[2], cacheEntries[1]},
+        new CacheEntry[] {cacheEntries[3], cacheEntries[2], cacheEntries[1]},
         toArray(wTinyLFU.eden()));
 
     Assert.assertEquals(4, cacheSize.get());
@@ -163,7 +163,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -204,7 +204,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -216,12 +216,12 @@ public class WTinyLFUPolicyTest {
 
     generateEntries(cacheEntries, cachePointers, pool);
 
-    when(admittor.frequency(new PageKey(1, 0).hashCode())).thenReturn(0);
-    when(admittor.frequency(new PageKey(1, 12).hashCode())).thenReturn(1);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 0))).thenReturn(0);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 12))).thenReturn(1);
 
     for (var i = 0; i < 16; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
@@ -253,7 +253,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -265,12 +265,12 @@ public class WTinyLFUPolicyTest {
 
     generateEntries(cacheEntries, cachePointers, pool);
 
-    when(admittor.frequency(new PageKey(1, 0).hashCode())).thenReturn(1);
-    when(admittor.frequency(new PageKey(1, 12).hashCode())).thenReturn(0);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 0))).thenReturn(1);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 12))).thenReturn(0);
 
     for (var i = 0; i < 16; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
@@ -302,7 +302,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -314,17 +314,17 @@ public class WTinyLFUPolicyTest {
 
     generateEntries(cacheEntries, cachePointers, pool);
 
-    when(admittor.frequency(new PageKey(1, 0).hashCode())).thenReturn(0);
-    when(admittor.frequency(new PageKey(1, 12).hashCode())).thenReturn(1);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 0))).thenReturn(0);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 12))).thenReturn(1);
 
-    when(admittor.frequency(new PageKey(1, 1).hashCode())).thenReturn(0);
-    when(admittor.frequency(new PageKey(1, 13).hashCode())).thenReturn(1);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 1))).thenReturn(0);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 13))).thenReturn(1);
 
     cacheEntries[0].acquireEntry();
 
     for (var i = 0; i < 16; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
@@ -360,7 +360,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -372,17 +372,17 @@ public class WTinyLFUPolicyTest {
 
     generateEntries(cacheEntries, cachePointers, pool);
 
-    when(admittor.frequency(new PageKey(1, 0).hashCode())).thenReturn(1);
-    when(admittor.frequency(new PageKey(1, 12).hashCode())).thenReturn(0);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 0))).thenReturn(1);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 12))).thenReturn(0);
 
-    when(admittor.frequency(new PageKey(1, 0).hashCode())).thenReturn(1);
-    when(admittor.frequency(new PageKey(1, 13).hashCode())).thenReturn(0);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 0))).thenReturn(1);
+    when(admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(1, 13))).thenReturn(0);
 
     cacheEntries[12].acquireEntry();
 
     for (var i = 0; i < 16; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
@@ -418,7 +418,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -432,7 +432,7 @@ public class WTinyLFUPolicyTest {
 
     for (var i = 0; i < 15; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
@@ -463,7 +463,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -477,7 +477,7 @@ public class WTinyLFUPolicyTest {
 
     for (var i = 0; i < 6; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
@@ -523,7 +523,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -536,11 +536,11 @@ public class WTinyLFUPolicyTest {
     generateEntries(cacheEntries, cachePointers, pool);
 
     cacheSize.incrementAndGet();
-    data.put(new PageKey(1, 0), cacheEntries[0]);
+    data.put(1, 0, cacheEntries[0]);
     wTinyLFU.onAdd(cacheEntries[0]);
 
     cacheEntries[0].freeze();
-    data.remove(new PageKey(1, 0), cacheEntries[0]);
+    data.remove(1, 0, cacheEntries[0]);
     cacheSize.decrementAndGet();
     wTinyLFU.onRemove(cacheEntries[0]);
 
@@ -562,7 +562,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -576,12 +576,12 @@ public class WTinyLFUPolicyTest {
 
     for (var i = 0; i < 6; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
     cacheEntries[0].freeze();
-    data.remove(new PageKey(1, 0), cacheEntries[0]);
+    data.remove(1, 0, cacheEntries[0]);
     cacheSize.decrementAndGet();
     wTinyLFU.onRemove(cacheEntries[0]);
 
@@ -614,7 +614,7 @@ public class WTinyLFUPolicyTest {
     var memoryAllocator = new DirectMemoryAllocator();
     var pool = new ByteBufferPool(1, memoryAllocator, 0);
 
-    var data = new ConcurrentHashMap<PageKey, CacheEntry>();
+    var data = new ConcurrentLongIntHashMap<CacheEntry>();
     var admittor = mock(Admittor.class);
 
     var cacheSize = new AtomicInteger();
@@ -628,7 +628,7 @@ public class WTinyLFUPolicyTest {
 
     for (var i = 0; i < 6; i++) {
       cacheSize.incrementAndGet();
-      data.put(new PageKey(1, i), cacheEntries[i]);
+      data.put(1, i, cacheEntries[i]);
       wTinyLFU.onAdd(cacheEntries[i]);
     }
 
@@ -637,7 +637,7 @@ public class WTinyLFUPolicyTest {
     }
 
     cacheEntries[0].freeze();
-    data.remove(new PageKey(1, 0), cacheEntries[0]);
+    data.remove(1, 0, cacheEntries[0]);
     cacheSize.decrementAndGet();
     wTinyLFU.onRemove(cacheEntries[0]);
 

--- a/docs/adr/ytdb-627-primitive-chm-cache/design-final.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/design-final.md
@@ -1,0 +1,431 @@
+# Primitive CHM Cache — Final Design
+
+## Overview
+
+The implementation replaced `ConcurrentHashMap<PageKey, CacheEntry>` in `LockFreeReadCache`
+with `ConcurrentLongIntHashMap<CacheEntry>` — a segmented, open-addressing hash map storing
+composite `(long fileId, int pageIndex)` keys inline in parallel primitive arrays. This
+eliminates all `PageKey` allocations on the hot read path and reduces per-entry memory
+overhead from ~96 bytes to ~20 bytes.
+
+**Deviations from the planned design:**
+
+1. **Section uses composition, not inheritance** — `Section` has-a `StampedLock` instead of
+   extending it. This was a review-driven change (A11/T6) to improve encapsulation.
+2. **removeByFileId uses unconditional same-capacity rehash** — the plan specified conditional
+   compaction (tombstone ratio threshold). The implementation always rehashes after bulk
+   removal since the sweep uses nullification (not backward-sweep per entry), leaving gaps
+   that must be compacted. Simpler and always correct.
+3. **hashForFrequencySketch uses independent hash** — the plan proposed truncating the
+   murmur hash to 32 bits. Review (A2) identified this correlates with bucket position.
+   The implementation uses `Long.hashCode(fileId) * 31 + pageIndex` instead.
+4. **Section count alignment** — the plan stated the map constructor aligns section count
+   to power of two internally. It does not — only per-section capacity is aligned. The
+   caller (`LockFreeReadCache`) wraps `N_CPU << 1` with `ceilingPowerOfTwo()`.
+5. **clearFile no longer takes filledUpTo** — a natural consequence of `removeByFileId()`
+   finding all entries by file regardless of page count. Simplified callers (`deleteStorage`,
+   `closeStorage`) no longer pre-collect `filledUpTo` into `RawPairLongInteger` lists.
+6. **rehashTo writes arrays before capacity** — a concurrency bug fix discovered during
+   Track 3 stress testing. The original BookKeeper-derived code wrote `capacity` before
+   the new arrays, allowing optimistic readers to see the new (larger) capacity with old
+   (smaller) arrays (AIOOBE). This is exactly the BOOKKEEPER-4317 class of bug.
+
+## Class Design
+
+```mermaid
+classDiagram
+    class ConcurrentLongIntHashMap~V~ {
+        -Section~V~[] sections
+        -int numSections
+        -int sectionShift
+        +get(long fileId, int pageIndex) V
+        +put(long fileId, int pageIndex, V value) V
+        +putIfAbsent(long fileId, int pageIndex, V value) V
+        +computeIfAbsent(long fileId, int pageIndex, LongIntFunction~V~ fn) V
+        +compute(long fileId, int pageIndex, LongIntKeyValueFunction~V~ fn) V
+        +remove(long fileId, int pageIndex) V
+        +remove(long fileId, int pageIndex, V expected) boolean
+        +removeByFileId(long fileId) List~V~
+        +clear()
+        +forEach(LongIntObjConsumer~V~ consumer)
+        +forEachValue(Consumer~V~ consumer)
+        +shrink()
+        +size() long
+        +capacity() long
+        +hash(long fileId, int pageIndex)$ long
+        +hashForFrequencySketch(long fileId, int pageIndex)$ int
+    }
+
+    class Section~V~ {
+        -StampedLock lock
+        -long[] fileIds
+        -int[] pageIndices
+        -V[] values
+        -volatile int size
+        -int usedBuckets
+        -int capacity
+        -int resizeThreshold
+        +get(long fileId, int pageIndex, int hashMix) V
+        +put(...) V
+        +compute(...) V
+        +remove(...) V
+        +removeByFileId(long fileId, List~V~ collector)
+        -probeForKey(long fileId, int pageIndex, int hashMix) int
+        -removeAt(int slotIdx)
+        -rehashTo(int newCapacity)
+    }
+
+    class LongIntFunction~R~ {
+        <<interface>>
+        +apply(long fileId, int pageIndex) R
+    }
+
+    class LongIntObjConsumer~T~ {
+        <<interface>>
+        +accept(long fileId, int pageIndex, T value)
+    }
+
+    class LongIntKeyValueFunction~T~ {
+        <<interface>>
+        +apply(long fileId, int pageIndex, T currentValue) T
+    }
+
+    ConcurrentLongIntHashMap --> Section : contains N
+    Section --> StampedLock : has-a
+    ConcurrentLongIntHashMap ..> LongIntFunction : uses
+    ConcurrentLongIntHashMap ..> LongIntObjConsumer : uses
+    ConcurrentLongIntHashMap ..> LongIntKeyValueFunction : uses
+```
+
+**ConcurrentLongIntHashMap** is the outer class holding a fixed-size array of `Section`
+objects (power-of-two count, default 16). It routes operations to the correct section using
+the upper bits of a 64-bit Murmur3 hash, then delegates. The three functional interfaces are
+nested inside the map class to avoid boxing primitive key components.
+
+**Section** holds per-segment parallel arrays (`long[] fileIds`, `int[] pageIndices`,
+`V[] values`) and manages probing, resize, and compaction. Unlike the planned design where
+Section extended `StampedLock`, the implementation uses composition (`StampedLock lock` field)
+for better encapsulation. `values[i] == null` marks an empty slot; null values are disallowed.
+The `size` field is `volatile` to support lock-free aggregate `size()` reads from the outer
+class.
+
+**probeForKey** is a shared helper extracted during implementation to eliminate 3x probe loop
+duplication. It returns a bitwise-encoded result: the position of a matching key, or the
+bitwise complement of the first empty slot encountered.
+
+```mermaid
+classDiagram
+    class LockFreeReadCache {
+        -ConcurrentLongIntHashMap~CacheEntry~ data
+        -WTinyLFUPolicy policy
+        -Lock evictionLock
+        -Buffer readBuffer
+        -MPSCLinkedQueue~CacheEntry~ writeBuffer
+        -AtomicInteger cacheSize
+        -ThreadLocal~ReadBatch~ readBatch
+        +doLoad(long fileId, int pageIndex, ...) CacheEntry
+        +clearFile(long fileId, WriteCache wc)
+        +deleteFile(long fileId, WriteCache wc)
+        +deleteStorage(WriteCache wc)
+        +closeStorage(WriteCache wc)
+    }
+
+    class WTinyLFUPolicy {
+        -ConcurrentLongIntHashMap~CacheEntry~ data
+        -Admittor admittor
+        -LRUList eden
+        -LRUList probation
+        -LRUList protection
+        +onAccess(CacheEntry entry)
+        +onAdd(CacheEntry entry)
+        +onRemove(CacheEntry entry)
+    }
+
+    class CacheEntryImpl {
+        -long fileId
+        -int pageIndex
+        -CachePointer dataPointer
+        -volatile int state
+        -volatile int usagesCount
+        +getFileId() long
+        +getPageIndex() int
+        +freeze() boolean
+        +makeDead()
+    }
+
+    class CacheEntry {
+        <<interface>>
+        +getFileId() long
+        +getPageIndex() int
+        +getCachePointer() CachePointer
+        +freeze() boolean
+    }
+
+    LockFreeReadCache --> ConcurrentLongIntHashMap~CacheEntry~ : data
+    LockFreeReadCache --> WTinyLFUPolicy : policy
+    WTinyLFUPolicy --> ConcurrentLongIntHashMap~CacheEntry~ : data
+    CacheEntryImpl ..|> CacheEntry
+    LockFreeReadCache ..> CacheEntry : stores/retrieves
+```
+
+**CacheEntryImpl** stores `long fileId` and `int pageIndex` directly as primitive fields.
+The `getPageKey()` method and `PageKey` field are removed. The `chm.PageKey` record class
+is deleted entirely. The `local.PageKey` class used by `WOWCache` is unaffected (different
+package, different field types: `int fileId, long pageIndex`).
+
+**CacheEntryImpl.hashCode()** uses `Long.hashCode(fileId) * 31 + pageIndex` — matching
+`ConcurrentLongIntHashMap.hashForFrequencySketch()`. This is intentional: the frequency
+sketch uses this hash for TinyLFU admission counting. `CacheEntryImpl` is not used as a
+hash key in any collection, so the hash formula serves only the frequency sketch.
+
+**clearFile** no longer takes a `filledUpTo` parameter. Since `removeByFileId()` finds all
+entries for a file via linear sweep, the caller does not need to know the page count.
+`deleteStorage` and `closeStorage` were simplified — they no longer pre-collect
+`filledUpTo` values into `RawPairLongInteger` lists.
+
+## Workflow
+
+### Read path (cache hit)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant LRC as LockFreeReadCache
+    participant MAP as ConcurrentLongIntHashMap
+    participant SEC as Section
+
+    Caller->>LRC: doLoad(fileId, pageIndex, ...)
+    LRC->>MAP: get(fileId, pageIndex)
+    MAP->>MAP: hash(fileId, pageIndex) → fullHash
+    MAP->>MAP: select section[fullHash >>> sectionShift]
+    MAP->>SEC: get(fileId, pageIndex, hashMix)
+    SEC->>SEC: stamp = lock.tryOptimisticRead()
+    SEC->>SEC: snapshot arrays + capacity to locals
+    SEC->>SEC: probe: fileIds[bucket]==fileId && pageIndices[bucket]==pageIndex?
+    SEC->>SEC: lock.validate(stamp) → success
+    SEC-->>MAP: values[bucket] (CacheEntry)
+    MAP-->>LRC: CacheEntry (hit)
+    LRC->>LRC: afterRead(entry) → batch in ThreadLocal
+    LRC-->>Caller: CacheEntry
+```
+
+The hot read path is lock-free on cache hit. `tryOptimisticRead()` captures a stamp, then
+all mutable fields (array references and capacity) are snapshotted to local variables before
+the probe loop. This is critical: reading fields directly (not via locals) would allow stale
+reads to pass validation after a concurrent resize. The probe compares both `fileIds[bucket]`
+and `pageIndices[bucket]` — two primitive comparisons, no virtual dispatch. If validation
+fails (rare — only during concurrent writes to the same segment), a single read-lock
+fallback re-probes. There is no retry loop to avoid livelock under heavy write contention.
+
+**Zero allocation**: no `PageKey`, no iterator, no lambda — just primitive field comparisons
+on flat arrays.
+
+### Read path (cache miss)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant LRC as LockFreeReadCache
+    participant MAP as ConcurrentLongIntHashMap
+    participant SEC as Section
+    participant WC as WriteCache
+
+    Caller->>LRC: doLoad(fileId, pageIndex, ...)
+    LRC->>MAP: get(fileId, pageIndex) → null (miss)
+    LRC->>MAP: compute(fileId, pageIndex, fn)
+    MAP->>SEC: lock.writeLock()
+    SEC->>SEC: probe for existing entry
+    alt entry found (concurrent insert)
+        SEC-->>LRC: existing CacheEntry
+    else not found
+        LRC->>WC: load(fileId, pageIndex) — disk I/O
+        LRC->>LRC: new CacheEntryImpl(fileId, pageIndex, pointer, true, this)
+        SEC->>SEC: insert into arrays
+        SEC->>SEC: lock.unlockWrite()
+        LRC->>LRC: afterAdd(entry)
+    end
+    LRC-->>Caller: CacheEntry
+```
+
+On cache miss, `compute()` acquires the segment write lock and calls the remapping function.
+Disk I/O (`writeCache.load()`) happens under the segment write lock. The `compute()` method
+supports null return from the remapping function: absent key + null return = no-op; present
+key + null return = removal. This matches `ConcurrentHashMap.compute()` semantics and is
+used by `silentLoadForRead()` as a virtual lock — the function stores via a side-channel
+and returns null.
+
+### clearFile (bulk removal)
+
+```mermaid
+sequenceDiagram
+    participant LRC as LockFreeReadCache
+    participant MAP as ConcurrentLongIntHashMap
+    participant SEC1 as Section 0
+    participant SEC2 as Section 1
+    participant SECN as Section N-1
+    participant POL as WTinyLFUPolicy
+
+    LRC->>LRC: flushCurrentThreadReadBatch()
+    LRC->>LRC: evictionLock.lock()
+    LRC->>LRC: emptyBuffers()
+    LRC->>MAP: removeByFileId(fileId) → List of removed entries
+    MAP->>SEC1: writeLock() + sweep fileIds[]
+    SEC1->>SEC1: for each slot: if fileIds[i]==fileId → collect, nullify
+    SEC1->>SEC1: rehashTo(capacity) — same-capacity rehash
+    SEC1->>SEC1: writeUnlock()
+    MAP->>SEC2: writeLock() + sweep
+    MAP->>SECN: writeLock() + sweep
+    MAP-->>LRC: collected entries
+    Note over LRC: process entries outside segment locks
+    loop for each removed entry
+        LRC->>LRC: freeze(entry)
+        LRC->>POL: onRemove(entry)
+        LRC->>LRC: cacheSize.decrementAndGet()
+        LRC->>LRC: writeCache.checkCacheOverflow()
+    end
+    LRC->>LRC: evictionLock.unlock()
+```
+
+Each section's sweep holds the segment write lock, scans all `fileIds[]` slots, collects
+matching entries (nullifying their slots), and performs a same-capacity rehash to restore
+probe chain integrity. The collected entries are returned to the caller for post-removal
+processing (freeze/onRemove/checkCacheOverflow) outside any segment lock.
+
+The unconditional rehash after sweep is simpler than the planned conditional tombstone
+threshold. Since the sweep nullifies slots (rather than using backward-sweep compaction per
+entry), probe chains may be broken. Rehash at the same capacity restores all chains without
+growing the array. The cost is acceptable because `clearFile()` is called on file
+close/truncate/delete — not a latency-sensitive path.
+
+## Hashing and Probing
+
+The hash function combines both key fields using a Murmur3-style 64-bit mixer:
+
+```
+h = fileId * 0xc6a4a7935bd1e995L
+h ^= h >>> 47
+h = (h ^ pageIndex) * 0xc6a4a7935bd1e995L
+h ^= h >>> 47
+```
+
+The 64-bit hash is split:
+- **Upper bits** select the section: `hash >>> sectionShift` (where
+  `sectionShift = 64 - log2(numSections)`)
+- **Lower bits** select the starting bucket: `(int) hash & (capacity - 1)`
+
+Linear probing advances by 1 on collision. Each probe step compares both `fileIds[bucket]`
+and `pageIndices[bucket]`. The probe terminates when a matching entry is found (both fields
+match and value is non-null) or a null value slot is encountered (end of probe chain).
+
+**Frequency sketch hashing** uses a deliberately independent formula:
+`Long.hashCode(fileId) * 31 + pageIndex`. This avoids correlation with bucket position
+(the murmur hash's lower 32 bits are used for both bucket selection and would be reused if
+truncated). The frequency sketch is approximate by design (Count-Min Sketch) and tolerates
+hash quality variations.
+
+## Concurrency Model
+
+Each `Section` holds a `StampedLock` providing three access modes:
+
+1. **Optimistic read** (`get()`): `tryOptimisticRead()` → snapshot locals → read arrays →
+   `validate(stamp)`. Zero contention on the fast path. Falls back to read lock on
+   validation failure — one attempt only, no retry loop to avoid livelock.
+
+2. **Read lock** (`get()` fallback, `forEach()`, `forEachValue()`): shared access for when
+   optimistic read fails or during iteration.
+
+3. **Write lock** (`put()`, `compute()`, `remove()`, `removeByFileId()`, `rehashTo()`):
+   exclusive access per segment. Multiple segments can be written concurrently.
+
+**Rehash safety**: `rehashTo()` allocates new arrays, populates them, then updates the
+array references. The `capacity` field is written **last** — after the array references.
+This ordering prevents the BOOKKEEPER-4317 class of bug where an optimistic reader could
+snapshot the new (larger) capacity with old (smaller) arrays, causing
+`ArrayIndexOutOfBoundsException`. Optimistic readers that captured old array references use
+the old capacity for bucket indexing, which is safe — they either find the entry or fail
+validation and fall back to read lock, where they see the new arrays.
+
+**`compute()` null-return semantics**: `silentLoadForRead()` uses `compute()` purely as a
+lock mechanism — the remapping function creates a `CacheEntryImpl` stored via a side-channel
+(`updatedEntry[0]`) and returns `null`, meaning "do not insert into the map." For absent
+key + null return = no-op; for present key + null return = removal. This matches
+`ConcurrentHashMap.compute()` semantics.
+
+## Backward-Sweep Compaction
+
+The `remove()` and conditional `remove()` operations use backward-sweep compaction instead
+of tombstones. When an entry is removed at slot `i`:
+
+1. Set `values[i] = null` and decrement `size` and `usedBuckets`.
+2. Walk forward from `i+1`. For each occupied slot `j`, check if its natural bucket (from
+   hash) lies "between" `i` and `j` in circular distance (`isBetween`). If so, the entry at
+   `j` was displaced past the now-empty `i` — move it back to `i`, set `values[j] = null`,
+   and continue from `j`.
+3. This eliminates tombstones entirely for single-entry removal, keeping `usedBuckets == size`.
+
+This is distinct from `removeByFileId`, which uses bulk nullification followed by
+same-capacity rehash. Backward-sweep would be O(n²) for bulk removal since each individual
+removal shifts entries that may themselves need removal. The unconditional rehash is O(n)
+and restores all probe chains in a single pass.
+
+## Lock Ordering
+
+`StampedLock` is not reentrant. Code running under a segment write lock must not re-enter
+the map. This constraint shapes the `removeByFileId` design:
+
+- `freeze()` — CAS on `CacheEntry.state`. Does not access the map. Safe.
+- `policy.onRemove()` — removes from LRU lists. Does not access the map. Safe.
+- `writeCache.checkCacheOverflow()` — may trigger operations that access the read cache
+  map. **Not safe** under segment lock — would deadlock if routed to the same segment.
+
+Therefore, `removeByFileId` collects entries during the sweep and returns them for the
+caller to process after the lock is released.
+
+**Lock acquisition order** (always in this order to prevent deadlock):
+1. `evictionLock` (`ReentrantLock`) — outermost
+2. Segment write lock (`StampedLock`) — innermost
+
+## CacheEntry State Machine
+
+`CacheEntryImpl` uses an `int state` field (via `AtomicIntegerFieldUpdater`) encoding both
+reader count and lifecycle:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Alive_0: new CacheEntryImpl(...)
+    Alive_0 --> Alive_N: acquireEntry() [CAS 0→1...N]
+    Alive_N --> Alive_0: releaseEntry() [CAS N→N-1...0]
+    Alive_0 --> FROZEN: freeze() [CAS 0→-1]
+    FROZEN --> DEAD: makeDead() [CAS -1→-2]
+
+    note right of Alive_N: state >= 0, value = reader count
+    note right of FROZEN: state = -1, ready for eviction
+    note right of DEAD: state = -2, post-eviction
+```
+
+- `acquireEntry()` succeeds only when `state >= 0` (alive), incrementing the reader count.
+- `freeze()` succeeds only when `state == 0` (released, no readers), transitioning to FROZEN.
+- `makeDead()` succeeds only from FROZEN, transitioning to DEAD.
+- All transitions are CAS-based, requiring no external locks.
+
+## WTinyLFU Three-Level Eviction
+
+The eviction policy is unchanged from the pre-migration design. Three LRU lists form a
+hierarchy:
+
+- **Eden** (20% of max capacity): newly inserted entries. FIFO order.
+- **Protection** (remaining 80% of second-level capacity): entries that proved their
+  frequency. LRU order.
+- **Probation** (20% of second-level capacity): entries demoted from protection or promoted
+  from eden. Second-chance entries.
+
+On eden overflow, the LRU victim from eden is compared against the LRU victim from
+probation by frequency (from the Count-Min Sketch). The loser is evicted; the winner enters
+probation. On access, probation entries that have sufficient frequency are promoted to
+protection.
+
+The only change is the frequency sketch keying: `hashForFrequencySketch(entry.getFileId(),
+entry.getPageIndex())` replaces `entry.getPageKey().hashCode()`. The formulas differ
+(`Long.hashCode * 31 + pageIndex` vs `Objects.hash(fileId, pageIndex)`) but the frequency
+sketch's approximate nature makes this a non-issue — the sketch periodically halves all
+counters and adapts to any hash distribution.

--- a/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
@@ -277,75 +277,24 @@ graph TD
   >
   > **Strategy refresh:** CONTINUE — no downstream impact detected.
 
-- [ ] Track 2: Integration into LockFreeReadCache and WTinyLFUPolicy
+- [x] Track 2: Integration into LockFreeReadCache and WTinyLFUPolicy
   > Replace `ConcurrentHashMap<PageKey, CacheEntry>` with
   > `ConcurrentLongIntHashMap<CacheEntry>` in `LockFreeReadCache` and update
   > all dependent code.
   >
-  > **What**: Swap the map type, eliminate all `PageKey` allocations on the hot
-  > path, update `WTinyLFUPolicy` and `CacheEntry` interface, replace
-  > `clearFile()` loop with `removeByFileId()`.
+  > **Track episode:**
+  > Replaced `ConcurrentHashMap<PageKey, CacheEntry>` with
+  > `ConcurrentLongIntHashMap<CacheEntry>` in `LockFreeReadCache` and
+  > `WTinyLFUPolicy`, eliminating all `PageKey` allocations on the hot read
+  > path. Key discoveries: (1) `N_CPU << 1` is not guaranteed power-of-two —
+  > fixed by wrapping with `ceilingPowerOfTwo()` (plan incorrectly stated map
+  > constructor aligns section count internally); (2) removing `filledUpTo`
+  > parameter from `clearFile()` was a natural consequence of
+  > `removeByFileId()` — simplified `deleteStorage`/`closeStorage` callers.
+  > No cross-track impact — Track 3 (stress tests) can proceed as planned
+  > against the integrated system.
   >
-  > **How**:
-  > - Replace `data` field type in `LockFreeReadCache`
-  > - Update `doLoad()` and `silentLoadForRead()`: pass `(fileId, pageIndex)`
-  >   directly instead of constructing `PageKey`
-  > - Update `addNewPagePointerToTheCache()`: use
-  >   `data.putIfAbsent(cacheEntry.getFileId(), cacheEntry.getPageIndex(), cacheEntry)`
-  >   instead of `data.putIfAbsent(cacheEntry.getPageKey(), cacheEntry)`
-  > - Update `releaseFromWrite()`: use `data.compute(fileId, pageIndex, fn)`
-  >   instead of `data.compute(entry.getPageKey(), fn)`
-  > - Update `clearFile()`: replace the per-page loop with
-  >   `data.removeByFileId(fileId)` which returns removed entries as a list
-  >   (collected during the sweep, consumer invoked *after* the segment write
-  >   lock is released — see Lock Ordering below). Then iterate the returned
-  >   entries under the eviction lock to perform per-entry: `freeze()` (throwing
-  >   `StorageException` if entry is in use — preserving current failure mode),
-  >   `policy.onRemove()`, `cacheSize.decrementAndGet()`, and
-  >   `writeCache.checkCacheOverflow()`.
-  > - **Lock ordering and reentrancy for removeByFileId**: the consumer callback
-  >   (`freeze`, `onRemove`, `checkCacheOverflow`) must NOT run under a segment
-  >   write lock because `StampedLock` is not reentrant — `checkCacheOverflow()`
-  >   or `onRemove()` could re-enter the map, causing deadlock. The current
-  >   `clearFile()` calls `data.remove()` which acquires/releases the segment
-  >   lock per entry, then does freeze/onRemove/checkCacheOverflow outside the
-  >   lock. The new design preserves this by having `removeByFileId` collect
-  >   entries and return them, with the caller processing entries after the
-  >   segment lock is released. Two API options: (a) return a `List<V>`, or
-  >   (b) accept a consumer but invoke it after `writeUnlock()` per segment.
-  > - Update `WTinyLFUPolicy`: change constructor to accept
-  >   `ConcurrentLongIntHashMap<CacheEntry>`, update `purgeEden()` eviction
-  >   calls, update `assertConsistency()` iteration
-  > - Update `CacheEntryImpl`: store `long fileId` and `int pageIndex` directly,
-  >   remove `PageKey` field
-  > - Remove `getPageKey()` from `CacheEntry` interface and all implementors
-  >   (`CacheEntryImpl`, `CacheEntryChanges`)
-  > - Delete `chm.PageKey` record class
-  > - Update frequency sketch keying in `WTinyLFUPolicy.onAccess/onAdd` to use
-  >   the static hash utility
-  >
-  > **Constraints**:
-  > - `clearFile()` must still call `freeze()` (with `StorageException` on
-  >   failure), `policy.onRemove()`, and `writeCache.checkCacheOverflow()` per
-  >   entry under eviction lock — only the map removal pattern changes
-  > - `releaseFromWrite()` compute must hold segment lock during
-  >   `writeCache.store()` — same virtual-lock pattern as before
-  > - `silentLoadForRead()` uses `compute()` returning null as a lock-only
-  >   mechanism — the entry is NOT inserted into the map. The new
-  >   `ConcurrentLongIntHashMap.compute()` must support the remapping function
-  >   returning null (meaning "do not insert / keep slot empty")
-  > - `CacheEntryChanges.getPageKey()` delegation must also be removed
-  > - All existing tests must pass without modification (apart from test code
-  >   that directly references `PageKey`)
-  >
-  > **Interactions**: depends on Track 1 for the `ConcurrentLongIntHashMap`
-  > class and its full API.
-  >
-  > **Scope:** ~5-6 steps covering data field replacement + constructor,
-  > hot-path methods (doLoad/silentLoadForRead), write-path methods
-  > (addNewPage/releaseFromWrite), WTinyLFUPolicy update,
-  > clearFile + removeByFileId integration, CacheEntry interface cleanup +
-  > PageKey deletion
+  > **Step file:** `tracks/track-2.md` (4 steps, 0 failed)
   >
   > **Depends on:** Track 1
 

--- a/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
@@ -274,6 +274,8 @@ graph TD
   > structure consumed by Track 2.
   >
   > **Step file:** `tracks/track-1.md` (5 steps, 0 failed)
+  >
+  > **Strategy refresh:** CONTINUE — no downstream impact detected.
 
 - [ ] Track 2: Integration into LockFreeReadCache and WTinyLFUPolicy
   > Replace `ConcurrentHashMap<PageKey, CacheEntry>` with

--- a/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
@@ -1,0 +1,390 @@
+# Primitive CHM Cache — Replace ConcurrentHashMap with Open-Addressing Primitive Map
+
+## High-level plan
+
+### Goals
+
+Replace `ConcurrentHashMap<PageKey, CacheEntry>` in `LockFreeReadCache` with a custom
+open-addressing concurrent hash map (`ConcurrentLongIntHashMap`) that stores
+`(long fileId, int pageIndex)` inline in parallel arrays. This achieves:
+
+1. **Zero per-access allocation**: eliminates transient `PageKey` objects on the hot
+   read path (`doLoad()`), reducing young-generation GC pressure under sustained workloads.
+2. **~80% reduction in per-entry memory overhead**: from ~96 bytes (CHM Node + PageKey +
+   amortized table slot) to ~20 bytes (3 array slots), saving ~38 MB at full cache
+   capacity (524K entries with 4 GB / 8 KB pages).
+3. **O(segment-capacity) bulk file removal**: `clearFile()` becomes a linear sweep per
+   segment instead of O(filledUpTo) individual allocations + hash probes, eliminating
+   the most expensive path called on every file close, truncate, and delete.
+4. **Improved CPU cache behavior**: linear array access replaces pointer-chasing through
+   Node and PageKey objects, benefiting hardware prefetcher on the probe loop.
+
+### Constraints
+
+- **Apache 2.0 license compatibility**: the fork is from Apache BookKeeper
+  (`ConcurrentLongHashMap`), which is Apache 2.0 — compatible with our license.
+  Must preserve attribution in file headers.
+- **Concurrency correctness**: BookKeeper's `ConcurrentLongHashMap` had known
+  concurrency bugs (BOOKKEEPER-4317). The adaptation introduces a second key field,
+  adding another dimension to the probe logic. Thorough concurrent stress testing
+  is mandatory.
+- **No behavioral change to eviction policy**: `WTinyLFUPolicy` must continue to
+  function identically — same admission decisions, same LRU ordering, same
+  eviction callbacks. Only the data structure backing its map reference changes.
+- **`compute()` as virtual lock**: `releaseFromWrite()` uses `data.compute()` purely
+  for its segment-locking side-effect (atomically storing to write cache). The new
+  map must support a `compute()` operation that holds the segment write lock while
+  the remapping function executes, even when the key is absent.
+- **Key 0 / pageIndex 0 are valid**: unlike BookKeeper's original where key `0L` is
+  the empty sentinel, our map must handle `fileId=0` and `pageIndex=0` as valid keys.
+  Emptiness is determined by the value slot (null), not the key slots.
+- **Existing test suite must pass unchanged**: the map replacement is an internal
+  implementation detail. All `LockFreeReadCache` tests, `WTinyLFUPolicy` tests,
+  batching tests, and integration tests must pass without modification.
+- **Thread safety model**: `get()` must remain lock-free on the fast path (optimistic
+  stamp read). `compute()`/`put()` use segment write locks. Segment count is
+  configurable (default 16).
+
+### Architecture Notes
+
+#### Component Map
+
+```mermaid
+graph TD
+    subgraph "LockFreeReadCache (modified)"
+        DATA["ConcurrentLongIntHashMap&lt;CacheEntry&gt;<br/>(replaces ConcurrentHashMap)"]
+        EVICT["evictionLock<br/>(ReentrantLock)"]
+        RBUF["readBuffer<br/>(BoundedBuffer)"]
+        WBUF["writeBuffer<br/>(MPSCLinkedQueue)"]
+    end
+
+    subgraph "WTinyLFUPolicy (modified)"
+        POLICY["WTinyLFUPolicy"]
+        EDEN["LRUList eden"]
+        PROB["LRUList probation"]
+        PROT["LRUList protection"]
+        ADMIT["Admittor (FrequencySketch)"]
+    end
+
+    subgraph "Cache entries (modified)"
+        CE["CacheEntryImpl"]
+        CEI["CacheEntry interface"]
+    end
+
+    subgraph "New classes"
+        MAP["ConcurrentLongIntHashMap&lt;V&gt;"]
+        SEC["Section (inner class)"]
+        FI["LongIntFunction&lt;R&gt;"]
+        CONSUMER["LongIntObjConsumer&lt;T&gt;"]
+        KVFN["LongIntKeyValueFunction&lt;V&gt;"]
+    end
+
+    DATA --> MAP
+    MAP --> SEC
+    POLICY -->|"eviction removal"| DATA
+    POLICY --> ADMIT
+    POLICY --> EDEN
+    POLICY --> PROB
+    POLICY --> PROT
+    CE -->|"implements"| CEI
+    CE -.->|"stored in"| DATA
+```
+
+- **ConcurrentLongIntHashMap** (new): open-addressing segmented hash map with
+  `(long fileId, int pageIndex)` composite key stored in parallel `long[]` and
+  `int[]` arrays. Forked from BookKeeper's `ConcurrentLongHashMap` and adapted
+  for two-field keys. Lives in `core/.../internal/common/collection/`.
+- **Section** (new, inner class): extends `StampedLock`, holds per-segment arrays
+  (`long[] fileIds`, `int[] pageIndices`, `V[] values`), manages probing, resize,
+  and tombstone cleanup.
+- **LongIntFunction** (new): `R apply(long fileId, int pageIndex)` — avoids boxing
+  for `computeIfAbsent` mapping function.
+- **LongIntObjConsumer** (new): `void accept(long fileId, int pageIndex, V value)` —
+  avoids boxing for `forEach` iteration.
+- **LongIntKeyValueFunction** (new): `V apply(long fileId, int pageIndex, V currentValue)` —
+  remapping function for `compute()`.
+- **LockFreeReadCache** (modified): `data` field type changes from
+  `ConcurrentHashMap<PageKey, CacheEntry>` to `ConcurrentLongIntHashMap<CacheEntry>`.
+  All `new PageKey(...)` allocations in `doLoad()`, `silentLoadForRead()`, `clearFile()`
+  are eliminated. `clearFile()` calls `removeByFileId()`.
+- **WTinyLFUPolicy** (modified): constructor and eviction methods updated to use
+  `ConcurrentLongIntHashMap` API. `data.remove(victim.getPageKey(), victim)` becomes
+  `data.remove(victim.getFileId(), victim.getPageIndex(), victim)`.
+- **CacheEntryImpl** (modified): stores `long fileId` and `int pageIndex` directly
+  instead of a `PageKey` field. Eliminates one object allocation per entry creation.
+- **CacheEntry interface** (modified): `getPageKey()` removed; callers already have
+  `getFileId()` and `getPageIndex()`.
+- **PageKey** (removed): `chm.PageKey` record is deleted. The `local.PageKey` class
+  used by `WOWCache` is unaffected (different package, different field types).
+
+#### D1: Fork BookKeeper's ConcurrentLongHashMap as the base
+
+- **Alternatives considered**:
+  - JCTools `NonBlockingHashMapLong` (lock-free, Cliff Click design) — single `long`
+    key only, no composite key support without boxing/combining into a single long
+    (lossy for `long fileId + int pageIndex`).
+  - Eclipse Collections `LongObjectHashMap` — not concurrent.
+  - Build from scratch — higher risk, no battle-tested probe/resize logic.
+  - Inline fileId+pageIndex into a single `long` key (`(fileId << 32) | pageIndex`) —
+    lossy since `fileId` is `long` (upper 32 bits lost).
+- **Rationale**: BookKeeper's design is well-matched: segmented open-addressing with
+  StampedLock, optimistic reads, ~740 LOC, Apache 2.0 licensed. The adaptation to a
+  composite key is mechanical — add a second key array and extend the probe/hash logic.
+  The existing probe/resize/tombstone logic has been production-hardened in BookKeeper.
+- **Risks/Caveats**: BookKeeper had concurrency bugs (BOOKKEEPER-4317 — race in
+  rehash + get). Review the fork carefully and add targeted concurrent stress tests.
+  The two-field key adds one more array read per probe step.
+- **Implemented in**: Track 1
+
+#### D2: Use null value slot (not key slots) to determine emptiness
+
+- **Alternatives considered**:
+  - Use sentinel key values (e.g., `fileId = Long.MIN_VALUE`) to mark empty slots,
+    matching BookKeeper's original approach.
+  - Use a separate `boolean[] occupied` array.
+- **Rationale**: `fileId=0` and `pageIndex=0` are valid keys in YouTrackDB (file IDs
+  start at 0). BookKeeper's original uses key `0L` as empty sentinel, which would
+  break here. Checking the value slot for null (same as BookKeeper's `EmptyValue`)
+  is safe because null values are disallowed. This avoids adding a sentinel scheme
+  or an extra array.
+- **Risks/Caveats**: Must ensure all probe loops check `values[idx] == null` for
+  emptiness, never `keys[idx] == 0`. BookKeeper already does this (it checks
+  `values[bucket]`), so the adaptation is natural.
+- **Implemented in**: Track 1
+
+#### D3: Eliminate PageKey from CacheEntry interface
+
+- **Alternatives considered**:
+  - Keep `getPageKey()` and return a lazily-constructed PageKey for backward
+    compatibility.
+  - Store fileId/pageIndex directly but keep PageKey as a convenience wrapper.
+- **Rationale**: `getPageKey()` is called at 2 sites in `LockFreeReadCache` and
+  9 sites in `WTinyLFUPolicy` (4 hash-based, 2 map-removal, 3 assertion lookups).
+  `CacheEntryChanges` has one delegation site. All callers ultimately need
+  `getFileId()` and `getPageIndex()`, which are already on the `CacheEntry`
+  interface. Removing `getPageKey()` is cleaner than maintaining a wrapper.
+- **Risks/Caveats**: This is a breaking change to the `CacheEntry` internal
+  interface. All usages must be updated in the same commit. `chm.PageKey` is
+  deleted; `local.PageKey` (used by WOWCache) is unaffected.
+- **Implemented in**: Track 2
+
+#### D4: Bulk removeByFileId via linear segment sweep
+
+- **Alternatives considered**:
+  - Keep per-page removal loop but without PageKey allocation (pass primitives
+    directly to `remove(fileId, pageIndex)`).
+  - Maintain a secondary index (fileId -> set of pageIndices) for O(1) lookup.
+- **Rationale**: Per-page removal still does O(filledUpTo) hash probes, most of
+  which are misses (the file may have 100K total pages but only 1K in cache).
+  A linear sweep over the segment arrays is O(segmentCapacity) with excellent
+  cache locality (sequential array reads). At 524K total entries / 16 segments,
+  each segment sweep touches ~50K slots — fast with hardware prefetch.
+  A secondary index adds memory and complexity for marginal benefit.
+- **Risks/Caveats**: The sweep touches all slots in each segment, not just those
+  belonging to the target fileId. For very small files, per-page removal might be
+  faster. In practice, `clearFile()` is called on file close/truncate/delete —
+  not a latency-sensitive path — and the elimination of 100K+ allocations more
+  than compensates.
+- **Implemented in**: Track 1 (map method), Track 2 (integration into clearFile)
+
+#### D5: Frequency sketch keying after PageKey removal
+
+- **Alternatives considered**:
+  - Use `Objects.hash(fileId, pageIndex)` (boxed).
+  - Use the murmur hash from the map itself (64-bit, truncated to int).
+  - Compute a separate lightweight int hash.
+- **Rationale**: The frequency sketch (`Admittor.increment/frequency`) takes an
+  `int` hash. Currently it uses `PageKey.hashCode()` — the record's
+  auto-generated `hashCode()` (functionally equivalent to
+  `Objects.hash(fileId, pageIndex)`). After removing PageKey, we need a
+  consistent int hash. We can expose a static `hash(long fileId, int pageIndex)`
+  method on `ConcurrentLongIntHashMap` that returns an int-range hash, or compute
+  it inline. Using the same hash function as the map (truncated to int) ensures
+  consistency and avoids a separate hash path.
+- **Risks/Caveats**: The frequency sketch uses the hash for approximate frequency
+  counting. Minor hash distribution changes may slightly alter admission decisions,
+  but TinyLFU is designed to be robust to hash quality. No functional impact.
+- **Implemented in**: Track 2
+
+#### Invariants
+
+- **No allocation on read hit path**: `get(long fileId, int pageIndex)` must not
+  allocate any objects. The optimistic read path (stamp + array reads + validate)
+  must be allocation-free. (Verified by code inspection: no `new` expressions, no
+  autoboxing, no iterator creation on the optimistic read path.)
+- **removeByFileId atomicity per segment**: each segment's sweep holds the segment
+  write lock for its duration. Cross-segment removal is not atomic, but this
+  matches the current behavior (individual `CHM.remove()` calls are not collectively
+  atomic).
+- **Tombstone bounds**: after `removeByFileId`, tombstone cleanup must run to prevent
+  unbounded tombstone accumulation. The backward-sweep cleanup from BookKeeper's
+  design handles this.
+- **Eviction policy consistency**: after any map mutation (put, remove, removeByFileId),
+  the WTinyLFU policy's LRU lists must be updated under the eviction lock. The
+  existing `afterAdd/afterRead/onRemove` protocol is preserved.
+
+#### Integration Points
+
+- **LockFreeReadCache.data**: the single field replacement that drives all changes.
+  All map operations flow through this field.
+- **WTinyLFUPolicy constructor**: changes from
+  `WTinyLFUPolicy(ConcurrentHashMap<PageKey, CacheEntry>, ...)` to
+  `WTinyLFUPolicy(ConcurrentLongIntHashMap<CacheEntry>, ...)`.
+- **WTinyLFUPolicy.purgeEden()**: eviction removal changes from
+  `data.remove(victim.getPageKey(), victim)` to
+  `data.remove(victim.getFileId(), victim.getPageIndex(), victim)`.
+- **CacheEntry interface**: `getPageKey()` is removed; `getFileId()` and
+  `getPageIndex()` remain.
+- **CacheEntryChanges**: delegates to `CacheEntry`; `getPageKey()` delegation removed.
+- **Admittor/FrequencySketch**: keying changes from `cacheEntry.getPageKey().hashCode()`
+  to a static hash utility method. This affects both `onAccess`/`onAdd` increment
+  calls and `purgeEden()` frequency comparison calls
+  (`candidate.getPageKey().hashCode()`, `victim.getPageKey().hashCode()`).
+
+#### Non-Goals
+
+- **Replacing PageKey in WOWCache**: `local.PageKey` (used by `WOWCache`,
+  `dirtyPages`, `exclusiveWritePages`, `lockManager`) is a completely separate class
+  in a different package with different field types (`int fileId, long pageIndex`).
+  It is out of scope.
+- **Lock-free writes**: the map uses StampedLock write locks per segment, matching
+  BookKeeper's design. A fully lock-free map (Cliff Click style) is significantly
+  more complex and not necessary for this use case.
+- **Auto-shrink by default**: shrinking is available but disabled by default (matching
+  BookKeeper). The cache has a stable working set size; shrinking adds complexity
+  without clear benefit.
+- **Changing the eviction algorithm**: WTinyLFU is retained as-is. Only the backing
+  map changes.
+
+## Checklist
+
+- [x] Track 1: ConcurrentLongIntHashMap — Core Data Structure
+  > Implement the open-addressing concurrent hash map with composite
+  > `(long fileId, int pageIndex)` key, forked from BookKeeper's
+  > `ConcurrentLongHashMap`.
+  >
+  > **Track episode:**
+  > Delivered `ConcurrentLongIntHashMap<V>` — segmented open-addressing
+  > concurrent hash map with composite `(long fileId, int pageIndex)` keys,
+  > 91 unit tests. Key deviations: Section uses composition (has-a StampedLock)
+  > not inheritance; removeByFileId uses unconditional same-capacity rehash
+  > (simpler than planned conditional tombstone threshold); probe loop and
+  > rehash duplication extracted into shared helpers. hashForFrequencySketch
+  > deferred to Track 2 as planned. No cross-track impact — standalone data
+  > structure consumed by Track 2.
+  >
+  > **Step file:** `tracks/track-1.md` (5 steps, 0 failed)
+
+- [ ] Track 2: Integration into LockFreeReadCache and WTinyLFUPolicy
+  > Replace `ConcurrentHashMap<PageKey, CacheEntry>` with
+  > `ConcurrentLongIntHashMap<CacheEntry>` in `LockFreeReadCache` and update
+  > all dependent code.
+  >
+  > **What**: Swap the map type, eliminate all `PageKey` allocations on the hot
+  > path, update `WTinyLFUPolicy` and `CacheEntry` interface, replace
+  > `clearFile()` loop with `removeByFileId()`.
+  >
+  > **How**:
+  > - Replace `data` field type in `LockFreeReadCache`
+  > - Update `doLoad()` and `silentLoadForRead()`: pass `(fileId, pageIndex)`
+  >   directly instead of constructing `PageKey`
+  > - Update `addNewPagePointerToTheCache()`: use
+  >   `data.putIfAbsent(cacheEntry.getFileId(), cacheEntry.getPageIndex(), cacheEntry)`
+  >   instead of `data.putIfAbsent(cacheEntry.getPageKey(), cacheEntry)`
+  > - Update `releaseFromWrite()`: use `data.compute(fileId, pageIndex, fn)`
+  >   instead of `data.compute(entry.getPageKey(), fn)`
+  > - Update `clearFile()`: replace the per-page loop with
+  >   `data.removeByFileId(fileId)` which returns removed entries as a list
+  >   (collected during the sweep, consumer invoked *after* the segment write
+  >   lock is released — see Lock Ordering below). Then iterate the returned
+  >   entries under the eviction lock to perform per-entry: `freeze()` (throwing
+  >   `StorageException` if entry is in use — preserving current failure mode),
+  >   `policy.onRemove()`, `cacheSize.decrementAndGet()`, and
+  >   `writeCache.checkCacheOverflow()`.
+  > - **Lock ordering and reentrancy for removeByFileId**: the consumer callback
+  >   (`freeze`, `onRemove`, `checkCacheOverflow`) must NOT run under a segment
+  >   write lock because `StampedLock` is not reentrant — `checkCacheOverflow()`
+  >   or `onRemove()` could re-enter the map, causing deadlock. The current
+  >   `clearFile()` calls `data.remove()` which acquires/releases the segment
+  >   lock per entry, then does freeze/onRemove/checkCacheOverflow outside the
+  >   lock. The new design preserves this by having `removeByFileId` collect
+  >   entries and return them, with the caller processing entries after the
+  >   segment lock is released. Two API options: (a) return a `List<V>`, or
+  >   (b) accept a consumer but invoke it after `writeUnlock()` per segment.
+  > - Update `WTinyLFUPolicy`: change constructor to accept
+  >   `ConcurrentLongIntHashMap<CacheEntry>`, update `purgeEden()` eviction
+  >   calls, update `assertConsistency()` iteration
+  > - Update `CacheEntryImpl`: store `long fileId` and `int pageIndex` directly,
+  >   remove `PageKey` field
+  > - Remove `getPageKey()` from `CacheEntry` interface and all implementors
+  >   (`CacheEntryImpl`, `CacheEntryChanges`)
+  > - Delete `chm.PageKey` record class
+  > - Update frequency sketch keying in `WTinyLFUPolicy.onAccess/onAdd` to use
+  >   the static hash utility
+  >
+  > **Constraints**:
+  > - `clearFile()` must still call `freeze()` (with `StorageException` on
+  >   failure), `policy.onRemove()`, and `writeCache.checkCacheOverflow()` per
+  >   entry under eviction lock — only the map removal pattern changes
+  > - `releaseFromWrite()` compute must hold segment lock during
+  >   `writeCache.store()` — same virtual-lock pattern as before
+  > - `silentLoadForRead()` uses `compute()` returning null as a lock-only
+  >   mechanism — the entry is NOT inserted into the map. The new
+  >   `ConcurrentLongIntHashMap.compute()` must support the remapping function
+  >   returning null (meaning "do not insert / keep slot empty")
+  > - `CacheEntryChanges.getPageKey()` delegation must also be removed
+  > - All existing tests must pass without modification (apart from test code
+  >   that directly references `PageKey`)
+  >
+  > **Interactions**: depends on Track 1 for the `ConcurrentLongIntHashMap`
+  > class and its full API.
+  >
+  > **Scope:** ~5-6 steps covering data field replacement + constructor,
+  > hot-path methods (doLoad/silentLoadForRead), write-path methods
+  > (addNewPage/releaseFromWrite), WTinyLFUPolicy update,
+  > clearFile + removeByFileId integration, CacheEntry interface cleanup +
+  > PageKey deletion
+  >
+  > **Depends on:** Track 1
+
+- [ ] Track 3: Concurrent Stress Testing
+  > Validate concurrency correctness of the full integrated system under
+  > realistic contention patterns.
+  >
+  > **What**: Multi-threaded stress tests that exercise the
+  > `ConcurrentLongIntHashMap` and `LockFreeReadCache` under concurrent
+  > read/write/remove/removeByFileId workloads to catch races, deadlocks,
+  > and data corruption.
+  >
+  > **How**:
+  > - **Map-level concurrent tests**: multiple threads performing interleaved
+  >   `get/put/remove/computeIfAbsent` on overlapping keys, verifying that
+  >   no entries are lost or duplicated. Include a specific test for concurrent
+  >   `removeByFileId` + `get/put` on the same and different files.
+  > - **clearFile under concurrent load**: simulate file close while other
+  >   threads are reading/writing pages from the same and different files.
+  >   Verify that all pages for the closed file are removed, no pages from
+  >   other files are affected, and no deadlock occurs.
+  > - **Optimistic read validation**: stress the optimistic-read-to-read-lock
+  >   fallback path by running high-frequency writes alongside reads, verifying
+  >   that get() never returns stale or corrupt data.
+  > - **Rehash under concurrent access**: trigger rehash (via many inserts) while
+  >   other threads read and remove, verifying correctness through the resize.
+  >
+  > **Constraints**:
+  > - Tests must be deterministic enough to reproduce failures (use
+  >   `ConcurrentTestHelper` from test-commons, controlled thread counts)
+  > - Run with `-ea` (assertions enabled) so map and policy invariants are
+  >   checked during stress runs
+  > - Tests should run in reasonable time (<30s each) for CI
+  > - Map-level tests go in `core/src/test/java/.../internal/common/collection/`
+  > - Integrated cache-level tests go in
+  >   `core/src/test/java/.../internal/core/storage/cache/chm/`
+  >
+  > **Interactions**: depends on Track 1 for the map class and Track 2 for the
+  > integrated `LockFreeReadCache` with the new map.
+  >
+  > **Scope:** ~3 steps covering map-level concurrent correctness tests,
+  > removeByFileId + concurrent access tests, integrated clearFile stress test
+  >
+  > **Depends on:** Track 1, Track 2

--- a/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
@@ -297,6 +297,8 @@ graph TD
   > **Step file:** `tracks/track-2.md` (4 steps, 0 failed)
   >
   > **Depends on:** Track 1
+  >
+  > **Strategy refresh:** CONTINUE — no downstream impact detected.
 
 - [ ] Track 3: Concurrent Stress Testing
   > Validate concurrency correctness of the full integrated system under

--- a/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/implementation-plan.md
@@ -300,44 +300,19 @@ graph TD
   >
   > **Strategy refresh:** CONTINUE — no downstream impact detected.
 
-- [ ] Track 3: Concurrent Stress Testing
+- [x] Track 3: Concurrent Stress Testing
   > Validate concurrency correctness of the full integrated system under
   > realistic contention patterns.
   >
-  > **What**: Multi-threaded stress tests that exercise the
-  > `ConcurrentLongIntHashMap` and `LockFreeReadCache` under concurrent
-  > read/write/remove/removeByFileId workloads to catch races, deadlocks,
-  > and data corruption.
+  > **Track episode:**
+  > Validated concurrency correctness of `ConcurrentLongIntHashMap` and
+  > `LockFreeReadCache` under multi-threaded stress. Found and fixed a real
+  > concurrency bug: `rehashTo()` wrote `capacity` before the new arrays,
+  > allowing optimistic readers to see the new (larger) capacity with old
+  > (smaller) arrays (AIOOBE). This is exactly the BOOKKEEPER-4317 class of
+  > bug the track was designed to catch. Fix: write arrays first, capacity last.
+  > No cross-track impact — this is the final track.
   >
-  > **How**:
-  > - **Map-level concurrent tests**: multiple threads performing interleaved
-  >   `get/put/remove/computeIfAbsent` on overlapping keys, verifying that
-  >   no entries are lost or duplicated. Include a specific test for concurrent
-  >   `removeByFileId` + `get/put` on the same and different files.
-  > - **clearFile under concurrent load**: simulate file close while other
-  >   threads are reading/writing pages from the same and different files.
-  >   Verify that all pages for the closed file are removed, no pages from
-  >   other files are affected, and no deadlock occurs.
-  > - **Optimistic read validation**: stress the optimistic-read-to-read-lock
-  >   fallback path by running high-frequency writes alongside reads, verifying
-  >   that get() never returns stale or corrupt data.
-  > - **Rehash under concurrent access**: trigger rehash (via many inserts) while
-  >   other threads read and remove, verifying correctness through the resize.
-  >
-  > **Constraints**:
-  > - Tests must be deterministic enough to reproduce failures (use
-  >   `ConcurrentTestHelper` from test-commons, controlled thread counts)
-  > - Run with `-ea` (assertions enabled) so map and policy invariants are
-  >   checked during stress runs
-  > - Tests should run in reasonable time (<30s each) for CI
-  > - Map-level tests go in `core/src/test/java/.../internal/common/collection/`
-  > - Integrated cache-level tests go in
-  >   `core/src/test/java/.../internal/core/storage/cache/chm/`
-  >
-  > **Interactions**: depends on Track 1 for the map class and Track 2 for the
-  > integrated `LockFreeReadCache` with the new map.
-  >
-  > **Scope:** ~3 steps covering map-level concurrent correctness tests,
-  > removeByFileId + concurrent access tests, integrated clearFile stress test
+  > **Step file:** `tracks/track-3.md` (3 steps, 0 failed)
   >
   > **Depends on:** Track 1, Track 2

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-1-adversarial.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-1-adversarial.md
@@ -1,0 +1,68 @@
+# Track 1 Adversarial Review
+
+## Findings
+
+### Finding A1 [should-fix]
+**Target**: Decision D1 — single-long key alternative
+**Challenge**: Composed fileId is `(storageId << 32) | fileId` — both ints. Could pack into single long.
+**Evidence**: `AbstractWriteCache.composeFileId()` shows int composition.
+**Decision**: REJECTED — `fileId` is `long` in the API contract. Relying on internal composition details is fragile.
+
+### Finding A2 [suggestion]
+**Target**: Decision D2 — write ordering in put()
+**Challenge**: Value must be written before key fields to prevent readers seeing matching keys with null values.
+**Decision**: ACCEPTED — document write ordering explicitly in implementation.
+
+### Finding A3 [should-fix]
+**Target**: Decision D1 — Koloboke alternative not considered
+**Challenge**: Koloboke provides primitive concurrent maps.
+**Decision**: REJECTED — Koloboke doesn't provide StampedLock optimistic reads or the compute() contract needed.
+
+### Finding A4 [suggestion]
+**Target**: Scope — removeByFileId could be split
+**Challenge**: Novel algorithm mixed with core fork increases blast radius.
+**Decision**: ACCEPTED as ordering — removeByFileId implemented after all base operations pass tests.
+
+### Finding A5 [suggestion]
+**Target**: Scope — values() iteration support
+**Challenge**: `clear()` and `assertConsistency()` use `data.values()`.
+**Decision**: ACCEPTED — add `forEachValue(Consumer<V>)` (merged with T5).
+
+### Finding A6 [blocker]
+**Target**: Invariant — "No allocation" overstated
+**Challenge**: `StampedLock.readLock()` fallback may allocate under contention.
+**Decision**: ACCEPTED as should-fix (not blocker) — narrow invariant to "optimistic read fast path is allocation-free."
+
+### Finding A7 [should-fix]
+**Target**: Invariant — tombstone accumulation after removeByFileId
+**Challenge**: Interleaved tombstones may trigger unnecessary resize.
+**Decision**: ACCEPTED (merged with T3/R4 — compaction rehash after bulk removal).
+
+### Finding A8 [should-fix]
+**Target**: Invariant — removal order change
+**Challenge**: Changes from page-index order to segment order.
+**Decision**: ACCEPTED as suggestion — document behavioral difference. Not a real concern since clearFile caller doesn't depend on ordering.
+
+### Finding A9 [withdrawn]
+**Target**: Assumption — compute() key parameter pattern
+**Challenge**: API already handles this correctly.
+
+### Finding A10 [should-fix]
+**Target**: Assumption — section-level locking coarser than CHM per-bin locking
+**Challenge**: Disk I/O under lock blocks entire segment.
+**Decision**: ACCEPTED (merged with R7 — configurable segment count).
+
+### Finding A11 [suggestion]
+**Target**: `Section extends StampedLock` vs composition
+**Challenge**: Codebase style favors composition.
+**Decision**: ACCEPTED as suggestion — use composition.
+
+### Finding A12 [should-fix]
+**Target**: Simplification — profiling evidence for PageKey allocation
+**Challenge**: Need to verify PageKey is not scalar-replaced by JIT.
+**Decision**: Noted — plan motivation is grounded in observed GC pressure. No Track 1 action.
+
+### Finding A13 [suggestion]
+**Target**: `hashForFrequencySketch` belongs in Track 2
+**Challenge**: Only used by WTinyLFUPolicy.
+**Decision**: ACCEPTED — moved to Track 2.

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-1-risk.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-1-risk.md
@@ -1,0 +1,57 @@
+# Track 1 Risk Review
+
+## Findings
+
+### Finding R1 [blocker]
+**Location**: Track 1, `compute()` null-return semantics
+**Issue**: `silentLoadForRead()` depends on compute returning null for absent keys without inserting. Track 1 description does not explicitly call this out as a constraint.
+**Proposed fix**: Add explicit constraint and tests for null-return cases.
+**Decision**: ACCEPTED (merged with T2).
+
+### Finding R2 [should-fix]
+**Location**: Track 1, `compute()` key parameters for absent keys
+**Issue**: Remapping function must receive caller-supplied fileId/pageIndex, not stale array contents. Related to R8.
+**Proposed fix**: Add unit test verifying correct key values in remapping function.
+**Decision**: ACCEPTED (merged with R8).
+
+### Finding R3 [should-fix]
+**Location**: Track 1, concurrent rehash + get stress test
+**Issue**: BookKeeper had BOOKKEEPER-4317 race in rehash + get. Two-field key adds another dimension.
+**Proposed fix**: Include basic rehash correctness test in Track 1 unit tests. Full concurrent stress in Track 3.
+**Decision**: PARTIALLY ACCEPTED — basic rehash test in Track 1, full stress in Track 3.
+
+### Finding R4 [should-fix]
+**Location**: Track 1, `removeByFileId` tombstone cleanup
+**Issue**: Non-contiguous tombstones may not be cleaned by backward sweep.
+**Proposed fix**: Same-capacity rehash compaction after bulk removal if tombstones exceed threshold.
+**Decision**: ACCEPTED (merged with T3).
+
+### Finding R5 [suggestion]
+**Location**: Track 1, hash function change impact on eviction
+**Issue**: Murmur hash will alter frequency sketch collision patterns.
+**Proposed fix**: Validate with `AsyncReadCacheTestIT` in Track 2.
+**Decision**: Noted for Track 2.
+
+### Finding R6 [suggestion]
+**Location**: Track 1, Section encapsulation
+**Issue**: `Section extends StampedLock` exposes all lock methods.
+**Proposed fix**: Make Section a private static final inner class.
+**Decision**: ACCEPTED — use composition instead.
+
+### Finding R7 [should-fix]
+**Location**: Track 1, segment count vs CHM concurrency level
+**Issue**: 16 segments is coarser than CHM's per-bin locking. Disk I/O under lock blocks entire segment. Potential latency regression.
+**Proposed fix**: Make segment count configurable in constructor. Default 16 for the map; LockFreeReadCache passes appropriate value in Track 2.
+**Decision**: ACCEPTED.
+
+### Finding R8 [blocker]
+**Location**: Track 1, `compute()` for absent key — key values passed to function
+**Issue**: For absent keys, array slots contain stale/zero values. Implementation must pass caller-supplied fileId/pageIndex to the remapping function, not read from arrays. Wrong values = silent data corruption.
+**Proposed fix**: Always pass caller-supplied values. Add unit test for absent-key compute.
+**Decision**: ACCEPTED.
+
+### Finding R9 [suggestion]
+**Location**: Track 1, probe-through-tombstone test
+**Issue**: `get()` must correctly skip tombstones during probing.
+**Proposed fix**: Add specific test for probe-through-tombstone scenario.
+**Decision**: ACCEPTED — include in unit tests.

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-1-technical.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-1-technical.md
@@ -1,0 +1,62 @@
+# Track 1 Technical Review
+
+## Findings
+
+### Finding T1 [suggestion]
+**Location**: Track 1, `compute()` API / Track 2 integration
+**Issue**: `doLoad`/`silentLoadForRead` lambdas use `page.fileId()` from the compute callback. The new `LongIntKeyValueFunction` provides these as parameters, so the translation is natural.
+**Proposed fix**: No Track 1 change. Track 2 integration note.
+
+### Finding T2 [blocker]
+**Location**: Track 1, `compute()` null-return semantics
+**Issue**: `silentLoadForRead()` uses `compute()` where the remapping function always returns null on the absent-key branch (lock-only pattern). `ConcurrentHashMap.compute()` contract: absent key + null return = no-op; present key + null return = removal. Track 1 description does not explicitly call this out.
+**Proposed fix**: Add explicit constraint and unit tests for both null-return cases.
+**Decision**: ACCEPTED — add as constraint in Track 1.
+
+### Finding T3 [should-fix]
+**Location**: Track 1, `removeByFileId` tombstone cleanup
+**Issue**: Scattered non-contiguous tombstones after bulk removal may not be cleaned by backward sweep, keeping `usedBuckets` high and potentially triggering unnecessary resize.
+**Proposed fix**: After sweep, if tombstones exceed threshold, do same-capacity rehash (compaction). Add unit test.
+**Decision**: ACCEPTED.
+
+### Finding T4 [suggestion]
+**Location**: Track 1, `hashForFrequencySketch` static method
+**Issue**: Hash values will differ from `PageKey.hashCode()`. Track 2 must update mock expectations.
+**Proposed fix**: Move `hashForFrequencySketch` to Track 2 scope entirely.
+**Decision**: ACCEPTED — moved to Track 2.
+
+### Finding T5 [should-fix]
+**Location**: Track 1, `values()` iteration API
+**Issue**: `clear()` and `assertConsistency()` use `data.values()`. Track 1 has `forEach(LongIntObjConsumer)` but not value-only iteration.
+**Proposed fix**: Add `forEachValue(Consumer<V>)` convenience method.
+**Decision**: ACCEPTED.
+
+### Finding T6 [suggestion]
+**Location**: Track 1, `Section extends StampedLock`
+**Issue**: Inheritance exposes all StampedLock methods. Codebase favors composition.
+**Proposed fix**: Use composition (has-a StampedLock field). 16 extra objects = negligible.
+**Decision**: ACCEPTED as suggestion — use composition.
+
+### Finding T7 [blocker]
+**Location**: Track 1, conditional `remove(fileId, pageIndex, expected)` semantics
+**Issue**: Must specify reference equality (`==`) vs `equals()` for value comparison. Current usage passes the exact same object reference.
+**Proposed fix**: Use reference equality (`==`). Add test verifying `.equals()` but `!=` does NOT remove.
+**Decision**: ACCEPTED.
+
+### Finding T8 [suggestion]
+**Location**: Track 1, target package organization
+**Issue**: Three functional interfaces could clutter `collection/` package.
+**Proposed fix**: Nest functional interfaces inside `ConcurrentLongIntHashMap`.
+**Decision**: ACCEPTED.
+
+### Finding T9 [should-fix]
+**Location**: Track 1, `compute()` side effects under lock
+**Issue**: Remapping function executes under segment write lock. Disk I/O blocks all segment access.
+**Proposed fix**: Add doc comment on `compute()` warning about lock-held execution.
+**Decision**: ACCEPTED.
+
+### Finding T10 [suggestion]
+**Location**: Track 1, `get()` used in `assertConsistency()` with optimistic reads
+**Issue**: Optimistic read fallback during assertion is fine — not a hot path.
+**Proposed fix**: No change needed.
+**Decision**: No action.

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-2-adversarial.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-2-adversarial.md
@@ -1,0 +1,67 @@
+# Track 2 Adversarial Review
+
+## Findings
+
+### Finding A1 [should-fix]
+**Target**: Decision D3 (Eliminate PageKey from CacheEntry interface)
+**Challenge**: `CacheEntryImpl.equals()` and `hashCode()` delegate to `PageKey`. Plan doesn't explicitly address their rewrite.
+**Evidence**: CacheEntryImpl.java lines 312-325
+**Decision**: Resolved — step 1 rewrites equals/hashCode to use `fileId`/`pageIndex` directly.
+
+### Finding A2 [blocker]
+**Target**: Decision D5 (Frequency sketch keying)
+**Challenge**: Truncating murmur hash to `int` correlates with bucket position (lower 32 bits used for both). `FrequencySketch.spread()` mitigates but doesn't eliminate correlation.
+**Evidence**: `ConcurrentLongIntHashMap.hash()` returns `long`; lower 32 bits index within section. `FrequencySketch` applies seed-based re-hashing.
+**Proposed fix**: Use `Long.hashCode(fileId) * 31 + pageIndex` (independent from map hash, matches spirit of `Objects.hash`). `FrequencySketch.spread()` provides additional decorrelation.
+**Decision**: Resolved — step 1 adds `hashForFrequencySketch` with independent hash function.
+
+### Finding A3 [blocker]
+**Target**: Missing API: `data.values()` iteration
+**Challenge**: `ConcurrentLongIntHashMap` has no `values()`. `clear()` and `assertConsistency()` iterate values. `clear()` throws `StorageException` (unchecked) from within loop.
+**Evidence**: LockFreeReadCache.java line 540, WTinyLFUPolicy.java line 201
+**Decision**: Resolved — collect via `forEachValue` into list, then iterate. `StorageException` propagates through Consumer since it's unchecked.
+
+### Finding A4 [should-fix]
+**Target**: Decision D3 — WTinyLFUPolicyTest rewrite scope
+**Challenge**: "All existing tests must pass without modification (apart from PageKey references)" underestimates scope. 10+ test methods, ~40+ lines, mock hash stubs all need updating.
+**Decision**: Resolved — explicit scope in step 2.
+
+### Finding A5 [should-fix]
+**Target**: Track scope
+**Challenge**: Track combines 6 distinct change areas. Could be split to reduce blast radius.
+**Evidence**: 6 areas listed under "How" in track description
+**Decision**: Partially addressed — 4 steps with compilable intermediates. CacheEntryImpl prep first, interface cleanup last, core swap in middle. Track stays monolithic but step ordering minimizes risk.
+
+### Finding A6 [suggestion]
+**Target**: `size()` return type mismatch (`long` vs `int`)
+**Challenge**: Widening promotion handles it correctly. Cache never exceeds `Integer.MAX_VALUE`.
+**Decision**: No change needed. Documented for implementor awareness.
+
+### Finding A7 [should-fix]
+**Target**: Invariant "Eviction policy consistency" — concurrent re-insertion race
+**Challenge**: With removeByFileId sweeping sections sequentially, a concurrent doLoad could re-insert an entry in an already-swept section. Pre-existing race (current per-page loop has same issue).
+**Evidence**: LockFreeReadCache.java lines 618-652 — current clearFile also vulnerable
+**Decision**: Acknowledged — pre-existing race. clearFile is called during file close/truncate/delete when no new loads should happen. Document precondition in code comment.
+
+### Finding A8 [suggestion]
+**Target**: Invariant "No allocation on read hit path"
+**Challenge**: `boolean[1]` array allocation on miss path. Invariant should say "hit path" not "read path."
+**Decision**: Acknowledged — invariant language is already correct ("read hit path" in plan).
+
+### Finding A9 [blocker]
+**Target**: Assumption: 16 sections sufficient for concurrent I/O workloads
+**Challenge**: CHM uses `N_CPU << 1` concurrency level. 16 sections on 16-core machine = half the concurrency. `doLoad` compute holds section lock during disk I/O.
+**Evidence**: LockFreeReadCache.java line 100 — `new ConcurrentHashMap<>(maxCacheSize, 0.5f, N_CPU << 1)`. ConcurrentLongIntHashMap DEFAULT_SECTION_COUNT = 16.
+**Proposed fix**: Pass `N_CPU << 1` as section count to match existing concurrency level.
+**Decision**: Resolved — step 2 passes `N_CPU << 1` as section count.
+
+### Finding A10 [should-fix]
+**Target**: Assumption: virtual-lock pattern works with new compute()
+**Challenge**: Verified correct — compute() holds write lock during function execution. Absent key + null return = no-op. Same semantics as CHM.
+**Decision**: Confirmed correct. Add code comment documenting the pattern.
+
+### Finding A11 [suggestion]
+**Target**: Steps may not produce compilable intermediate states
+**Challenge**: Changing `data` type breaks all call sites simultaneously. No meaningful partially-migrated state.
+**Evidence**: data field used by ~10 methods across 2 classes
+**Decision**: Addressed — step 1 is purely additive (prep), step 2 is the atomic big-bang swap, step 3 is focused clearFile optimization, step 4 is interface cleanup. Each compiles.

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-2-risk.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-2-risk.md
@@ -1,0 +1,59 @@
+# Track 2 Risk Review
+
+## Findings
+
+### Finding R1 [should-fix]
+**Location**: `clearFile()` overflow check timing
+**Issue**: With bulk `removeByFileId`, all entries are removed first, then overflow checks run. Current code interleaves per-entry removal with overflow checks. Changes flush timing.
+**Decision**: Resolved — addressed in step 3 with explicit testing. The new timing is actually better (reduces cache pressure faster before checking overflow).
+
+### Finding R2 [should-fix]
+**Location**: `assertConsistency()` and `assertSize()` API adaptation
+**Issue**: `assertConsistency()` uses `data.values()` (doesn't exist) and `data.get(cacheEntry.getPageKey())`. `assertSize()` has `long` vs `int` comparison.
+**Decision**: Resolved — rewritten in step 2 using `forEachValue` + `data.get(fileId, pageIndex)`.
+
+### Finding R3 [should-fix]
+**Location**: `hashForFrequencySketch` not exposed publicly; test mock hash values will break
+**Issue**: WTinyLFUPolicyTest sets up mock expectations using `new PageKey(1, 0).hashCode()`. After hash function change, stubs won't match.
+**Decision**: Resolved — hash method added in step 1, test mocks updated in step 2.
+
+### Finding R4 [blocker]
+**Location**: `silentLoadForRead()` and `doLoad()` compute lambdas
+**Issue**: Lambda receives `(long fileId, int pageIndex, CacheEntry entry)` but also captures outer-scope `fileId`/`pageIndex`. Mixing parameters risks silent correctness bugs.
+**Proposed fix**: Consistently use outer-scope captured variables. Add comment explaining they're identical to compute key parameters.
+**Decision**: Resolved — implementor guidance in step 2 description.
+
+### Finding R5 [should-fix]
+**Location**: `LockFreeReadCache.clear()` — needs `forEachValue` adaptation
+**Issue**: `clear()` iterates `data.values()` to freeze entries and call `policy.onRemove()`. Must convert to `forEachValue`.
+**Decision**: Resolved — updated in step 2.
+
+### Finding R6 [should-fix]
+**Location**: `clear()` + `forEachValue` lock ordering
+**Issue**: Window between `forEachValue` (read-locked) and `data.clear()` (write-locked) where entries could be inserted. Pre-existing race, not a regression.
+**Decision**: Acknowledged — note in code comments. No track change.
+
+### Finding R7 [suggestion]
+**Location**: `CacheEntryImpl.equals()`/`hashCode()` — hash value change
+**Issue**: No `HashSet<CacheEntry>` or `HashMap<CacheEntry, ...>` usage found. Reference equality used by new map. Safe to change.
+**Decision**: Verified safe. Rewritten in step 1.
+
+### Finding R8 [should-fix]
+**Location**: `WTinyLFUPolicyTest` rewrite scope
+**Issue**: ~40+ lines of test code need updating. Mechanical but error-prone.
+**Decision**: Resolved — dedicated scope in step 2. Helper methods to reduce duplication.
+
+### Finding R9 [suggestion]
+**Location**: `releaseFromWrite()` virtual lock pattern
+**Issue**: `writeCache.store()` runs under StampedLock write lock. Same behavior as CHM segment lock. No regression.
+**Decision**: Acknowledged — add code comment documenting intentional design.
+
+### Finding R10 [should-fix]
+**Location**: Step ordering — `CacheEntry` interface change atomicity
+**Issue**: Removing `getPageKey()` from interface must happen after all callers updated, or compilation fails.
+**Decision**: Resolved — step 4 is dedicated to interface cleanup + PageKey deletion.
+
+### Finding R11 [suggestion]
+**Location**: `clear()` under `forEachValue` read lock
+**Issue**: Holding section read lock while doing CAS on entries is unnecessary since eviction lock is held.
+**Decision**: Acceptable overhead. Not worth adding a specialized `drainAll()` method for this edge case.

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-2-technical.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-2-technical.md
@@ -1,0 +1,57 @@
+# Track 2 Technical Review
+
+## Findings
+
+### Finding T1 [blocker]
+**Location**: `LockFreeReadCache.clear()` (line 540), `WTinyLFUPolicy.assertConsistency()` (line 201)
+**Issue**: Both iterate `data.values()` which doesn't exist on `ConcurrentLongIntHashMap`. The new map only provides `forEach(LongIntObjConsumer)` and `forEachValue(Consumer<V>)`.
+**Proposed fix**: Use `forEachValue` to collect into a list, then iterate. `StorageException` is unchecked (extends `BaseException` → `RuntimeException`), so it propagates through the consumer.
+**Decision**: Resolved — both sites rewritten to use `forEachValue` + list collection pattern in step 2.
+
+### Finding T2 [blocker]
+**Location**: Step ordering for `getPageKey()` removal
+**Issue**: The lambda body in `releaseFromWrite` uses `cacheEntry.getPageKey()` to extract fileId/pageIndex. If `getPageKey()` is removed before all callers are migrated, compilation fails.
+**Proposed fix**: Remove `getPageKey()` + delete `PageKey` as the very last step, after all callers are updated.
+**Decision**: Resolved — step 4 handles interface cleanup after all callers migrated.
+
+### Finding T3 [should-fix]
+**Location**: `ConcurrentLongIntHashMap` — `hash()` is package-private `long`, frequency sketch needs public `int`
+**Issue**: Track 1's `hash()` is package-private and returns `long`. The frequency sketch needs a public `int` hash. Using truncated murmur would correlate with bucket position (see A2).
+**Proposed fix**: Add `public static int hashForFrequencySketch(long, int)` using an independent hash.
+**Decision**: Resolved — added in step 1 using `Long.hashCode(fileId) * 31 + pageIndex`.
+
+### Finding T4 [should-fix]
+**Location**: `WTinyLFUPolicy.assertSize()`, `assertConsistency()`
+**Issue**: `ConcurrentLongIntHashMap.size()` returns `long` vs CHM's `int`. Comparisons with `int` counters auto-widen safely.
+**Decision**: Acknowledged — no code change needed, documented for implementor awareness.
+
+### Finding T5 [should-fix]
+**Location**: `CacheEntryImpl.equals()` and `hashCode()` (lines 312-325)
+**Issue**: Both delegate to `PageKey` which is being removed. Must be rewritten to use `fileId` and `pageIndex` directly.
+**Decision**: Resolved — rewritten in step 1 as prep.
+
+### Finding T6 [should-fix]
+**Location**: `WTinyLFUPolicyTest` — ~10 test methods with ~40+ lines of PageKey usage
+**Issue**: Extensive test rewrite needed — map construction, put/remove calls, and admittor mock hash stubs all reference PageKey.
+**Decision**: Resolved — included in step 2 scope.
+
+### Finding T7 [should-fix]
+**Location**: `silentLoadForRead()` compute lambda
+**Issue**: Mixed usage of lambda parameters vs captured outer variables for fileId/pageIndex.
+**Proposed fix**: Use outer-scope captured variables consistently (guaranteed identical to compute key).
+**Decision**: Resolved — implementor guidance added to step 2 description.
+
+### Finding T8 [suggestion]
+**Location**: `LockFreeReadCache` constructor, section count
+**Issue**: Current CHM concurrency level is `N_CPU << 1`, new map defaults to 16 sections.
+**Decision**: Resolved — pass `N_CPU << 1` as section count (see A9).
+
+### Finding T9 [suggestion]
+**Location**: `clearFile()` bulk-then-process pattern
+**Issue**: If `freeze()` fails mid-iteration of removeByFileId results, remaining entries are already removed from map but won't get `onRemove()`. Same issue exists in current code but with narrower window.
+**Decision**: Acknowledged — `freeze()` failure throws fatal `StorageException`. Documented as pre-existing behavior.
+
+### Finding T10 [suggestion]
+**Location**: `CacheEntryChanges.getPageKey()` removal
+**Issue**: Confirmed safe — no external callers beyond the chm package.
+**Decision**: No action needed.

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-3-risk.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-3-risk.md
@@ -1,0 +1,54 @@
+# Track 3 Risk Review
+
+## Findings
+
+### Finding R1 [should-fix]
+**Location**: Track 3 Step 1 — optimistic read fallback path under sustained writes
+**Issue**: When `tryOptimisticRead()` returns 0 (writer active), the fallback to read lock must remain correct. Test should force frequent fallbacks with sustained high write rates.
+**Proposed fix**: Include a slow `compute()` variant that holds write lock longer, forcing readers through the read-lock fallback path consistently.
+**Decision**: Accepted — fold into compute stress scenario.
+
+### Finding R2 [should-fix]
+**Location**: Track 3 "clearFile under concurrent load" — `clearFile()`/`doLoad()` race
+**Issue**: Comment at line 630-634 documents pre-existing race: `doLoad` can re-insert entries after `removeByFileId` completes. Asserting "zero entries" while concurrent loaders run will flake.
+**Proposed fix**: Split into: (1) clearFile with concurrent reads on different files (verify isolation); (2) clearFile with concurrent reads on same file (expect re-insertion, verify second clear works).
+**Decision**: Accepted — important for test correctness.
+
+### Finding R3 [should-fix]
+**Location**: Track 3 — `removeByFileId` write lock hold time
+**Issue**: `removeByFileId` + `rehashSameCapacity()` holds write lock for O(segment-capacity) work. Stress test should observe whether this causes unacceptable p99 read latency.
+**Proposed fix**: Add latency measurement as optional observation, not hard assertion.
+**Decision**: Noted — useful observation but not a hard test requirement. Defer to future optimization if needed.
+
+### Finding R4 [suggestion]
+**Location**: Track 3 — `compute()` holding segment write lock during I/O
+**Issue**: `doLoad()` calls `writeCache.load()` inside `compute()` lambda, holding the segment write lock. This is broader than CHM's per-bin lock.
+**Proposed fix**: Include slow-compute stress variant.
+**Decision**: Accepted — aligns with R1.
+
+### Finding R5 [suggestion]
+**Location**: Track 3 — `ConcurrentTestHelper` usage
+**Issue**: 30-minute timeout, not matching existing cache test patterns.
+**Proposed fix**: Use raw `ExecutorService` + `Future.get(timeout)`.
+**Decision**: Accepted — aligns with T1.
+
+### Finding R6 [suggestion]
+**Location**: Track 3 — rehash test key space bounds
+**Issue**: Unbounded inserts could cause OOM during rehash stress test.
+**Proposed fix**: Use bounded key space (~10K unique keys) with mix of inserts and removes.
+**Decision**: Accepted.
+
+### Finding R7 [blocker]
+**Location**: Track 3 — test placement and CI flakiness
+**Issue**: Integrated cache-level stress tests are nondeterministic. If named as unit tests, they run on every PR and may cause false CI failures.
+**Proposed fix**: Map-level concurrent tests as regular unit tests (fast, reasonably deterministic). Integrated cache-level tests as `*IT` with `@Category(SequentialTest.class)`.
+**Decision**: Accepted.
+
+### Finding R8 [suggestion]
+**Location**: Track 3 — coverage gate
+**Issue**: Track 3 adds no production code; coverage gate is N/A.
+**Proposed fix**: Note explicitly that coverage gate doesn't apply.
+**Decision**: Noted.
+
+## Summary
+Key risks addressed: (1) R2 — clearFile race makes naive assertions flaky, split test scenarios; (2) R7 — integrated tests must be `*IT` for CI stability. All other findings accepted as test design improvements.

--- a/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-3-technical.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/reviews/track-3-technical.md
@@ -1,0 +1,48 @@
+# Track 3 Technical Review
+
+## Findings
+
+### Finding T1 [should-fix]
+**Location**: Track 3 constraint "use ConcurrentTestHelper" + `ConcurrentTestHelper.java`
+**Issue**: `ConcurrentTestHelper` has a hardcoded 30-minute timeout and is designed for N identical workers. The track's mixed reader/writer/remover scenarios are a better fit for direct `ExecutorService` + `Future.get(timeout)`, matching the existing `AsyncReadCacheTestIT` pattern.
+**Proposed fix**: Use raw `ExecutorService` + `Future.get(30, SECONDS)` pattern. Do not use `ConcurrentTestHelper`.
+**Decision**: Accepted.
+
+### Finding T2 [should-fix]
+**Location**: Track 3 "clearFile under concurrent load" + `LockFreeReadCache.clearFile()` (private method)
+**Issue**: `clearFile()` is private. The public API paths (`deleteStorage`/`closeStorage`) clear ALL files, not a single file. To test concurrent single-file removal, must use `removeByFileId()` directly at the map level (which is public).
+**Proposed fix**: Test `removeByFileId` at map level for concurrent correctness. Integration test uses `deleteStorage` for single-threaded post-condition verification.
+**Decision**: Accepted. Restructures the integrated test.
+
+### Finding T3 [suggestion]
+**Location**: Track 3 "Map-level concurrent tests" test placement
+**Issue**: Existing `ConcurrentLongIntHashMapTest.java` is 1688 lines of single-threaded tests. Concurrent stress tests warrant a separate class.
+**Proposed fix**: Create `ConcurrentLongIntHashMapConcurrentTest.java` in the same package.
+**Decision**: Accepted.
+
+### Finding T4 [should-fix]
+**Location**: Track 3 "Rehash under concurrent access" + `Section.rehashTo()`
+**Issue**: Test needs small initial capacity and minimal section count to maximize rehash frequency and race windows.
+**Proposed fix**: Use `new ConcurrentLongIntHashMap<>(4, 1)` (1 section, minimal capacity) for rehash stress tests.
+**Decision**: Accepted.
+
+### Finding T5 [suggestion]
+**Location**: Track 3 overall — iteration count guidance
+**Issue**: No guidance on iteration counts for <30s runtime target.
+**Proposed fix**: ~100K-500K operations per thread for map-level tests (5-15s runtime), scaled down for integrated tests.
+**Decision**: Accepted.
+
+### Finding T6 [suggestion]
+**Location**: Track 3 "Map-level concurrent tests" operation mix
+**Issue**: `compute()` not mentioned in the concurrent operation mix, but it's used as a virtual lock in `LockFreeReadCache`.
+**Proposed fix**: Include `compute()` alongside `get/put/remove/computeIfAbsent` in mixed operation tests.
+**Decision**: Accepted.
+
+### Finding T7 [blocker]
+**Location**: Track 3 "clearFile under concurrent load" — no public API for single-file clear
+**Issue**: `clearFile` is private; only bulk `deleteStorage`/`closeStorage` are public. Cannot test single-file concurrent removal at integrated level.
+**Proposed fix**: Map-level `removeByFileId` for concurrent correctness; integration `deleteStorage` for correctness.
+**Decision**: Accepted. Same resolution as T2.
+
+## Summary
+All findings accepted. The key restructuring: test `removeByFileId` concurrency at the map level (public API), and use `deleteStorage` for integrated-level correctness checks. Use raw `ExecutorService` pattern, separate test class for concurrent tests.

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -3,7 +3,7 @@
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation (5/5 complete)
-- [ ] Track-level code review
+- [x] Track-level code review (2/3 iterations — all PASS)
 
 ## Base commit
 `a3bf557`

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation
+- [ ] Step implementation (1/5 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -36,21 +36,22 @@ Key decisions from reviews that affect step implementation:
 
 ## Steps
 
-- [ ] Step 1: Class skeleton, Section with StampedLock composition, hash function, and get()
-  > Create `ConcurrentLongIntHashMap<V>` in `core/.../internal/common/collection/` with:
-  > - Class skeleton with constructor (expectedItems, concurrencyLevel/sectionCount)
-  > - Nested functional interfaces: `LongIntFunction<R>`, `LongIntObjConsumer<T>`,
-  >   `LongIntKeyValueFunction<V>`
-  > - `Section` as private static inner class with StampedLock composition (not inheritance)
-  > - Per-section parallel arrays: `long[] fileIds`, `int[] pageIndices`, `V[] values`
-  > - Murmur3-style hash mixing both fileId and pageIndex
-  > - `get(long fileId, int pageIndex)` with optimistic read + single read-lock fallback
-  > - `size()`, `isEmpty()`, `capacity()`
-  > - Apache 2.0 attribution header from BookKeeper
-  > - Unit tests: get on empty map, get with fileId=0/pageIndex=0, size/isEmpty on empty map,
-  >   hash distribution sanity test
+- [x] Step 1: Class skeleton, Section with StampedLock composition, hash function, and get()
+  > **What was done:** Created `ConcurrentLongIntHashMap<V>` with class skeleton, Section
+  > inner class (StampedLock composition), Murmur3 hash mixing both key fields, get() with
+  > optimistic read + read-lock fallback, size/isEmpty/capacity, three nested functional
+  > interfaces, and Apache 2.0 attribution header. 22 unit tests covering constructors,
+  > get on empty map, hash distribution (fileIds and pageIndices separately), edge cases
+  > (zero/negative/extreme keys), and alignToPowerOfTwo with overflow boundary.
   >
-  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+  > **What was discovered:** Optimistic read correctness requires snapshotting all mutable
+  > fields (array refs + capacity) to locals after the stamp, before the probe loop — reading
+  > fields directly would allow stale reads to pass validation after a concurrent resize.
+  > Also, alignToPowerOfTwo overflows to Integer.MIN_VALUE for n > 2^30 — added an explicit
+  > guard. LongIntKeyValueFunction type param renamed from V to T to avoid shadowing the
+  > outer class type parameter.
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java` (new), `ConcurrentLongIntHashMapTest.java` (new)
 
 - [ ] Step 2: put(), putIfAbsent(), computeIfAbsent()
   > Implement write operations:

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (3/5 complete)
+- [ ] Step implementation (4/5 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -84,19 +84,23 @@ Key decisions from reviews that affect step implementation:
   >
   > **Key files:** `ConcurrentLongIntHashMap.java` (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
-- [ ] Step 4: removeByFileId() with tombstone compaction
-  > Implement bulk removal:
-  > - `removeByFileId(long fileId)` — linear sweep per segment under write lock
-  > - Collects removed entries into a list, returns `List<V>` after lock release
-  >   (deferred consumer model — caller processes entries outside segment lock)
-  > - After sweep, if tombstone ratio exceeds threshold (usedBuckets - size > capacity/4),
-  >   perform same-capacity rehash for compaction (T3/R4/A7)
-  > - Unit tests: removeByFileId with interleaved entries from multiple files (verify only
-  >   target file removed), removeByFileId returns correct entries, tombstone compaction
-  >   triggers correctly, usedBuckets == size after compaction, removeByFileId on empty
-  >   map, removeByFileId for non-existent fileId
+- [x] Step 4: removeByFileId() with same-capacity rehash compaction
+  > **What was done:** Implemented removeByFileId(long) sweeping each section linearly
+  > under write lock. Matching entries collected into returned List<V> (deferred consumer
+  > model). After sweep, always performs same-capacity rehash to restore probe chain
+  > integrity. 12 new tests (76 total) covering: only target file removed, correct values
+  > returned, empty map, non-existent fileId, compaction with interleaved entries,
+  > reinsertion after removal, many entries across sections, fileId=0 edge case,
+  > remove-all-then-fill to threshold, consecutive calls, repeated cycles, idempotent
+  > double-removal.
   >
-  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+  > **What changed from the plan:** Plan specified conditional compaction (tombstone ratio
+  > threshold). Implemented unconditional same-capacity rehash instead — simpler and
+  > always correct since removeByFileId uses bulk nullification (not backward-sweep per
+  > entry), leaving gaps that must be compacted. The cost is acceptable since
+  > removeByFileId is called on file close/truncate/delete, not a latency-sensitive path.
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java` (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
 - [ ] Step 5: resize, shrink, clear, forEach, forEachValue, and remaining unit tests
   > Complete the API and comprehensive testing:

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -6,6 +6,7 @@
 - [ ] Track-level code review
 
 ## Base commit
+`a3bf557`
 
 ## Reviews completed
 - [x] Technical

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (1/5 complete)
+- [ ] Step implementation (2/5 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -53,19 +53,20 @@ Key decisions from reviews that affect step implementation:
   >
   > **Key files:** `ConcurrentLongIntHashMap.java` (new), `ConcurrentLongIntHashMapTest.java` (new)
 
-- [ ] Step 2: put(), putIfAbsent(), computeIfAbsent()
-  > Implement write operations:
-  > - `put(long fileId, int pageIndex, V value)` — insert or update, returns previous value
-  > - `putIfAbsent(long fileId, int pageIndex, V value)` — returns existing or inserts new
-  > - `computeIfAbsent(long fileId, int pageIndex, LongIntFunction<V> mappingFunction)`
-  > - Write ordering: value written before key fields in array slots (A2)
-  > - Null value disallowed (IllegalArgumentException)
-  > - Auto-resize when `usedBuckets > capacity * fillFactor` (default 0.66)
-  > - Unit tests: basic put/get roundtrip, putIfAbsent when present/absent, computeIfAbsent
-  >   when present/absent, null value rejection, fileId=0 and pageIndex=0 as valid keys,
-  >   resize trigger verification
+- [x] Step 2: put(), putIfAbsent(), computeIfAbsent()
+  > **What was done:** Implemented put/putIfAbsent/computeIfAbsent with auto-resize
+  > (66% fill factor, capacity doubling). Write ordering: value before keys. Null value
+  > rejection. 23 new tests (45 total) covering roundtrips, replacement, probe chains
+  > (same fileId/different pageIndex), negative keys, exact resize threshold, resize
+  > via computeIfAbsent, many-pages-same-file pattern, function-throws consistency.
   >
-  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+  > **What was discovered:** Code review identified 3x probe loop duplication —
+  > extracted into `probeForKey()` returning bitwise-encoded result. Also found that
+  > `findEmptySlot` redundantly recomputed the hash — now passes hashMix through
+  > insertAt. Added rehash overflow guard for capacity >= 2^30 and defensive assertion
+  > for probe loop invariant (firstEmpty must be non-negative).
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java` (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
 - [ ] Step 3: compute(), remove(), conditional remove()
   > Implement mutation operations:

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (4/5 complete)
+- [x] Step implementation (5/5 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -102,16 +102,17 @@ Key decisions from reviews that affect step implementation:
   >
   > **Key files:** `ConcurrentLongIntHashMap.java` (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
-- [ ] Step 5: resize, shrink, clear, forEach, forEachValue, and remaining unit tests
-  > Complete the API and comprehensive testing:
-  > - Explicit `shrink()` method (available but not called automatically)
-  > - `clear()` — reset all sections
-  > - `forEach(LongIntObjConsumer<V>)` — iterates all entries under read locks
-  > - `forEachValue(Consumer<V>)` — value-only iteration (T5/A5)
-  > - Doc comment on `compute()` warning about lock-held execution (T9)
-  > - Unit tests: resize with many entries (verify all entries survive), shrink reduces
-  >   capacity, clear resets size to 0, forEach visits all entries, forEachValue visits
-  >   all values, concurrent rehash + get correctness (basic — full stress in Track 3),
-  >   large map with many sections, edge case: single-section map
+- [x] Step 5: resize, shrink, clear, forEach, forEachValue, and remaining unit tests
+  > **What was done:** Completed the API: clear() under write locks, forEach/forEachValue
+  > under read locks, shrink() reducing capacity to fit current entries. Added lock-held
+  > warning Javadoc to computeIfAbsent (T9). 15 new tests (91 total) covering clear with
+  > reinsertion, forEach/forEachValue, shrink (basic, empty, no-op, after bulk removal),
+  > clear+shrink, forEach after mutations, shrink-then-insert resize, 1000-entry resize
+  > survival, large map with 16 sections.
   >
-  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+  > **What was discovered:** Code review found rehash logic duplicated 3x across rehash(),
+  > rehashSameCapacity(), and shrink(). Extracted into shared rehashTo(int newCapacity)
+  > method, eliminating ~40 duplicated lines. Also fixed Consumer import (was FQN inline)
+  > and shrink() Javadoc (was incorrectly describing caller-held lock).
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java` (modified), `ConcurrentLongIntHashMapTest.java` (modified)

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (2/5 complete)
+- [ ] Step implementation (3/5 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -68,23 +68,21 @@ Key decisions from reviews that affect step implementation:
   >
   > **Key files:** `ConcurrentLongIntHashMap.java` (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
-- [ ] Step 3: compute(), remove(), conditional remove()
-  > Implement mutation operations:
-  > - `compute(long fileId, int pageIndex, LongIntKeyValueFunction<V> fn)` with:
-  >   - Passes caller-supplied fileId/pageIndex to remapping function (R8)
-  >   - Null return on absent key = no-op (R1/T2)
-  >   - Null return on present key = removal (R1/T2)
-  >   - Holds segment write lock during function execution
-  > - `remove(long fileId, int pageIndex)` — returns removed value or null
-  > - `remove(long fileId, int pageIndex, V expected)` — conditional remove using
-  >   reference equality `==` (T7), returns boolean
-  > - Backward-sweep tombstone cleanup after individual removal
-  > - Unit tests: compute on absent key with null return (no-op), compute on present key
-  >   with null return (removal), compute with side effects under lock, remove returning
-  >   previous value, conditional remove with same reference (succeeds), conditional remove
-  >   with equals-but-different reference (fails), probe-through-tombstone after removal (R9)
+- [x] Step 3: compute(), remove(), conditional remove()
+  > **What was done:** Implemented compute() with full ConcurrentHashMap semantics (4 branches),
+  > remove() returning previous value, conditional remove with reference equality (==), and
+  > backward-sweep compaction in removeAt() — eliminates tombstones by shifting displaced
+  > entries back to fill gaps. 19 new tests (64 total) including all compute branches, probe
+  > chain integrity after removal, drain-all-entries in non-sequential order, single-entry
+  > removal with reinsert, compute resize, function-throws consistency, (0,0) key lifecycle.
   >
-  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+  > **What was discovered:** Bugs & concurrency review verified the backward-sweep algorithm
+  > (isBetween circular distance formula) is correct with no issues. Code quality review
+  > noted the terminology should be "backward-sweep compaction" not "tombstone cleanup"
+  > since the algorithm prevents tombstones entirely. removeAt does not need hashMix
+  > parameter — it recomputes hash for each candidate entry in the sweep.
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java` (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
 - [ ] Step 4: removeByFileId() with tombstone compaction
   > Implement bulk removal:

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-1.md
@@ -1,0 +1,112 @@
+# Track 1: ConcurrentLongIntHashMap — Core Data Structure
+
+## Progress
+- [x] Review + decomposition
+- [ ] Step implementation
+- [ ] Track-level code review
+
+## Base commit
+
+## Reviews completed
+- [x] Technical
+- [x] Risk
+- [x] Adversarial
+
+## Review decisions summary
+
+Key decisions from reviews that affect step implementation:
+
+1. **compute() null-return semantics** (T2/R1 — blocker): Must match ConcurrentHashMap.compute()
+   contract. Absent key + null return = no-op. Present key + null return = removal. Add unit tests.
+2. **compute() passes caller-supplied keys** (R8 — blocker): For absent keys, pass the
+   caller's fileId/pageIndex to the remapping function, NOT array contents.
+3. **Conditional remove uses reference equality** (T7 — blocker): `remove(fileId, pageIndex, expected)`
+   uses `==` not `equals()` for value comparison. Add test.
+4. **removeByFileId tombstone compaction** (T3/R4/A7): After bulk sweep, if tombstones exceed
+   threshold, do same-capacity rehash. Add unit test.
+5. **Configurable segment count** (R7/A10): Constructor takes segment count parameter. Default 16.
+6. **Composition over inheritance** (A11/T6): Section has-a StampedLock, not extends.
+7. **forEachValue(Consumer)** (T5/A5): Add value-only iteration alongside forEach.
+8. **Write ordering** (A2): In put(), value written before key fields. Document in code.
+9. **Functional interfaces nested** (T8): Nest LongIntFunction, LongIntObjConsumer,
+   LongIntKeyValueFunction inside ConcurrentLongIntHashMap.
+10. **hashForFrequencySketch moved to Track 2** (A13/T4): Not in Track 1 scope.
+11. **removeByFileId last** (A4): Implement after all base operations pass tests.
+
+## Steps
+
+- [ ] Step 1: Class skeleton, Section with StampedLock composition, hash function, and get()
+  > Create `ConcurrentLongIntHashMap<V>` in `core/.../internal/common/collection/` with:
+  > - Class skeleton with constructor (expectedItems, concurrencyLevel/sectionCount)
+  > - Nested functional interfaces: `LongIntFunction<R>`, `LongIntObjConsumer<T>`,
+  >   `LongIntKeyValueFunction<V>`
+  > - `Section` as private static inner class with StampedLock composition (not inheritance)
+  > - Per-section parallel arrays: `long[] fileIds`, `int[] pageIndices`, `V[] values`
+  > - Murmur3-style hash mixing both fileId and pageIndex
+  > - `get(long fileId, int pageIndex)` with optimistic read + single read-lock fallback
+  > - `size()`, `isEmpty()`, `capacity()`
+  > - Apache 2.0 attribution header from BookKeeper
+  > - Unit tests: get on empty map, get with fileId=0/pageIndex=0, size/isEmpty on empty map,
+  >   hash distribution sanity test
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+
+- [ ] Step 2: put(), putIfAbsent(), computeIfAbsent()
+  > Implement write operations:
+  > - `put(long fileId, int pageIndex, V value)` — insert or update, returns previous value
+  > - `putIfAbsent(long fileId, int pageIndex, V value)` — returns existing or inserts new
+  > - `computeIfAbsent(long fileId, int pageIndex, LongIntFunction<V> mappingFunction)`
+  > - Write ordering: value written before key fields in array slots (A2)
+  > - Null value disallowed (IllegalArgumentException)
+  > - Auto-resize when `usedBuckets > capacity * fillFactor` (default 0.66)
+  > - Unit tests: basic put/get roundtrip, putIfAbsent when present/absent, computeIfAbsent
+  >   when present/absent, null value rejection, fileId=0 and pageIndex=0 as valid keys,
+  >   resize trigger verification
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+
+- [ ] Step 3: compute(), remove(), conditional remove()
+  > Implement mutation operations:
+  > - `compute(long fileId, int pageIndex, LongIntKeyValueFunction<V> fn)` with:
+  >   - Passes caller-supplied fileId/pageIndex to remapping function (R8)
+  >   - Null return on absent key = no-op (R1/T2)
+  >   - Null return on present key = removal (R1/T2)
+  >   - Holds segment write lock during function execution
+  > - `remove(long fileId, int pageIndex)` — returns removed value or null
+  > - `remove(long fileId, int pageIndex, V expected)` — conditional remove using
+  >   reference equality `==` (T7), returns boolean
+  > - Backward-sweep tombstone cleanup after individual removal
+  > - Unit tests: compute on absent key with null return (no-op), compute on present key
+  >   with null return (removal), compute with side effects under lock, remove returning
+  >   previous value, conditional remove with same reference (succeeds), conditional remove
+  >   with equals-but-different reference (fails), probe-through-tombstone after removal (R9)
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+
+- [ ] Step 4: removeByFileId() with tombstone compaction
+  > Implement bulk removal:
+  > - `removeByFileId(long fileId)` — linear sweep per segment under write lock
+  > - Collects removed entries into a list, returns `List<V>` after lock release
+  >   (deferred consumer model — caller processes entries outside segment lock)
+  > - After sweep, if tombstone ratio exceeds threshold (usedBuckets - size > capacity/4),
+  >   perform same-capacity rehash for compaction (T3/R4/A7)
+  > - Unit tests: removeByFileId with interleaved entries from multiple files (verify only
+  >   target file removed), removeByFileId returns correct entries, tombstone compaction
+  >   triggers correctly, usedBuckets == size after compaction, removeByFileId on empty
+  >   map, removeByFileId for non-existent fileId
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`
+
+- [ ] Step 5: resize, shrink, clear, forEach, forEachValue, and remaining unit tests
+  > Complete the API and comprehensive testing:
+  > - Explicit `shrink()` method (available but not called automatically)
+  > - `clear()` — reset all sections
+  > - `forEach(LongIntObjConsumer<V>)` — iterates all entries under read locks
+  > - `forEachValue(Consumer<V>)` — value-only iteration (T5/A5)
+  > - Doc comment on `compute()` warning about lock-held execution (T9)
+  > - Unit tests: resize with many entries (verify all entries survive), shrink reduces
+  >   capacity, clear resets size to 0, forEach visits all entries, forEachValue visits
+  >   all values, concurrent rehash + get correctness (basic — full stress in Track 3),
+  >   large map with many sections, edge case: single-section map
+  >
+  > **Key files:** `ConcurrentLongIntHashMap.java`, `ConcurrentLongIntHashMapTest.java`

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (2/4 complete)
+- [ ] Step implementation (3/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -82,25 +82,22 @@ Key decisions from reviews that affect step implementation:
   > **Key files:** `LockFreeReadCache.java` (modified), `WTinyLFUPolicy.java` (modified),
   > `WTinyLFUPolicyTest.java` (modified)
 
-- [ ] Step 3: clearFile → removeByFileId integration
-  > **Files:** `LockFreeReadCache.java`
+- [x] Step 3: clearFile → removeByFileId integration
+  > **What was done:** Replaced clearFile() per-page loop with
+  > `data.removeByFileId(fileId)` bulk sweep. Post-removal processing (freeze,
+  > onRemove, checkCacheOverflow) runs after segment locks released. Removed
+  > `filledUpTo` parameter from clearFile and all callers (truncateFile,
+  > closeFile, deleteFile, deleteStorage, closeStorage). Simplified deleteStorage
+  > and closeStorage — no longer pre-collect filledUpTo into RawPairLongInteger
+  > lists. Removed unused RawPairLongInteger and List imports.
   >
-  > Replace the per-page loop in `clearFile()` with `data.removeByFileId(fileId)`.
-  > Process returned `List<CacheEntry>` entries under eviction lock: for each entry,
-  > call `freeze()` (throws `StorageException` if in use — preserving current failure
-  > mode), `policy.onRemove()`, `cacheSize.decrementAndGet()`, and
-  > `writeCache.checkCacheOverflow()`.
+  > **What was discovered:** Removing the `filledUpTo` parameter was a natural
+  > consequence — removeByFileId finds all entries by file regardless of page
+  > count. The semantic change (remove ALL vs only 0..filledUpTo) is safe because
+  > the cache only contains entries for pages that exist. Review confirmed no
+  > new bugs; partial failure behavior during post-removal freeze is pre-existing.
   >
-  > This changes the removal pattern from O(filledUpTo) hash probes (most misses) to
-  > O(segment-capacity) linear sweep per segment. All entries removed in bulk, then
-  > processed sequentially (review decision #8 — overflow check timing change is
-  > acceptable).
-  >
-  > Add code comment documenting: (a) entries processed after segment lock release
-  > to avoid StampedLock reentrancy deadlock, (b) concurrent re-insertion precondition
-  > — clearFile assumes no concurrent doLoad for the same fileId (review decision #9).
-  >
-  > **Compiles, all tests pass.** Focused single-method optimization.
+  > **Key files:** `LockFreeReadCache.java` (modified)
 
 - [ ] Step 4: CacheEntry interface cleanup + PageKey deletion
   > **Files:** `CacheEntry.java`, `CacheEntryImpl.java`,

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (1/4 complete)
+- [ ] Step implementation (2/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -64,61 +64,23 @@ Key decisions from reviews that affect step implementation:
   > **Key files:** `CacheEntryImpl.java` (modified), `ConcurrentLongIntHashMap.java`
   > (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
-- [ ] Step 2: Core swap — data field type + LockFreeReadCache + WTinyLFUPolicy + tests
-  > **Files:** `LockFreeReadCache.java`, `WTinyLFUPolicy.java`,
-  > `WTinyLFUPolicyTest.java`
+- [x] Step 2: Core swap — data field type + LockFreeReadCache + WTinyLFUPolicy + tests
+  > **What was done:** Atomic big-bang swap of `ConcurrentHashMap<PageKey, CacheEntry>`
+  > to `ConcurrentLongIntHashMap<CacheEntry>` in LockFreeReadCache and WTinyLFUPolicy.
+  > All call sites updated: doLoad(), silentLoadForRead(), addNewPagePointerToTheCache(),
+  > releaseFromWrite(), clear(), clearFile(). WTinyLFUPolicy: constructor, onAccess(),
+  > onAdd(), purgeEden(), assertConsistency() all migrated. WTinyLFUPolicyTest: all 12
+  > test methods updated (PageKey → primitive API, mock stubs use hashForFrequencySketch).
+  > clearFile() still uses per-page loop — removeByFileId deferred to Step 3.
   >
-  > This is the atomic big-bang swap — changing `data` type breaks all call sites
-  > simultaneously, so all must be updated in one commit.
+  > **What was discovered:** Review found critical bug: `N_CPU << 1` is not guaranteed
+  > to be a power of two (e.g., 6 CPUs → 12), but `ConcurrentLongIntHashMap` requires
+  > power-of-two section count. Fixed by wrapping with `ceilingPowerOfTwo()`. The plan's
+  > review decision #5 incorrectly stated "constructor aligns to power of two internally"
+  > — it only aligns per-section capacity, not section count.
   >
-  > **LockFreeReadCache changes:**
-  > - Replace `data` field: `ConcurrentHashMap<PageKey, CacheEntry>` →
-  >   `ConcurrentLongIntHashMap<CacheEntry>`
-  > - Update constructor: `new ConcurrentLongIntHashMap<>(maxCacheSize, N_CPU << 1)`
-  >   (review decision #5 — match CHM concurrency level)
-  > - `doLoad()` (line 217): remove `new PageKey(...)`, use `data.get(fileId, pageIndex)`
-  >   and `data.compute(fileId, pageIndex, fn)`. In compute lambda, use outer-scope
-  >   captured variables consistently (review decision #3). Add comment explaining
-  >   lambda parameters are identical to captured variables.
-  > - `silentLoadForRead()` (line 159): same pattern as doLoad
-  > - `addNewPagePointerToTheCache()` (line 307): use
-  >   `data.putIfAbsent(entry.getFileId(), entry.getPageIndex(), entry)`
-  > - `releaseFromWrite()` (line 349): use
-  >   `data.compute(entry.getFileId(), entry.getPageIndex(), fn)`. Add comment
-  >   documenting virtual-lock pattern (review decision #10).
-  > - `clear()` (line 540): collect entries via `data.forEachValue()` into a list,
-  >   then iterate for freeze/onRemove/clear. `StorageException` is unchecked and
-  >   propagates through Consumer (review decision #1).
-  > - `clearFile()` (line 625): temporarily keep per-page loop pattern using
-  >   `data.remove(fileId, pageIndex)` — removeByFileId deferred to step 3.
-  >   Remove `new PageKey(...)` allocation.
-  > - `size()` returns `long` from new map — auto-widens safely (review decision T4).
-  >
-  > **WTinyLFUPolicy changes:**
-  > - Constructor: accept `ConcurrentLongIntHashMap<CacheEntry>` instead of
-  >   `ConcurrentHashMap<PageKey, CacheEntry>`
-  > - `onAccess()` (line 58): replace `cacheEntry.getPageKey().hashCode()` with
-  >   `ConcurrentLongIntHashMap.hashForFrequencySketch(cacheEntry.getFileId(), cacheEntry.getPageIndex())`
-  > - `onAdd()` (line 83): same hash replacement
-  > - `purgeEden()` (lines 110-111, 121, 137): replace `getPageKey().hashCode()` for
-  >   frequency comparisons, replace `data.remove(victim.getPageKey(), victim)` with
-  >   `data.remove(victim.getFileId(), victim.getPageIndex(), victim)`
-  > - `assertConsistency()` (line 201): replace `data.values()` iteration with
-  >   `forEachValue` collection pattern. Replace `data.get(cacheEntry.getPageKey())`
-  >   with `data.get(cacheEntry.getFileId(), cacheEntry.getPageIndex())`
-  > - `assertSize()` (line 197): `data.size()` returns `long` — comparison auto-widens
-  >
-  > **WTinyLFUPolicyTest changes:**
-  > - Replace all `ConcurrentHashMap<PageKey, CacheEntry>` with
-  >   `ConcurrentLongIntHashMap<CacheEntry>`
-  > - Replace all `data.put(new PageKey(f, p), entry)` with `data.put(f, p, entry)`
-  > - Replace all `data.remove(new PageKey(f, p), entry)` with
-  >   `data.remove(f, p, entry)`
-  > - Replace all mock stubs `admittor.frequency(new PageKey(f, p).hashCode())` with
-  >   `admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(f, p))`
-  > - Remove PageKey import
-  >
-  > **Compiles, all tests pass.** Every changed call site updated atomically.
+  > **Key files:** `LockFreeReadCache.java` (modified), `WTinyLFUPolicy.java` (modified),
+  > `WTinyLFUPolicyTest.java` (modified)
 
 - [ ] Step 3: clearFile → removeByFileId integration
   > **Files:** `LockFreeReadCache.java`

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -1,0 +1,17 @@
+# Track 2: Integration into LockFreeReadCache and WTinyLFUPolicy
+
+## Progress
+- [ ] Review + decomposition
+- [ ] Step implementation
+- [ ] Track-level code review
+
+## Base commit
+_(to be written at Phase B start)_
+
+## Reviews completed
+- [x] Technical
+- [x] Risk
+- [x] Adversarial
+
+## Steps
+_(to be decomposed after reviews)_

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (3/4 complete)
+- [x] Step implementation (4/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -99,18 +99,12 @@ Key decisions from reviews that affect step implementation:
   >
   > **Key files:** `LockFreeReadCache.java` (modified)
 
-- [ ] Step 4: CacheEntry interface cleanup + PageKey deletion
-  > **Files:** `CacheEntry.java`, `CacheEntryImpl.java`,
-  > `CacheEntryChanges.java`, `PageKey.java` (deleted)
+- [x] Step 4: CacheEntry interface cleanup + PageKey deletion
+  > **What was done:** Removed `getPageKey()` from CacheEntry interface,
+  > CacheEntryImpl, and CacheEntryChanges. Removed `pageKey` field and
+  > `new PageKey(...)` allocation from CacheEntryImpl constructor. Removed
+  > PageKey imports from all three files. Deleted `chm/PageKey.java`.
+  > The `local.PageKey` used by WOWCache is unaffected.
   >
-  > - Remove `getPageKey()` from `CacheEntry` interface (line 111)
-  > - Remove `getPageKey()` from `CacheEntryImpl` (lines 328-330)
-  > - Remove `pageKey` field from `CacheEntryImpl` (line 57), remove
-  >   `new PageKey(...)` from constructor (line 77)
-  > - Remove `getPageKey()` from `CacheEntryChanges` (lines 223-225)
-  > - Remove `PageKey` imports from CacheEntry, CacheEntryImpl, CacheEntryChanges
-  > - Delete `chm/PageKey.java`
-  >
-  > All callers were migrated in steps 1-3 so no `getPageKey()` references remain.
-  >
-  > **Compiles, all tests pass.** Pure cleanup/deletion step.
+  > **Key files:** `CacheEntry.java` (modified), `CacheEntryImpl.java` (modified),
+  > `CacheEntryChanges.java` (modified), `PageKey.java` (deleted)

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation
+- [ ] Step implementation (1/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -47,25 +47,22 @@ Key decisions from reviews that affect step implementation:
 
 ## Steps
 
-- [ ] Step 1: CacheEntryImpl prep + hashForFrequencySketch
-  > **Files:** `CacheEntryImpl.java`, `ConcurrentLongIntHashMap.java`,
-  > `ConcurrentLongIntHashMapTest.java`
+- [x] Step 1: CacheEntryImpl prep + hashForFrequencySketch
+  > **What was done:** Added `long fileId` and `int pageIndex` fields to
+  > `CacheEntryImpl` alongside existing `pageKey`. Updated `getFileId()`,
+  > `getPageIndex()`, `equals()`, and `hashCode()` to use primitive fields
+  > directly. Added `hashForFrequencySketch(long, int)` to
+  > `ConcurrentLongIntHashMap` with 5 unit tests. Review fix: improved test
+  > names, added documentation comment to `hashCode()`.
   >
-  > Add `long fileId` and `int pageIndex` fields to `CacheEntryImpl` alongside
-  > the existing `pageKey` field. Update `getFileId()` and `getPageIndex()` to
-  > return the new fields directly (currently they delegate to
-  > `pageKey.fileId()` / `pageKey.pageIndex()`). Update `equals()` and
-  > `hashCode()` to use the new fields (currently delegate to `pageKey`).
-  > Keep `pageKey` field and `getPageKey()` temporarily — they'll be removed
-  > in step 4.
+  > **What was discovered:** `CacheEntryImpl.hashCode()` now differs from
+  > `PageKey.hashCode()` (record-generated vs explicit formula). Not a
+  > correctness issue — `CacheEntryImpl` is not used as a hash key in any
+  > collection. The frequency sketch hash distribution change during migration
+  > is transient and acceptable per D5.
   >
-  > Add `public static int hashForFrequencySketch(long fileId, int pageIndex)`
-  > to `ConcurrentLongIntHashMap`. Use `Long.hashCode(fileId) * 31 + pageIndex`
-  > — independent from the map's internal murmur hash to avoid correlation with
-  > bucket position (review decision #4). Add unit test verifying consistency
-  > and basic distribution.
-  >
-  > **Compiles, all tests pass.** Purely additive changes.
+  > **Key files:** `CacheEntryImpl.java` (modified), `ConcurrentLongIntHashMap.java`
+  > (modified), `ConcurrentLongIntHashMapTest.java` (modified)
 
 - [ ] Step 2: Core swap — data field type + LockFreeReadCache + WTinyLFUPolicy + tests
   > **Files:** `LockFreeReadCache.java`, `WTinyLFUPolicy.java`,

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -1,7 +1,7 @@
 # Track 2: Integration into LockFreeReadCache and WTinyLFUPolicy
 
 ## Progress
-- [ ] Review + decomposition
+- [x] Review + decomposition
 - [ ] Step implementation
 - [ ] Track-level code review
 
@@ -13,5 +13,148 @@ _(to be written at Phase B start)_
 - [x] Risk
 - [x] Adversarial
 
+## Review decisions summary
+
+Key decisions from reviews that affect step implementation:
+
+1. **data.values() missing** (T1/A3 — blocker): `ConcurrentLongIntHashMap` has no `values()`.
+   `clear()` and `assertConsistency()` must use `forEachValue` to collect into a list, then
+   iterate. `StorageException` is unchecked and propagates through Consumer.
+2. **Step ordering for getPageKey() removal** (T2/R10 — blocker): All callers must be migrated
+   to `getFileId()`/`getPageIndex()` before `getPageKey()` is removed from the interface.
+   Interface cleanup is the final step.
+3. **Compute lambda parameter mapping** (R4 — blocker): In `silentLoadForRead()` and `doLoad()`,
+   the compute lambda receives `(long fileId, int pageIndex, CacheEntry entry)` but also
+   captures outer-scope variables. Use the outer-scope captured variables consistently (they're
+   guaranteed identical to compute key parameters). Add comment explaining why.
+4. **Frequency sketch hash independence** (A2 — blocker): Do NOT truncate the murmur hash — it
+   correlates with bucket position (lower 32 bits used for both). Use
+   `Long.hashCode(fileId) * 31 + pageIndex` (independent from map hash, matches spirit of
+   `Objects.hash`). Add as `public static int hashForFrequencySketch(long, int)` on the map.
+5. **Section count must match CHM concurrency** (A9 — blocker): Current CHM uses
+   `N_CPU << 1` concurrency level. New map constructor must pass `N_CPU << 1` as section count
+   to match. The map constructor aligns to power of two internally.
+6. **CacheEntryImpl equals/hashCode** (T5/A1): Rewrite to use `fileId`/`pageIndex` directly
+   when the primitive fields are added.
+7. **WTinyLFUPolicyTest rewrite** (T6/R8/A4): ~10 test methods, ~40+ PageKey references.
+   Mock hash stubs must use the new `hashForFrequencySketch` method.
+8. **clearFile overflow-check timing** (R1): With removeByFileId, all entries removed first,
+   then overflow checks. Acceptable — reduces cache pressure faster. Test explicitly.
+9. **Concurrent re-insertion race** (A7): Pre-existing race where `doLoad` can re-insert an
+   entry for a file being cleared. Not a regression. Document precondition in code comment.
+10. **Virtual-lock pattern verified** (A10/R9): `compute()` holds write lock during function
+    execution. Absent key + null return = no-op. Same semantics as CHM.
+
 ## Steps
-_(to be decomposed after reviews)_
+
+- [ ] Step 1: CacheEntryImpl prep + hashForFrequencySketch
+  > **Files:** `CacheEntryImpl.java`, `ConcurrentLongIntHashMap.java`,
+  > `ConcurrentLongIntHashMapTest.java`
+  >
+  > Add `long fileId` and `int pageIndex` fields to `CacheEntryImpl` alongside
+  > the existing `pageKey` field. Update `getFileId()` and `getPageIndex()` to
+  > return the new fields directly (currently they delegate to
+  > `pageKey.fileId()` / `pageKey.pageIndex()`). Update `equals()` and
+  > `hashCode()` to use the new fields (currently delegate to `pageKey`).
+  > Keep `pageKey` field and `getPageKey()` temporarily — they'll be removed
+  > in step 4.
+  >
+  > Add `public static int hashForFrequencySketch(long fileId, int pageIndex)`
+  > to `ConcurrentLongIntHashMap`. Use `Long.hashCode(fileId) * 31 + pageIndex`
+  > — independent from the map's internal murmur hash to avoid correlation with
+  > bucket position (review decision #4). Add unit test verifying consistency
+  > and basic distribution.
+  >
+  > **Compiles, all tests pass.** Purely additive changes.
+
+- [ ] Step 2: Core swap — data field type + LockFreeReadCache + WTinyLFUPolicy + tests
+  > **Files:** `LockFreeReadCache.java`, `WTinyLFUPolicy.java`,
+  > `WTinyLFUPolicyTest.java`
+  >
+  > This is the atomic big-bang swap — changing `data` type breaks all call sites
+  > simultaneously, so all must be updated in one commit.
+  >
+  > **LockFreeReadCache changes:**
+  > - Replace `data` field: `ConcurrentHashMap<PageKey, CacheEntry>` →
+  >   `ConcurrentLongIntHashMap<CacheEntry>`
+  > - Update constructor: `new ConcurrentLongIntHashMap<>(maxCacheSize, N_CPU << 1)`
+  >   (review decision #5 — match CHM concurrency level)
+  > - `doLoad()` (line 217): remove `new PageKey(...)`, use `data.get(fileId, pageIndex)`
+  >   and `data.compute(fileId, pageIndex, fn)`. In compute lambda, use outer-scope
+  >   captured variables consistently (review decision #3). Add comment explaining
+  >   lambda parameters are identical to captured variables.
+  > - `silentLoadForRead()` (line 159): same pattern as doLoad
+  > - `addNewPagePointerToTheCache()` (line 307): use
+  >   `data.putIfAbsent(entry.getFileId(), entry.getPageIndex(), entry)`
+  > - `releaseFromWrite()` (line 349): use
+  >   `data.compute(entry.getFileId(), entry.getPageIndex(), fn)`. Add comment
+  >   documenting virtual-lock pattern (review decision #10).
+  > - `clear()` (line 540): collect entries via `data.forEachValue()` into a list,
+  >   then iterate for freeze/onRemove/clear. `StorageException` is unchecked and
+  >   propagates through Consumer (review decision #1).
+  > - `clearFile()` (line 625): temporarily keep per-page loop pattern using
+  >   `data.remove(fileId, pageIndex)` — removeByFileId deferred to step 3.
+  >   Remove `new PageKey(...)` allocation.
+  > - `size()` returns `long` from new map — auto-widens safely (review decision T4).
+  >
+  > **WTinyLFUPolicy changes:**
+  > - Constructor: accept `ConcurrentLongIntHashMap<CacheEntry>` instead of
+  >   `ConcurrentHashMap<PageKey, CacheEntry>`
+  > - `onAccess()` (line 58): replace `cacheEntry.getPageKey().hashCode()` with
+  >   `ConcurrentLongIntHashMap.hashForFrequencySketch(cacheEntry.getFileId(), cacheEntry.getPageIndex())`
+  > - `onAdd()` (line 83): same hash replacement
+  > - `purgeEden()` (lines 110-111, 121, 137): replace `getPageKey().hashCode()` for
+  >   frequency comparisons, replace `data.remove(victim.getPageKey(), victim)` with
+  >   `data.remove(victim.getFileId(), victim.getPageIndex(), victim)`
+  > - `assertConsistency()` (line 201): replace `data.values()` iteration with
+  >   `forEachValue` collection pattern. Replace `data.get(cacheEntry.getPageKey())`
+  >   with `data.get(cacheEntry.getFileId(), cacheEntry.getPageIndex())`
+  > - `assertSize()` (line 197): `data.size()` returns `long` — comparison auto-widens
+  >
+  > **WTinyLFUPolicyTest changes:**
+  > - Replace all `ConcurrentHashMap<PageKey, CacheEntry>` with
+  >   `ConcurrentLongIntHashMap<CacheEntry>`
+  > - Replace all `data.put(new PageKey(f, p), entry)` with `data.put(f, p, entry)`
+  > - Replace all `data.remove(new PageKey(f, p), entry)` with
+  >   `data.remove(f, p, entry)`
+  > - Replace all mock stubs `admittor.frequency(new PageKey(f, p).hashCode())` with
+  >   `admittor.frequency(ConcurrentLongIntHashMap.hashForFrequencySketch(f, p))`
+  > - Remove PageKey import
+  >
+  > **Compiles, all tests pass.** Every changed call site updated atomically.
+
+- [ ] Step 3: clearFile → removeByFileId integration
+  > **Files:** `LockFreeReadCache.java`
+  >
+  > Replace the per-page loop in `clearFile()` with `data.removeByFileId(fileId)`.
+  > Process returned `List<CacheEntry>` entries under eviction lock: for each entry,
+  > call `freeze()` (throws `StorageException` if in use — preserving current failure
+  > mode), `policy.onRemove()`, `cacheSize.decrementAndGet()`, and
+  > `writeCache.checkCacheOverflow()`.
+  >
+  > This changes the removal pattern from O(filledUpTo) hash probes (most misses) to
+  > O(segment-capacity) linear sweep per segment. All entries removed in bulk, then
+  > processed sequentially (review decision #8 — overflow check timing change is
+  > acceptable).
+  >
+  > Add code comment documenting: (a) entries processed after segment lock release
+  > to avoid StampedLock reentrancy deadlock, (b) concurrent re-insertion precondition
+  > — clearFile assumes no concurrent doLoad for the same fileId (review decision #9).
+  >
+  > **Compiles, all tests pass.** Focused single-method optimization.
+
+- [ ] Step 4: CacheEntry interface cleanup + PageKey deletion
+  > **Files:** `CacheEntry.java`, `CacheEntryImpl.java`,
+  > `CacheEntryChanges.java`, `PageKey.java` (deleted)
+  >
+  > - Remove `getPageKey()` from `CacheEntry` interface (line 111)
+  > - Remove `getPageKey()` from `CacheEntryImpl` (lines 328-330)
+  > - Remove `pageKey` field from `CacheEntryImpl` (line 57), remove
+  >   `new PageKey(...)` from constructor (line 77)
+  > - Remove `getPageKey()` from `CacheEntryChanges` (lines 223-225)
+  > - Remove `PageKey` imports from CacheEntry, CacheEntryImpl, CacheEntryChanges
+  > - Delete `chm/PageKey.java`
+  >
+  > All callers were migrated in steps 1-3 so no `getPageKey()` references remain.
+  >
+  > **Compiles, all tests pass.** Pure cleanup/deletion step.

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -3,7 +3,7 @@
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation (4/4 complete)
-- [ ] Track-level code review (1/3 iterations)
+- [x] Track-level code review (2/3 iterations — all gate checks PASS)
 
 ## Base commit
 `63344506774da6606d949ae50d6f81dce2a5222b`

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -6,7 +6,7 @@
 - [ ] Track-level code review
 
 ## Base commit
-_(to be written at Phase B start)_
+`63344506774da6606d949ae50d6f81dce2a5222b`
 
 ## Reviews completed
 - [x] Technical

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-2.md
@@ -3,7 +3,7 @@
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation (4/4 complete)
-- [ ] Track-level code review
+- [ ] Track-level code review (1/3 iterations)
 
 ## Base commit
 `63344506774da6606d949ae50d6f81dce2a5222b`

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
@@ -6,7 +6,7 @@
 - [ ] Track-level code review
 
 ## Base commit
-_(to be recorded at Phase B start)_
+`5fdd4ecbcd`
 
 ## Reviews completed
 - [x] Technical

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
@@ -3,7 +3,7 @@
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation (3/3 complete)
-- [ ] Track-level code review
+- [x] Track-level code review
 
 ## Base commit
 `5fdd4ecbcd`

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
@@ -1,0 +1,105 @@
+# Track 3: Concurrent Stress Testing
+
+## Progress
+- [x] Review + decomposition
+- [ ] Step implementation (0/3 complete)
+- [ ] Track-level code review
+
+## Base commit
+_(to be recorded at Phase B start)_
+
+## Reviews completed
+- [x] Technical
+- [x] Risk
+
+## Review decisions summary
+
+Key decisions from reviews that affect step implementation:
+
+1. **No ConcurrentTestHelper** (T1/R5): Use raw `ExecutorService` + `Future.get(30, SECONDS)`
+   pattern, matching `AsyncReadCacheTestIT`. Gives faster failure detection and better
+   diagnostics.
+2. **clearFile is private — test removeByFileId at map level** (T2/T7): Single-file concurrent
+   removal tested via the public `removeByFileId()` on `ConcurrentLongIntHashMap`. Integrated
+   cache-level test uses `deleteStorage` for correctness verification.
+3. **Separate concurrent test class** (T3): Create `ConcurrentLongIntHashMapConcurrentTest.java`
+   in `core/src/test/.../internal/common/collection/`. Keeps the 1688-line single-threaded test
+   file clean.
+4. **Rehash test: minimal capacity + single section** (T4/R6): Use
+   `new ConcurrentLongIntHashMap<>(4, 1)` to maximize rehash frequency. Bounded key space
+   (~10K unique keys) to prevent OOM.
+5. **Include compute() in operation mix** (T6/R1/R4): `compute()` is used as a virtual lock
+   in `doLoad()`. Include slow-compute variant to force optimistic-read fallback.
+6. **Iteration counts** (T5): ~100K-500K ops/thread for map-level tests (5-15s runtime),
+   scaled down for integrated tests (~50K ops).
+7. **Integrated tests are *IT** (R7): Cache-level stress tests use `*IT` suffix with
+   `@Category(SequentialTest.class)` to avoid CI flakiness on PR builds.
+8. **clearFile/doLoad race** (R2): Pre-existing race where `doLoad` re-inserts after
+   `removeByFileId`. Split test scenarios: different-file (verify isolation) and same-file
+   (expect re-insertion, verify second clear). Do NOT assert "zero entries" while concurrent
+   loaders are active.
+9. **Coverage gate N/A** (R8): Track 3 adds no production code. Coverage gate doesn't apply.
+
+## Steps
+
+- [ ] Step 1: Map-level concurrent correctness tests — mixed operations + rehash
+  > **Scope**: Create `ConcurrentLongIntHashMapConcurrentTest.java` with two test methods:
+  >
+  > 1. **Mixed concurrent operations**: N threads (4-8) performing random
+  >    `get/put/remove/computeIfAbsent/compute` on overlapping keys (bounded key space
+  >    ~10K keys, ~200K ops/thread). Post-run: verify map consistency (size matches
+  >    expected entries, all remaining values retrievable). Include slow-compute variant
+  >    where compute lambda does `Thread.sleep(1)` to force readers through read-lock
+  >    fallback path.
+  >
+  > 2. **Rehash under concurrent access**: 1-section map with minimal capacity
+  >    (`new ConcurrentLongIntHashMap<>(4, 1)`). Writer threads insert entries to trigger
+  >    frequent rehash. Reader threads continuously get entries. Remover threads remove
+  >    random entries. Verify no `ArrayIndexOutOfBoundsException`, no stale/corrupt values
+  >    returned, correct final state. ~100K ops/thread.
+  >
+  > Pattern: raw `ExecutorService` + `Future.get(30, SECONDS)`. JUnit 4.
+  >
+  > **Key files**: `ConcurrentLongIntHashMapConcurrentTest.java` (new)
+
+- [ ] Step 2: Map-level removeByFileId concurrent test
+  > **Scope**: Add test methods to `ConcurrentLongIntHashMapConcurrentTest.java`:
+  >
+  > 1. **removeByFileId + concurrent get/put on different files**: One thread calls
+  >    `removeByFileId(targetFileId)` while other threads read/write entries for different
+  >    file IDs. Verify: all target-file entries removed, all other-file entries unaffected,
+  >    no exceptions.
+  >
+  > 2. **removeByFileId + concurrent put on same file**: One thread calls
+  >    `removeByFileId(fileId)` while another thread inserts entries for the same file.
+  >    After both complete, verify map contains only entries inserted after removeByFileId
+  >    (or is empty if removeByFileId ran last). Use barriers for controlled interleaving.
+  >
+  > 3. **Multiple concurrent removeByFileId for different files**: Several threads each
+  >    call `removeByFileId` for their own file ID simultaneously. Verify each file's
+  >    entries are fully removed and no cross-file interference.
+  >
+  > **Key files**: `ConcurrentLongIntHashMapConcurrentTest.java` (modified)
+
+- [ ] Step 3: Integrated LockFreeReadCache concurrent stress test
+  > **Scope**: Create `LockFreeReadCacheConcurrentTestIT.java` in
+  > `core/src/test/.../internal/core/storage/cache/chm/` with
+  > `@Category(SequentialTest.class)`. Two test methods:
+  >
+  > 1. **Concurrent reads + writes with eviction**: Multiple threads call
+  >    `loadForRead`/`loadForWrite` on a small cache (forces eviction). Verify:
+  >    no exceptions, no data corruption, returned `CachePointer` values are valid.
+  >    Scale: 4MB cache, ~50K operations, 4 reader + 4 writer threads. Follow
+  >    `AsyncReadCacheTestIT` pattern with `MockedWriteCache`.
+  >
+  > 2. **deleteStorage under concurrent load**: Pre-populate cache with entries from
+  >    multiple files. Start reader threads on all files. Call `deleteStorage` (clears
+  >    all). After readers stop, verify cache is empty. This tests the public API path
+  >    through `clearFile` → `removeByFileId`. Note: readers may re-populate entries
+  >    during deletion (documented race R2) — verify that after readers stop + a final
+  >    clear, the cache is empty.
+  >
+  > Pattern: raw `ExecutorService` + `Future.get(30, SECONDS)`, `MockedWriteCache`,
+  > `ByteBufferPool`. JUnit 4 with `@Category(SequentialTest.class)`.
+  >
+  > **Key files**: `LockFreeReadCacheConcurrentTestIT.java` (new)

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (1/3 complete)
+- [ ] Step implementation (2/3 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -61,24 +61,21 @@ Key decisions from reviews that affect step implementation:
   >
   > **Key files:** `ConcurrentLongIntHashMapConcurrentTest.java` (new)
 
-- [ ] Step 2: Map-level removeByFileId concurrent test
-  > **Scope**: Add test methods to `ConcurrentLongIntHashMapConcurrentTest.java`:
+- [x] Step 2: Map-level removeByFileId concurrent test
+  > **What was done:** Added three removeByFileId concurrent test methods: (1)
+  > removeByFileId on target file with 4 concurrent workers on other files — validates
+  > isolation and counts remaining entries; (2) removeByFileId + concurrent put + readers
+  > on same file with single section for max contention — validates return values and
+  > reader correctness during removal; (3) 8 threads each removing their own file
+  > simultaneously — validates returned list size and map emptiness.
   >
-  > 1. **removeByFileId + concurrent get/put on different files**: One thread calls
-  >    `removeByFileId(targetFileId)` while other threads read/write entries for different
-  >    file IDs. Verify: all target-file entries removed, all other-file entries unaffected,
-  >    no exceptions.
+  > **What was discovered:** Review identified that without concurrent readers in the
+  > same-file test, the optimistic-read fallback during removeByFileId's rehash was
+  > never exercised. Added reader threads and switched to single section. Also
+  > strengthened assertions: validate removeByFileId return values (all must belong to
+  > correct file), count remaining other-file entries, assert exact returned list size.
   >
-  > 2. **removeByFileId + concurrent put on same file**: One thread calls
-  >    `removeByFileId(fileId)` while another thread inserts entries for the same file.
-  >    After both complete, verify map contains only entries inserted after removeByFileId
-  >    (or is empty if removeByFileId ran last). Use barriers for controlled interleaving.
-  >
-  > 3. **Multiple concurrent removeByFileId for different files**: Several threads each
-  >    call `removeByFileId` for their own file ID simultaneously. Verify each file's
-  >    entries are fully removed and no cross-file interference.
-  >
-  > **Key files**: `ConcurrentLongIntHashMapConcurrentTest.java` (modified)
+  > **Key files:** `ConcurrentLongIntHashMapConcurrentTest.java` (modified)
 
 - [ ] Step 3: Integrated LockFreeReadCache concurrent stress test
   > **Scope**: Create `LockFreeReadCacheConcurrentTestIT.java` in

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (2/3 complete)
+- [x] Step implementation (3/3 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -77,25 +77,24 @@ Key decisions from reviews that affect step implementation:
   >
   > **Key files:** `ConcurrentLongIntHashMapConcurrentTest.java` (modified)
 
-- [ ] Step 3: Integrated LockFreeReadCache concurrent stress test
-  > **Scope**: Create `LockFreeReadCacheConcurrentTestIT.java` in
-  > `core/src/test/.../internal/core/storage/cache/chm/` with
-  > `@Category(SequentialTest.class)`. Two test methods:
+- [x] Step 3: Integrated LockFreeReadCache concurrent stress test
+  > **What was done:** Created `LockFreeReadCacheConcurrentTestIT.java` with two test
+  > methods: (1) concurrent reads + writes with eviction — 4 readers + 4 writers,
+  > 50K ops/thread, 4MB cache; (2) deleteFile after concurrent load — 8 readers
+  > then sequential deleteFile for each file, verifying empty + consistent state.
   >
-  > 1. **Concurrent reads + writes with eviction**: Multiple threads call
-  >    `loadForRead`/`loadForWrite` on a small cache (forces eviction). Verify:
-  >    no exceptions, no data corruption, returned `CachePointer` values are valid.
-  >    Scale: 4MB cache, ~50K operations, 4 reader + 4 writer threads. Follow
-  >    `AsyncReadCacheTestIT` pattern with `MockedWriteCache`.
+  > **What was discovered:** **Found a real concurrency bug in ConcurrentLongIntHashMap!**
+  > `rehashTo()` wrote `capacity` before the new arrays, allowing an optimistic reader
+  > to snapshot the new (larger) capacity with old (smaller) arrays → AIOOBE. Fix:
+  > write arrays first, capacity last. This is exactly the BOOKKEEPER-4317 class of
+  > bug this track was designed to catch.
   >
-  > 2. **deleteStorage under concurrent load**: Pre-populate cache with entries from
-  >    multiple files. Start reader threads on all files. Call `deleteStorage` (clears
-  >    all). After readers stop, verify cache is empty. This tests the public API path
-  >    through `clearFile` → `removeByFileId`. Note: readers may re-populate entries
-  >    during deletion (documented race R2) — verify that after readers stop + a final
-  >    clear, the cache is empty.
+  > **What changed from the plan:** Used `deleteFile` per file instead of
+  > `deleteStorage` (which requires `writeCache.files()` to return real data).
+  > deleteFile cannot run while readers hold entries, so the test stops readers
+  > first then deletes — different from the original plan's concurrent deletion
+  > design. Review led to adding fileId/pageIndex assertions on CacheEntry, wrapping
+  > clear() in finally blocks, and asserting non-empty before deletion.
   >
-  > Pattern: raw `ExecutorService` + `Future.get(30, SECONDS)`, `MockedWriteCache`,
-  > `ByteBufferPool`. JUnit 4 with `@Category(SequentialTest.class)`.
-  >
-  > **Key files**: `LockFreeReadCacheConcurrentTestIT.java` (new)
+  > **Key files:** `LockFreeReadCacheConcurrentTestIT.java` (new),
+  > `ConcurrentLongIntHashMap.java` (modified — bug fix in rehashTo)

--- a/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
+++ b/docs/adr/ytdb-627-primitive-chm-cache/tracks/track-3.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (0/3 complete)
+- [ ] Step implementation (1/3 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -42,25 +42,24 @@ Key decisions from reviews that affect step implementation:
 
 ## Steps
 
-- [ ] Step 1: Map-level concurrent correctness tests — mixed operations + rehash
-  > **Scope**: Create `ConcurrentLongIntHashMapConcurrentTest.java` with two test methods:
+- [x] Step 1: Map-level concurrent correctness tests — mixed operations + rehash
+  > **What was done:** Created `ConcurrentLongIntHashMapConcurrentTest.java` with two test
+  > methods: (1) mixed concurrent operations — 8 threads, 200K ops/thread, 12-way operation
+  > mix (get/put/putIfAbsent/remove/conditional-remove/computeIfAbsent/compute/slow-compute)
+  > on 10K key space; (2) rehash under concurrent access — 1-section map, capacity 4, 3
+  > writers + 3 readers + 2 removers with CyclicBarrier for synchronized startup.
   >
-  > 1. **Mixed concurrent operations**: N threads (4-8) performing random
-  >    `get/put/remove/computeIfAbsent/compute` on overlapping keys (bounded key space
-  >    ~10K keys, ~200K ops/thread). Post-run: verify map consistency (size matches
-  >    expected entries, all remaining values retrievable). Include slow-compute variant
-  >    where compute lambda does `Thread.sleep(1)` to force readers through read-lock
-  >    fallback path.
+  > **What was discovered:** Thread.sleep(1) in the slow-compute path was too expensive
+  > (~30s wall-clock). Replaced with LockSupport.parkNanos(100µs) — test now runs in ~7s.
+  > Review also identified that without a startup barrier, threads may not overlap during
+  > rehash events, defeating the purpose of the rehash test.
   >
-  > 2. **Rehash under concurrent access**: 1-section map with minimal capacity
-  >    (`new ConcurrentLongIntHashMap<>(4, 1)`). Writer threads insert entries to trigger
-  >    frequent rehash. Reader threads continuously get entries. Remover threads remove
-  >    random entries. Verify no `ArrayIndexOutOfBoundsException`, no stale/corrupt values
-  >    returned, correct final state. ~100K ops/thread.
+  > **What changed from the plan:** Expanded operation mix beyond plan (added putIfAbsent,
+  > conditional remove). Used LockSupport.parkNanos instead of Thread.sleep. Added
+  > CyclicBarrier (not in original plan). Added inline value assertions during concurrent
+  > phase (not just post-run). Added rehash capacity growth assertion.
   >
-  > Pattern: raw `ExecutorService` + `Future.get(30, SECONDS)`. JUnit 4.
-  >
-  > **Key files**: `ConcurrentLongIntHashMapConcurrentTest.java` (new)
+  > **Key files:** `ConcurrentLongIntHashMapConcurrentTest.java` (new)
 
 - [ ] Step 2: Map-level removeByFileId concurrent test
   > **Scope**: Add test methods to `ConcurrentLongIntHashMapConcurrentTest.java`:


### PR DESCRIPTION
#### Motivation:

The `LockFreeReadCache` used `ConcurrentHashMap<PageKey, CacheEntry>` which required boxing composite `(fileId, pageIndex)` keys into `PageKey` objects on every lookup — adding GC pressure and pointer-chasing overhead on the hot read path.

This PR replaces it with a custom `ConcurrentLongIntHashMap<V>` — a segmented, open-addressing hash map that stores `long fileId` and `int pageIndex` keys inline in parallel primitive arrays. The design is forked from Apache BookKeeper's `ConcurrentLongHashMap` and adapted for two-field composite keys.

**Key changes:**

- **`ConcurrentLongIntHashMap`** — new segmented map with `StampedLock` per segment: `get()` uses optimistic reads with single read-lock fallback; mutations use write locks
- **`LockFreeReadCache`** — switched to the new map, eliminating `PageKey` allocations entirely
- **`WTinyLFUPolicy`** — updated to reference the new map type
- **`CacheEntry`/`CacheEntryImpl`** — simplified: `getPageKey()` removed, `fileId`/`pageIndex` stored as primitive fields directly
- **`PageKey`** — deleted (no longer needed)

**Benefits:**
- Zero per-lookup object allocation (no `PageKey` boxing)
- Cache-friendly memory layout (parallel primitive arrays)
- Reduced GC pressure on the hot read path

**Testing:**
- 1,688-line unit test suite for `ConcurrentLongIntHashMap` covering all operations, resize, shrink, edge cases
- 554-line concurrent stress tests for the map (multi-threaded put/get/remove/compute races)
- 466-line `LockFreeReadCacheConcurrentTestIT` integration stress tests
- `CacheEntryImplTest` for the simplified cache entry
- Updated `WTinyLFUPolicyTest`

## Test plan
- [x] Unit tests pass: `./mvnw -pl core clean test`
- [x] Integration tests pass: `./mvnw -pl core clean verify -P ci-integration-tests`
- [x] Coverage gate meets thresholds (85% line / 70% branch)