### PR TITLE
YTDB-628: In-place property comparison for SQL WHERE clauses

### DIFF
--- a/.claude/skills/profile-jmh-regressions/SKILL.md
+++ b/.claude/skills/profile-jmh-regressions/SKILL.md
@@ -9,7 +9,6 @@ Profile benchmark regressions found in a PR's JMH comparison comment. Provisions
 ## Prerequisites
 
 - `hcloud` CLI installed and authenticated
-- `boto3` Python library installed locally
 - SSH key pair at `~/.ssh/id_ed25519`
 - A PR with a JMH benchmark comparison comment (posted by `ldbc-jmh-compare.yml` or manually)
 - Environment variables: `HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`, `HETZNER_S3_ENDPOINT`
@@ -24,8 +23,8 @@ Read the benchmark comparison comment from the PR on the current branch:
 # Find the PR
 gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number,url
 
-# Read the latest benchmark comment (filtering by content to avoid noise)
-gh pr view <NUMBER> --json comments --jq '.comments | map(select(.body | contains("## JMH LDBC Benchmark Comparison"))) | last | .body'
+# Read the latest benchmark comment
+gh pr view <NUMBER> --json comments --jq '.comments[-1].body'
 ```
 
 Parse the markdown table to extract all benchmarks marked with `:red_circle:` (regression). Record for each:
@@ -40,19 +39,15 @@ git merge-base HEAD origin/develop
 
 ### Step 1: Determine JMH parameters per regression
 
-Each benchmark belongs to a tier with different profiling settings. Benchmarks are assigned to tiers by query name (see `jmh-ldbc/README.md`), not by dynamic ops/s lookup. To determine the tier, check which base class the benchmark extends.
+Each benchmark belongs to a tier with different profiling settings. Choose parameters based on the base ops/s from the PR comment:
 
-**Note**: The profiling args below are intentionally reduced from the production annotations (fewer forks, shorter warmup/measurement). Profiling needs only 1 fork — we're analyzing CPU distribution, not statistical throughput. Warmup is shortened but kept long enough for JIT to stabilize.
-
-| Tier | Base Class | Queries | Production annotations | Profiling args |
-|------|-----------|---------|----------------------|----------------|
-| IS-ultra-fast | `LdbcISUltraFastBenchmarkBase` | IS1, IS3-IS6, IC13 | 5f, 1×5s wi, 3×10s | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
-| IS-noisy | `LdbcISBenchmarkBase` | IS2, IS7, IC8 | 10f, 3×5s wi, 3×10s | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
-| IC | `LdbcICBenchmarkBase` | IC2, IC7, IC11 | 3f, 1×10s wi, 5×20s | `-f 1 -wi 1 -w 10s -i 3 -r 20s -t 1` (ST) |
-| IC-slow | `LdbcICSlowBenchmarkBase` | IC1, IC4, IC6, IC9, IC12 | 3f, 1×30s wi, 5×30s | `-f 1 -wi 1 -w 30s -i 3 -r 30s -t 1` (ST) |
-| IC-ultra-slow | `LdbcICUltraSlowBenchmarkBase` | IC3, IC5, IC10 | 5f, 1×60s wi, 3×120s | `-f 1 -wi 1 -w 60s -i 3 -r 60s -t 1` (ST) |
-
-**IC4 exception**: `ic4_newTopics` has a method-level override `@Warmup(iterations = 3, time = 30)`. For profiling, use `-wi 2 -w 30s` instead of the IC-slow default.
+| Tier | Base ops/s | Profiling args |
+|------|-----------|----------------|
+| IS-ultra-fast | >2,700 | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
+| IS-noisy | 400–2,700 | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
+| IC | 17–215 | `-f 1 -wi 1 -w 5s -i 3 -r 15s -t 1` (ST) |
+| IC-slow | 1–21 | `-f 1 -wi 2 -w 10s -i 3 -r 30s -t 1` (ST) |
+| IC-ultra-slow | <0.2 | `-f 1 -wi 2 -w 10s -i 3 -r 60s -t 1` (ST) |
 
 For multi-thread regressions, use the same warmup/measurement but omit `-t 1` (uses `@Threads(Threads.MAX)` default).
 
@@ -61,7 +56,7 @@ For multi-thread regressions, use the same warmup/measurement but omit `-t 1` (u
 Use the same naming convention as `run-jmh-benchmarks-hetzner`:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
+BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]/' '[:lower:]-' | cut -c1-40)
 SERVER_NAME="jmh-prof-${BRANCH}"
 KEY_NAME="jmh-prof-key-${BRANCH}"
 
@@ -78,7 +73,7 @@ ssh-keygen -f ~/.ssh/known_hosts -R <IP>
 
 ```bash
 ssh -o StrictHostKeyChecking=no root@<IP> \
-  'apt-get update -qq && apt-get install -y -qq openjdk-21-jdk-headless git tmux > /dev/null 2>&1 && java -version'
+  'apt-get update -qq && apt-get install -y -qq openjdk-21-jdk-headless git tmux zstd > /dev/null 2>&1 && java -version'
 ```
 
 Install async-profiler:
@@ -96,7 +91,7 @@ The async-profiler library path is: `/tmp/async-profiler-3.0-linux-x64/lib/libas
 
 **HEAD** (current worktree):
 ```bash
-rsync -az --exclude='.git' --exclude='target' --exclude='.idea' "$(git rev-parse --show-toplevel)/" root@<IP>:/root/ytdb/
+rsync -az --exclude='.git' --exclude='target' --exclude='.idea' <worktree-root>/ root@<IP>:/root/ytdb/
 ssh root@<IP> 'git config --global --add safe.directory /root/ytdb && \
   git config --global user.email "bench@test" && \
   git config --global user.name "bench" && \
@@ -106,213 +101,124 @@ ssh root@<IP> 'git config --global --add safe.directory /root/ytdb && \
 **BASE** (fork-point commit): Create a local worktree, rsync to a separate directory:
 ```bash
 BASE_COMMIT=$(git merge-base HEAD origin/develop)
-WORKTREE_DIR="/tmp/ytdb-base-profiling-$$"
-rm -rf "$WORKTREE_DIR" && git worktree prune
-git worktree add "$WORKTREE_DIR" "$BASE_COMMIT"
+git worktree add /tmp/ytdb-base-$$ $BASE_COMMIT
 
-rsync -az --exclude='.git' --exclude='target' --exclude='.idea' "$WORKTREE_DIR/" root@<IP>:/root/ytdb-base/
-ssh root@<IP> 'cd /root/ytdb-base && git init && git add -A && git commit -m "base" --quiet'
+rsync -az --exclude='.git' --exclude='target' --exclude='.idea' /tmp/ytdb-base-$$/ root@<IP>:/root/ytdb-base/
+ssh root@<IP> 'git config --global --add safe.directory /root/ytdb-base && \
+  cd /root/ytdb-base && git init && git add -A && git commit -m "base" --quiet'
 ```
 
-### Step 5: Compile both versions and download LDBC CSV dataset
+### Step 5: Compile both versions and download LDBC data
 
-Compile both in parallel using isolated local repositories to avoid `~/.m2/repository` corruption from concurrent writes:
+Compile both in parallel (they use separate directories):
 ```bash
-ssh root@<IP> '
-  (cd /root/ytdb && chmod +x mvnw && ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q -Dmaven.repo.local=/root/.m2-head) &
-  (cd /root/ytdb-base && chmod +x mvnw && ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q -Dmaven.repo.local=/root/.m2-base) &
-  wait'
+# HEAD
+ssh root@<IP> 'cd /root/ytdb && chmod +x mvnw && \
+  ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q'
+
+# BASE
+ssh root@<IP> 'cd /root/ytdb-base && chmod +x mvnw && \
+  ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q'
 ```
 
-Download the LDBC SF 1 CSV dataset and canonical curated parameters from Hetzner S3. Generate presigned URLs locally (see `run-jmh-benchmarks-hetzner` skill Step 3b for the boto3 presigned URL generation):
-
+Download pre-built LDBC database (see `run-jmh-benchmarks-hetzner` skill for S3 presigned URL generation):
 ```bash
-# Generate presigned URLs locally (boto3 required)
-python3 -c "
+# Generate presigned URL locally
+S3_KEY="ldbc/ldbc-sf1-bench-db.tar.zst"
+PRESIGNED_URL=$(python3 -c "
 import boto3, os
 s3 = boto3.client('s3',
-    endpoint_url=os.environ['HETZNER_S3_ENDPOINT'],
+    endpoint_url='https://nbg1.your-objectstorage.com',
     aws_access_key_id=os.environ['HETZNER_S3_ACCESS_KEY'],
     aws_secret_access_key=os.environ['HETZNER_S3_SECRET_KEY'])
-for key in ['ldbc/ldbc-sf1-composite-merged-fk.tar.zst', 'ldbc/curated-params-v3.json', 'ldbc/factor-tables.json']:
-    url = s3.generate_presigned_url('get_object',
-        Params={'Bucket': 'bench-cache', 'Key': key},
-        ExpiresIn=7200)
-    print(f'{key}: {url}')
-"
+url = s3.generate_presigned_url('get_object',
+    Params={'Bucket': 'bench-cache', 'Key': '$S3_KEY'},
+    ExpiresIn=7200)
+print(url)
+")
+
+# Download and extract to HEAD
+ssh root@<IP> "mkdir -p /root/ytdb/jmh-ldbc/target && \
+  curl -sS -o /tmp/bench-db.tar.zst '$PRESIGNED_URL' && \
+  cd /root/ytdb/jmh-ldbc/target && \
+  zstd -d /tmp/bench-db.tar.zst -o /tmp/bench-db.tar && \
+  tar xf /tmp/bench-db.tar && rm -f /tmp/bench-db.tar.zst /tmp/bench-db.tar"
+
+# Clear curation caches
+ssh root@<IP> 'rm -f /root/ytdb/jmh-ldbc/target/ldbc-bench-db/curated-params*.json \
+  /root/ytdb/jmh-ldbc/target/ldbc-bench-db/factor-tables.json'
+
+# Copy to BASE
+ssh root@<IP> 'cp -r /root/ytdb/jmh-ldbc/target/ldbc-bench-db /root/ytdb-base/jmh-ldbc/target/'
 ```
 
-Download and extract CSV dataset:
-```bash
-# Download and extract CSV dataset to HEAD
-ssh root@<IP> 'apt-get install -y -qq zstd > /dev/null 2>&1 && \
-  mkdir -p /root/ytdb/jmh-ldbc/target/ldbc-dataset/sf1 && \
-  cd /root/ytdb/jmh-ldbc/target/ldbc-dataset/sf1 && \
-  curl -sS "<CSV_PRESIGNED_URL>" | zstd -dc | tar xf - && \
-  echo "Dataset ready" && ls static/ dynamic/'
+### Step 6: Pre-load and curate parameters
 
-# Copy CSV dataset to BASE
-ssh root@<IP> 'cp -r /root/ytdb/jmh-ldbc/target/ldbc-dataset /root/ytdb-base/jmh-ldbc/target/'
-```
-
-Download canonical curated parameters for both HEAD and BASE:
-```bash
-# Install canonical curated params into HEAD DB directory
-ssh root@<IP> 'mkdir -p /root/ytdb/jmh-ldbc/target/ldbc-bench-db && \
-  curl -sS -o /root/ytdb/jmh-ldbc/target/ldbc-bench-db/factor-tables.json "<FACTOR_TABLES_URL>" && \
-  curl -sS -o /root/ytdb/jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json "<CURATED_PARAMS_URL>" && \
-  echo "HEAD curated params installed"'
-
-# Install canonical curated params into BASE DB directory
-ssh root@<IP> 'mkdir -p /root/ytdb-base/jmh-ldbc/target/ldbc-bench-db && \
-  curl -sS -o /root/ytdb-base/jmh-ldbc/target/ldbc-bench-db/factor-tables.json "<FACTOR_TABLES_URL>" && \
-  curl -sS -o /root/ytdb-base/jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json "<CURATED_PARAMS_URL>" && \
-  echo "BASE curated params installed"'
-```
-
-**Critical**: Both HEAD and BASE must use the same canonical curated parameters downloaded from S3. Never let either version regenerate params independently — internal data structure changes can alter iteration order and produce incomparable parameter sets (see IC4 desync incident in `jmh-ldbc/README.md`).
-
-### Step 6: Pre-load database
-
-Run a throwaway fork on **each** version to trigger DB creation from CSV files (~21 min for SF 1) and load canonical curated parameters. Any benchmark name works here — the goal is just to trigger `@Setup(Level.Trial)` which creates the DB from CSV and loads the pre-downloaded curated parameters from the JSON cache files installed in Step 5.
-
-**Important**: Use `-f 1` (not `-f 0`). With `-f 0` the benchmark runs in-process and JMH exits 0 even when all benchmarks fail — silent failures are hard to diagnose on a remote server.
+Run a throwaway fork on **each** version to trigger DB open + parameter curation:
 
 ```bash
 # HEAD
 ssh root@<IP> 'cd /root/ytdb/jmh-ldbc && java \
   --add-opens java.base/java.lang=ALL-UNNAMED \
-  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
-  --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
-  --add-opens java.base/java.io=ALL-UNNAMED \
-  --add-opens java.base/java.nio=ALL-UNNAMED \
   --add-opens java.base/java.util=ALL-UNNAMED \
-  --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
-  --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
-  --add-opens java.base/java.net=ALL-UNNAMED \
   --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
-  --add-opens java.base/sun.nio.cs=ALL-UNNAMED \
-  --add-opens java.base/sun.security.x509=ALL-UNNAMED \
-  --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED \
+  --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
   -Xms4096m -Xmx4096m \
-  -jar target/youtrackdb-jmh-ldbc-*.jar \
+  -jar target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar \
   "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1'
 
-# BASE (separate directory — no JMH lock conflict with HEAD)
+# BASE (use -Djmh.ignoreLock=true if HEAD is still running, but prefer sequential)
 ssh root@<IP> 'cd /root/ytdb-base/jmh-ldbc && java \
   --add-opens java.base/java.lang=ALL-UNNAMED \
-  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
-  --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
-  --add-opens java.base/java.io=ALL-UNNAMED \
-  --add-opens java.base/java.nio=ALL-UNNAMED \
   --add-opens java.base/java.util=ALL-UNNAMED \
-  --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
-  --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
-  --add-opens java.base/java.net=ALL-UNNAMED \
   --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
-  --add-opens java.base/sun.nio.cs=ALL-UNNAMED \
-  --add-opens java.base/sun.security.x509=ALL-UNNAMED \
-  --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED \
-  -Xms4096m -Xmx4096m \
-  -jar target/youtrackdb-jmh-ldbc-*.jar \
+  --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  -Xms4096m -Xmx4096m -Djmh.ignoreLock=true \
+  -jar target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar \
   "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1'
 ```
 
-### Step 7: Triage run — filter false positives
+### Step 7: Profile regressions
 
-Before spending time on profiling, run each regressing benchmark **without async-profiler** on both HEAD and BASE to confirm the regression reproduces. Use the same tier-based JMH parameters from Step 1.
-
-Use the wrapper script (without `-prof`):
-```bash
-ssh root@<IP> 'cat > /root/run-bench.sh << '\''SCRIPT'\''
-#!/bin/bash
-DIR=$1        # /root/ytdb or /root/ytdb-base
-BENCH=$2      # benchmark regex
-ARGS=$3       # JMH args
-
-JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.nio.cs=ALL-UNNAMED --add-opens java.base/sun.security.x509=ALL-UNNAMED --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED -Xms4096m -Xmx4096m"
-
-cd $DIR/jmh-ldbc && java $JVM_ARGS \
-  -jar target/youtrackdb-jmh-ldbc-*.jar \
-  "$BENCH" $ARGS
-SCRIPT
-chmod +x /root/run-bench.sh'
-```
-
-For each regression, run HEAD then BASE sequentially:
-```bash
-ssh root@<IP> '/root/run-bench.sh /root/ytdb "<benchmark-regex>" "<jmh-args>"'
-ssh root@<IP> '/root/run-bench.sh /root/ytdb-base "<benchmark-regex>" "<jmh-args>"'
-```
-
-**Decision rule**: Compare HEAD vs BASE ops/s from the triage run. If the delta is **<3%** or in the **opposite direction** (HEAD faster), classify as **measurement noise** and skip profiling. Only proceed to Step 8 for benchmarks that reproduce a **≥3% regression** in the triage run.
-
-Record the triage results in the final report alongside profiling throughput for transparency.
-
-### Step 8: Profile confirmed regressions
-
-Run each **confirmed** regressing benchmark with async-profiler **collapsed-stack** output. Use the uber-jar directly to avoid shell escaping issues with Maven's `-Djmh.args`.
+Run each regressing benchmark with async-profiler **collapsed-stack** output. Use the uber-jar directly to avoid shell escaping issues with Maven's `-Djmh.args`.
 
 **Important**: Run benchmarks sequentially — never concurrently on the same server. HEAD and BASE can interleave (HEAD-ic4, BASE-ic4, HEAD-is3, BASE-is3...) or run all HEAD first then all BASE. Sequential within a version is easier to manage.
 
-**SSH escaping**: The `-prof async:...;...;...` argument contains semicolons that are interpreted by the remote shell when passed through SSH, causing the profiler to silently not attach. To avoid this, create a wrapper script on the server:
-
 ```bash
-ssh root@<IP> 'cat > /root/run-profile.sh << '\''SCRIPT'\''
-#!/bin/bash
-VERSION=$1    # head or base
-DIR=$2        # /root/ytdb or /root/ytdb-base
-BENCH=$3      # benchmark regex
-ARGS=$4       # JMH args
+JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED \
+  --add-opens java.base/java.util=ALL-UNNAMED \
+  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens java.base/java.nio=ALL-UNNAMED \
+  -Xms4096m -Xmx4096m -Djmh.ignoreLock=true"
 
-JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.nio.cs=ALL-UNNAMED --add-opens java.base/sun.security.x509=ALL-UNNAMED --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED -Xms4096m -Xmx4096m"
-
-mkdir -p /root/profiles/$VERSION
-
-cd $DIR/jmh-ldbc && java $JVM_ARGS \
-  -jar target/youtrackdb-jmh-ldbc-*.jar \
-  "$BENCH" $ARGS \
-  -prof "async:libPath=/tmp/async-profiler-3.0-linux-x64/lib/libasyncProfiler.so;output=collapsed;dir=/root/profiles/$VERSION;event=cpu"
-SCRIPT
-chmod +x /root/run-profile.sh'
+PROF_ARGS='-prof async:libPath=/tmp/async-profiler-3.0-linux-x64/lib/libasyncProfiler.so;output=collapsed;dir=/root/profiles/<version>;event=cpu'
 ```
 
 For each regression, run:
 ```bash
-ssh root@<IP> '/root/run-profile.sh <version> /root/ytdb<-base> "<benchmark-regex>" "<jmh-args>"'
+ssh root@<IP> "mkdir -p /root/profiles/<version> && \
+  cd /root/ytdb<-base>/jmh-ldbc && \
+  java $JVM_ARGS -jar target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar \
+  '<benchmark-regex>' <jmh-args> $PROF_ARGS"
 ```
 
 **Benchmark regex format**: `LdbcSingleThread.*<benchmark_name>` or `LdbcMultiThread.*<benchmark_name>`
 
 **Output files**: Collapsed stacks are written as `.csv` files under `/root/profiles/<version>/<fully-qualified-benchmark-name>-Throughput/collapsed-cpu.csv`
 
-### Step 9: Analyze profiles
+### Step 8: Analyze profiles
 
-All analysis commands in this step run **on the remote server** via SSH (the profile `.csv` files are in `/root/profiles/` on the server). Either wrap each command in `ssh root@<IP> '...'` or open an interactive SSH session.
+For each regression, perform three levels of analysis:
 
-For each confirmed regression, perform five levels of analysis:
-
-#### 9a. Filter non-measurement stacks
-
-Async-profiler captures ALL JVM threads across the entire fork lifetime — including `@TearDown`, WAL vacuum, GC, and JVM service threads. These inflate HEAD/BASE sample counts unevenly and obscure the real benchmark-thread signal. **Always filter before computing leaf self-time.**
-
-```bash
-# Filter out non-measurement stacks
-grep -vE 'tearDown|WALVacuum|G1Conc|G1ParScan|GCThread|GangWorker|VMThread|CompilerThread|ServiceThread|SafepointSynchronize|SafepointCleanup|MonitorDeflation' <file.csv> > <file-filtered.csv>
-```
-
-Compare total samples before and after filtering for both HEAD and BASE. Large deltas indicate:
-- **TearDown overhead**: new code paths in storage shutdown (e.g., O(n) cache eviction) — a production concern but not a measurement regression
-- **Background thread contention**: spinning/yielding on locks (e.g., WALVacuum on ScalableRWLock) — visible as `sched_yield`/`__schedule_[k]` samples; does not steal CPU on multi-core servers for single-threaded benchmarks
-
-Use the filtered files for all subsequent analysis steps.
-
-#### 9b. Leaf self-time comparison
+#### 8a. Leaf self-time comparison
 
 Extract the method with the most self-time (CPU samples where this method is the leaf frame):
 
 ```bash
-awk -F";" '{split($NF, a, " "); method=a[1]; samples=a[2]; if(method != "") leaf[method]+=samples} END {for(m in leaf) print leaf[m], m}' <file-filtered.csv> | sort -rn | head -30
+awk -F";" '{split($NF, a, " "); method=a[1]; samples=a[2]; if(method != "") leaf[method]+=samples} END {for(m in leaf) print leaf[m], m}' <file.csv> | sort -rn | head -30
 ```
 
 Compare HEAD vs BASE top-30 leaf methods. Look for:
@@ -320,27 +226,22 @@ Compare HEAD vs BASE top-30 leaf methods. Look for:
 - Methods with >20% increase in sample count
 - Methods disappearing from HEAD (may indicate JIT inlining changes)
 
-#### 9c. Inclusive method time
+#### 8b. Inclusive method time
 
-Sum the sample counts across all stacks containing a given method (measures total time including children):
+Count how many stacks contain a given method (measures total time including children):
 
 ```bash
-grep -E "(^|;)<method-name>(;| )" <file-filtered.csv> | awk '{sum += $NF} END {print sum}'
-# Note: escape dots in method names for exact matching, e.g. EntityImpl\.hasProperty
+grep -c "<method-name>" <file.csv>
 ```
 
-Focus on methods from the current branch's changed code. To identify them, diff HEAD vs BASE:
-```bash
-git diff --name-only $(git merge-base HEAD origin/develop) HEAD -- '*.java' | head -30
-```
-Then grep the profiles for class/method names from those changed files. Common hot-path methods worth checking in any regression: `executeReadRecord`, `EntityImpl.deserializeProperties`, `LockFreeReadCache`, `ConcurrentHashMap`.
+Focus on methods from the changed code: `SQLBinaryCondition.evaluate`, `getCollate`, `tryInPlaceComparison`, `isPropertyEqual`, `comparePropertyTo`, `deserializeFieldForComparison`, `InPlaceCompar`, `EntityImpl.hasProperty`, `EntityImpl.deserializeProperties`, `checkPropertyNameIfValid`, `getFieldSizeAndType`, `executeReadRecord`.
 
-#### 9d. Children of hot methods
+#### 8c. Children of hot methods
 
 Extract what a specific method calls (its direct children in the profile):
 
 ```bash
-grep -E "(^|;)<parent-method>;" <file-filtered.csv> | sed 's/^[^;]*<parent-method>;//' | awk -F"[ ;]" '{sum[$1]+=$NF} END {for (c in sum) print sum[c], c}' | sort -rn | head -15
+grep "<parent-method>;" <file.csv> | sed 's/.*<parent-method>;//' | awk -F";" '{print $1}' | sort | uniq -c | sort -rn | head -15
 ```
 
 Compare HEAD vs BASE children. Changes in child method distribution indicate:
@@ -348,37 +249,34 @@ Compare HEAD vs BASE children. Changes in child method distribution indicate:
 - **Shifted sample counts**: JIT inlining/de-inlining effects (method bytecode size changes)
 - **Disappeared children**: methods being inlined into the parent
 
-#### 9e. Bytecode size check (if JIT effects suspected)
+#### 8d. Bytecode size check (if JIT effects suspected)
 
 ```bash
-# Compare method bytecode sizes by checking the last instruction offset
-# The last offset in javap output is the actual bytecode size — counting lines is NOT a reliable proxy
-# Search in core/target/classes (not jmh-ldbc/target/classes — the shade uber-jar doesn't unpack dependency classes there)
-javap -c $(find /root/ytdb/core/target/classes -name "SQLBinaryCondition.class" | head -n 1) | awk '/evaluate/,/^$/' | tail -5
-javap -c $(find /root/ytdb-base/core/target/classes -name "SQLBinaryCondition.class" | head -n 1) | awk '/evaluate/,/^$/' | tail -5
+# Compare evaluate method bytecode sizes
+javap -c <HEAD-class-file> | awk '/<method-signature>/,/^$/' | wc -l
+javap -c <BASE-class-file> | awk '/<method-signature>/,/^$/' | wc -l
 ```
 
-The **last instruction's offset** (e.g., `324:` in `javap` output) indicates the bytecode size. HotSpot default inlining threshold is ~325 bytecodes. Methods exceeding this won't be inlined at call sites, causing cascading de-inlining effects.
+HotSpot default inlining threshold is ~325 bytecodes. Methods exceeding this won't be inlined at call sites, causing cascading de-inlining effects.
 
-### Step 10: Report findings
+### Step 9: Report findings
 
 For each regression, report:
 
-1. **Triage throughput** (HEAD vs BASE ops/s from Step 7) and **profiling throughput** (from Step 8) — confirms whether the regression reproduces or is noise
+1. **Profiling throughput** (HEAD vs BASE ops/s from the profiling run) — confirms whether the regression reproduces or is noise
 2. **Root cause category**:
    - **Guard overhead**: new condition checks that always execute but rarely succeed
    - **Double work**: same computation performed redundantly (e.g., `getCollate` called in guard + fallthrough)
    - **JIT de-inlining**: method grew past inlining budget, causing cascade
-   - **TearDown overhead**: new code in `@TearDown` (e.g., O(n) cache eviction) that inflates raw sample counts but does not affect throughput measurement — flag as a production concern, not a benchmark regression
    - **Measurement noise**: profiling shows no regression or opposite direction
 3. **Key evidence**: specific method sample counts (HEAD vs BASE) and percentages
 4. **Suggested fix** (if applicable)
 
-### Step 11: Cleanup
+### Step 10: Cleanup
 
 ```bash
-# Remove local worktree (use the same $WORKTREE_DIR from Step 4)
-git worktree remove --force "$WORKTREE_DIR"
+# Remove local worktree
+git worktree remove /tmp/ytdb-base-$$
 
 # Destroy server
 hcloud server delete "$SERVER_NAME"
@@ -387,11 +285,11 @@ hcloud ssh-key delete "$KEY_NAME"
 
 Always destroy the server — CCX33 costs ~0.09 EUR/hour.
 
-### Step 12: Self-improvement review
+### Step 11: Self-improvement review
 
 After completing the analysis, review the entire session for desynchronizations and improvements. This step is **mandatory** — do not skip it.
 
-#### 12a. Skill desynchronization check
+#### 11a. Skill desynchronization check
 
 Compare what actually happened during execution against what this skill document describes. Flag any discrepancies:
 
@@ -401,18 +299,16 @@ Compare what actually happened during execution against what this skill document
 - **Benchmark names or tiers that shifted**: e.g., a query moved tiers, new benchmarks added, class names changed
 - **Analysis methods that didn't work or needed adaptation**: e.g., `awk` field separator assumptions, stack frame format changes
 
-#### 12b. Routine improvement proposals
+#### 11b. Routine improvement proposals
 
 Reflect on the profiling session and identify improvements to the workflow:
 
 - **Efficiency**: Were there unnecessary sequential steps that could be parallelized? Did any step take much longer than expected?
 - **Analysis gaps**: Was any important signal missed that required backtracking? Would a different analysis order have been faster?
-- **New patterns**: Did a new root cause category emerge that isn't listed in Step 10? Were new methods or code paths important that aren't in the Step 9c focus list?
+- **New patterns**: Did a new root cause category emerge that isn't listed in Step 9? Were new methods or code paths important that aren't in the Step 8b focus list?
 - **Tooling**: Would a different async-profiler output format (e.g., `jfr`, `tree`) have been more useful? Would differential flamegraphs help?
 
-**Important**: All proposed improvements must be **generally applicable** — they should benefit any future profiling session, not just the specific benchmarks or regressions analyzed in this session. Do not propose narrow fixes that only apply to one query, one benchmark tier, or one particular code path.
-
-#### 12c. Propose updates
+#### 11c. Propose updates
 
 If any desynchronizations or improvements were found, **present them to the user** as a numbered list of proposed skill edits. Include:
 
@@ -426,12 +322,12 @@ Apply changes only after user approval. If nothing needs updating, explicitly st
 
 | Problem | Solution |
 |---------|----------|
-| `Another JMH instance might be running` | A prior run left a stale lock file. Delete `/tmp/jmh-*.lock` in the benchmark directory, or add `-Djmh.ignoreLock=true` to JVM_ARGS |
+| `Another JMH instance might be running` | Add `-Djmh.ignoreLock=true` to JVM_ARGS |
 | `No matching benchmarks` | List benchmarks with `-l` flag; use `LdbcSingleThread*` / `LdbcMultiThread*` prefix |
 | async-profiler `perf_event_open failed` | Run `echo 1 > /proc/sys/kernel/perf_event_paranoid` |
 | Collapsed output is `.csv` not `.collapsed` | This is normal for async-profiler 3.0 — the format is the same (semicolon-separated stacks, space, count) |
 | Profiling throughput doesn't match benchmark | Expected — profiling adds ~5-15% overhead uniformly. Compare relative differences, not absolutes |
-| Profiler produces no output files (empty `/root/profiles/`) | Semicolons in `-prof async:...;...;...` are eaten by the remote shell. Use the wrapper script approach documented in Step 8 |
+| High variance in slow benchmarks (IC4, IC3) | These benchmarks are inherently noisy. If profiling shows <5% regression or opposite direction, classify as noise |
 
 ## Notes
 
@@ -439,3 +335,4 @@ Apply changes only after user approval. If nothing needs updating, explicitly st
 - **One fork is sufficient** for profiling. We're looking at CPU distribution, not precise throughput numbers.
 - **Collapsed stacks** are preferred over flamegraph HTML because they can be analyzed programmatically with `awk`/`grep`/`sort`.
 - **JIT warmup matters** — always include at least 1 warmup iteration to avoid profiling the interpreter.
+- **IC4 and IC3** are extremely noisy benchmarks (±10-15% error). Treat regressions in these with skepticism unless profiling clearly confirms.

--- a/.claude/skills/profile-jmh-regressions/SKILL.md
+++ b/.claude/skills/profile-jmh-regressions/SKILL.md
@@ -9,6 +9,7 @@ Profile benchmark regressions found in a PR's JMH comparison comment. Provisions
 ## Prerequisites
 
 - `hcloud` CLI installed and authenticated
+- `boto3` Python library installed locally
 - SSH key pair at `~/.ssh/id_ed25519`
 - A PR with a JMH benchmark comparison comment (posted by `ldbc-jmh-compare.yml` or manually)
 - Environment variables: `HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`, `HETZNER_S3_ENDPOINT`
@@ -23,8 +24,8 @@ Read the benchmark comparison comment from the PR on the current branch:
 # Find the PR
 gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number,url
 
-# Read the latest benchmark comment
-gh pr view <NUMBER> --json comments --jq '.comments[-1].body'
+# Read the latest benchmark comment (filtering by content to avoid noise)
+gh pr view <NUMBER> --json comments --jq '.comments | map(select(.body | contains("## JMH LDBC Benchmark Comparison"))) | last | .body'
 ```
 
 Parse the markdown table to extract all benchmarks marked with `:red_circle:` (regression). Record for each:
@@ -39,15 +40,19 @@ git merge-base HEAD origin/develop
 
 ### Step 1: Determine JMH parameters per regression
 
-Each benchmark belongs to a tier with different profiling settings. Choose parameters based on the base ops/s from the PR comment:
+Each benchmark belongs to a tier with different profiling settings. Benchmarks are assigned to tiers by query name (see `jmh-ldbc/README.md`), not by dynamic ops/s lookup. To determine the tier, check which base class the benchmark extends.
 
-| Tier | Base ops/s | Profiling args |
-|------|-----------|----------------|
-| IS-ultra-fast | >2,700 | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
-| IS-noisy | 400–2,700 | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
-| IC | 17–215 | `-f 1 -wi 1 -w 5s -i 3 -r 15s -t 1` (ST) |
-| IC-slow | 1–21 | `-f 1 -wi 2 -w 10s -i 3 -r 30s -t 1` (ST) |
-| IC-ultra-slow | <0.2 | `-f 1 -wi 2 -w 10s -i 3 -r 60s -t 1` (ST) |
+**Note**: The profiling args below are intentionally reduced from the production annotations (fewer forks, shorter warmup/measurement). Profiling needs only 1 fork — we're analyzing CPU distribution, not statistical throughput. Warmup is shortened but kept long enough for JIT to stabilize.
+
+| Tier | Base Class | Queries | Production annotations | Profiling args |
+|------|-----------|---------|----------------------|----------------|
+| IS-ultra-fast | `LdbcISUltraFastBenchmarkBase` | IS1, IS3-IS6, IC13 | 5f, 1×5s wi, 3×10s | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
+| IS-noisy | `LdbcISBenchmarkBase` | IS2, IS7, IC8 | 10f, 3×5s wi, 3×10s | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` (ST) |
+| IC | `LdbcICBenchmarkBase` | IC2, IC7, IC11 | 3f, 1×10s wi, 5×20s | `-f 1 -wi 1 -w 10s -i 3 -r 20s -t 1` (ST) |
+| IC-slow | `LdbcICSlowBenchmarkBase` | IC1, IC4, IC6, IC9, IC12 | 3f, 1×30s wi, 5×30s | `-f 1 -wi 1 -w 30s -i 3 -r 30s -t 1` (ST) |
+| IC-ultra-slow | `LdbcICUltraSlowBenchmarkBase` | IC3, IC5, IC10 | 5f, 1×60s wi, 3×120s | `-f 1 -wi 1 -w 60s -i 3 -r 60s -t 1` (ST) |
+
+**IC4 exception**: `ic4_newTopics` has a method-level override `@Warmup(iterations = 3, time = 30)`. For profiling, use `-wi 2 -w 30s` instead of the IC-slow default.
 
 For multi-thread regressions, use the same warmup/measurement but omit `-t 1` (uses `@Threads(Threads.MAX)` default).
 
@@ -56,7 +61,7 @@ For multi-thread regressions, use the same warmup/measurement but omit `-t 1` (u
 Use the same naming convention as `run-jmh-benchmarks-hetzner`:
 
 ```bash
-BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]/' '[:lower:]-' | cut -c1-40)
+BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | cut -c1-40)
 SERVER_NAME="jmh-prof-${BRANCH}"
 KEY_NAME="jmh-prof-key-${BRANCH}"
 
@@ -73,7 +78,7 @@ ssh-keygen -f ~/.ssh/known_hosts -R <IP>
 
 ```bash
 ssh -o StrictHostKeyChecking=no root@<IP> \
-  'apt-get update -qq && apt-get install -y -qq openjdk-21-jdk-headless git tmux zstd > /dev/null 2>&1 && java -version'
+  'apt-get update -qq && apt-get install -y -qq openjdk-21-jdk-headless git tmux > /dev/null 2>&1 && java -version'
 ```
 
 Install async-profiler:
@@ -91,7 +96,7 @@ The async-profiler library path is: `/tmp/async-profiler-3.0-linux-x64/lib/libas
 
 **HEAD** (current worktree):
 ```bash
-rsync -az --exclude='.git' --exclude='target' --exclude='.idea' <worktree-root>/ root@<IP>:/root/ytdb/
+rsync -az --exclude='.git' --exclude='target' --exclude='.idea' "$(git rev-parse --show-toplevel)/" root@<IP>:/root/ytdb/
 ssh root@<IP> 'git config --global --add safe.directory /root/ytdb && \
   git config --global user.email "bench@test" && \
   git config --global user.name "bench" && \
@@ -101,124 +106,213 @@ ssh root@<IP> 'git config --global --add safe.directory /root/ytdb && \
 **BASE** (fork-point commit): Create a local worktree, rsync to a separate directory:
 ```bash
 BASE_COMMIT=$(git merge-base HEAD origin/develop)
-git worktree add /tmp/ytdb-base-$$ $BASE_COMMIT
+WORKTREE_DIR="/tmp/ytdb-base-profiling-$$"
+rm -rf "$WORKTREE_DIR" && git worktree prune
+git worktree add "$WORKTREE_DIR" "$BASE_COMMIT"
 
-rsync -az --exclude='.git' --exclude='target' --exclude='.idea' /tmp/ytdb-base-$$/ root@<IP>:/root/ytdb-base/
-ssh root@<IP> 'git config --global --add safe.directory /root/ytdb-base && \
-  cd /root/ytdb-base && git init && git add -A && git commit -m "base" --quiet'
+rsync -az --exclude='.git' --exclude='target' --exclude='.idea' "$WORKTREE_DIR/" root@<IP>:/root/ytdb-base/
+ssh root@<IP> 'cd /root/ytdb-base && git init && git add -A && git commit -m "base" --quiet'
 ```
 
-### Step 5: Compile both versions and download LDBC data
+### Step 5: Compile both versions and download LDBC CSV dataset
 
-Compile both in parallel (they use separate directories):
+Compile both in parallel using isolated local repositories to avoid `~/.m2/repository` corruption from concurrent writes:
 ```bash
-# HEAD
-ssh root@<IP> 'cd /root/ytdb && chmod +x mvnw && \
-  ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q'
-
-# BASE
-ssh root@<IP> 'cd /root/ytdb-base && chmod +x mvnw && \
-  ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q'
+ssh root@<IP> '
+  (cd /root/ytdb && chmod +x mvnw && ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q -Dmaven.repo.local=/root/.m2-head) &
+  (cd /root/ytdb-base && chmod +x mvnw && ./mvnw -pl jmh-ldbc -am package -DskipTests -Dspotless.check.skip=true -q -Dmaven.repo.local=/root/.m2-base) &
+  wait'
 ```
 
-Download pre-built LDBC database (see `run-jmh-benchmarks-hetzner` skill for S3 presigned URL generation):
+Download the LDBC SF 1 CSV dataset and canonical curated parameters from Hetzner S3. Generate presigned URLs locally (see `run-jmh-benchmarks-hetzner` skill Step 3b for the boto3 presigned URL generation):
+
 ```bash
-# Generate presigned URL locally
-S3_KEY="ldbc/ldbc-sf1-bench-db.tar.zst"
-PRESIGNED_URL=$(python3 -c "
+# Generate presigned URLs locally (boto3 required)
+python3 -c "
 import boto3, os
 s3 = boto3.client('s3',
-    endpoint_url='https://nbg1.your-objectstorage.com',
+    endpoint_url=os.environ['HETZNER_S3_ENDPOINT'],
     aws_access_key_id=os.environ['HETZNER_S3_ACCESS_KEY'],
     aws_secret_access_key=os.environ['HETZNER_S3_SECRET_KEY'])
-url = s3.generate_presigned_url('get_object',
-    Params={'Bucket': 'bench-cache', 'Key': '$S3_KEY'},
-    ExpiresIn=7200)
-print(url)
-")
-
-# Download and extract to HEAD
-ssh root@<IP> "mkdir -p /root/ytdb/jmh-ldbc/target && \
-  curl -sS -o /tmp/bench-db.tar.zst '$PRESIGNED_URL' && \
-  cd /root/ytdb/jmh-ldbc/target && \
-  zstd -d /tmp/bench-db.tar.zst -o /tmp/bench-db.tar && \
-  tar xf /tmp/bench-db.tar && rm -f /tmp/bench-db.tar.zst /tmp/bench-db.tar"
-
-# Clear curation caches
-ssh root@<IP> 'rm -f /root/ytdb/jmh-ldbc/target/ldbc-bench-db/curated-params*.json \
-  /root/ytdb/jmh-ldbc/target/ldbc-bench-db/factor-tables.json'
-
-# Copy to BASE
-ssh root@<IP> 'cp -r /root/ytdb/jmh-ldbc/target/ldbc-bench-db /root/ytdb-base/jmh-ldbc/target/'
+for key in ['ldbc/ldbc-sf1-composite-merged-fk.tar.zst', 'ldbc/curated-params-v3.json', 'ldbc/factor-tables.json']:
+    url = s3.generate_presigned_url('get_object',
+        Params={'Bucket': 'bench-cache', 'Key': key},
+        ExpiresIn=7200)
+    print(f'{key}: {url}')
+"
 ```
 
-### Step 6: Pre-load and curate parameters
+Download and extract CSV dataset:
+```bash
+# Download and extract CSV dataset to HEAD
+ssh root@<IP> 'apt-get install -y -qq zstd > /dev/null 2>&1 && \
+  mkdir -p /root/ytdb/jmh-ldbc/target/ldbc-dataset/sf1 && \
+  cd /root/ytdb/jmh-ldbc/target/ldbc-dataset/sf1 && \
+  curl -sS "<CSV_PRESIGNED_URL>" | zstd -dc | tar xf - && \
+  echo "Dataset ready" && ls static/ dynamic/'
 
-Run a throwaway fork on **each** version to trigger DB open + parameter curation:
+# Copy CSV dataset to BASE
+ssh root@<IP> 'cp -r /root/ytdb/jmh-ldbc/target/ldbc-dataset /root/ytdb-base/jmh-ldbc/target/'
+```
+
+Download canonical curated parameters for both HEAD and BASE:
+```bash
+# Install canonical curated params into HEAD DB directory
+ssh root@<IP> 'mkdir -p /root/ytdb/jmh-ldbc/target/ldbc-bench-db && \
+  curl -sS -o /root/ytdb/jmh-ldbc/target/ldbc-bench-db/factor-tables.json "<FACTOR_TABLES_URL>" && \
+  curl -sS -o /root/ytdb/jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json "<CURATED_PARAMS_URL>" && \
+  echo "HEAD curated params installed"'
+
+# Install canonical curated params into BASE DB directory
+ssh root@<IP> 'mkdir -p /root/ytdb-base/jmh-ldbc/target/ldbc-bench-db && \
+  curl -sS -o /root/ytdb-base/jmh-ldbc/target/ldbc-bench-db/factor-tables.json "<FACTOR_TABLES_URL>" && \
+  curl -sS -o /root/ytdb-base/jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json "<CURATED_PARAMS_URL>" && \
+  echo "BASE curated params installed"'
+```
+
+**Critical**: Both HEAD and BASE must use the same canonical curated parameters downloaded from S3. Never let either version regenerate params independently — internal data structure changes can alter iteration order and produce incomparable parameter sets (see IC4 desync incident in `jmh-ldbc/README.md`).
+
+### Step 6: Pre-load database
+
+Run a throwaway fork on **each** version to trigger DB creation from CSV files (~21 min for SF 1) and load canonical curated parameters. Any benchmark name works here — the goal is just to trigger `@Setup(Level.Trial)` which creates the DB from CSV and loads the pre-downloaded curated parameters from the JSON cache files installed in Step 5.
+
+**Important**: Use `-f 1` (not `-f 0`). With `-f 0` the benchmark runs in-process and JMH exits 0 even when all benchmarks fail — silent failures are hard to diagnose on a remote server.
 
 ```bash
 # HEAD
 ssh root@<IP> 'cd /root/ytdb/jmh-ldbc && java \
   --add-opens java.base/java.lang=ALL-UNNAMED \
-  --add-opens java.base/java.util=ALL-UNNAMED \
-  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
   --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens java.base/java.io=ALL-UNNAMED \
   --add-opens java.base/java.nio=ALL-UNNAMED \
+  --add-opens java.base/java.util=ALL-UNNAMED \
+  --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
+  --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+  --add-opens java.base/java.net=ALL-UNNAMED \
+  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens java.base/sun.nio.cs=ALL-UNNAMED \
+  --add-opens java.base/sun.security.x509=ALL-UNNAMED \
+  --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED \
   -Xms4096m -Xmx4096m \
-  -jar target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar \
+  -jar target/youtrackdb-jmh-ldbc-*.jar \
   "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1'
 
-# BASE (use -Djmh.ignoreLock=true if HEAD is still running, but prefer sequential)
+# BASE (separate directory — no JMH lock conflict with HEAD)
 ssh root@<IP> 'cd /root/ytdb-base/jmh-ldbc && java \
   --add-opens java.base/java.lang=ALL-UNNAMED \
-  --add-opens java.base/java.util=ALL-UNNAMED \
-  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
   --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens java.base/java.io=ALL-UNNAMED \
   --add-opens java.base/java.nio=ALL-UNNAMED \
-  -Xms4096m -Xmx4096m -Djmh.ignoreLock=true \
-  -jar target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar \
+  --add-opens java.base/java.util=ALL-UNNAMED \
+  --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
+  --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+  --add-opens java.base/java.net=ALL-UNNAMED \
+  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  --add-opens java.base/sun.nio.cs=ALL-UNNAMED \
+  --add-opens java.base/sun.security.x509=ALL-UNNAMED \
+  --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED \
+  -Xms4096m -Xmx4096m \
+  -jar target/youtrackdb-jmh-ldbc-*.jar \
   "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1'
 ```
 
-### Step 7: Profile regressions
+### Step 7: Triage run — filter false positives
 
-Run each regressing benchmark with async-profiler **collapsed-stack** output. Use the uber-jar directly to avoid shell escaping issues with Maven's `-Djmh.args`.
+Before spending time on profiling, run each regressing benchmark **without async-profiler** on both HEAD and BASE to confirm the regression reproduces. Use the same tier-based JMH parameters from Step 1.
+
+Use the wrapper script (without `-prof`):
+```bash
+ssh root@<IP> 'cat > /root/run-bench.sh << '\''SCRIPT'\''
+#!/bin/bash
+DIR=$1        # /root/ytdb or /root/ytdb-base
+BENCH=$2      # benchmark regex
+ARGS=$3       # JMH args
+
+JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.nio.cs=ALL-UNNAMED --add-opens java.base/sun.security.x509=ALL-UNNAMED --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED -Xms4096m -Xmx4096m"
+
+cd $DIR/jmh-ldbc && java $JVM_ARGS \
+  -jar target/youtrackdb-jmh-ldbc-*.jar \
+  "$BENCH" $ARGS
+SCRIPT
+chmod +x /root/run-bench.sh'
+```
+
+For each regression, run HEAD then BASE sequentially:
+```bash
+ssh root@<IP> '/root/run-bench.sh /root/ytdb "<benchmark-regex>" "<jmh-args>"'
+ssh root@<IP> '/root/run-bench.sh /root/ytdb-base "<benchmark-regex>" "<jmh-args>"'
+```
+
+**Decision rule**: Compare HEAD vs BASE ops/s from the triage run. If the delta is **<3%** or in the **opposite direction** (HEAD faster), classify as **measurement noise** and skip profiling. Only proceed to Step 8 for benchmarks that reproduce a **≥3% regression** in the triage run.
+
+Record the triage results in the final report alongside profiling throughput for transparency.
+
+### Step 8: Profile confirmed regressions
+
+Run each **confirmed** regressing benchmark with async-profiler **collapsed-stack** output. Use the uber-jar directly to avoid shell escaping issues with Maven's `-Djmh.args`.
 
 **Important**: Run benchmarks sequentially — never concurrently on the same server. HEAD and BASE can interleave (HEAD-ic4, BASE-ic4, HEAD-is3, BASE-is3...) or run all HEAD first then all BASE. Sequential within a version is easier to manage.
 
-```bash
-JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED \
-  --add-opens java.base/java.util=ALL-UNNAMED \
-  --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
-  --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
-  --add-opens java.base/java.nio=ALL-UNNAMED \
-  -Xms4096m -Xmx4096m -Djmh.ignoreLock=true"
+**SSH escaping**: The `-prof async:...;...;...` argument contains semicolons that are interpreted by the remote shell when passed through SSH, causing the profiler to silently not attach. To avoid this, create a wrapper script on the server:
 
-PROF_ARGS='-prof async:libPath=/tmp/async-profiler-3.0-linux-x64/lib/libasyncProfiler.so;output=collapsed;dir=/root/profiles/<version>;event=cpu'
+```bash
+ssh root@<IP> 'cat > /root/run-profile.sh << '\''SCRIPT'\''
+#!/bin/bash
+VERSION=$1    # head or base
+DIR=$2        # /root/ytdb or /root/ytdb-base
+BENCH=$3      # benchmark regex
+ARGS=$4       # JMH args
+
+JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.nio.cs=ALL-UNNAMED --add-opens java.base/sun.security.x509=ALL-UNNAMED --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED -Xms4096m -Xmx4096m"
+
+mkdir -p /root/profiles/$VERSION
+
+cd $DIR/jmh-ldbc && java $JVM_ARGS \
+  -jar target/youtrackdb-jmh-ldbc-*.jar \
+  "$BENCH" $ARGS \
+  -prof "async:libPath=/tmp/async-profiler-3.0-linux-x64/lib/libasyncProfiler.so;output=collapsed;dir=/root/profiles/$VERSION;event=cpu"
+SCRIPT
+chmod +x /root/run-profile.sh'
 ```
 
 For each regression, run:
 ```bash
-ssh root@<IP> "mkdir -p /root/profiles/<version> && \
-  cd /root/ytdb<-base>/jmh-ldbc && \
-  java $JVM_ARGS -jar target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar \
-  '<benchmark-regex>' <jmh-args> $PROF_ARGS"
+ssh root@<IP> '/root/run-profile.sh <version> /root/ytdb<-base> "<benchmark-regex>" "<jmh-args>"'
 ```
 
 **Benchmark regex format**: `LdbcSingleThread.*<benchmark_name>` or `LdbcMultiThread.*<benchmark_name>`
 
 **Output files**: Collapsed stacks are written as `.csv` files under `/root/profiles/<version>/<fully-qualified-benchmark-name>-Throughput/collapsed-cpu.csv`
 
-### Step 8: Analyze profiles
+### Step 9: Analyze profiles
 
-For each regression, perform three levels of analysis:
+All analysis commands in this step run **on the remote server** via SSH (the profile `.csv` files are in `/root/profiles/` on the server). Either wrap each command in `ssh root@<IP> '...'` or open an interactive SSH session.
 
-#### 8a. Leaf self-time comparison
+For each confirmed regression, perform five levels of analysis:
+
+#### 9a. Filter non-measurement stacks
+
+Async-profiler captures ALL JVM threads across the entire fork lifetime — including `@TearDown`, WAL vacuum, GC, and JVM service threads. These inflate HEAD/BASE sample counts unevenly and obscure the real benchmark-thread signal. **Always filter before computing leaf self-time.**
+
+```bash
+# Filter out non-measurement stacks
+grep -vE 'tearDown|WALVacuum|G1Conc|G1ParScan|GCThread|GangWorker|VMThread|CompilerThread|ServiceThread|SafepointSynchronize|SafepointCleanup|MonitorDeflation' <file.csv> > <file-filtered.csv>
+```
+
+Compare total samples before and after filtering for both HEAD and BASE. Large deltas indicate:
+- **TearDown overhead**: new code paths in storage shutdown (e.g., O(n) cache eviction) — a production concern but not a measurement regression
+- **Background thread contention**: spinning/yielding on locks (e.g., WALVacuum on ScalableRWLock) — visible as `sched_yield`/`__schedule_[k]` samples; does not steal CPU on multi-core servers for single-threaded benchmarks
+
+Use the filtered files for all subsequent analysis steps.
+
+#### 9b. Leaf self-time comparison
 
 Extract the method with the most self-time (CPU samples where this method is the leaf frame):
 
 ```bash
-awk -F";" '{split($NF, a, " "); method=a[1]; samples=a[2]; if(method != "") leaf[method]+=samples} END {for(m in leaf) print leaf[m], m}' <file.csv> | sort -rn | head -30
+awk -F";" '{split($NF, a, " "); method=a[1]; samples=a[2]; if(method != "") leaf[method]+=samples} END {for(m in leaf) print leaf[m], m}' <file-filtered.csv> | sort -rn | head -30
 ```
 
 Compare HEAD vs BASE top-30 leaf methods. Look for:
@@ -226,22 +320,27 @@ Compare HEAD vs BASE top-30 leaf methods. Look for:
 - Methods with >20% increase in sample count
 - Methods disappearing from HEAD (may indicate JIT inlining changes)
 
-#### 8b. Inclusive method time
+#### 9c. Inclusive method time
 
-Count how many stacks contain a given method (measures total time including children):
+Sum the sample counts across all stacks containing a given method (measures total time including children):
 
 ```bash
-grep -c "<method-name>" <file.csv>
+grep -E "(^|;)<method-name>(;| )" <file-filtered.csv> | awk '{sum += $NF} END {print sum}'
+# Note: escape dots in method names for exact matching, e.g. EntityImpl\.hasProperty
 ```
 
-Focus on methods from the changed code: `SQLBinaryCondition.evaluate`, `getCollate`, `tryInPlaceComparison`, `isPropertyEqual`, `comparePropertyTo`, `deserializeFieldForComparison`, `InPlaceCompar`, `EntityImpl.hasProperty`, `EntityImpl.deserializeProperties`, `checkPropertyNameIfValid`, `getFieldSizeAndType`, `executeReadRecord`.
+Focus on methods from the current branch's changed code. To identify them, diff HEAD vs BASE:
+```bash
+git diff --name-only $(git merge-base HEAD origin/develop) HEAD -- '*.java' | head -30
+```
+Then grep the profiles for class/method names from those changed files. Common hot-path methods worth checking in any regression: `executeReadRecord`, `EntityImpl.deserializeProperties`, `LockFreeReadCache`, `ConcurrentHashMap`.
 
-#### 8c. Children of hot methods
+#### 9d. Children of hot methods
 
 Extract what a specific method calls (its direct children in the profile):
 
 ```bash
-grep "<parent-method>;" <file.csv> | sed 's/.*<parent-method>;//' | awk -F";" '{print $1}' | sort | uniq -c | sort -rn | head -15
+grep -E "(^|;)<parent-method>;" <file-filtered.csv> | sed 's/^[^;]*<parent-method>;//' | awk -F"[ ;]" '{sum[$1]+=$NF} END {for (c in sum) print sum[c], c}' | sort -rn | head -15
 ```
 
 Compare HEAD vs BASE children. Changes in child method distribution indicate:
@@ -249,34 +348,37 @@ Compare HEAD vs BASE children. Changes in child method distribution indicate:
 - **Shifted sample counts**: JIT inlining/de-inlining effects (method bytecode size changes)
 - **Disappeared children**: methods being inlined into the parent
 
-#### 8d. Bytecode size check (if JIT effects suspected)
+#### 9e. Bytecode size check (if JIT effects suspected)
 
 ```bash
-# Compare evaluate method bytecode sizes
-javap -c <HEAD-class-file> | awk '/<method-signature>/,/^$/' | wc -l
-javap -c <BASE-class-file> | awk '/<method-signature>/,/^$/' | wc -l
+# Compare method bytecode sizes by checking the last instruction offset
+# The last offset in javap output is the actual bytecode size — counting lines is NOT a reliable proxy
+# Search in core/target/classes (not jmh-ldbc/target/classes — the shade uber-jar doesn't unpack dependency classes there)
+javap -c $(find /root/ytdb/core/target/classes -name "SQLBinaryCondition.class" | head -n 1) | awk '/evaluate/,/^$/' | tail -5
+javap -c $(find /root/ytdb-base/core/target/classes -name "SQLBinaryCondition.class" | head -n 1) | awk '/evaluate/,/^$/' | tail -5
 ```
 
-HotSpot default inlining threshold is ~325 bytecodes. Methods exceeding this won't be inlined at call sites, causing cascading de-inlining effects.
+The **last instruction's offset** (e.g., `324:` in `javap` output) indicates the bytecode size. HotSpot default inlining threshold is ~325 bytecodes. Methods exceeding this won't be inlined at call sites, causing cascading de-inlining effects.
 
-### Step 9: Report findings
+### Step 10: Report findings
 
 For each regression, report:
 
-1. **Profiling throughput** (HEAD vs BASE ops/s from the profiling run) — confirms whether the regression reproduces or is noise
+1. **Triage throughput** (HEAD vs BASE ops/s from Step 7) and **profiling throughput** (from Step 8) — confirms whether the regression reproduces or is noise
 2. **Root cause category**:
    - **Guard overhead**: new condition checks that always execute but rarely succeed
    - **Double work**: same computation performed redundantly (e.g., `getCollate` called in guard + fallthrough)
    - **JIT de-inlining**: method grew past inlining budget, causing cascade
+   - **TearDown overhead**: new code in `@TearDown` (e.g., O(n) cache eviction) that inflates raw sample counts but does not affect throughput measurement — flag as a production concern, not a benchmark regression
    - **Measurement noise**: profiling shows no regression or opposite direction
 3. **Key evidence**: specific method sample counts (HEAD vs BASE) and percentages
 4. **Suggested fix** (if applicable)
 
-### Step 10: Cleanup
+### Step 11: Cleanup
 
 ```bash
-# Remove local worktree
-git worktree remove /tmp/ytdb-base-$$
+# Remove local worktree (use the same $WORKTREE_DIR from Step 4)
+git worktree remove --force "$WORKTREE_DIR"
 
 # Destroy server
 hcloud server delete "$SERVER_NAME"
@@ -285,11 +387,11 @@ hcloud ssh-key delete "$KEY_NAME"
 
 Always destroy the server — CCX33 costs ~0.09 EUR/hour.
 
-### Step 11: Self-improvement review
+### Step 12: Self-improvement review
 
 After completing the analysis, review the entire session for desynchronizations and improvements. This step is **mandatory** — do not skip it.
 
-#### 11a. Skill desynchronization check
+#### 12a. Skill desynchronization check
 
 Compare what actually happened during execution against what this skill document describes. Flag any discrepancies:
 
@@ -299,16 +401,18 @@ Compare what actually happened during execution against what this skill document
 - **Benchmark names or tiers that shifted**: e.g., a query moved tiers, new benchmarks added, class names changed
 - **Analysis methods that didn't work or needed adaptation**: e.g., `awk` field separator assumptions, stack frame format changes
 
-#### 11b. Routine improvement proposals
+#### 12b. Routine improvement proposals
 
 Reflect on the profiling session and identify improvements to the workflow:
 
 - **Efficiency**: Were there unnecessary sequential steps that could be parallelized? Did any step take much longer than expected?
 - **Analysis gaps**: Was any important signal missed that required backtracking? Would a different analysis order have been faster?
-- **New patterns**: Did a new root cause category emerge that isn't listed in Step 9? Were new methods or code paths important that aren't in the Step 8b focus list?
+- **New patterns**: Did a new root cause category emerge that isn't listed in Step 10? Were new methods or code paths important that aren't in the Step 9c focus list?
 - **Tooling**: Would a different async-profiler output format (e.g., `jfr`, `tree`) have been more useful? Would differential flamegraphs help?
 
-#### 11c. Propose updates
+**Important**: All proposed improvements must be **generally applicable** — they should benefit any future profiling session, not just the specific benchmarks or regressions analyzed in this session. Do not propose narrow fixes that only apply to one query, one benchmark tier, or one particular code path.
+
+#### 12c. Propose updates
 
 If any desynchronizations or improvements were found, **present them to the user** as a numbered list of proposed skill edits. Include:
 
@@ -322,12 +426,12 @@ Apply changes only after user approval. If nothing needs updating, explicitly st
 
 | Problem | Solution |
 |---------|----------|
-| `Another JMH instance might be running` | Add `-Djmh.ignoreLock=true` to JVM_ARGS |
+| `Another JMH instance might be running` | A prior run left a stale lock file. Delete `/tmp/jmh-*.lock` in the benchmark directory, or add `-Djmh.ignoreLock=true` to JVM_ARGS |
 | `No matching benchmarks` | List benchmarks with `-l` flag; use `LdbcSingleThread*` / `LdbcMultiThread*` prefix |
 | async-profiler `perf_event_open failed` | Run `echo 1 > /proc/sys/kernel/perf_event_paranoid` |
 | Collapsed output is `.csv` not `.collapsed` | This is normal for async-profiler 3.0 — the format is the same (semicolon-separated stacks, space, count) |
 | Profiling throughput doesn't match benchmark | Expected — profiling adds ~5-15% overhead uniformly. Compare relative differences, not absolutes |
-| High variance in slow benchmarks (IC4, IC3) | These benchmarks are inherently noisy. If profiling shows <5% regression or opposite direction, classify as noise |
+| Profiler produces no output files (empty `/root/profiles/`) | Semicolons in `-prof async:...;...;...` are eaten by the remote shell. Use the wrapper script approach documented in Step 8 |
 
 ## Notes
 
@@ -335,4 +439,3 @@ Apply changes only after user approval. If nothing needs updating, explicitly st
 - **One fork is sufficient** for profiling. We're looking at CPU distribution, not precise throughput numbers.
 - **Collapsed stacks** are preferred over flamegraph HTML because they can be analyzed programmatically with `awk`/`grep`/`sort`.
 - **JIT warmup matters** — always include at least 1 warmup iteration to avoid profiling the interpreter.
-- **IC4 and IC3** are extremely noisy benchmarks (±10-15% error). Treat regressions in these with skepticism unless profiling clearly confirms.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -624,12 +624,13 @@ public class EntityImpl extends RecordAbstract implements Entity {
       return null;
     }
 
-    var schemaClass = getImmutableSchemaClass(session);
+    var immutableSchema = session.getMetadata().getImmutableSchemaSnapshot();
+    var schemaClass = getImmutableSchemaClass(session, immutableSchema);
     var serializer = RecordSerializerBinary.INSTANCE.getSerializer(source[0]);
     var bytes = new BytesContainer(source, 1);
     var field = serializer.deserializeField(
         session, bytes, schemaClass, name, isEmbedded(),
-        session.getMetadata().getImmutableSchemaSnapshot(), propertyEncryption);
+        immutableSchema, propertyEncryption);
 
     if (field == null) {
       return null;
@@ -3684,11 +3685,17 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
   @Nullable public SchemaImmutableClass getImmutableSchemaClass(
       @Nonnull DatabaseSessionEmbedded session) {
+    return getImmutableSchemaClass(session,
+        session.getMetadata().getImmutableSchemaSnapshot());
+  }
+
+  @Nullable private SchemaImmutableClass getImmutableSchemaClass(
+      @Nonnull DatabaseSessionEmbedded session,
+      @Nullable ImmutableSchema immutableSchema) {
     if (this.session != null && this.session != session) {
       throw new DatabaseException("The entity is bounded to another session");
     }
 
-    var immutableSchema = session.getMetadata().getImmutableSchemaSnapshot();
     if (immutableClazz == null) {
       if (className == null) {
         fetchClassName(session);
@@ -3704,7 +3711,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
       }
     } else if (immutableSchemaVersion != immutableSchema.getVersion()) {
       immutableClazz = null;
-      return getImmutableSchemaClass(session);
+      return getImmutableSchemaClass(session, immutableSchema);
     }
 
     return immutableClazz;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -641,16 +641,36 @@ public class EntityImpl extends RecordAbstract implements Entity {
   }
 
   /**
-   * Type-aware equality comparison of two Java values. Delegates to
-   * {@link #compareJavaValuesOrdering} and maps the result.
+   * Type-aware equality comparison of two Java values. Handles LINK equality directly
+   * (comparing RID components), then delegates to {@link #compareJavaValuesOrdering}
+   * for all other types.
    */
   private static InPlaceResult compareJavaValues(
       PropertyTypeInternal type, Object entryValue, Object value) {
+    // LINK: equality via RID components (ordering is not supported)
+    if (type == PropertyTypeInternal.LINK) {
+      return compareLinkJavaValues(entryValue, value);
+    }
     var cmp = compareJavaValuesOrdering(type, entryValue, value);
     if (cmp.isEmpty()) {
       return InPlaceResult.FALLBACK;
     }
     return cmp.getAsInt() == 0 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+  }
+
+  /**
+   * LINK equality: compare cluster ID and cluster position from both Identifiable instances.
+   */
+  private static InPlaceResult compareLinkJavaValues(Object entryValue, Object value) {
+    if (!(entryValue instanceof Identifiable entryId)
+        || !(value instanceof Identifiable valueId)) {
+      return InPlaceResult.FALLBACK;
+    }
+    var entryRid = entryId.getIdentity();
+    var valueRid = valueId.getIdentity();
+    return (entryRid.getCollectionId() == valueRid.getCollectionId()
+        && entryRid.getCollectionPosition() == valueRid.getCollectionPosition())
+            ? InPlaceResult.TRUE : InPlaceResult.FALSE;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -72,6 +72,7 @@ import com.jetbrains.youtrackdb.internal.core.query.collection.links.LinkList;
 import com.jetbrains.youtrackdb.internal.core.query.collection.links.LinkMap;
 import com.jetbrains.youtrackdb.internal.core.query.collection.links.LinkSet;
 import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.BinaryField;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.BytesContainer;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.InPlaceComparator;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.RecordSerializerBinary;
@@ -582,29 +583,12 @@ public class EntityImpl extends RecordAbstract implements Entity {
    * Compare against the serialized bytes in source using InPlaceComparator (equality check).
    */
   private InPlaceResult compareFromSource(String name, Object value) {
-    if (value == null) {
-      return InPlaceResult.FALLBACK;
-    }
-    if (propertyEncryption != null && propertyEncryption.isEncrypted(name)) {
-      return InPlaceResult.FALLBACK;
-    }
-
-    var schemaClass = getImmutableSchemaClass(session);
-    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(source[0]);
-    var bytes = new BytesContainer(source, 1);
-    var encryption = propertyEncryption;
-    var field = serializer.deserializeField(
-        session, bytes, schemaClass, name, isEmbedded(),
-        session.getMetadata().getImmutableSchemaSnapshot(), encryption);
-
+    var field = deserializeFieldForComparison(name, value);
     if (field == null) {
       return InPlaceResult.FALLBACK;
     }
-    if (field.collate != null && !(field.collate instanceof DefaultCollate)) {
-      return InPlaceResult.FALLBACK;
-    }
-
     var dbTimeZone = DateHelper.getDatabaseTimeZone(session);
+    // InPlaceComparator.isEqual returns 1 for equal, 0 for not equal
     var result = InPlaceComparator.isEqual(field, value, dbTimeZone);
     if (result.isEmpty()) {
       return InPlaceResult.FALLBACK;
@@ -616,105 +600,60 @@ public class EntityImpl extends RecordAbstract implements Entity {
    * Compare against the serialized bytes in source using InPlaceComparator (ordering).
    */
   private OptionalInt compareFromSourceOrdering(String name, Object value) {
-    if (value == null) {
-      return OptionalInt.empty();
-    }
-    if (propertyEncryption != null && propertyEncryption.isEncrypted(name)) {
-      return OptionalInt.empty();
-    }
-
-    var schemaClass = getImmutableSchemaClass(session);
-    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(source[0]);
-    var bytes = new BytesContainer(source, 1);
-    var encryption = propertyEncryption;
-    var field = serializer.deserializeField(
-        session, bytes, schemaClass, name, isEmbedded(),
-        session.getMetadata().getImmutableSchemaSnapshot(), encryption);
-
+    var field = deserializeFieldForComparison(name, value);
     if (field == null) {
       return OptionalInt.empty();
     }
-    if (field.collate != null && !(field.collate instanceof DefaultCollate)) {
-      return OptionalInt.empty();
-    }
-
     var dbTimeZone = DateHelper.getDatabaseTimeZone(session);
     return InPlaceComparator.compare(field, value, dbTimeZone);
   }
 
   /**
-   * Type-aware equality comparison of two Java values, using the same semantics as
-   * InPlaceComparator (Float.compare, BigDecimal.compareTo, etc.).
+   * Shared setup for source-bytes comparison: validates preconditions, locates the field
+   * in the serialized record, and checks collation. Returns null if any guard fails.
    */
-  @SuppressWarnings("unchecked")
-  private static InPlaceResult compareJavaValues(
-      PropertyTypeInternal type, Object entryValue, Object value) {
-    try {
-      return switch (type) {
-        case INTEGER, LONG, SHORT, BYTE -> {
-          if (!(entryValue instanceof Number entryNum) || !(value instanceof Number valNum)) {
-            yield InPlaceResult.FALLBACK;
-          }
-          // Compare as longs to handle cross-type (Integer vs Long, etc.)
-          yield Long.compare(entryNum.longValue(), valNum.longValue()) == 0
-              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-        }
-        case FLOAT -> {
-          if (!(entryValue instanceof Float f) || !(value instanceof Number n)) {
-            yield InPlaceResult.FALLBACK;
-          }
-          if (value instanceof Double d) {
-            yield Double.compare(f, d) == 0
-                ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-          }
-          yield Float.compare(f, n.floatValue()) == 0
-              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-        }
-        case DOUBLE -> {
-          if (!(entryValue instanceof Double d) || !(value instanceof Number n)) {
-            yield InPlaceResult.FALLBACK;
-          }
-          yield Double.compare(d, n.doubleValue()) == 0
-              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-        }
-        case DECIMAL -> {
-          if (!(entryValue instanceof BigDecimal bd)) {
-            yield InPlaceResult.FALLBACK;
-          }
-          BigDecimal converted;
-          if (value instanceof BigDecimal bdv) {
-            converted = bdv;
-          } else if (value instanceof Number n) {
-            if (n instanceof Double || n instanceof Float) {
-              converted = BigDecimal.valueOf(n.doubleValue());
-            } else {
-              converted = BigDecimal.valueOf(n.longValue());
-            }
-          } else {
-            yield InPlaceResult.FALLBACK;
-          }
-          yield bd.compareTo(converted) == 0
-              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-        }
-        default -> {
-          if (entryValue instanceof Comparable c) {
-            try {
-              yield c.compareTo(value) == 0
-                  ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-            } catch (ClassCastException e) {
-              yield InPlaceResult.FALLBACK;
-            }
-          }
-          yield entryValue.equals(value) ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-        }
-      };
-    } catch (Exception e) {
-      return InPlaceResult.FALLBACK;
+  @Nullable private BinaryField deserializeFieldForComparison(String name, Object value) {
+    if (value == null) {
+      return null;
     }
+    if (propertyEncryption != null && propertyEncryption.isEncrypted(name)) {
+      return null;
+    }
+
+    var schemaClass = getImmutableSchemaClass(session);
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(source[0]);
+    var bytes = new BytesContainer(source, 1);
+    var field = serializer.deserializeField(
+        session, bytes, schemaClass, name, isEmbedded(),
+        session.getMetadata().getImmutableSchemaSnapshot(), propertyEncryption);
+
+    if (field == null) {
+      return null;
+    }
+    if (field.collate != null && !(field.collate instanceof DefaultCollate)) {
+      return null;
+    }
+    return field;
   }
 
   /**
-   * Type-aware ordering comparison of two Java values.
+   * Type-aware equality comparison of two Java values. Delegates to
+   * {@link #compareJavaValuesOrdering} and maps the result.
+   */
+  private static InPlaceResult compareJavaValues(
+      PropertyTypeInternal type, Object entryValue, Object value) {
+    var cmp = compareJavaValuesOrdering(type, entryValue, value);
+    if (cmp.isEmpty()) {
+      return InPlaceResult.FALLBACK;
+    }
+    return cmp.getAsInt() == 0 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+  }
+
+  /**
+   * Type-aware ordering comparison of two Java values, using the same semantics as
+   * InPlaceComparator (Float.compare, BigDecimal.compareTo, etc.). Float/Double values
+   * are rejected for integer types to match InPlaceComparator's fallback behavior.
+   * byte[] uses Arrays.compare since byte[] does not implement Comparable.
    */
   @SuppressWarnings("unchecked")
   private static OptionalInt compareJavaValuesOrdering(
@@ -723,6 +662,10 @@ public class EntityImpl extends RecordAbstract implements Entity {
       return switch (type) {
         case INTEGER, LONG, SHORT, BYTE -> {
           if (!(entryValue instanceof Number entryNum) || !(value instanceof Number valNum)) {
+            yield OptionalInt.empty();
+          }
+          // Float/Double -> integer: fall back to match InPlaceComparator behavior
+          if (valNum instanceof Float || valNum instanceof Double) {
             yield OptionalInt.empty();
           }
           yield OptionalInt.of(Long.compare(entryNum.longValue(), valNum.longValue()));
@@ -760,12 +703,20 @@ public class EntityImpl extends RecordAbstract implements Entity {
           }
           yield OptionalInt.of(bd.compareTo(converted));
         }
+        case BINARY -> {
+          // byte[] does not implement Comparable; use Arrays.compare
+          if (entryValue instanceof byte[] entryBytes && value instanceof byte[] valBytes) {
+            yield OptionalInt.of(java.util.Arrays.compare(entryBytes, valBytes));
+          }
+          yield OptionalInt.empty();
+        }
         case LINK -> OptionalInt.empty(); // ordering not supported for LINKs
         default -> {
           if (entryValue instanceof Comparable c) {
             try {
               yield OptionalInt.of(c.compareTo(value));
             } catch (ClassCastException e) {
+              // compareTo type mismatch — fall back
               yield OptionalInt.empty();
             }
           }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -22,6 +22,7 @@ package com.jetbrains.youtrackdb.internal.core.record.impl;
 import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.common.collection.MultiValue;
 import com.jetbrains.youtrackdb.internal.common.log.LogManager;
+import com.jetbrains.youtrackdb.internal.core.collate.DefaultCollate;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.EntityEmbeddedListImpl;
 import com.jetbrains.youtrackdb.internal.core.db.record.EntityEmbeddedMapImpl;
@@ -71,11 +72,16 @@ import com.jetbrains.youtrackdb.internal.core.query.collection.links.LinkList;
 import com.jetbrains.youtrackdb.internal.core.query.collection.links.LinkMap;
 import com.jetbrains.youtrackdb.internal.core.query.collection.links.LinkSet;
 import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.BytesContainer;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.InPlaceComparator;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.RecordSerializerBinary;
 import com.jetbrains.youtrackdb.internal.core.sql.SQLHelper;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.BTreeBasedLinkBag;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
+import com.jetbrains.youtrackdb.internal.core.util.DateHelper;
 import java.lang.ref.WeakReference;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -88,6 +94,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -469,6 +476,305 @@ public class EntityImpl extends RecordAbstract implements Entity {
     }
 
     return returnValue.choose(entry.type, convertToGraphElement(value));
+  }
+
+  /**
+   * Compares a property's value to the given object without triggering full deserialization.
+   * Checks the in-memory properties map first; if the property is not yet deserialized, compares
+   * directly against the serialized bytes in {@code source}.
+   *
+   * @return {@link InPlaceResult#TRUE} if equal, {@link InPlaceResult#FALSE} if not equal,
+   *     {@link InPlaceResult#FALLBACK} if the comparison could not be performed in-place
+   */
+  public InPlaceResult isPropertyEqualTo(String name, Object value) {
+    checkForBinding();
+
+    if (status != STATUS.LOADED) {
+      return InPlaceResult.FALLBACK;
+    }
+    if (propertyAccess != null && !propertyAccess.isReadable(name)) {
+      return InPlaceResult.FALLBACK;
+    }
+
+    // Check the deserialized properties map first (without triggering deserialization)
+    if (properties != null && properties.containsKey(name)) {
+      return compareDeserialized(name, value);
+    }
+
+    // Fall back to serialized comparison via source bytes
+    if (source != null) {
+      return compareFromSource(name, value);
+    }
+
+    return InPlaceResult.FALLBACK;
+  }
+
+  /**
+   * Compares a property's value to the given object, returning ordering information, without
+   * triggering full deserialization. Checks the in-memory properties map first; if the property
+   * is not yet deserialized, compares directly against the serialized bytes in {@code source}.
+   *
+   * @return comparison result (negative, zero, positive) or empty if fallback is needed
+   */
+  public OptionalInt comparePropertyTo(String name, Object value) {
+    checkForBinding();
+
+    if (status != STATUS.LOADED) {
+      return OptionalInt.empty();
+    }
+    if (propertyAccess != null && !propertyAccess.isReadable(name)) {
+      return OptionalInt.empty();
+    }
+
+    // Check the deserialized properties map first (without triggering deserialization)
+    if (properties != null && properties.containsKey(name)) {
+      return compareDeserializedOrdering(name, value);
+    }
+
+    // Fall back to serialized comparison via source bytes
+    if (source != null) {
+      return compareFromSourceOrdering(name, value);
+    }
+
+    return OptionalInt.empty();
+  }
+
+  /**
+   * Compare against the deserialized value in the properties map (equality check).
+   */
+  private InPlaceResult compareDeserialized(String name, Object value) {
+    var entry = properties.get(name);
+    if (entry == null || !entry.exists()) {
+      return InPlaceResult.FALLBACK;
+    }
+    var entryValue = entry.value;
+    if (entryValue == null || value == null) {
+      return InPlaceResult.FALLBACK;
+    }
+    if (entry.type == null) {
+      return InPlaceResult.FALLBACK;
+    }
+
+    // Type-aware comparison using the same conversion logic as InPlaceComparator
+    return compareJavaValues(entry.type, entryValue, value);
+  }
+
+  /**
+   * Compare against the deserialized value in the properties map (ordering).
+   */
+  private OptionalInt compareDeserializedOrdering(String name, Object value) {
+    var entry = properties.get(name);
+    if (entry == null || !entry.exists()) {
+      return OptionalInt.empty();
+    }
+    var entryValue = entry.value;
+    if (entryValue == null || value == null) {
+      return OptionalInt.empty();
+    }
+    if (entry.type == null) {
+      return OptionalInt.empty();
+    }
+
+    return compareJavaValuesOrdering(entry.type, entryValue, value);
+  }
+
+  /**
+   * Compare against the serialized bytes in source using InPlaceComparator (equality check).
+   */
+  private InPlaceResult compareFromSource(String name, Object value) {
+    if (value == null) {
+      return InPlaceResult.FALLBACK;
+    }
+    if (propertyEncryption != null && propertyEncryption.isEncrypted(name)) {
+      return InPlaceResult.FALLBACK;
+    }
+
+    var schemaClass = getImmutableSchemaClass(session);
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(source[0]);
+    var bytes = new BytesContainer(source, 1);
+    var encryption = propertyEncryption;
+    var field = serializer.deserializeField(
+        session, bytes, schemaClass, name, isEmbedded(),
+        session.getMetadata().getImmutableSchemaSnapshot(), encryption);
+
+    if (field == null) {
+      return InPlaceResult.FALLBACK;
+    }
+    if (field.collate != null && !(field.collate instanceof DefaultCollate)) {
+      return InPlaceResult.FALLBACK;
+    }
+
+    var dbTimeZone = DateHelper.getDatabaseTimeZone(session);
+    var result = InPlaceComparator.isEqual(field, value, dbTimeZone);
+    if (result.isEmpty()) {
+      return InPlaceResult.FALLBACK;
+    }
+    return result.getAsInt() == 1 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+  }
+
+  /**
+   * Compare against the serialized bytes in source using InPlaceComparator (ordering).
+   */
+  private OptionalInt compareFromSourceOrdering(String name, Object value) {
+    if (value == null) {
+      return OptionalInt.empty();
+    }
+    if (propertyEncryption != null && propertyEncryption.isEncrypted(name)) {
+      return OptionalInt.empty();
+    }
+
+    var schemaClass = getImmutableSchemaClass(session);
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(source[0]);
+    var bytes = new BytesContainer(source, 1);
+    var encryption = propertyEncryption;
+    var field = serializer.deserializeField(
+        session, bytes, schemaClass, name, isEmbedded(),
+        session.getMetadata().getImmutableSchemaSnapshot(), encryption);
+
+    if (field == null) {
+      return OptionalInt.empty();
+    }
+    if (field.collate != null && !(field.collate instanceof DefaultCollate)) {
+      return OptionalInt.empty();
+    }
+
+    var dbTimeZone = DateHelper.getDatabaseTimeZone(session);
+    return InPlaceComparator.compare(field, value, dbTimeZone);
+  }
+
+  /**
+   * Type-aware equality comparison of two Java values, using the same semantics as
+   * InPlaceComparator (Float.compare, BigDecimal.compareTo, etc.).
+   */
+  @SuppressWarnings("unchecked")
+  private static InPlaceResult compareJavaValues(
+      PropertyTypeInternal type, Object entryValue, Object value) {
+    try {
+      return switch (type) {
+        case INTEGER, LONG, SHORT, BYTE -> {
+          if (!(entryValue instanceof Number entryNum) || !(value instanceof Number valNum)) {
+            yield InPlaceResult.FALLBACK;
+          }
+          // Compare as longs to handle cross-type (Integer vs Long, etc.)
+          yield Long.compare(entryNum.longValue(), valNum.longValue()) == 0
+              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+        }
+        case FLOAT -> {
+          if (!(entryValue instanceof Float f) || !(value instanceof Number n)) {
+            yield InPlaceResult.FALLBACK;
+          }
+          if (value instanceof Double d) {
+            yield Double.compare(f, d) == 0
+                ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+          }
+          yield Float.compare(f, n.floatValue()) == 0
+              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+        }
+        case DOUBLE -> {
+          if (!(entryValue instanceof Double d) || !(value instanceof Number n)) {
+            yield InPlaceResult.FALLBACK;
+          }
+          yield Double.compare(d, n.doubleValue()) == 0
+              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+        }
+        case DECIMAL -> {
+          if (!(entryValue instanceof BigDecimal bd)) {
+            yield InPlaceResult.FALLBACK;
+          }
+          BigDecimal converted;
+          if (value instanceof BigDecimal bdv) {
+            converted = bdv;
+          } else if (value instanceof Number n) {
+            if (n instanceof Double || n instanceof Float) {
+              converted = BigDecimal.valueOf(n.doubleValue());
+            } else {
+              converted = BigDecimal.valueOf(n.longValue());
+            }
+          } else {
+            yield InPlaceResult.FALLBACK;
+          }
+          yield bd.compareTo(converted) == 0
+              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+        }
+        default -> {
+          if (entryValue instanceof Comparable c) {
+            try {
+              yield c.compareTo(value) == 0
+                  ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+            } catch (ClassCastException e) {
+              yield InPlaceResult.FALLBACK;
+            }
+          }
+          yield entryValue.equals(value) ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+        }
+      };
+    } catch (Exception e) {
+      return InPlaceResult.FALLBACK;
+    }
+  }
+
+  /**
+   * Type-aware ordering comparison of two Java values.
+   */
+  @SuppressWarnings("unchecked")
+  private static OptionalInt compareJavaValuesOrdering(
+      PropertyTypeInternal type, Object entryValue, Object value) {
+    try {
+      return switch (type) {
+        case INTEGER, LONG, SHORT, BYTE -> {
+          if (!(entryValue instanceof Number entryNum) || !(value instanceof Number valNum)) {
+            yield OptionalInt.empty();
+          }
+          yield OptionalInt.of(Long.compare(entryNum.longValue(), valNum.longValue()));
+        }
+        case FLOAT -> {
+          if (!(entryValue instanceof Float f) || !(value instanceof Number n)) {
+            yield OptionalInt.empty();
+          }
+          if (value instanceof Double d) {
+            yield OptionalInt.of(Double.compare(f, d));
+          }
+          yield OptionalInt.of(Float.compare(f, n.floatValue()));
+        }
+        case DOUBLE -> {
+          if (!(entryValue instanceof Double d) || !(value instanceof Number n)) {
+            yield OptionalInt.empty();
+          }
+          yield OptionalInt.of(Double.compare(d, n.doubleValue()));
+        }
+        case DECIMAL -> {
+          if (!(entryValue instanceof BigDecimal bd)) {
+            yield OptionalInt.empty();
+          }
+          BigDecimal converted;
+          if (value instanceof BigDecimal bdv) {
+            converted = bdv;
+          } else if (value instanceof Number n) {
+            if (n instanceof Double || n instanceof Float) {
+              converted = BigDecimal.valueOf(n.doubleValue());
+            } else {
+              converted = BigDecimal.valueOf(n.longValue());
+            }
+          } else {
+            yield OptionalInt.empty();
+          }
+          yield OptionalInt.of(bd.compareTo(converted));
+        }
+        case LINK -> OptionalInt.empty(); // ordering not supported for LINKs
+        default -> {
+          if (entryValue instanceof Comparable c) {
+            try {
+              yield OptionalInt.of(c.compareTo(value));
+            } catch (ClassCastException e) {
+              yield OptionalInt.empty();
+            }
+          }
+          yield OptionalInt.empty();
+        }
+      };
+    } catch (Exception e) {
+      return OptionalInt.empty();
+    }
   }
 
   @SuppressWarnings("TypeParameterUnusedInFormals")

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -113,6 +113,10 @@ public class EntityImpl extends RecordAbstract implements Entity {
   public static final byte RECORD_TYPE = 'd';
 
   public static final String RESULT_PROPERTY_TYPES = "$propertyTypes";
+
+  // Precision boundaries for safe integer-to-floating-point conversion (matching InPlaceComparator)
+  private static final int FLOAT_EXACT_INT_MAX = 1 << 24; // 2^24 = 16_777_216
+  private static final long DOUBLE_EXACT_LONG_MAX = 1L << 53; // 2^53
   private int propertiesCount;
 
   private Map<String, EntityEntry> properties;
@@ -677,11 +681,27 @@ public class EntityImpl extends RecordAbstract implements Entity {
           if (value instanceof Double d) {
             yield OptionalInt.of(Double.compare(f, d));
           }
+          // Guard: integer values beyond float's exact range must fall back
+          // to match InPlaceComparator.convertToFloat precision boundaries
+          if (!(n instanceof Float)) {
+            long lv = n.longValue();
+            if (lv > FLOAT_EXACT_INT_MAX || lv < -FLOAT_EXACT_INT_MAX) {
+              yield OptionalInt.empty();
+            }
+          }
           yield OptionalInt.of(Float.compare(f, n.floatValue()));
         }
         case DOUBLE -> {
           if (!(entryValue instanceof Double d) || !(value instanceof Number n)) {
             yield OptionalInt.empty();
+          }
+          // Guard: long values beyond double's exact range must fall back
+          // to match InPlaceComparator.convertToDouble precision boundaries
+          if (n instanceof Long || n instanceof Integer) {
+            long lv = n.longValue();
+            if (lv > DOUBLE_EXACT_LONG_MAX || lv < -DOUBLE_EXACT_LONG_MAX) {
+              yield OptionalInt.empty();
+            }
           }
           yield OptionalInt.of(Double.compare(d, n.doubleValue()));
         }
@@ -694,7 +714,11 @@ public class EntityImpl extends RecordAbstract implements Entity {
             converted = bdv;
           } else if (value instanceof Number n) {
             if (n instanceof Double || n instanceof Float) {
-              converted = BigDecimal.valueOf(n.doubleValue());
+              double dv = n.doubleValue();
+              if (Double.isNaN(dv) || Double.isInfinite(dv)) {
+                yield OptionalInt.empty();
+              }
+              converted = BigDecimal.valueOf(dv);
             } else {
               converted = BigDecimal.valueOf(n.longValue());
             }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -559,6 +559,11 @@ public class EntityImpl extends RecordAbstract implements Entity {
     if (entry.type == null) {
       return InPlaceResult.FALLBACK;
     }
+    // Non-default collation (e.g. CI) requires collation transforms that
+    // in-place comparison does not apply — fall back to the standard path.
+    if (hasNonDefaultCollation(name)) {
+      return InPlaceResult.FALLBACK;
+    }
 
     // Type-aware comparison using the same conversion logic as InPlaceComparator
     return compareJavaValues(entry.type, entryValue, value);
@@ -579,8 +584,31 @@ public class EntityImpl extends RecordAbstract implements Entity {
     if (entry.type == null) {
       return OptionalInt.empty();
     }
+    // Non-default collation (e.g. CI) requires collation transforms that
+    // in-place comparison does not apply — fall back to the standard path.
+    if (hasNonDefaultCollation(name)) {
+      return OptionalInt.empty();
+    }
 
     return compareJavaValuesOrdering(entry.type, entryValue, value);
+  }
+
+  /**
+   * Returns {@code true} if the named property has a non-default collation
+   * (e.g. case-insensitive) in the schema. Properties without a schema definition
+   * or with the default collation return {@code false}.
+   */
+  private boolean hasNonDefaultCollation(String name) {
+    var schemaClass = getImmutableSchemaClass(session);
+    if (schemaClass == null) {
+      return false;
+    }
+    var prop = schemaClass.getPropertyInternal(name);
+    if (prop == null) {
+      return false;
+    }
+    var collate = prop.getCollate();
+    return collate != null && !(collate instanceof DefaultCollate);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceResult.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceResult.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+/**
+ * Tri-state result for in-place property comparison. Replaces {@code Optional<Boolean>} for
+ * clarity.
+ *
+ * <ul>
+ *   <li>{@link #TRUE} — the comparison succeeded and the result is true (equal).
+ *   <li>{@link #FALSE} — the comparison succeeded and the result is false (not equal).
+ *   <li>{@link #FALLBACK} — the comparison could not be performed in-place; the caller must fall
+ *       back to the standard deserialization + Java comparison path.
+ * </ul>
+ */
+public enum InPlaceResult {
+  TRUE, FALSE, FALLBACK
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -23,8 +23,17 @@ package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.b
 import static com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.HelperClasses.readInteger;
 import static com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.HelperClasses.readLong;
 
+import com.jetbrains.youtrackdb.internal.common.serialization.types.DecimalSerializer;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.TimeZone;
+import javax.annotation.Nullable;
 
 /**
  * Compares a serialized property value (in a {@link BinaryField}) against a Java object without
@@ -45,12 +54,26 @@ public final class InPlaceComparator {
   private InPlaceComparator() {
   }
 
+  private static final long MILLISEC_PER_DAY = HelperClasses.MILLISEC_PER_DAY;
+
   /**
-   * Compares a serialized field value against a Java object.
+   * Compares a serialized field value against a Java object. For DATE fields, use the overload
+   * that accepts a {@link TimeZone} parameter.
    *
    * @return comparison result (negative, zero, positive) or empty if fallback is needed
    */
   public static OptionalInt compare(BinaryField field, Object value) {
+    return compare(field, value, null);
+  }
+
+  /**
+   * Compares a serialized field value against a Java object.
+   *
+   * @param dbTimeZone the database timezone for DATE fields (required for DATE, ignored for others)
+   * @return comparison result (negative, zero, positive) or empty if fallback is needed
+   */
+  public static OptionalInt compare(
+      BinaryField field, Object value, @Nullable TimeZone dbTimeZone) {
     assert field != null : "BinaryField must not be null";
     assert field.type != null : "BinaryField.type must not be null";
     assert value != null : "Comparison value must not be null";
@@ -62,22 +85,40 @@ public final class InPlaceComparator {
       case BYTE -> compareByte(field.bytes, value);
       case FLOAT -> compareFloat(field.bytes, value);
       case DOUBLE -> compareDouble(field.bytes, value);
+      case STRING -> compareString(field.bytes, value);
+      case BOOLEAN -> compareBoolean(field.bytes, value);
+      case DATETIME -> compareDatetime(field.bytes, value);
+      case DATE -> compareDate(field.bytes, value, dbTimeZone);
+      case DECIMAL -> compareDecimal(field.bytes, value);
+      case BINARY -> compareBinary(field.bytes, value);
+      case LINK -> OptionalInt.empty(); // ordering not defined for LINKs
       default -> OptionalInt.empty();
     };
   }
 
   /**
-   * Checks equality of a serialized field value against a Java object. Delegates to {@link
-   * #compare} for numeric types — specialized equality checks for non-numeric types will be added
-   * in a follow-up step.
+   * Checks equality of a serialized field value against a Java object.
    *
    * @return 1 (equal) or 0 (not equal) if comparison succeeded, or empty if fallback is needed
    */
   public static OptionalInt isEqual(BinaryField field, Object value) {
-    // For numeric types, equality is derived from compare() == 0.
-    // Non-numeric types (STRING, LINK, etc.) can override with specialized equality
-    // in a follow-up step.
-    var cmp = compare(field, value);
+    return isEqual(field, value, null);
+  }
+
+  /**
+   * Checks equality of a serialized field value against a Java object.
+   *
+   * @param dbTimeZone the database timezone for DATE fields
+   * @return 1 (equal) or 0 (not equal) if comparison succeeded, or empty if fallback is needed
+   */
+  public static OptionalInt isEqual(
+      BinaryField field, Object value, @Nullable TimeZone dbTimeZone) {
+    // LINK: specialized equality (ordering is undefined but equality is well-defined)
+    if (field.type == PropertyTypeInternal.LINK) {
+      return compareLinkEquality(field.bytes, value);
+    }
+
+    var cmp = compare(field, value, dbTimeZone);
     if (cmp.isEmpty()) {
       return OptionalInt.empty();
     }
@@ -198,6 +239,127 @@ public final class InPlaceComparator {
     var serialized = Double.longBitsToDouble(readLong(bytes));
     return OptionalInt.of(
         Double.compare(serialized, Double.longBitsToDouble(converted.getAsLong())));
+  }
+
+  // ---------------------------------------------------------------------------
+  // STRING (VarInt length + UTF-8 bytes)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareString(BytesContainer bytes, Object value) {
+    if (!(value instanceof String strValue)) {
+      return OptionalInt.empty();
+    }
+    var serialized = HelperClasses.readString(bytes);
+    return OptionalInt.of(serialized.compareTo(strValue));
+  }
+
+  // ---------------------------------------------------------------------------
+  // BOOLEAN (single byte: 0 or 1)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareBoolean(BytesContainer bytes, Object value) {
+    if (!(value instanceof Boolean boolValue)) {
+      return OptionalInt.empty();
+    }
+    var serialized = HelperClasses.readByte(bytes) == 1;
+    return OptionalInt.of(Boolean.compare(serialized, boolValue));
+  }
+
+  // ---------------------------------------------------------------------------
+  // DATETIME (VarInt millis since epoch)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareDatetime(BytesContainer bytes, Object value) {
+    long valueMillis;
+    if (value instanceof Date date) {
+      valueMillis = date.getTime();
+    } else if (value instanceof Number number) {
+      valueMillis = number.longValue();
+    } else {
+      return OptionalInt.empty();
+    }
+    var serialized = VarIntSerializer.readAsLong(bytes);
+    return OptionalInt.of(Long.compare(serialized, valueMillis));
+  }
+
+  // ---------------------------------------------------------------------------
+  // DATE (VarInt days since epoch, requires timezone conversion)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareDate(
+      BytesContainer bytes, Object value, @Nullable TimeZone dbTimeZone) {
+    if (dbTimeZone == null) {
+      return OptionalInt.empty();
+    }
+    long valueMillis;
+    if (value instanceof Date date) {
+      valueMillis = date.getTime();
+    } else if (value instanceof Number number) {
+      valueMillis = number.longValue();
+    } else {
+      return OptionalInt.empty();
+    }
+    var savedTime = VarIntSerializer.readAsLong(bytes) * MILLISEC_PER_DAY;
+    savedTime =
+        HelperClasses.convertDayToTimezone(
+            TimeZone.getTimeZone("GMT"), dbTimeZone, savedTime);
+    return OptionalInt.of(Long.compare(savedTime, valueMillis));
+  }
+
+  // ---------------------------------------------------------------------------
+  // DECIMAL (BigDecimal via DecimalSerializer)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareDecimal(BytesContainer bytes, Object value) {
+    BigDecimal decimalValue;
+    if (value instanceof BigDecimal bd) {
+      decimalValue = bd;
+    } else if (value instanceof Number number) {
+      if (number instanceof Double || number instanceof Float) {
+        decimalValue = BigDecimal.valueOf(number.doubleValue());
+      } else {
+        decimalValue = BigDecimal.valueOf(number.longValue());
+      }
+    } else {
+      return OptionalInt.empty();
+    }
+    var serialized = DecimalSerializer.staticDeserialize(bytes.bytes, bytes.offset);
+    return OptionalInt.of(serialized.compareTo(decimalValue));
+  }
+
+  // ---------------------------------------------------------------------------
+  // BINARY (VarInt length + raw bytes)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareBinary(BytesContainer bytes, Object value) {
+    if (!(value instanceof byte[] byteArray)) {
+      return OptionalInt.empty();
+    }
+    var serialized = HelperClasses.readBinary(bytes);
+    return OptionalInt.of(Arrays.compare(serialized, byteArray));
+  }
+
+  // ---------------------------------------------------------------------------
+  // LINK (VarInt clusterId + VarInt clusterPosition) — equality only
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareLinkEquality(BytesContainer bytes, Object value) {
+    int valueCollectionId;
+    long valueCollectionPos;
+    if (value instanceof RID rid) {
+      valueCollectionId = rid.getCollectionId();
+      valueCollectionPos = rid.getCollectionPosition();
+    } else if (value instanceof Identifiable identifiable) {
+      var identity = identifiable.getIdentity();
+      valueCollectionId = identity.getCollectionId();
+      valueCollectionPos = identity.getCollectionPosition();
+    } else {
+      return OptionalInt.empty();
+    }
+    var serializedId = VarIntSerializer.readAsInteger(bytes);
+    var serializedPos = VarIntSerializer.readAsLong(bytes);
+    var equal = serializedId == valueCollectionId && serializedPos == valueCollectionPos;
+    return OptionalInt.of(equal ? 1 : 0);
   }
 
   // ===========================================================================

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -55,6 +55,7 @@ public final class InPlaceComparator {
   }
 
   private static final long MILLISEC_PER_DAY = HelperClasses.MILLISEC_PER_DAY;
+  private static final TimeZone GMT = TimeZone.getTimeZone("GMT");
 
   /**
    * Compares a serialized field value against a Java object. For DATE fields, use the overload
@@ -91,7 +92,7 @@ public final class InPlaceComparator {
       case DATE -> compareDate(field.bytes, value, dbTimeZone);
       case DECIMAL -> compareDecimal(field.bytes, value);
       case BINARY -> compareBinary(field.bytes, value);
-      case LINK -> OptionalInt.empty(); // ordering not defined for LINKs
+      case LINK -> OptionalInt.empty(); // ordering not supported; use isEqual() for equality
       default -> OptionalInt.empty();
     };
   }
@@ -300,9 +301,7 @@ public final class InPlaceComparator {
       return OptionalInt.empty();
     }
     var savedTime = VarIntSerializer.readAsLong(bytes) * MILLISEC_PER_DAY;
-    savedTime =
-        HelperClasses.convertDayToTimezone(
-            TimeZone.getTimeZone("GMT"), dbTimeZone, savedTime);
+    savedTime = HelperClasses.convertDayToTimezone(GMT, dbTimeZone, savedTime);
     return OptionalInt.of(Long.compare(savedTime, valueMillis));
   }
 
@@ -324,6 +323,7 @@ public final class InPlaceComparator {
       return OptionalInt.empty();
     }
     var serialized = DecimalSerializer.staticDeserialize(bytes.bytes, bytes.offset);
+    bytes.skip(DecimalSerializer.staticGetObjectSize(bytes.bytes, bytes.offset));
     return OptionalInt.of(serialized.compareTo(decimalValue));
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -24,6 +24,7 @@ import static com.jetbrains.youtrackdb.internal.core.serialization.serializer.re
 import static com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.HelperClasses.readLong;
 
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 /**
  * Compares a serialized property value (in a {@link BinaryField}) against a Java object without
@@ -70,7 +71,7 @@ public final class InPlaceComparator {
    * #compare} for numeric types — specialized equality checks for non-numeric types will be added
    * in a follow-up step.
    *
-   * @return true/false if comparison succeeded, or empty if fallback is needed
+   * @return 1 (equal) or 0 (not equal) if comparison succeeded, or empty if fallback is needed
    */
   public static OptionalInt isEqual(BinaryField field, Object value) {
     // For numeric types, equality is derived from compare() == 0.
@@ -227,15 +228,15 @@ public final class InPlaceComparator {
   /**
    * Converts a Number to long. Falls back for float/double types.
    */
-  private static java.util.OptionalLong convertToLong(Number number) {
+  private static OptionalLong convertToLong(Number number) {
     if (number instanceof Long) {
-      return java.util.OptionalLong.of(number.longValue());
+      return OptionalLong.of(number.longValue());
     }
     if (number instanceof Integer || number instanceof Short || number instanceof Byte) {
-      return java.util.OptionalLong.of(number.longValue());
+      return OptionalLong.of(number.longValue());
     }
     // Float, Double -> long: always fall back
-    return java.util.OptionalLong.empty();
+    return OptionalLong.empty();
   }
 
   /**
@@ -305,6 +306,11 @@ public final class InPlaceComparator {
     if (number instanceof Double) {
       return OptionalInt.empty();
     }
+    // Only standard integer boxed types — reject BigDecimal, BigInteger, etc.
+    if (!(number instanceof Integer || number instanceof Long
+        || number instanceof Short || number instanceof Byte)) {
+      return OptionalInt.empty();
+    }
     // Integer types -> float: safe only if |value| <= 2^24
     long longValue = number.longValue();
     if (longValue > FLOAT_EXACT_INT_MAX || longValue < -FLOAT_EXACT_INT_MAX) {
@@ -317,18 +323,23 @@ public final class InPlaceComparator {
    * Converts a Number to double bits (as long). Falls back for long values outside the exact
    * representable range (|value| > 2^53).
    */
-  private static java.util.OptionalLong convertToDouble(Number number) {
+  private static OptionalLong convertToDouble(Number number) {
     if (number instanceof Double d) {
-      return java.util.OptionalLong.of(Double.doubleToLongBits(d));
+      return OptionalLong.of(Double.doubleToLongBits(d));
     }
     if (number instanceof Float f) {
-      return java.util.OptionalLong.of(Double.doubleToLongBits(f.doubleValue()));
+      return OptionalLong.of(Double.doubleToLongBits(f.doubleValue()));
+    }
+    // Only standard integer boxed types — reject BigDecimal, BigInteger, etc.
+    if (!(number instanceof Integer || number instanceof Long
+        || number instanceof Short || number instanceof Byte)) {
+      return OptionalLong.empty();
     }
     // Integer types -> double: safe if |value| <= 2^53
     long longValue = number.longValue();
     if (longValue > DOUBLE_EXACT_LONG_MAX || longValue < -DOUBLE_EXACT_LONG_MAX) {
-      return java.util.OptionalLong.empty();
+      return OptionalLong.empty();
     }
-    return java.util.OptionalLong.of(Double.doubleToLongBits(number.doubleValue()));
+    return OptionalLong.of(Double.doubleToLongBits(number.doubleValue()));
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -1,0 +1,334 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.HelperClasses.readInteger;
+import static com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.HelperClasses.readLong;
+
+import java.util.OptionalInt;
+
+/**
+ * Compares a serialized property value (in a {@link BinaryField}) against a Java object without
+ * deserializing the property. Returns comparison results as {@link OptionalInt} (empty = fallback
+ * to deserialization needed) or {@code boolean} for equality checks.
+ *
+ * <p>Type conversion: the passed-in Java value is converted to the property's serialized type
+ * before same-type comparison. Narrowing conversions that would lose precision return empty
+ * (fallback). Float-to-integer and double-to-integer conversions always fall back.
+ */
+public final class InPlaceComparator {
+
+  // Precision boundaries for safe integer-to-floating-point conversion.
+  // Beyond these thresholds, the float/double cannot represent the integer exactly.
+  private static final int FLOAT_EXACT_INT_MAX = 1 << 24; // 2^24 = 16_777_216
+  private static final long DOUBLE_EXACT_LONG_MAX = 1L << 53; // 2^53
+
+  private InPlaceComparator() {
+  }
+
+  /**
+   * Compares a serialized field value against a Java object.
+   *
+   * @return comparison result (negative, zero, positive) or empty if fallback is needed
+   */
+  public static OptionalInt compare(BinaryField field, Object value) {
+    assert field != null : "BinaryField must not be null";
+    assert field.type != null : "BinaryField.type must not be null";
+    assert value != null : "Comparison value must not be null";
+
+    return switch (field.type) {
+      case INTEGER -> compareInteger(field.bytes, value);
+      case LONG -> compareLong(field.bytes, value);
+      case SHORT -> compareShort(field.bytes, value);
+      case BYTE -> compareByte(field.bytes, value);
+      case FLOAT -> compareFloat(field.bytes, value);
+      case DOUBLE -> compareDouble(field.bytes, value);
+      default -> OptionalInt.empty();
+    };
+  }
+
+  /**
+   * Checks equality of a serialized field value against a Java object. Delegates to {@link
+   * #compare} for numeric types — specialized equality checks for non-numeric types will be added
+   * in a follow-up step.
+   *
+   * @return true/false if comparison succeeded, or empty if fallback is needed
+   */
+  public static OptionalInt isEqual(BinaryField field, Object value) {
+    // For numeric types, equality is derived from compare() == 0.
+    // Non-numeric types (STRING, LINK, etc.) can override with specialized equality
+    // in a follow-up step.
+    var cmp = compare(field, value);
+    if (cmp.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    return OptionalInt.of(cmp.getAsInt() == 0 ? 1 : 0);
+  }
+
+  // ---------------------------------------------------------------------------
+  // INTEGER (VarInt encoded)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareInteger(BytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+
+    var converted = convertToInt(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+
+    var serialized = VarIntSerializer.readAsInteger(bytes);
+    return OptionalInt.of(Integer.compare(serialized, converted.getAsInt()));
+  }
+
+  // ---------------------------------------------------------------------------
+  // LONG (VarInt encoded)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareLong(BytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+
+    var converted = convertToLong(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+
+    var serialized = VarIntSerializer.readAsLong(bytes);
+    return OptionalInt.of(Long.compare(serialized, converted.getAsLong()));
+  }
+
+  // ---------------------------------------------------------------------------
+  // SHORT (VarInt encoded)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareShort(BytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+
+    var converted = convertToShort(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+
+    var serialized = VarIntSerializer.readAsShort(bytes);
+    return OptionalInt.of(Short.compare(serialized, (short) converted.getAsInt()));
+  }
+
+  // ---------------------------------------------------------------------------
+  // BYTE (single raw byte)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareByte(BytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+
+    var converted = convertToByte(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+
+    var serialized = HelperClasses.readByte(bytes);
+    return OptionalInt.of(Byte.compare(serialized, (byte) converted.getAsInt()));
+  }
+
+  // ---------------------------------------------------------------------------
+  // FLOAT (4 bytes, int bits)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareFloat(BytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+
+    // If either operand is double-precision, widen both to double for comparison
+    if (value instanceof Double) {
+      var serializedFloat = Float.intBitsToFloat(readInteger(bytes));
+      return OptionalInt.of(Double.compare(serializedFloat, number.doubleValue()));
+    }
+
+    var converted = convertToFloat(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+
+    var serialized = Float.intBitsToFloat(readInteger(bytes));
+    return OptionalInt.of(
+        Float.compare(serialized, Float.intBitsToFloat(converted.getAsInt())));
+  }
+
+  // ---------------------------------------------------------------------------
+  // DOUBLE (8 bytes, long bits)
+  // ---------------------------------------------------------------------------
+
+  private static OptionalInt compareDouble(BytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+
+    var converted = convertToDouble(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+
+    var serialized = Double.longBitsToDouble(readLong(bytes));
+    return OptionalInt.of(
+        Double.compare(serialized, Double.longBitsToDouble(converted.getAsLong())));
+  }
+
+  // ===========================================================================
+  // Type conversion helpers
+  // ===========================================================================
+
+  /**
+   * Converts a Number to int. Falls back (returns empty) for float/double types and for
+   * long/short/byte values outside int range.
+   */
+  private static OptionalInt convertToInt(Number number) {
+    if (number instanceof Integer) {
+      return OptionalInt.of(number.intValue());
+    }
+    if (number instanceof Long l) {
+      if (l < Integer.MIN_VALUE || l > Integer.MAX_VALUE) {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of(l.intValue());
+    }
+    if (number instanceof Short || number instanceof Byte) {
+      return OptionalInt.of(number.intValue());
+    }
+    // Float, Double -> integer: always fall back
+    return OptionalInt.empty();
+  }
+
+  /**
+   * Converts a Number to long. Falls back for float/double types.
+   */
+  private static java.util.OptionalLong convertToLong(Number number) {
+    if (number instanceof Long) {
+      return java.util.OptionalLong.of(number.longValue());
+    }
+    if (number instanceof Integer || number instanceof Short || number instanceof Byte) {
+      return java.util.OptionalLong.of(number.longValue());
+    }
+    // Float, Double -> long: always fall back
+    return java.util.OptionalLong.empty();
+  }
+
+  /**
+   * Converts a Number to short. Falls back for float/double and out-of-range values.
+   */
+  private static OptionalInt convertToShort(Number number) {
+    if (number instanceof Short) {
+      return OptionalInt.of(number.shortValue());
+    }
+    if (number instanceof Byte) {
+      return OptionalInt.of(number.shortValue());
+    }
+    if (number instanceof Integer i) {
+      if (i < Short.MIN_VALUE || i > Short.MAX_VALUE) {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of(i.shortValue());
+    }
+    if (number instanceof Long l) {
+      if (l < Short.MIN_VALUE || l > Short.MAX_VALUE) {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of((int) l.shortValue());
+    }
+    // Float, Double -> short: always fall back
+    return OptionalInt.empty();
+  }
+
+  /**
+   * Converts a Number to byte. Falls back for float/double and out-of-range values.
+   */
+  private static OptionalInt convertToByte(Number number) {
+    if (number instanceof Byte) {
+      return OptionalInt.of(number.byteValue());
+    }
+    if (number instanceof Short s) {
+      if (s < Byte.MIN_VALUE || s > Byte.MAX_VALUE) {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of(s.byteValue());
+    }
+    if (number instanceof Integer i) {
+      if (i < Byte.MIN_VALUE || i > Byte.MAX_VALUE) {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of(i.byteValue());
+    }
+    if (number instanceof Long l) {
+      if (l < Byte.MIN_VALUE || l > Byte.MAX_VALUE) {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of((int) l.byteValue());
+    }
+    // Float, Double -> byte: always fall back
+    return OptionalInt.empty();
+  }
+
+  /**
+   * Converts a Number to float bits (as int). Falls back for integers outside the exact
+   * representable range (|value| > 2^24), and for doubles that would lose precision.
+   */
+  private static OptionalInt convertToFloat(Number number) {
+    if (number instanceof Float f) {
+      return OptionalInt.of(Float.floatToIntBits(f));
+    }
+    // Double -> float: always fall back (potential precision loss)
+    if (number instanceof Double) {
+      return OptionalInt.empty();
+    }
+    // Integer types -> float: safe only if |value| <= 2^24
+    long longValue = number.longValue();
+    if (longValue > FLOAT_EXACT_INT_MAX || longValue < -FLOAT_EXACT_INT_MAX) {
+      return OptionalInt.empty();
+    }
+    return OptionalInt.of(Float.floatToIntBits(number.floatValue()));
+  }
+
+  /**
+   * Converts a Number to double bits (as long). Falls back for long values outside the exact
+   * representable range (|value| > 2^53).
+   */
+  private static java.util.OptionalLong convertToDouble(Number number) {
+    if (number instanceof Double d) {
+      return java.util.OptionalLong.of(Double.doubleToLongBits(d));
+    }
+    if (number instanceof Float f) {
+      return java.util.OptionalLong.of(Double.doubleToLongBits(f.doubleValue()));
+    }
+    // Integer types -> double: safe if |value| <= 2^53
+    long longValue = number.longValue();
+    if (longValue > DOUBLE_EXACT_LONG_MAX || longValue < -DOUBLE_EXACT_LONG_MAX) {
+      return java.util.OptionalLong.empty();
+    }
+    return java.util.OptionalLong.of(Double.doubleToLongBits(number.doubleValue()));
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -315,7 +315,11 @@ public final class InPlaceComparator {
       decimalValue = bd;
     } else if (value instanceof Number number) {
       if (number instanceof Double || number instanceof Float) {
-        decimalValue = BigDecimal.valueOf(number.doubleValue());
+        double dv = number.doubleValue();
+        if (Double.isNaN(dv) || Double.isInfinite(dv)) {
+          return OptionalInt.empty();
+        }
+        decimalValue = BigDecimal.valueOf(dv);
       } else {
         decimalValue = BigDecimal.valueOf(number.longValue());
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
@@ -10,6 +10,8 @@ import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionExceptio
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrackdb.internal.core.record.impl.InPlaceResult;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.IndexSearchInfo;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.metadata.IndexCandidate;
@@ -53,6 +55,44 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
     if (left.isFunctionAll()) {
       return evaluateAllFunction(currentRecord, ctx);
     }
+
+    // In-place comparison fast path: avoid deserialization for simple
+    // "property <op> constant" patterns when no collation is involved.
+    if (left.isBaseIdentifier()
+        && left.mathExpression instanceof SQLBaseExpression baseExpr
+        && right.isEarlyCalculated(ctx)
+        && left.getCollate(currentRecord, ctx) == null
+        && right.getCollate(currentRecord, ctx) == null
+        && currentRecord instanceof ResultInternal ri
+        && ri.asEntityOrNull() instanceof EntityImpl entityImpl) {
+      var propName = baseExpr.getIdentifier().getSuffix()
+          .getIdentifier().getStringValue();
+      var rightVal = right.execute(currentRecord, ctx);
+
+      if (operator instanceof SQLEqualsOperator) {
+        var result = entityImpl.isPropertyEqualTo(propName, rightVal);
+        if (result != InPlaceResult.FALLBACK) {
+          return result == InPlaceResult.TRUE;
+        }
+      } else if (operator instanceof SQLNeqOperator
+          || operator instanceof SQLNeOperator) {
+        var result = entityImpl.isPropertyEqualTo(propName, rightVal);
+        if (result != InPlaceResult.FALLBACK) {
+          return result == InPlaceResult.FALSE;
+        }
+      } else if (operator.isRangeOperator()) {
+        var cmp = entityImpl.comparePropertyTo(propName, rightVal);
+        if (cmp.isPresent()) {
+          int c = cmp.getAsInt();
+          return evaluateRangeResult(c);
+        }
+      }
+
+      // FALLBACK: rightVal already computed, only need leftVal
+      var leftVal = left.execute(currentRecord, ctx);
+      return operator.execute(ctx.getDatabaseSession(), leftVal, rightVal);
+    }
+
     var leftVal = left.execute(currentRecord, ctx);
     var rightVal = right.execute(currentRecord, ctx);
     var collate = left.getCollate(currentRecord, ctx);
@@ -64,6 +104,24 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
       rightVal = collate.transform(rightVal);
     }
     return operator.execute(ctx.getDatabaseSession(), leftVal, rightVal);
+  }
+
+  /**
+   * Interprets a comparison result (from {@code comparePropertyTo}) according to
+   * the range operator type (Lt, Gt, Le, Ge).
+   */
+  private boolean evaluateRangeResult(int cmp) {
+    if (operator instanceof SQLLtOperator) {
+      return cmp < 0;
+    } else if (operator instanceof SQLGtOperator) {
+      return cmp > 0;
+    } else if (operator instanceof SQLLeOperator) {
+      return cmp <= 0;
+    } else if (operator instanceof SQLGeOperator) {
+      return cmp >= 0;
+    }
+    // Should not happen — isRangeOperator() was true
+    return false;
   }
 
   private boolean evaluateAny(Result currentRecord, CommandContext ctx) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
@@ -77,12 +77,11 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
     }
 
     // In-place comparison fast path: avoid deserialization for simple
-    // "property <op> constant" patterns when no collation is involved.
+    // "property <op> constant" patterns.  Collation is checked inside
+    // EntityImpl.deserializeFieldForComparison, so no getCollate guard needed here.
     if (left.isBaseIdentifier()
         && left.mathExpression instanceof SQLBaseExpression baseExpr
         && right.isEarlyCalculated(ctx)
-        && left.getCollate(currentRecord, ctx) == null
-        && right.getCollate(currentRecord, ctx) == null
         && currentRecord instanceof ResultInternal ri
         && ri.asEntityOrNull() instanceof EntityImpl entityImpl) {
       var propName = baseExpr.getIdentifier().getSuffix()

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
@@ -42,6 +42,26 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
 
   @Override
   public boolean evaluate(Identifiable currentRecord, CommandContext ctx) {
+    // In-place comparison fast path for the Identifiable overload.
+    // No collation guard — the existing overload never applies collation.
+    if (left.isBaseIdentifier()
+        && left.mathExpression instanceof SQLBaseExpression baseExpr
+        && right.isEarlyCalculated(ctx)
+        && currentRecord instanceof EntityImpl entityImpl) {
+      var propName = baseExpr.getIdentifier().getSuffix()
+          .getIdentifier().getStringValue();
+      var rightVal = right.execute(currentRecord, ctx);
+
+      var inPlaceResult = tryInPlaceComparison(entityImpl, propName, rightVal);
+      if (inPlaceResult != null) {
+        return inPlaceResult;
+      }
+
+      // FALLBACK: rightVal already computed, only need leftVal
+      var leftVal = left.execute(currentRecord, ctx);
+      return operator.execute(ctx.getDatabaseSession(), leftVal, rightVal);
+    }
+
     return operator.execute(ctx.getDatabaseSession(), left.execute(currentRecord, ctx),
         right.execute(currentRecord, ctx));
   }
@@ -69,23 +89,9 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
           .getIdentifier().getStringValue();
       var rightVal = right.execute(currentRecord, ctx);
 
-      if (operator instanceof SQLEqualsOperator) {
-        var result = entityImpl.isPropertyEqualTo(propName, rightVal);
-        if (result != InPlaceResult.FALLBACK) {
-          return result == InPlaceResult.TRUE;
-        }
-      } else if (operator instanceof SQLNeqOperator
-          || operator instanceof SQLNeOperator) {
-        var result = entityImpl.isPropertyEqualTo(propName, rightVal);
-        if (result != InPlaceResult.FALLBACK) {
-          return result == InPlaceResult.FALSE;
-        }
-      } else if (operator.isRangeOperator()) {
-        var cmp = entityImpl.comparePropertyTo(propName, rightVal);
-        if (cmp.isPresent()) {
-          int c = cmp.getAsInt();
-          return evaluateRangeResult(c);
-        }
+      var inPlaceResult = tryInPlaceComparison(entityImpl, propName, rightVal);
+      if (inPlaceResult != null) {
+        return inPlaceResult;
       }
 
       // FALLBACK: rightVal already computed, only need leftVal
@@ -107,21 +113,42 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
   }
 
   /**
-   * Interprets a comparison result (from {@code comparePropertyTo}) according to
-   * the range operator type (Lt, Gt, Le, Ge).
+   * Attempts in-place comparison of an entity property against a right-hand value.
+   * Dispatches to the appropriate EntityImpl method based on the operator type.
+   *
+   * @return the comparison result (true/false) if in-place succeeded, or {@code null}
+   *     if the caller must fall back to the standard deserialization path
    */
-  private boolean evaluateRangeResult(int cmp) {
-    if (operator instanceof SQLLtOperator) {
-      return cmp < 0;
-    } else if (operator instanceof SQLGtOperator) {
-      return cmp > 0;
-    } else if (operator instanceof SQLLeOperator) {
-      return cmp <= 0;
-    } else if (operator instanceof SQLGeOperator) {
-      return cmp >= 0;
+  @Nullable
+  private Boolean tryInPlaceComparison(
+      EntityImpl entityImpl, String propName, Object rightVal) {
+    if (operator instanceof SQLEqualsOperator) {
+      var result = entityImpl.isPropertyEqualTo(propName, rightVal);
+      if (result != InPlaceResult.FALLBACK) {
+        return result == InPlaceResult.TRUE;
+      }
+    } else if (operator instanceof SQLNeqOperator
+        || operator instanceof SQLNeOperator) {
+      var result = entityImpl.isPropertyEqualTo(propName, rightVal);
+      if (result != InPlaceResult.FALLBACK) {
+        return result == InPlaceResult.FALSE;
+      }
+    } else if (operator.isRangeOperator()) {
+      var cmp = entityImpl.comparePropertyTo(propName, rightVal);
+      if (cmp.isPresent()) {
+        int c = cmp.getAsInt();
+        if (operator instanceof SQLLtOperator) {
+          return c < 0;
+        } else if (operator instanceof SQLGtOperator) {
+          return c > 0;
+        } else if (operator instanceof SQLLeOperator) {
+          return c <= 0;
+        } else if (operator instanceof SQLGeOperator) {
+          return c >= 0;
+        }
+      }
     }
-    // Should not happen — isRangeOperator() was true
-    return false;
+    return null;
   }
 
   private boolean evaluateAny(Result currentRecord, CommandContext ctx) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
@@ -78,7 +78,8 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
 
     // In-place comparison fast path: avoid deserialization for simple
     // "property <op> constant" patterns.  Collation is checked inside
-    // EntityImpl.deserializeFieldForComparison, so no getCollate guard needed here.
+    // EntityImpl (both serialized and deserialized paths return FALLBACK
+    // for non-default collation), so no getCollate guard needed here.
     if (left.isBaseIdentifier()
         && left.mathExpression instanceof SQLBaseExpression baseExpr
         && right.isEarlyCalculated(ctx)
@@ -92,10 +93,7 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
       if (inPlaceResult != null) {
         return inPlaceResult;
       }
-
-      // FALLBACK: rightVal already computed, only need leftVal
-      var leftVal = left.execute(currentRecord, ctx);
-      return operator.execute(ctx.getDatabaseSession(), leftVal, rightVal);
+      // FALLBACK: fall through to standard path which handles collation
     }
 
     var leftVal = left.execute(currentRecord, ctx);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
@@ -40,9 +40,23 @@ import org.junit.Test;
 public class EntityImplInPlaceComparisonTest extends DbTestBase {
 
   /**
-   * Creates a new entity, serializes it, and deserializes it into a fresh entity.
-   * The returned entity has {@code source} bytes (serialized form) — properties are not yet
-   * deserialized until accessed.
+   * Creates a new entity with source bytes set but properties NOT deserialized.
+   * Uses {@code RecordAbstract.fromStream(byte[])} which sets source + STATUS.LOADED
+   * without calling deserialize(). This exercises the serialized (InPlaceComparator) path.
+   */
+  private EntityImpl serializeWithSourceOnly(EntityImpl entity) {
+    var ser = session.getSerializer();
+    var bytes = ser.toStream(session, entity);
+    var reloaded = (EntityImpl) session.newEntity();
+    reloaded.unsetDirty();
+    reloaded.fromStream(bytes);
+    return reloaded;
+  }
+
+  /**
+   * Creates a new entity, serializes it, and fully deserializes it into a fresh entity.
+   * Properties are populated in memory; source is cleared. This exercises the deserialized
+   * (properties map) path.
    */
   private EntityImpl serializeAndReload(EntityImpl entity) {
     var ser = session.getSerializer();
@@ -64,7 +78,7 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     entity.setProperty("name", "Alice");
     entity.setProperty("age", 30, PropertyType.INTEGER);
 
-    var loaded = serializeAndReload(entity);
+    var loaded = serializeWithSourceOnly(entity);
     assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("name", "Alice"));
     assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("name", "Bob"));
     assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("age", 30));
@@ -79,7 +93,7 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.setProperty("score", 100L, PropertyType.LONG);
 
-    var loaded = serializeAndReload(entity);
+    var loaded = serializeWithSourceOnly(entity);
     assertEquals(OptionalInt.of(0), loaded.comparePropertyTo("score", 100L));
     assertTrue(loaded.comparePropertyTo("score", 50L).getAsInt() > 0);
     assertTrue(loaded.comparePropertyTo("score", 200L).getAsInt() < 0);
@@ -134,7 +148,7 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.setProperty("name", "Alice");
 
-    var loaded = serializeAndReload(entity);
+    var loaded = serializeWithSourceOnly(entity);
     assertEquals(InPlaceResult.FALLBACK, loaded.isPropertyEqualTo("name", null));
     assertTrue(loaded.comparePropertyTo("name", null).isEmpty());
     session.rollback();
@@ -147,7 +161,7 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.setProperty("name", "Alice");
 
-    var loaded = serializeAndReload(entity);
+    var loaded = serializeWithSourceOnly(entity);
     assertEquals(InPlaceResult.FALLBACK, loaded.isPropertyEqualTo("nonExistent", "value"));
     assertTrue(loaded.comparePropertyTo("nonExistent", "value").isEmpty());
     session.rollback();
@@ -169,7 +183,7 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     entity.setProperty("boolVal", true, PropertyType.BOOLEAN);
     entity.setProperty("dateVal", new Date(1700000000000L), PropertyType.DATETIME);
 
-    var loaded = serializeAndReload(entity);
+    var loaded = serializeWithSourceOnly(entity);
     assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("str", "hello"));
     assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("intVal", 42));
     assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("longVal", 999L));
@@ -192,7 +206,7 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.setProperty("intVal", 42, PropertyType.INTEGER);
 
-    var loaded = serializeAndReload(entity);
+    var loaded = serializeWithSourceOnly(entity);
     assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("intVal", 42L));
     assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("intVal", 99L));
     session.rollback();
@@ -239,7 +253,7 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.setProperty("name", "Bob");
 
-    var loaded = serializeAndReload(entity);
+    var loaded = serializeWithSourceOnly(entity);
     assertTrue(loaded.comparePropertyTo("name", "Alice").getAsInt() > 0);
     assertTrue(loaded.comparePropertyTo("name", "Charlie").getAsInt() < 0);
     assertEquals(OptionalInt.of(0), loaded.comparePropertyTo("name", "Bob"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
@@ -246,6 +246,61 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
   // String ordering
   // ===========================================================================
 
+  // ===========================================================================
+  // Status guard: entity must be in LOADED status
+  // ===========================================================================
+
+  /**
+   * After mutating a loaded entity, the properties map has the updated value, so the
+   * deserialized path returns the correct result based on the in-memory data. This verifies
+   * that mutations are reflected in comparison results — the comparison uses the properties
+   * map (which has the new value), not the stale source bytes.
+   */
+  @Test
+  public void testMutatedEntityUsesPropertiesMap() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+
+    var loaded = serializeWithSourceOnly(entity);
+    // Verify it works via source path before mutation
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("name", "Alice"));
+
+    // Mutate — properties map is populated with new value
+    loaded.setProperty("name", "Bob");
+
+    // Comparison uses properties map (with "Bob"), not stale source (with "Alice")
+    assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("name", "Alice"));
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("name", "Bob"));
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Null property value in properties map
+  // ===========================================================================
+
+  /**
+   * When a property exists in the map but has a null value, comparison must return FALLBACK
+   * to delegate null handling to the standard SQL NULL semantics.
+   */
+  @Test
+  public void testNullPropertyValueInMapReturnsFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+    entity.setProperty("nullProp", (String) null);
+
+    // New entity — properties are in the map, no serialization
+    assertEquals(InPlaceResult.FALLBACK,
+        entity.isPropertyEqualTo("nullProp", "anything"));
+    assertTrue(entity.comparePropertyTo("nullProp", "anything").isEmpty());
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // String ordering
+  // ===========================================================================
+
   /** String ordering via comparePropertyTo. */
   @Test
   public void testStringOrdering() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
@@ -1,0 +1,248 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import java.util.Date;
+import java.util.OptionalInt;
+import org.junit.Test;
+
+/**
+ * Tests for {@link EntityImpl#isPropertyEqualTo(String, Object)} and
+ * {@link EntityImpl#comparePropertyTo(String, Object)}. Covers both the deserialized (properties
+ * map) path and the serialized (source bytes) path, plus guard conditions.
+ *
+ * <p>Entities are serialized via {@code toStream/fromStream} to create entities with {@code source}
+ * bytes without requiring a full save/reload cycle.
+ */
+public class EntityImplInPlaceComparisonTest extends DbTestBase {
+
+  /**
+   * Creates a new entity, serializes it, and deserializes it into a fresh entity.
+   * The returned entity has {@code source} bytes (serialized form) — properties are not yet
+   * deserialized until accessed.
+   */
+  private EntityImpl serializeAndReload(EntityImpl entity) {
+    var ser = session.getSerializer();
+    var bytes = ser.toStream(session, entity);
+    var reloaded = (EntityImpl) session.newEntity();
+    ser.fromStream(session, bytes, reloaded, null);
+    return reloaded;
+  }
+
+  // ===========================================================================
+  // Serialized path — entity has source bytes, properties not yet deserialized
+  // ===========================================================================
+
+  /** isPropertyEqualTo against serialized source bytes — matching and non-matching. */
+  @Test
+  public void testIsPropertyEqualToFromSource() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+    entity.setProperty("age", 30, PropertyType.INTEGER);
+
+    var loaded = serializeAndReload(entity);
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("name", "Alice"));
+    assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("name", "Bob"));
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("age", 30));
+    assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("age", 99));
+    session.rollback();
+  }
+
+  /** comparePropertyTo against serialized source bytes — equal, greater, less. */
+  @Test
+  public void testComparePropertyToFromSource() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("score", 100L, PropertyType.LONG);
+
+    var loaded = serializeAndReload(entity);
+    assertEquals(OptionalInt.of(0), loaded.comparePropertyTo("score", 100L));
+    assertTrue(loaded.comparePropertyTo("score", 50L).getAsInt() > 0);
+    assertTrue(loaded.comparePropertyTo("score", 200L).getAsInt() < 0);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Deserialized path — properties already in memory
+  // ===========================================================================
+
+  /** After accessing a property via getProperty(), the comparison uses the deserialized path. */
+  @Test
+  public void testIsPropertyEqualToFromPropertiesMap() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+    entity.setProperty("age", 30, PropertyType.INTEGER);
+
+    var loaded = serializeAndReload(entity);
+    // Trigger deserialization by reading a property
+    loaded.getProperty("name");
+
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("name", "Alice"));
+    assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("name", "Bob"));
+    session.rollback();
+  }
+
+  /** comparePropertyTo from deserialized properties. */
+  @Test
+  public void testComparePropertyToFromPropertiesMap() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("score", 100L, PropertyType.LONG);
+
+    var loaded = serializeAndReload(entity);
+    // Trigger deserialization
+    loaded.getProperty("score");
+
+    assertEquals(OptionalInt.of(0), loaded.comparePropertyTo("score", 100L));
+    assertTrue(loaded.comparePropertyTo("score", 50L).getAsInt() > 0);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Null handling
+  // ===========================================================================
+
+  /** Null comparison value — should fall back. */
+  @Test
+  public void testNullValueFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+
+    var loaded = serializeAndReload(entity);
+    assertEquals(InPlaceResult.FALLBACK, loaded.isPropertyEqualTo("name", null));
+    assertTrue(loaded.comparePropertyTo("name", null).isEmpty());
+    session.rollback();
+  }
+
+  /** Non-existent property — should fall back via source path (deserializeField returns null). */
+  @Test
+  public void testNonExistentPropertyFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+
+    var loaded = serializeAndReload(entity);
+    assertEquals(InPlaceResult.FALLBACK, loaded.isPropertyEqualTo("nonExistent", "value"));
+    assertTrue(loaded.comparePropertyTo("nonExistent", "value").isEmpty());
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Multiple types
+  // ===========================================================================
+
+  /** Test various property types through the source path. */
+  @Test
+  public void testMultiplePropertyTypes() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("str", "hello");
+    entity.setProperty("intVal", 42, PropertyType.INTEGER);
+    entity.setProperty("longVal", 999L, PropertyType.LONG);
+    entity.setProperty("dblVal", 3.14, PropertyType.DOUBLE);
+    entity.setProperty("boolVal", true, PropertyType.BOOLEAN);
+    entity.setProperty("dateVal", new Date(1700000000000L), PropertyType.DATETIME);
+
+    var loaded = serializeAndReload(entity);
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("str", "hello"));
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("intVal", 42));
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("longVal", 999L));
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("dblVal", 3.14));
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("boolVal", true));
+    assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("boolVal", false));
+    assertEquals(InPlaceResult.TRUE,
+        loaded.isPropertyEqualTo("dateVal", new Date(1700000000000L)));
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Cross-type numeric conversion
+  // ===========================================================================
+
+  /** INTEGER property compared with Long value — should work via type conversion. */
+  @Test
+  public void testCrossTypeNumericComparison() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("intVal", 42, PropertyType.INTEGER);
+
+    var loaded = serializeAndReload(entity);
+    assertEquals(InPlaceResult.TRUE, loaded.isPropertyEqualTo("intVal", 42L));
+    assertEquals(InPlaceResult.FALSE, loaded.isPropertyEqualTo("intVal", 99L));
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Entity without source (new, unsaved)
+  // ===========================================================================
+
+  /** New entity with properties but no source — comparison uses deserialized path. */
+  @Test
+  public void testNewEntityNoSource() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+    entity.setProperty("age", 30, PropertyType.INTEGER);
+
+    assertEquals(InPlaceResult.TRUE, entity.isPropertyEqualTo("name", "Alice"));
+    assertEquals(InPlaceResult.FALSE, entity.isPropertyEqualTo("name", "Bob"));
+    assertEquals(InPlaceResult.TRUE, entity.isPropertyEqualTo("age", 30));
+    session.rollback();
+  }
+
+  /** New entity — comparePropertyTo via deserialized path. */
+  @Test
+  public void testNewEntityComparePropertyTo() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("score", 100L, PropertyType.LONG);
+
+    assertEquals(OptionalInt.of(0), entity.comparePropertyTo("score", 100L));
+    assertTrue(entity.comparePropertyTo("score", 50L).getAsInt() > 0);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // String ordering
+  // ===========================================================================
+
+  /** String ordering via comparePropertyTo. */
+  @Test
+  public void testStringOrdering() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Bob");
+
+    var loaded = serializeAndReload(entity);
+    assertTrue(loaded.comparePropertyTo("name", "Alice").getAsInt() > 0);
+    assertTrue(loaded.comparePropertyTo("name", "Charlie").getAsInt() < 0);
+    assertEquals(OptionalInt.of(0), loaded.comparePropertyTo("name", "Bob"));
+    session.rollback();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplInPlaceComparisonTest.java
@@ -314,4 +314,62 @@ public class EntityImplInPlaceComparisonTest extends DbTestBase {
     assertEquals(OptionalInt.of(0), loaded.comparePropertyTo("name", "Bob"));
     session.rollback();
   }
+
+  // ===========================================================================
+  // Collation — non-default collation must cause FALLBACK on deserialized path
+  // ===========================================================================
+
+  /**
+   * Regression test: compareDeserialized must return FALLBACK for CI-collated properties
+   * so the caller falls through to the collation-aware standard path. Before the fix,
+   * compareDeserialized did a raw String.compareTo, returning FALSE for "Alice" vs "alice".
+   */
+  @Test
+  public void testDeserializedPathReturnsFallbackForCiCollation() {
+    // Schema changes must happen outside a transaction
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("CiCollateEqTest");
+    clazz.createProperty("name", PropertyType.STRING).setCollate("ci");
+
+    // Insert via SQL so the record is properly schema-bound
+    session.begin();
+    session.execute("INSERT INTO CiCollateEqTest SET name = 'Alice'");
+    session.commit();
+
+    // Reload from DB, then force deserialization into properties map
+    session.begin();
+    var loaded = (EntityImpl) session.query("SELECT FROM CiCollateEqTest").next().asEntity();
+    loaded.getProperty("name"); // force deserialized (properties map) path
+    // Must return FALLBACK, not TRUE or FALSE, because CI collation
+    // cannot be applied by in-place comparison
+    assertEquals(InPlaceResult.FALLBACK, loaded.isPropertyEqualTo("name", "alice"));
+    assertEquals(InPlaceResult.FALLBACK, loaded.isPropertyEqualTo("name", "ALICE"));
+    session.rollback();
+  }
+
+  /**
+   * Regression test: compareDeserializedOrdering must return empty for CI-collated properties
+   * so ordering comparisons fall back to the collation-aware standard path.
+   */
+  @Test
+  public void testDeserializedOrderingPathReturnsEmptyForCiCollation() {
+    // Schema changes must happen outside a transaction
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("CiCollateOrdTest");
+    clazz.createProperty("name", PropertyType.STRING).setCollate("ci");
+
+    // Insert via SQL so the record is properly schema-bound
+    session.begin();
+    session.execute("INSERT INTO CiCollateOrdTest SET name = 'Bob'");
+    session.commit();
+
+    // Reload from DB, then force deserialization into properties map
+    session.begin();
+    var loaded = (EntityImpl) session.query("SELECT FROM CiCollateOrdTest").next().asEntity();
+    loaded.getProperty("name"); // force deserialized (properties map) path
+    // Must return empty so the caller uses the collation-aware comparator
+    assertTrue(loaded.comparePropertyTo("name", "bob").isEmpty());
+    assertTrue(loaded.comparePropertyTo("name", "BOB").isEmpty());
+    session.rollback();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import java.math.BigDecimal;
@@ -137,6 +138,14 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     // For byte arrays, standard equals uses reference equality — use Arrays.equals
     if (propValue instanceof byte[] pb && value instanceof byte[] vb) {
       return Arrays.equals(pb, vb) ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+    }
+    // LINK equality: compare RID components
+    if (propValue instanceof Identifiable entryId && value instanceof Identifiable valueId) {
+      var entryRid = entryId.getIdentity();
+      var valueRid = valueId.getIdentity();
+      return (entryRid.getCollectionId() == valueRid.getCollectionId()
+          && entryRid.getCollectionPosition() == valueRid.getCollectionPosition())
+              ? InPlaceResult.TRUE : InPlaceResult.FALSE;
     }
     return InPlaceResult.FALSE;
   }
@@ -899,9 +908,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
   // ===========================================================================
 
   /**
-   * LINK property equality via source path (InPlaceComparator). The deserialized path falls back
-   * for LINK (compareJavaValuesOrdering returns empty), so we test the source path directly
-   * rather than using the cross-path equivalence helper.
+   * LINK property equality — both source and deserialized paths support equality. Source path
+   * uses InPlaceComparator.compareLinkEquality; deserialized path uses compareLinkJavaValues.
+   * Ordering returns empty for LINK (not supported).
+   *
+   * <p>Note: cannot use assertEqualityEquivalence for LINK because getProperty() on the
+   * deserialized entity may return null (the linked RID doesn't exist in the test DB),
+   * while the in-place methods work directly on the raw entry value.
    */
   @Test
   public void testLinkEqualityFromSource() {
@@ -912,25 +925,24 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
 
     var source = serializeWithSourceOnly(entity);
 
-    // Source path supports LINK equality via InPlaceComparator
+    // Source path supports LINK equality
     assertEquals(InPlaceResult.TRUE, source.isPropertyEqualTo("val", new RecordId(10, 42)));
     assertEquals(InPlaceResult.FALSE, source.isPropertyEqualTo("val", new RecordId(10, 99)));
-    // Different cluster ID, same position
     assertEquals(InPlaceResult.FALSE, source.isPropertyEqualTo("val", new RecordId(11, 42)));
 
-    // Ordering should return empty for LINK type
+    // Ordering returns empty for LINK type
     assertTrue(
-        "LINK ordering should return empty",
+        "LINK ordering should return empty (source path)",
         source.comparePropertyTo("val", new RecordId(10, 42)).isEmpty());
     session.rollback();
   }
 
   /**
-   * LINK property via deserialized path — falls back because the properties-map comparison
-   * does not support LINK ordering (and equality delegates through ordering).
+   * LINK property equality via deserialized path — returns TRUE/FALSE (not FALLBACK),
+   * matching the source path behavior. Both paths agree on equality results.
    */
   @Test
-  public void testLinkDeserializedPathFallback() {
+  public void testLinkDeserializedPathEquality() {
     session.begin();
     var rid = new RecordId(10, 42);
     var entity = (EntityImpl) session.newEntity();
@@ -938,9 +950,14 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
 
     var deserialized = serializeAndReload(entity);
 
-    // Deserialized path returns FALLBACK for LINK (compareJavaValuesOrdering returns empty)
-    assertEquals(InPlaceResult.FALLBACK,
+    // Deserialized path supports LINK equality via compareLinkJavaValues
+    assertEquals(InPlaceResult.TRUE,
         deserialized.isPropertyEqualTo("val", new RecordId(10, 42)));
+    assertEquals(InPlaceResult.FALSE,
+        deserialized.isPropertyEqualTo("val", new RecordId(10, 99)));
+    assertEquals(InPlaceResult.FALSE,
+        deserialized.isPropertyEqualTo("val", new RecordId(11, 42)));
+    // Ordering still returns empty
     assertTrue(deserialized.comparePropertyTo("val", new RecordId(10, 42)).isEmpty());
     session.rollback();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
@@ -91,7 +91,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
         if (value instanceof BigDecimal bdv) {
           other = bdv;
         } else if (vn instanceof Double || vn instanceof Float) {
-          other = BigDecimal.valueOf(vn.doubleValue());
+          double dv = vn.doubleValue();
+          if (Double.isNaN(dv) || Double.isInfinite(dv)) {
+            return InPlaceResult.FALLBACK;
+          }
+          other = BigDecimal.valueOf(dv);
         } else {
           other = BigDecimal.valueOf(vn.longValue());
         }
@@ -101,10 +105,24 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
         if (value instanceof Double d) {
           return Double.compare(f, d) == 0 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
         }
+        // Guard: integer values beyond float's exact range must fall back
+        if (!(vn instanceof Float)) {
+          long lv = vn.longValue();
+          if (lv > (1 << 24) || lv < -(1 << 24)) {
+            return InPlaceResult.FALLBACK;
+          }
+        }
         return Float.compare(f, vn.floatValue()) == 0
             ? InPlaceResult.TRUE : InPlaceResult.FALSE;
       }
       if (propValue instanceof Double d) {
+        // Guard: long values beyond double's exact range must fall back
+        if (vn instanceof Long || vn instanceof Integer) {
+          long lv = vn.longValue();
+          if (lv > (1L << 53) || lv < -(1L << 53)) {
+            return InPlaceResult.FALLBACK;
+          }
+        }
         return Double.compare(d, vn.doubleValue()) == 0
             ? InPlaceResult.TRUE : InPlaceResult.FALSE;
       }
@@ -136,9 +154,23 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
       if (value instanceof Double d) {
         return OptionalInt.of(Double.compare(f, d));
       }
+      // Guard: integer values beyond float's exact range must fall back
+      if (!(n instanceof Float)) {
+        long lv = n.longValue();
+        if (lv > (1 << 24) || lv < -(1 << 24)) {
+          return OptionalInt.empty();
+        }
+      }
       return OptionalInt.of(Float.compare(f, n.floatValue()));
     }
     if (propValue instanceof Double d && value instanceof Number n) {
+      // Guard: long values beyond double's exact range must fall back
+      if (n instanceof Long || n instanceof Integer) {
+        long lv = n.longValue();
+        if (lv > (1L << 53) || lv < -(1L << 53)) {
+          return OptionalInt.empty();
+        }
+      }
       return OptionalInt.of(Double.compare(d, n.doubleValue()));
     }
     if (propValue instanceof BigDecimal bd) {
@@ -147,7 +179,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
         other = bdv;
       } else if (value instanceof Number n) {
         if (n instanceof Double || n instanceof Float) {
-          other = BigDecimal.valueOf(n.doubleValue());
+          double dv = n.doubleValue();
+          if (Double.isNaN(dv) || Double.isInfinite(dv)) {
+            return OptionalInt.empty();
+          }
+          other = BigDecimal.valueOf(dv);
         } else {
           other = BigDecimal.valueOf(n.longValue());
         }
@@ -577,6 +613,50 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     assertEqualityEquivalence(aboveSrc, aboveDeserialized, "val", (1L << 53) + 1);
     assertOrderingEquivalence(aboveSrc, aboveDeserialized, "val", (1L << 53) + 1);
 
+    session.rollback();
+  }
+
+  /**
+   * FLOAT property compared with Integer above 2^24 — must fall back because float cannot
+   * represent the integer exactly. Both source and deserialized paths must agree.
+   */
+  @Test
+  public void testFloatPropertyWithIntegerAbovePrecisionBoundary() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 16_777_216.0f, PropertyType.FLOAT);
+
+    var source = serializeWithSourceOnly(entity);
+    var deserialized = serializeAndReload(entity);
+
+    // 16_777_217 > 2^24, cannot be exactly represented as float → FALLBACK
+    assertEqualityEquivalence(source, deserialized, "val", 16_777_217);
+    assertOrderingEquivalence(source, deserialized, "val", 16_777_217);
+    // At boundary — should succeed
+    assertEqualityEquivalence(source, deserialized, "val", 16_777_216);
+    assertOrderingEquivalence(source, deserialized, "val", 16_777_216);
+    session.rollback();
+  }
+
+  /**
+   * DOUBLE property compared with Long above 2^53 — must fall back because double cannot
+   * represent the long exactly. Both source and deserialized paths must agree.
+   */
+  @Test
+  public void testDoublePropertyWithLongAbovePrecisionBoundary() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 9_007_199_254_740_992.0, PropertyType.DOUBLE);
+
+    var source = serializeWithSourceOnly(entity);
+    var deserialized = serializeAndReload(entity);
+
+    // 2^53 + 1, cannot be exactly represented as double → FALLBACK
+    assertEqualityEquivalence(source, deserialized, "val", 9_007_199_254_740_993L);
+    assertOrderingEquivalence(source, deserialized, "val", 9_007_199_254_740_993L);
+    // At boundary — should succeed
+    assertEqualityEquivalence(source, deserialized, "val", 9_007_199_254_740_992L);
+    assertOrderingEquivalence(source, deserialized, "val", 9_007_199_254_740_992L);
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
@@ -29,6 +29,8 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyTyp
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.OptionalInt;
 import org.junit.Test;
 
@@ -106,6 +108,10 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
         return Double.compare(d, vn.doubleValue()) == 0
             ? InPlaceResult.TRUE : InPlaceResult.FALSE;
       }
+      // Float/Double → integer: fall back to match production behavior
+      if (vn instanceof Float || vn instanceof Double) {
+        return InPlaceResult.FALLBACK;
+      }
       // Integer types: compare via long
       return Long.compare(pn.longValue(), vn.longValue()) == 0
           ? InPlaceResult.TRUE : InPlaceResult.FALSE;
@@ -151,6 +157,10 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
       return OptionalInt.of(bd.compareTo(other));
     }
     if (propValue instanceof Number pn && value instanceof Number vn) {
+      // Float/Double → integer: fall back to match production behavior
+      if (vn instanceof Float || vn instanceof Double) {
+        return OptionalInt.empty();
+      }
       return OptionalInt.of(Long.compare(pn.longValue(), vn.longValue()));
     }
     if (propValue instanceof byte[] pb && value instanceof byte[] vb) {
@@ -209,13 +219,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42, PropertyType.INTEGER);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42);
-    assertEqualityEquivalence(source, java, "val", 99);
-    assertOrderingEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 10);
-    assertOrderingEquivalence(source, java, "val", 100);
+    assertEqualityEquivalence(source, deserialized, "val", 42);
+    assertEqualityEquivalence(source, deserialized, "val", 99);
+    assertOrderingEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 10);
+    assertOrderingEquivalence(source, deserialized, "val", 100);
     session.rollback();
   }
 
@@ -227,12 +237,12 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42, PropertyType.INTEGER);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42L);
-    assertEqualityEquivalence(source, java, "val", 99L);
-    assertOrderingEquivalence(source, java, "val", 42L);
-    assertOrderingEquivalence(source, java, "val", 10L);
+    assertEqualityEquivalence(source, deserialized, "val", 42L);
+    assertEqualityEquivalence(source, deserialized, "val", 99L);
+    assertOrderingEquivalence(source, deserialized, "val", 42L);
+    assertOrderingEquivalence(source, deserialized, "val", 10L);
     session.rollback();
   }
 
@@ -244,11 +254,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42, PropertyType.INTEGER);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", (short) 42);
-    assertEqualityEquivalence(source, java, "val", (short) 10);
-    assertOrderingEquivalence(source, java, "val", (short) 42);
+    assertEqualityEquivalence(source, deserialized, "val", (short) 42);
+    assertEqualityEquivalence(source, deserialized, "val", (short) 10);
+    assertOrderingEquivalence(source, deserialized, "val", (short) 42);
     session.rollback();
   }
 
@@ -264,13 +274,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 1_000_000_000_000L, PropertyType.LONG);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 1_000_000_000_000L);
-    assertEqualityEquivalence(source, java, "val", 999L);
-    assertOrderingEquivalence(source, java, "val", 1_000_000_000_000L);
-    assertOrderingEquivalence(source, java, "val", 0L);
-    assertOrderingEquivalence(source, java, "val", Long.MAX_VALUE);
+    assertEqualityEquivalence(source, deserialized, "val", 1_000_000_000_000L);
+    assertEqualityEquivalence(source, deserialized, "val", 999L);
+    assertOrderingEquivalence(source, deserialized, "val", 1_000_000_000_000L);
+    assertOrderingEquivalence(source, deserialized, "val", 0L);
+    assertOrderingEquivalence(source, deserialized, "val", Long.MAX_VALUE);
     session.rollback();
   }
 
@@ -282,11 +292,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42L, PropertyType.LONG);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 100);
+    assertEqualityEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 100);
     session.rollback();
   }
 
@@ -302,12 +312,12 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", (short) 100, PropertyType.SHORT);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", (short) 100);
-    assertEqualityEquivalence(source, java, "val", (short) 50);
-    assertOrderingEquivalence(source, java, "val", (short) 100);
-    assertOrderingEquivalence(source, java, "val", (short) 200);
+    assertEqualityEquivalence(source, deserialized, "val", (short) 100);
+    assertEqualityEquivalence(source, deserialized, "val", (short) 50);
+    assertOrderingEquivalence(source, deserialized, "val", (short) 100);
+    assertOrderingEquivalence(source, deserialized, "val", (short) 200);
     session.rollback();
   }
 
@@ -319,10 +329,10 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", (short) 42, PropertyType.SHORT);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 42);
+    assertEqualityEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 42);
     session.rollback();
   }
 
@@ -338,12 +348,12 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", (byte) 7, PropertyType.BYTE);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", (byte) 7);
-    assertEqualityEquivalence(source, java, "val", (byte) 0);
-    assertOrderingEquivalence(source, java, "val", (byte) 7);
-    assertOrderingEquivalence(source, java, "val", (byte) 127);
+    assertEqualityEquivalence(source, deserialized, "val", (byte) 7);
+    assertEqualityEquivalence(source, deserialized, "val", (byte) 0);
+    assertOrderingEquivalence(source, deserialized, "val", (byte) 7);
+    assertOrderingEquivalence(source, deserialized, "val", (byte) 127);
     session.rollback();
   }
 
@@ -359,13 +369,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 3.14f, PropertyType.FLOAT);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 3.14f);
-    assertEqualityEquivalence(source, java, "val", 2.71f);
-    assertOrderingEquivalence(source, java, "val", 3.14f);
-    assertOrderingEquivalence(source, java, "val", 0.0f);
-    assertOrderingEquivalence(source, java, "val", 100.0f);
+    assertEqualityEquivalence(source, deserialized, "val", 3.14f);
+    assertEqualityEquivalence(source, deserialized, "val", 2.71f);
+    assertOrderingEquivalence(source, deserialized, "val", 3.14f);
+    assertOrderingEquivalence(source, deserialized, "val", 0.0f);
+    assertOrderingEquivalence(source, deserialized, "val", 100.0f);
     session.rollback();
   }
 
@@ -418,11 +428,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 3.14f, PropertyType.FLOAT);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", (double) 3.14f);
-    assertOrderingEquivalence(source, java, "val", (double) 3.14f);
-    assertOrderingEquivalence(source, java, "val", 100.0);
+    assertEqualityEquivalence(source, deserialized, "val", (double) 3.14f);
+    assertOrderingEquivalence(source, deserialized, "val", (double) 3.14f);
+    assertOrderingEquivalence(source, deserialized, "val", 100.0);
     session.rollback();
   }
 
@@ -438,13 +448,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 2.718281828, PropertyType.DOUBLE);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 2.718281828);
-    assertEqualityEquivalence(source, java, "val", 3.14);
-    assertOrderingEquivalence(source, java, "val", 2.718281828);
-    assertOrderingEquivalence(source, java, "val", 0.0);
-    assertOrderingEquivalence(source, java, "val", 1000.0);
+    assertEqualityEquivalence(source, deserialized, "val", 2.718281828);
+    assertEqualityEquivalence(source, deserialized, "val", 3.14);
+    assertOrderingEquivalence(source, deserialized, "val", 2.718281828);
+    assertOrderingEquivalence(source, deserialized, "val", 0.0);
+    assertOrderingEquivalence(source, deserialized, "val", 1000.0);
     session.rollback();
   }
 
@@ -475,6 +485,16 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     assertEqualityEquivalence(posInfSource, posInfJava, "val", Double.POSITIVE_INFINITY);
     assertOrderingEquivalence(posInfSource, posInfJava, "val", Double.MAX_VALUE);
 
+    // -Infinity
+    var negInf = (EntityImpl) session.newEntity();
+    negInf.setProperty("val", Double.NEGATIVE_INFINITY, PropertyType.DOUBLE);
+    var negInfSource = serializeWithSourceOnly(negInf);
+    var negInfDeserialized = serializeAndReload(negInf);
+    assertEqualityEquivalence(negInfSource, negInfDeserialized,
+        "val", Double.NEGATIVE_INFINITY);
+    assertOrderingEquivalence(negInfSource, negInfDeserialized,
+        "val", -Double.MAX_VALUE);
+
     session.rollback();
   }
 
@@ -486,11 +506,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42.0, PropertyType.DOUBLE);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 100);
+    assertEqualityEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 100);
     session.rollback();
   }
 
@@ -515,8 +535,16 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     var belowBoundary = (EntityImpl) session.newEntity();
     belowBoundary.setProperty("val", (1 << 24) - 1, PropertyType.INTEGER);
     var belowSrc = serializeWithSourceOnly(belowBoundary);
-    var belowJava = serializeAndReload(belowBoundary);
-    assertEqualityEquivalence(belowSrc, belowJava, "val", (1 << 24) - 1);
+    var belowDeserialized = serializeAndReload(belowBoundary);
+    assertEqualityEquivalence(belowSrc, belowDeserialized, "val", (1 << 24) - 1);
+
+    // Above boundary — (1 << 24) + 1 cannot be exactly represented as float
+    var aboveBoundary = (EntityImpl) session.newEntity();
+    aboveBoundary.setProperty("val", (1 << 24) + 1, PropertyType.INTEGER);
+    var aboveSrc = serializeWithSourceOnly(aboveBoundary);
+    var aboveDeserialized = serializeAndReload(aboveBoundary);
+    assertEqualityEquivalence(aboveSrc, aboveDeserialized, "val", (1 << 24) + 1);
+    assertOrderingEquivalence(aboveSrc, aboveDeserialized, "val", (1 << 24) + 1);
 
     session.rollback();
   }
@@ -530,16 +558,24 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     var atBoundary = (EntityImpl) session.newEntity();
     atBoundary.setProperty("val", (1L << 53), PropertyType.LONG);
     var atSrc = serializeWithSourceOnly(atBoundary);
-    var atJava = serializeAndReload(atBoundary);
-    assertEqualityEquivalence(atSrc, atJava, "val", (1L << 53));
-    assertOrderingEquivalence(atSrc, atJava, "val", (1L << 53));
+    var atDeserialized = serializeAndReload(atBoundary);
+    assertEqualityEquivalence(atSrc, atDeserialized, "val", (1L << 53));
+    assertOrderingEquivalence(atSrc, atDeserialized, "val", (1L << 53));
 
     // Below boundary
     var belowBoundary = (EntityImpl) session.newEntity();
     belowBoundary.setProperty("val", (1L << 53) - 1, PropertyType.LONG);
     var belowSrc = serializeWithSourceOnly(belowBoundary);
-    var belowJava = serializeAndReload(belowBoundary);
-    assertEqualityEquivalence(belowSrc, belowJava, "val", (1L << 53) - 1);
+    var belowDeserialized = serializeAndReload(belowBoundary);
+    assertEqualityEquivalence(belowSrc, belowDeserialized, "val", (1L << 53) - 1);
+
+    // Above boundary — (1L << 53) + 1 cannot be exactly represented as double
+    var aboveBoundary = (EntityImpl) session.newEntity();
+    aboveBoundary.setProperty("val", (1L << 53) + 1, PropertyType.LONG);
+    var aboveSrc = serializeWithSourceOnly(aboveBoundary);
+    var aboveDeserialized = serializeAndReload(aboveBoundary);
+    assertEqualityEquivalence(aboveSrc, aboveDeserialized, "val", (1L << 53) + 1);
+    assertOrderingEquivalence(aboveSrc, aboveDeserialized, "val", (1L << 53) + 1);
 
     session.rollback();
   }
@@ -556,13 +592,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", "Hello, World!");
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", "Hello, World!");
-    assertEqualityEquivalence(source, java, "val", "Goodbye");
-    assertOrderingEquivalence(source, java, "val", "Hello, World!");
-    assertOrderingEquivalence(source, java, "val", "AAA");
-    assertOrderingEquivalence(source, java, "val", "ZZZ");
+    assertEqualityEquivalence(source, deserialized, "val", "Hello, World!");
+    assertEqualityEquivalence(source, deserialized, "val", "Goodbye");
+    assertOrderingEquivalence(source, deserialized, "val", "Hello, World!");
+    assertOrderingEquivalence(source, deserialized, "val", "AAA");
+    assertOrderingEquivalence(source, deserialized, "val", "ZZZ");
     session.rollback();
   }
 
@@ -574,11 +610,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", "\u00e9\u00e0\u00fc \u4e16\u754c");
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", "\u00e9\u00e0\u00fc \u4e16\u754c");
-    assertEqualityEquivalence(source, java, "val", "plain ascii");
-    assertOrderingEquivalence(source, java, "val", "\u00e9\u00e0\u00fc \u4e16\u754c");
+    assertEqualityEquivalence(source, deserialized, "val", "\u00e9\u00e0\u00fc \u4e16\u754c");
+    assertEqualityEquivalence(source, deserialized, "val", "plain ascii");
+    assertOrderingEquivalence(source, deserialized, "val", "\u00e9\u00e0\u00fc \u4e16\u754c");
     session.rollback();
   }
 
@@ -592,13 +628,17 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.setProperty("val", "");
 
+    // Source path: empty string is handled by deserializeField + InPlaceComparator
     var source = serializeWithSourceOnly(entity);
-    // Empty string via source path falls back (deserializeField returns null for zero-length)
-    var result = source.isPropertyEqualTo("val", "");
-    // Either FALLBACK or TRUE is acceptable — the key invariant is no wrong answer
-    assertTrue(
-        "Empty string should either match or fall back",
-        result == InPlaceResult.TRUE || result == InPlaceResult.FALLBACK);
+    assertEquals(
+        "Empty string via source path should match",
+        InPlaceResult.TRUE, source.isPropertyEqualTo("val", ""));
+
+    // Deserialized path: properties map retains the empty string, so equality succeeds
+    var deserialized = serializeAndReload(entity);
+    assertEquals(
+        "Empty string via deserialized path should match",
+        InPlaceResult.TRUE, deserialized.isPropertyEqualTo("val", ""));
     session.rollback();
   }
 
@@ -614,12 +654,12 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", true, PropertyType.BOOLEAN);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", true);
-    assertEqualityEquivalence(source, java, "val", false);
-    assertOrderingEquivalence(source, java, "val", true);
-    assertOrderingEquivalence(source, java, "val", false);
+    assertEqualityEquivalence(source, deserialized, "val", true);
+    assertEqualityEquivalence(source, deserialized, "val", false);
+    assertOrderingEquivalence(source, deserialized, "val", true);
+    assertOrderingEquivalence(source, deserialized, "val", false);
 
     // Also test false property
     var falseEntity = (EntityImpl) session.newEntity();
@@ -645,13 +685,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", now, PropertyType.DATETIME);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", now);
-    assertEqualityEquivalence(source, java, "val", new Date(0));
-    assertOrderingEquivalence(source, java, "val", now);
-    assertOrderingEquivalence(source, java, "val", new Date(0));
-    assertOrderingEquivalence(source, java, "val", new Date(Long.MAX_VALUE));
+    assertEqualityEquivalence(source, deserialized, "val", now);
+    assertEqualityEquivalence(source, deserialized, "val", new Date(0));
+    assertOrderingEquivalence(source, deserialized, "val", now);
+    assertOrderingEquivalence(source, deserialized, "val", new Date(0));
+    assertOrderingEquivalence(source, deserialized, "val", new Date(Long.MAX_VALUE));
     session.rollback();
   }
 
@@ -663,10 +703,10 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", new Date(0), PropertyType.DATETIME);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", new Date(0));
-    assertOrderingEquivalence(source, java, "val", new Date(1000));
+    assertEqualityEquivalence(source, deserialized, "val", new Date(0));
+    assertOrderingEquivalence(source, deserialized, "val", new Date(1000));
     session.rollback();
   }
 
@@ -684,14 +724,14 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", date, PropertyType.DATE);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
     // DATE truncates to day precision; use the reloaded value as the comparison target
-    var reloadedDate = (Date) java.getProperty("val");
-    assertEqualityEquivalence(source, java, "val", reloadedDate);
-    assertOrderingEquivalence(source, java, "val", reloadedDate);
+    var reloadedDate = (Date) deserialized.getProperty("val");
+    assertEqualityEquivalence(source, deserialized, "val", reloadedDate);
+    assertOrderingEquivalence(source, deserialized, "val", reloadedDate);
     // Compare with a different date
-    assertOrderingEquivalence(source, java, "val", new Date(0));
+    assertOrderingEquivalence(source, deserialized, "val", new Date(0));
     session.rollback();
   }
 
@@ -707,13 +747,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", new BigDecimal("123.456"), PropertyType.DECIMAL);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", new BigDecimal("123.456"));
-    assertEqualityEquivalence(source, java, "val", new BigDecimal("999.999"));
-    assertOrderingEquivalence(source, java, "val", new BigDecimal("123.456"));
-    assertOrderingEquivalence(source, java, "val", BigDecimal.ZERO);
-    assertOrderingEquivalence(source, java, "val", new BigDecimal("1000"));
+    assertEqualityEquivalence(source, deserialized, "val", new BigDecimal("123.456"));
+    assertEqualityEquivalence(source, deserialized, "val", new BigDecimal("999.999"));
+    assertOrderingEquivalence(source, deserialized, "val", new BigDecimal("123.456"));
+    assertOrderingEquivalence(source, deserialized, "val", BigDecimal.ZERO);
+    assertOrderingEquivalence(source, deserialized, "val", new BigDecimal("1000"));
     session.rollback();
   }
 
@@ -725,13 +765,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", new BigDecimal("1.0"), PropertyType.DECIMAL);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
     // BigDecimal("1.0").equals(BigDecimal("1")) is false, but compareTo returns 0
     // The in-place path uses compareTo semantics
-    assertEqualityEquivalence(source, java, "val", new BigDecimal("1"));
-    assertEqualityEquivalence(source, java, "val", new BigDecimal("1.00"));
-    assertOrderingEquivalence(source, java, "val", new BigDecimal("1"));
+    assertEqualityEquivalence(source, deserialized, "val", new BigDecimal("1"));
+    assertEqualityEquivalence(source, deserialized, "val", new BigDecimal("1.00"));
+    assertOrderingEquivalence(source, deserialized, "val", new BigDecimal("1"));
     session.rollback();
   }
 
@@ -743,11 +783,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", new BigDecimal("42"), PropertyType.DECIMAL);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42L);
-    assertOrderingEquivalence(source, java, "val", 42L);
-    assertOrderingEquivalence(source, java, "val", 100L);
+    assertEqualityEquivalence(source, deserialized, "val", 42L);
+    assertOrderingEquivalence(source, deserialized, "val", 42L);
+    assertOrderingEquivalence(source, deserialized, "val", 100L);
     session.rollback();
   }
 
@@ -764,13 +804,13 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", bytes, PropertyType.BINARY);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", new byte[] {1, 2, 3, 4, 5});
-    assertEqualityEquivalence(source, java, "val", new byte[] {9, 8, 7});
-    assertOrderingEquivalence(source, java, "val", new byte[] {1, 2, 3, 4, 5});
-    assertOrderingEquivalence(source, java, "val", new byte[] {0});
-    assertOrderingEquivalence(source, java, "val", new byte[] {9, 9, 9});
+    assertEqualityEquivalence(source, deserialized, "val", new byte[] {1, 2, 3, 4, 5});
+    assertEqualityEquivalence(source, deserialized, "val", new byte[] {9, 8, 7});
+    assertOrderingEquivalence(source, deserialized, "val", new byte[] {1, 2, 3, 4, 5});
+    assertOrderingEquivalence(source, deserialized, "val", new byte[] {0});
+    assertOrderingEquivalence(source, deserialized, "val", new byte[] {9, 9, 9});
     session.rollback();
   }
 
@@ -795,6 +835,8 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     // Source path supports LINK equality via InPlaceComparator
     assertEquals(InPlaceResult.TRUE, source.isPropertyEqualTo("val", new RecordId(10, 42)));
     assertEquals(InPlaceResult.FALSE, source.isPropertyEqualTo("val", new RecordId(10, 99)));
+    // Different cluster ID, same position
+    assertEquals(InPlaceResult.FALSE, source.isPropertyEqualTo("val", new RecordId(11, 42)));
 
     // Ordering should return empty for LINK type
     assertTrue(
@@ -814,11 +856,12 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.setProperty("val", rid, PropertyType.LINK);
 
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
     // Deserialized path returns FALLBACK for LINK (compareJavaValuesOrdering returns empty)
-    assertEquals(InPlaceResult.FALLBACK, java.isPropertyEqualTo("val", new RecordId(10, 42)));
-    assertTrue(java.comparePropertyTo("val", new RecordId(10, 42)).isEmpty());
+    assertEquals(InPlaceResult.FALLBACK,
+        deserialized.isPropertyEqualTo("val", new RecordId(10, 42)));
+    assertTrue(deserialized.comparePropertyTo("val", new RecordId(10, 42)).isEmpty());
     session.rollback();
   }
 
@@ -838,9 +881,9 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     assertTrue(source.comparePropertyTo("val", null).isEmpty());
 
     // Deserialized path too
-    var java = serializeAndReload(entity);
-    assertEquals(InPlaceResult.FALLBACK, java.isPropertyEqualTo("val", null));
-    assertTrue(java.comparePropertyTo("val", null).isEmpty());
+    var deserialized = serializeAndReload(entity);
+    assertEquals(InPlaceResult.FALLBACK, deserialized.isPropertyEqualTo("val", null));
+    assertTrue(deserialized.comparePropertyTo("val", null).isEmpty());
     session.rollback();
   }
 
@@ -875,18 +918,18 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("score", 99.5, PropertyType.DOUBLE);
 
     var loaded = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
     // Access one property to trigger partial deserialization
     loaded.getProperty("name");
 
     // Now "name" is in the properties map; "age" and "score" may still use source
-    assertEqualityEquivalence(loaded, java, "name", "Alice");
-    assertEqualityEquivalence(loaded, java, "age", 30);
-    assertEqualityEquivalence(loaded, java, "score", 99.5);
-    assertOrderingEquivalence(loaded, java, "name", "Alice");
-    assertOrderingEquivalence(loaded, java, "age", 30);
-    assertOrderingEquivalence(loaded, java, "score", 99.5);
+    assertEqualityEquivalence(loaded, deserialized, "name", "Alice");
+    assertEqualityEquivalence(loaded, deserialized, "age", 30);
+    assertEqualityEquivalence(loaded, deserialized, "score", 99.5);
+    assertOrderingEquivalence(loaded, deserialized, "name", "Alice");
+    assertOrderingEquivalence(loaded, deserialized, "age", 30);
+    assertOrderingEquivalence(loaded, deserialized, "score", 99.5);
     session.rollback();
   }
 
@@ -917,10 +960,10 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
   public void testEmbeddedListFallback() {
     session.begin();
     var entity = (EntityImpl) session.newEntity();
-    entity.getOrCreateEmbeddedList("val").addAll(java.util.List.of("a", "b", "c"));
+    entity.getOrCreateEmbeddedList("val").addAll(List.of("a", "b", "c"));
 
     var source = serializeWithSourceOnly(entity);
-    var list = java.util.List.of("a", "b", "c");
+    var list = List.of("a", "b", "c");
     assertEquals(InPlaceResult.FALLBACK, source.isPropertyEqualTo("val", list));
     assertTrue(source.comparePropertyTo("val", list).isEmpty());
     session.rollback();
@@ -934,7 +977,7 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.getOrCreateEmbeddedMap("val").put("key", "value");
 
     var source = serializeWithSourceOnly(entity);
-    var map = java.util.Map.of("key", "value");
+    var map = Map.of("key", "value");
     assertEquals(InPlaceResult.FALLBACK, source.isPropertyEqualTo("val", map));
     assertTrue(source.comparePropertyTo("val", map).isEmpty());
     session.rollback();
@@ -965,34 +1008,34 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("binary", new byte[] {1, 2, 3}, PropertyType.BINARY);
 
     // Use serializeAndReload to get a fully deserialized entity
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
     // Equality checks — matching values
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("int", 42));
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("long", 999L));
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("short", (short) 10));
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("byte", (byte) 5));
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("float", 3.14f));
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("double", 2.71828));
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("string", "hello"));
-    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("bool", true));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("int", 42));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("long", 999L));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("short", (short) 10));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("byte", (byte) 5));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("float", 3.14f));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("double", 2.71828));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("string", "hello"));
+    assertEquals(InPlaceResult.TRUE, deserialized.isPropertyEqualTo("bool", true));
     assertEquals(InPlaceResult.TRUE,
-        java.isPropertyEqualTo("datetime", new Date(1700000000000L)));
+        deserialized.isPropertyEqualTo("datetime", new Date(1700000000000L)));
     assertEquals(InPlaceResult.TRUE,
-        java.isPropertyEqualTo("decimal", new BigDecimal("42.5")));
+        deserialized.isPropertyEqualTo("decimal", new BigDecimal("42.5")));
     assertEquals(InPlaceResult.TRUE,
-        java.isPropertyEqualTo("binary", new byte[] {1, 2, 3}));
+        deserialized.isPropertyEqualTo("binary", new byte[] {1, 2, 3}));
 
     // Equality checks — non-matching values
-    assertEquals(InPlaceResult.FALSE, java.isPropertyEqualTo("int", 99));
-    assertEquals(InPlaceResult.FALSE, java.isPropertyEqualTo("string", "world"));
-    assertEquals(InPlaceResult.FALSE, java.isPropertyEqualTo("bool", false));
+    assertEquals(InPlaceResult.FALSE, deserialized.isPropertyEqualTo("int", 99));
+    assertEquals(InPlaceResult.FALSE, deserialized.isPropertyEqualTo("string", "world"));
+    assertEquals(InPlaceResult.FALSE, deserialized.isPropertyEqualTo("bool", false));
 
     // Ordering checks
-    assertEquals(OptionalInt.of(0), java.comparePropertyTo("int", 42));
-    assertTrue(java.comparePropertyTo("int", 10).getAsInt() > 0);
-    assertTrue(java.comparePropertyTo("string", "aaa").getAsInt() > 0);
-    assertTrue(java.comparePropertyTo("string", "zzz").getAsInt() < 0);
+    assertEquals(OptionalInt.of(0), deserialized.comparePropertyTo("int", 42));
+    assertTrue(deserialized.comparePropertyTo("int", 10).getAsInt() > 0);
+    assertTrue(deserialized.comparePropertyTo("string", "aaa").getAsInt() > 0);
+    assertTrue(deserialized.comparePropertyTo("string", "zzz").getAsInt() < 0);
 
     session.rollback();
   }
@@ -1009,23 +1052,23 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42, PropertyType.INTEGER);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
     // Byte
-    assertEqualityEquivalence(source, java, "val", (byte) 42);
-    assertOrderingEquivalence(source, java, "val", (byte) 42);
+    assertEqualityEquivalence(source, deserialized, "val", (byte) 42);
+    assertOrderingEquivalence(source, deserialized, "val", (byte) 42);
 
     // Short
-    assertEqualityEquivalence(source, java, "val", (short) 42);
-    assertOrderingEquivalence(source, java, "val", (short) 42);
+    assertEqualityEquivalence(source, deserialized, "val", (short) 42);
+    assertOrderingEquivalence(source, deserialized, "val", (short) 42);
 
     // Long
-    assertEqualityEquivalence(source, java, "val", 42L);
-    assertOrderingEquivalence(source, java, "val", 42L);
+    assertEqualityEquivalence(source, deserialized, "val", 42L);
+    assertOrderingEquivalence(source, deserialized, "val", 42L);
 
     // Long — non-matching
-    assertEqualityEquivalence(source, java, "val", 99L);
-    assertOrderingEquivalence(source, java, "val", 99L);
+    assertEqualityEquivalence(source, deserialized, "val", 99L);
+    assertOrderingEquivalence(source, deserialized, "val", 99L);
 
     session.rollback();
   }
@@ -1040,11 +1083,11 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42.0f, PropertyType.FLOAT);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 42);
-    assertOrderingEquivalence(source, java, "val", 100);
+    assertEqualityEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 42);
+    assertOrderingEquivalence(source, deserialized, "val", 100);
     session.rollback();
   }
 
@@ -1058,11 +1101,108 @@ public class InPlaceComparisonEquivalenceTest extends DbTestBase {
     entity.setProperty("val", 42.0, PropertyType.DOUBLE);
 
     var source = serializeWithSourceOnly(entity);
-    var java = serializeAndReload(entity);
+    var deserialized = serializeAndReload(entity);
 
-    assertEqualityEquivalence(source, java, "val", 42L);
-    assertOrderingEquivalence(source, java, "val", 42L);
-    assertOrderingEquivalence(source, java, "val", 100L);
+    assertEqualityEquivalence(source, deserialized, "val", 42L);
+    assertOrderingEquivalence(source, deserialized, "val", 42L);
+    assertOrderingEquivalence(source, deserialized, "val", 100L);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Float/Double → integer type fallback
+  // ===========================================================================
+
+  /** Float/Double values compared against INTEGER property should fall back on both paths. */
+  @Test
+  public void testIntegerWithFloatAndDoubleValueFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42, PropertyType.INTEGER);
+
+    var source = serializeWithSourceOnly(entity);
+    var deserialized = serializeAndReload(entity);
+
+    // Float → int: both paths should fall back
+    assertEqualityEquivalence(source, deserialized, "val", 42.0f);
+    assertEqualityEquivalence(source, deserialized, "val", 42.5f);
+    assertOrderingEquivalence(source, deserialized, "val", 42.0f);
+    // Double → int: both paths should fall back
+    assertEqualityEquivalence(source, deserialized, "val", 42.0);
+    assertEqualityEquivalence(source, deserialized, "val", 42.5);
+    assertOrderingEquivalence(source, deserialized, "val", 42.0);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // DECIMAL with Double/Float — double conversion artifacts
+  // ===========================================================================
+
+  /** DECIMAL compared with Double value — exercises double-to-BigDecimal conversion. */
+  @Test
+  public void testDecimalWithDoubleValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", new BigDecimal("0.1"), PropertyType.DECIMAL);
+
+    var source = serializeWithSourceOnly(entity);
+    var deserialized = serializeAndReload(entity);
+
+    // 0.1d is not exactly 0.1 — exercises the conversion artifact path
+    assertEqualityEquivalence(source, deserialized, "val", 0.1);
+    assertOrderingEquivalence(source, deserialized, "val", 0.1);
+    assertOrderingEquivalence(source, deserialized, "val", 0.2);
+
+    // DECIMAL vs Float
+    assertEqualityEquivalence(source, deserialized, "val", 0.1f);
+    assertOrderingEquivalence(source, deserialized, "val", 0.1f);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Integer boundary values
+  // ===========================================================================
+
+  /** INTEGER property with MIN/MAX boundary values and narrowing Long overflow. */
+  @Test
+  public void testIntegerBoundaryValues() {
+    session.begin();
+
+    var maxEntity = (EntityImpl) session.newEntity();
+    maxEntity.setProperty("val", Integer.MAX_VALUE, PropertyType.INTEGER);
+    var maxSrc = serializeWithSourceOnly(maxEntity);
+    var maxDeserialized = serializeAndReload(maxEntity);
+    assertEqualityEquivalence(maxSrc, maxDeserialized, "val", Integer.MAX_VALUE);
+    assertEqualityEquivalence(maxSrc, maxDeserialized, "val", (long) Integer.MAX_VALUE);
+    assertOrderingEquivalence(maxSrc, maxDeserialized, "val", 0);
+
+    var minEntity = (EntityImpl) session.newEntity();
+    minEntity.setProperty("val", Integer.MIN_VALUE, PropertyType.INTEGER);
+    var minSrc = serializeWithSourceOnly(minEntity);
+    var minDeserialized = serializeAndReload(minEntity);
+    assertEqualityEquivalence(minSrc, minDeserialized, "val", Integer.MIN_VALUE);
+    assertOrderingEquivalence(minSrc, minDeserialized, "val", 0);
+
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // BYTE with negative and boundary values
+  // ===========================================================================
+
+  /** BYTE property with negative values and MIN/MAX boundaries. */
+  @Test
+  public void testByteNegativeAndBoundary() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", Byte.MIN_VALUE, PropertyType.BYTE);
+
+    var source = serializeWithSourceOnly(entity);
+    var deserialized = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, deserialized, "val", Byte.MIN_VALUE);
+    assertOrderingEquivalence(source, deserialized, "val", (byte) 0);
+    assertOrderingEquivalence(source, deserialized, "val", Byte.MAX_VALUE);
     session.rollback();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/InPlaceComparisonEquivalenceTest.java
@@ -1,0 +1,1068 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.OptionalInt;
+import org.junit.Test;
+
+/**
+ * Cross-path equivalence tests verifying that in-place comparison (both the serialized/source path
+ * and the deserialized/properties-map path) produces identical results to the standard {@code
+ * getProperty()} + Java comparison path for all supported types and edge cases.
+ *
+ * <p>Pattern: create entity with property, serialize to source-only form, then assert that {@code
+ * isPropertyEqualTo} / {@code comparePropertyTo} matches the result of {@code getProperty()} +
+ * Java comparison.
+ */
+public class InPlaceComparisonEquivalenceTest extends DbTestBase {
+
+  /**
+   * Creates a new entity with source bytes set but properties NOT deserialized. Exercises the
+   * serialized (InPlaceComparator) path.
+   */
+  private EntityImpl serializeWithSourceOnly(EntityImpl entity) {
+    var ser = session.getSerializer();
+    var bytes = ser.toStream(session, entity);
+    var reloaded = (EntityImpl) session.newEntity();
+    reloaded.unsetDirty();
+    reloaded.fromStream(bytes);
+    return reloaded;
+  }
+
+  /**
+   * Creates a new entity, serializes it, and fully deserializes it into a fresh entity. Properties
+   * are populated in memory; exercises the deserialized (properties map) path.
+   */
+  private EntityImpl serializeAndReload(EntityImpl entity) {
+    var ser = session.getSerializer();
+    var bytes = ser.toStream(session, entity);
+    var reloaded = (EntityImpl) session.newEntity();
+    ser.fromStream(session, bytes, reloaded, null);
+    return reloaded;
+  }
+
+  /**
+   * Computes the expected equality result by using standard getProperty() + Java comparison. If the
+   * property is null or value is null, returns FALLBACK (matching in-place behavior).
+   */
+  private InPlaceResult expectedEquality(EntityImpl entity, String name, Object value) {
+    var propValue = entity.getProperty(name);
+    if (propValue == null || value == null) {
+      return InPlaceResult.FALLBACK;
+    }
+    if (propValue.equals(value)) {
+      return InPlaceResult.TRUE;
+    }
+    // For numeric cross-type, standard equals may return false even when values
+    // are logically equal (e.g., Integer(42).equals(Long(42)) == false).
+    // The in-place path does type conversion, so we need to check numeric equality.
+    if (propValue instanceof Number pn && value instanceof Number vn) {
+      if (propValue instanceof BigDecimal bd) {
+        BigDecimal other;
+        if (value instanceof BigDecimal bdv) {
+          other = bdv;
+        } else if (vn instanceof Double || vn instanceof Float) {
+          other = BigDecimal.valueOf(vn.doubleValue());
+        } else {
+          other = BigDecimal.valueOf(vn.longValue());
+        }
+        return bd.compareTo(other) == 0 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+      }
+      if (propValue instanceof Float f) {
+        if (value instanceof Double d) {
+          return Double.compare(f, d) == 0 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+        }
+        return Float.compare(f, vn.floatValue()) == 0
+            ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+      }
+      if (propValue instanceof Double d) {
+        return Double.compare(d, vn.doubleValue()) == 0
+            ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+      }
+      // Integer types: compare via long
+      return Long.compare(pn.longValue(), vn.longValue()) == 0
+          ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+    }
+    // For byte arrays, standard equals uses reference equality — use Arrays.equals
+    if (propValue instanceof byte[] pb && value instanceof byte[] vb) {
+      return Arrays.equals(pb, vb) ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+    }
+    return InPlaceResult.FALSE;
+  }
+
+  /**
+   * Computes the expected ordering result using standard getProperty() + Java comparison.
+   */
+  @SuppressWarnings("unchecked")
+  private OptionalInt expectedOrdering(EntityImpl entity, String name, Object value) {
+    var propValue = entity.getProperty(name);
+    if (propValue == null || value == null) {
+      return OptionalInt.empty();
+    }
+    if (propValue instanceof Float f && value instanceof Number n) {
+      if (value instanceof Double d) {
+        return OptionalInt.of(Double.compare(f, d));
+      }
+      return OptionalInt.of(Float.compare(f, n.floatValue()));
+    }
+    if (propValue instanceof Double d && value instanceof Number n) {
+      return OptionalInt.of(Double.compare(d, n.doubleValue()));
+    }
+    if (propValue instanceof BigDecimal bd) {
+      BigDecimal other;
+      if (value instanceof BigDecimal bdv) {
+        other = bdv;
+      } else if (value instanceof Number n) {
+        if (n instanceof Double || n instanceof Float) {
+          other = BigDecimal.valueOf(n.doubleValue());
+        } else {
+          other = BigDecimal.valueOf(n.longValue());
+        }
+      } else {
+        return OptionalInt.empty();
+      }
+      return OptionalInt.of(bd.compareTo(other));
+    }
+    if (propValue instanceof Number pn && value instanceof Number vn) {
+      return OptionalInt.of(Long.compare(pn.longValue(), vn.longValue()));
+    }
+    if (propValue instanceof byte[] pb && value instanceof byte[] vb) {
+      return OptionalInt.of(Arrays.compare(pb, vb));
+    }
+    if (propValue instanceof Comparable c) {
+      try {
+        return OptionalInt.of(c.compareTo(value));
+      } catch (ClassCastException e) {
+        return OptionalInt.empty();
+      }
+    }
+    return OptionalInt.empty();
+  }
+
+  /**
+   * Asserts equivalence of in-place equality check (source path) with the standard Java path.
+   */
+  private void assertEqualityEquivalence(
+      EntityImpl sourceEntity, EntityImpl javaEntity, String name, Object value) {
+    var expected = expectedEquality(javaEntity, name, value);
+    var actual = sourceEntity.isPropertyEqualTo(name, value);
+    assertEquals(
+        "isPropertyEqualTo mismatch for property '" + name + "' with value " + value,
+        expected, actual);
+  }
+
+  /**
+   * Asserts equivalence of in-place ordering check (source path) with the standard Java path.
+   * Compares sign of ordering result rather than exact value, since different comparison
+   * implementations may return different magnitudes.
+   */
+  private void assertOrderingEquivalence(
+      EntityImpl sourceEntity, EntityImpl javaEntity, String name, Object value) {
+    var expected = expectedOrdering(javaEntity, name, value);
+    var actual = sourceEntity.comparePropertyTo(name, value);
+    assertEquals(
+        "comparePropertyTo emptiness mismatch for property '" + name + "' with value " + value,
+        expected.isEmpty(), actual.isEmpty());
+    if (expected.isPresent() && actual.isPresent()) {
+      assertEquals(
+          "comparePropertyTo sign mismatch for property '" + name + "' with value " + value,
+          Integer.signum(expected.getAsInt()), Integer.signum(actual.getAsInt()));
+    }
+  }
+
+  // ===========================================================================
+  // INTEGER
+  // ===========================================================================
+
+  /** INTEGER property: matching, greater, less values. */
+  @Test
+  public void testIntegerEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42, PropertyType.INTEGER);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42);
+    assertEqualityEquivalence(source, java, "val", 99);
+    assertOrderingEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 10);
+    assertOrderingEquivalence(source, java, "val", 100);
+    session.rollback();
+  }
+
+  /** INTEGER property with Long comparison value — cross-type conversion. */
+  @Test
+  public void testIntegerWithLongValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42, PropertyType.INTEGER);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42L);
+    assertEqualityEquivalence(source, java, "val", 99L);
+    assertOrderingEquivalence(source, java, "val", 42L);
+    assertOrderingEquivalence(source, java, "val", 10L);
+    session.rollback();
+  }
+
+  /** INTEGER property with Short comparison value — cross-type conversion. */
+  @Test
+  public void testIntegerWithShortValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42, PropertyType.INTEGER);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", (short) 42);
+    assertEqualityEquivalence(source, java, "val", (short) 10);
+    assertOrderingEquivalence(source, java, "val", (short) 42);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // LONG
+  // ===========================================================================
+
+  /** LONG property: matching, greater, less values. */
+  @Test
+  public void testLongEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 1_000_000_000_000L, PropertyType.LONG);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 1_000_000_000_000L);
+    assertEqualityEquivalence(source, java, "val", 999L);
+    assertOrderingEquivalence(source, java, "val", 1_000_000_000_000L);
+    assertOrderingEquivalence(source, java, "val", 0L);
+    assertOrderingEquivalence(source, java, "val", Long.MAX_VALUE);
+    session.rollback();
+  }
+
+  /** LONG property with Integer comparison value. */
+  @Test
+  public void testLongWithIntegerValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42L, PropertyType.LONG);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 100);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // SHORT
+  // ===========================================================================
+
+  /** SHORT property equivalence. */
+  @Test
+  public void testShortEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", (short) 100, PropertyType.SHORT);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", (short) 100);
+    assertEqualityEquivalence(source, java, "val", (short) 50);
+    assertOrderingEquivalence(source, java, "val", (short) 100);
+    assertOrderingEquivalence(source, java, "val", (short) 200);
+    session.rollback();
+  }
+
+  /** SHORT property with Integer comparison value. */
+  @Test
+  public void testShortWithIntegerValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", (short) 42, PropertyType.SHORT);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 42);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // BYTE
+  // ===========================================================================
+
+  /** BYTE property equivalence. */
+  @Test
+  public void testByteEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", (byte) 7, PropertyType.BYTE);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", (byte) 7);
+    assertEqualityEquivalence(source, java, "val", (byte) 0);
+    assertOrderingEquivalence(source, java, "val", (byte) 7);
+    assertOrderingEquivalence(source, java, "val", (byte) 127);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // FLOAT
+  // ===========================================================================
+
+  /** FLOAT property equivalence. */
+  @Test
+  public void testFloatEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 3.14f, PropertyType.FLOAT);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 3.14f);
+    assertEqualityEquivalence(source, java, "val", 2.71f);
+    assertOrderingEquivalence(source, java, "val", 3.14f);
+    assertOrderingEquivalence(source, java, "val", 0.0f);
+    assertOrderingEquivalence(source, java, "val", 100.0f);
+    session.rollback();
+  }
+
+  /** FLOAT edge cases: NaN, -0.0, infinities. */
+  @Test
+  public void testFloatEdgeCases() {
+    session.begin();
+
+    // NaN — NaN != NaN per IEEE 754, but Float.compare(NaN, NaN) == 0
+    var nanEntity = (EntityImpl) session.newEntity();
+    nanEntity.setProperty("val", Float.NaN, PropertyType.FLOAT);
+    var nanSource = serializeWithSourceOnly(nanEntity);
+    var nanJava = serializeAndReload(nanEntity);
+    assertEqualityEquivalence(nanSource, nanJava, "val", Float.NaN);
+    assertOrderingEquivalence(nanSource, nanJava, "val", Float.NaN);
+    assertOrderingEquivalence(nanSource, nanJava, "val", 1.0f);
+
+    // -0.0 vs +0.0 — Float.compare distinguishes them
+    var negZero = (EntityImpl) session.newEntity();
+    negZero.setProperty("val", -0.0f, PropertyType.FLOAT);
+    var negZeroSource = serializeWithSourceOnly(negZero);
+    var negZeroJava = serializeAndReload(negZero);
+    assertEqualityEquivalence(negZeroSource, negZeroJava, "val", 0.0f);
+    assertOrderingEquivalence(negZeroSource, negZeroJava, "val", 0.0f);
+
+    // +Infinity
+    var posInf = (EntityImpl) session.newEntity();
+    posInf.setProperty("val", Float.POSITIVE_INFINITY, PropertyType.FLOAT);
+    var posInfSource = serializeWithSourceOnly(posInf);
+    var posInfJava = serializeAndReload(posInf);
+    assertEqualityEquivalence(posInfSource, posInfJava, "val", Float.POSITIVE_INFINITY);
+    assertOrderingEquivalence(posInfSource, posInfJava, "val", Float.MAX_VALUE);
+
+    // -Infinity
+    var negInf = (EntityImpl) session.newEntity();
+    negInf.setProperty("val", Float.NEGATIVE_INFINITY, PropertyType.FLOAT);
+    var negInfSource = serializeWithSourceOnly(negInf);
+    var negInfJava = serializeAndReload(negInf);
+    assertEqualityEquivalence(negInfSource, negInfJava, "val", Float.NEGATIVE_INFINITY);
+    assertOrderingEquivalence(negInfSource, negInfJava, "val", -Float.MAX_VALUE);
+
+    session.rollback();
+  }
+
+  /** FLOAT with Double comparison value — widened to double precision. */
+  @Test
+  public void testFloatWithDoubleValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 3.14f, PropertyType.FLOAT);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", (double) 3.14f);
+    assertOrderingEquivalence(source, java, "val", (double) 3.14f);
+    assertOrderingEquivalence(source, java, "val", 100.0);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // DOUBLE
+  // ===========================================================================
+
+  /** DOUBLE property equivalence. */
+  @Test
+  public void testDoubleEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 2.718281828, PropertyType.DOUBLE);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 2.718281828);
+    assertEqualityEquivalence(source, java, "val", 3.14);
+    assertOrderingEquivalence(source, java, "val", 2.718281828);
+    assertOrderingEquivalence(source, java, "val", 0.0);
+    assertOrderingEquivalence(source, java, "val", 1000.0);
+    session.rollback();
+  }
+
+  /** DOUBLE edge cases: NaN, -0.0, infinities. */
+  @Test
+  public void testDoubleEdgeCases() {
+    session.begin();
+
+    var nanEntity = (EntityImpl) session.newEntity();
+    nanEntity.setProperty("val", Double.NaN, PropertyType.DOUBLE);
+    var nanSource = serializeWithSourceOnly(nanEntity);
+    var nanJava = serializeAndReload(nanEntity);
+    assertEqualityEquivalence(nanSource, nanJava, "val", Double.NaN);
+    assertOrderingEquivalence(nanSource, nanJava, "val", Double.NaN);
+    assertOrderingEquivalence(nanSource, nanJava, "val", 1.0);
+
+    var negZero = (EntityImpl) session.newEntity();
+    negZero.setProperty("val", -0.0, PropertyType.DOUBLE);
+    var negZeroSource = serializeWithSourceOnly(negZero);
+    var negZeroJava = serializeAndReload(negZero);
+    assertEqualityEquivalence(negZeroSource, negZeroJava, "val", 0.0);
+    assertOrderingEquivalence(negZeroSource, negZeroJava, "val", 0.0);
+
+    var posInf = (EntityImpl) session.newEntity();
+    posInf.setProperty("val", Double.POSITIVE_INFINITY, PropertyType.DOUBLE);
+    var posInfSource = serializeWithSourceOnly(posInf);
+    var posInfJava = serializeAndReload(posInf);
+    assertEqualityEquivalence(posInfSource, posInfJava, "val", Double.POSITIVE_INFINITY);
+    assertOrderingEquivalence(posInfSource, posInfJava, "val", Double.MAX_VALUE);
+
+    session.rollback();
+  }
+
+  /** DOUBLE with Integer comparison value. */
+  @Test
+  public void testDoubleWithIntegerValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42.0, PropertyType.DOUBLE);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 100);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Precision boundaries
+  // ===========================================================================
+
+  /** INT→FLOAT precision boundary: 2^24 ± 1. Above 2^24, integer→float loses precision. */
+  @Test
+  public void testIntToFloatPrecisionBoundary() {
+    session.begin();
+
+    // Exactly at boundary — should succeed
+    var atBoundary = (EntityImpl) session.newEntity();
+    atBoundary.setProperty("val", (1 << 24), PropertyType.INTEGER);
+    var atSrc = serializeWithSourceOnly(atBoundary);
+    var atJava = serializeAndReload(atBoundary);
+    assertEqualityEquivalence(atSrc, atJava, "val", (1 << 24));
+    assertOrderingEquivalence(atSrc, atJava, "val", (1 << 24));
+
+    // Below boundary — should succeed
+    var belowBoundary = (EntityImpl) session.newEntity();
+    belowBoundary.setProperty("val", (1 << 24) - 1, PropertyType.INTEGER);
+    var belowSrc = serializeWithSourceOnly(belowBoundary);
+    var belowJava = serializeAndReload(belowBoundary);
+    assertEqualityEquivalence(belowSrc, belowJava, "val", (1 << 24) - 1);
+
+    session.rollback();
+  }
+
+  /** LONG→DOUBLE precision boundary: 2^53 ± 1. Above 2^53, long→double loses precision. */
+  @Test
+  public void testLongToDoublePrecisionBoundary() {
+    session.begin();
+
+    // Exactly at boundary
+    var atBoundary = (EntityImpl) session.newEntity();
+    atBoundary.setProperty("val", (1L << 53), PropertyType.LONG);
+    var atSrc = serializeWithSourceOnly(atBoundary);
+    var atJava = serializeAndReload(atBoundary);
+    assertEqualityEquivalence(atSrc, atJava, "val", (1L << 53));
+    assertOrderingEquivalence(atSrc, atJava, "val", (1L << 53));
+
+    // Below boundary
+    var belowBoundary = (EntityImpl) session.newEntity();
+    belowBoundary.setProperty("val", (1L << 53) - 1, PropertyType.LONG);
+    var belowSrc = serializeWithSourceOnly(belowBoundary);
+    var belowJava = serializeAndReload(belowBoundary);
+    assertEqualityEquivalence(belowSrc, belowJava, "val", (1L << 53) - 1);
+
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // STRING
+  // ===========================================================================
+
+  /** STRING property: matching, non-matching, ordering. */
+  @Test
+  public void testStringEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", "Hello, World!");
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", "Hello, World!");
+    assertEqualityEquivalence(source, java, "val", "Goodbye");
+    assertOrderingEquivalence(source, java, "val", "Hello, World!");
+    assertOrderingEquivalence(source, java, "val", "AAA");
+    assertOrderingEquivalence(source, java, "val", "ZZZ");
+    session.rollback();
+  }
+
+  /** STRING with unicode characters. */
+  @Test
+  public void testStringUnicode() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", "\u00e9\u00e0\u00fc \u4e16\u754c");
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", "\u00e9\u00e0\u00fc \u4e16\u754c");
+    assertEqualityEquivalence(source, java, "val", "plain ascii");
+    assertOrderingEquivalence(source, java, "val", "\u00e9\u00e0\u00fc \u4e16\u754c");
+    session.rollback();
+  }
+
+  /**
+   * Empty string — known to fall back via deserializeField returning null for zero-length fields.
+   * Both source and Java paths should agree on FALLBACK behavior.
+   */
+  @Test
+  public void testEmptyStringFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", "");
+
+    var source = serializeWithSourceOnly(entity);
+    // Empty string via source path falls back (deserializeField returns null for zero-length)
+    var result = source.isPropertyEqualTo("val", "");
+    // Either FALLBACK or TRUE is acceptable — the key invariant is no wrong answer
+    assertTrue(
+        "Empty string should either match or fall back",
+        result == InPlaceResult.TRUE || result == InPlaceResult.FALLBACK);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // BOOLEAN
+  // ===========================================================================
+
+  /** BOOLEAN property equivalence. */
+  @Test
+  public void testBooleanEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", true, PropertyType.BOOLEAN);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", true);
+    assertEqualityEquivalence(source, java, "val", false);
+    assertOrderingEquivalence(source, java, "val", true);
+    assertOrderingEquivalence(source, java, "val", false);
+
+    // Also test false property
+    var falseEntity = (EntityImpl) session.newEntity();
+    falseEntity.setProperty("val", false, PropertyType.BOOLEAN);
+    var falseSrc = serializeWithSourceOnly(falseEntity);
+    var falseJava = serializeAndReload(falseEntity);
+    assertEqualityEquivalence(falseSrc, falseJava, "val", false);
+    assertEqualityEquivalence(falseSrc, falseJava, "val", true);
+
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // DATETIME
+  // ===========================================================================
+
+  /** DATETIME property equivalence. */
+  @Test
+  public void testDatetimeEquivalence() {
+    session.begin();
+    var now = new Date();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", now, PropertyType.DATETIME);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", now);
+    assertEqualityEquivalence(source, java, "val", new Date(0));
+    assertOrderingEquivalence(source, java, "val", now);
+    assertOrderingEquivalence(source, java, "val", new Date(0));
+    assertOrderingEquivalence(source, java, "val", new Date(Long.MAX_VALUE));
+    session.rollback();
+  }
+
+  /** DATETIME with epoch zero. */
+  @Test
+  public void testDatetimeEpochZero() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", new Date(0), PropertyType.DATETIME);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", new Date(0));
+    assertOrderingEquivalence(source, java, "val", new Date(1000));
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // DATE (day-level precision, timezone-sensitive)
+  // ===========================================================================
+
+  /** DATE property equivalence — uses convertDayToTimezone internally. */
+  @Test
+  public void testDateEquivalence() {
+    session.begin();
+    // Use a date well past epoch to avoid timezone edge cases at day boundary
+    var date = new Date(1700000000000L); // 2023-11-14
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", date, PropertyType.DATE);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    // DATE truncates to day precision; use the reloaded value as the comparison target
+    var reloadedDate = (Date) java.getProperty("val");
+    assertEqualityEquivalence(source, java, "val", reloadedDate);
+    assertOrderingEquivalence(source, java, "val", reloadedDate);
+    // Compare with a different date
+    assertOrderingEquivalence(source, java, "val", new Date(0));
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // DECIMAL
+  // ===========================================================================
+
+  /** DECIMAL property equivalence. */
+  @Test
+  public void testDecimalEquivalence() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", new BigDecimal("123.456"), PropertyType.DECIMAL);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", new BigDecimal("123.456"));
+    assertEqualityEquivalence(source, java, "val", new BigDecimal("999.999"));
+    assertOrderingEquivalence(source, java, "val", new BigDecimal("123.456"));
+    assertOrderingEquivalence(source, java, "val", BigDecimal.ZERO);
+    assertOrderingEquivalence(source, java, "val", new BigDecimal("1000"));
+    session.rollback();
+  }
+
+  /** DECIMAL with different scales — 1.0 vs 1 should be equal via compareTo (not equals). */
+  @Test
+  public void testDecimalDifferentScales() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", new BigDecimal("1.0"), PropertyType.DECIMAL);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    // BigDecimal("1.0").equals(BigDecimal("1")) is false, but compareTo returns 0
+    // The in-place path uses compareTo semantics
+    assertEqualityEquivalence(source, java, "val", new BigDecimal("1"));
+    assertEqualityEquivalence(source, java, "val", new BigDecimal("1.00"));
+    assertOrderingEquivalence(source, java, "val", new BigDecimal("1"));
+    session.rollback();
+  }
+
+  /** DECIMAL with long comparison value. */
+  @Test
+  public void testDecimalWithLongValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", new BigDecimal("42"), PropertyType.DECIMAL);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42L);
+    assertOrderingEquivalence(source, java, "val", 42L);
+    assertOrderingEquivalence(source, java, "val", 100L);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // BINARY
+  // ===========================================================================
+
+  /** BINARY property equivalence. */
+  @Test
+  public void testBinaryEquivalence() {
+    session.begin();
+    var bytes = new byte[] {1, 2, 3, 4, 5};
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", bytes, PropertyType.BINARY);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", new byte[] {1, 2, 3, 4, 5});
+    assertEqualityEquivalence(source, java, "val", new byte[] {9, 8, 7});
+    assertOrderingEquivalence(source, java, "val", new byte[] {1, 2, 3, 4, 5});
+    assertOrderingEquivalence(source, java, "val", new byte[] {0});
+    assertOrderingEquivalence(source, java, "val", new byte[] {9, 9, 9});
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // LINK (equality only — ordering returns empty)
+  // ===========================================================================
+
+  /**
+   * LINK property equality via source path (InPlaceComparator). The deserialized path falls back
+   * for LINK (compareJavaValuesOrdering returns empty), so we test the source path directly
+   * rather than using the cross-path equivalence helper.
+   */
+  @Test
+  public void testLinkEqualityFromSource() {
+    session.begin();
+    var rid = new RecordId(10, 42);
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", rid, PropertyType.LINK);
+
+    var source = serializeWithSourceOnly(entity);
+
+    // Source path supports LINK equality via InPlaceComparator
+    assertEquals(InPlaceResult.TRUE, source.isPropertyEqualTo("val", new RecordId(10, 42)));
+    assertEquals(InPlaceResult.FALSE, source.isPropertyEqualTo("val", new RecordId(10, 99)));
+
+    // Ordering should return empty for LINK type
+    assertTrue(
+        "LINK ordering should return empty",
+        source.comparePropertyTo("val", new RecordId(10, 42)).isEmpty());
+    session.rollback();
+  }
+
+  /**
+   * LINK property via deserialized path — falls back because the properties-map comparison
+   * does not support LINK ordering (and equality delegates through ordering).
+   */
+  @Test
+  public void testLinkDeserializedPathFallback() {
+    session.begin();
+    var rid = new RecordId(10, 42);
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", rid, PropertyType.LINK);
+
+    var java = serializeAndReload(entity);
+
+    // Deserialized path returns FALLBACK for LINK (compareJavaValuesOrdering returns empty)
+    assertEquals(InPlaceResult.FALLBACK, java.isPropertyEqualTo("val", new RecordId(10, 42)));
+    assertTrue(java.comparePropertyTo("val", new RecordId(10, 42)).isEmpty());
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Null handling
+  // ===========================================================================
+
+  /** Null comparison value — both paths should return FALLBACK. */
+  @Test
+  public void testNullComparisonValue() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", "Alice");
+
+    var source = serializeWithSourceOnly(entity);
+    assertEquals(InPlaceResult.FALLBACK, source.isPropertyEqualTo("val", null));
+    assertTrue(source.comparePropertyTo("val", null).isEmpty());
+
+    // Deserialized path too
+    var java = serializeAndReload(entity);
+    assertEquals(InPlaceResult.FALLBACK, java.isPropertyEqualTo("val", null));
+    assertTrue(java.comparePropertyTo("val", null).isEmpty());
+    session.rollback();
+  }
+
+  /** Non-existent property — both paths should return FALLBACK. */
+  @Test
+  public void testNonExistentProperty() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", "Alice");
+
+    var source = serializeWithSourceOnly(entity);
+    assertEquals(InPlaceResult.FALLBACK, source.isPropertyEqualTo("missing", "x"));
+    assertTrue(source.comparePropertyTo("missing", "x").isEmpty());
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Partially deserialized entities
+  // ===========================================================================
+
+  /**
+   * Entity with some properties deserialized (in the map) and others still in source bytes.
+   * After accessing one property via getProperty(), the properties map gets populated, but the
+   * remaining properties may still use the source path.
+   */
+  @Test
+  public void testPartiallyDeserializedEntity() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("name", "Alice");
+    entity.setProperty("age", 30, PropertyType.INTEGER);
+    entity.setProperty("score", 99.5, PropertyType.DOUBLE);
+
+    var loaded = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    // Access one property to trigger partial deserialization
+    loaded.getProperty("name");
+
+    // Now "name" is in the properties map; "age" and "score" may still use source
+    assertEqualityEquivalence(loaded, java, "name", "Alice");
+    assertEqualityEquivalence(loaded, java, "age", 30);
+    assertEqualityEquivalence(loaded, java, "score", 99.5);
+    assertOrderingEquivalence(loaded, java, "name", "Alice");
+    assertOrderingEquivalence(loaded, java, "age", 30);
+    assertOrderingEquivalence(loaded, java, "score", 99.5);
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Non-comparable types — should fall back
+  // ===========================================================================
+
+  /**
+   * EMBEDDED property should return FALLBACK since embedded entities are not binary-comparable.
+   */
+  @Test
+  public void testEmbeddedTypeFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    var embedded = (EntityImpl) session.newEmbeddedEntity();
+    embedded.setProperty("inner", "value");
+    entity.setProperty("val", embedded, PropertyType.EMBEDDED);
+
+    var source = serializeWithSourceOnly(entity);
+    // EMBEDDED is not binary-comparable — should fall back
+    assertEquals(InPlaceResult.FALLBACK, source.isPropertyEqualTo("val", embedded));
+    assertTrue(source.comparePropertyTo("val", embedded).isEmpty());
+    session.rollback();
+  }
+
+  /** EMBEDDEDLIST should fall back. */
+  @Test
+  public void testEmbeddedListFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.getOrCreateEmbeddedList("val").addAll(java.util.List.of("a", "b", "c"));
+
+    var source = serializeWithSourceOnly(entity);
+    var list = java.util.List.of("a", "b", "c");
+    assertEquals(InPlaceResult.FALLBACK, source.isPropertyEqualTo("val", list));
+    assertTrue(source.comparePropertyTo("val", list).isEmpty());
+    session.rollback();
+  }
+
+  /** EMBEDDEDMAP should fall back. */
+  @Test
+  public void testEmbeddedMapFallback() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.getOrCreateEmbeddedMap("val").put("key", "value");
+
+    var source = serializeWithSourceOnly(entity);
+    var map = java.util.Map.of("key", "value");
+    assertEquals(InPlaceResult.FALLBACK, source.isPropertyEqualTo("val", map));
+    assertTrue(source.comparePropertyTo("val", map).isEmpty());
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Deserialized path equivalence (properties-map path vs Java comparison)
+  // ===========================================================================
+
+  /**
+   * Verifies that the deserialized (properties-map) path produces the same results as standard
+   * Java comparison for all 13 comparable types.
+   */
+  @Test
+  public void testDeserializedPathAllTypes() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("int", 42, PropertyType.INTEGER);
+    entity.setProperty("long", 999L, PropertyType.LONG);
+    entity.setProperty("short", (short) 10, PropertyType.SHORT);
+    entity.setProperty("byte", (byte) 5, PropertyType.BYTE);
+    entity.setProperty("float", 3.14f, PropertyType.FLOAT);
+    entity.setProperty("double", 2.71828, PropertyType.DOUBLE);
+    entity.setProperty("string", "hello");
+    entity.setProperty("bool", true, PropertyType.BOOLEAN);
+    entity.setProperty("datetime", new Date(1700000000000L), PropertyType.DATETIME);
+    entity.setProperty("decimal", new BigDecimal("42.5"), PropertyType.DECIMAL);
+    entity.setProperty("binary", new byte[] {1, 2, 3}, PropertyType.BINARY);
+
+    // Use serializeAndReload to get a fully deserialized entity
+    var java = serializeAndReload(entity);
+
+    // Equality checks — matching values
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("int", 42));
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("long", 999L));
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("short", (short) 10));
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("byte", (byte) 5));
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("float", 3.14f));
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("double", 2.71828));
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("string", "hello"));
+    assertEquals(InPlaceResult.TRUE, java.isPropertyEqualTo("bool", true));
+    assertEquals(InPlaceResult.TRUE,
+        java.isPropertyEqualTo("datetime", new Date(1700000000000L)));
+    assertEquals(InPlaceResult.TRUE,
+        java.isPropertyEqualTo("decimal", new BigDecimal("42.5")));
+    assertEquals(InPlaceResult.TRUE,
+        java.isPropertyEqualTo("binary", new byte[] {1, 2, 3}));
+
+    // Equality checks — non-matching values
+    assertEquals(InPlaceResult.FALSE, java.isPropertyEqualTo("int", 99));
+    assertEquals(InPlaceResult.FALSE, java.isPropertyEqualTo("string", "world"));
+    assertEquals(InPlaceResult.FALSE, java.isPropertyEqualTo("bool", false));
+
+    // Ordering checks
+    assertEquals(OptionalInt.of(0), java.comparePropertyTo("int", 42));
+    assertTrue(java.comparePropertyTo("int", 10).getAsInt() > 0);
+    assertTrue(java.comparePropertyTo("string", "aaa").getAsInt() > 0);
+    assertTrue(java.comparePropertyTo("string", "zzz").getAsInt() < 0);
+
+    session.rollback();
+  }
+
+  // ===========================================================================
+  // Cross-type numeric: INTEGER property vs various numeric types
+  // ===========================================================================
+
+  /** INTEGER property compared against Byte, Short, Long values — all should work. */
+  @Test
+  public void testIntegerCrossTypeMatrix() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42, PropertyType.INTEGER);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    // Byte
+    assertEqualityEquivalence(source, java, "val", (byte) 42);
+    assertOrderingEquivalence(source, java, "val", (byte) 42);
+
+    // Short
+    assertEqualityEquivalence(source, java, "val", (short) 42);
+    assertOrderingEquivalence(source, java, "val", (short) 42);
+
+    // Long
+    assertEqualityEquivalence(source, java, "val", 42L);
+    assertOrderingEquivalence(source, java, "val", 42L);
+
+    // Long — non-matching
+    assertEqualityEquivalence(source, java, "val", 99L);
+    assertOrderingEquivalence(source, java, "val", 99L);
+
+    session.rollback();
+  }
+
+  /**
+   * FLOAT property compared with Integer value — integer→float precision safe within 2^24.
+   */
+  @Test
+  public void testFloatCrossTypeWithInteger() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42.0f, PropertyType.FLOAT);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 42);
+    assertOrderingEquivalence(source, java, "val", 100);
+    session.rollback();
+  }
+
+  /**
+   * DOUBLE property compared with Long value — long→double precision safe within 2^53.
+   */
+  @Test
+  public void testDoubleCrossTypeWithLong() {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("val", 42.0, PropertyType.DOUBLE);
+
+    var source = serializeWithSourceOnly(entity);
+    var java = serializeAndReload(entity);
+
+    assertEqualityEquivalence(source, java, "val", 42L);
+    assertOrderingEquivalence(source, java, "val", 42L);
+    assertOrderingEquivalence(source, java, "val", 100L);
+    session.rollback();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNonNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNonNumericTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.common.serialization.types.DecimalSerializer;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import java.math.BigDecimal;
@@ -550,5 +552,149 @@ public class InPlaceComparatorNonNumericTest {
     var result =
         InPlaceComparator.isEqual(decimalField(new BigDecimal("1.0")), new BigDecimal("1"));
     assertEquals(OptionalInt.of(1), result);
+  }
+
+  // ===========================================================================
+  // Review fix: non-GMT DATE timezone tests
+  // ===========================================================================
+
+  /** DATE with non-GMT timezone — timezone offset is applied to the serialized day value. */
+  @Test
+  public void testDateWithNonGmtTimezone() {
+    var eastern = TimeZone.getTimeZone("US/Eastern");
+    long days = 1;
+    // Convert using the same helper the production code uses
+    long convertedMillis =
+        HelperClasses.convertDayToTimezone(
+            TimeZone.getTimeZone("GMT"), eastern, days * 86400000L);
+    var result = InPlaceComparator.compare(dateField(days), new Date(convertedMillis), eastern);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATE with positive-offset timezone (Asia/Tokyo = UTC+9). */
+  @Test
+  public void testDateWithPositiveOffsetTimezone() {
+    var tokyo = TimeZone.getTimeZone("Asia/Tokyo");
+    long days = 0;
+    long convertedMillis =
+        HelperClasses.convertDayToTimezone(TimeZone.getTimeZone("GMT"), tokyo, 0L);
+    var result = InPlaceComparator.compare(dateField(days), new Date(convertedMillis), tokyo);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATE epoch day 0 with GMT — should equal Date(0). */
+  @Test
+  public void testDateEpochDayZeroGmt() {
+    var gmtTz = TimeZone.getTimeZone("GMT");
+    var result = InPlaceComparator.compare(dateField(0), new Date(0L), gmtTz);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // Review fix: LINK Identifiable path + boundary values
+  // ===========================================================================
+
+  /** LINK isEqual with Identifiable (non-RID) value — exercises the Identifiable branch. */
+  @Test
+  public void testLinkIsEqualWithIdentifiable() {
+    Identifiable identifiable = new Identifiable() {
+      @Override
+      public RID getIdentity() {
+        return new RecordId(5, 10L);
+      }
+
+      @Override
+      public int compareTo(Identifiable o) {
+        return getIdentity().compareTo(o.getIdentity());
+      }
+    };
+    var result = InPlaceComparator.isEqual(linkField(5, 10L), identifiable);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** LINK isEqual with non-matching Identifiable. */
+  @Test
+  public void testLinkIsEqualWithIdentifiableNotEqual() {
+    Identifiable identifiable = new Identifiable() {
+      @Override
+      public RID getIdentity() {
+        return new RecordId(99, 99L);
+      }
+
+      @Override
+      public int compareTo(Identifiable o) {
+        return getIdentity().compareTo(o.getIdentity());
+      }
+    };
+    var result = InPlaceComparator.isEqual(linkField(5, 10L), identifiable);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LINK isEqual with cluster 0, position 0. */
+  @Test
+  public void testLinkIsEqualZeroRid() {
+    var result = InPlaceComparator.isEqual(linkField(0, 0L), new RecordId(0, 0L));
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  // ===========================================================================
+  // Review fix: DECIMAL with Float, additional fallback tests
+  // ===========================================================================
+
+  /** DECIMAL with Float value — converts via BigDecimal.valueOf(doubleValue()). */
+  @Test
+  public void testDecimalWithFloat() {
+    // 42.5f converts exactly to double, so this should match
+    var result = InPlaceComparator.compare(decimalField(new BigDecimal("42.5")), 42.5f);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with Float that has representation noise (0.1f != 0.1d). */
+  @Test
+  public void testDecimalWithFloatRepresentationDifference() {
+    // 0.1f widens to ~0.10000000149011612d, not 0.1d
+    var result = InPlaceComparator.compare(decimalField(new BigDecimal("0.1")), 0.1f);
+    assertTrue(result.isPresent());
+    // Should NOT be equal due to float representation noise
+    assertTrue(result.getAsInt() != 0);
+  }
+
+  /** EMBEDDEDSET type returns empty. */
+  @Test
+  public void testEmbeddedSetFallback() {
+    var field = new BinaryField(
+        "test", PropertyTypeInternal.EMBEDDEDSET, new BytesContainer(new byte[4], 0), null);
+    assertTrue(InPlaceComparator.compare(field, "value").isEmpty());
+  }
+
+  /** LINKMAP type returns empty. */
+  @Test
+  public void testLinkMapFallback() {
+    var field = new BinaryField(
+        "test", PropertyTypeInternal.LINKMAP, new BytesContainer(new byte[4], 0), null);
+    assertTrue(InPlaceComparator.compare(field, "value").isEmpty());
+  }
+
+  /** LINKBAG type returns empty. */
+  @Test
+  public void testLinkBagFallback() {
+    var field = new BinaryField(
+        "test", PropertyTypeInternal.LINKBAG, new BytesContainer(new byte[4], 0), null);
+    assertTrue(InPlaceComparator.compare(field, "value").isEmpty());
+  }
+
+  /** DATETIME with negative millis — pre-epoch date. */
+  @Test
+  public void testDatetimeNegativeMillis() {
+    long millis = -86400000L; // 1969-12-31
+    var result = InPlaceComparator.compare(datetimeField(millis), new Date(millis));
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATETIME with Integer value (small millis within int range). */
+  @Test
+  public void testDatetimeWithInteger() {
+    var result = InPlaceComparator.compare(datetimeField(5000L), 5000);
+    assertEquals(OptionalInt.of(0), result);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNonNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNonNumericTest.java
@@ -697,4 +697,38 @@ public class InPlaceComparatorNonNumericTest {
     var result = InPlaceComparator.compare(datetimeField(5000L), 5000);
     assertEquals(OptionalInt.of(0), result);
   }
+
+  // ===========================================================================
+  // DECIMAL with Double.NaN and Infinity — must fall back, not throw
+  // ===========================================================================
+
+  /** DECIMAL compared with Double.NaN must return empty (fallback), not throw. */
+  @Test
+  public void testDecimalWithDoubleNaN() {
+    var result = InPlaceComparator.compare(decimalField(new BigDecimal("42")), Double.NaN);
+    assertTrue("DECIMAL vs Double.NaN should fall back", result.isEmpty());
+  }
+
+  /** DECIMAL compared with Double.POSITIVE_INFINITY must return empty (fallback), not throw. */
+  @Test
+  public void testDecimalWithDoublePositiveInfinity() {
+    var result = InPlaceComparator.compare(
+        decimalField(new BigDecimal("42")), Double.POSITIVE_INFINITY);
+    assertTrue("DECIMAL vs +Infinity should fall back", result.isEmpty());
+  }
+
+  /** DECIMAL compared with Double.NEGATIVE_INFINITY must return empty (fallback), not throw. */
+  @Test
+  public void testDecimalWithDoubleNegativeInfinity() {
+    var result = InPlaceComparator.compare(
+        decimalField(new BigDecimal("42")), Double.NEGATIVE_INFINITY);
+    assertTrue("DECIMAL vs -Infinity should fall back", result.isEmpty());
+  }
+
+  /** DECIMAL compared with Float.NaN must return empty (fallback), not throw. */
+  @Test
+  public void testDecimalWithFloatNaN() {
+    var result = InPlaceComparator.compare(decimalField(new BigDecimal("42")), Float.NaN);
+    assertTrue("DECIMAL vs Float.NaN should fall back", result.isEmpty());
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNonNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNonNumericTest.java
@@ -1,0 +1,554 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.common.serialization.types.DecimalSerializer;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.OptionalInt;
+import java.util.TimeZone;
+import org.junit.Test;
+
+/**
+ * Tests for {@link InPlaceComparator} non-numeric type comparison (STRING, BOOLEAN, DATETIME, DATE,
+ * DECIMAL, BINARY, LINK). Covers type-specific edge cases, excluded types, and the isEqual
+ * specialization for LINK.
+ */
+public class InPlaceComparatorNonNumericTest {
+
+  // ---- Helper methods to create BinaryFields with serialized values ----
+
+  private static BinaryField stringField(String value) {
+    var bytes = new BytesContainer();
+    var encoded = value.getBytes(StandardCharsets.UTF_8);
+    VarIntSerializer.write(bytes, encoded.length);
+    var pos = bytes.alloc(encoded.length);
+    System.arraycopy(encoded, 0, bytes.bytes, pos, encoded.length);
+    return new BinaryField(
+        "test", PropertyTypeInternal.STRING, new BytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static BinaryField booleanField(boolean value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(1);
+    bytes.bytes[pos] = value ? (byte) 1 : (byte) 0;
+    return new BinaryField(
+        "test", PropertyTypeInternal.BOOLEAN, new BytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static BinaryField datetimeField(long millis) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, millis);
+    return new BinaryField(
+        "test", PropertyTypeInternal.DATETIME, new BytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static BinaryField dateField(long days) {
+    // Stores days since epoch (not millis) — same as RecordSerializerBinaryV1
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, days);
+    return new BinaryField(
+        "test", PropertyTypeInternal.DATE, new BytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static BinaryField decimalField(BigDecimal value) {
+    var size = DecimalSerializer.staticGetObjectSize(value);
+    var bytes = new byte[size];
+    DecimalSerializer.staticSerialize(value, bytes, 0);
+    return new BinaryField(
+        "test", PropertyTypeInternal.DECIMAL, new BytesContainer(bytes, 0), null);
+  }
+
+  private static BinaryField binaryField(byte[] value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value.length);
+    var pos = bytes.alloc(value.length);
+    System.arraycopy(value, 0, bytes.bytes, pos, value.length);
+    return new BinaryField(
+        "test", PropertyTypeInternal.BINARY, new BytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static BinaryField linkField(int collectionId, long collectionPos) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, collectionId);
+    VarIntSerializer.write(bytes, collectionPos);
+    return new BinaryField(
+        "test", PropertyTypeInternal.LINK, new BytesContainer(bytes.bytes, 0), null);
+  }
+
+  // ===========================================================================
+  // STRING tests
+  // ===========================================================================
+
+  /** STRING equality — same value. */
+  @Test
+  public void testStringEqual() {
+    var result = InPlaceComparator.compare(stringField("hello"), "hello");
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** STRING less than — "abc" < "def". */
+  @Test
+  public void testStringLessThan() {
+    var result = InPlaceComparator.compare(stringField("abc"), "def");
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** STRING greater than — "xyz" > "abc". */
+  @Test
+  public void testStringGreaterThan() {
+    var result = InPlaceComparator.compare(stringField("xyz"), "abc");
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** STRING empty string comparison. */
+  @Test
+  public void testStringEmpty() {
+    var result = InPlaceComparator.compare(stringField(""), "");
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** STRING with non-String value — should fall back. */
+  @Test
+  public void testStringWithNonStringFallback() {
+    var result = InPlaceComparator.compare(stringField("42"), 42);
+    assertTrue(result.isEmpty());
+  }
+
+  /** STRING with Unicode characters. */
+  @Test
+  public void testStringUnicode() {
+    var result = InPlaceComparator.compare(stringField("привет"), "привет");
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** STRING with Unicode ordering. */
+  @Test
+  public void testStringUnicodeOrdering() {
+    var result = InPlaceComparator.compare(stringField("a"), "б");
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  // ===========================================================================
+  // BOOLEAN tests
+  // ===========================================================================
+
+  /** BOOLEAN true == true. */
+  @Test
+  public void testBooleanTrueEqual() {
+    var result = InPlaceComparator.compare(booleanField(true), true);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BOOLEAN false == false. */
+  @Test
+  public void testBooleanFalseEqual() {
+    var result = InPlaceComparator.compare(booleanField(false), false);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BOOLEAN true > false (Boolean.compare semantics). */
+  @Test
+  public void testBooleanTrueGreaterThanFalse() {
+    var result = InPlaceComparator.compare(booleanField(true), false);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** BOOLEAN false < true. */
+  @Test
+  public void testBooleanFalseLessThanTrue() {
+    var result = InPlaceComparator.compare(booleanField(false), true);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** BOOLEAN with non-Boolean value — should fall back. */
+  @Test
+  public void testBooleanWithNonBooleanFallback() {
+    var result = InPlaceComparator.compare(booleanField(true), 1);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // DATETIME tests
+  // ===========================================================================
+
+  /** DATETIME with matching Date. */
+  @Test
+  public void testDatetimeEqualDate() {
+    long millis = 1700000000000L;
+    var result = InPlaceComparator.compare(datetimeField(millis), new Date(millis));
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATETIME less than. */
+  @Test
+  public void testDatetimeLessThan() {
+    var result = InPlaceComparator.compare(datetimeField(1000L), new Date(2000L));
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DATETIME greater than. */
+  @Test
+  public void testDatetimeGreaterThan() {
+    var result = InPlaceComparator.compare(datetimeField(2000L), new Date(1000L));
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** DATETIME with Number value (millis as long). */
+  @Test
+  public void testDatetimeWithNumber() {
+    long millis = 1700000000000L;
+    var result = InPlaceComparator.compare(datetimeField(millis), millis);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATETIME with non-Date/Number — should fall back. */
+  @Test
+  public void testDatetimeWithStringFallback() {
+    var result = InPlaceComparator.compare(datetimeField(1000L), "2024-01-01");
+    assertTrue(result.isEmpty());
+  }
+
+  /** DATETIME epoch zero. */
+  @Test
+  public void testDatetimeEpochZero() {
+    var result = InPlaceComparator.compare(datetimeField(0L), new Date(0L));
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // DATE tests
+  // ===========================================================================
+
+  /** DATE with GMT timezone — stored days * MILLISEC_PER_DAY should match. */
+  @Test
+  public void testDateEqualGmt() {
+    // Day 0 = epoch, 1 day = 86400000 millis
+    long days = 1;
+    long expectedMillis = 86400000L;
+    var gmtTz = TimeZone.getTimeZone("GMT");
+    var result = InPlaceComparator.compare(dateField(days), new Date(expectedMillis), gmtTz);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATE without timezone — should fall back. */
+  @Test
+  public void testDateWithoutTimezoneFallback() {
+    var result = InPlaceComparator.compare(dateField(1), new Date(86400000L));
+    assertTrue(result.isEmpty());
+  }
+
+  /** DATE ordering. */
+  @Test
+  public void testDateOrdering() {
+    var gmtTz = TimeZone.getTimeZone("GMT");
+    var result = InPlaceComparator.compare(dateField(1), new Date(2 * 86400000L), gmtTz);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DATE with Number value. */
+  @Test
+  public void testDateWithNumber() {
+    var gmtTz = TimeZone.getTimeZone("GMT");
+    long days = 5;
+    long expectedMillis = 5 * 86400000L;
+    var result = InPlaceComparator.compare(dateField(days), expectedMillis, gmtTz);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATE with non-Date/Number — should fall back. */
+  @Test
+  public void testDateWithStringFallback() {
+    var gmtTz = TimeZone.getTimeZone("GMT");
+    var result = InPlaceComparator.compare(dateField(1), "2024-01-01", gmtTz);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // DECIMAL tests
+  // ===========================================================================
+
+  /** DECIMAL equality — same value. */
+  @Test
+  public void testDecimalEqual() {
+    var bd = new BigDecimal("123.456");
+    var result = InPlaceComparator.compare(decimalField(bd), bd);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with different scale but same value — compareTo ignores scale. */
+  @Test
+  public void testDecimalDifferentScale() {
+    var result =
+        InPlaceComparator.compare(decimalField(new BigDecimal("1.0")), new BigDecimal("1"));
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL less than. */
+  @Test
+  public void testDecimalLessThan() {
+    var result =
+        InPlaceComparator.compare(
+            decimalField(new BigDecimal("1.5")), new BigDecimal("2.5"));
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DECIMAL greater than. */
+  @Test
+  public void testDecimalGreaterThan() {
+    var result =
+        InPlaceComparator.compare(
+            decimalField(new BigDecimal("2.5")), new BigDecimal("1.5"));
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** DECIMAL with Double value — converts via BigDecimal.valueOf(). */
+  @Test
+  public void testDecimalWithDouble() {
+    var result = InPlaceComparator.compare(decimalField(new BigDecimal("42.0")), 42.0);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with Integer value — converts via BigDecimal.valueOf(long). */
+  @Test
+  public void testDecimalWithInteger() {
+    var result = InPlaceComparator.compare(decimalField(new BigDecimal("42")), 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with Long value. */
+  @Test
+  public void testDecimalWithLong() {
+    var result = InPlaceComparator.compare(decimalField(new BigDecimal("42")), 42L);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with non-Number — should fall back. */
+  @Test
+  public void testDecimalWithStringFallback() {
+    var result =
+        InPlaceComparator.compare(decimalField(new BigDecimal("42")), "42");
+    assertTrue(result.isEmpty());
+  }
+
+  /** DECIMAL negative value. */
+  @Test
+  public void testDecimalNegative() {
+    var result =
+        InPlaceComparator.compare(
+            decimalField(new BigDecimal("-99.99")), new BigDecimal("-99.99"));
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL zero. */
+  @Test
+  public void testDecimalZero() {
+    var result =
+        InPlaceComparator.compare(decimalField(BigDecimal.ZERO), BigDecimal.ZERO);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // BINARY tests
+  // ===========================================================================
+
+  /** BINARY equality. */
+  @Test
+  public void testBinaryEqual() {
+    var data = new byte[] {1, 2, 3, 4, 5};
+    var result = InPlaceComparator.compare(binaryField(data), data);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BINARY less than (lexicographic). */
+  @Test
+  public void testBinaryLessThan() {
+    var result = InPlaceComparator.compare(
+        binaryField(new byte[] {1, 2, 3}), new byte[] {1, 2, 4});
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** BINARY greater than. */
+  @Test
+  public void testBinaryGreaterThan() {
+    var result = InPlaceComparator.compare(
+        binaryField(new byte[] {1, 2, 4}), new byte[] {1, 2, 3});
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** BINARY different lengths — shorter array is less. */
+  @Test
+  public void testBinaryDifferentLengths() {
+    var result = InPlaceComparator.compare(
+        binaryField(new byte[] {1, 2}), new byte[] {1, 2, 3});
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** BINARY empty arrays. */
+  @Test
+  public void testBinaryEmpty() {
+    var result = InPlaceComparator.compare(
+        binaryField(new byte[0]), new byte[0]);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BINARY with non-byte-array — should fall back. */
+  @Test
+  public void testBinaryWithNonByteArrayFallback() {
+    var result = InPlaceComparator.compare(binaryField(new byte[] {1}), "data");
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // LINK tests
+  // ===========================================================================
+
+  /** LINK compare returns empty (ordering undefined). */
+  @Test
+  public void testLinkCompareReturnsEmpty() {
+    var result = InPlaceComparator.compare(linkField(5, 10L), new RecordId(5, 10L));
+    assertTrue(result.isEmpty());
+  }
+
+  /** LINK isEqual returns 1 for matching RID. */
+  @Test
+  public void testLinkIsEqualTrue() {
+    var result = InPlaceComparator.isEqual(linkField(5, 10L), new RecordId(5, 10L));
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** LINK isEqual returns 0 for different collectionId. */
+  @Test
+  public void testLinkIsEqualDifferentCollectionId() {
+    var result = InPlaceComparator.isEqual(linkField(5, 10L), new RecordId(6, 10L));
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LINK isEqual returns 0 for different collectionPosition. */
+  @Test
+  public void testLinkIsEqualDifferentCollectionPos() {
+    var result = InPlaceComparator.isEqual(linkField(5, 10L), new RecordId(5, 11L));
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LINK isEqual with non-RID value — should fall back. */
+  @Test
+  public void testLinkIsEqualWithNonRidFallback() {
+    var result = InPlaceComparator.isEqual(linkField(5, 10L), "5:10");
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // Excluded types fallback tests
+  // ===========================================================================
+
+  /** EMBEDDED type returns empty (not binary-comparable). */
+  @Test
+  public void testEmbeddedFallback() {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, 42);
+    var field = new BinaryField(
+        "test", PropertyTypeInternal.EMBEDDED, new BytesContainer(bytes.bytes, 0), null);
+    var result = InPlaceComparator.compare(field, "value");
+    assertTrue(result.isEmpty());
+  }
+
+  /** EMBEDDEDLIST type returns empty. */
+  @Test
+  public void testEmbeddedListFallback() {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, 42);
+    var field = new BinaryField(
+        "test", PropertyTypeInternal.EMBEDDEDLIST, new BytesContainer(bytes.bytes, 0), null);
+    var result = InPlaceComparator.compare(field, "value");
+    assertTrue(result.isEmpty());
+  }
+
+  /** LINKLIST type returns empty. */
+  @Test
+  public void testLinkListFallback() {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, 42);
+    var field = new BinaryField(
+        "test", PropertyTypeInternal.LINKLIST, new BytesContainer(bytes.bytes, 0), null);
+    var result = InPlaceComparator.compare(field, "value");
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // isEqual for non-numeric types (derived from compare)
+  // ===========================================================================
+
+  /** isEqual for STRING — equal. */
+  @Test
+  public void testIsEqualStringTrue() {
+    var result = InPlaceComparator.isEqual(stringField("hello"), "hello");
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual for STRING — not equal. */
+  @Test
+  public void testIsEqualStringFalse() {
+    var result = InPlaceComparator.isEqual(stringField("hello"), "world");
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual for BOOLEAN — equal. */
+  @Test
+  public void testIsEqualBooleanTrue() {
+    var result = InPlaceComparator.isEqual(booleanField(true), true);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual for BOOLEAN — not equal. */
+  @Test
+  public void testIsEqualBooleanFalse() {
+    var result = InPlaceComparator.isEqual(booleanField(true), false);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual for DECIMAL with different scale — still equal via compareTo. */
+  @Test
+  public void testIsEqualDecimalDifferentScale() {
+    var result =
+        InPlaceComparator.isEqual(decimalField(new BigDecimal("1.0")), new BigDecimal("1"));
+    assertEquals(OptionalInt.of(1), result);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNumericTest.java
@@ -1,0 +1,762 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
+import com.jetbrains.youtrackdb.internal.common.serialization.types.LongSerializer;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import java.util.OptionalInt;
+import org.junit.Test;
+
+/**
+ * Tests for {@link InPlaceComparator} numeric type comparison (INTEGER, LONG, SHORT, BYTE, FLOAT,
+ * DOUBLE). Covers same-type comparison, cross-type conversion, precision boundaries, and edge
+ * cases.
+ */
+public class InPlaceComparatorNumericTest {
+
+  // ---- Helper methods to create BinaryFields with serialized values ----
+
+  private static BinaryField intField(int value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value);
+    return new BinaryField("test", PropertyTypeInternal.INTEGER, new BytesContainer(bytes.bytes, 0),
+        null);
+  }
+
+  private static BinaryField longField(long value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value);
+    return new BinaryField("test", PropertyTypeInternal.LONG, new BytesContainer(bytes.bytes, 0),
+        null);
+  }
+
+  private static BinaryField shortField(short value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value);
+    return new BinaryField("test", PropertyTypeInternal.SHORT, new BytesContainer(bytes.bytes, 0),
+        null);
+  }
+
+  private static BinaryField byteField(byte value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(1);
+    bytes.bytes[pos] = value;
+    return new BinaryField("test", PropertyTypeInternal.BYTE, new BytesContainer(bytes.bytes, 0),
+        null);
+  }
+
+  private static BinaryField floatField(float value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(IntegerSerializer.INT_SIZE);
+    IntegerSerializer.serializeLiteral(Float.floatToIntBits(value), bytes.bytes, pos);
+    return new BinaryField("test", PropertyTypeInternal.FLOAT, new BytesContainer(bytes.bytes, 0),
+        null);
+  }
+
+  private static BinaryField doubleField(double value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(LongSerializer.LONG_SIZE);
+    LongSerializer.serializeLiteral(Double.doubleToLongBits(value), bytes.bytes, pos);
+    return new BinaryField("test", PropertyTypeInternal.DOUBLE, new BytesContainer(bytes.bytes, 0),
+        null);
+  }
+
+  // ===========================================================================
+  // INTEGER tests
+  // ===========================================================================
+
+  /** Compare INTEGER field with matching Integer value — should return 0. */
+  @Test
+  public void testIntegerEqualSameType() {
+    var result = InPlaceComparator.compare(intField(42), 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** Compare INTEGER field with greater Integer value — serialized < value, so result < 0. */
+  @Test
+  public void testIntegerLessThan() {
+    var result = InPlaceComparator.compare(intField(10), 20);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** Compare INTEGER field with smaller Integer value — serialized > value, so result > 0. */
+  @Test
+  public void testIntegerGreaterThan() {
+    var result = InPlaceComparator.compare(intField(20), 10);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** INTEGER compared with a Long value that fits in int range — should succeed. */
+  @Test
+  public void testIntegerWithLongInRange() {
+    var result = InPlaceComparator.compare(intField(100), 100L);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER compared with a Long value outside int range — should fall back. */
+  @Test
+  public void testIntegerWithLongOutOfRange() {
+    var result = InPlaceComparator.compare(intField(100), (long) Integer.MAX_VALUE + 1);
+    assertTrue(result.isEmpty());
+  }
+
+  /** INTEGER compared with a Short value — should widen Short to int. */
+  @Test
+  public void testIntegerWithShort() {
+    var result = InPlaceComparator.compare(intField(42), (short) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER compared with a Byte value — should widen Byte to int. */
+  @Test
+  public void testIntegerWithByte() {
+    var result = InPlaceComparator.compare(intField(7), (byte) 7);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER compared with a Float — should fall back (float-to-int not supported). */
+  @Test
+  public void testIntegerWithFloatFallback() {
+    var result = InPlaceComparator.compare(intField(42), 42.0f);
+    assertTrue(result.isEmpty());
+  }
+
+  /** INTEGER compared with a Double — should fall back (double-to-int not supported). */
+  @Test
+  public void testIntegerWithDoubleFallback() {
+    var result = InPlaceComparator.compare(intField(42), 42.0);
+    assertTrue(result.isEmpty());
+  }
+
+  /** INTEGER at Integer.MAX_VALUE — boundary test. */
+  @Test
+  public void testIntegerMaxValue() {
+    var result = InPlaceComparator.compare(intField(Integer.MAX_VALUE), Integer.MAX_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER at Integer.MIN_VALUE — boundary test. */
+  @Test
+  public void testIntegerMinValue() {
+    var result = InPlaceComparator.compare(intField(Integer.MIN_VALUE), Integer.MIN_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER with non-Number value — should fall back. */
+  @Test
+  public void testIntegerWithNonNumber() {
+    var result = InPlaceComparator.compare(intField(42), "42");
+    assertTrue(result.isEmpty());
+  }
+
+  /** INTEGER zero — boundary test. */
+  @Test
+  public void testIntegerZero() {
+    var result = InPlaceComparator.compare(intField(0), 0);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER negative value. */
+  @Test
+  public void testIntegerNegative() {
+    var result = InPlaceComparator.compare(intField(-100), -100);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // LONG tests
+  // ===========================================================================
+
+  /** Compare LONG field with matching Long value. */
+  @Test
+  public void testLongEqualSameType() {
+    var result = InPlaceComparator.compare(longField(123456789L), 123456789L);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LONG less than comparison. */
+  @Test
+  public void testLongLessThan() {
+    var result = InPlaceComparator.compare(longField(10L), 20L);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** LONG greater than comparison. */
+  @Test
+  public void testLongGreaterThan() {
+    var result = InPlaceComparator.compare(longField(20L), 10L);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** LONG compared with Integer — should widen Integer to long. */
+  @Test
+  public void testLongWithInteger() {
+    var result = InPlaceComparator.compare(longField(42L), 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LONG compared with Short — should widen to long. */
+  @Test
+  public void testLongWithShort() {
+    var result = InPlaceComparator.compare(longField(42L), (short) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LONG compared with Float — should fall back. */
+  @Test
+  public void testLongWithFloatFallback() {
+    var result = InPlaceComparator.compare(longField(42L), 42.0f);
+    assertTrue(result.isEmpty());
+  }
+
+  /** LONG compared with Double — should fall back. */
+  @Test
+  public void testLongWithDoubleFallback() {
+    var result = InPlaceComparator.compare(longField(42L), 42.0);
+    assertTrue(result.isEmpty());
+  }
+
+  /** LONG at Long.MAX_VALUE. */
+  @Test
+  public void testLongMaxValue() {
+    var result = InPlaceComparator.compare(longField(Long.MAX_VALUE), Long.MAX_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LONG at Long.MIN_VALUE. */
+  @Test
+  public void testLongMinValue() {
+    var result = InPlaceComparator.compare(longField(Long.MIN_VALUE), Long.MIN_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // SHORT tests
+  // ===========================================================================
+
+  /** Compare SHORT field with matching Short value. */
+  @Test
+  public void testShortEqualSameType() {
+    var result = InPlaceComparator.compare(shortField((short) 42), (short) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT less than comparison. */
+  @Test
+  public void testShortLessThan() {
+    var result = InPlaceComparator.compare(shortField((short) 10), (short) 20);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** SHORT with Integer in range — should narrow Integer to short. */
+  @Test
+  public void testShortWithIntegerInRange() {
+    var result = InPlaceComparator.compare(shortField((short) 100), 100);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT with Integer out of range — should fall back. */
+  @Test
+  public void testShortWithIntegerOutOfRange() {
+    var result = InPlaceComparator.compare(shortField((short) 100), 100_000);
+    assertTrue(result.isEmpty());
+  }
+
+  /** SHORT with Long in range — should narrow Long to short. */
+  @Test
+  public void testShortWithLongInRange() {
+    var result = InPlaceComparator.compare(shortField((short) 100), 100L);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT with Long out of range — should fall back. */
+  @Test
+  public void testShortWithLongOutOfRange() {
+    var result = InPlaceComparator.compare(shortField((short) 100), 100_000L);
+    assertTrue(result.isEmpty());
+  }
+
+  /** SHORT with Byte — should widen Byte to short. */
+  @Test
+  public void testShortWithByte() {
+    var result = InPlaceComparator.compare(shortField((short) 42), (byte) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT with Float — should fall back. */
+  @Test
+  public void testShortWithFloatFallback() {
+    var result = InPlaceComparator.compare(shortField((short) 42), 42.0f);
+    assertTrue(result.isEmpty());
+  }
+
+  /** SHORT at Short.MAX_VALUE. */
+  @Test
+  public void testShortMaxValue() {
+    var result = InPlaceComparator.compare(shortField(Short.MAX_VALUE), (short) Short.MAX_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT at Short.MIN_VALUE. */
+  @Test
+  public void testShortMinValue() {
+    var result = InPlaceComparator.compare(shortField(Short.MIN_VALUE), (short) Short.MIN_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // BYTE tests
+  // ===========================================================================
+
+  /** Compare BYTE field with matching Byte value. */
+  @Test
+  public void testByteEqualSameType() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), (byte) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BYTE less than comparison. */
+  @Test
+  public void testByteLessThan() {
+    var result = InPlaceComparator.compare(byteField((byte) 10), (byte) 20);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** BYTE with Integer in range — should narrow Integer to byte. */
+  @Test
+  public void testByteWithIntegerInRange() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BYTE with Integer out of range — should fall back. */
+  @Test
+  public void testByteWithIntegerOutOfRange() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), 1000);
+    assertTrue(result.isEmpty());
+  }
+
+  /** BYTE with Short in range — should narrow Short to byte. */
+  @Test
+  public void testByteWithShortInRange() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), (short) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BYTE with Short out of range — should fall back. */
+  @Test
+  public void testByteWithShortOutOfRange() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), (short) 1000);
+    assertTrue(result.isEmpty());
+  }
+
+  /** BYTE with Long in range — should narrow Long to byte. */
+  @Test
+  public void testByteWithLongInRange() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), 42L);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BYTE with Long out of range — should fall back. */
+  @Test
+  public void testByteWithLongOutOfRange() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), 1000L);
+    assertTrue(result.isEmpty());
+  }
+
+  /** BYTE with Float — should fall back. */
+  @Test
+  public void testByteWithFloatFallback() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), 42.0f);
+    assertTrue(result.isEmpty());
+  }
+
+  /** BYTE at Byte.MAX_VALUE. */
+  @Test
+  public void testByteMaxValue() {
+    var result = InPlaceComparator.compare(byteField(Byte.MAX_VALUE), (byte) Byte.MAX_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BYTE at Byte.MIN_VALUE. */
+  @Test
+  public void testByteMinValue() {
+    var result = InPlaceComparator.compare(byteField(Byte.MIN_VALUE), (byte) Byte.MIN_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // FLOAT tests
+  // ===========================================================================
+
+  /** Compare FLOAT field with matching Float value. */
+  @Test
+  public void testFloatEqualSameType() {
+    var result = InPlaceComparator.compare(floatField(3.14f), 3.14f);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT less than comparison. */
+  @Test
+  public void testFloatLessThan() {
+    var result = InPlaceComparator.compare(floatField(1.0f), 2.0f);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** FLOAT greater than comparison. */
+  @Test
+  public void testFloatGreaterThan() {
+    var result = InPlaceComparator.compare(floatField(2.0f), 1.0f);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /**
+   * FLOAT compared with Double — should widen float to double for comparison. A float value
+   * of 3.14f widened to double != 3.14d, so they should not be equal.
+   */
+  @Test
+  public void testFloatWithDoubleWidening() {
+    // 3.14f cast to double is 3.140000104904175, not 3.14
+    var result = InPlaceComparator.compare(floatField(3.14f), 3.14);
+    assertTrue(result.isPresent());
+    // They should NOT be equal due to float precision
+    assertTrue(result.getAsInt() != 0);
+  }
+
+  /** FLOAT compared with Double where both are exactly representable. */
+  @Test
+  public void testFloatWithDoubleExactMatch() {
+    var result = InPlaceComparator.compare(floatField(1.0f), 1.0);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * FLOAT compared with Integer within safe range (|value| <= 2^24) — should convert int to
+   * float.
+   */
+  @Test
+  public void testFloatWithIntegerInSafeRange() {
+    var result = InPlaceComparator.compare(floatField(42.0f), 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * FLOAT compared with Integer at precision boundary (2^24) — should succeed since 2^24 is
+   * exactly representable.
+   */
+  @Test
+  public void testFloatWithIntegerAtPrecisionBoundary() {
+    int boundary = 1 << 24; // 16_777_216
+    var result = InPlaceComparator.compare(floatField((float) boundary), boundary);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * FLOAT compared with Integer above precision boundary (2^24 + 1) — should fall back because
+   * float cannot represent this integer exactly.
+   */
+  @Test
+  public void testFloatWithIntegerAbovePrecisionBoundary() {
+    int aboveBoundary = (1 << 24) + 1; // 16_777_217
+    var result = InPlaceComparator.compare(floatField(42.0f), aboveBoundary);
+    assertTrue(result.isEmpty());
+  }
+
+  /** FLOAT NaN compared with NaN — Float.compare(NaN, NaN) == 0. */
+  @Test
+  public void testFloatNaN() {
+    var result = InPlaceComparator.compare(floatField(Float.NaN), Float.NaN);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT -0.0 compared with +0.0 — Float.compare(-0.0f, 0.0f) < 0. */
+  @Test
+  public void testFloatNegativeZero() {
+    var result = InPlaceComparator.compare(floatField(-0.0f), 0.0f);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** FLOAT positive infinity. */
+  @Test
+  public void testFloatPositiveInfinity() {
+    var result =
+        InPlaceComparator.compare(floatField(Float.POSITIVE_INFINITY), Float.POSITIVE_INFINITY);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT negative infinity. */
+  @Test
+  public void testFloatNegativeInfinity() {
+    var result =
+        InPlaceComparator.compare(floatField(Float.NEGATIVE_INFINITY), Float.NEGATIVE_INFINITY);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT MAX_VALUE. */
+  @Test
+  public void testFloatMaxValue() {
+    var result = InPlaceComparator.compare(floatField(Float.MAX_VALUE), Float.MAX_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT MIN_VALUE (smallest positive). */
+  @Test
+  public void testFloatMinValue() {
+    var result = InPlaceComparator.compare(floatField(Float.MIN_VALUE), Float.MIN_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // DOUBLE tests
+  // ===========================================================================
+
+  /** Compare DOUBLE field with matching Double value. */
+  @Test
+  public void testDoubleEqualSameType() {
+    var result = InPlaceComparator.compare(doubleField(3.14159265358979), 3.14159265358979);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE less than comparison. */
+  @Test
+  public void testDoubleLessThan() {
+    var result = InPlaceComparator.compare(doubleField(1.0), 2.0);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DOUBLE greater than comparison. */
+  @Test
+  public void testDoubleGreaterThan() {
+    var result = InPlaceComparator.compare(doubleField(2.0), 1.0);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** DOUBLE compared with Float — should widen float to double. */
+  @Test
+  public void testDoubleWithFloat() {
+    var result = InPlaceComparator.compare(doubleField(1.0), 1.0f);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE compared with Integer — safe, int < 2^53. */
+  @Test
+  public void testDoubleWithInteger() {
+    var result = InPlaceComparator.compare(doubleField(42.0), 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE compared with Long within safe range (|value| <= 2^53). */
+  @Test
+  public void testDoubleWithLongInSafeRange() {
+    var result = InPlaceComparator.compare(doubleField(123456789.0), 123456789L);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * DOUBLE compared with Long at precision boundary (2^53) — should succeed since 2^53 is exactly
+   * representable.
+   */
+  @Test
+  public void testDoubleWithLongAtPrecisionBoundary() {
+    long boundary = 1L << 53; // 9_007_199_254_740_992
+    var result = InPlaceComparator.compare(doubleField((double) boundary), boundary);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * DOUBLE compared with Long above precision boundary (2^53 + 1) — should fall back because
+   * double cannot represent this long exactly.
+   */
+  @Test
+  public void testDoubleWithLongAbovePrecisionBoundary() {
+    long aboveBoundary = (1L << 53) + 1; // 9_007_199_254_740_993
+    var result = InPlaceComparator.compare(doubleField(42.0), aboveBoundary);
+    assertTrue(result.isEmpty());
+  }
+
+  /** DOUBLE NaN compared with NaN — Double.compare(NaN, NaN) == 0. */
+  @Test
+  public void testDoubleNaN() {
+    var result = InPlaceComparator.compare(doubleField(Double.NaN), Double.NaN);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE -0.0 compared with +0.0 — Double.compare(-0.0, 0.0) < 0. */
+  @Test
+  public void testDoubleNegativeZero() {
+    var result = InPlaceComparator.compare(doubleField(-0.0), 0.0);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DOUBLE positive infinity. */
+  @Test
+  public void testDoublePositiveInfinity() {
+    var result =
+        InPlaceComparator.compare(
+            doubleField(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE negative infinity. */
+  @Test
+  public void testDoubleNegativeInfinity() {
+    var result =
+        InPlaceComparator.compare(
+            doubleField(Double.NEGATIVE_INFINITY), Double.NEGATIVE_INFINITY);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE MAX_VALUE. */
+  @Test
+  public void testDoubleMaxValue() {
+    var result = InPlaceComparator.compare(doubleField(Double.MAX_VALUE), Double.MAX_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE MIN_VALUE (smallest positive). */
+  @Test
+  public void testDoubleMinValue() {
+    var result = InPlaceComparator.compare(doubleField(Double.MIN_VALUE), Double.MIN_VALUE);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // isEqual tests
+  // ===========================================================================
+
+  /** isEqual returns 1 (true) for equal values. */
+  @Test
+  public void testIsEqualTrue() {
+    var result = InPlaceComparator.isEqual(intField(42), 42);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual returns 0 (false) for non-equal values. */
+  @Test
+  public void testIsEqualFalse() {
+    var result = InPlaceComparator.isEqual(intField(42), 99);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual falls back for unsupported type conversion. */
+  @Test
+  public void testIsEqualFallback() {
+    var result = InPlaceComparator.isEqual(intField(42), "42");
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // Unsupported type fallback
+  // ===========================================================================
+
+  /** Unsupported PropertyTypeInternal returns empty (fallback). */
+  @Test
+  public void testUnsupportedTypeFallback() {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, 42);
+    var field = new BinaryField("test", PropertyTypeInternal.EMBEDDED,
+        new BytesContainer(bytes.bytes, 0), null);
+    var result = InPlaceComparator.compare(field, 42);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // Cross-type ordering verification
+  // ===========================================================================
+
+  /**
+   * Verify that INTEGER cross-type comparison with Long preserves correct ordering: serialized
+   * value 10 compared with Long value 20 → negative.
+   */
+  @Test
+  public void testIntegerVsLongOrdering() {
+    var result = InPlaceComparator.compare(intField(10), 20L);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /**
+   * Verify that LONG cross-type comparison with Integer preserves correct ordering: serialized
+   * value 20 compared with Integer value 10 → positive.
+   */
+  @Test
+  public void testLongVsIntegerOrdering() {
+    var result = InPlaceComparator.compare(longField(20L), 10);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /**
+   * FLOAT with Integer at negative precision boundary: -(2^24) should be exactly representable.
+   */
+  @Test
+  public void testFloatWithNegativeIntegerAtPrecisionBoundary() {
+    int boundary = -(1 << 24);
+    var result = InPlaceComparator.compare(floatField((float) boundary), boundary);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * FLOAT with Integer at negative precision boundary - 1: should fall back.
+   */
+  @Test
+  public void testFloatWithNegativeIntegerBelowPrecisionBoundary() {
+    int belowBoundary = -(1 << 24) - 1;
+    var result = InPlaceComparator.compare(floatField(42.0f), belowBoundary);
+    assertTrue(result.isEmpty());
+  }
+
+  /**
+   * DOUBLE with Long at negative precision boundary: -(2^53) should be exactly representable.
+   */
+  @Test
+  public void testDoubleWithNegativeLongAtPrecisionBoundary() {
+    long boundary = -(1L << 53);
+    var result = InPlaceComparator.compare(doubleField((double) boundary), boundary);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * DOUBLE with Long at negative precision boundary - 1: should fall back.
+   */
+  @Test
+  public void testDoubleWithNegativeLongBelowPrecisionBoundary() {
+    long belowBoundary = -(1L << 53) - 1;
+    var result = InPlaceComparator.compare(doubleField(42.0), belowBoundary);
+    assertTrue(result.isEmpty());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorNumericTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
 import com.jetbrains.youtrackdb.internal.common.serialization.types.LongSerializer;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.OptionalInt;
 import org.junit.Test;
 
@@ -446,11 +448,10 @@ public class InPlaceComparatorNumericTest {
    */
   @Test
   public void testFloatWithDoubleWidening() {
-    // 3.14f cast to double is 3.140000104904175, not 3.14
+    // 3.14f cast to double is ~3.14000010..., which is greater than 3.14d
     var result = InPlaceComparator.compare(floatField(3.14f), 3.14);
     assertTrue(result.isPresent());
-    // They should NOT be equal due to float precision
-    assertTrue(result.getAsInt() != 0);
+    assertTrue(result.getAsInt() > 0);
   }
 
   /** FLOAT compared with Double where both are exactly representable. */
@@ -758,5 +759,219 @@ public class InPlaceComparatorNumericTest {
     long belowBoundary = -(1L << 53) - 1;
     var result = InPlaceComparator.compare(doubleField(42.0), belowBoundary);
     assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // BigDecimal / BigInteger fallback tests (BC1/TC1 — must not silently truncate)
+  // ===========================================================================
+
+  /** BigDecimal passed to INTEGER comparison — should fall back. */
+  @Test
+  public void testIntegerWithBigDecimalFallback() {
+    var result = InPlaceComparator.compare(intField(42), new BigDecimal("42"));
+    assertTrue(result.isEmpty());
+  }
+
+  /** BigInteger passed to LONG comparison — should fall back. */
+  @Test
+  public void testLongWithBigIntegerFallback() {
+    var result = InPlaceComparator.compare(longField(42L), BigInteger.valueOf(42));
+    assertTrue(result.isEmpty());
+  }
+
+  /** BigDecimal passed to FLOAT comparison — must NOT silently convert via longValue(). */
+  @Test
+  public void testFloatWithBigDecimalFallback() {
+    var result = InPlaceComparator.compare(floatField(42.0f), new BigDecimal("42.0"));
+    assertTrue(result.isEmpty());
+  }
+
+  /** BigDecimal passed to DOUBLE comparison — must fall back. */
+  @Test
+  public void testDoubleWithBigDecimalFallback() {
+    var result = InPlaceComparator.compare(doubleField(42.0), new BigDecimal("42.0"));
+    assertTrue(result.isEmpty());
+  }
+
+  /** BigInteger passed to SHORT comparison — should fall back. */
+  @Test
+  public void testShortWithBigIntegerFallback() {
+    var result = InPlaceComparator.compare(shortField((short) 42), BigInteger.valueOf(42));
+    assertTrue(result.isEmpty());
+  }
+
+  /** BigDecimal passed to BYTE comparison — should fall back. */
+  @Test
+  public void testByteWithBigDecimalFallback() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), new BigDecimal("42"));
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // Missing cross-type conversion tests
+  // ===========================================================================
+
+  /** INTEGER compared with Long below Integer.MIN_VALUE — should fall back. */
+  @Test
+  public void testIntegerWithLongBelowMinValue() {
+    var result = InPlaceComparator.compare(intField(-100), (long) Integer.MIN_VALUE - 1);
+    assertTrue(result.isEmpty());
+  }
+
+  /** LONG compared with Byte — should widen to long. */
+  @Test
+  public void testLongWithByte() {
+    var result = InPlaceComparator.compare(longField(7L), (byte) 7);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT compared with Long within safe range — should convert long to float. */
+  @Test
+  public void testFloatWithLongInSafeRange() {
+    var result = InPlaceComparator.compare(floatField(1000.0f), 1000L);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT compared with Long above precision boundary — should fall back. */
+  @Test
+  public void testFloatWithLongAbovePrecisionBoundary() {
+    long aboveBoundary = (1L << 24) + 1;
+    var result = InPlaceComparator.compare(floatField(42.0f), aboveBoundary);
+    assertTrue(result.isEmpty());
+  }
+
+  /** FLOAT compared with Short — should convert to float (always within safe range). */
+  @Test
+  public void testFloatWithShort() {
+    var result = InPlaceComparator.compare(floatField(42.0f), (short) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT compared with Byte — should convert to float. */
+  @Test
+  public void testFloatWithByte() {
+    var result = InPlaceComparator.compare(floatField(7.0f), (byte) 7);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE compared with Short — should convert to double. */
+  @Test
+  public void testDoubleWithShort() {
+    var result = InPlaceComparator.compare(doubleField(42.0), (short) 42);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE compared with Byte — should convert to double. */
+  @Test
+  public void testDoubleWithByte() {
+    var result = InPlaceComparator.compare(doubleField(7.0), (byte) 7);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT with Double — should fall back. */
+  @Test
+  public void testShortWithDoubleFallback() {
+    var result = InPlaceComparator.compare(shortField((short) 42), 42.0);
+    assertTrue(result.isEmpty());
+  }
+
+  /** BYTE with Double — should fall back. */
+  @Test
+  public void testByteWithDoubleFallback() {
+    var result = InPlaceComparator.compare(byteField((byte) 42), 42.0);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // Boundary ordering tests (TB2)
+  // ===========================================================================
+
+  /** INTEGER at MAX_VALUE should compare greater than MAX_VALUE - 1. */
+  @Test
+  public void testIntegerMaxValueOrdering() {
+    var result = InPlaceComparator.compare(intField(Integer.MAX_VALUE), Integer.MAX_VALUE - 1);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** INTEGER at MIN_VALUE should compare less than MIN_VALUE + 1. */
+  @Test
+  public void testIntegerMinValueOrdering() {
+    var result = InPlaceComparator.compare(intField(Integer.MIN_VALUE), Integer.MIN_VALUE + 1);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** LONG at MAX_VALUE should compare greater than MAX_VALUE - 1. */
+  @Test
+  public void testLongMaxValueOrdering() {
+    var result = InPlaceComparator.compare(longField(Long.MAX_VALUE), Long.MAX_VALUE - 1);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** LONG at MIN_VALUE should compare less than MIN_VALUE + 1. */
+  @Test
+  public void testLongMinValueOrdering() {
+    var result = InPlaceComparator.compare(longField(Long.MIN_VALUE), Long.MIN_VALUE + 1);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  // ===========================================================================
+  // NaN ordering tests (TB3)
+  // ===========================================================================
+
+  /** FLOAT NaN should compare as greater than any finite value per Float.compare contract. */
+  @Test
+  public void testFloatNaNGreaterThanFinite() {
+    var result = InPlaceComparator.compare(floatField(Float.NaN), 1.0f);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** FLOAT NaN should compare as greater than positive infinity per Float.compare contract. */
+  @Test
+  public void testFloatNaNGreaterThanPositiveInfinity() {
+    var result = InPlaceComparator.compare(floatField(Float.NaN), Float.POSITIVE_INFINITY);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** DOUBLE NaN should compare as greater than any finite value per Double.compare contract. */
+  @Test
+  public void testDoubleNaNGreaterThanFinite() {
+    var result = InPlaceComparator.compare(doubleField(Double.NaN), 1.0);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** DOUBLE NaN should compare as greater than positive infinity per Double.compare contract. */
+  @Test
+  public void testDoubleNaNGreaterThanPositiveInfinity() {
+    var result = InPlaceComparator.compare(doubleField(Double.NaN), Double.POSITIVE_INFINITY);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  // ===========================================================================
+  // Additional precision / isEqual tests
+  // ===========================================================================
+
+  /** DOUBLE compared with Float where widening reveals precision difference. */
+  @Test
+  public void testDoubleWithFloatPrecisionDifference() {
+    // 3.14f widened to double is ~3.14000010..., which differs from 3.14d
+    var result = InPlaceComparator.compare(doubleField(3.14), 3.14f);
+    assertTrue(result.isPresent());
+    // 3.14d < 3.14f widened to double
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** isEqual returns 0 (not-equal, not fallback) for float-vs-double precision mismatch. */
+  @Test
+  public void testIsEqualFloatVsDoublePrecisionMismatch() {
+    var result = InPlaceComparator.isEqual(floatField(3.14f), 3.14);
+    assertEquals(OptionalInt.of(0), result);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
@@ -453,6 +453,50 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
     session.commit();
   }
 
+  // ----- Negative values (TC1: zigzag encoding edge cases) -----
+
+  @Test
+  public void testRangeWithNegativeValues() {
+    // Verifies range comparison works correctly with negative integers, which
+    // use different byte representations in VarInt zigzag encoding.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("NegRange");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    for (int v : new int[] {-10, -1, 0, 1, 10}) {
+      var e = session.newEntity("NegRange");
+      e.setProperty("val", v);
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM NegRange WHERE val > -1")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(3);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(0, 1, 10);
+    }
+
+    try (var rs = session.query("SELECT FROM NegRange WHERE val <= 0")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(3);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(-10, -1, 0);
+    }
+
+    try (var rs = session.query("SELECT FROM NegRange WHERE val = -1")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<Integer>getProperty("val")).isEqualTo(-1);
+    }
+    session.commit();
+  }
+
   // ----- No match -----
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
@@ -573,4 +573,182 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
     }
     session.commit();
   }
+
+  // ===== MATCH query integration (Step 3) =====
+
+  @Test
+  public void testMatchWhereEquality() {
+    // Verifies that MATCH queries with WHERE clauses exercise the in-place
+    // comparison path via the Result-based evaluate().
+    session.execute("CREATE class MatchPerson extends V");
+
+    session.begin();
+    session.execute("CREATE VERTEX MatchPerson set name = 'Alice', age = 30");
+    session.execute("CREATE VERTEX MatchPerson set name = 'Bob', age = 25");
+    session.execute("CREATE VERTEX MatchPerson set name = 'Carol', age = 35");
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query(
+        "MATCH {class: MatchPerson, where: (name = 'Bob'), as: p} "
+            + "RETURN p.name as name, p.age as age")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("Bob");
+      assertThat(results.get(0).<Integer>getProperty("age")).isEqualTo(25);
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testMatchWhereRange() {
+    // Verifies MATCH with range operators in WHERE clause.
+    session.execute("CREATE class MatchItem extends V");
+
+    session.begin();
+    for (int i = 1; i <= 5; i++) {
+      session.execute("CREATE VERTEX MatchItem set val = " + i);
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query(
+        "MATCH {class: MatchItem, where: (val >= 3), as: i} "
+            + "RETURN i.val as val")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(3);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(3, 4, 5);
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testMatchWhereNotEqual() {
+    // Verifies MATCH with <> operator in WHERE clause.
+    session.execute("CREATE class MatchColor extends V");
+
+    session.begin();
+    session.execute("CREATE VERTEX MatchColor set color = 'red'");
+    session.execute("CREATE VERTEX MatchColor set color = 'blue'");
+    session.execute("CREATE VERTEX MatchColor set color = 'green'");
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query(
+        "MATCH {class: MatchColor, where: (color <> 'blue'), as: c} "
+            + "RETURN c.color as color")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(2);
+      var colors = results.stream()
+          .map(r -> r.<String>getProperty("color"))
+          .collect(Collectors.toList());
+      assertThat(colors).containsExactlyInAnyOrder("red", "green");
+    }
+    session.commit();
+  }
+
+  // ===== Edge cases (Step 3) =====
+
+  @Test
+  public void testNonEntityProjectionPassesThrough() {
+    // Verifies that projection-only queries (no entity, just computed fields)
+    // pass through without error — the in-place path should not activate.
+    session.begin();
+    try (var rs = session.query("SELECT 1 + 2 as result")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<Integer>getProperty("result")).isEqualTo(3);
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testSchemalessPropertyFallsBack() {
+    // Verifies that properties not in the schema (schema-less mode) fall back
+    // correctly — the in-place path should still work because deserializeField
+    // handles schema-less fields.
+    session.execute("CREATE class Schemaless");
+
+    session.begin();
+    // Insert without schema — properties are stored dynamically
+    session.execute("INSERT INTO Schemaless SET x = 42, y = 'hello'");
+    session.execute("INSERT INTO Schemaless SET x = 99, y = 'world'");
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM Schemaless WHERE x = 42")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("y")).isEqualTo("hello");
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testMultipleMatchWhereConditions() {
+    // Verifies that multiple WHERE conditions in a MATCH pattern each get
+    // independently optimized.
+    session.execute("CREATE class MatchMulti extends V");
+
+    session.begin();
+    session.execute("CREATE VERTEX MatchMulti set x = 10, y = 'a'");
+    session.execute("CREATE VERTEX MatchMulti set x = 10, y = 'b'");
+    session.execute("CREATE VERTEX MatchMulti set x = 20, y = 'a'");
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query(
+        "MATCH {class: MatchMulti, where: (x = 10 AND y = 'a'), as: m} "
+            + "RETURN m.x as x, m.y as y")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<Integer>getProperty("x")).isEqualTo(10);
+      assertThat(results.get(0).<String>getProperty("y")).isEqualTo("a");
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testMatchWithTraversalAndWhere() {
+    // Verifies in-place comparison works correctly in MATCH with graph
+    // traversal — the WHERE clause on a traversed vertex should use the
+    // Result-based evaluate with the in-place path.
+    session.execute("CREATE class MNode extends V");
+    session.execute("CREATE class MEdge extends E");
+
+    session.begin();
+    session.execute("CREATE VERTEX MNode set name = 'root', level = 0");
+    session.execute("CREATE VERTEX MNode set name = 'child1', level = 1");
+    session.execute("CREATE VERTEX MNode set name = 'child2', level = 1");
+    session.execute("CREATE VERTEX MNode set name = 'grandchild', level = 2");
+
+    session.execute(
+        "CREATE EDGE MEdge from (SELECT FROM MNode WHERE name = 'root') "
+            + "to (SELECT FROM MNode WHERE name = 'child1')");
+    session.execute(
+        "CREATE EDGE MEdge from (SELECT FROM MNode WHERE name = 'root') "
+            + "to (SELECT FROM MNode WHERE name = 'child2')");
+    session.execute(
+        "CREATE EDGE MEdge from (SELECT FROM MNode WHERE name = 'child1') "
+            + "to (SELECT FROM MNode WHERE name = 'grandchild')");
+    session.commit();
+
+    session.begin();
+    // Find all descendants of root at level > 0
+    try (var rs = session.query(
+        "MATCH {class: MNode, where: (name = 'root'), as: r}"
+            + ".out('MEdge'){where: (level > 0), as: c} "
+            + "RETURN c.name as name, c.level as level")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(2);
+      var names = results.stream()
+          .map(r -> r.<String>getProperty("name"))
+          .collect(Collectors.toList());
+      assertThat(names).containsExactlyInAnyOrder("child1", "child2");
+    }
+    session.commit();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
@@ -1,0 +1,478 @@
+package com.jetbrains.youtrackdb.internal.core.sql.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests for the in-place comparison fast path in
+ * {@link SQLBinaryCondition#evaluate(Result, com.jetbrains.youtrackdb.internal.core.command.CommandContext)}.
+ *
+ * <p>Each test inserts records, commits (so they have serialized {@code source} bytes),
+ * then queries via SQL SELECT with WHERE clauses to exercise the in-place comparison path
+ * for the Result-based evaluate method. Results are compared against expected values to
+ * verify correctness.
+ */
+@Category(SequentialTest.class)
+public class SQLBinaryConditionInPlaceTest extends DbTestBase {
+
+  // ----- Equality (=) -----
+
+  @Test
+  public void testEqualsInteger() {
+    // Verifies that integer equality comparison works via the in-place path.
+    // Records with serialized source bytes are queried with WHERE age = 25.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("EqInt");
+    clazz.createProperty("name", PropertyType.STRING);
+    clazz.createProperty("age", PropertyType.INTEGER);
+
+    session.begin();
+    var e1 = session.newEntity("EqInt");
+    e1.setProperty("name", "Alice");
+    e1.setProperty("age", 25);
+
+    var e2 = session.newEntity("EqInt");
+    e2.setProperty("name", "Bob");
+    e2.setProperty("age", 30);
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM EqInt WHERE age = 25")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("Alice");
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testEqualsString() {
+    // Verifies that string equality comparison works via the in-place path.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("EqStr");
+    clazz.createProperty("name", PropertyType.STRING);
+
+    session.begin();
+    var e1 = session.newEntity("EqStr");
+    e1.setProperty("name", "hello");
+
+    var e2 = session.newEntity("EqStr");
+    e2.setProperty("name", "world");
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM EqStr WHERE name = 'hello'")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("hello");
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testEqualsDouble() {
+    // Verifies that double equality comparison works via the in-place path.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("EqDbl");
+    clazz.createProperty("val", PropertyType.DOUBLE);
+    clazz.createProperty("label", PropertyType.STRING);
+
+    session.begin();
+    var e1 = session.newEntity("EqDbl");
+    e1.setProperty("val", 2.5);
+    e1.setProperty("label", "twoAndHalf");
+
+    var e2 = session.newEntity("EqDbl");
+    e2.setProperty("val", 1.25);
+    e2.setProperty("label", "oneAndQuarter");
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM EqDbl WHERE val = 2.5")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("label")).isEqualTo("twoAndHalf");
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testEqualsBoolean() {
+    // Verifies that boolean equality comparison works via the in-place path.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("EqBool");
+    clazz.createProperty("active", PropertyType.BOOLEAN);
+    clazz.createProperty("name", PropertyType.STRING);
+
+    session.begin();
+    var e1 = session.newEntity("EqBool");
+    e1.setProperty("active", true);
+    e1.setProperty("name", "on");
+
+    var e2 = session.newEntity("EqBool");
+    e2.setProperty("active", false);
+    e2.setProperty("name", "off");
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM EqBool WHERE active = true")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("on");
+    }
+    session.commit();
+  }
+
+  // ----- Not-equal (<>, !=) -----
+
+  @Test
+  public void testNotEqualNeq() {
+    // Verifies the <> operator works correctly via the in-place path.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("NeqTest");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    for (int i = 1; i <= 3; i++) {
+      var e = session.newEntity("NeqTest");
+      e.setProperty("val", i);
+
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM NeqTest WHERE val <> 2")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(2);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(1, 3);
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testNotEqualNe() {
+    // Verifies the != operator works correctly via the in-place path.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("NeTest");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    for (int i = 1; i <= 3; i++) {
+      var e = session.newEntity("NeTest");
+      e.setProperty("val", i);
+
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM NeTest WHERE val != 2")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(2);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(1, 3);
+    }
+    session.commit();
+  }
+
+  // ----- Range operators (<, >, <=, >=) -----
+
+  @Test
+  public void testLessThan() {
+    // Verifies < operator via the in-place path on integer property.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("LtTest");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    for (int i = 1; i <= 5; i++) {
+      var e = session.newEntity("LtTest");
+      e.setProperty("val", i);
+
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM LtTest WHERE val < 3")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(2);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(1, 2);
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testGreaterThan() {
+    // Verifies > operator via the in-place path on integer property.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("GtTest");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    for (int i = 1; i <= 5; i++) {
+      var e = session.newEntity("GtTest");
+      e.setProperty("val", i);
+
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM GtTest WHERE val > 3")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(2);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(4, 5);
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testLessThanOrEqual() {
+    // Verifies <= operator via the in-place path on integer property.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("LeTest");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    for (int i = 1; i <= 5; i++) {
+      var e = session.newEntity("LeTest");
+      e.setProperty("val", i);
+
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM LeTest WHERE val <= 3")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(3);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(1, 2, 3);
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testGreaterThanOrEqual() {
+    // Verifies >= operator via the in-place path on integer property.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("GeTest");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    for (int i = 1; i <= 5; i++) {
+      var e = session.newEntity("GeTest");
+      e.setProperty("val", i);
+
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM GeTest WHERE val >= 3")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(3);
+      var vals = results.stream()
+          .map(r -> r.<Integer>getProperty("val"))
+          .collect(Collectors.toList());
+      assertThat(vals).containsExactlyInAnyOrder(3, 4, 5);
+    }
+    session.commit();
+  }
+
+  // ----- String range comparison -----
+
+  @Test
+  public void testStringRangeComparison() {
+    // Verifies that string range comparison (lexicographic) works via
+    // the in-place path.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("StrRange");
+    clazz.createProperty("name", PropertyType.STRING);
+
+    session.begin();
+    for (var name : List.of("apple", "banana", "cherry", "date")) {
+      var e = session.newEntity("StrRange");
+      e.setProperty("name", name);
+
+    }
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM StrRange WHERE name < 'cherry'")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(2);
+      var names = results.stream()
+          .map(r -> r.<String>getProperty("name"))
+          .collect(Collectors.toList());
+      assertThat(names).containsExactlyInAnyOrder("apple", "banana");
+    }
+    session.commit();
+  }
+
+  // ----- Null handling -----
+
+  @Test
+  public void testNullPropertyFallsBackCorrectly() {
+    // Verifies that null property values fall back to the standard SQL NULL
+    // handling path (NULL = X yields false per SQL semantics).
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("NullProp");
+    clazz.createProperty("val", PropertyType.INTEGER);
+    clazz.createProperty("name", PropertyType.STRING);
+
+    session.begin();
+    var e1 = session.newEntity("NullProp");
+    e1.setProperty("val", 10);
+    e1.setProperty("name", "hasVal");
+
+    var e2 = session.newEntity("NullProp");
+    // val is null
+    e2.setProperty("name", "noVal");
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM NullProp WHERE val = 10")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("hasVal");
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testNullRightValueFallsBackCorrectly() {
+    // Verifies that comparing against a null right-hand value works correctly.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("NullRight");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    var e = session.newEntity("NullRight");
+    e.setProperty("val", 10);
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM NullRight WHERE val = null")) {
+      var results = rs.stream().collect(Collectors.toList());
+      // SQL semantics: val = NULL is false
+      assertThat(results).isEmpty();
+    }
+    session.commit();
+  }
+
+  // ----- Cross-type numeric comparison -----
+
+  @Test
+  public void testIntegerPropertyVsLongLiteral() {
+    // Verifies cross-type numeric comparison: INTEGER property vs LONG literal.
+    // The SQL parser will produce a LONG for large numeric literals.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("CrossType");
+    clazz.createProperty("val", PropertyType.INTEGER);
+    clazz.createProperty("name", PropertyType.STRING);
+
+    session.begin();
+    var e1 = session.newEntity("CrossType");
+    e1.setProperty("val", 42);
+    e1.setProperty("name", "match");
+
+    var e2 = session.newEntity("CrossType");
+    e2.setProperty("val", 99);
+    e2.setProperty("name", "noMatch");
+
+    session.commit();
+
+    session.begin();
+    // The literal 42L is a long; the property type is INTEGER
+    try (var rs = session.query("SELECT FROM CrossType WHERE val = 42")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("match");
+    }
+    session.commit();
+  }
+
+  // ----- Multiple WHERE conditions on same record -----
+
+  @Test
+  public void testMultipleWhereConditions() {
+    // Verifies that multiple WHERE conditions on the same record each get
+    // independently optimized via the in-place path.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("MultiWhere");
+    clazz.createProperty("x", PropertyType.INTEGER);
+    clazz.createProperty("y", PropertyType.STRING);
+
+    session.begin();
+    var e1 = session.newEntity("MultiWhere");
+    e1.setProperty("x", 10);
+    e1.setProperty("y", "alpha");
+
+    var e2 = session.newEntity("MultiWhere");
+    e2.setProperty("x", 10);
+    e2.setProperty("y", "beta");
+
+    var e3 = session.newEntity("MultiWhere");
+    e3.setProperty("x", 20);
+    e3.setProperty("y", "alpha");
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query(
+        "SELECT FROM MultiWhere WHERE x = 10 AND y = 'alpha'")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<Integer>getProperty("x")).isEqualTo(10);
+      assertThat(results.get(0).<String>getProperty("y")).isEqualTo("alpha");
+    }
+    session.commit();
+  }
+
+  // ----- No match -----
+
+  @Test
+  public void testNoMatchReturnsEmpty() {
+    // Verifies that when no records match, the result set is empty.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("NoMatch");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    var e = session.newEntity("NoMatch");
+    e.setProperty("val", 42);
+
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM NoMatch WHERE val = 999")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).isEmpty();
+    }
+    session.commit();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
@@ -387,31 +387,63 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
   // ----- Cross-type numeric comparison -----
 
   @Test
-  public void testIntegerPropertyVsLongLiteral() {
-    // Verifies cross-type numeric comparison: INTEGER property vs LONG literal.
-    // The SQL parser will produce a LONG for large numeric literals.
+  public void testLongPropertyVsIntegerLiteral() {
+    // Verifies cross-type numeric comparison: LONG property vs integer-range
+    // literal. The SQL parser produces an Integer for small numeric literals,
+    // but the property is stored as LONG — this exercises the type conversion
+    // path in InPlaceComparator.
     var schema = session.getMetadata().getSchema();
-    var clazz = schema.createClass("CrossType");
-    clazz.createProperty("val", PropertyType.INTEGER);
+    var clazz = schema.createClass("CrossLongInt");
+    clazz.createProperty("val", PropertyType.LONG);
     clazz.createProperty("name", PropertyType.STRING);
 
     session.begin();
-    var e1 = session.newEntity("CrossType");
-    e1.setProperty("val", 42);
+    var e1 = session.newEntity("CrossLongInt");
+    e1.setProperty("val", 42L);
     e1.setProperty("name", "match");
 
-    var e2 = session.newEntity("CrossType");
-    e2.setProperty("val", 99);
+    var e2 = session.newEntity("CrossLongInt");
+    e2.setProperty("val", 99L);
     e2.setProperty("name", "noMatch");
 
     session.commit();
 
     session.begin();
-    // The literal 42L is a long; the property type is INTEGER
-    try (var rs = session.query("SELECT FROM CrossType WHERE val = 42")) {
+    // Literal 42 is parsed as Integer; property type is LONG
+    try (var rs = session.query("SELECT FROM CrossLongInt WHERE val = 42")) {
       var results = rs.stream().collect(Collectors.toList());
       assertThat(results).hasSize(1);
       assertThat(results.get(0).<String>getProperty("name")).isEqualTo("match");
+    }
+    // Also verify range comparison cross-type
+    try (var rs = session.query("SELECT FROM CrossLongInt WHERE val > 50")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("noMatch");
+    }
+    session.commit();
+  }
+
+  @Test
+  public void testIntegerPropertyVsOverflowLongLiteral() {
+    // Verifies that comparing an INTEGER property against a literal exceeding
+    // Integer range correctly returns no match (the in-place path should
+    // detect the overflow and fall back).
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("CrossIntOverflow");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    var e = session.newEntity("CrossIntOverflow");
+    e.setProperty("val", 42);
+    session.commit();
+
+    session.begin();
+    // 4294967296 exceeds Integer.MAX_VALUE — no INTEGER can match
+    try (var rs = session.query(
+        "SELECT FROM CrossIntOverflow WHERE val = 4294967296")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).isEmpty();
     }
     session.commit();
   }
@@ -654,22 +686,32 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
 
   @Test
   public void testNonEntityProjectionPassesThrough() {
-    // Verifies that projection-only queries (no entity, just computed fields)
-    // pass through without error — the in-place path should not activate.
+    // Verifies that WHERE on a projected (non-entity) result falls back
+    // gracefully — the in-place path requires an EntityImpl, so subquery
+    // projections that produce plain ResultInternal should use the standard
+    // evaluation path.
+    session.execute("CREATE class ProjTest");
+
     session.begin();
-    try (var rs = session.query("SELECT 1 + 2 as result")) {
+    session.execute("INSERT INTO ProjTest SET x = 10");
+    session.execute("INSERT INTO ProjTest SET x = 20");
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query(
+        "SELECT x FROM (SELECT x FROM ProjTest) WHERE x = 10")) {
       var results = rs.stream().collect(Collectors.toList());
       assertThat(results).hasSize(1);
-      assertThat(results.get(0).<Integer>getProperty("result")).isEqualTo(3);
+      assertThat(results.get(0).<Integer>getProperty("x")).isEqualTo(10);
     }
     session.commit();
   }
 
   @Test
-  public void testSchemalessPropertyFallsBack() {
-    // Verifies that properties not in the schema (schema-less mode) fall back
-    // correctly — the in-place path should still work because deserializeField
-    // handles schema-less fields.
+  public void testSchemalessPropertyWorksViaInPlacePath() {
+    // Verifies that schema-less properties (no explicit property definition)
+    // produce correct results — deserializeField handles dynamic fields, so
+    // the in-place path works for schema-less mode too.
     session.execute("CREATE class Schemaless");
 
     session.begin();
@@ -724,6 +766,8 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
     session.execute("CREATE VERTEX MNode set name = 'child1', level = 1");
     session.execute("CREATE VERTEX MNode set name = 'child2', level = 1");
     session.execute("CREATE VERTEX MNode set name = 'grandchild', level = 2");
+    // phantom has level = 0, same as root — should be filtered OUT by level > 0
+    session.execute("CREATE VERTEX MNode set name = 'phantom', level = 0");
 
     session.execute(
         "CREATE EDGE MEdge from (SELECT FROM MNode WHERE name = 'root') "
@@ -732,12 +776,16 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
         "CREATE EDGE MEdge from (SELECT FROM MNode WHERE name = 'root') "
             + "to (SELECT FROM MNode WHERE name = 'child2')");
     session.execute(
+        "CREATE EDGE MEdge from (SELECT FROM MNode WHERE name = 'root') "
+            + "to (SELECT FROM MNode WHERE name = 'phantom')");
+    session.execute(
         "CREATE EDGE MEdge from (SELECT FROM MNode WHERE name = 'child1') "
             + "to (SELECT FROM MNode WHERE name = 'grandchild')");
     session.commit();
 
     session.begin();
-    // Find all descendants of root at level > 0
+    // Find direct children of root at level > 0 — phantom (level=0) should
+    // be excluded by the WHERE filter, proving the range comparison works.
     try (var rs = session.query(
         "MATCH {class: MNode, where: (name = 'root'), as: r}"
             + ".out('MEdge'){where: (level > 0), as: c} "
@@ -748,6 +796,65 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
           .map(r -> r.<String>getProperty("name"))
           .collect(Collectors.toList());
       assertThat(names).containsExactlyInAnyOrder("child1", "child2");
+    }
+    session.commit();
+  }
+
+  // ===== Collation bypass (TC2) =====
+
+  @Test
+  public void testCollationPropertyBypassesInPlacePath() {
+    // Verifies that a property with COLLATE ci skips the in-place path
+    // (which does raw byte comparison ignoring collation) and still produces
+    // correct case-insensitive matching via the standard evaluation path.
+    session.execute("CREATE class CollateTest");
+    session.execute("CREATE PROPERTY CollateTest.name STRING (COLLATE ci)");
+
+    session.begin();
+    session.execute("INSERT INTO CollateTest SET name = 'Alice'");
+    session.execute("INSERT INTO CollateTest SET name = 'bob'");
+    session.commit();
+
+    session.begin();
+    // Case-insensitive collation: 'alice' should match 'Alice'
+    try (var rs = session.query(
+        "SELECT FROM CollateTest WHERE name = 'alice'")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("Alice");
+    }
+    session.commit();
+  }
+
+  // ===== Le/Ge exact boundary (TC3) =====
+
+  @Test
+  public void testLeGeExactBoundary() {
+    // Verifies that <= and >= return true when the property value exactly
+    // equals the comparison value (comparePropertyTo returns 0), and that
+    // strict < and > exclude the exact value.
+    var schema = session.getMetadata().getSchema();
+    var clazz = schema.createClass("LeGeExact");
+    clazz.createProperty("val", PropertyType.INTEGER);
+
+    session.begin();
+    var e = session.newEntity("LeGeExact");
+    e.setProperty("val", 42);
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query("SELECT FROM LeGeExact WHERE val <= 42")) {
+      assertThat(rs.stream().collect(Collectors.toList())).hasSize(1);
+    }
+    try (var rs = session.query("SELECT FROM LeGeExact WHERE val >= 42")) {
+      assertThat(rs.stream().collect(Collectors.toList())).hasSize(1);
+    }
+    // Strict operators should exclude the exact boundary value
+    try (var rs = session.query("SELECT FROM LeGeExact WHERE val < 42")) {
+      assertThat(rs.stream().collect(Collectors.toList())).isEmpty();
+    }
+    try (var rs = session.query("SELECT FROM LeGeExact WHERE val > 42")) {
+      assertThat(rs.stream().collect(Collectors.toList())).isEmpty();
     }
     session.commit();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryConditionInPlaceTest.java
@@ -497,6 +497,60 @@ public class SQLBinaryConditionInPlaceTest extends DbTestBase {
     session.commit();
   }
 
+  // ----- Identifiable overload (via CONTAINS with linked entities) -----
+
+  @Test
+  public void testContainsWithLinkedEntityCondition() {
+    // Verifies that the Identifiable-based evaluate() overload is exercised
+    // when using CONTAINS with a condition on linked entities.
+    // The CONTAINS (condition) syntax iterates collection items and calls
+    // evaluate(Identifiable, ctx) on the SQLBinaryCondition inside the
+    // condition.
+    var schema = session.getMetadata().getSchema();
+    schema.createClass("ContTag");
+    var clazz = schema.createClass("ContParent");
+    clazz.createProperty("name", PropertyType.STRING);
+    clazz.createProperty("tags", PropertyType.LINKLIST);
+
+    session.begin();
+    // Create tag entities
+    session.execute(
+        "INSERT INTO ContTag SET label = 'important', priority = 1");
+    session.execute(
+        "INSERT INTO ContTag SET label = 'minor', priority = 5");
+    session.execute(
+        "INSERT INTO ContTag SET label = 'minor', priority = 3");
+    session.commit();
+
+    session.begin();
+    // Link tags to parents
+    session.execute(
+        "INSERT INTO ContParent SET name = 'first', tags = "
+            + "(SELECT FROM ContTag WHERE priority IN [1, 5])");
+    session.execute(
+        "INSERT INTO ContParent SET name = 'second', tags = "
+            + "(SELECT FROM ContTag WHERE priority = 3)");
+    session.commit();
+
+    session.begin();
+    try (var rs = session.query(
+        "SELECT FROM ContParent WHERE tags CONTAINS (label = 'important')")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("first");
+    }
+
+    // Range comparison inside CONTAINS — exercises comparePropertyTo
+    // through the Identifiable overload
+    try (var rs = session.query(
+        "SELECT FROM ContParent WHERE tags CONTAINS (priority < 3)")) {
+      var results = rs.stream().collect(Collectors.toList());
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).<String>getProperty("name")).isEqualTo("first");
+    }
+    session.commit();
+  }
+
   // ----- No match -----
 
   @Test

--- a/docs/adr/ytdb-628-in-place-comparison/design-final.md
+++ b/docs/adr/ytdb-628-in-place-comparison/design-final.md
@@ -1,0 +1,398 @@
+# In-Place Property Comparison for SQL WHERE Clauses — Final Design
+
+## Overview
+
+This feature avoids property deserialization overhead during SQL WHERE clause
+evaluation by comparing property values in-place — either against the
+already-deserialized Java object in the `properties` map, or directly against
+the serialized bytes in the `source` buffer.
+
+Two layers were implemented, matching the planned design:
+1. **InPlaceComparator** — stateless utility with per-type binary comparison
+   methods and type conversion logic (13 types).
+2. **EntityImpl dispatch methods** — `isPropertyEqualTo()` and
+   `comparePropertyTo()` that route to either the deserialized or serialized
+   comparison path.
+
+These are wired into `SQLBinaryCondition.evaluate()` (both overloads) as a
+fast path before the existing deserialization-based evaluation.
+
+**Deviations from the planned design:**
+- `Optional<Boolean>` (D5) was replaced with `InPlaceResult` enum
+  (TRUE/FALSE/FALLBACK) for clarity — this was recommended during Track 1
+  review and adopted before any code was committed.
+- The deserialized path in EntityImpl uses the same type conversion and
+  precision guards as InPlaceComparator (not plain `Objects.equals`) to ensure
+  cross-path equivalence. This emerged during Track 1 technical review.
+- LINK equality is supported in both source and deserialized paths, while LINK
+  ordering returns FALLBACK/empty in both.
+- `SQLBinaryCondition.tryInPlaceComparison()` returns `Boolean` (null =
+  fallback) instead of `Optional<Boolean>` — simpler for the if-null-fallback
+  pattern.
+
+All changes are in the `core` module.
+
+## Class Design
+
+```mermaid
+classDiagram
+    class RecordAbstract {
+        #source: byte[]
+    }
+
+    class EntityImpl {
+        -properties: Map~String, EntityEntry~
+        -propertyAccess: PropertyAccess
+        -propertyEncryption: PropertyEncryption
+        -session: DatabaseSessionEmbedded
+        +isPropertyEqualTo(name, value) InPlaceResult
+        +comparePropertyTo(name, value) OptionalInt
+        -compareDeserialized(name, value) InPlaceResult
+        -compareDeserializedOrdering(name, value) OptionalInt
+        -compareFromSource(name, value) InPlaceResult
+        -compareFromSourceOrdering(name, value) OptionalInt
+        -deserializeFieldForComparison(name, value) BinaryField
+        -compareJavaValues(type, entryValue, value)$ InPlaceResult
+        -compareJavaValuesOrdering(type, entryValue, value)$ OptionalInt
+        -compareLinkJavaValues(entryValue, value)$ InPlaceResult
+    }
+
+    RecordAbstract <|-- EntityImpl
+
+    class InPlaceResult {
+        <<enum>>
+        TRUE
+        FALSE
+        FALLBACK
+    }
+
+    class InPlaceComparator {
+        <<utility>>
+        +compare(field, value) OptionalInt$
+        +compare(field, value, dbTimeZone) OptionalInt$
+        +isEqual(field, value) OptionalInt$
+        +isEqual(field, value, dbTimeZone) OptionalInt$
+        -compareInteger(bytes, value) OptionalInt$
+        -compareLong(bytes, value) OptionalInt$
+        -compareShort(bytes, value) OptionalInt$
+        -compareByte(bytes, value) OptionalInt$
+        -compareFloat(bytes, value) OptionalInt$
+        -compareDouble(bytes, value) OptionalInt$
+        -compareString(bytes, value) OptionalInt$
+        -compareBoolean(bytes, value) OptionalInt$
+        -compareDatetime(bytes, value) OptionalInt$
+        -compareDate(bytes, value, tz) OptionalInt$
+        -compareDecimal(bytes, value) OptionalInt$
+        -compareBinary(bytes, value) OptionalInt$
+        -compareLinkEquality(bytes, value) OptionalInt$
+    }
+
+    class BinaryField {
+        +name: String
+        +type: PropertyTypeInternal
+        +bytes: BytesContainer
+        +collate: Collate
+    }
+
+    class EntitySerializer {
+        <<interface>>
+        +deserializeField(...) BinaryField
+    }
+
+    class SQLBinaryCondition {
+        -left: SQLExpression
+        -operator: SQLBinaryCompareOperator
+        -right: SQLExpression
+        +evaluate(Identifiable, CommandContext) boolean
+        +evaluate(Result, CommandContext) boolean
+        -tryInPlaceComparison(entityImpl, propName, rightVal) Boolean
+    }
+
+    EntityImpl --> InPlaceResult : returns
+    EntityImpl --> InPlaceComparator : delegates binary comparison
+    EntityImpl --> EntitySerializer : deserializeField()
+    EntitySerializer --> BinaryField : returns
+    InPlaceComparator --> BinaryField : reads bytes from
+    SQLBinaryCondition --> EntityImpl : isPropertyEqualTo / comparePropertyTo
+    SQLBinaryCondition --> InPlaceResult : checks result
+```
+
+**EntityImpl** has two new public methods: `isPropertyEqualTo` returns
+`InPlaceResult` (tri-state enum), `comparePropertyTo` returns `OptionalInt`.
+Both follow the same three-tier dispatch: deserialized properties map →
+serialized source bytes → FALLBACK. Six private helper methods handle the
+two paths (equality and ordering) and shared setup.
+
+**InPlaceComparator** is a stateless utility class with per-type comparison
+methods. It accepts `BinaryField` (type + bytes pointer) and a Java object.
+The `compare` and `isEqual` methods have overloads accepting an optional
+`TimeZone` parameter for DATE fields. LINK is supported for equality only
+(via `compareLinkEquality`); LINK ordering returns empty.
+
+**InPlaceResult** is a tri-state enum (TRUE/FALSE/FALLBACK) replacing the
+originally planned `Optional<Boolean>`. This was adopted after review found
+`Optional<Boolean>` prone to semantic confusion.
+
+**SQLBinaryCondition** has a private `tryInPlaceComparison()` method shared
+by both `evaluate()` overloads. It returns `Boolean` (null = fallback),
+dispatching to `isPropertyEqualTo` for `=`/`<>`/`!=` and
+`comparePropertyTo` for `<`/`>`/`<=`/`>=`.
+
+## Workflow
+
+### In-Place Comparison Path (Result-based overload)
+
+```mermaid
+sequenceDiagram
+    participant BC as SQLBinaryCondition
+    participant RI as ResultInternal
+    participant EI as EntityImpl
+    participant IPC as InPlaceComparator
+    participant ES as EntitySerializer
+
+    BC->>BC: Guard checks
+    Note over BC: isBaseIdentifier()<br/>instanceof SQLBaseExpression<br/>isEarlyCalculated()<br/>no collation<br/>ResultInternal → EntityImpl
+
+    BC->>RI: asEntityOrNull()
+    RI-->>BC: EntityImpl
+
+    BC->>BC: right.execute(currentRecord, ctx)
+    Note over BC: Compute rightVal once
+
+    BC->>EI: comparePropertyTo(name, rightVal)
+
+    alt Property in properties map
+        EI->>EI: properties.get(name)
+        EI->>EI: compareJavaValuesOrdering(type, val, rightVal)
+        EI-->>BC: OptionalInt(result)
+    else source != null
+        EI->>EI: deserializeFieldForComparison(name, rightVal)
+        EI->>ES: deserializeField(...)
+        ES-->>EI: BinaryField
+        EI->>IPC: compare(field, rightVal, dbTimeZone)
+        IPC-->>EI: OptionalInt(result)
+        EI-->>BC: OptionalInt(result)
+    else neither available
+        EI-->>BC: OptionalInt.empty()
+    end
+
+    BC->>BC: tryInPlaceComparison()
+    alt result != null
+        BC-->>BC: return boolean
+    else null (fallback)
+        BC->>BC: left.execute() + operator.execute()
+        BC-->>BC: return boolean
+    end
+```
+
+The Identifiable-based overload follows the same structure but skips collation
+guards (the existing overload never applies collation) and casts
+`currentRecord` directly to `EntityImpl` instead of unwrapping from
+`ResultInternal`.
+
+### EntityImpl Dispatch (Equality Path)
+
+```mermaid
+flowchart TD
+    Start["isPropertyEqualTo(name, value)"]
+    Binding["checkForBinding()"]
+    Status{"status == LOADED?"}
+    Access{"propertyAccess\nnon-null AND\n!isReadable(name)?"}
+    CheckMap{"properties != null\nAND containsKey(name)?"}
+
+    Start --> Binding --> Status
+    Status -->|No| Fallback
+    Status -->|Yes| Access
+    Access -->|Yes| Fallback
+    Access -->|No| CheckMap
+
+    subgraph "Deserialized Path"
+        GetEntry["entry = properties.get(name)"]
+        EntryNull{"entry null or\n!entry.exists()?"}
+        ValNull{"entryValue null\nor value null?"}
+        TypeNull{"entry.type null?"}
+        JavaCmp["compareJavaValues(type, entryVal, value)"]
+    end
+
+    CheckMap -->|Yes| GetEntry
+    GetEntry --> EntryNull
+    EntryNull -->|Yes| Fallback
+    EntryNull -->|No| ValNull
+    ValNull -->|Yes| Fallback
+    ValNull -->|No| TypeNull
+    TypeNull -->|Yes| Fallback
+    TypeNull -->|No| JavaCmp --> Result
+
+    CheckSource{"source != null?"}
+    CheckMap -->|No| CheckSource
+
+    subgraph "Serialized Path"
+        ValNull2{"value null?"}
+        Encrypted{"encryption\nactive for name?"}
+        Deser["deserializeField(name)"]
+        FieldNull{"field null?"}
+        Collation{"non-default\ncollation?"}
+        GetTZ["getDatabaseTimeZone()"]
+        BinCmp["InPlaceComparator.isEqual(field, value, tz)"]
+        BinEmpty{"result empty?"}
+    end
+
+    CheckSource -->|Yes| ValNull2
+    ValNull2 -->|Yes| Fallback
+    ValNull2 -->|No| Encrypted
+    Encrypted -->|Yes| Fallback
+    Encrypted -->|No| Deser
+    Deser --> FieldNull
+    FieldNull -->|Yes| Fallback
+    FieldNull -->|No| Collation
+    Collation -->|Yes| Fallback
+    Collation -->|No| GetTZ --> BinCmp --> BinEmpty
+    BinEmpty -->|Yes| Fallback
+    BinEmpty -->|No| Result
+
+    CheckSource -->|No| Fallback
+
+    Fallback["FALLBACK"]
+    Result["TRUE / FALSE"]
+```
+
+`comparePropertyTo()` follows the same structure but returns `OptionalInt`
+and uses `compareJavaValuesOrdering()` / `InPlaceComparator.compare()`.
+
+## Type Conversion Strategy
+
+The passed-in Java value is converted to match the serialized property's type
+before comparison. This avoids an NxN cross-type matrix.
+
+### Conversion Rules (as implemented)
+
+| Serialized Type | Accepted Java Types | Conversion | Overflow Handling |
+|---|---|---|---|
+| INTEGER | Integer, Long, Short, Byte | `Number.intValue()` | Long out of int range → empty (fallback) |
+| LONG | Integer, Long, Short, Byte | `Number.longValue()` | Always fits |
+| SHORT | Short, Byte, Integer, Long | `Number.shortValue()` | Out of short range → empty |
+| BYTE | Byte, Short, Integer, Long | `Number.byteValue()` | Out of byte range → empty |
+| FLOAT | Float; Integer/Long/Short/Byte (if |val| ≤ 2^24); Double (widen to double) | `Float.floatToIntBits()` or widen both to double | Precision-unsafe integers → empty |
+| DOUBLE | Double, Float; Integer/Long/Short/Byte (if |val| ≤ 2^53) | `Double.doubleToLongBits()` | Precision-unsafe longs → empty |
+| STRING | String | Identity | N/A |
+| BOOLEAN | Boolean | Identity | N/A |
+| DATETIME | Date, Number | `Date.getTime()` or `longValue()` | N/A |
+| DATE | Date, Number | millis via timezone conversion | Requires non-null `TimeZone` |
+| DECIMAL | BigDecimal; Number (NaN/Infinity → empty) | `BigDecimal.valueOf()` | N/A |
+| BINARY | byte[] | Identity | N/A |
+| LINK | RID, Identifiable | `getIdentity()` | Equality only |
+
+**Key difference from planned design:** Float/Double → integer type
+conversions always fall back (return empty). This was a deliberate choice —
+floating-point to integer truncation could silently change comparison
+semantics. The planned design mentioned overflow detection for narrowing
+conversions; the implementation goes further by rejecting Float/Double
+entirely for integer target types.
+
+**Precision boundaries for integer → floating-point:**
+- `int → float`: safe if `|value| ≤ 2^24` (16,777,216)
+- `long → double`: safe if `|value| ≤ 2^53` (9,007,199,254,740,992)
+
+These boundaries apply in both the InPlaceComparator (source path) and the
+EntityImpl `compareJavaValuesOrdering` (deserialized path) to ensure
+cross-path equivalence.
+
+## Cross-Path Equivalence
+
+A critical invariant: for any given property and value, the deserialized
+path (properties map) and the serialized path (source bytes) must produce
+the same comparison result. This is enforced by:
+
+1. **Same type conversion logic** in both paths. EntityImpl's
+   `compareJavaValuesOrdering()` applies the same precision boundaries
+   (2^24 for float, 2^53 for double) and the same Float/Double rejection
+   for integer types as InPlaceComparator's `convertToInt/Long/Short/Byte`.
+
+2. **Same comparison methods**: `Float.compare()` (not `==`),
+   `Double.compare()` (not `==`), `BigDecimal.compareTo()` (not `equals()`),
+   `Arrays.compare()` for byte arrays.
+
+3. **Float widening to double**: When comparing a FLOAT property against a
+   Double value, both paths widen the float to double precision before
+   comparison (avoiding precision loss from double → float narrowing).
+
+4. **235 unit tests + 43 cross-path equivalence tests** verify this invariant
+   across all 13 types, cross-type conversions, precision boundaries, NaN,
+   -0.0, infinity, and null handling.
+
+**Known intentional asymmetry:** LINK equality in the deserialized path
+compares RID components directly via `compareLinkJavaValues()`. The source
+path uses `InPlaceComparator.compareLinkEquality()`. Both produce the same
+result. However, `compareJavaValuesOrdering()` returns empty for LINK (no
+ordering), so `comparePropertyTo` on a deserialized LINK returns empty while
+`isPropertyEqualTo` succeeds.
+
+## NULL Handling
+
+When either the property value or the passed-in comparison value is null,
+both `isPropertyEqualTo` and `comparePropertyTo` return FALLBACK/empty.
+This defers NULL semantics to the standard SQL evaluation path, which
+implements SQL three-valued logic (`NULL = NULL` → `NULL`, not `true`).
+
+In the deserialized path, null is detected at `entry.value == null` or
+`value == null`. In the serialized path, `value == null` is checked in
+`deserializeFieldForComparison()`, and `deserializeField()` returns null
+for missing properties.
+
+## Property Access Security
+
+Both methods check `propertyAccess.isReadable(name)` when `propertyAccess`
+is non-null, falling back to the deserialization path if the property is
+restricted. This maintains defense-in-depth consistency with
+`EntityImpl.getProperty()`.
+
+Additionally, encrypted properties are detected via
+`propertyEncryption.isEncrypted(name)` and fall back — the in-place
+comparator cannot read encrypted bytes.
+
+## SQLBinaryCondition Integration
+
+The integration uses a shared `tryInPlaceComparison(EntityImpl, String,
+Object)` method called by both `evaluate()` overloads. Key design choices:
+
+1. **Right value computed once**: `right.execute()` is called before
+   attempting in-place comparison. On FALLBACK, only `left.execute()` is
+   needed — avoiding double evaluation of the right side.
+
+2. **Zero-allocation property name extraction**: Uses direct traversal
+   `((SQLBaseExpression) left.mathExpression).getIdentifier().getSuffix()
+   .getIdentifier().getStringValue()` instead of `getDefaultAlias()` (which
+   allocates `new SQLIdentifier()` per call). Safe because
+   `isBaseIdentifier()` guarantees the structure, and the additional
+   `instanceof SQLBaseExpression` guard filters out
+   `SQLGetInternalPropertyExpression` (which also passes `isBaseIdentifier()`
+   but has a different internal structure).
+
+3. **Result overload guards**: `isBaseIdentifier()`, `instanceof
+   SQLBaseExpression`, `isEarlyCalculated()`, both collations null,
+   `ResultInternal.asEntityOrNull() instanceof EntityImpl`.
+
+4. **Identifiable overload guards**: Same as Result minus collation checks
+   (this overload never applies collation) and minus ResultInternal
+   unwrapping (cast directly to EntityImpl).
+
+5. **Operator dispatch**: Equality (`=`) and not-equal (`<>`, `!=`) use
+   `isPropertyEqualTo`; range operators (`<`, `>`, `<=`, `>=`) use
+   `comparePropertyTo`. The `isRangeOperator()` method covers all four
+   range operators.
+
+## Performance Considerations
+
+The optimization avoids Java object allocation during WHERE clause evaluation
+for records that don't match the filter condition. For scan-heavy queries
+(large result sets with selective filters), this eliminates the dominant cost
+of `getProperty()` → deserialization → discard.
+
+The per-property cost is a single header scan via `deserializeField()` — a
+sequential read of the field-name/offset table at the start of the serialized
+record. Multi-property optimization (batch header scan for
+`WHERE a = 1 AND b = 2`) is explicitly a non-goal for v1.
+
+When the property is already in the `properties` map (previously accessed),
+the deserialized path avoids even the header scan — it compares Java objects
+directly with the same type-safe conversion logic.

--- a/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
+++ b/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
@@ -315,6 +315,8 @@ flowchart LR
   > filter. All fixed. 28 integration tests total.
   >
   > **Step file:** `tracks/track-2.md` (3 steps, 0 failed)
+  >
+  > **Strategy refresh:** CONTINUE — all tracks complete, no downstream impact.
 
 ## Final Design Document
 - [ ] Phase 4: Final design document (`design-final.md`)

--- a/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
+++ b/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
@@ -319,4 +319,4 @@ flowchart LR
   > **Strategy refresh:** CONTINUE — all tracks complete, no downstream impact.
 
 ## Final Design Document
-- [ ] Phase 4: Final design document (`design-final.md`)
+- [>] Phase 4: Final design document (`design-final.md`)

--- a/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
+++ b/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
@@ -1,0 +1,303 @@
+# In-Place Property Comparison for SQL WHERE Clauses
+
+## Design Document
+[design.md](design.md)
+
+## High-level plan
+
+### Goals
+
+Avoid property deserialization overhead during SQL WHERE clause evaluation
+(SELECT and MATCH queries) by comparing property values in-place — either
+against the already-deserialized Java object in the `properties` map, or
+directly against the serialized bytes in the `source` buffer.
+
+This targets the hot path in `SQLBinaryCondition.evaluate()`, which currently
+always calls `Entity.getProperty()` (triggering full deserialization) before
+any comparison. The optimization applies to simple comparisons of the form
+`property <op> constant` where `<op>` is `=`, `<>`, `!=`, `<`, `>`, `<=`, `>=`.
+
+### Constraints
+
+- **Pure read-only on serialized bytes.** The comparison must not trigger
+  deserialization or modify `source`. The `properties` map and `source`
+  buffer remain untouched after comparison.
+- **Fallback required.** If the property type is not binary-comparable
+  (collections, embedded, etc.), or if type conversion fails, fall back to
+  the existing deserialization path transparently.
+- **Single header scan per property.** For v1, each in-place comparison
+  scans the serialized record header to locate the field. Multi-property
+  optimization is out of scope.
+- **Cross-type numeric support.** The passed-in Java value is converted to
+  the serialized property's type before same-type binary comparison. This
+  covers common cases like INTEGER property vs LONG literal.
+- **Generated code.** `SQLBinaryCondition.java` is JavaCC-generated but
+  already has hand-written methods. Modifications must preserve the JavaCC
+  checksum comment and not break regeneration.
+- **No collation support in v1.** Collated string comparisons fall back to
+  the deserialization path. This can be added in a follow-up.
+
+### Architecture Notes
+
+#### Component Map
+
+```mermaid
+flowchart LR
+    SQLBC["SQLBinaryCondition\n(evaluate)"]
+    EI["EntityImpl\n(new comparison methods)"]
+    IPC["InPlaceComparator\n(new: binary comparison logic)"]
+    ES["EntitySerializer\n(deserializeField)"]
+    RI["ResultInternal\n(getProperty)"]
+    BF["BinaryField\n(existing)"]
+
+    SQLBC -->|"in-place path\n(new)"| EI
+    SQLBC -.->|"fallback path\n(existing)"| RI
+    EI -->|"source != null"| ES
+    ES --> BF
+    EI -->|"compare bytes"| IPC
+    EI -->|"source == null\nor property loaded"| EI
+```
+
+- **SQLBinaryCondition** — Hook point. `evaluate(Result, CommandContext)` is
+  modified to detect simple `property <op> constant` patterns and delegate
+  to EntityImpl's new comparison methods before falling back to the existing
+  `left.execute()` / `right.execute()` path.
+- **EntityImpl** — Gets new public methods `isPropertyEqualTo(name, value)`
+  and `comparePropertyTo(name, value)`. These check the `properties` map
+  directly (via `properties.get(name)`, not `checkForProperties()`) first,
+  navigating `EntityEntry` indirection (`exists()`, null value handling),
+  then fall back to serialized comparison via `source`. The `source` field
+  is inherited from `RecordAbstract`.
+- **InPlaceComparator** — New utility class with static methods for
+  same-type binary comparison. Reads values directly from `BytesContainer`
+  without allocation. Handles type conversion of the passed-in Java value.
+- **EntitySerializer / RecordSerializerBinaryV1** — Existing
+  `deserializeField()` method locates a field in serialized bytes and returns
+  a `BinaryField` (type + raw bytes pointer). Used as-is.
+- **ResultInternal** — Existing `getProperty()` path. Used as fallback when
+  in-place comparison is not applicable.
+- **BinaryField** — Existing class. Holds field name, type, and a
+  `BytesContainer` pointing at the raw serialized value bytes.
+
+#### D1: Comparison methods on EntityImpl, not on ResultInternal or operator level
+- **Alternatives considered**: (a) Add methods to `ResultInternal`; (b) Add
+  binary evaluation to `SQLBinaryCompareOperator`; (c) Intercept in
+  `SQLSuffixIdentifier.execute()`.
+- **Rationale**: EntityImpl owns both the `properties` map and the `source`
+  buffer. It is the natural place to decide "deserialized or serialized?"
+  and dispatch accordingly. ResultInternal would need to reach through to
+  EntityImpl anyway. Operator-level interception is too late (values already
+  extracted).
+- **Risks/Caveats**: EntityImpl is already a large class. The new methods
+  should be thin dispatchers, delegating binary logic to InPlaceComparator.
+- **Implemented in**: Track 1
+
+#### D2: Convert passed-in value to property's serialized type (not NxN matrix)
+- **Alternatives considered**: (a) Full NxN cross-type matrix like
+  `BinaryComparatorV0`; (b) Serialize the Java value and compare bytes;
+  (c) Convert Java value to match property type, then same-type comparison.
+- **Rationale**: Option (c) is simplest. The Java value is already
+  deserialized, so converting `Integer → Short` is trivial
+  (`Number.shortValue()`). This gives ~13 same-type comparison methods
+  instead of ~170 type-pair branches. For incompatible conversions, we
+  fall back to deserialization.
+- **Risks/Caveats**: Narrowing conversions (e.g., LONG → SHORT) may lose
+  precision. If the value doesn't fit, fall back rather than silently
+  truncate.
+- **Implemented in**: Track 1
+
+#### D3: New clean comparison logic instead of reusing BinaryComparatorV0
+- **Alternatives considered**: Reuse `BinaryComparatorV0.isEqual()` and
+  `compare()`.
+- **Rationale**: BinaryComparatorV0 has semantic inconsistencies (isEqual
+  parses strings to numbers, compare does lexical comparison). It also
+  operates on two `BinaryField` objects, while our case has one BinaryField
+  and one Java object. Building clean logic is simpler and avoids inheriting
+  bugs.
+- **Risks/Caveats**: Must ensure the new logic matches standard Java
+  `Comparable.compareTo()` semantics that the rest of the SQL engine expects.
+- **Implemented in**: Track 1
+
+#### D4: Integration at SQLBinaryCondition.evaluate() level
+- **Alternatives considered**: (a) FilterStep level; (b) SQLSuffixIdentifier
+  level; (c) Operator level.
+- **Rationale**: SQLBinaryCondition has access to left expression (property
+  name), right expression (constant value), operator type, and the Result.
+  It can check `isBaseIdentifier()` and `isEarlyCalculated()` to detect the
+  optimizable pattern. The existing `isIndexAware()` method already uses the
+  same pattern detection, confirming this is the right abstraction level.
+- **Risks/Caveats**: SQLBinaryCondition is generated code. Changes must be
+  careful to preserve the JavaCC structure.
+- **Implemented in**: Track 2
+
+#### D5: Use `Optional<Boolean>` for tri-state return type
+- **Alternatives considered**: (a) Custom `OptionalBoolean` class; (b)
+  Custom enum `ComparisonResult { TRUE, FALSE, FALLBACK }`; (c)
+  `OptionalInt` with convention (0 = false, 1 = true, empty = fallback);
+  (d) `Optional<Boolean>`.
+- **Rationale**: `Optional<Boolean>` is the simplest option — it uses
+  standard library types, is self-documenting, and the boxing overhead is
+  negligible since this is not the inner comparison loop (the actual byte
+  comparison is the hot path). A custom enum would be cleaner semantically
+  but adds a class for minimal benefit.
+- **Risks/Caveats**: The risk is accidentally using
+  `Optional.ofNullable(someNullBoolean)` which returns `Optional.empty()`
+  instead of the intended tri-state signal. Callers must use
+  `Optional.of(true)` / `Optional.of(false)` / `Optional.empty()`.
+  Note: `Optional.of(null)` throws `NullPointerException`, so it is not
+  a silent-corruption risk.
+- **Implemented in**: Track 1
+
+#### D6: Property access security — fall back when `propertyAccess` restricts
+- **Alternatives considered**: (a) Always check `propertyAccess.isReadable()`
+  in the in-place path; (b) Skip the check entirely (SQL engine enforces
+  access at a higher level); (c) Fall back to deserialization path when
+  `propertyAccess` is non-null and restricts the property.
+- **Rationale**: Option (c) maintains defense-in-depth consistency with
+  `getProperty()` while keeping the fast path simple. When `propertyAccess`
+  is null (the common case), no check is needed. When it's non-null,
+  checking `isReadable()` and falling back if false avoids diverging from
+  `getProperty()` security behavior.
+- **Risks/Caveats**: None significant — the `propertyAccess` field is
+  rarely non-null in production.
+- **Implemented in**: Track 1
+
+#### Invariants
+
+- In-place comparison must produce the same result as the existing
+  deserialization + `Comparable.compareTo()` path for all supported types.
+- The `source` byte array and `properties` map must not be modified by
+  comparison operations.
+- When `source` is `null` (entity dirty or fully deserialized), comparison
+  must use the deserialized Java value from the `properties` map.
+- Narrowing numeric conversions that would lose precision must fall back to
+  the deserialization path, not silently truncate.
+- When either the property value or the passed-in value is null, the
+  comparison must return empty (`Optional.empty()` / `OptionalInt.empty()`)
+  to fall back to the standard SQL NULL handling in `SQLBinaryCondition`.
+  SQL NULL semantics (`NULL = NULL` → `NULL`, not `true`) are enforced by
+  the existing operator path, not by the in-place comparison methods.
+
+#### Integration Points
+
+- `SQLBinaryCondition.evaluate(Result, CommandContext)` — entry point for
+  the optimization. Detects optimizable patterns and delegates to EntityImpl.
+- `EntityImpl.isPropertyEqualTo(String, Object)` — new public method.
+- `EntityImpl.comparePropertyTo(String, Object)` — new public method
+  returning `OptionalInt` (empty = fallback needed).
+- `RecordSerializerBinaryV1.deserializeField()` — existing method used to
+  locate field bytes without deserialization. Full signature:
+  `deserializeField(DatabaseSessionEmbedded db, BytesContainer bytes,
+  SchemaClass iClass, String iFieldName, boolean embedded,
+  ImmutableSchema schema, PropertyEncryption encryption)`. Parameters are
+  sourced from EntityImpl: `session` (field), `new BytesContainer(source, 1)`
+  (skip version byte at `source[0]`), `getImmutableSchemaClass(session)`,
+  field name, `isEmbedded()`,
+  `session.getMetadata().getImmutableSchemaSnapshot()`,
+  `propertyEncryption` (field).
+- `RecordSerializerBinary.INSTANCE.getSerializer(source[0])` — used to get
+  the versioned serializer matching the record's format version byte
+  (stored at `source[0]`). Do not use `getCurrentSerializer()` as it may
+  return a different version than the record was serialized with.
+
+#### Non-Goals
+
+- Multi-property optimization (batch header scan for multiple WHERE
+  conditions on the same record).
+- Collation-aware string comparison in the binary path.
+- Replacing or deprecating BinaryComparatorV0 / legacy SQLFilterCondition.
+- Optimizing non-simple expressions (nested paths, function calls,
+  arithmetic expressions).
+
+## Checklist
+
+- [x] Track 1: InPlaceComparator and EntityImpl comparison methods
+  > Implement the core in-place comparison infrastructure:
+  >
+  > - **InPlaceComparator** — new utility class with static methods for
+  >   same-type binary comparison of each supported PropertyTypeInternal
+  >   (INTEGER, LONG, SHORT, BYTE, FLOAT, DOUBLE, STRING, BOOLEAN, DATETIME,
+  >   DATE, DECIMAL, BINARY, LINK). Each method reads the serialized value
+  >   from a `BytesContainer` and compares against a passed-in Java object.
+  >   Includes type conversion logic to convert the Java value to the
+  >   property's serialized type (e.g., `Integer → Short` via
+  >   `Number.shortValue()`) with overflow/precision checks that signal
+  >   "fallback needed" rather than silently truncating.
+  >
+  > - **EntityImpl.isPropertyEqualTo(String, Object)** — returns
+  >   `Optional<Boolean>`: true/false if comparison succeeded, empty if
+  >   fallback needed. Checks `properties` map first (deserialized path),
+  >   then uses `deserializeField()` + InPlaceComparator (serialized path).
+  >   **Critical**: the `properties` map must be checked directly via
+  >   `properties.get(name)` — not via `checkForProperties()` or
+  >   `getProperty()`, which trigger deserialization from `source` and
+  >   would defeat the optimization. Must navigate `EntityEntry`
+  >   indirection: check `entry.exists()`, handle `entry.value == null`.
+  >
+  > - **EntityImpl.comparePropertyTo(String, Object)** — returns
+  >   `OptionalInt`: comparison result if succeeded, empty if fallback
+  >   needed. Same dispatch logic as isPropertyEqualTo.
+  >
+  > - Both methods are pure read-only: no deserialization triggered, `source`
+  >   unchanged. When `propertyAccess` is non-null and restricts the
+  >   property, fall back to the deserialization path.
+  >
+  > - Unit tests covering all 13 comparable types, cross-type numeric
+  >   conversion, null handling, overflow fallback, and equivalence with
+  >   the standard Java comparison path.
+  >
+  > **Scope:** ~5-7 steps covering InPlaceComparator implementation (types
+  > batched by encoding similarity), EntityImpl dispatch methods,
+  > type conversion with overflow detection, and unit tests
+  >
+  > **Track episode:**
+  > Built InPlaceComparator (13 types, type conversion with precision-safe
+  > overflow detection), InPlaceResult enum, and EntityImpl dispatch methods
+  > (isPropertyEqualTo, comparePropertyTo). Both methods check properties
+  > map first without triggering deserialization, then fall back to
+  > serialized bytes, then FALLBACK. Track-level review caught 4 blockers:
+  > FLOAT/DOUBLE precision guards missing in deserialized path (cross-path
+  > equivalence violation), DECIMAL NaN/Infinity crash, and matching bugs
+  > in the test oracle. All fixed. LINK equality added to deserialized
+  > path (was FALLBACK-only, now matches source path). 235 tests total.
+  >
+  > **Step file:** `tracks/track-1.md` (4 steps, 0 failed)
+
+- [ ] Track 2: SQLBinaryCondition integration
+  > Wire the EntityImpl comparison methods into the modern SQL execution
+  > engine:
+  >
+  > - Modify `SQLBinaryCondition.evaluate(Result, CommandContext)` to detect
+  >   optimizable patterns: `left.isBaseIdentifier()` AND
+  >   `right.isEarlyCalculated(ctx)` AND `currentRecord.isEntity()` AND
+  >   `left.getCollate(currentRecord, ctx)` is null AND
+  >   `right.getCollate(currentRecord, ctx)` is null AND
+  >   operator is one of `=`, `<>`, `!=`, `<`, `>`, `<=`, `>=`
+  >   (note: `<>` is `SQLNeqOperator`, `!=` is `SQLNeOperator` — both must
+  >   be recognized).
+  >
+  > - When the pattern matches, extract the property name from
+  >   `left.getDefaultAlias().getStringValue()`, compute the right-hand
+  >   value via `right.execute(currentRecord, ctx)`, and delegate to
+  >   `EntityImpl.isPropertyEqualTo()` or `comparePropertyTo()`.
+  >
+  > - If the EntityImpl method returns empty (fallback), fall through to
+  >   the existing deserialization path.
+  >
+  > - Handle the `evaluate(Identifiable, CommandContext)` overload
+  >   similarly: check `instanceof EntityImpl`, apply the same pattern
+  >   detection and in-place comparison. This overload receives an
+  >   `Identifiable` directly (no `Result` wrapper to unwrap), so the
+  >   EntityImpl is accessed via a direct cast instead of `asEntity()`.
+  >
+  > - SQL-level integration tests verifying that SELECT and MATCH queries
+  >   with WHERE clauses produce identical results with and without the
+  >   optimization (correctness, not performance).
+  >
+  > **Scope:** ~3-5 steps covering SQLBinaryCondition modification,
+  > operator dispatch, fallback logic, and SQL-level integration tests
+  >
+  > **Depends on:** Track 1
+
+## Final Design Document
+- [ ] Phase 4: Final design document (`design-final.md`)

--- a/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
+++ b/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
@@ -319,4 +319,4 @@ flowchart LR
   > **Strategy refresh:** CONTINUE — all tracks complete, no downstream impact.
 
 ## Final Design Document
-- [>] Phase 4: Final design document (`design-final.md`)
+- [x] Phase 4: Final design document (`design-final.md`)

--- a/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
+++ b/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
@@ -262,6 +262,8 @@ flowchart LR
   > path (was FALLBACK-only, now matches source path). 235 tests total.
   >
   > **Step file:** `tracks/track-1.md` (4 steps, 0 failed)
+  >
+  > **Strategy refresh:** CONTINUE — no downstream impact detected.
 
 - [ ] Track 2: SQLBinaryCondition integration
   > Wire the EntityImpl comparison methods into the modern SQL execution

--- a/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
+++ b/docs/adr/ytdb-628-in-place-comparison/implementation-plan.md
@@ -265,7 +265,7 @@ flowchart LR
   >
   > **Strategy refresh:** CONTINUE — no downstream impact detected.
 
-- [ ] Track 2: SQLBinaryCondition integration
+- [x] Track 2: SQLBinaryCondition integration
   > Wire the EntityImpl comparison methods into the modern SQL execution
   > engine:
   >
@@ -300,6 +300,21 @@ flowchart LR
   > operator dispatch, fallback logic, and SQL-level integration tests
   >
   > **Depends on:** Track 1
+  >
+  > **Track episode:**
+  > Wired InPlaceComparator + EntityImpl comparison methods into
+  > SQLBinaryCondition's two evaluate() overloads. Both the Result-based
+  > path (SELECT, MATCH) and Identifiable-based path (CONTAINS) now detect
+  > optimizable `property <op> constant` patterns and attempt in-place
+  > comparison before falling back to the deserialization path. Extracted
+  > shared tryInPlaceComparison() method to eliminate duplication between
+  > overloads. Track-level review caught 5 should-fix items: cross-type
+  > test wasn't actually cross-type, missing collation bypass test, missing
+  > exact boundary test for <=/>= , non-entity projection test didn't
+  > exercise SQLBinaryCondition, MATCH traversal filter didn't actually
+  > filter. All fixed. 28 integration tests total.
+  >
+  > **Step file:** `tracks/track-2.md` (3 steps, 0 failed)
 
 ## Final Design Document
 - [ ] Phase 4: Final design document (`design-final.md`)

--- a/docs/adr/ytdb-628-in-place-comparison/reviews/track-1-adversarial.md
+++ b/docs/adr/ytdb-628-in-place-comparison/reviews/track-1-adversarial.md
@@ -1,0 +1,83 @@
+# Track 1 Adversarial Review: InPlaceComparator and EntityImpl comparison methods
+
+## Finding A1 [should-fix]
+**Target**: Decision D3 (New logic vs reusing BinaryComparatorV0)
+**Challenge**: The plan dismisses BinaryComparatorV0 but InPlaceComparator will use the exact same `HelperClasses` static methods (`readByte`, `readInteger`, `readLong`, `readString`, etc.). The argument is not "BinaryComparatorV0 is bad code we must avoid" but rather "BinaryComparatorV0 operates on (BinaryField, BinaryField) while we need (BinaryField, Object), so a new entry point is needed."
+**Evidence**: BinaryComparatorV0 lines 86-130 show the exact varint/byte/float/double/decimal reading patterns that InPlaceComparator will replicate using the same `HelperClasses`/`VarIntSerializer` utilities.
+**Proposed fix**: Acknowledge in the rationale that InPlaceComparator uses the same low-level reading primitives. The justification is the different API shape, not code quality concerns.
+
+## Finding A2 [blocker]
+**Target**: Invariant — "The `source` byte array and `properties` map must not be modified by comparison operations"
+**Challenge**: `deserializeField()` returns a `BinaryField` whose `BytesContainer` points into `source`. InPlaceComparator's `HelperClasses.read*` methods advance `bytes.offset`. The `BytesContainer` is freshly created per call so `source` contents are safe, but the invariant wording could mislead someone into thinking the `BinaryField` is reusable.
+**Evidence**: `BytesContainer.offset` is a mutable public field. `VarIntSerializer.readAsInteger(bytes)` advances `bytes.offset`. The `BinaryField.bytes` at RecordSerializerBinaryV1 line 240 is the same `BytesContainer` passed into `deserializeField`.
+**Proposed fix**: Tighten the invariant language to clarify that the `BinaryField` is ephemeral and its `BytesContainer` offset is consumed by the comparison.
+
+## Finding A3 [should-fix]
+**Target**: Decision D5 (Optional<Boolean> for tri-state return)
+**Challenge**: `Optional<Boolean>` has zero precedent in this codebase and is a well-known Java anti-pattern. It boxes the boolean, has confusing semantics, and the plan's own risk section flags the `Optional.ofNullable` trap. A 4-line enum like `InPlaceResult { TRUE, FALSE, FALLBACK }` costs nothing and eliminates the entire risk class.
+**Evidence**: Zero uses of `Optional<Boolean>` in `core/src/main/java`. The D5 risk section explicitly acknowledges the foot-gun.
+**Proposed fix**: Replace `Optional<Boolean>` with a simple enum. Similarly replace `OptionalInt` for `comparePropertyTo`.
+
+## Finding A4 [should-fix]
+**Target**: Assumption — `properties.get(name)` without `checkForProperties()` is safe
+**Challenge**: The novel access pattern must handle `entry.type == null` (schema-less mode where `derivePropertyType` returns null). `EntityEntry` constructor does not initialize `type`. When the type is unknown, the deserialized-value comparison path cannot do type-based binary comparison.
+**Evidence**: `EntityEntry` constructor (line 47) does not initialize `type`. `EntityImpl.setPropertyInternal` only sets `entry.type` when `oldType != propertyType`, and `derivePropertyType` can return null.
+**Proposed fix**: When `entry.type == null`, fall back to standard Java `Comparable.compareTo()` / `equals()` rather than type-based comparison.
+
+## Finding A5 [should-fix]
+**Target**: Decision D2 (Convert value to property type, not NxN)
+**Challenge**: FLOAT vs DOUBLE conversion has a semantic mismatch with the existing path. Converting `Double.valueOf(0.1)` to Float via `Number.floatValue()` gives `0.1f`. Both compare equal as floats. But the existing deserialization path deserializes FLOAT to `Float(0.1f)` and Java's standard promotion compares it to `Double(0.1)` — which gives `false` because `0.1f != 0.1d`.
+**Evidence**: `Float.compare(0.1f, 0.1f) == 0` but `Double.compare((double)0.1f, 0.1) != 0`. BinaryComparatorV0 explicitly handles this with double-precision promotion.
+**Proposed fix**: For floating-point conversions, always widen to the larger type (compare at double precision when either operand is double). Document this exception to the "convert to property type" strategy.
+
+## Finding A6 [should-fix]
+**Target**: Scope — Track doing too much
+**Challenge**: Track 1 includes three distinct units: (1) InPlaceComparator utility, (2) EntityImpl dispatch methods, (3) type conversion with overflow detection. EntityImpl is 3972 lines and the proposed change adds a novel access pattern (`properties.get(name)` without `checkForProperties()`) with no precedent.
+**Evidence**: EntityImpl.java is 3972 lines with 25+ calls to `checkForProperties()`.
+**Proposed fix**: This doesn't require splitting into separate tracks — just sequence as separate steps within Track 1: (1a) InPlaceComparator standalone + tests, then (1b) EntityImpl integration + tests.
+
+## Finding A7 [blocker]
+**Target**: Invariant — "In-place comparison must produce the same result as deserialization + Comparable.compareTo()"
+**Challenge**: `deserializeField()` returns `null` when `fieldLength == 0` (empty/default value). An empty string has `fieldLength == 0`. The proposed methods would interpret `null` from `deserializeField` as "fallback needed" and delegate to deserialization — defeating the optimization for empty/default property values.
+**Evidence**: RecordSerializerBinaryV1 line 235-237: `if (fieldLength == 0 || !getComparator().isBinaryComparable(type)) { return null; }`. Empty strings and default values trigger this.
+**Proposed fix**: Either handle zero-length fields specially, or document as a known performance gap in v1.
+
+## Finding A8 [suggestion]
+**Target**: Assumption — 13 types is the right count
+**Challenge**: The plan should explicitly list the 8 excluded types (EMBEDDED, EMBEDDEDLIST, EMBEDDEDSET, EMBEDDEDMAP, LINKLIST, LINKSET, LINKMAP, LINKBAG) rather than "collections, embedded, etc."
+**Evidence**: `PropertyTypeInternal` has 21 enum values total: 13 supported, 8 excluded.
+**Proposed fix**: Add an explicit "Excluded types" list to the track description.
+
+## Finding A9 [should-fix]
+**Target**: Invariant — "Narrowing numeric conversions that would lose precision must fall back"
+**Challenge**: The plan does not define precision boundaries for integer-to-float conversions. `(float) Long.MAX_VALUE == (float) (Long.MAX_VALUE - 1)` is `true` in Java. Similarly for long-to-double outside `[-2^53, 2^53]`.
+**Evidence**: `(float) Long.MAX_VALUE == (float) (Long.MAX_VALUE - 1)` evaluates to `true`. These are real values SQL queries could compare.
+**Proposed fix**: Define explicit precision boundaries: int/long to float safe if `|value| <= 2^24`; long to double safe if `|value| <= 2^53`; double to float safe if `(double)(float)value == value`.
+
+## Finding A10 [suggestion]
+**Target**: Non-Goal — "Replacing or deprecating BinaryComparatorV0"
+**Challenge**: Two parallel binary comparison implementations with different semantics creates maintenance burden. BinaryComparatorV0's STRING isEqual parses to number; InPlaceComparator won't.
+**Evidence**: BinaryComparatorV0 is used by the index layer, not just SQL evaluation. Different behavior for the same types is a correctness divergence risk.
+**Proposed fix**: Add a follow-up item to reconcile the two implementations.
+
+## Finding A11 [should-fix]
+**Target**: Assumption — `properties` map can be null
+**Challenge**: The plan must handle all 6 state combinations: `properties` null/non-null × entry present/absent/deleted × `source` null/non-null.
+**Evidence**: EntityImpl line 110: `properties` starts as `null`. `checkForProperties()` initializes it on first call. The new methods bypass this initialization.
+**Proposed fix**: Add an explicit state matrix covering all combinations as a decision table in the step file.
+
+## Summary
+
+| ID | Severity | Core Issue |
+|----|----------|------------|
+| A1 | should-fix | D3 rationale should focus on API shape, not code quality |
+| A2 | blocker | BinaryField BytesContainer is ephemeral; tighten invariant language |
+| A3 | should-fix | Replace Optional<Boolean> with a simple enum |
+| A4 | should-fix | Handle entry.type == null in deserialized comparison path |
+| A5 | should-fix | FLOAT/DOUBLE conversion mismatch — must widen, not narrow |
+| A6 | should-fix | Sequence as separate steps within Track 1 |
+| A7 | blocker | deserializeField returns null for zero-length fields (empty strings) |
+| A8 | suggestion | Explicitly list all 8 excluded types |
+| A9 | should-fix | Define precision boundaries for integer-to-float conversions |
+| A10 | suggestion | Follow-up to reconcile with BinaryComparatorV0 |
+| A11 | should-fix | Explicit state matrix for properties/source null combinations |

--- a/docs/adr/ytdb-628-in-place-comparison/reviews/track-1-risk.md
+++ b/docs/adr/ytdb-628-in-place-comparison/reviews/track-1-risk.md
@@ -1,0 +1,81 @@
+# Track 1 Risk Review: InPlaceComparator and EntityImpl comparison methods
+
+## Finding R1 [blocker]
+**Location**: EntityImpl dispatch logic (plan's `isPropertyEqualTo`/`comparePropertyTo` → `properties.get(name)` check), EntityImpl.java `deserializeProperties`
+**Issue**: The plan states that the new methods should check `properties.get(name)` directly — **not** `checkForProperties()` — to avoid triggering deserialization. However, `properties.get(name) == null` conflates "key absent" with "key present but null-valued." After partial deserialization, `properties` may contain some keys but not others. The entry `null` vs "key absent" distinction matters: a property that has been lazily deserialized with a null value would have an `EntityEntry` with `exists() == true` and `value == null`.
+**Proposed fix**: The dispatch logic must be:
+1. If `properties != null` and `properties.containsKey(name)`: use the deserialized `EntityEntry` (checking `entry.exists()` and `entry.value`).
+2. Else if `source != null`: use the serialized comparison via `deserializeField()`.
+3. Else: return `Optional.empty()` (fallback — property not found and no source).
+
+## Finding R2 [should-fix]
+**Location**: EntityImpl dispatch logic → `status` check, EntityImpl.java
+**Issue**: The plan does not mention checking `status` before accessing `source`. During `STATUS.UNMARSHALLING` (recursive deserialization of embedded entities), `source` bytes are being actively consumed — reading `source` concurrently via `deserializeField()` would be incorrect because the `BytesContainer` is stateful.
+**Proposed fix**: Add a precondition check: if `status != STATUS.LOADED`, return `Optional.empty()` (fallback). This is cheap and ensures the optimization only fires on fully-loaded records whose `source` is stable.
+
+## Finding R3 [should-fix]
+**Location**: InPlaceComparator — `BytesContainer` mutability
+**Issue**: `deserializeField()` mutates the `BytesContainer.offset` field as it scans the header. The plan creates a `new BytesContainer(source, 1)` which wraps the `source` byte array. After `deserializeField()` returns a `BinaryField`, the `BinaryField.bytes` is the **same** `BytesContainer` instance with `offset` repositioned to the value data. This is safe for single-property comparison but must be documented as an invariant.
+**Proposed fix**: Add a comment/invariant in InPlaceComparator that each comparison reads exactly one serialized value starting at `field.bytes.offset` and does not reuse the `BytesContainer` afterward.
+
+## Finding R4 [should-fix]
+**Location**: InPlaceComparator — DECIMAL type comparison
+**Issue**: DECIMAL comparison allocates a `BigDecimal` from bytes (effectively full deserialization). More importantly, `BigDecimal.compareTo()` has different semantics than `BigDecimal.equals()` (`new BigDecimal("1.0").equals(new BigDecimal("1"))` is `false` but `compareTo` returns 0).
+**Proposed fix**: (a) Always use `BigDecimal.compareTo()` for equality checks. (b) For passed-in value conversion: use `BigDecimal.valueOf(double)` (not `new BigDecimal(double)`) to avoid floating-point representation artifacts.
+
+## Finding R5 [should-fix]
+**Location**: InPlaceComparator — FLOAT/DOUBLE comparison semantics
+**Issue**: NaN handling: `Float.NaN != Float.NaN` by IEEE 754, but `Float.compare(Float.NaN, Float.NaN) == 0`. The plan must specify whether to use `==` or `Float.compare()`.
+**Proposed fix**: Use `Float.compare()` and `Double.compare()` for all float/double comparisons, including equality. This matches Java `Comparable` semantics and handles NaN and negative zero correctly.
+
+## Finding R6 [should-fix]
+**Location**: EntityImpl dispatch — `propertyEncryption` check
+**Issue**: The plan mentions falling back when `propertyAccess` restricts the property, but does not mention encrypted properties. If a property is encrypted, `deserializeField()` returns ciphertext — comparing ciphertext against a plaintext Java value would produce wrong results.
+**Proposed fix**: Before calling `deserializeField()`, check `propertyEncryption != null && !(propertyEncryption instanceof PropertyEncryptionNone) && propertyEncryption.isEncrypted(name)`. If encrypted, return `Optional.empty()` (fallback).
+
+## Finding R7 [suggestion]
+**Location**: EntityImpl dispatch — `className` not yet resolved
+**Issue**: `deserializeField()` requires a `SchemaClass` parameter. If `getImmutableSchemaClass()` returns null (schema-less records), `deserializeField()` could encounter issues.
+**Proposed fix**: If `getImmutableSchemaClass(session)` returns null, fall back to the deserialization path.
+
+## Finding R8 [should-fix]
+**Location**: Track 1 — numeric overflow detection for narrowing conversions
+**Issue**: The plan says "narrowing conversions that would lose precision must fall back" but doesn't specify exact range checks or handle float-to-integer conversions. Converting `3.14f` to `int` would be `3`, wrong for `=` comparison.
+**Proposed fix**: (a) For floating-point to integer conversions: always fall back. (b) For integer narrowing: check `value >= Type.MIN_VALUE && value <= Type.MAX_VALUE`. (c) Document all conversion rules in a table.
+
+## Finding R9 [suggestion]
+**Location**: InPlaceComparator — collation check
+**Issue**: `deserializeField()` may return a `BinaryField` with non-null `collate` field. Track 2 checks `getCollate()` at the SQL level, but Track 1 should also guard at EntityImpl level for defense-in-depth.
+**Proposed fix**: After `deserializeField()`, check `if (field.collate != null && !(field.collate instanceof DefaultCollate)) return Optional.empty()`.
+
+## Finding R10 [suggestion]
+**Location**: InPlaceComparator — LINK comparison
+**Issue**: LINK ordering semantics (`<`/`>`) are not well-defined for binary comparison.
+**Proposed fix**: For LINK, only support `isPropertyEqualTo` (equality). For `comparePropertyTo`, return `OptionalInt.empty()` (fallback).
+
+## Finding R11 [suggestion]
+**Location**: InPlaceComparator — DATE type and timezone handling
+**Issue**: DATE values are serialized as days-since-epoch and require timezone conversion via `convertDayToTimezone()`. The plan doesn't mention timezone handling.
+**Proposed fix**: Replicate `convertDayToTimezone()` logic in the DATE comparison path, or convert the passed-in `Date` to days-since-epoch using the same timezone logic.
+
+## Finding R12 [suggestion]
+**Location**: Unit test coverage — testing with actual serialized records
+**Issue**: Testing EntityImpl methods requires actual serialized records with `source != null`.
+**Proposed fix**: Use pattern: create entity → save to DB → reload → immediately call `isPropertyEqualTo` before any `getProperty()`. Also test partially deserialized scenario.
+
+## Summary
+
+| ID | Severity | Core Issue |
+|----|----------|------------|
+| R1 | blocker | `properties.get(name) == null` conflates "absent" with "null-valued"; must use `containsKey` |
+| R2 | should-fix | Missing `status` check — could read `source` during UNMARSHALLING |
+| R3 | should-fix | `BytesContainer` mutability needs explicit invariant documentation |
+| R4 | should-fix | DECIMAL comparison allocates `BigDecimal`; must use `compareTo`, not `equals` |
+| R5 | should-fix | Float/double NaN and negative-zero handling — must use `Float.compare()` |
+| R6 | should-fix | Encrypted properties would compare ciphertext vs plaintext |
+| R7 | suggestion | `getImmutableSchemaClass()` returning null could cause NPE |
+| R8 | should-fix | Numeric narrowing and float-to-int conversions need explicit rules |
+| R9 | suggestion | `BinaryField.collate` should be checked at EntityImpl level too |
+| R10 | suggestion | LINK ordering semantics undefined; limit to equality only |
+| R11 | suggestion | DATE timezone conversion must match `convertDayToTimezone()` |
+| R12 | suggestion | Test setup must preserve `source` for realistic EntityImpl testing |

--- a/docs/adr/ytdb-628-in-place-comparison/reviews/track-1-technical.md
+++ b/docs/adr/ytdb-628-in-place-comparison/reviews/track-1-technical.md
@@ -1,0 +1,60 @@
+# Track 1 Technical Review: InPlaceComparator and EntityImpl comparison methods
+
+## Finding T1 [blocker]
+**Location**: Track 1 — EntityImpl deserialized path, using `Objects.equals(entry.value, value)` for equality
+**Issue**: The plan proposes `Objects.equals(entry.value, value)` for the deserialized equality path. This does not match SQL engine comparison semantics. The existing SQL path uses `PropertyTypeInternal.castComparableNumber()` for cross-type numeric comparisons (e.g., `Integer(5).equals(Long(5L))` returns `false` in Java, but the SQL engine casts both to LONG and returns `true`). Using `Objects.equals` will produce wrong results for cross-type numeric comparisons on the deserialized path.
+**Proposed fix**: For the deserialized path, perform type-aware comparison: use the same type conversion as InPlaceComparator's `convertToType()` on the deserialized Java values, ensuring both values are the same type before comparing. Alternatively use `QueryOperatorEquals.equals(session, entry.value, value)` or replicate the numeric casting logic.
+
+## Finding T2 [blocker]
+**Location**: Track 1 — EntityImpl dispatch methods, `properties` field null-safety
+**Issue**: The `properties` field in EntityImpl is initialized to `null` (line 110). When an entity has been loaded from storage but no properties have been accessed yet, `properties` is `null`. Calling `properties.get(name)` would throw `NullPointerException`.
+**Proposed fix**: Check `properties != null` before calling `properties.get(name)`. When `properties` is null, proceed directly to the serialized comparison path (check `source != null`).
+
+## Finding T3 [should-fix]
+**Location**: Track 1 — EntityImpl dispatch methods, missing `checkForBinding()` call
+**Issue**: Every public method in EntityImpl calls `checkForBinding()` as its first action, ensuring the entity is in valid state. The new methods would be the only public methods that skip this check. While in SQL evaluation the entity is always LOADED, these are public methods that could be called from user code.
+**Proposed fix**: Call `checkForBinding()` at the start of both methods. This is cheap and maintains the EntityImpl contract. The key optimization of not calling `checkForProperties()` is preserved.
+
+## Finding T4 [should-fix]
+**Location**: Track 1 — InPlaceComparator, DECIMAL comparison
+**Issue**: `DecimalSerializer.staticDeserialize()` allocates a `BigDecimal` from bytes — cannot be truly zero-allocation. Also, `staticDeserialize` takes `(byte[], offset)` not `BytesContainer`, so the offset needs to be passed as `bytes.offset`.
+**Proposed fix**: Acknowledge DECIMAL allocates a `BigDecimal`. Use `DecimalSerializer.staticDeserialize(bytes.bytes, bytes.offset)`.
+
+## Finding T5 [should-fix]
+**Location**: Track 1 — EntityImpl, `propertyEncryption` null handling
+**Issue**: `propertyEncryption` is initialized to `null` and only set in `initPropertyAccess()`. The `encryption` parameter in `deserializeField()` is currently a dead parameter (never used in the method body), but passing null is fragile.
+**Proposed fix**: Defensively handle null by falling back to `PropertyEncryptionNone.instance()`.
+
+## Finding T6 [should-fix]
+**Location**: Track 1 — Design, `deserializeField` returns null for non-binary-comparable types
+**Issue**: `deserializeField()` already returns null when `!getComparator().isBinaryComparable(type)`. The plan's separate "Type binary-comparable?" check is redundant.
+**Proposed fix**: Remove the separate binary-comparability check from the flowchart/implementation since `deserializeField()` already handles this.
+
+## Finding T7 [suggestion]
+**Location**: Track 1 — BinaryField `collate` field for collation-aware fallback
+**Issue**: `deserializeField()` returns a `BinaryField` with non-null `collate` when the property has a collation. EntityImpl-level methods should check this for defense-in-depth, not rely solely on Track 2's SQLBinaryCondition check.
+**Proposed fix**: After `deserializeField()`, check `binaryField.collate != null && !(binaryField.collate instanceof DefaultCollate)` and return empty (fallback).
+
+## Finding T8 [suggestion]
+**Location**: Track 1 — FLOAT/DOUBLE comparison with NaN and special values
+**Issue**: `Float.compare`/`Double.compare` handle NaN and -0.0 specially, differing from IEEE 754 `==`. The plan should confirm these are the intended comparison methods.
+**Proposed fix**: Use `Float.compare()`/`Double.compare()` to match `Float.compareTo()`/`Double.compareTo()` semantics.
+
+## Finding T9 [suggestion]
+**Location**: Track 1 — `deserializeField` with null `iClass` parameter
+**Issue**: For schema-less entities, `getImmutableSchemaClass(session)` can be null. Passing null is safe for inline-name fields but fragile if a schema-less entity has a global property reference.
+**Proposed fix**: Add a null guard or document the assumption.
+
+## Summary
+
+| ID | Severity | Core Issue |
+|----|----------|------------|
+| T1 | blocker | Deserialized path needs type-aware comparison, not Objects.equals |
+| T2 | blocker | `properties` field can be null — NPE risk |
+| T3 | should-fix | Missing `checkForBinding()` in new public methods |
+| T4 | should-fix | DECIMAL allocates BigDecimal; API takes (byte[], offset) not BytesContainer |
+| T5 | should-fix | `propertyEncryption` can be null — defensive handling needed |
+| T6 | should-fix | Binary-comparability check redundant with deserializeField() |
+| T7 | suggestion | Check BinaryField.collate at EntityImpl level for defense-in-depth |
+| T8 | suggestion | Confirm Float.compare/Double.compare for NaN handling |
+| T9 | suggestion | Null guard for schema-less entities in deserializeField |

--- a/docs/adr/ytdb-628-in-place-comparison/reviews/track-2-risk.md
+++ b/docs/adr/ytdb-628-in-place-comparison/reviews/track-2-risk.md
@@ -1,0 +1,46 @@
+# Track 2 Risk Review
+
+## Iteration 1
+
+### Finding R1 [should-fix]
+**Location**: Track 2 + D5 — InPlaceResult enum vs Optional<Boolean>
+**Issue**: Same as T1. Plan D5 outdated. Compiler catches immediately.
+**Proposed fix**: Addressed in step decomposition.
+
+### Finding R2 [should-fix]
+**Location**: Track 2 — evaluate(Identifiable) collation check
+**Issue**: Same as T5. `getCollate()` takes `Result`, not `Identifiable`. Existing overload never applies collation anyway.
+**Proposed fix**: Skip collation guard in Identifiable overload; document intent.
+
+### Finding R3 [should-fix]
+**Location**: Track 2 — hot path allocation
+**Issue**: `left.getDefaultAlias().getStringValue()` allocates `SQLIdentifier` per record. Use direct identifier traversal instead.
+**Proposed fix**: Extract property name via `((SQLBaseExpression) left.mathExpression).getIdentifier().getSuffix().getIdentifier().getStringValue()`.
+
+### Finding R4 [should-fix]
+**Location**: Track 2 — double right.execute() on FALLBACK
+**Issue**: Same as T3. Compute once, reuse.
+**Proposed fix**: Addressed in step decomposition.
+
+### Finding R5 [suggestion]
+**Location**: Track 2 — SQLGetInternalPropertyExpression
+**Issue**: `isBaseIdentifier()` returns true for internal property expressions. These safely FALLBACK (not in properties map or serialized index).
+**Proposed fix**: Add code comment documenting the safe FALLBACK behavior.
+
+### Finding R6 [suggestion]
+**Location**: Track 2 — test strategy
+**Issue**: No mechanism to disable optimization. Tests verify correctness, not "with vs without."
+**Proposed fix**: Rename test goal to "SQL-level correctness tests for all 7 operators."
+
+## Critical Path Exposure
+SQLBinaryCondition.evaluate() is called per-record for WHERE-filtered scans. Blast radius: silent wrong query results. Mitigated by FALLBACK mechanism — unsupported cases always fall through to existing path.
+
+## Performance
+Guard cost is ~5 instanceof/null checks (O(1), no allocation). R3 allocation on hot path needs fixing. Non-optimizable records pay guard cost but it's negligible vs record processing.
+
+## Rollback
+Full revert possible — Track 1 code stays but goes unused.
+
+## Summary
+- 0 blockers, 4 should-fix, 2 suggestions
+- **PASS** — all should-fix items addressed in step decomposition

--- a/docs/adr/ytdb-628-in-place-comparison/reviews/track-2-technical.md
+++ b/docs/adr/ytdb-628-in-place-comparison/reviews/track-2-technical.md
@@ -1,0 +1,37 @@
+# Track 2 Technical Review
+
+## Iteration 1
+
+### Finding T1 [should-fix]
+**Location**: Track 2 description + D5 — `isPropertyEqualTo()` return type
+**Issue**: Plan D5 still documents `Optional<Boolean>` but Track 1 implemented `InPlaceResult` enum. Track 2 dispatch must use `InPlaceResult.TRUE/FALSE/FALLBACK`, not `Optional` API.
+**Proposed fix**: Address in step decomposition — specify InPlaceResult dispatch pattern.
+
+### Finding T2 [should-fix]
+**Location**: Track 2 — extracting EntityImpl from Result
+**Issue**: `currentRecord.isEntity()` returns true even for unloaded RIDs. `asEntity()` may trigger disk loading. Safer to check `instanceof EntityImpl` directly on the underlying identifiable.
+**Proposed fix**: Use pattern matching: check if the result's identifiable is an EntityImpl without triggering loading.
+
+### Finding T3 [should-fix]
+**Location**: Track 2 — FALLBACK path
+**Issue**: If in-place returns FALLBACK, `right.execute()` would be called twice (once for optimization, once for standard path).
+**Proposed fix**: Compute `rightVal` once before optimization attempt; reuse on FALLBACK.
+
+### Finding T4 [suggestion]
+**Location**: Track 2 — imports in generated file
+**Issue**: SQLBinaryCondition.java is generated; imports must preserve JavaCC header.
+**Proposed fix**: Note in step: preserve `OriginalChecksum` comment, run spotless:apply.
+
+### Finding T5 [suggestion]
+**Location**: Track 2 — evaluate(Identifiable) overload collation
+**Issue**: Existing `evaluate(Identifiable, ctx)` never applies collation. The Identifiable overload should intentionally skip the collation guard.
+**Proposed fix**: Document intentional omission; don't add collation guard to Identifiable path.
+
+### Finding T6 [suggestion]
+**Location**: Track 2 — operator dispatch
+**Issue**: Range operators implement `isRangeOperator()`. Can simplify dispatch.
+**Proposed fix**: Use `operator.isRangeOperator()` instead of four separate instanceof checks.
+
+## Summary
+- 0 blockers, 3 should-fix, 3 suggestions
+- **PASS** — no blockers, should-fix items addressed in step decomposition

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (2/4 complete)
+- [ ] Step implementation (3/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -113,37 +113,13 @@ isPropertyEqualTo(name, value) / comparePropertyTo(name, value):
   >
   > **Key files:** `InPlaceComparator.java` (modified), `InPlaceComparatorNonNumericTest.java` (new)
 
-- [ ] Step 3: InPlaceResult enum + EntityImpl comparison methods
-  > Add the `InPlaceResult` enum and two new public methods to EntityImpl:
-  > `isPropertyEqualTo(String, Object)` and `comparePropertyTo(String, Object)`.
+- [x] Step 3: InPlaceResult enum + EntityImpl comparison methods
+  - [x] Context: warning
+  > **What was done:** Added `InPlaceResult` enum (TRUE/FALSE/FALLBACK) and two new methods on EntityImpl: `isPropertyEqualTo` and `comparePropertyTo`. Both check properties map first (without triggering deserialization), then fall back to serialized source bytes via InPlaceComparator. Handles all guards: status, propertyAccess, encryption, collation, null values. Shared `deserializeFieldForComparison` helper eliminates DRY violations. Single `compareJavaValuesOrdering` method handles all type-aware comparisons.
   >
-  > Key design points:
-  > - `InPlaceResult { TRUE, FALSE, FALLBACK }` — replaces `Optional<Boolean>`
-  >   per review finding A3
-  > - `isPropertyEqualTo` returns `InPlaceResult`
-  > - `comparePropertyTo` returns `OptionalInt` (empty = fallback)
-  > - Both methods share the same dispatch logic (see state matrix above)
-  > - Call `checkForBinding()` first (T3)
-  > - Check `status == STATUS.LOADED` (R2)
-  > - Check `propertyAccess` (D6)
-  > - Properties map path: `containsKey` (not `get`), navigate EntityEntry
-  >   (`exists()`, null value, null type → fallback) (R1, A4)
-  > - Deserialized comparison: type-aware, same conversion as InPlaceComparator,
-  >   NOT `Objects.equals` (T1)
-  > - Source path: check encryption (R6), null iClass (R7), collation on
-  >   BinaryField (T7), delegate to InPlaceComparator
-  > - `deserializeField()` returning null → fallback (covers zero-length fields
-  >   and non-comparable types) (A7, T6)
+  > **What was discovered:** Three review-caught bugs: (1) `serializeAndReload` via `ser.fromStream` fully deserializes and clears `source`, so tests never exercised the serialized path — fixed with `fromStream(byte[])`. (2) Float/Double truncation via `longValue()` in INTEGER/LONG/SHORT/BYTE comparison — fixed by rejecting Float/Double values. (3) BINARY deserialized path used `byte[].equals()` (reference equality) — fixed with `Arrays.compare` case.
   >
-  > Unit tests using save→reload pattern to preserve `source`:
-  > - All dispatch paths (properties null, entry present/absent/deleted,
-  >   source null, status checks)
-  > - Guard paths (encryption, collation, propertyAccess)
-  > - Partially deserialized entity (one property read, another compared in-place)
-  > - Schema-less entity
-  >
-  > **Files**: `InPlaceResult.java` (new), `EntityImpl.java` (modify),
-  > `EntityImplInPlaceComparisonTest.java` (new)
+  > **Key files:** `InPlaceResult.java` (new), `EntityImpl.java` (modified), `EntityImplInPlaceComparisonTest.java` (new)
 
 - [ ] Step 4: Cross-path equivalence tests
   > Comprehensive test suite verifying that in-place comparison produces

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -5,6 +5,9 @@
 - [ ] Step implementation
 - [ ] Track-level code review
 
+## Base commit
+`44955206a4`
+
 ## Reviews completed
 - [x] Technical
 - [x] Risk

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (1/4 complete)
+- [ ] Step implementation (2/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -103,36 +103,15 @@ isPropertyEqualTo(name, value) / comparePropertyTo(name, value):
   >
   > **Key files:** `InPlaceComparator.java` (new), `InPlaceComparatorNumericTest.java` (new)
 
-- [ ] Step 2: InPlaceComparator — non-numeric types (STRING, BOOLEAN, DATETIME, DATE, DECIMAL, BINARY, LINK)
-  > Extend InPlaceComparator with comparison methods for the remaining 7
-  > binary-comparable types.
+- [x] Step 2: InPlaceComparator — non-numeric types (STRING, BOOLEAN, DATETIME, DATE, DECIMAL, BINARY, LINK)
+  - [x] Context: info
+  > **What was done:** Extended InPlaceComparator with 7 non-numeric types. Added `compare(BinaryField, Object, TimeZone)` overload for DATE timezone support. STRING via `readString()`+`compareTo()`, BOOLEAN via byte read+`Boolean.compare()`, DATETIME via VarInt millis, DATE via days*MILLISEC_PER_DAY+`convertDayToTimezone()`, DECIMAL via `staticDeserialize()`+`BigDecimal.compareTo()`, BINARY via `readBinary()`+`Arrays.compare()`, LINK equality only (ordering returns empty). 60+ tests including non-GMT timezone, Identifiable path, Float-to-DECIMAL precision.
   >
-  > Key design points:
-  > - STRING: read length + UTF-8 bytes via `HelperClasses.readString()`;
-  >   compare with `String.compareTo()`. No collation support (falls back
-  >   at EntityImpl level).
-  > - BOOLEAN: read single byte; compare as boolean values
-  > - DATETIME: read long millis via `VarIntSerializer.readAsLong()`;
-  >   compare passed-in `Date.getTime()` as long
-  > - DATE: read days-since-epoch via `VarIntSerializer.readAsLong()`;
-  >   apply `HelperClasses.convertDayToTimezone()` then compare against
-  >   passed-in `Date.getTime()` converted back to millis
-  > - DECIMAL: `DecimalSerializer.staticDeserialize(bytes.bytes, bytes.offset)`;
-  >   allocates BigDecimal (acknowledged perf gap). Use `BigDecimal.compareTo()`
-  >   (not `equals()`). Convert passed-in value via `BigDecimal.valueOf()`
-  >   for doubles.
-  > - BINARY: compare byte arrays with `Arrays.compare()`
-  > - LINK: read clusterId + clusterPosition via `readOptimizedLink()`;
-  >   for `compare()`, return `OptionalInt.empty()` (ordering undefined).
-  >   For `isEqual()`, compare both components.
+  > **What was discovered:** Review caught DECIMAL bug — `bytes.offset` not advanced after `staticDeserialize()` (unlike all other types that advance offset via read methods). Fixed by adding `bytes.skip(staticGetObjectSize(...))`. Also: DATE requires `TimeZone` parameter, so added overloaded `compare`/`isEqual` that accept optional timezone.
   >
-  > Excluded types (always fall back): EMBEDDED, EMBEDDEDLIST, EMBEDDEDSET,
-  > EMBEDDEDMAP, LINKLIST, LINKSET, LINKMAP, LINKBAG.
+  > **What changed from the plan:** Added `TimeZone` parameter to `compare`/`isEqual` signatures. Step 3 (EntityImpl) will need to pass the database timezone when calling these methods for DATE fields.
   >
-  > Unit tests: all 7 types, edge cases (empty string perf gap documented,
-  > DATE timezone, DECIMAL scale differences, LINK equality, null values).
-  >
-  > **Files**: `InPlaceComparator.java` (extend), `InPlaceComparatorNonNumericTest.java` (new)
+  > **Key files:** `InPlaceComparator.java` (modified), `InPlaceComparatorNonNumericTest.java` (new)
 
 - [ ] Step 3: InPlaceResult enum + EntityImpl comparison methods
   > Add the `InPlaceResult` enum and two new public methods to EntityImpl:

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -3,7 +3,7 @@
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation (4/4 complete)
-- [ ] Track-level code review
+- [ ] Track-level code review (1/3 iterations)
 
 ## Base commit
 `44955206a4`

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -3,7 +3,7 @@
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation (4/4 complete)
-- [ ] Track-level code review (1/3 iterations)
+- [x] Track-level code review (2/3 iterations — pass)
 
 ## Base commit
 `44955206a4`

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation
+- [ ] Step implementation (1/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -95,34 +95,13 @@ isPropertyEqualTo(name, value) / comparePropertyTo(name, value):
 
 ## Steps
 
-- [ ] Step 1: InPlaceComparator — numeric types with type conversion
-  > Create new `InPlaceComparator` utility class with static methods for
-  > binary comparison of numeric property types: INTEGER, LONG, SHORT, BYTE,
-  > FLOAT, DOUBLE. Implement the type conversion infrastructure that converts
-  > a passed-in Java value to the property's serialized type before same-type
-  > comparison.
+- [x] Step 1: InPlaceComparator — numeric types with type conversion
+  - [x] Context: safe
+  > **What was done:** Created `InPlaceComparator` utility class with `compare(BinaryField, Object)` → `OptionalInt` and `isEqual(BinaryField, Object)` → `OptionalInt` (1/0/empty). Supports INTEGER, LONG, SHORT, BYTE, FLOAT, DOUBLE with type conversion infrastructure. Precision boundaries: 2^24 for int→float, 2^53 for long→double. Float/Double→integer always falls back. 90+ unit tests covering all 6 types, all cross-type combinations, precision boundaries, NaN/-0.0/infinity, BigDecimal/BigInteger fallback.
   >
-  > Key design points:
-  > - Main entry: `static OptionalInt compare(BinaryField field, Object value)`
-  >   dispatches by `field.type`
-  > - Main entry: `static InPlaceResult isEqual(BinaryField field, Object value)`
-  >   derives from compare (can optimize STRING later)
-  > - Use `Float.compare()` / `Double.compare()` for NaN and -0.0 correctness
-  > - Float↔Double: always widen to double precision (compare at double when
-  >   either operand is double)
-  > - Integer narrowing: range check `value >= Type.MIN_VALUE && value <= Type.MAX_VALUE`
-  > - Integer→Float precision: safe only if `|value| <= (1 << 24)` (2^24)
-  > - Long→Double precision: safe only if `|value| <= (1L << 53)` (2^53)
-  > - Float→integer, Double→integer: always fall back
-  > - Conversion failure → return `OptionalInt.empty()`
-  > - Read serialized values using `HelperClasses` / `VarIntSerializer` methods
+  > **What was discovered:** Review caught a blocker: `convertToFloat` and `convertToDouble` had a silent truncation bug for `BigDecimal`/`BigInteger` values that fell through to the integer catch-all path via `longValue()`. Fixed by adding explicit guards for standard integer boxed types only.
   >
-  > Unit tests: all 6 numeric types, cross-type conversion (Integer→Long,
-  > Long→Short with overflow, Double→Float precision loss, Float→Integer
-  > fallback), edge cases (NaN, -0.0, MAX_VALUE, MIN_VALUE, precision
-  > boundaries at 2^24 and 2^53).
-  >
-  > **Files**: `InPlaceComparator.java` (new), `InPlaceComparatorNumericTest.java` (new)
+  > **Key files:** `InPlaceComparator.java` (new), `InPlaceComparatorNumericTest.java` (new)
 
 - [ ] Step 2: InPlaceComparator — non-numeric types (STRING, BOOLEAN, DATETIME, DATE, DECIMAL, BINARY, LINK)
   > Extend InPlaceComparator with comparison methods for the remaining 7

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (3/4 complete)
+- [x] Step implementation (4/4 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -121,27 +121,10 @@ isPropertyEqualTo(name, value) / comparePropertyTo(name, value):
   >
   > **Key files:** `InPlaceResult.java` (new), `EntityImpl.java` (modified), `EntityImplInPlaceComparisonTest.java` (new)
 
-- [ ] Step 4: Cross-path equivalence tests
-  > Comprehensive test suite verifying that in-place comparison produces
-  > identical results to the standard deserialization + Java comparison path
-  > for all supported types and edge cases.
+- [x] Step 4: Cross-path equivalence tests
+  - [x] Context: info
+  > **What was done:** Created `InPlaceComparisonEquivalenceTest` with 43 test methods verifying cross-path equivalence. Uses `expectedEquality`/`expectedOrdering` helper methods that replicate Java comparison semantics as an oracle, comparing source-path (InPlaceComparator) results against deserialized-path results. Covers all 13 binary-comparable types (matching + non-matching + ordering), cross-type numeric conversions (Integer vs Long/Short/Byte, Float vs Double/Integer, Double vs Long/Integer), precision boundaries (2^24 ± 1 for int→float, 2^53 ± 1 for long→double, including above-boundary), Float/Double edge cases (NaN, -0.0, ±Infinity for both), DECIMAL different scales + double/float conversion artifacts, DATE with timezone, null handling, empty string, partially deserialized entities, non-comparable types (EMBEDDED, EMBEDDEDLIST, EMBEDDEDMAP → FALLBACK), LINK equality (source vs deserialized asymmetry), Float/Double→integer fallback, and Integer/Byte boundary values.
   >
-  > Test matrix:
-  > - All 13 binary-comparable types with matching values (→ equal)
-  > - All 13 types with non-matching values (→ not equal, correct ordering)
-  > - Cross-type numeric: Integer property vs Long value, Short vs Integer,
-  >   Float vs Double, Integer vs Double, etc.
-  > - Precision boundary values: 2^24 ± 1 for int→float, 2^53 ± 1 for long→double
-  > - Float/Double edge cases: NaN, -0.0, +Infinity, -Infinity
-  > - DECIMAL: different scales (`1.0` vs `1`), double conversion artifacts
-  > - DATE: different timezones (verify convertDayToTimezone correctness)
-  > - Null property value, null comparison value
-  > - Empty string (verifies graceful fallback for zero-length field)
-  > - Partially deserialized entities (mix of map and source lookups)
-  > - Property types that fall back (EMBEDDED, LINKLIST, etc.)
+  > **What was discovered:** (1) Empty string via source path returns TRUE (not FALLBACK as previously documented in track review findings A7). The `deserializeField` handles zero-length string fields correctly. (2) LINK type has an intentional asymmetry: source path supports equality via InPlaceComparator, but deserialized path returns FALLBACK because `compareJavaValuesOrdering` returns empty for LINK (by design — ordering not supported, and equality delegates through ordering).
   >
-  > Pattern: for each test case, create entity with property, save, reload,
-  > then assert `isPropertyEqualTo` / `comparePropertyTo` matches
-  > `getProperty()` + Java comparison.
-  >
-  > **Files**: `InPlaceComparisonEquivalenceTest.java` (new)
+  > **Key files:** `InPlaceComparisonEquivalenceTest.java` (new)

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-1.md
@@ -1,0 +1,210 @@
+# Track 1: InPlaceComparator and EntityImpl comparison methods
+
+## Progress
+- [x] Review + decomposition
+- [ ] Step implementation
+- [ ] Track-level code review
+
+## Reviews completed
+- [x] Technical
+- [x] Risk
+- [x] Adversarial
+
+## Review findings summary
+
+### Blockers addressed in decomposition
+- **Properties null + containsKey semantics** (R1, T2, A11): Full state matrix
+  implemented in Step 3. Uses `containsKey` + `entry.exists()` + null guards.
+- **Deserialized path needs type-aware comparison** (T1): Step 3 uses the same
+  type conversion as InPlaceComparator, not `Objects.equals`.
+- **deserializeField returns null for zero-length fields** (A7): Known performance
+  gap in v1. Zero-length fields (empty strings, defaults) fall back to
+  deserialization. Documented here.
+- **BinaryField BytesContainer is ephemeral** (A2, R3): Each call creates a fresh
+  `BytesContainer`. InPlaceComparator consumes it once. Documented as invariant.
+
+### Should-fix items incorporated
+- Status check (R2): `status != STATUS.LOADED` → fallback (Step 3)
+- Float/Double use `Float.compare`/`Double.compare` (R5, T8) (Steps 1-2)
+- Float↔Double: widen to double precision (A5) (Step 1)
+- Integer→float precision: safe if |value| ≤ 2^24 (float), 2^53 (double) (A9, R8) (Step 1)
+- DECIMAL: `BigDecimal.compareTo()`, not `equals()` (R4, T4) (Step 2)
+- Encrypted properties → fallback (R6, T5) (Step 3)
+- `InPlaceResult` enum replaces `Optional<Boolean>` (A3) (Step 3)
+- `checkForBinding()` in new public methods (T3) (Step 3)
+- `entry.type == null` → fallback to Java comparison (A4) (Step 3)
+- BinaryField.collate check for defense-in-depth (R9, T7) (Step 3)
+- LINK: equality only for `comparePropertyTo`; ordering returns empty (R10) (Step 2)
+- DATE timezone via `convertDayToTimezone` (R11) (Step 2)
+- Null iClass → fallback (R7, T9) (Step 3)
+- Binary-comparability check redundant — rely on `deserializeField()` (T6) (Step 3)
+
+### Suggestions incorporated
+- Explicit excluded types: EMBEDDED, EMBEDDEDLIST, EMBEDDEDSET, EMBEDDEDMAP,
+  LINKLIST, LINKSET, LINKMAP, LINKBAG (A8)
+- Step sequencing: InPlaceComparator standalone first, then EntityImpl (A6)
+
+### Out of scope
+- BinaryComparatorV0 reconciliation (A10) — follow-up after Track 2
+
+## EntityImpl dispatch state matrix
+
+Used by Step 3. Covers all combinations of `properties` and `source` state.
+
+```
+isPropertyEqualTo(name, value) / comparePropertyTo(name, value):
+
+1. checkForBinding()
+2. if (status != STATUS.LOADED) → FALLBACK
+3. if (propertyAccess != null && !propertyAccess.isReadable(name)) → FALLBACK
+
+4. if (properties != null && properties.containsKey(name)):
+   a. entry = properties.get(name)
+   b. if (!entry.exists()) → FALLBACK  // property deleted
+   c. entryValue = entry.value
+   d. if (entryValue == null || value == null) → FALLBACK  // null handling
+   e. if (entry.type == null) → FALLBACK  // schema-less, type unknown
+   f. Convert value to entry.type using same conversion as InPlaceComparator
+   g. If conversion fails → FALLBACK
+   h. Compare using type-appropriate Java comparison (Float.compare, etc.)
+   i. Return result
+
+5. else if (source != null):
+   a. session = getSessionIfAlive()
+   b. if (session == null) → FALLBACK
+   c. schemaClass = getImmutableSchemaClass(session)
+   d. if (value == null) → FALLBACK
+   e. encryption = propertyEncryption
+   f. if (encryption != null && !(encryption instanceof PropertyEncryptionNone)
+         && encryption.isEncrypted(name)) → FALLBACK
+   g. serializer = RecordSerializerBinary.INSTANCE.getSerializer(source[0])
+   h. bytes = new BytesContainer(source, 1)
+   i. field = serializer.deserializeField(session, bytes, schemaClass, name,
+         isEmbedded(), session.getMetadata().getImmutableSchemaSnapshot(),
+         encryption)
+   j. if (field == null) → FALLBACK  // not found or zero-length or non-comparable
+   k. if (field.collate != null && !(field.collate instanceof DefaultCollate))
+         → FALLBACK
+   l. return InPlaceComparator.compare(field, value) / .isEqual(field, value)
+
+6. else → FALLBACK  // no properties, no source
+```
+
+## Steps
+
+- [ ] Step 1: InPlaceComparator — numeric types with type conversion
+  > Create new `InPlaceComparator` utility class with static methods for
+  > binary comparison of numeric property types: INTEGER, LONG, SHORT, BYTE,
+  > FLOAT, DOUBLE. Implement the type conversion infrastructure that converts
+  > a passed-in Java value to the property's serialized type before same-type
+  > comparison.
+  >
+  > Key design points:
+  > - Main entry: `static OptionalInt compare(BinaryField field, Object value)`
+  >   dispatches by `field.type`
+  > - Main entry: `static InPlaceResult isEqual(BinaryField field, Object value)`
+  >   derives from compare (can optimize STRING later)
+  > - Use `Float.compare()` / `Double.compare()` for NaN and -0.0 correctness
+  > - Float↔Double: always widen to double precision (compare at double when
+  >   either operand is double)
+  > - Integer narrowing: range check `value >= Type.MIN_VALUE && value <= Type.MAX_VALUE`
+  > - Integer→Float precision: safe only if `|value| <= (1 << 24)` (2^24)
+  > - Long→Double precision: safe only if `|value| <= (1L << 53)` (2^53)
+  > - Float→integer, Double→integer: always fall back
+  > - Conversion failure → return `OptionalInt.empty()`
+  > - Read serialized values using `HelperClasses` / `VarIntSerializer` methods
+  >
+  > Unit tests: all 6 numeric types, cross-type conversion (Integer→Long,
+  > Long→Short with overflow, Double→Float precision loss, Float→Integer
+  > fallback), edge cases (NaN, -0.0, MAX_VALUE, MIN_VALUE, precision
+  > boundaries at 2^24 and 2^53).
+  >
+  > **Files**: `InPlaceComparator.java` (new), `InPlaceComparatorNumericTest.java` (new)
+
+- [ ] Step 2: InPlaceComparator — non-numeric types (STRING, BOOLEAN, DATETIME, DATE, DECIMAL, BINARY, LINK)
+  > Extend InPlaceComparator with comparison methods for the remaining 7
+  > binary-comparable types.
+  >
+  > Key design points:
+  > - STRING: read length + UTF-8 bytes via `HelperClasses.readString()`;
+  >   compare with `String.compareTo()`. No collation support (falls back
+  >   at EntityImpl level).
+  > - BOOLEAN: read single byte; compare as boolean values
+  > - DATETIME: read long millis via `VarIntSerializer.readAsLong()`;
+  >   compare passed-in `Date.getTime()` as long
+  > - DATE: read days-since-epoch via `VarIntSerializer.readAsLong()`;
+  >   apply `HelperClasses.convertDayToTimezone()` then compare against
+  >   passed-in `Date.getTime()` converted back to millis
+  > - DECIMAL: `DecimalSerializer.staticDeserialize(bytes.bytes, bytes.offset)`;
+  >   allocates BigDecimal (acknowledged perf gap). Use `BigDecimal.compareTo()`
+  >   (not `equals()`). Convert passed-in value via `BigDecimal.valueOf()`
+  >   for doubles.
+  > - BINARY: compare byte arrays with `Arrays.compare()`
+  > - LINK: read clusterId + clusterPosition via `readOptimizedLink()`;
+  >   for `compare()`, return `OptionalInt.empty()` (ordering undefined).
+  >   For `isEqual()`, compare both components.
+  >
+  > Excluded types (always fall back): EMBEDDED, EMBEDDEDLIST, EMBEDDEDSET,
+  > EMBEDDEDMAP, LINKLIST, LINKSET, LINKMAP, LINKBAG.
+  >
+  > Unit tests: all 7 types, edge cases (empty string perf gap documented,
+  > DATE timezone, DECIMAL scale differences, LINK equality, null values).
+  >
+  > **Files**: `InPlaceComparator.java` (extend), `InPlaceComparatorNonNumericTest.java` (new)
+
+- [ ] Step 3: InPlaceResult enum + EntityImpl comparison methods
+  > Add the `InPlaceResult` enum and two new public methods to EntityImpl:
+  > `isPropertyEqualTo(String, Object)` and `comparePropertyTo(String, Object)`.
+  >
+  > Key design points:
+  > - `InPlaceResult { TRUE, FALSE, FALLBACK }` — replaces `Optional<Boolean>`
+  >   per review finding A3
+  > - `isPropertyEqualTo` returns `InPlaceResult`
+  > - `comparePropertyTo` returns `OptionalInt` (empty = fallback)
+  > - Both methods share the same dispatch logic (see state matrix above)
+  > - Call `checkForBinding()` first (T3)
+  > - Check `status == STATUS.LOADED` (R2)
+  > - Check `propertyAccess` (D6)
+  > - Properties map path: `containsKey` (not `get`), navigate EntityEntry
+  >   (`exists()`, null value, null type → fallback) (R1, A4)
+  > - Deserialized comparison: type-aware, same conversion as InPlaceComparator,
+  >   NOT `Objects.equals` (T1)
+  > - Source path: check encryption (R6), null iClass (R7), collation on
+  >   BinaryField (T7), delegate to InPlaceComparator
+  > - `deserializeField()` returning null → fallback (covers zero-length fields
+  >   and non-comparable types) (A7, T6)
+  >
+  > Unit tests using save→reload pattern to preserve `source`:
+  > - All dispatch paths (properties null, entry present/absent/deleted,
+  >   source null, status checks)
+  > - Guard paths (encryption, collation, propertyAccess)
+  > - Partially deserialized entity (one property read, another compared in-place)
+  > - Schema-less entity
+  >
+  > **Files**: `InPlaceResult.java` (new), `EntityImpl.java` (modify),
+  > `EntityImplInPlaceComparisonTest.java` (new)
+
+- [ ] Step 4: Cross-path equivalence tests
+  > Comprehensive test suite verifying that in-place comparison produces
+  > identical results to the standard deserialization + Java comparison path
+  > for all supported types and edge cases.
+  >
+  > Test matrix:
+  > - All 13 binary-comparable types with matching values (→ equal)
+  > - All 13 types with non-matching values (→ not equal, correct ordering)
+  > - Cross-type numeric: Integer property vs Long value, Short vs Integer,
+  >   Float vs Double, Integer vs Double, etc.
+  > - Precision boundary values: 2^24 ± 1 for int→float, 2^53 ± 1 for long→double
+  > - Float/Double edge cases: NaN, -0.0, +Infinity, -Infinity
+  > - DECIMAL: different scales (`1.0` vs `1`), double conversion artifacts
+  > - DATE: different timezones (verify convertDayToTimezone correctness)
+  > - Null property value, null comparison value
+  > - Empty string (verifies graceful fallback for zero-length field)
+  > - Partially deserialized entities (mix of map and source lookups)
+  > - Property types that fall back (EMBEDDED, LINKLIST, etc.)
+  >
+  > Pattern: for each test case, create entity with property, save, reload,
+  > then assert `isPropertyEqualTo` / `comparePropertyTo` matches
+  > `getProperty()` + Java comparison.
+  >
+  > **Files**: `InPlaceComparisonEquivalenceTest.java` (new)

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
@@ -1,7 +1,7 @@
 # Track 2: SQLBinaryCondition integration
 
 ## Progress
-- [ ] Review + decomposition
+- [x] Review + decomposition
 - [ ] Step implementation
 - [ ] Track-level code review
 
@@ -12,3 +12,115 @@
 - [x] Risk
 
 ## Steps
+
+- [ ] Step 1: In-place comparison in `evaluate(Result, CommandContext)`
+  Add the in-place comparison fast path to the `evaluate(Result, CommandContext)`
+  method in `SQLBinaryCondition.java`. This is the primary integration point
+  used by modern SQL execution (SELECT, MATCH).
+
+  **Pattern detection guard** (all must be true to attempt in-place):
+  - `!left.isFunctionAny() && !left.isFunctionAll()` — already handled by
+    early returns, so the guard goes after those
+  - `left.isBaseIdentifier()` — property reference, not expression/function
+  - `right.isEarlyCalculated(ctx)` — constant or parameter, not subquery
+  - `left.getCollate(currentRecord, ctx) == null` AND
+    `right.getCollate(currentRecord, ctx) == null` — no collation
+    (v1 limitation: collated comparisons fall back)
+  - `currentRecord instanceof ResultInternal ri` — need access to underlying
+    identifiable
+  - `ri.asEntityOrNull() instanceof EntityImpl entityImpl` — entity must be
+    loaded and concrete EntityImpl (not raw RID, not projection result).
+    `asEntityOrNull()` is safe: returns null for non-entities without throwing
+  - Operator is supported: `operator instanceof SQLEqualsOperator`,
+    `operator instanceof SQLNeqOperator`, `operator instanceof SQLNeOperator`,
+    or `operator.isRangeOperator()` (covers Lt, Gt, Le, Ge)
+
+  **Property name extraction** (zero-allocation):
+  Use direct traversal instead of `getDefaultAlias()` (which allocates
+  `new SQLIdentifier()` per call — see R3):
+  ```java
+  ((SQLBaseExpression) left.mathExpression)
+      .getIdentifier().getSuffix().getIdentifier().getStringValue()
+  ```
+  This is safe because `isBaseIdentifier()` guarantees the structure.
+
+  **Right value computation**:
+  Compute `rightVal = right.execute(currentRecord, ctx)` ONCE before attempting
+  in-place. On FALLBACK, pass `rightVal` into the standard path to avoid
+  double evaluation (T3/R4).
+
+  **Operator dispatch**:
+  - Equality (`SQLEqualsOperator`): `entityImpl.isPropertyEqualTo(propName, rightVal)`
+    → `InPlaceResult.TRUE` returns `true`, `FALSE` returns `false`,
+    `FALLBACK` falls through
+  - Not-equal (`SQLNeqOperator`, `SQLNeOperator`): same call, negate result
+    (TRUE → `false`, FALSE → `true`, FALLBACK falls through)
+  - Range (`isRangeOperator()`): `entityImpl.comparePropertyTo(propName, rightVal)`
+    → `OptionalInt` present: interpret sign per operator (Lt: `cmp < 0`,
+    Gt: `cmp > 0`, Le: `cmp <= 0`, Ge: `cmp >= 0`). Empty: FALLBACK
+
+  **FALLBACK path**:
+  When in-place returns FALLBACK, must still compute `leftVal`:
+  ```java
+  var leftVal = left.execute(currentRecord, ctx);
+  // rightVal already computed
+  // apply collation (will be null since we checked, but keep structure
+  // consistent with the non-optimized path)
+  return operator.execute(ctx.getDatabaseSession(), leftVal, rightVal);
+  ```
+
+  **Note on SQLGetInternalPropertyExpression**: `isBaseIdentifier()` returns
+  true for internal property expressions (from MATCH graph navigation
+  flattening). These safely FALLBACK — internal properties are not in the
+  properties map or serialized property index (R5).
+
+  **Files**: `SQLBinaryCondition.java` (production), new or existing test class
+  **Tests**: SQL SELECT queries exercising all 7 operators with integer, string,
+  double, and boolean types. Include records fetched from DB (serialized source)
+  to ensure the in-place path is exercised. Verify null property handling
+  falls back correctly.
+
+- [ ] Step 2: In-place comparison in `evaluate(Identifiable, CommandContext)`
+  Add the same in-place comparison fast path to the
+  `evaluate(Identifiable, CommandContext)` overload. This overload is used by
+  `SQLContainsCondition`, `SQLContainsAllCondition`, and
+  `SQLContainsAnyCondition` when iterating over collection items.
+
+  **Key differences from the Result overload**:
+  - `currentRecord` is an `Identifiable`, not a `Result`
+  - Check `currentRecord instanceof EntityImpl entityImpl` directly
+  - **No collation guard** — the existing overload never applies collation,
+    so omitting the check preserves behavioral parity (T5/R2)
+  - Same pattern detection otherwise: `left.isBaseIdentifier()`,
+    `right.isEarlyCalculated(ctx)`, supported operator
+
+  **Operator dispatch**: identical to Step 1 (can extract a shared private
+  method to avoid duplication if appropriate).
+
+  **FALLBACK**: reuse rightVal, compute leftVal, call `operator.execute()`.
+
+  **Files**: `SQLBinaryCondition.java` (production), test class
+  **Tests**: SQL queries using CONTAINS with EntityImpl items to exercise the
+  Identifiable path. Verify non-EntityImpl identifiables pass through to
+  the existing path.
+
+- [ ] Step 3: MATCH and edge case integration tests
+  Comprehensive SQL-level integration tests ensuring end-to-end correctness
+  across both query engines (SELECT and MATCH) and edge cases.
+
+  **MATCH queries**: WHERE clauses in MATCH patterns should exercise the
+  Result-based `evaluate()` path. Verify all 7 operators produce correct
+  results in MATCH context.
+
+  **Edge cases to cover**:
+  - Collated string queries fall back correctly (not silently wrong)
+  - Non-entity results (projection-only queries) pass through without error
+  - Type conversion: integer property vs long literal, float vs double, etc.
+  - Null property values → correct SQL NULL semantics (fall back to standard path)
+  - Null right-hand value → correct behavior
+  - Multiple WHERE conditions on the same record (each independently optimized)
+  - Properties not in schema (schema-less mode) — fall back correctly
+  - Encrypted properties — fall back correctly (if testable)
+
+  **Files**: test class only (no production code changes)
+  **Tests**: focused on breadth of coverage across query patterns and data types

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation
+- [ ] Step implementation (1/3 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -14,7 +14,8 @@
 
 ## Steps
 
-- [ ] Step 1: In-place comparison in `evaluate(Result, CommandContext)`
+- [x] Step 1: In-place comparison in `evaluate(Result, CommandContext)`
+  - [x] Context: safe
   Add the in-place comparison fast path to the `evaluate(Result, CommandContext)`
   method in `SQLBinaryCondition.java`. This is the primary integration point
   used by modern SQL execution (SELECT, MATCH).
@@ -80,6 +81,28 @@
   double, and boolean types. Include records fetched from DB (serialized source)
   to ensure the in-place path is exercised. Verify null property handling
   falls back correctly.
+
+  > **What was done:** Added in-place comparison fast path to
+  > `evaluate(Result, CommandContext)` in SQLBinaryCondition. The guard checks
+  > `isBaseIdentifier()`, `instanceof SQLBaseExpression` (filters out
+  > SQLGetInternalPropertyExpression), `isEarlyCalculated()`, no collation,
+  > and ResultInternal → EntityImpl unwrapping. Supports all 7 operators via
+  > `isPropertyEqualTo` (=, <>, !=) and `comparePropertyTo` (<, >, <=, >=)
+  > with `evaluateRangeResult()` helper. FALLBACK reuses pre-computed rightVal.
+  > 17 tests: 4 equality types, 2 not-equal variants, 4 range operators,
+  > string range, 2 null cases, cross-type, multi-WHERE, no-match, negative
+  > values (review fix TC1).
+  >
+  > **What was discovered:** SQL parser `SQLFloatingPoint.getValue()` casts
+  > double literals that fit in float range to `Float` (line 47:
+  > `if (Math.abs(returnValue) < Float.MAX_VALUE)`). This means `3.14` in SQL
+  > becomes `Float(3.14f)` but DOUBLE properties store `Double(3.14d)`.
+  > These differ in IEEE 754 representation. Used exact-representable values
+  > (2.5) in tests. Not a bug in the in-place path — the existing path has
+  > the same behavior.
+  >
+  > **Key files:** `SQLBinaryCondition.java` (modified),
+  > `SQLBinaryConditionInPlaceTest.java` (new)
 
 - [ ] Step 2: In-place comparison in `evaluate(Identifiable, CommandContext)`
   Add the same in-place comparison fast path to the

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (2/3 complete)
+- [x] Step implementation
 - [ ] Track-level code review
 
 ## Base commit
@@ -140,7 +140,8 @@
   > **Key files:** `SQLBinaryCondition.java` (modified),
   > `SQLBinaryConditionInPlaceTest.java` (modified)
 
-- [ ] Step 3: MATCH and edge case integration tests
+- [x] Step 3: MATCH and edge case integration tests
+  - [x] Context: info
   Comprehensive SQL-level integration tests ensuring end-to-end correctness
   across both query engines (SELECT and MATCH) and edge cases.
 
@@ -160,3 +161,10 @@
 
   **Files**: test class only (no production code changes)
   **Tests**: focused on breadth of coverage across query patterns and data types
+
+  > **What was done:** Added 7 integration tests: 3 MATCH queries (equality,
+  > range, not-equal), 1 MATCH with graph traversal + WHERE, 1 MATCH with
+  > multiple WHERE conditions, 1 non-entity projection (verifies pass-through),
+  > 1 schema-less property test. 25 total tests across all 3 steps.
+  >
+  > **Key files:** `SQLBinaryConditionInPlaceTest.java` (modified)

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
@@ -6,6 +6,7 @@
 - [ ] Track-level code review
 
 ## Base commit
+`aa78e7d452`
 
 ## Reviews completed
 - [x] Technical

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
@@ -3,7 +3,7 @@
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation
-- [ ] Track-level code review
+- [x] Track-level code review (1/3 iterations — all findings resolved)
 
 ## Base commit
 `aa78e7d452`

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
@@ -2,7 +2,7 @@
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation (1/3 complete)
+- [ ] Step implementation (2/3 complete)
 - [ ] Track-level code review
 
 ## Base commit
@@ -104,7 +104,8 @@
   > **Key files:** `SQLBinaryCondition.java` (modified),
   > `SQLBinaryConditionInPlaceTest.java` (new)
 
-- [ ] Step 2: In-place comparison in `evaluate(Identifiable, CommandContext)`
+- [x] Step 2: In-place comparison in `evaluate(Identifiable, CommandContext)`
+  - [x] Context: info
   Add the same in-place comparison fast path to the
   `evaluate(Identifiable, CommandContext)` overload. This overload is used by
   `SQLContainsCondition`, `SQLContainsAllCondition`, and
@@ -127,6 +128,17 @@
   **Tests**: SQL queries using CONTAINS with EntityImpl items to exercise the
   Identifiable path. Verify non-EntityImpl identifiables pass through to
   the existing path.
+
+  > **What was done:** Added in-place comparison to the Identifiable-based
+  > evaluate() overload. Extracted shared `tryInPlaceComparison()` method
+  > (returns Boolean, null = fallback) to eliminate code duplication between
+  > the two evaluate() overloads. No collation guard — the existing overload
+  > never applies collation. Test: `testContainsWithLinkedEntityCondition`
+  > using LINKLIST + CONTAINS (condition) syntax for both equality and range
+  > comparison.
+  >
+  > **Key files:** `SQLBinaryCondition.java` (modified),
+  > `SQLBinaryConditionInPlaceTest.java` (modified)
 
 - [ ] Step 3: MATCH and edge case integration tests
   Comprehensive SQL-level integration tests ensuring end-to-end correctness

--- a/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
+++ b/docs/adr/ytdb-628-in-place-comparison/tracks/track-2.md
@@ -1,0 +1,14 @@
+# Track 2: SQLBinaryCondition integration
+
+## Progress
+- [ ] Review + decomposition
+- [ ] Step implementation
+- [ ] Track-level code review
+
+## Base commit
+
+## Reviews completed
+- [x] Technical
+- [x] Risk
+
+## Steps


### PR DESCRIPTION
#### Motivation:

SQL WHERE clause evaluation currently deserializes every property value before comparison, even for simple equality and ordering checks. This is wasteful when the property is either already deserialized in the `properties` map or can be compared directly against its serialized bytes in the `source` buffer.

This PR adds an in-place comparison fast path that avoids unnecessary deserialization:

- **`InPlaceComparator`** — stateless utility that compares a `BinaryField` (serialized bytes + type tag) against a Java value, supporting 13 property types (all numerics, STRING, BOOLEAN, DATE/DATETIME, DECIMAL, LINK) with proper cross-type promotion and precision guards
- **`EntityImpl.isPropertyEqualTo()` / `comparePropertyTo()`** — dispatch methods that check the deserialized properties map first, then fall back to serialized byte comparison via `InPlaceComparator`
- **`SQLBinaryCondition.evaluate()`** — both overloads (`Result` and `Identifiable`) now attempt in-place comparison before the existing deserialization path
- **`InPlaceResult`** enum (TRUE/FALSE/FALLBACK) replaces `Optional<Boolean>` for clarity

Key design decisions:
- The deserialized path uses the same type conversion and precision guards as the serialized path to ensure cross-path equivalence
- LINK equality is supported; LINK ordering returns FALLBACK
- Non-default collations cause immediate fallback to preserve correctness
- Encrypted properties cause immediate fallback

All changes are in the `core` module. ~4200 lines of tests cover numeric types, non-numeric types, cross-path equivalence, MATCH integration, and edge cases.

## Test plan
- [x] `InPlaceComparatorNumericTest` — all 13 numeric cross-type combinations with precision guards
- [x] `InPlaceComparatorNonNumericTest` — STRING, BOOLEAN, DATE, DATETIME, DECIMAL, LINK
- [x] `InPlaceComparisonEquivalenceTest` — verifies deserialized and serialized paths produce identical results
- [x] `EntityImplInPlaceComparisonTest` — EntityImpl dispatch method tests
- [x] `SQLBinaryConditionInPlaceTest` — end-to-end SQL evaluation with MATCH queries and edge cases