### PR TITLE
Fix JMH compare workflow SIGPIPE failure in DB extraction

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -184,7 +184,7 @@ jobs:
 
           if [ -d "$DB_DIR/ldbc_benchmark" ]; then
             echo "Database found at expected path"
-            ls -la "$DB_DIR/ldbc_benchmark/" | head -20
+            ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
           elif [ -d "$DB_DIR/ldbc-bench-db/ldbc_benchmark" ]; then
             echo "::warning::Tar has nested ldbc-bench-db/ directory — relocating"
             # Move contents up one level to fix double-nesting
@@ -192,7 +192,7 @@ jobs:
             mv "$DB_DIR/ldbc-bench-db" "$tmp_dir"
             rm -rf "$DB_DIR"
             mv "$tmp_dir" "$DB_DIR"
-            ls -la "$DB_DIR/ldbc_benchmark/" | head -20
+            ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
           else
             echo "::error::Pre-built database missing 'ldbc_benchmark' directory."
             echo "Top-level contents:"
@@ -236,7 +236,7 @@ jobs:
                ! grep -qE '^[A-Za-z].*\s+sample\s+' /tmp/jmh-warm-base-${{ github.run_id }}.txt && \
                ! grep -qE '^[A-Za-z].*\s+ss\s+' /tmp/jmh-warm-base-${{ github.run_id }}.txt; then
               echo "::error::All warm-up benchmarks failed. Check database setup."
-              grep 'IllegalStateException\|Exception\|Error' /tmp/jmh-warm-base-${{ github.run_id }}.txt | head -5
+              grep 'IllegalStateException\|Exception\|Error' /tmp/jmh-warm-base-${{ github.run_id }}.txt | head -5 || true
               exit 1
             fi
           fi
@@ -291,14 +291,14 @@ jobs:
 
           if [ -d "$DB_DIR/ldbc_benchmark" ]; then
             echo "Database found at expected path"
-            ls -la "$DB_DIR/ldbc_benchmark/" | head -20
+            ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
           elif [ -d "$DB_DIR/ldbc-bench-db/ldbc_benchmark" ]; then
             echo "::warning::Tar has nested ldbc-bench-db/ directory — relocating"
             tmp_dir="${DB_DIR}_tmp_$$"
             mv "$DB_DIR/ldbc-bench-db" "$tmp_dir"
             rm -rf "$DB_DIR"
             mv "$tmp_dir" "$DB_DIR"
-            ls -la "$DB_DIR/ldbc_benchmark/" | head -20
+            ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
           else
             echo "::error::Pre-built database missing 'ldbc_benchmark' directory."
             echo "Top-level contents:"
@@ -340,7 +340,7 @@ jobs:
                ! grep -qE '^[A-Za-z].*\s+sample\s+' /tmp/jmh-warm-head-${{ github.run_id }}.txt && \
                ! grep -qE '^[A-Za-z].*\s+ss\s+' /tmp/jmh-warm-head-${{ github.run_id }}.txt; then
               echo "::error::All warm-up benchmarks failed. Check database setup."
-              grep 'IllegalStateException\|Exception\|Error' /tmp/jmh-warm-head-${{ github.run_id }}.txt | head -5
+              grep 'IllegalStateException\|Exception\|Error' /tmp/jmh-warm-head-${{ github.run_id }}.txt | head -5 || true
               exit 1
             fi
           fi


### PR DESCRIPTION
## Motivation

The JMH compare workflow fails at the "Base: extract pre-built database" step with
`ls: write error: Broken pipe` (exit code 2). This happens because `ls -la | head -20`
runs under `set -euo pipefail` — when `head` closes the pipe early after reading 20 lines,
`ls` receives SIGPIPE and returns a non-zero exit code, which `pipefail` propagates as
a step failure.

Failing run: https://github.com/JetBrains/youtrackdb/actions/runs/23746247592/job/69175566040

## Changes

Append `|| true` to all 6 diagnostic `| head` pipelines in `ldbc-jmh-compare.yml`:
- 4 × `ls -la ... | head -20` in Base/Head DB extraction steps
- 2 × `grep ... | head -5` in warm-up failure diagnostics

These pipelines are purely informational — their exit codes should never fail the step.

## Test plan

- [ ] Re-run the JMH compare workflow on a branch with a pre-built DB to verify the extraction step passes