### PR TITLE
YTDB-644: Index-assisted traversal for edge-method MATCH patterns

### DIFF
--- a/.claude/skills/profile-query-bottleneck/SKILL.md
+++ b/.claude/skills/profile-query-bottleneck/SKILL.md
@@ -52,15 +52,25 @@ ssh root@<IP> 'cd /tmp && \
 Run the target benchmark with async-profiler attached:
 
 ```bash
-ssh root@<IP> 'cd /root/ytdb && ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
-  -Dspotless.check.skip=true \
-  -Djmh.args="<BenchmarkClass>.<method> -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1 \
-  -prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so;output=flamegraph;dir=/root/profiles" \
+ssh root@<IP> 'cd /root/ytdb && mkdir -p /root/profiles && \
+  ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests -Dspotless.check.skip=true \
+  "-Djmh.args=<BenchmarkClass>.<method> -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1 \
+  -prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so\\;output=flamegraph\\;dir=/root/profiles" \
   2>&1 | tee /root/prof.log'
 ```
 
+**Critical — semicolon escaping**: The Maven exec plugin passes `${jmh.args}` through
+`/bin/sh -c`, so bare semicolons are interpreted as shell command separators. You **must**
+double-escape them as `\\;` inside the `-Djmh.args` value. Without this, the `-prof async`
+option silently receives truncated arguments and produces no output files.
+
 **Important**: Use `-t 1` (single thread) for profiling — multi-threaded profiles are
 harder to interpret and the contention patterns differ from the actual bottleneck.
+
+**Important**: Do NOT run any other CPU-intensive process (builds, other benchmarks,
+diagnostic programs) while profiling. Concurrent processes compete for CPU and memory,
+causing OOM kills (exit 137), corrupted profiles, and skewed results. Finish all other
+work first, then run the profiler on a quiet machine.
 
 Download the flame graphs:
 ```bash
@@ -70,10 +80,11 @@ scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-forward.html 
 
 ### 2b. Collapsed Stacks for Programmatic Analysis
 
-Run again with `output=collapsed` to get machine-parseable stacks:
+Run again with `output=collapsed` to get machine-parseable stacks (same escaping rules):
 
 ```bash
--prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so;output=collapsed;dir=/root/profiles2
+"-Djmh.args=<BenchmarkClass>.<method> -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1 \
+-prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so\\;output=collapsed\\;dir=/root/profiles2"
 ```
 
 Download:
@@ -223,11 +234,20 @@ public class QueryDiag {
   `Map<String, Object>` (not a `Result` instance). Cast directly to `Map`.
 - **DB locking**: If the program crashes or is killed, remove lock files before re-running:
   `find /root/ytdb/jmh-ldbc/target/ldbc-bench-db -name "*.lock" -exec rm -f {} \;`
+- **JMH lock file**: If JMH exits abnormally (OOM kill, SIGKILL), it leaves `/tmp/jmh.lock`.
+  Remove it before re-running: `rm -f /tmp/jmh.lock`
+- **SQL parser limitations**: The YouTrackDB SQL parser does not support function calls
+  like `out('KNOWS').size()` in ORDER BY. Always alias computed expressions first:
+  `SELECT out('KNOWS').size() as cnt ... ORDER BY cnt DESC` (not `ORDER BY out('KNOWS').size() DESC`)
 
 ### 3c. Compiling and Running
 
+**Important**: Run from the **project root** (`/root/ytdb`), not from `jmh-ldbc/`.
+The diagnostic program uses `./jmh-ldbc/target/ldbc-bench-db` as the DB path.
+The benchmark itself (JMH via Maven) runs from `jmh-ldbc/` and uses `./target/ldbc-bench-db`.
+
 ```bash
-# Compile against the uber-jar (has all dependencies)
+# From /root/ytdb — compile against the uber-jar (has all dependencies)
 javac -proc:none -cp "jmh-ldbc/target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar" QueryDiag.java
 
 # Run with required --add-opens flags
@@ -240,8 +260,12 @@ java --add-opens java.base/java.lang=ALL-UNNAMED \
      --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
      --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
      --add-opens java.base/java.net=ALL-UNNAMED \
+     --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED \
      -cp ".:jmh-ldbc/target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar" -Xmx4g QueryDiag
 ```
+
+Note: the `jdk.unsupported/sun.misc=ALL-UNNAMED` flag is required for the storage engine.
+Without it, the DB opens but fails with `InaccessibleObjectException` on first record load.
 
 ### 3d. What to Measure
 
@@ -339,16 +363,30 @@ hcloud ssh-key delete "$KEY_NAME"
 | Post | 1,192,942 |
 | Comment | ~2,000,000 |
 | Forum | 106,594 |
-| HAS_MEMBER edges | 3,260,692 |
+| Company | ~1,575 |
+| Country | ~111 |
 | KNOWS edges | ~360,000 |
 | HAS_CREATOR edges | ~3,200,000 |
+| HAS_MEMBER edges | 3,260,692 |
+| WORK_AT edges | 22,766 |
+| STUDY_AT edges | ~17,000 |
+| IS_LOCATED_IN edges | ~4,400,000 |
 
 Average degrees:
-- KNOWS: ~34 per person
+- KNOWS: ~34 per person (min 0, max 977)
 - HAS_CREATOR (Post only): ~112 posts per person
 - HAS_MEMBER: ~30 members per forum, ~307 forums per person
 - CONTAINER_OF: ~11 posts per forum
+- WORK_AT: ~2.15 per person (min 0, max 5)
+- Companies per country: ~14 on average
+
+WORK_AT.workFrom distribution (year → edge count):
+1998: 117, 1999: 411, 2000: 887, 2001: 1227, 2002: 1667, 2003: 1999,
+2004: 2155, 2005: 2127, 2006: 2168, 2007: 2332, 2008: 2252, 2009: 1918,
+2010: 1484, 2011: 1105, 2012: 825, 2013: 92
+→ 85% of WORK_AT edges have workFrom < 2010
 
 These numbers are essential for estimating query cost. A `while: ($depth < 2)` KNOWS
 traversal from a typical person produces 34 + 34*34 ≈ 1,190 paths (with duplicates),
-~800 distinct friends.
+~800 distinct friends. For high-degree persons (top 5 have 936-977 KNOWS), this
+explodes to ~51K paths (~8.4K distinct) with 6.1x duplication.

--- a/.claude/skills/profile-query-bottleneck/SKILL.md
+++ b/.claude/skills/profile-query-bottleneck/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: profile-query-bottleneck
+description: "Profile and diagnose YouTrackDB SQL/MATCH query bottlenecks. Combines async-profiler flame graphs, step-by-step selectivity measurement, and fan-out analysis on a Hetzner CCX33 server against the LDBC SF 1 dataset. Use when a query is slower than expected and you need to understand WHERE time is spent and WHY."
+user-invocable: true
+---
+
+# Profile Query Bottleneck
+
+Diagnose performance bottlenecks in YouTrackDB SQL and MATCH queries by combining
+CPU profiling (async-profiler), step-by-step selectivity analysis, and fan-out
+measurement on a dedicated Hetzner CCX33 server with the LDBC SF 1 dataset.
+
+## When to Use
+
+- A query is slower than expected after optimization
+- You need to understand WHERE time is spent (CPU profile) and WHY (data selectivity)
+- You want to quantify the fan-out at each step of a multi-step MATCH query
+- You need to decide between query rewrite vs engine-level optimization
+
+## Prerequisites
+
+- `hcloud` CLI installed and authenticated
+- SSH key pair at `~/.ssh/id_ed25519`
+- The `jmh-ldbc` module compiles locally
+- Hetzner S3 credentials in env vars (`HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`)
+
+## Phase 1: Infrastructure Setup
+
+Follow the `run-jmh-benchmarks-hetzner` skill's Steps 1–4 to:
+1. Provision a CCX33 server
+2. Install JDK 21, git, tmux, zstd, wget
+3. Deploy the project via rsync
+4. Download the pre-built LDBC SF 1 database from Hetzner S3
+5. Compile `jmh-ldbc`
+6. Run a pre-load fork to build curation caches
+
+Additionally install async-profiler:
+```bash
+ssh root@<IP> 'cd /tmp && \
+  wget -q https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz && \
+  tar xzf async-profiler-3.0-linux-x64.tar.gz && \
+  ln -sf /tmp/async-profiler-3.0-linux-x64 /opt/async-profiler && \
+  echo 1 > /proc/sys/kernel/perf_event_paranoid && \
+  echo 0 > /proc/sys/kernel/kptr_restrict && \
+  echo "async-profiler ready"'
+```
+
+## Phase 2: CPU Profiling with async-profiler
+
+### 2a. Flame Graph via JMH `-prof async`
+
+Run the target benchmark with async-profiler attached:
+
+```bash
+ssh root@<IP> 'cd /root/ytdb && ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+  -Dspotless.check.skip=true \
+  -Djmh.args="<BenchmarkClass>.<method> -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1 \
+  -prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so;output=flamegraph;dir=/root/profiles" \
+  2>&1 | tee /root/prof.log'
+```
+
+**Important**: Use `-t 1` (single thread) for profiling — multi-threaded profiles are
+harder to interpret and the contention patterns differ from the actual bottleneck.
+
+Download the flame graphs:
+```bash
+scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-reverse.html /tmp/flame-reverse.html
+scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-forward.html /tmp/flame-forward.html
+```
+
+### 2b. Collapsed Stacks for Programmatic Analysis
+
+Run again with `output=collapsed` to get machine-parseable stacks:
+
+```bash
+-prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so;output=collapsed;dir=/root/profiles2
+```
+
+Download:
+```bash
+scp root@<IP>:/root/profiles2/<benchmark-name>-Throughput/collapsed-cpu.csv /tmp/collapsed.csv
+```
+
+### 2c. Analyzing Collapsed Stacks
+
+The collapsed stack format is: `frame1;frame2;...;leafFrame count`
+
+**Find hottest leaf methods** (actual CPU consumers):
+```bash
+cat collapsed.csv | awk '{
+    n = split($0, parts, ";")
+    last = parts[n]
+    idx = match(last, / [0-9]+$/)
+    if (idx > 0) { count = substr(last, idx+1)+0; frame = substr(last, 1, idx-1) }
+    else next
+    leaves[frame] += count
+  } END { for (f in leaves) print leaves[f], f }' | sort -rn | head -30
+```
+
+**Aggregate by YouTrackDB/Gremlin method** (inclusive samples):
+```bash
+cat collapsed.csv | awk -F';' '{
+    n = split($0, parts, ";")
+    last = parts[n]; split(last, lp, " "); count = lp[length(lp)]
+    for (i=1; i<=n; i++) {
+      frame = parts[i]; if (i == n) { split(frame, fp, " "); frame = fp[1] }
+      if (frame ~ /youtrackdb|tinkerpop|gremlin/) {
+        gsub(/ $/, "", frame); frames[frame] += count
+      }
+    }
+  } END { for (f in frames) print frames[f], f }' | sort -rn | head -40
+```
+
+**Trace call chains from a specific method** (e.g., what calls `loadEntity`):
+```bash
+cat collapsed.csv | grep 'loadEntity' | awk '{
+    n = split($0, parts, ";"); last = parts[n]
+    idx = match(last, / [0-9]+$/); count = substr(last, idx+1)+0
+    for (i=1; i<=n; i++) {
+      if (parts[i] ~ /loadEntity/) {
+        key = ""
+        for (j=i-3; j<=i; j++) {
+          if (j >= 1) { frame = parts[j]; gsub(/ [0-9]+$/, "", frame)
+            gsub(/.*\//, "", frame); key = key (key=="" ? "" : " -> ") frame }
+        }
+        paths[key] += count; break
+      }
+    }
+  } END { for (p in paths) print paths[p], p }' | sort -rn | head -20
+```
+
+### 2d. Key Methods to Watch For
+
+| Method | What it means |
+|---|---|
+| `EdgeFromLinkBagIterator.loadEdge` | Loading edge records — proportional to edges traversed |
+| `VertexFromLinkBagIterator.loadVertex` | Loading vertex records from link bags |
+| `EdgeEntityImpl.getTo/getFrom` | Resolving edge→vertex (each triggers a record load) |
+| `SQLFunctionMove.execute` | Graph traversal step (.out/.in/.outE/.inE) |
+| `SQLFunctionInV/OutV.move` | .inV()/.outV() resolution |
+| `SQLAndBlock.evaluate` | WHERE clause filter evaluation |
+| `MatchEdgeTraverser.executeTraversal` | MATCH edge step execution |
+| `MatchEdgeTraverser.applyPreFilter` | Pre-filter (RID intersection) application |
+| `AbstractLinkBag$MergingSpliterator` | Link bag iteration (proportional to adjacency list size) |
+| `RecordCacheWeakRefs.get` | Record cache lookups |
+| `EntityImpl.deserializeProperties` | Deserialization cost |
+| `FrontendTransactionImpl.loadEntity` | Full entity load (cache miss → disk read) |
+| `DatabaseSessionEmbedded.executeReadRecord` | Lowest-level record read |
+
+**High `loadEdge`/`loadVertex` samples** = too many records being loaded.
+**High `SQLAndBlock.evaluate`** = filter evaluation is expensive (complex WHERE clauses).
+**High `deserializeProperties`** = loading properties that aren't needed.
+
+## Phase 3: Step-by-Step Selectivity Analysis
+
+This is the most valuable diagnostic. For a multi-step MATCH query, measure the row count
+and execution time at each intermediate step to find the combinatorial explosion point.
+
+### 3a. Write a Diagnostic Java Program
+
+Create a Java file that opens the LDBC database and runs progressively longer prefixes
+of the MATCH query, measuring row count and time at each step.
+
+**Template** (adapt the MATCH chain to your query):
+
+```java
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.api.gremlin.YTDBGraphTraversalSourceDSL;
+import com.jetbrains.youtrackdb.api.gremlin.YTDBGraphTraversalSource;
+import java.util.*;
+
+public class QueryDiag {
+  static YTDBGraphTraversalSourceDSL g;
+
+  @SuppressWarnings("unchecked")
+  static List<Map<String, Object>> sql(String q, Object... kv) {
+    return g.computeInTx(tx -> {
+      var dsl = (YTDBGraphTraversalSource) tx;
+      var results = new ArrayList<Map<String, Object>>();
+      for (Object r : dsl.yql(q, kv).toList()) results.add((Map<String, Object>) r);
+      return results;
+    });
+  }
+
+  static int count(String q, Object... kv) { return sql(q, kv).size(); }
+
+  public static void main(String[] args) throws Exception {
+    var db = YourTracks.instance("./jmh-ldbc/target/ldbc-bench-db");
+    g = (YTDBGraphTraversalSourceDSL) db.openTraversal("ldbc_benchmark", "admin", "admin");
+
+    // Get sample parameter values
+    var persons = sql("SELECT id FROM Person ORDER BY id LIMIT 3");
+    // ... extract IDs ...
+
+    for (long pid : pids) {
+      // Step 1: first edge only
+      long t0 = System.nanoTime();
+      int step1 = count("MATCH {class: Person, where: (id = :pid)}"
+          + ".out('KNOWS'){as: friend} RETURN friend", "pid", pid);
+      System.out.printf("Step 1: %d rows [%d ms]%n", step1, (System.nanoTime()-t0)/1_000_000);
+
+      // Step 2: first + second edge
+      // ... progressively add edges ...
+
+      // Step N: full query
+      // ... measure full query ...
+    }
+
+    g.close();
+    db.close();
+  }
+}
+```
+
+### 3b. API Gotchas
+
+- **Named parameters**: `yql()` takes key/value pairs: `"paramName", value, "param2", value2`
+  NOT positional `?` placeholders.
+- **Date parameters**: Pass `new Date(epochMillis)`, NOT raw `Long`. The histogram
+  selectivity estimator will throw `ClassCastException: Long cannot be cast to Date`
+  if you pass Long for a Date-typed indexed property.
+- **Return type**: `yql().toList()` returns `List<Object>` where each object is a
+  `Map<String, Object>` (not a `Result` instance). Cast directly to `Map`.
+- **DB locking**: If the program crashes or is killed, remove lock files before re-running:
+  `find /root/ytdb/jmh-ldbc/target/ldbc-bench-db -name "*.lock" -exec rm -f {} \;`
+
+### 3c. Compiling and Running
+
+```bash
+# Compile against the uber-jar (has all dependencies)
+javac -proc:none -cp "jmh-ldbc/target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar" QueryDiag.java
+
+# Run with required --add-opens flags
+java --add-opens java.base/java.lang=ALL-UNNAMED \
+     --add-opens java.base/java.util=ALL-UNNAMED \
+     --add-opens java.base/java.nio=ALL-UNNAMED \
+     --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+     --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+     --add-opens java.base/java.io=ALL-UNNAMED \
+     --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
+     --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+     --add-opens java.base/java.net=ALL-UNNAMED \
+     -cp ".:jmh-ldbc/target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar" -Xmx4g QueryDiag
+```
+
+### 3d. What to Measure
+
+For each step in the MATCH chain, record:
+
+| Metric | Why |
+|---|---|
+| **Row count** | Identifies the fan-out explosion point |
+| **Distinct row count** | Reveals duplicate amplification |
+| **Execution time** | Shows per-step cost |
+| **Time delta vs previous step** | Isolates the expensive step |
+
+Also compute **selectivity ratios**:
+- `rows[N] / rows[N-1]` = fan-out at step N
+- `final_rows / intermediate_rows` = overall selectivity (how much work is wasted)
+- `distinct / total` = duplicate ratio
+
+### 3e. Fan-Out Statistics
+
+For key edges, measure the degree distribution:
+
+```sql
+-- Average out-degree for an edge class from a specific vertex set
+SELECT min(cnt) as minD, max(cnt) as maxD, avg(cnt) as avgD FROM (
+  SELECT out('EDGE_CLASS').size() as cnt FROM (
+    MATCH {class: StartClass, where: (id = :id)}
+    .out('PREV_EDGE'){as: v} RETURN v))
+```
+
+This reveals whether fan-out is uniform or skewed (a few vertices with huge adjacency lists).
+
+## Phase 4: Interpreting Results
+
+### Decision Framework
+
+After collecting profile + selectivity data, classify the bottleneck:
+
+**1. Combinatorial explosion in intermediate rows**
+- Symptom: Step K produces 100K+ rows, but final result is <1% of that
+- Profile: CPU spread across many methods, no single hotspot dominates
+- Fix: Query rewrite (reorder joins, add early filtering, pre-compute sets)
+
+**2. Expensive per-row operation**
+- Symptom: A specific step takes disproportionate time relative to its row count
+- Profile: Single method dominates (e.g., `loadEdge`, `deserializeProperties`)
+- Fix: Reduce per-row cost (caching, avoid unnecessary loads, batch operations)
+
+**3. Large adjacency list iteration**
+- Symptom: High samples in `AbstractLinkBag$MergingSpliterator`, `LinkBag.iterator`
+- Profile: `EdgeFromLinkBagIterator.hasNext` dominates
+- Fix: Pre-filter with RID intersection, index-assisted traversal, limit iteration
+
+**4. Filter evaluation overhead**
+- Symptom: High samples in `SQLAndBlock.evaluate`, `SQLOrBlock.evaluate`
+- Profile: WHERE clause evaluation dominates, not data access
+- Fix: Push filters earlier, simplify expressions, use index pre-filters
+
+### Common MATCH Query Patterns and Their Costs
+
+| Pattern | Cost Model | Notes |
+|---|---|---|
+| `.out('E'){class: V}` | O(adjacency list size) | Filtered by collection ID |
+| `.outE('E').inV()` | O(adjacency list) + O(edge load per match) | Each edge must be loaded to resolve target vertex |
+| `while: ($depth < N)` | O(fan-out^N) | Exponential — the most expensive pattern |
+| `where: (@rid = $matched.X.@rid)` | O(1) with pre-filter, O(adjacency list) without | Back-reference check |
+| `where: (prop >= :val)` on indexed edge | O(log N) with index pre-filter | Requires index on edge class property |
+
+### The "700K Rows" Anti-Pattern
+
+A common bottleneck in LDBC queries: `while: ($depth < 2)` on KNOWS produces
+~3-5K friends, each with ~100-200 posts = 300K-1M intermediate rows. Even with
+O(1) per-row filtering downstream, the sheer volume dominates.
+
+**Mitigations**:
+1. **Pre-compute filter sets**: Before MATCH, compute the set of valid target IDs
+   (e.g., forums the person belongs to), then filter during traversal
+2. **Hash join**: Collect one side of a join into a set, probe during the other side
+3. **Early DISTINCT**: If downstream steps only need distinct values, deduplicate early
+4. **Inverted direction**: Sometimes traversing from the "filter side" first produces
+   fewer intermediate rows
+
+## Phase 5: Cleanup
+
+Always destroy the Hetzner server when done:
+```bash
+hcloud server delete "$SERVER_NAME"
+hcloud ssh-key delete "$KEY_NAME"
+```
+
+## Reference: LDBC SF 1 Dataset Statistics
+
+| Entity | Count |
+|---|---|
+| Person | 10,620 |
+| Post | 1,192,942 |
+| Comment | ~2,000,000 |
+| Forum | 106,594 |
+| HAS_MEMBER edges | 3,260,692 |
+| KNOWS edges | ~360,000 |
+| HAS_CREATOR edges | ~3,200,000 |
+
+Average degrees:
+- KNOWS: ~34 per person
+- HAS_CREATOR (Post only): ~112 posts per person
+- HAS_MEMBER: ~30 members per forum, ~307 forums per person
+- CONTAINER_OF: ~11 posts per forum
+
+These numbers are essential for estimating query cost. A `while: ($depth < 2)` KNOWS
+traversal from a typical person produces 34 + 34*34 ≈ 1,190 paths (with duplicates),
+~800 distinct friends.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterable.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterable.java
@@ -1,0 +1,102 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Iterator;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Iterable that wraps a LinkBag and yields edge records directly from the primary RIDs
+ * stored in each RidPair. This provides an optimized path for {@code getEdgesInternal()}
+ * when the underlying storage is a LinkBag, supporting zero-I/O pre-filtering by
+ * collection ID or RID set.
+ *
+ * <p>Mirrors {@link VertexFromLinkBagIterable} but yields {@link EdgeInternal} from
+ * primary RIDs (edge records) instead of vertices from secondary RIDs.
+ *
+ * <p>Use {@link #withClassFilter(IntSet)} to create a filtered copy that skips
+ * edges whose collection ID is not in the accepted set — this avoids loading
+ * records from storage entirely (only the in-memory RID is inspected).
+ */
+public class EdgeFromLinkBagIterable
+    implements PreFilterableLinkBagIterable, Iterable<EdgeInternal> {
+
+  @Nonnull
+  private final LinkBag linkBag;
+  @Nonnull
+  private final DatabaseSessionEmbedded session;
+
+  /**
+   * When non-null, only edges whose collection ID is in this set are loaded.
+   * Passed through to {@link EdgeFromLinkBagIterator}.
+   */
+  @Nullable private final IntSet acceptedCollectionIds;
+
+  @Nullable private final Set<RID> acceptedRids;
+
+  public EdgeFromLinkBagIterable(
+      @Nonnull LinkBag linkBag,
+      @Nonnull DatabaseSessionEmbedded session) {
+    this(linkBag, session, null, null);
+  }
+
+  private EdgeFromLinkBagIterable(
+      @Nonnull LinkBag linkBag,
+      @Nonnull DatabaseSessionEmbedded session,
+      @Nullable IntSet acceptedCollectionIds,
+      @Nullable Set<RID> acceptedRids) {
+    this.linkBag = linkBag;
+    this.session = session;
+    this.acceptedCollectionIds = acceptedCollectionIds;
+    this.acceptedRids = acceptedRids;
+  }
+
+  /**
+   * Returns a new iterable that only yields edges whose collection (cluster)
+   * ID is in the given set. Edges with non-matching collection IDs are
+   * skipped without any disk I/O.
+   *
+   * @param collectionIds accepted collection IDs
+   */
+  @Nonnull
+  @Override
+  public EdgeFromLinkBagIterable withClassFilter(@Nonnull IntSet collectionIds) {
+    return new EdgeFromLinkBagIterable(
+        linkBag, session, collectionIds, acceptedRids);
+  }
+
+  /**
+   * Returns a new iterable that only yields edges whose RID is in the given set.
+   * Edges not in the set are skipped without any disk I/O.
+   *
+   * @param ridSet accepted RIDs (typically built from an index query)
+   */
+  @Nonnull
+  @Override
+  public EdgeFromLinkBagIterable withRidFilter(@Nonnull Set<RID> ridSet) {
+    return new EdgeFromLinkBagIterable(
+        linkBag, session, acceptedCollectionIds, ridSet);
+  }
+
+  @Nonnull
+  @Override
+  public Iterator<EdgeInternal> iterator() {
+    return new EdgeFromLinkBagIterator(
+        linkBag.iterator(), session, linkBag.size(),
+        acceptedCollectionIds, acceptedRids);
+  }
+
+  @Override
+  public int size() {
+    return linkBag.size();
+  }
+
+  @Override
+  public boolean isSizeable() {
+    return linkBag.isSizeable();
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterator.java
@@ -1,0 +1,160 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
+import com.jetbrains.youtrackdb.internal.common.log.LogManager;
+import com.jetbrains.youtrackdb.internal.common.util.Sizeable;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Iterator that loads edge records directly from LinkBag's primary RIDs.
+ * The primary RID in each {@link RidPair} is the edge record RID. Missing
+ * records are skipped gracefully.
+ *
+ * <p>Validates each {@link RidPair} via {@link RidPair#validateEdgePair()}
+ * to detect corrupt entries (where primaryRid == secondaryRid).
+ *
+ * <p>When {@code acceptedCollectionIds} is set, the iterator checks the
+ * edge's collection (cluster) ID <em>before</em> loading it from storage.
+ * Edges whose collection ID is not in the accepted set are skipped without
+ * any disk I/O — only the RID (already in memory from the LinkBag) is
+ * inspected.
+ *
+ * <p>Mirrors {@link VertexFromLinkBagIterator} but uses primary RIDs
+ * (edges) instead of secondary RIDs (vertices).
+ *
+ * <p>Requires an active transaction on the session.
+ *
+ * <p>Note: {@link #size()} returns an upper bound (the LinkBag size), not the
+ * exact count of edges yielded, since entries with missing records are
+ * silently skipped.
+ */
+public class EdgeFromLinkBagIterator implements Iterator<EdgeInternal>, Sizeable {
+
+  @Nonnull
+  private final Iterator<RidPair> ridPairIterator;
+  @Nonnull
+  private final DatabaseSessionEmbedded session;
+  private final int size;
+
+  /**
+   * When non-null, only edges whose collection ID is in this set are loaded.
+   * All others are skipped without touching storage — the collection ID is
+   * extracted directly from the RID which is already in memory.
+   */
+  @Nullable private final IntSet acceptedCollectionIds;
+
+  /**
+   * When non-null, only edges whose RID is in this set are loaded from storage.
+   * Built at execution time from an index query; provides zero-I/O skipping for
+   * records that do not satisfy an indexed property condition.
+   */
+  @Nullable private final Set<RID> acceptedRids;
+
+  @Nullable private EdgeInternal nextEdge;
+
+  public EdgeFromLinkBagIterator(
+      @Nonnull Iterator<RidPair> ridPairIterator,
+      @Nonnull DatabaseSessionEmbedded session,
+      int size) {
+    this(ridPairIterator, session, size, null, null);
+  }
+
+  public EdgeFromLinkBagIterator(
+      @Nonnull Iterator<RidPair> ridPairIterator,
+      @Nonnull DatabaseSessionEmbedded session,
+      int size,
+      @Nullable IntSet acceptedCollectionIds) {
+    this(ridPairIterator, session, size, acceptedCollectionIds, null);
+  }
+
+  public EdgeFromLinkBagIterator(
+      @Nonnull Iterator<RidPair> ridPairIterator,
+      @Nonnull DatabaseSessionEmbedded session,
+      int size,
+      @Nullable IntSet acceptedCollectionIds,
+      @Nullable Set<RID> acceptedRids) {
+    this.ridPairIterator = ridPairIterator;
+    this.session = session;
+    this.size = size;
+    this.acceptedCollectionIds = acceptedCollectionIds;
+    this.acceptedRids = acceptedRids;
+  }
+
+  @Override
+  public boolean hasNext() {
+    while (nextEdge == null && ridPairIterator.hasNext()) {
+      nextEdge = loadEdge(ridPairIterator.next());
+    }
+    return nextEdge != null;
+  }
+
+  @Override
+  public EdgeInternal next() {
+    if (hasNext()) {
+      var current = nextEdge;
+      nextEdge = null;
+      return current;
+    }
+    throw new NoSuchElementException();
+  }
+
+  @Nullable private EdgeInternal loadEdge(RidPair ridPair) {
+    ridPair.validateEdgePair();
+    var rid = ridPair.primaryRid();
+
+    // Class filter: check the collection (cluster) ID before loading from storage.
+    // The collection ID is part of the RID and already in memory — no disk I/O.
+    if (acceptedCollectionIds != null
+        && !acceptedCollectionIds.contains(rid.getCollectionId())) {
+      return null;
+    }
+
+    if (acceptedRids != null && !acceptedRids.contains(rid)) {
+      return null;
+    }
+
+    try {
+      var transaction = session.getActiveTransaction();
+      var entity = transaction.loadEntity(rid);
+      if (entity.isEdge()) {
+        return (EdgeInternal) entity.asEdge();
+      }
+      if (entity.isVertex()) {
+        // Legacy lightweight edges stored raw vertex RIDs in LinkBags. After edge
+        // unification, all LinkBag entries must point to edge records, not vertices.
+        throw new IllegalStateException(
+            "Legacy lightweight edge detected: LinkBag entry "
+                + rid
+                + " points to a vertex instead of an edge record. "
+                + "Legacy lightweight edges are no longer supported.");
+      }
+      LogManager.instance().warn(this,
+          "Expected edge but found %s for primary RID %s (secondary RID %s)",
+          entity.getClass().getSimpleName(), rid, ridPair.secondaryRid());
+      return null;
+    } catch (RecordNotFoundException rnf) {
+      LogManager.instance().warn(this,
+          "Edge record (%s) not found (secondary RID %s), skipping",
+          rid, ridPair.secondaryRid());
+      return null;
+    }
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public boolean isSizeable() {
+    return size >= 0;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableLinkBagIterable.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableLinkBagIterable.java
@@ -1,0 +1,41 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import com.jetbrains.youtrackdb.internal.common.util.Sizeable;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ * Shared interface for LinkBag-backed iterables that support zero-I/O pre-filtering
+ * by collection ID (class filter) or RID set (index-based filter). Both vertex and
+ * edge iterables implement this interface, allowing {@code applyPreFilter} in
+ * {@code MatchEdgeTraverser} to handle them uniformly.
+ *
+ * <p>Extends {@link Sizeable} to inherit {@code size()} and {@code isSizeable()},
+ * which are used by the adaptive abort guards to decide whether pre-filtering is
+ * worthwhile.
+ */
+public interface PreFilterableLinkBagIterable extends Sizeable {
+
+  /**
+   * Returns a new iterable that only yields records whose collection (cluster) ID
+   * is in the given set. Records with non-matching collection IDs are skipped
+   * without any disk I/O.
+   *
+   * @param collectionIds accepted collection IDs
+   * @return a filtered copy of this iterable
+   */
+  @Nonnull
+  PreFilterableLinkBagIterable withClassFilter(@Nonnull IntSet collectionIds);
+
+  /**
+   * Returns a new iterable that only yields records whose RID is in the given set.
+   * Records not in the set are skipped without any disk I/O.
+   *
+   * @param ridSet accepted RIDs (typically built from an index query)
+   * @return a filtered copy of this iterable
+   */
+  @Nonnull
+  PreFilterableLinkBagIterable withRidFilter(@Nonnull Set<RID> ridSet);
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableLinkBagIterable.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableLinkBagIterable.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.record.impl;
 import com.jetbrains.youtrackdb.internal.common.util.Sizeable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Iterator;
 import java.util.Set;
 import javax.annotation.Nonnull;
 
@@ -38,4 +39,13 @@ public interface PreFilterableLinkBagIterable extends Sizeable {
    */
   @Nonnull
   PreFilterableLinkBagIterable withRidFilter(@Nonnull Set<RID> ridSet);
+
+  /**
+   * Returns an iterator over the records in this iterable (after any applied
+   * filters). Concrete implementations return a typed iterator (e.g.
+   * {@code Iterator<Vertex>} or {@code Iterator<EdgeInternal>}); this method
+   * provides a common accessor so callers don't need to cast to {@code Iterable}.
+   */
+  @Nonnull
+  Iterator<?> iterator();
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
@@ -17,7 +17,6 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeIntern
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Schema;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
-import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -350,12 +349,8 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
               new EdgeIterable(session, set, -1, set));
           case EntityLinkListImpl list -> iterables.add(
               new EdgeIterable(session, list, -1, list));
-          case LinkBag bag -> {
-            Iterable<RID> ridIterable =
-                () -> bag.stream().map(RidPair::primaryRid).iterator();
-            iterables.add(
-                new EdgeIterable(session, ridIterable, bag.size(), bag));
-          }
+          case LinkBag bag ->
+              iterables.add(new EdgeFromLinkBagIterable(bag, session));
           default -> {
             throw new IllegalArgumentException(
                 "Unsupported property type: " + getPropertyType(fieldName));

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexFromLinkBagIterable.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexFromLinkBagIterable.java
@@ -1,6 +1,5 @@
 package com.jetbrains.youtrackdb.internal.core.record.impl;
 
-import com.jetbrains.youtrackdb.internal.common.util.Sizeable;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Vertex;
@@ -21,7 +20,8 @@ import javax.annotation.Nullable;
  * vertices whose collection ID is not in the accepted set — this avoids loading
  * records from storage entirely (only the in-memory RID is inspected).
  */
-public class VertexFromLinkBagIterable implements Iterable<Vertex>, Sizeable {
+public class VertexFromLinkBagIterable
+    implements PreFilterableLinkBagIterable, Iterable<Vertex> {
 
   @Nonnull
   private final LinkBag linkBag;
@@ -62,6 +62,7 @@ public class VertexFromLinkBagIterable implements Iterable<Vertex>, Sizeable {
    *     {@link VertexFromLinkBagIterator#collectionIdsForClass})
    */
   @Nonnull
+  @Override
   public VertexFromLinkBagIterable withClassFilter(@Nonnull IntSet collectionIds) {
     return new VertexFromLinkBagIterable(linkBag, session, collectionIds, acceptedRids);
   }
@@ -73,6 +74,7 @@ public class VertexFromLinkBagIterable implements Iterable<Vertex>, Sizeable {
    * @param ridSet accepted RIDs (typically built from an index query)
    */
   @Nonnull
+  @Override
   public VertexFromLinkBagIterable withRidFilter(@Nonnull Set<RID> ridSet) {
     return new VertexFromLinkBagIterable(linkBag, session, acceptedCollectionIds, ridSet);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStep.java
@@ -8,7 +8,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
-import com.jetbrains.youtrackdb.internal.core.record.impl.VertexFromLinkBagIterable;
+import com.jetbrains.youtrackdb.internal.core.record.impl.PreFilterableLinkBagIterable;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -189,7 +189,10 @@ public class ExpandStep extends AbstractExecutionStep {
         return ExecutionStream.iterator(iterator, expandAlias);
       }
       case Iterable<?> iterable -> {
-        if (iterable instanceof VertexFromLinkBagIterable linkBagIterable
+        // PreFilterableLinkBagIterable covers both vertex and edge LinkBag
+        // iterables. ChainedIterable (from bothE/both) does not implement the
+        // interface, so it silently degrades to unfiltered iteration.
+        if (iterable instanceof PreFilterableLinkBagIterable linkBagIterable
             && (acceptedCollectionIds != null || indexRidSet != null)) {
           var filtered = linkBagIterable;
           if (acceptedCollectionIds != null) {
@@ -201,7 +204,10 @@ public class ExpandStep extends AbstractExecutionStep {
                   indexRidSet.size(), filtered.size())) {
             filtered = filtered.withRidFilter(indexRidSet);
           }
-          return ExecutionStream.iterator(filtered.iterator(), expandAlias);
+          // Both concrete PreFilterableLinkBagIterable types (vertex and edge)
+          // implement Iterable, so this cast is always safe.
+          return ExecutionStream.iterator(
+              ((Iterable<?>) filtered).iterator(), expandAlias);
         }
         return ExecutionStream.iterator(iterable.iterator(), expandAlias);
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStep.java
@@ -204,10 +204,7 @@ public class ExpandStep extends AbstractExecutionStep {
                   indexRidSet.size(), filtered.size())) {
             filtered = filtered.withRidFilter(indexRidSet);
           }
-          // Both concrete PreFilterableLinkBagIterable types (vertex and edge)
-          // implement Iterable, so this cast is always safe.
-          return ExecutionStream.iterator(
-              ((Iterable<?>) filtered).iterator(), expandAlias);
+          return ExecutionStream.iterator(filtered.iterator(), expandAlias);
         }
         return ExecutionStream.iterator(iterable.iterator(), expandAlias);
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RidFilterDescriptor.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RidFilterDescriptor.java
@@ -132,11 +132,17 @@ public sealed interface RidFilterDescriptor {
    * when a pattern has {@code {B}.edge{C, where: (@rid = $matched.X.@rid)}},
    * the expression resolves to the already-bound X's RID, and the reverse
    * lookup produces the set of vertices connected to X via the edge.
+   *
+   * <p>When {@code collectEdgeRids} is {@code true}, collects primary RIDs
+   * (edge records) instead of secondary RIDs (vertices). This is needed
+   * for {@code .outE()}/{@code .inE()} traversals where the link bag
+   * iterator filters on edge RIDs, not vertex RIDs.
    */
   record EdgeRidLookup(
       String edgeClassName,
       String traversalDirection,
-      SQLExpression targetRidExpression) implements RidFilterDescriptor {
+      SQLExpression targetRidExpression,
+      boolean collectEdgeRids) implements RidFilterDescriptor {
 
     /**
      * Returns the reverse link bag size — exact, O(1) stored field.
@@ -164,7 +170,7 @@ public sealed interface RidFilterDescriptor {
         return null;
       }
       return TraversalPreFilterHelper.resolveReverseEdgeLookup(
-          targetRid, edgeClassName, traversalDirection, ctx);
+          targetRid, edgeClassName, traversalDirection, collectEdgeRids, ctx);
     }
 
     /** Resolves the target RID from the expression. */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -3412,7 +3412,8 @@ public class SelectExecutionPlanner {
           ridFilter = new RidFilterDescriptor.EdgeRidLookup(
               edgeExtraction.edgeClassName(),
               edgeExtraction.traversalDirection(),
-              edgeExtraction.targetRidExpression());
+              edgeExtraction.targetRidExpression(),
+              false);
           remainingWhere = edgeExtraction.remainingWhere();
         }
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/TraversalPreFilterHelper.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/TraversalPreFilterHelper.java
@@ -165,6 +165,32 @@ public final class TraversalPreFilterHelper {
       String edgeClassName,
       String traversalDirection,
       CommandContext ctx) {
+    return resolveReverseEdgeLookup(
+        targetRid, edgeClassName, traversalDirection, false, ctx);
+  }
+
+  /**
+   * Resolves the reverse edge lookup, optionally collecting edge RIDs
+   * (primary) instead of vertex RIDs (secondary).
+   *
+   * <p>When {@code collectEdgeRids} is {@code false} (default), collects
+   * secondary RIDs (the vertices on the other side of each edge). This is
+   * correct for {@code .out()}/{@code .in()} traversals whose link bag
+   * iterators filter on vertex RIDs.
+   *
+   * <p>When {@code collectEdgeRids} is {@code true}, collects primary RIDs
+   * (the edge records themselves). This is needed for {@code .outE()}/
+   * {@code .inE()} traversals whose link bag iterators filter on edge RIDs.
+   *
+   * @param collectEdgeRids if {@code true}, collect edge RIDs (primary);
+   *     if {@code false}, collect vertex RIDs (secondary)
+   */
+  @Nullable public static RidSet resolveReverseEdgeLookup(
+      RID targetRid,
+      String edgeClassName,
+      String traversalDirection,
+      boolean collectEdgeRids,
+      CommandContext ctx) {
     var db = ctx.getDatabaseSession();
     EntityImpl targetEntity;
     try {
@@ -193,7 +219,7 @@ public final class TraversalPreFilterHelper {
     var ridSet = new RidSet();
     var count = 0;
     for (RidPair pair : linkBag) {
-      ridSet.add(pair.secondaryRid());
+      ridSet.add(collectEdgeRids ? pair.primaryRid() : pair.secondaryRid());
       count++;
       if ((count & CHECKPOINT_INTERVAL_MASK) == 0
           && shouldAbort(count)) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
@@ -432,19 +432,20 @@ public class MatchEdgeTraverser implements ExecutionStream {
         }
       }
 
+      // Mark the starting point as visited to prevent re-entry from sibling
+      // branches at any depth level. This must be OUTSIDE the expansion block
+      // because leaf-level nodes (where the while condition fails) would
+      // otherwise never be marked, causing O(fan-out) duplication.
+      if (dedupVisited != null && startingPoint != null
+          && startingPoint.getIdentity() != null) {
+        dedupVisited.add(startingPoint.getIdentity());
+      }
+
       // Recurse into neighbors if depth allows and WHILE condition holds
       if (startingPoint != null
           && (maxDepth == null || depth < maxDepth)
           && (whileCondition == null
               || whileCondition.matchesFilters(startingPoint, iCommandContext))) {
-
-        // Mark the starting point as visited before expanding neighbors so
-        // that cycles back to it are detected.
-        if (dedupVisited != null) {
-          assert startingPoint.getIdentity() != null
-              : "graph vertex identity must not be null";
-          dedupVisited.add(startingPoint.getIdentity());
-        }
 
         var queryResult = traversePatternEdge(startingPoint, iCommandContext);
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchEdgeTraverser.java
@@ -6,7 +6,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
-import com.jetbrains.youtrackdb.internal.core.record.impl.VertexFromLinkBagIterable;
+import com.jetbrains.youtrackdb.internal.core.record.impl.PreFilterableLinkBagIterable;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.RidFilterDescriptor;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.RidSet;
@@ -629,13 +629,13 @@ public class MatchEdgeTraverser implements ExecutionStream {
     if (edge == null) {
       return qR;
     }
-    if (!(qR instanceof VertexFromLinkBagIterable vfli)) {
+    if (!(qR instanceof PreFilterableLinkBagIterable pfli)) {
       return qR;
     }
 
     // Apply class filter (zero I/O — collection ID is embedded in the RID)
     if (edge.getAcceptedCollectionIds() != null) {
-      vfli = vfli.withClassFilter(edge.getAcceptedCollectionIds());
+      pfli = pfli.withClassFilter(edge.getAcceptedCollectionIds());
     }
 
     // Apply RidSet intersection filter.
@@ -644,7 +644,7 @@ public class MatchEdgeTraverser implements ExecutionStream {
     // it returns null without materializing. Only the first vertex whose
     // link bag is large enough triggers actual resolution and caching.
     if (edge.getIntersectionDescriptor() != null) {
-      int linkBagSize = vfli.size();
+      int linkBagSize = pfli.size();
       if (linkBagSize >= TraversalPreFilterHelper.minLinkBagSize()) {
         var ridSet = edge.resolveWithCache(ctx, linkBagSize);
         if (ridSet != null
@@ -656,12 +656,12 @@ public class MatchEdgeTraverser implements ExecutionStream {
                 "MATCH pre-filter applied: linkBag={} ridSet={} descriptor={}",
                 linkBagSize, ridSet.size(), edge.getIntersectionDescriptor());
           }
-          vfli = vfli.withRidFilter(ridSet);
+          pfli = pfli.withRidFilter(ridSet);
         }
       }
     }
 
-    return vfli;
+    return pfli;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2283,12 +2283,14 @@ public class MatchExecutionPlanner {
       return extractEdgeClassName(method);
     }
 
-    // inV() / outV(): look up the linked vertex class from the preceding edge
+    // inV() / outV(): look up the linked vertex class from the preceding edge.
+    // inV() reads the "in" property; outV() reads the "out" property.
     if ("inv".equals(dirName) || "outv".equals(dirName)) {
       if (currentEdgeClass == null) {
         return null;
       }
-      return lookupLinkedVertexClass(currentEdgeClass, dirName, context);
+      var prop = "inv".equals(dirName) ? "in" : "out";
+      return lookupLinkedVertexClass(currentEdgeClass, prop, context);
     }
 
     // out('X') / in('X'): infer the target vertex class from the edge LINK schema
@@ -2310,32 +2312,24 @@ public class MatchExecutionPlanner {
    * Looks up the linked vertex class from an edge class's LINK property.
    *
    * @param edgeClassName the edge class to look up
-   * @param propName the property name to read ("in" or "out", or "inv"/"outv"
-   *     which are mapped to "in"/"out" respectively)
+   * @param propName the property name to read — must be {@code "in"} or {@code "out"}
    * @return the linked class name, or {@code null} if not found
    */
   @Nullable private static String lookupLinkedVertexClass(
       String edgeClassName, String propName, CommandContext context) {
-    // Map inV/outV method names to the corresponding edge property
-    var resolvedProp = switch (propName) {
-      case "inv" -> "in";
-      case "outv" -> "out";
-      default -> propName;
-    };
-
     var session = context.getDatabaseSession();
     var schema = session.getMetadata().getImmutableSchemaSnapshot();
     var edgeClass = schema.getClassInternal(edgeClassName);
     if (edgeClass == null) {
       return null;
     }
-    var prop = edgeClass.getPropertyInternal(resolvedProp);
+    var prop = edgeClass.getPropertyInternal(propName);
     if (prop == null || prop.getLinkedClass() == null) {
       return null;
     }
     assert prop.getLinkedClass().getName() != null
         && !prop.getLinkedClass().getName().isEmpty()
-        : "inferClassFromEdgeSchema: linked class has null/empty name for edge "
+        : "lookupLinkedVertexClass: linked class has null/empty name for edge "
             + edgeClassName;
     return prop.getLinkedClass().getName();
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2245,14 +2245,11 @@ public class MatchExecutionPlanner {
               ? methodName.toLowerCase(Locale.ROOT) : null;
 
           // Update currentEdgeClass state based on the method type.
+          // inV/outV is deferred: it consumes currentEdgeClass after inference below.
+          var isInVOrOutV = "inv".equals(methodLower) || "outv".equals(methodLower);
           if ("oute".equals(methodLower) || "ine".equals(methodLower)) {
             currentEdgeClass = extractEdgeClassName(method);
-          } else if ("inv".equals(methodLower) || "outv".equals(methodLower)) {
-            // inV/outV consumes the currentEdgeClass — pass it to inference,
-            // then reset so a subsequent inV/outV without a preceding outE/inE
-            // correctly gets null.
-            // (currentEdgeClass is read below, then reset after inference)
-          } else {
+          } else if (!isInVOrOutV) {
             // Any other method (out, in, both, bothE, etc.) resets the state.
             currentEdgeClass = null;
           }
@@ -2273,7 +2270,7 @@ public class MatchExecutionPlanner {
           }
 
           // Reset currentEdgeClass after inV/outV consumes it.
-          if ("inv".equals(methodLower) || "outv".equals(methodLower)) {
+          if (isInVOrOutV) {
             currentEdgeClass = null;
           }
         }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2235,7 +2235,7 @@ public class MatchExecutionPlanner {
           // LINK Message, the target class is Message.
           var alias = item.getFilter().getAlias();
           if (alias != null && !aliasClasses.containsKey(alias)) {
-            var inferred = inferClassFromEdgeSchema(item.getMethod(), context);
+            var inferred = inferClassFromEdgeSchema(item.getMethod(), null, context);
             if (inferred != null) {
               aliasClasses.put(alias, inferred);
               logger.debug(
@@ -2250,14 +2250,25 @@ public class MatchExecutionPlanner {
   }
 
   /**
-   * Infers the target vertex class from the edge schema LINK declarations.
-   * For {@code out('X')}, the target is the "in" endpoint of edge class X;
-   * for {@code in('X')}, the target is the "out" endpoint.
+   * Infers the alias class from the edge schema LINK declarations.
    *
-   * @return the linked class name, or {@code null} if it cannot be inferred
+   * <p>Handles six method types:
+   * <ul>
+   *   <li>{@code out('X')} / {@code in('X')}: target is the opposite endpoint
+   *       of edge class X (vertex class)</li>
+   *   <li>{@code outE('X')} / {@code inE('X')}: alias class is X itself
+   *       (the edge class)</li>
+   *   <li>{@code inV()} / {@code outV()}: alias class is the linked vertex
+   *       class from the preceding edge's LINK schema ({@code currentEdgeClass})</li>
+   * </ul>
+   *
+   * @param currentEdgeClass the edge class set by a preceding {@code outE}/{@code inE},
+   *     or {@code null} if none
+   * @return the inferred class name, or {@code null} if it cannot be inferred
    */
   @Nullable static String inferClassFromEdgeSchema(
-      @Nullable SQLMethodCall method, CommandContext context) {
+      @Nullable SQLMethodCall method, @Nullable String currentEdgeClass,
+      CommandContext context) {
     if (method == null) {
       return null;
     }
@@ -2266,24 +2277,51 @@ public class MatchExecutionPlanner {
       return null;
     }
     dirName = dirName.toLowerCase(Locale.ROOT);
+
+    // outE('X') / inE('X'): the edge class itself is the alias class
+    if ("oute".equals(dirName) || "ine".equals(dirName)) {
+      return extractEdgeClassName(method);
+    }
+
+    // inV() / outV(): look up the linked vertex class from the preceding edge
+    if ("inv".equals(dirName) || "outv".equals(dirName)) {
+      if (currentEdgeClass == null) {
+        return null;
+      }
+      return lookupLinkedVertexClass(currentEdgeClass, dirName, context);
+    }
+
+    // out('X') / in('X'): infer the target vertex class from the edge LINK schema
     if (!"in".equals(dirName) && !"out".equals(dirName)) {
       return null;
     }
 
-    if (method.getParams() == null || method.getParams().isEmpty()) {
+    var edgeClassName = extractEdgeClassName(method);
+    if (edgeClassName == null) {
       return null;
     }
-    String edgeClassName;
-    try {
-      var value = method.getParams().getFirst()
-          .execute((Result) null, new BasicCommandContext());
-      if (!(value instanceof String s) || s.isEmpty()) {
-        return null;
-      }
-      edgeClassName = s;
-    } catch (RuntimeException e) {
-      return null;
-    }
+
+    // out('X') targets the "in" side; in('X') targets the "out" side
+    var targetPropName = "out".equals(dirName) ? "in" : "out";
+    return lookupLinkedVertexClass(edgeClassName, targetPropName, context);
+  }
+
+  /**
+   * Looks up the linked vertex class from an edge class's LINK property.
+   *
+   * @param edgeClassName the edge class to look up
+   * @param propName the property name to read ("in" or "out", or "inv"/"outv"
+   *     which are mapped to "in"/"out" respectively)
+   * @return the linked class name, or {@code null} if not found
+   */
+  @Nullable private static String lookupLinkedVertexClass(
+      String edgeClassName, String propName, CommandContext context) {
+    // Map inV/outV method names to the corresponding edge property
+    var resolvedProp = switch (propName) {
+      case "inv" -> "in";
+      case "outv" -> "out";
+      default -> propName;
+    };
 
     var session = context.getDatabaseSession();
     var schema = session.getMetadata().getImmutableSchemaSnapshot();
@@ -2291,9 +2329,7 @@ public class MatchExecutionPlanner {
     if (edgeClass == null) {
       return null;
     }
-    // out('X') targets the "in" side; in('X') targets the "out" side
-    var targetPropName = "out".equals(dirName) ? "in" : "out";
-    var prop = edgeClass.getPropertyInternal(targetPropName);
+    var prop = edgeClass.getPropertyInternal(resolvedProp);
     if (prop == null || prop.getLinkedClass() == null) {
       return null;
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -302,6 +302,17 @@ public class MatchExecutionPlanner {
   /** Maps each alias to a specific RID if one was provided in the pattern. */
   private Map<String, SQLRid> aliasRids;
 
+  /**
+   * Aliases whose class was inferred from edge LINK schema rather than
+   * explicitly declared. Inferred aliases must NOT outcompete explicit
+   * roots during scheduling — a low-cardinality inferred class can cause
+   * the scheduler to reverse traversal direction across while steps,
+   * producing 0 results. Their estimates are inflated to {@code
+   * Long.MAX_VALUE} so they sort last in root selection while remaining
+   * available for prefetching and collection-ID filtering.
+   */
+  private Set<String> inferredWhileExprAliases = Set.of();
+
   /** Set to `true` if at least one node in the pattern is marked `optional: true`. */
   private boolean foundOptional = false;
 
@@ -429,9 +440,18 @@ public class MatchExecutionPlanner {
 
     var result = new SelectExecutionPlan(context);
 
-    // Phase 3: Estimate how many root records each aliased node will produce
+    // Phase 3: Estimate how many root records each aliased node will produce.
     var estimatedRootEntries =
         estimateRootEntries(aliasClasses, aliasRids, aliasFilters, context);
+    // Inflate estimates for inferred-class aliases so they never outcompete
+    // explicitly declared roots. A low-cardinality inferred class can cause
+    // the scheduler to reverse traversal direction across while steps.
+    // The alias stays in the map for prefetching; only root priority changes.
+    for (var alias : inferredWhileExprAliases) {
+      if (estimatedRootEntries.containsKey(alias)) {
+        estimatedRootEntries.put(alias, Long.MAX_VALUE);
+      }
+    }
 
     // Aliases with fewer records than THRESHOLD and no dependency on $matched are prefetched
     var aliasesToPrefetch =
@@ -1810,6 +1830,25 @@ public class MatchExecutionPlanner {
         if (involvedAliases != null && !involvedAliases.isEmpty()) {
           var edgeClass = getEdgeClassName(edgeJ);
           var edgeDirection = getEdgeDirection(edgeJ);
+          var collectEdgeRids = false;
+
+          // .inV()/.outV() steps have no edge class — propagate from the
+          // preceding .outE('CLASS')/.inE('CLASS') step if present.
+          // The preceding edge iterates edge RIDs, so collectEdgeRids=true.
+          if (edgeClass == null && j > 0) {
+            var prevEdge = schedule.get(j - 1);
+            var prevMethodName = getMethodName(prevEdge);
+            if ("oute".equals(prevMethodName) || "ine".equals(prevMethodName)) {
+              edgeClass = getEdgeClassName(prevEdge);
+              // Normalize direction: "oute" -> "out", "ine" -> "in"
+              edgeDirection = getEdgeDirection(prevEdge);
+              if (edgeDirection != null && edgeDirection.endsWith("e")) {
+                edgeDirection =
+                    edgeDirection.substring(0, edgeDirection.length() - 1);
+              }
+              collectEdgeRids = true;
+            }
+          }
 
           if (edgeClass != null && edgeDirection != null) {
             var sourceAliasJ = edgeJ.out
@@ -1819,11 +1858,12 @@ public class MatchExecutionPlanner {
               var edgeI = schedule.get(producingEdgeIdx);
               edgeI.addIntersectionDescriptor(
                   new RidFilterDescriptor.EdgeRidLookup(
-                      edgeClass, edgeDirection, ridExpr));
+                      edgeClass, edgeDirection, ridExpr, collectEdgeRids));
               logger.debug(
                   "MATCH pre-filter: EdgeRidLookup on edge[{}] "
-                      + "({}({}) back-ref from alias '{}')",
-                  producingEdgeIdx, edgeDirection, edgeClass, targetAliasJ);
+                      + "({}({}) back-ref from alias '{}', edgeRids={})",
+                  producingEdgeIdx, edgeDirection, edgeClass, targetAliasJ,
+                  collectEdgeRids);
             }
           }
         }
@@ -1938,6 +1978,19 @@ public class MatchExecutionPlanner {
       case "in" -> "out";
       default -> syntacticDirection;
     };
+  }
+
+  /**
+   * Returns the lowercased method name for the given edge traversal
+   * (e.g. {@code "out"}, {@code "oute"}, {@code "inv"}).
+   */
+  @Nullable static String getMethodName(EdgeTraversal et) {
+    var method = et.edge.item.getMethod();
+    if (method == null) {
+      return null;
+    }
+    var name = method.getMethodNameString();
+    return name != null ? name.toLowerCase(Locale.ROOT) : null;
   }
 
   /**
@@ -2126,14 +2179,16 @@ public class MatchExecutionPlanner {
     // traversed in the wrong direction.  Non-recursive aliases in the same
     // expression (downstream of the while) are safe to infer.
     var whileAliases = collectAliasesFromWhilePatterns(this.matchExpressions);
+    var inferredAliases = new HashSet<String>();
     for (var expr : this.matchExpressions) {
       addAliases(expr, aliasFilters, aliasClasses, aliasCollections, aliasRids,
-          ctx, whileAliases);
+          ctx, whileAliases, inferredAliases);
     }
 
     this.aliasFilters = aliasFilters;
     this.aliasClasses = aliasClasses;
     this.aliasRids = aliasRids;
+    this.inferredWhileExprAliases = inferredAliases;
 
     rebindFilters(aliasFilters);
   }
@@ -2198,7 +2253,8 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasCollections,
       Map<String, SQLRid> aliasRids,
       CommandContext context,
-      Set<String> whileAliases) {
+      Set<String> whileAliases,
+      Set<String> inferredWhileExprAliases) {
     addAliases(expr.getOrigin(), aliasFilters, aliasClasses, aliasCollections, aliasRids, context);
 
     // Track the edge class set by the most recent outE/inE item, so that a
@@ -2240,6 +2296,7 @@ public class MatchExecutionPlanner {
             var inferred = inferClassFromEdgeSchema(method, currentEdgeClass, context);
             if (inferred != null) {
               aliasClasses.put(alias, inferred);
+              inferredWhileExprAliases.add(alias);
               logger.debug(
                   "MATCH class inference: alias '{}' -> class '{}' "
                       + "(from edge LINK schema)",

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2213,8 +2213,12 @@ public class MatchExecutionPlanner {
   /**
    * Extracts alias metadata (filters, class, collection, RID) from a single match
    * expression and merges them into the accumulation maps.
+   *
+   * <p>Tracks a {@code currentEdgeClass} state across items: {@code outE('X')}/{@code inE('X')}
+   * set it to {@code X}; {@code inV()}/{@code outV()} consume it for vertex class inference
+   * then reset it; all other methods reset it to {@code null}.
    */
-  private static void addAliases(
+  static void addAliases(
       SQLMatchExpression expr,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, String> aliasClasses,
@@ -2224,18 +2228,41 @@ public class MatchExecutionPlanner {
       boolean skipClassInference) {
     addAliases(expr.getOrigin(), aliasFilters, aliasClasses, aliasCollections, aliasRids, context);
 
+    // Track the edge class set by the most recent outE/inE item, so that a
+    // following inV/outV can look up the linked vertex class from the edge schema.
+    // Reset after inV/outV consumes it, or when a non-edge-method item is seen.
+    @Nullable String currentEdgeClass = null;
+
     for (var item : expr.getItems()) {
       if (item.getFilter() != null) {
         addAliases(item.getFilter(), aliasFilters, aliasClasses, aliasCollections, aliasRids,
             context);
         if (!skipClassInference) {
+          // Determine the method name for edge-class state tracking.
+          var method = item.getMethod();
+          var methodName = method != null ? method.getMethodNameString() : null;
+          var methodLower = methodName != null
+              ? methodName.toLowerCase(Locale.ROOT) : null;
+
+          // Update currentEdgeClass state based on the method type.
+          if ("oute".equals(methodLower) || "ine".equals(methodLower)) {
+            currentEdgeClass = extractEdgeClassName(method);
+          } else if ("inv".equals(methodLower) || "outv".equals(methodLower)) {
+            // inV/outV consumes the currentEdgeClass — pass it to inference,
+            // then reset so a subsequent inV/outV without a preceding outE/inE
+            // correctly gets null.
+            // (currentEdgeClass is read below, then reset after inference)
+          } else {
+            // Any other method (out, in, both, bothE, etc.) resets the state.
+            currentEdgeClass = null;
+          }
+
           // Infer target class from edge LINK schema when no explicit class
-          // is set. For out('CONTAINER_OF'), the target vertices are the "in"
-          // endpoint of the CONTAINER_OF edge class; if that endpoint declares
-          // LINK Message, the target class is Message.
+          // is set. Handles both vertex-to-vertex traversals (out/in) and
+          // edge-method traversals (outE/inE/inV/outV).
           var alias = item.getFilter().getAlias();
           if (alias != null && !aliasClasses.containsKey(alias)) {
-            var inferred = inferClassFromEdgeSchema(item.getMethod(), null, context);
+            var inferred = inferClassFromEdgeSchema(method, currentEdgeClass, context);
             if (inferred != null) {
               aliasClasses.put(alias, inferred);
               logger.debug(
@@ -2243,6 +2270,11 @@ public class MatchExecutionPlanner {
                       + "(from edge LINK schema)",
                   alias, inferred);
             }
+          }
+
+          // Reset currentEdgeClass after inV/outV consumes it.
+          if ("inv".equals(methodLower) || "outv".equals(methodLower)) {
+            currentEdgeClass = null;
           }
         }
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2119,16 +2119,16 @@ public class MatchExecutionPlanner {
     Map<String, String> aliasClasses = new LinkedHashMap<>();
     Map<String, String> aliasCollections = new LinkedHashMap<>();
     Map<String, SQLRid> aliasRids = new LinkedHashMap<>();
-    // Collect aliases from patterns that contain a while condition.
-    // Class inference on these (and patterns sharing aliases with them)
+    // Collect aliases that are directly part of a while-condition's recursive
+    // zone (origin + while-item).  Class inference on these specific aliases
     // must be skipped — inferred classes change cost estimates which can
     // reorder the schedule, causing while/where recursive steps to be
-    // traversed in the wrong direction.
+    // traversed in the wrong direction.  Non-recursive aliases in the same
+    // expression (downstream of the while) are safe to infer.
     var whileAliases = collectAliasesFromWhilePatterns(this.matchExpressions);
     for (var expr : this.matchExpressions) {
-      boolean skipInference = sharesAliases(expr, whileAliases);
       addAliases(expr, aliasFilters, aliasClasses, aliasCollections, aliasRids,
-          ctx, skipInference);
+          ctx, whileAliases);
     }
 
     this.aliasFilters = aliasFilters;
@@ -2163,51 +2163,23 @@ public class MatchExecutionPlanner {
       List<SQLMatchExpression> expressions) {
     var result = new HashSet<String>();
     for (var expr : expressions) {
-      boolean hasWhile = false;
       for (var item : expr.getItems()) {
         if (item.getFilter() != null
             && item.getFilter().getWhileCondition() != null) {
-          hasWhile = true;
-          break;
-        }
-      }
-      if (hasWhile) {
-        // Collect origin alias
-        if (expr.getOrigin() != null && expr.getOrigin().getAlias() != null) {
-          result.add(expr.getOrigin().getAlias());
-        }
-        // Collect all item aliases
-        for (var item : expr.getItems()) {
-          if (item.getFilter() != null && item.getFilter().getAlias() != null) {
+          // Only the origin alias and the while-item's own alias are in the
+          // recursive zone.  Downstream items (after the while in the pattern
+          // chain) are not recursive and can safely have class inference —
+          // their inferred classes do not affect while-traversal direction.
+          if (expr.getOrigin() != null && expr.getOrigin().getAlias() != null) {
+            result.add(expr.getOrigin().getAlias());
+          }
+          if (item.getFilter().getAlias() != null) {
             result.add(item.getFilter().getAlias());
           }
         }
       }
     }
     return result;
-  }
-
-  /**
-   * Returns true if the expression shares any alias with the given set.
-   * Used to detect patterns connected to while-containing patterns via
-   * shared aliases (e.g. {@code {as: post}} appearing in both patterns).
-   */
-  private static boolean sharesAliases(
-      SQLMatchExpression expr, Set<String> aliases) {
-    if (aliases.isEmpty()) {
-      return false;
-    }
-    if (expr.getOrigin() != null && expr.getOrigin().getAlias() != null
-        && aliases.contains(expr.getOrigin().getAlias())) {
-      return true;
-    }
-    for (var item : expr.getItems()) {
-      if (item.getFilter() != null && item.getFilter().getAlias() != null
-          && aliases.contains(item.getFilter().getAlias())) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**
@@ -2226,7 +2198,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasCollections,
       Map<String, SQLRid> aliasRids,
       CommandContext context,
-      boolean skipClassInference) {
+      Set<String> whileAliases) {
     addAliases(expr.getOrigin(), aliasFilters, aliasClasses, aliasCollections, aliasRids, context);
 
     // Track the edge class set by the most recent outE/inE item, so that a
@@ -2238,7 +2210,13 @@ public class MatchExecutionPlanner {
       if (item.getFilter() != null) {
         addAliases(item.getFilter(), aliasFilters, aliasClasses, aliasCollections, aliasRids,
             context);
-        if (!skipClassInference) {
+
+        // Skip class inference only for aliases in the recursive zone
+        // (origin + while-item).  Downstream aliases are safe to infer.
+        var alias = item.getFilter().getAlias();
+        boolean skipThisItem = alias != null && whileAliases.contains(alias);
+
+        if (!skipThisItem) {
           // Determine the method name for edge-class state tracking.
           var method = item.getMethod();
           var methodName = method != null ? method.getMethodNameString() : null;
@@ -2258,7 +2236,6 @@ public class MatchExecutionPlanner {
           // Infer target class from edge LINK schema when no explicit class
           // is set. Handles both vertex-to-vertex traversals (out/in) and
           // edge-method traversals (outE/inE/inV/outV).
-          var alias = item.getFilter().getAlias();
           if (alias != null && !aliasClasses.containsKey(alias)) {
             var inferred = inferClassFromEdgeSchema(method, currentEdgeClass, context);
             if (inferred != null) {
@@ -2274,6 +2251,9 @@ public class MatchExecutionPlanner {
           if (isInVOrOutV) {
             currentEdgeClass = null;
           }
+        } else {
+          // While-alias: reset edge class state since we skip inference.
+          currentEdgeClass = null;
         }
       }
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -1734,7 +1734,7 @@ public class MatchExecutionPlanner {
     // throw NPE, ClassCastException, etc. — not just CommandExecutionException.
     try {
       var value = firstParam.execute((Result) null, new BasicCommandContext());
-      if (value instanceof String s) {
+      if (value instanceof String s && !s.isEmpty()) {
         return s;
       }
     } catch (RuntimeException e) {
@@ -2218,6 +2218,7 @@ public class MatchExecutionPlanner {
    * set it to {@code X}; {@code inV()}/{@code outV()} consume it for vertex class inference
    * then reset it; all other methods reset it to {@code null}.
    */
+  // Visible for testing
   static void addAliases(
       SQLMatchExpression expr,
       Map<String, SQLWhereClause> aliasFilters,

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/graph/DoubleSidedEdgeLinkBagTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/graph/DoubleSidedEdgeLinkBagTest.java
@@ -24,7 +24,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Vertex;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
-import com.jetbrains.youtrackdb.internal.core.record.impl.EdgeIterator;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EdgeFromLinkBagIterator;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityHelper;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
@@ -1523,7 +1523,7 @@ public class DoubleSidedEdgeLinkBagTest {
   }
 
   /**
-   * Verifies EdgeIterator.next() throws NoSuchElementException when exhausted.
+   * Verifies that the edge iterator's next() throws NoSuchElementException when exhausted.
    */
   @Test
   public void testEdgeIteratorNextOnExhausted() {
@@ -1554,8 +1554,8 @@ public class DoubleSidedEdgeLinkBagTest {
   }
 
   /**
-   * Verifies EdgeIterator.size() returns the correct count for LinkBag-backed edges,
-   * and EdgeIterator.isSizeable() returns true.
+   * Verifies the edge iterator's size() returns the correct count for LinkBag-backed edges,
+   * and isSizeable() returns true.
    */
   @Test
   public void testEdgeIteratorSizeAndIsSizeable() {
@@ -1572,8 +1572,8 @@ public class DoubleSidedEdgeLinkBagTest {
     var loaded = tx.load(centerRid).asVertex();
     var edgeIter = loaded.getEdges(Direction.OUT, "HeavyEdge").iterator();
 
-    // EdgeIterator implements Sizeable
-    assertTrue("EdgeIterator should be Sizeable", edgeIter instanceof Sizeable);
+    // EdgeFromLinkBagIterator implements Sizeable
+    assertTrue("Edge iterator should be Sizeable", edgeIter instanceof Sizeable);
     var sizeable = (Sizeable) edgeIter;
     assertTrue("isSizeable should be true for LinkBag-backed edges", sizeable.isSizeable());
     assertEquals("size should be 5", 5, sizeable.size());
@@ -1598,8 +1598,8 @@ public class DoubleSidedEdgeLinkBagTest {
     var loaded = tx.load(centerRid).asVertex();
     var edgeIterable = loaded.getEdges(Direction.OUT, "HeavyEdge");
 
-    // EdgeIterable implements Sizeable
-    assertTrue("EdgeIterable should be Sizeable", edgeIterable instanceof Sizeable);
+    // EdgeFromLinkBagIterable implements Sizeable via PreFilterableLinkBagIterable
+    assertTrue("Edge iterable should be Sizeable", edgeIterable instanceof Sizeable);
     var sizeable = (Sizeable) edgeIterable;
     assertTrue("isSizeable should be true", sizeable.isSizeable());
     assertEquals("size should be 3", 3, sizeable.size());
@@ -1607,43 +1607,12 @@ public class DoubleSidedEdgeLinkBagTest {
   }
 
   /**
-   * Verifies EdgeIterator.reset() throws UnsupportedOperationException when the underlying
-   * LinkBag iterator does not support reset, and that isResetable() returns false.
+   * Verifies that the LinkBag edge iterator is an EdgeFromLinkBagIterator (not the
+   * general EdgeIterator). This confirms that getEdgesInternal uses the optimized
+   * EdgeFromLinkBagIterable path for LinkBag storage.
    */
   @Test
-  public void testEdgeIteratorResetThrowsForNonResettable() {
-    var tx = session.begin();
-    var center = tx.newVertex("TestVertex");
-    center.addEdge(tx.newVertex("TestVertex"), "HeavyEdge");
-    var centerRid = center.getIdentity();
-    tx.commit();
-
-    tx = session.begin();
-    var loaded = tx.load(centerRid).asVertex();
-    var edgeIter = loaded.getEdges(Direction.OUT, "HeavyEdge").iterator();
-
-    // Consume the edge
-    assertTrue(edgeIter.hasNext());
-    edgeIter.next();
-
-    // The runtime type is EdgeIterator; LinkBag iterator is not Resettable
-    var ei = (EdgeIterator) (Object) edgeIter;
-    assertFalse("LinkBag-backed EdgeIterator should not be resetable", ei.isResetable());
-
-    try {
-      ei.reset();
-      fail("Expected UnsupportedOperationException from reset()");
-    } catch (UnsupportedOperationException expected) {
-      // Expected: the underlying LinkBag iterator is not Resettable
-    }
-    tx.commit();
-  }
-
-  /**
-   * Verifies EdgeIterator.getMultiValue() returns the backing multiValue object.
-   */
-  @Test
-  public void testEdgeIteratorGetMultiValue() {
+  public void testLinkBagEdgeIteratorIsEdgeFromLinkBagIterator() {
     var tx = session.begin();
     var center = tx.newVertex("TestVertex");
     center.addEdge(tx.newVertex("TestVertex"), "HeavyEdge");
@@ -1654,13 +1623,9 @@ public class DoubleSidedEdgeLinkBagTest {
     var loaded = tx.load(centerRid).asVertex();
     var iter = loaded.getEdges(Direction.OUT, "HeavyEdge").iterator();
 
-    var rawIter = (Object) iter;
-    assertTrue("Expected EdgeIterator instance", rawIter instanceof EdgeIterator);
-    var edgeIter = (EdgeIterator) rawIter;
-    Object multiValue = edgeIter.getMultiValue();
-    // The multiValue should be a LinkBag for standard edge storage
-    assertNotNull("getMultiValue should return non-null", multiValue);
-    assertTrue("multiValue should be a LinkBag", multiValue instanceof LinkBag);
+    assertTrue(
+        "LinkBag case should use EdgeFromLinkBagIterator",
+        (Object) iter instanceof EdgeFromLinkBagIterator);
     tx.commit();
   }
 
@@ -1971,6 +1936,170 @@ public class DoubleSidedEdgeLinkBagTest {
       count++;
     }
     assertEquals(1, count);
+    tx.commit();
+  }
+
+  // --- EdgeFromLinkBagIterable integration tests ---
+
+  /**
+   * Verifies that getEdges(OUT) returns the correct edge records when using
+   * EdgeFromLinkBagIterable (the new optimized path for LinkBag edge traversal).
+   * This validates that getEdgesInternal's LinkBag case produces identical results
+   * via EdgeFromLinkBagIterable as the old EdgeIterable path.
+   */
+  @Test
+  public void testGetEdgesOutReturnsCorrectEdgeRecords() {
+    var tx = session.begin();
+
+    var outVertex = tx.newVertex("TestVertex");
+    var inVertex = tx.newVertex("TestVertex");
+    var edge = outVertex.addEdge(inVertex, "HeavyEdge");
+    edge.setProperty("weight", 42);
+    var edgeRid = edge.getIdentity();
+
+    tx.commit();
+
+    tx = session.begin();
+    var loadedOut = tx.load(outVertex.getIdentity()).asVertex();
+
+    var edges = loadedOut.getEdges(Direction.OUT, "HeavyEdge");
+    var iter = edges.iterator();
+    assertTrue("Should have at least one edge", iter.hasNext());
+    var loadedEdge = iter.next();
+    assertEquals("Edge RID should match", edgeRid, loadedEdge.getIdentity());
+    assertEquals(
+        "Edge property should be preserved",
+        42, loadedEdge.<Integer>getProperty("weight").intValue());
+    assertFalse("Should have exactly one edge", iter.hasNext());
+
+    tx.commit();
+  }
+
+  /**
+   * Verifies that getEdges(IN) returns the correct edge records from the
+   * perspective of the target vertex.
+   */
+  @Test
+  public void testGetEdgesInReturnsCorrectEdgeRecords() {
+    var tx = session.begin();
+
+    var outVertex = tx.newVertex("TestVertex");
+    var inVertex = tx.newVertex("TestVertex");
+    var edge = outVertex.addEdge(inVertex, "HeavyEdge");
+    var edgeRid = edge.getIdentity();
+
+    tx.commit();
+
+    tx = session.begin();
+    var loadedIn = tx.load(inVertex.getIdentity()).asVertex();
+
+    var edges = loadedIn.getEdges(Direction.IN, "HeavyEdge");
+    var iter = edges.iterator();
+    assertTrue("Should have at least one edge", iter.hasNext());
+    assertEquals("Edge RID should match", edgeRid, iter.next().getIdentity());
+    assertFalse("Should have exactly one edge", iter.hasNext());
+
+    tx.commit();
+  }
+
+  /**
+   * Verifies that getEdges returns all edges from multiple edge classes when
+   * no label filter is applied.
+   */
+  @Test
+  public void testGetEdgesWithMixedEdgeTypesReturnsAll() {
+    var tx = session.begin();
+
+    var center = tx.newVertex("TestVertex");
+    var heavyTarget = tx.newVertex("TestVertex");
+    var lightTarget = tx.newVertex("TestVertex");
+
+    var heavyEdge = center.addEdge(heavyTarget, "HeavyEdge");
+    var lightEdge = center.addEdge(lightTarget, "LightEdge");
+
+    tx.commit();
+
+    tx = session.begin();
+    var loadedCenter = tx.load(center.getIdentity()).asVertex();
+
+    Set<RID> edgeRids = new HashSet<>();
+    for (var e : loadedCenter.getEdges(Direction.OUT)) {
+      edgeRids.add(e.getIdentity());
+    }
+
+    assertEquals("Should have 2 edges", 2, edgeRids.size());
+    assertTrue(
+        "Should contain HeavyEdge",
+        edgeRids.contains(heavyEdge.getIdentity()));
+    assertTrue(
+        "Should contain LightEdge",
+        edgeRids.contains(lightEdge.getIdentity()));
+
+    tx.commit();
+  }
+
+  /**
+   * Verifies that getEdges with label filtering returns only edges of the
+   * specified class.
+   */
+  @Test
+  public void testGetEdgesWithLabelFilterReturnsOnlyMatchingEdgeClass() {
+    var tx = session.begin();
+
+    var center = tx.newVertex("TestVertex");
+    var heavyTarget = tx.newVertex("TestVertex");
+    var lightTarget = tx.newVertex("TestVertex");
+
+    var heavyEdge = center.addEdge(heavyTarget, "HeavyEdge");
+    center.addEdge(lightTarget, "LightEdge");
+
+    tx.commit();
+
+    tx = session.begin();
+    var loadedCenter = tx.load(center.getIdentity()).asVertex();
+
+    // Only request HeavyEdge edges
+    var edges = loadedCenter.getEdges(Direction.OUT, "HeavyEdge");
+    var iter = edges.iterator();
+    assertTrue(iter.hasNext());
+    assertEquals(heavyEdge.getIdentity(), iter.next().getIdentity());
+    assertFalse("Should have only 1 edge for HeavyEdge", iter.hasNext());
+
+    tx.commit();
+  }
+
+  /**
+   * Verifies that getEdges returns multiple edges when a vertex has multiple
+   * heavyweight edges of the same class.
+   */
+  @Test
+  public void testGetEdgesOutWithMultipleEdgesOfSameClass() {
+    var tx = session.begin();
+
+    var center = tx.newVertex("TestVertex");
+    var target1 = tx.newVertex("TestVertex");
+    var target2 = tx.newVertex("TestVertex");
+    var target3 = tx.newVertex("TestVertex");
+
+    var edge1 = center.addEdge(target1, "HeavyEdge");
+    var edge2 = center.addEdge(target2, "HeavyEdge");
+    var edge3 = center.addEdge(target3, "HeavyEdge");
+
+    tx.commit();
+
+    tx = session.begin();
+    var loadedCenter = tx.load(center.getIdentity()).asVertex();
+
+    Set<RID> edgeRids = new HashSet<>();
+    for (var e : loadedCenter.getEdges(Direction.OUT, "HeavyEdge")) {
+      edgeRids.add(e.getIdentity());
+    }
+
+    assertEquals("Should have 3 edges", 3, edgeRids.size());
+    assertTrue(edgeRids.contains(edge1.getIdentity()));
+    assertTrue(edgeRids.contains(edge2.getIdentity()));
+    assertTrue(edgeRids.contains(edge3.getIdentity()));
+
     tx.commit();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterableTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterableTest.java
@@ -144,6 +144,37 @@ public class EdgeFromLinkBagIterableTest {
     assertFalse(iterator.hasNext());
   }
 
+  /**
+   * Chaining withClassFilter() then withRidFilter() should produce an iterable
+   * that applies both filters, because each method preserves the other filter.
+   * An edge must pass both the collection ID check and the RID set check.
+   */
+  @Test
+  public void testChainingBothFiltersPreservesBoth() {
+    var matchingRid = new RecordId(20, 1); // collection 20 + in RID set
+    var wrongClassRid = new RecordId(30, 1); // collection 30 (rejected by class)
+    var wrongRidRid = new RecordId(20, 2); // collection 20 but not in RID set
+
+    when(linkBag.iterator()).thenReturn(List.of(
+        RidPair.ofPair(wrongClassRid, new RecordId(10, 1)),
+        RidPair.ofPair(wrongRidRid, new RecordId(10, 2)),
+        RidPair.ofPair(matchingRid, new RecordId(10, 3))).iterator());
+    when(linkBag.size()).thenReturn(3);
+    mockLoadReturnsEdge(matchingRid);
+
+    var acceptedRids = new HashSet<RID>();
+    acceptedRids.add(matchingRid);
+
+    var filtered = new EdgeFromLinkBagIterable(linkBag, session)
+        .withClassFilter(IntOpenHashSet.of(20))
+        .withRidFilter(acceptedRids);
+
+    var iter = filtered.iterator();
+    assertTrue(iter.hasNext());
+    assertEquals(matchingRid, iter.next().getIdentity());
+    assertFalse(iter.hasNext());
+  }
+
   private void mockLoadReturnsEdge(RID rid) {
     var entity = mock(Entity.class);
     var edge = mock(Edge.class, org.mockito.Mockito.withSettings()

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterableTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIterableTest.java
@@ -1,0 +1,156 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Edge;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests EdgeFromLinkBagIterable — the thin wrapper around EdgeFromLinkBagIterator.
+ * Verifies construction, filter copy semantics, iteration delegation, and size
+ * delegation to the underlying LinkBag.
+ */
+public class EdgeFromLinkBagIterableTest {
+
+  private DatabaseSessionEmbedded session;
+  private FrontendTransactionImpl transaction;
+  private LinkBag linkBag;
+
+  @Before
+  public void setUp() {
+    session = mock(DatabaseSessionEmbedded.class);
+    transaction = mock(FrontendTransactionImpl.class);
+    linkBag = mock(LinkBag.class);
+    when(session.getActiveTransaction()).thenReturn(transaction);
+  }
+
+  /**
+   * iterator() should produce an EdgeFromLinkBagIterator that yields edge records
+   * from the LinkBag's primary RIDs.
+   */
+  @Test
+  public void testIteratorYieldsEdgesFromLinkBag() {
+    var edgeRid = new RecordId(20, 1);
+    var vertexRid = new RecordId(10, 1);
+    var pair = RidPair.ofPair(edgeRid, vertexRid);
+
+    when(linkBag.iterator()).thenReturn(List.of(pair).iterator());
+    when(linkBag.size()).thenReturn(1);
+    mockLoadReturnsEdge(edgeRid);
+
+    var iterable = new EdgeFromLinkBagIterable(linkBag, session);
+    var iterator = iterable.iterator();
+
+    assertTrue(iterator.hasNext());
+    assertEquals(edgeRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * size() delegates to the LinkBag's size.
+   */
+  @Test
+  public void testSizeDelegatesToLinkBag() {
+    when(linkBag.size()).thenReturn(42);
+    when(linkBag.isSizeable()).thenReturn(true);
+
+    var iterable = new EdgeFromLinkBagIterable(linkBag, session);
+
+    assertEquals(42, iterable.size());
+    assertTrue(iterable.isSizeable());
+  }
+
+  /**
+   * isSizeable() returns false when LinkBag reports not sizeable.
+   */
+  @Test
+  public void testIsSizeableDelegatesToLinkBag() {
+    when(linkBag.isSizeable()).thenReturn(false);
+
+    var iterable = new EdgeFromLinkBagIterable(linkBag, session);
+
+    assertFalse(iterable.isSizeable());
+  }
+
+  /**
+   * withClassFilter returns a new iterable (immutable copy pattern) that filters
+   * edges by collection ID.
+   */
+  @Test
+  public void testWithClassFilterReturnsFilteredCopy() {
+    var matchingRid = new RecordId(20, 1);
+    var nonMatchingRid = new RecordId(30, 1);
+    var matchingPair = RidPair.ofPair(matchingRid, new RecordId(10, 1));
+    var nonMatchingPair = RidPair.ofPair(nonMatchingRid, new RecordId(10, 2));
+
+    when(linkBag.iterator())
+        .thenReturn(List.of(nonMatchingPair, matchingPair).iterator());
+    when(linkBag.size()).thenReturn(2);
+    mockLoadReturnsEdge(matchingRid);
+
+    var original = new EdgeFromLinkBagIterable(linkBag, session);
+    var filtered = original.withClassFilter(IntOpenHashSet.of(20));
+
+    assertNotSame("withClassFilter must return a new instance", original, filtered);
+
+    var iterator = filtered.iterator();
+    assertTrue(iterator.hasNext());
+    assertEquals(matchingRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * withRidFilter returns a new iterable that filters edges by RID set.
+   */
+  @Test
+  public void testWithRidFilterReturnsFilteredCopy() {
+    var matchingRid = new RecordId(20, 1);
+    var nonMatchingRid = new RecordId(20, 2);
+    var matchingPair = RidPair.ofPair(matchingRid, new RecordId(10, 1));
+    var nonMatchingPair = RidPair.ofPair(nonMatchingRid, new RecordId(10, 2));
+
+    when(linkBag.iterator())
+        .thenReturn(List.of(nonMatchingPair, matchingPair).iterator());
+    when(linkBag.size()).thenReturn(2);
+    mockLoadReturnsEdge(matchingRid);
+
+    var acceptedRids = new HashSet<RID>();
+    acceptedRids.add(matchingRid);
+
+    var original = new EdgeFromLinkBagIterable(linkBag, session);
+    var filtered = original.withRidFilter(acceptedRids);
+
+    assertNotSame("withRidFilter must return a new instance", original, filtered);
+
+    var iterator = filtered.iterator();
+    assertTrue(iterator.hasNext());
+    assertEquals(matchingRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  private void mockLoadReturnsEdge(RID rid) {
+    var entity = mock(Entity.class);
+    var edge = mock(Edge.class, org.mockito.Mockito.withSettings()
+        .extraInterfaces(EdgeInternal.class));
+    when(entity.isEdge()).thenReturn(true);
+    when(entity.asEdge()).thenReturn(edge);
+    when(edge.getIdentity()).thenReturn(rid);
+    when(transaction.loadEntity(rid)).thenReturn(entity);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIteratorTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIteratorTest.java
@@ -3,7 +3,10 @@ package com.jetbrains.youtrackdb.internal.core.record.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +18,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -99,9 +103,10 @@ public class EdgeFromLinkBagIteratorTest {
 
   /**
    * When the primary RID points to a vertex entity (legacy lightweight edge),
-   * the iterator should throw IllegalStateException.
+   * the iterator should throw IllegalStateException with a message identifying
+   * the legacy edge and the offending RID.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testThrowsOnLegacyVertexEntry() {
     var vertexRid = new RecordId(20, 1);
     var pair = RidPair.ofPair(vertexRid, new RecordId(10, 1));
@@ -114,7 +119,15 @@ public class EdgeFromLinkBagIteratorTest {
     var iterator = new EdgeFromLinkBagIterator(
         List.of(pair).iterator(), session, 1);
 
-    iterator.hasNext(); // triggers loadEdge → IllegalStateException
+    try {
+      iterator.hasNext();
+      fail("Expected IllegalStateException for legacy vertex entry");
+    } catch (IllegalStateException e) {
+      assertTrue("Message should mention legacy lightweight edge",
+          e.getMessage().contains("Legacy lightweight edge detected"));
+      assertTrue("Message should contain the offending RID",
+          e.getMessage().contains(vertexRid.toString()));
+    }
   }
 
   /**
@@ -239,9 +252,10 @@ public class EdgeFromLinkBagIteratorTest {
   /**
    * RidPair.validateEdgePair() rejects legacy lightweight pairs where
    * primaryRid == secondaryRid. After edge unification (YTDB-605), all edges
-   * must have distinct edge and vertex RIDs.
+   * must have distinct edge and vertex RIDs. Verify the exception comes from
+   * validateEdgePair (not from the legacy-vertex branch) by checking its message.
    */
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testValidateEdgePairRejectsEqualRids() {
     var rid = new RecordId(10, 1);
     var pair = new RidPair(rid, rid);
@@ -249,7 +263,13 @@ public class EdgeFromLinkBagIteratorTest {
     var iterator = new EdgeFromLinkBagIterator(
         List.of(pair).iterator(), session, 1);
 
-    iterator.hasNext(); // triggers validateEdgePair → IllegalStateException
+    try {
+      iterator.hasNext();
+      fail("Expected IllegalStateException from validateEdgePair");
+    } catch (IllegalStateException e) {
+      assertTrue("Message should mention primaryRid == secondaryRid",
+          e.getMessage().contains("primaryRid == secondaryRid"));
+    }
   }
 
   // =========================================================================
@@ -269,13 +289,15 @@ public class EdgeFromLinkBagIteratorTest {
     mockLoadReturnsEdge(matchingRid);
     // nonMatchingRid should never be loaded — no mock needed
 
-    var accepted = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var accepted = IntOpenHashSet.of(20);
     var iterator = new EdgeFromLinkBagIterator(
         List.of(nonMatchingPair, matchingPair).iterator(), session, 2, accepted);
 
     assertTrue(iterator.hasNext());
     assertEquals(matchingRid, iterator.next().getIdentity());
     assertFalse(iterator.hasNext());
+    // Verify zero-I/O: nonMatchingRid should never have been loaded from storage
+    verify(transaction, never()).loadEntity(nonMatchingRid);
   }
 
   /**
@@ -288,7 +310,7 @@ public class EdgeFromLinkBagIteratorTest {
     mockLoadReturnsEdge(rid1);
     mockLoadReturnsEdge(rid2);
 
-    var accepted = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var accepted = IntOpenHashSet.of(20);
     var iterator = new EdgeFromLinkBagIterator(
         List.of(
             RidPair.ofPair(rid1, new RecordId(10, 1)),
@@ -310,7 +332,7 @@ public class EdgeFromLinkBagIteratorTest {
   public void classFilter_noneMatch_yieldsEmpty_noIO() {
     var rid = new RecordId(30, 1); // collection 30 — not accepted
 
-    var accepted = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var accepted = IntOpenHashSet.of(20);
     var iterator = new EdgeFromLinkBagIterator(
         List.of(RidPair.ofPair(rid, new RecordId(10, 1))).iterator(),
         session, 1, accepted);
@@ -348,13 +370,16 @@ public class EdgeFromLinkBagIteratorTest {
     assertTrue(iterator.hasNext());
     assertEquals(matchingRid, iterator.next().getIdentity());
     assertFalse(iterator.hasNext());
+    // Verify zero-I/O: nonMatchingRid should never have been loaded from storage
+    verify(transaction, never()).loadEntity(nonMatchingRid);
   }
 
   /**
-   * When acceptedRids is empty, no edges are yielded.
+   * When acceptedRids is empty, no edges are yielded and no records are loaded
+   * from storage (zero-I/O optimization).
    */
   @Test
-  public void ridFilter_emptySet_yieldsEmpty() {
+  public void ridFilter_emptySet_yieldsEmpty_noIO() {
     var rid = new RecordId(20, 1);
 
     var iterator = new EdgeFromLinkBagIterator(
@@ -362,6 +387,8 @@ public class EdgeFromLinkBagIteratorTest {
         session, 1, null, new HashSet<>());
 
     assertFalse(iterator.hasNext());
+    // Verify zero-I/O: loadEntity should never have been called
+    verifyNoMoreInteractions(transaction);
   }
 
   // =========================================================================
@@ -383,7 +410,7 @@ public class EdgeFromLinkBagIteratorTest {
 
     mockLoadReturnsEdge(rid1);
 
-    var acceptedCollections = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var acceptedCollections = IntOpenHashSet.of(20);
     var acceptedRids = new HashSet<RID>();
     acceptedRids.add(rid1);
 
@@ -397,6 +424,24 @@ public class EdgeFromLinkBagIteratorTest {
     assertTrue(iterator.hasNext());
     assertEquals(rid1, iterator.next().getIdentity());
     assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * Calling next() directly without a preceding hasNext() should still return
+   * the correct edge, since next() delegates to hasNext() internally. This
+   * verifies the iterator contract holds for callers that skip hasNext().
+   */
+  @Test
+  public void testNextWithoutHasNextReturnsEdge() {
+    var edgeRid = new RecordId(20, 1);
+    var pair = RidPair.ofPair(edgeRid, new RecordId(10, 1));
+    mockLoadReturnsEdge(edgeRid);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(pair).iterator(), session, 1);
+
+    // Call next() directly without hasNext()
+    assertEquals(edgeRid, iterator.next().getIdentity());
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIteratorTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EdgeFromLinkBagIteratorTest.java
@@ -1,0 +1,415 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Edge;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests EdgeFromLinkBagIterator behavior when loading edge records from LinkBag
+ * primary RIDs. Verifies:
+ * <ul>
+ *   <li>Normal iteration over valid edge RIDs (loads from primaryRid)</li>
+ *   <li>Graceful skipping of deleted records (RecordNotFoundException)</li>
+ *   <li>IllegalStateException for legacy vertex entries</li>
+ *   <li>Empty iterator behavior</li>
+ *   <li>NoSuchElementException on exhausted iteration</li>
+ *   <li>hasNext() idempotency</li>
+ *   <li>Class filter (acceptedCollectionIds) — zero-I/O skipping</li>
+ *   <li>RID filter (acceptedRids) — zero-I/O skipping</li>
+ *   <li>Combined class + RID filter</li>
+ *   <li>validateEdgePair rejects corrupt entries</li>
+ * </ul>
+ */
+public class EdgeFromLinkBagIteratorTest {
+
+  private DatabaseSessionEmbedded session;
+  private FrontendTransactionImpl transaction;
+
+  @Before
+  public void setUp() {
+    session = mock(DatabaseSessionEmbedded.class);
+    transaction = mock(FrontendTransactionImpl.class);
+    when(session.getActiveTransaction()).thenReturn(transaction);
+  }
+
+  /**
+   * The iterator loads from primaryRid (the edge record), not secondaryRid (the
+   * opposite vertex). Verify it yields the edge at primaryRid.
+   */
+  @Test
+  public void testLoadsEdgeFromPrimaryRid() {
+    var edgeRid = new RecordId(20, 1);
+    var vertexRid = new RecordId(10, 1);
+    var pair = RidPair.ofPair(edgeRid, vertexRid);
+    mockLoadReturnsEdge(edgeRid);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(pair).iterator(), session, 1);
+
+    assertTrue(iterator.hasNext());
+    assertEquals(
+        "Should load edge from primary RID, not secondary",
+        edgeRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * When the primary RID points to a deleted record, the iterator should skip
+   * that entry and continue to the next valid one.
+   */
+  @Test
+  public void testSkipsDeletedRecordsGracefully() {
+    var deletedRid = new RecordId(20, 1);
+    var validRid = new RecordId(20, 2);
+
+    var deletedPair = RidPair.ofPair(deletedRid, new RecordId(10, 1));
+    var validPair = RidPair.ofPair(validRid, new RecordId(10, 2));
+
+    when(transaction.loadEntity(deletedRid))
+        .thenThrow(new RecordNotFoundException("test", deletedRid));
+    mockLoadReturnsEdge(validRid);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(deletedPair, validPair).iterator(), session, 2);
+
+    assertTrue(
+        "Should have a next edge after skipping deleted record",
+        iterator.hasNext());
+    assertEquals(validRid, iterator.next().getIdentity());
+    assertFalse("Should have no more edges", iterator.hasNext());
+  }
+
+  /**
+   * When the primary RID points to a vertex entity (legacy lightweight edge),
+   * the iterator should throw IllegalStateException.
+   */
+  @Test(expected = IllegalStateException.class)
+  public void testThrowsOnLegacyVertexEntry() {
+    var vertexRid = new RecordId(20, 1);
+    var pair = RidPair.ofPair(vertexRid, new RecordId(10, 1));
+
+    var entity = mock(Entity.class);
+    when(entity.isEdge()).thenReturn(false);
+    when(entity.isVertex()).thenReturn(true);
+    when(transaction.loadEntity(vertexRid)).thenReturn(entity);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(pair).iterator(), session, 1);
+
+    iterator.hasNext(); // triggers loadEdge → IllegalStateException
+  }
+
+  /**
+   * When the primary RID points to a non-edge, non-vertex entity, the iterator
+   * should skip it gracefully (log warning, return null).
+   */
+  @Test
+  public void testSkipsNonEdgeNonVertexRecordsGracefully() {
+    var unknownRid = new RecordId(20, 1);
+    var validRid = new RecordId(20, 2);
+
+    var unknownPair = RidPair.ofPair(unknownRid, new RecordId(10, 1));
+    var validPair = RidPair.ofPair(validRid, new RecordId(10, 2));
+
+    var nonEdge = mock(Entity.class);
+    when(nonEdge.isEdge()).thenReturn(false);
+    when(nonEdge.isVertex()).thenReturn(false);
+    when(transaction.loadEntity(unknownRid)).thenReturn(nonEdge);
+
+    mockLoadReturnsEdge(validRid);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(unknownPair, validPair).iterator(), session, 2);
+
+    assertTrue("Should skip non-edge and find the edge", iterator.hasNext());
+    assertEquals(validRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * An empty LinkBag should produce an iterator that immediately reports
+   * no elements.
+   */
+  @Test
+  public void testEmptyIterator() {
+    var iterator = new EdgeFromLinkBagIterator(
+        Collections.<RidPair>emptyList().iterator(), session, 0);
+
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * Calling next() after the iterator is exhausted should throw
+   * NoSuchElementException.
+   */
+  @Test(expected = NoSuchElementException.class)
+  public void testThrowsNoSuchElementWhenExhausted() {
+    var iterator = new EdgeFromLinkBagIterator(
+        Collections.<RidPair>emptyList().iterator(), session, 0);
+
+    iterator.next();
+  }
+
+  /**
+   * When all primary RIDs point to deleted records, the iterator should yield
+   * no elements at all.
+   */
+  @Test
+  public void testAllRecordsDeletedYieldsEmptyIteration() {
+    var rid1 = new RecordId(20, 1);
+    var rid2 = new RecordId(20, 2);
+    var pair1 = RidPair.ofPair(rid1, new RecordId(10, 1));
+    var pair2 = RidPair.ofPair(rid2, new RecordId(10, 2));
+
+    when(transaction.loadEntity(rid1))
+        .thenThrow(new RecordNotFoundException("test", rid1));
+    when(transaction.loadEntity(rid2))
+        .thenThrow(new RecordNotFoundException("test", rid2));
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(pair1, pair2).iterator(), session, 2);
+
+    assertFalse(
+        "All records deleted, should have no elements",
+        iterator.hasNext());
+  }
+
+  /**
+   * Calling hasNext() multiple times before next() should not advance past
+   * elements. The lazy-load pattern must be idempotent.
+   */
+  @Test
+  public void testHasNextIsIdempotent() {
+    var edgeRid = new RecordId(20, 1);
+    var pair = RidPair.ofPair(edgeRid, new RecordId(10, 1));
+    mockLoadReturnsEdge(edgeRid);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(pair).iterator(), session, 1);
+
+    assertTrue(iterator.hasNext());
+    assertTrue("Second hasNext() should still return true", iterator.hasNext());
+    assertTrue("Third hasNext() should still return true", iterator.hasNext());
+    assertEquals(edgeRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * size() returns the upper-bound count from the LinkBag, not the actual number
+   * of edges yielded. isSizeable() returns true when size is non-negative.
+   */
+  @Test
+  public void testSizeReturnsUpperBoundFromLinkBag() {
+    var iterator = new EdgeFromLinkBagIterator(
+        Collections.<RidPair>emptyList().iterator(), session, 42);
+
+    assertEquals(42, iterator.size());
+    assertTrue(iterator.isSizeable());
+  }
+
+  /**
+   * isSizeable() returns false when size is negative (unknown size).
+   */
+  @Test
+  public void testIsSizeableReturnsFalseForNegativeSize() {
+    var iterator = new EdgeFromLinkBagIterator(
+        Collections.<RidPair>emptyList().iterator(), session, -1);
+
+    assertFalse(iterator.isSizeable());
+  }
+
+  /**
+   * RidPair.validateEdgePair() rejects legacy lightweight pairs where
+   * primaryRid == secondaryRid. After edge unification (YTDB-605), all edges
+   * must have distinct edge and vertex RIDs.
+   */
+  @Test(expected = IllegalStateException.class)
+  public void testValidateEdgePairRejectsEqualRids() {
+    var rid = new RecordId(10, 1);
+    var pair = new RidPair(rid, rid);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(pair).iterator(), session, 1);
+
+    iterator.hasNext(); // triggers validateEdgePair → IllegalStateException
+  }
+
+  // =========================================================================
+  // Class filter (acceptedCollectionIds)
+  // =========================================================================
+
+  /**
+   * When acceptedCollectionIds is set, edges whose collection ID is NOT
+   * in the set are skipped without loading from storage.
+   */
+  @Test
+  public void classFilter_skipsNonMatchingCollectionId() {
+    var matchingRid = new RecordId(20, 1); // collection 20 — accepted
+    var nonMatchingRid = new RecordId(30, 1); // collection 30 — rejected
+    var matchingPair = RidPair.ofPair(matchingRid, new RecordId(10, 1));
+    var nonMatchingPair = RidPair.ofPair(nonMatchingRid, new RecordId(10, 2));
+    mockLoadReturnsEdge(matchingRid);
+    // nonMatchingRid should never be loaded — no mock needed
+
+    var accepted = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(nonMatchingPair, matchingPair).iterator(), session, 2, accepted);
+
+    assertTrue(iterator.hasNext());
+    assertEquals(matchingRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * When all edges match the class filter, all are yielded.
+   */
+  @Test
+  public void classFilter_allMatch_yieldsAll() {
+    var rid1 = new RecordId(20, 1);
+    var rid2 = new RecordId(20, 2);
+    mockLoadReturnsEdge(rid1);
+    mockLoadReturnsEdge(rid2);
+
+    var accepted = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(
+            RidPair.ofPair(rid1, new RecordId(10, 1)),
+            RidPair.ofPair(rid2, new RecordId(10, 2))).iterator(),
+        session, 2, accepted);
+
+    assertTrue(iterator.hasNext());
+    assertEquals(rid1, iterator.next().getIdentity());
+    assertTrue(iterator.hasNext());
+    assertEquals(rid2, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * When no edges match the class filter, the iterator is empty. Verify that
+   * no records are loaded from storage (zero-I/O optimization).
+   */
+  @Test
+  public void classFilter_noneMatch_yieldsEmpty_noIO() {
+    var rid = new RecordId(30, 1); // collection 30 — not accepted
+
+    var accepted = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(RidPair.ofPair(rid, new RecordId(10, 1))).iterator(),
+        session, 1, accepted);
+
+    assertFalse(iterator.hasNext());
+    // Verify zero-I/O: loadEntity should never have been called since all
+    // entries were rejected by the collection ID check before reaching I/O.
+    verifyNoMoreInteractions(transaction);
+  }
+
+  // =========================================================================
+  // RID filter (acceptedRids)
+  // =========================================================================
+
+  /**
+   * When acceptedRids is set, only edges whose RID is in the set are loaded
+   * from storage.
+   */
+  @Test
+  public void ridFilter_skipsNonMatchingRid() {
+    var matchingRid = new RecordId(20, 1);
+    var nonMatchingRid = new RecordId(20, 2);
+    mockLoadReturnsEdge(matchingRid);
+    // nonMatchingRid should never be loaded
+
+    var acceptedRids = new HashSet<RID>();
+    acceptedRids.add(matchingRid);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(
+            RidPair.ofPair(nonMatchingRid, new RecordId(10, 1)),
+            RidPair.ofPair(matchingRid, new RecordId(10, 2))).iterator(),
+        session, 2, null, acceptedRids);
+
+    assertTrue(iterator.hasNext());
+    assertEquals(matchingRid, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * When acceptedRids is empty, no edges are yielded.
+   */
+  @Test
+  public void ridFilter_emptySet_yieldsEmpty() {
+    var rid = new RecordId(20, 1);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(RidPair.ofPair(rid, new RecordId(10, 1))).iterator(),
+        session, 1, null, new HashSet<>());
+
+    assertFalse(iterator.hasNext());
+  }
+
+  // =========================================================================
+  // Combined class + RID filter
+  // =========================================================================
+
+  /**
+   * When both filters are set, an edge must pass both to be yielded.
+   * Class filter is checked first (cheaper — no set lookup).
+   */
+  @Test
+  public void combinedFilter_requiresBothToPass() {
+    // rid1: collection 20 (accepted) AND in ridSet → yielded
+    var rid1 = new RecordId(20, 1);
+    // rid2: collection 20 (accepted) but NOT in ridSet → skipped
+    var rid2 = new RecordId(20, 2);
+    // rid3: collection 30 (rejected by class filter) → skipped
+    var rid3 = new RecordId(30, 1);
+
+    mockLoadReturnsEdge(rid1);
+
+    var acceptedCollections = it.unimi.dsi.fastutil.ints.IntOpenHashSet.of(20);
+    var acceptedRids = new HashSet<RID>();
+    acceptedRids.add(rid1);
+
+    var iterator = new EdgeFromLinkBagIterator(
+        List.of(
+            RidPair.ofPair(rid3, new RecordId(10, 1)),
+            RidPair.ofPair(rid2, new RecordId(10, 2)),
+            RidPair.ofPair(rid1, new RecordId(10, 3))).iterator(),
+        session, 3, acceptedCollections, acceptedRids);
+
+    assertTrue(iterator.hasNext());
+    assertEquals(rid1, iterator.next().getIdentity());
+    assertFalse(iterator.hasNext());
+  }
+
+  /**
+   * Configures the mock transaction to return an edge entity when loadEntity
+   * is called with the given RID.
+   */
+  private void mockLoadReturnsEdge(RID rid) {
+    var entity = mock(Entity.class);
+    var edge = mock(Edge.class, org.mockito.Mockito.withSettings()
+        .extraInterfaces(EdgeInternal.class));
+    when(entity.isEdge()).thenReturn(true);
+    when(entity.asEdge()).thenReturn(edge);
+    when(edge.getIdentity()).thenReturn(rid);
+    when(transaction.loadEntity(rid)).thenReturn(entity);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStepPrettyPrintTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStepPrettyPrintTest.java
@@ -66,7 +66,7 @@ public class ExpandStepPrettyPrintTest {
   @Test
   public void prettyPrint_edgeRidLookupFilter() {
     var ridExpr = mock(com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression.class);
-    var desc = new RidFilterDescriptor.EdgeRidLookup("HAS_CREATOR", "out", ridExpr);
+    var desc = new RidFilterDescriptor.EdgeRidLookup("HAS_CREATOR", "out", ridExpr, false);
     var step = new ExpandStep(ctx, false, null, null, null, desc, null);
     var output = step.prettyPrint(0, 2);
 
@@ -112,7 +112,7 @@ public class ExpandStepPrettyPrintTest {
     IntSet ids = new IntOpenHashSet(new int[] {5, 6});
 
     var ridExpr = mock(com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression.class);
-    var ridDesc = new RidFilterDescriptor.EdgeRidLookup("KNOWS", "in", ridExpr);
+    var ridDesc = new RidFilterDescriptor.EdgeRidLookup("KNOWS", "in", ridExpr, false);
 
     var indexDesc = mock(IndexSearchDescriptor.class);
     var index = mock(Index.class);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStepTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStepTest.java
@@ -6,14 +6,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.record.impl.PreFilterableLinkBagIterable;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
 import org.junit.Test;
 
 /**
@@ -402,6 +409,92 @@ public class ExpandStepTest extends DbTestBase {
     assertThat(results).hasSize(1);
     assertThat(results.get(0).<String>getProperty("myField"))
         .isEqualTo("val");
+  }
+
+  // =========================================================================
+  // PreFilterableLinkBagIterable dispatch (interface-based)
+  // =========================================================================
+
+  /**
+   * ExpandStep with acceptedCollectionIds applies a class filter to any
+   * PreFilterableLinkBagIterable — not just VertexFromLinkBagIterable.
+   * This test uses a stub that implements both PreFilterableLinkBagIterable
+   * and Iterable to verify the class filter is applied and iteration works.
+   */
+  @Test
+  public void expandPreFilterableIterableAppliesClassFilter() {
+    var ctx = newContext();
+    var collectionIds = IntOpenHashSet.of(42);
+    var step = new ExpandStep(ctx, false, "alias", null, collectionIds);
+
+    var stubIterable = new StubPreFilterableIterable(
+        List.of("val1", "val2"));
+    var upstream = new ResultInternal(ctx.getDatabaseSession());
+    // Bypass setProperty: store the stub directly as an Iterable
+    upstream.content.put("field", stubIterable);
+    step.setPrevious(sourceStep(ctx, List.of(upstream)));
+
+    var results = drain(step.start(ctx), ctx);
+
+    // The stub records that withClassFilter was called; it still yields
+    // all elements (the stub doesn't actually filter — that's tested in
+    // the concrete iterable tests). The key assertion is that ExpandStep
+    // recognised the interface and attempted filtering.
+    assertThat(stubIterable.classFilterApplied).isFalse();
+    assertThat(results).hasSize(2);
+    assertThat(results.get(0).<String>getProperty("alias"))
+        .isEqualTo("val1");
+  }
+
+  /**
+   * Lightweight stub implementing both PreFilterableLinkBagIterable and
+   * Iterable<String>. Used to verify that ExpandStep's instanceof check
+   * dispatches on the interface, not the concrete VertexFromLinkBagIterable.
+   */
+  private static class StubPreFilterableIterable
+      implements PreFilterableLinkBagIterable, Iterable<String> {
+
+    private final List<String> elements;
+    boolean classFilterApplied;
+    boolean ridFilterApplied;
+
+    StubPreFilterableIterable(List<String> elements) {
+      this.elements = elements;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<String> iterator() {
+      return elements.iterator();
+    }
+
+    @Override
+    public int size() {
+      return elements.size();
+    }
+
+    @Override
+    public boolean isSizeable() {
+      return true;
+    }
+
+    @Nonnull
+    @Override
+    public PreFilterableLinkBagIterable withClassFilter(
+        @Nonnull IntSet collectionIds) {
+      var copy = new StubPreFilterableIterable(elements);
+      copy.classFilterApplied = true;
+      return copy;
+    }
+
+    @Nonnull
+    @Override
+    public PreFilterableLinkBagIterable withRidFilter(
+        @Nonnull Set<RID> ridSet) {
+      var copy = new StubPreFilterableIterable(elements);
+      copy.ridFilterApplied = true;
+      return copy;
+    }
   }
 
   // =========================================================================

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStepTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStepTest.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
 import org.junit.Test;
 
@@ -418,8 +419,8 @@ public class ExpandStepTest extends DbTestBase {
   /**
    * ExpandStep with acceptedCollectionIds applies a class filter to any
    * PreFilterableLinkBagIterable — not just VertexFromLinkBagIterable.
-   * This test uses a stub that implements both PreFilterableLinkBagIterable
-   * and Iterable to verify the class filter is applied and iteration works.
+   * Uses a shared AtomicBoolean to verify the filter was actually requested,
+   * since ExpandStep consumes the filtered copy internally.
    */
   @Test
   public void expandPreFilterableIterableAppliesClassFilter() {
@@ -436,30 +437,68 @@ public class ExpandStepTest extends DbTestBase {
 
     var results = drain(step.start(ctx), ctx);
 
-    // The stub records that withClassFilter was called; it still yields
-    // all elements (the stub doesn't actually filter — that's tested in
-    // the concrete iterable tests). The key assertion is that ExpandStep
-    // recognised the interface and attempted filtering.
-    assertThat(stubIterable.classFilterApplied).isFalse();
+    // Shared flag confirms withClassFilter was called on a copy
+    assertThat(stubIterable.classFilterRequested.get())
+        .as("ExpandStep should call withClassFilter on PreFilterableLinkBagIterable")
+        .isTrue();
     assertThat(results).hasSize(2);
+    assertThat(results.get(0).<String>getProperty("alias"))
+        .isEqualTo("val1");
+    assertThat(results.get(1).<String>getProperty("alias"))
+        .isEqualTo("val2");
+  }
+
+  /**
+   * When acceptedCollectionIds is null, ExpandStep does not call
+   * withClassFilter even if the iterable is a PreFilterableLinkBagIterable.
+   */
+  @Test
+  public void expandPreFilterableIterableSkipsFilterWhenNoCollectionIds() {
+    var ctx = newContext();
+    // No acceptedCollectionIds (null)
+    var step = new ExpandStep(ctx, false, "alias", null, null);
+
+    var stubIterable = new StubPreFilterableIterable(
+        List.of("val1"));
+    var upstream = new ResultInternal(ctx.getDatabaseSession());
+    upstream.content.put("field", stubIterable);
+    step.setPrevious(sourceStep(ctx, List.of(upstream)));
+
+    var results = drain(step.start(ctx), ctx);
+
+    assertThat(stubIterable.classFilterRequested.get())
+        .as("withClassFilter should not be called when acceptedCollectionIds is null")
+        .isFalse();
+    assertThat(results).hasSize(1);
     assertThat(results.get(0).<String>getProperty("alias"))
         .isEqualTo("val1");
   }
 
   /**
    * Lightweight stub implementing both PreFilterableLinkBagIterable and
-   * Iterable<String>. Used to verify that ExpandStep's instanceof check
-   * dispatches on the interface, not the concrete VertexFromLinkBagIterable.
+   * Iterable<String>. Uses shared AtomicBoolean flags so the test can
+   * observe filter calls even though ExpandStep consumes the copy internally.
    */
   private static class StubPreFilterableIterable
       implements PreFilterableLinkBagIterable, Iterable<String> {
 
     private final List<String> elements;
-    boolean classFilterApplied;
-    boolean ridFilterApplied;
+    final AtomicBoolean classFilterRequested;
+    final AtomicBoolean ridFilterRequested;
 
     StubPreFilterableIterable(List<String> elements) {
       this.elements = elements;
+      this.classFilterRequested = new AtomicBoolean(false);
+      this.ridFilterRequested = new AtomicBoolean(false);
+    }
+
+    private StubPreFilterableIterable(
+        List<String> elements,
+        AtomicBoolean classFilterRequested,
+        AtomicBoolean ridFilterRequested) {
+      this.elements = elements;
+      this.classFilterRequested = classFilterRequested;
+      this.ridFilterRequested = ridFilterRequested;
     }
 
     @Nonnull
@@ -482,18 +521,18 @@ public class ExpandStepTest extends DbTestBase {
     @Override
     public PreFilterableLinkBagIterable withClassFilter(
         @Nonnull IntSet collectionIds) {
-      var copy = new StubPreFilterableIterable(elements);
-      copy.classFilterApplied = true;
-      return copy;
+      classFilterRequested.set(true);
+      return new StubPreFilterableIterable(
+          elements, classFilterRequested, ridFilterRequested);
     }
 
     @Nonnull
     @Override
     public PreFilterableLinkBagIterable withRidFilter(
         @Nonnull Set<RID> ridSet) {
-      var copy = new StubPreFilterableIterable(elements);
-      copy.ridFilterApplied = true;
-      return copy;
+      ridFilterRequested.set(true);
+      return new StubPreFilterableIterable(
+          elements, classFilterRequested, ridFilterRequested);
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
@@ -1,0 +1,435 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Integration tests for class inference correctness and adaptive abort behavior
+ * in edge-method MATCH patterns.
+ *
+ * <p>Class inference tests verify that the planner correctly resolves edge and
+ * vertex classes from edge-method patterns, affecting scheduling order.
+ *
+ * <p>Adaptive abort tests verify that when the pre-filter configuration knobs
+ * are set to restrictive values, the pre-filter is skipped and the query falls
+ * back to unfiltered traversal while still producing correct results.
+ *
+ * <p>Marked as {@link SequentialTest} because the adaptive abort tests mutate
+ * {@link GlobalConfiguration} settings.
+ */
+@Category(SequentialTest.class)
+public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
+
+  @After
+  public void restoreDefaults() {
+    GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(100_000);
+    GlobalConfiguration.QUERY_PREFILTER_MAX_SELECTIVITY_RATIO.setValue(0.8);
+    GlobalConfiguration.QUERY_PREFILTER_MIN_LINKBAG_SIZE.setValue(50);
+  }
+
+  // ---- Class inference: scheduling order ----
+
+  /**
+   * Verify that the planner infers the edge class for outE('WORK_AT') aliases
+   * and uses index selectivity to schedule more selective aliases first.
+   *
+   * <p>Graph: 10 persons, 2 companies, 200 tags. Each person works at one
+   * company (selective) and has 20 tags (broad). The query has two branches
+   * from person: one selective (WORK_AT with WHERE) and one broad (HAS_TAG).
+   * The planner should schedule the selective WORK_AT branch first.
+   */
+  @Test
+  public void testEdgeAliasSchedulingOrder() {
+    // Schema
+    session.execute("CREATE class SOPerson extends V").close();
+    session.execute("CREATE property SOPerson.name STRING").close();
+
+    session.execute("CREATE class SOCompany extends V").close();
+    session.execute("CREATE property SOCompany.name STRING").close();
+
+    session.execute("CREATE class SOTag extends V").close();
+    session.execute("CREATE property SOTag.name STRING").close();
+
+    session.execute("CREATE class SOWorkAt extends E").close();
+    session.execute("CREATE property SOWorkAt.out LINK SOPerson").close();
+    session.execute("CREATE property SOWorkAt.in LINK SOCompany").close();
+    session.execute("CREATE property SOWorkAt.workFrom INTEGER").close();
+    session.execute(
+        "CREATE index SOWorkAt_workFrom on SOWorkAt (workFrom) NOTUNIQUE")
+        .close();
+
+    session.execute("CREATE class SOHasTag extends E").close();
+    session.execute("CREATE property SOHasTag.out LINK SOPerson").close();
+    session.execute("CREATE property SOHasTag.in LINK SOTag").close();
+
+    session.begin();
+    // 2 companies
+    session.execute("CREATE VERTEX SOCompany set name = 'corpA'").close();
+    session.execute("CREATE VERTEX SOCompany set name = 'corpB'").close();
+
+    // 200 tags
+    for (int i = 0; i < 200; i++) {
+      session.execute("CREATE VERTEX SOTag set name = 'tag" + i + "'").close();
+    }
+
+    // 10 persons: each works at one company and has 20 tags
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX SOPerson set name = 'person" + i + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE SOWorkAt FROM"
+              + " (SELECT FROM SOPerson WHERE name = 'person" + i + "')"
+              + " TO (SELECT FROM SOCompany WHERE name = '"
+              + (i < 5 ? "corpA" : "corpB") + "')"
+              + " SET workFrom = " + (2010 + i))
+          .close();
+      for (int j = 0; j < 20; j++) {
+        session.execute(
+            "CREATE EDGE SOHasTag FROM"
+                + " (SELECT FROM SOPerson WHERE name = 'person" + i + "')"
+                + " TO (SELECT FROM SOTag WHERE name = 'tag"
+                + (i * 20 + j) + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    // Query: two branches — selective WORK_AT and broad HAS_TAG
+    session.begin();
+    var query =
+        "MATCH {class: SOPerson, as: person}"
+            + ".outE('SOWorkAt'){as: workEdge, where: (workFrom = 2015)}"
+            + ".inV(){as: company},"
+            + " {as: person}"
+            + ".out('SOHasTag'){as: tag}"
+            + " RETURN person.name, company.name, tag.name";
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    assertEquals(1, explainResult.size());
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+
+    // The selective WORK_AT edge alias {workEdge} should appear before
+    // the broad HAS_TAG alias {tag} in the plan
+    int workEdgePos = plan.indexOf("{workEdge}");
+    int tagPos = plan.indexOf("{tag}");
+    assertTrue("workEdge alias should appear in plan", workEdgePos >= 0);
+    assertTrue("tag alias should appear in plan", tagPos >= 0);
+    assertTrue(
+        "Selective workEdge should be scheduled before broad tag,"
+            + " but plan was:\n" + plan,
+        workEdgePos < tagPos);
+
+    // Also verify the query produces correct results
+    var result = session.query(query).toList();
+    // person5 has workFrom=2015, and has 20 tags -> 20 result rows
+    assertEquals(20, result.size());
+    for (var r : result) {
+      assertEquals("person5", r.getProperty("person.name"));
+      assertEquals("corpB", r.getProperty("company.name"));
+    }
+
+    session.commit();
+  }
+
+  /**
+   * Verify that the planner infers the vertex class for inV() from the edge
+   * schema and applies index intersection, even without an explicit class:
+   * constraint on the vertex alias. Similar to the existing
+   * {@code testSelectivityInferredFromEdgeSchemaWithoutExplicitClass} but
+   * using edge-method patterns (outE→inV instead of out).
+   *
+   * <p>Graph: posts with broad tags and a single selective tag. The selective
+   * branch uses {@code name = 'targetTag'} which has an index on VITag.name.
+   * The planner must: (1) infer VITag from VIHasTag.in LINK, and (2) use the
+   * VITag_name index for intersection pre-filtering.
+   */
+  @Test
+  public void testVertexClassInferenceEnablesIndexIntersection() {
+    // Schema
+    session.execute("CREATE class VIPost extends V").close();
+    session.execute("CREATE property VIPost.title STRING").close();
+
+    session.execute("CREATE class VITag extends V").close();
+    session.execute("CREATE property VITag.name STRING").close();
+    session.execute(
+        "CREATE index VITag_name on VITag (name) NOTUNIQUE").close();
+
+    session.execute("CREATE class VIHasTag extends E").close();
+    session.execute("CREATE property VIHasTag.out LINK VIPost").close();
+    session.execute("CREATE property VIHasTag.in LINK VITag").close();
+
+    session.begin();
+    // 1 selective tag + 50 broad tags
+    session.execute("CREATE VERTEX VITag set name = 'targetTag'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX VITag set name = 'tag" + i + "'").close();
+    }
+
+    // 10 posts, each linked to targetTag and 5 other tags
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX VIPost set title = 'post" + i + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE VIHasTag FROM"
+              + " (SELECT FROM VIPost WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM VITag WHERE name = 'targetTag')")
+          .close();
+      for (int j = 0; j < 5; j++) {
+        session.execute(
+            "CREATE EDGE VIHasTag FROM"
+                + " (SELECT FROM VIPost WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM VITag WHERE name = 'tag" + j + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    // No explicit class: on tag aliases — planner should infer VITag
+    // from VIHasTag.in LINK VITag
+    session.begin();
+    var query =
+        "MATCH {class: VIPost, as: post}"
+            + ".outE('VIHasTag').inV(){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: post}"
+            + ".outE('VIHasTag').inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN post.title, broadTag.name, selectiveTag.name";
+
+    // Verify correct results
+    var result = session.query(query).toList();
+    assertEquals(50, result.size());
+
+    // Verify EXPLAIN shows index intersection on the selective tag alias,
+    // proving the planner inferred VITag class and selected the index
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+
+    // Both aliases should appear in the plan
+    assertTrue(
+        "selectiveTag should appear in plan, but plan was:\n" + plan,
+        plan.contains("{selectiveTag}"));
+    assertTrue(
+        "broadTag should appear in plan, but plan was:\n" + plan,
+        plan.contains("{broadTag}"));
+
+    // The index intersection proves class inference worked end-to-end:
+    // the planner inferred VITag from VIHasTag.in LINK, found the
+    // VITag_name index, and attached it as an intersection descriptor
+    assertTrue(
+        "Plan should show index intersection for VITag_name (proves class"
+            + " inference), but plan was:\n" + plan,
+        plan.contains("(intersection: index VITag_name)"));
+
+    session.commit();
+  }
+
+  // ---- Adaptive abort ----
+
+  /**
+   * Verify that when {@code QUERY_PREFILTER_MAX_RIDSET_SIZE} is set to 1,
+   * the pre-filter is skipped (because the index returns more than 1 RID)
+   * but the query still produces correct results via unfiltered scan.
+   *
+   * <p>With maxRidSetSize=1, any index lookup returning more than 1 RID
+   * triggers the adaptive abort guard in {@code TraversalPreFilterHelper
+   * .resolveIndexToRidSet()}, causing it to return null. The traverser
+   * then falls back to loading all edges without filtering.
+   */
+  @Test
+  public void testAdaptiveAbortSkipsPreFilterWithSmallRidSetCap() {
+    // Schema with indexed edge property
+    session.execute("CREATE class AAPerson extends V").close();
+    session.execute("CREATE property AAPerson.name STRING").close();
+
+    session.execute("CREATE class AACompany extends V").close();
+    session.execute("CREATE property AACompany.name STRING").close();
+
+    session.execute("CREATE class AAWorkAt extends E").close();
+    session.execute("CREATE property AAWorkAt.out LINK AAPerson").close();
+    session.execute("CREATE property AAWorkAt.in LINK AACompany").close();
+    session.execute("CREATE property AAWorkAt.workFrom INTEGER").close();
+    session.execute(
+        "CREATE index AAWorkAt_workFrom on AAWorkAt (workFrom) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute("CREATE VERTEX AACompany set name = 'corp'").close();
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX AAPerson set name = 'emp" + i + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE AAWorkAt FROM"
+              + " (SELECT FROM AAPerson WHERE name = 'emp" + i + "')"
+              + " TO (SELECT FROM AACompany WHERE name = 'corp')"
+              + " SET workFrom = " + (2010 + i))
+          .close();
+    }
+    session.commit();
+
+    // Override maxRidSetSize to 1 — any index lookup with > 1 result aborts
+    GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(1);
+
+    session.begin();
+    var query =
+        "MATCH {class: AAPerson, as: p}"
+            + ".outE('AAWorkAt'){where: (workFrom < 2015)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var result = session.query(query).toList();
+
+    // The query should still return correct results even without pre-filter
+    assertEquals(5, result.size());
+
+    Set<String> names = new HashSet<>();
+    for (var r : result) {
+      names.add(r.getProperty("p.name"));
+    }
+    for (int i = 0; i < 5; i++) {
+      assertTrue(
+          "Should contain emp" + i,
+          names.contains("emp" + i));
+    }
+
+    session.commit();
+  }
+
+  /**
+   * Verify that when {@code QUERY_PREFILTER_MIN_LINKBAG_SIZE} is set to a
+   * very large value (larger than any link bag in the graph), the pre-filter
+   * is skipped for all vertices but correct results are still produced.
+   *
+   * <p>This tests the min-linkbag-size guard: link bags smaller than the
+   * threshold skip pre-filtering entirely because loading a few records
+   * is cheaper than building a RidSet.
+   */
+  @Test
+  public void testAdaptiveAbortSkipsPreFilterWithLargeMinLinkBagSize() {
+    // Schema with indexed edge property
+    session.execute("CREATE class MLPerson extends V").close();
+    session.execute("CREATE property MLPerson.name STRING").close();
+
+    session.execute("CREATE class MLForum extends V").close();
+    session.execute("CREATE property MLForum.title STRING").close();
+
+    session.execute("CREATE class MLHasMember extends E").close();
+    session.execute("CREATE property MLHasMember.out LINK MLPerson").close();
+    session.execute("CREATE property MLHasMember.in LINK MLForum").close();
+    session.execute("CREATE property MLHasMember.joinDate LONG").close();
+    session.execute(
+        "CREATE index MLHasMember_joinDate on MLHasMember (joinDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    // 3 forums, each with several members
+    for (int i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX MLForum set title = 'forum" + i + "'")
+          .close();
+    }
+    for (int i = 0; i < 6; i++) {
+      session.execute("CREATE VERTEX MLPerson set name = 'user" + i + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE MLHasMember FROM"
+              + " (SELECT FROM MLPerson WHERE name = 'user" + i + "')"
+              + " TO (SELECT FROM MLForum WHERE title = 'forum" + (i % 3) + "')"
+              + " SET joinDate = " + (1000 + i * 100))
+          .close();
+    }
+    session.commit();
+
+    // Override minLinkBagSize to 999999 — all link bags are too small
+    GlobalConfiguration.QUERY_PREFILTER_MIN_LINKBAG_SIZE.setValue(999999);
+
+    session.begin();
+    var query =
+        "MATCH {class: MLForum, as: f}"
+            + ".inE('MLHasMember'){where: (joinDate >= 1400)}"
+            + ".outV(){as: p}"
+            + " RETURN p.name, f.title";
+    var result = session.query(query).toList();
+
+    // user4 (1400) and user5 (1500) match
+    assertEquals(2, result.size());
+
+    Set<String> names = new HashSet<>();
+    for (var r : result) {
+      names.add(r.getProperty("p.name"));
+    }
+    assertEquals(Set.of("user4", "user5"), names);
+
+    session.commit();
+  }
+
+  /**
+   * Verify that when {@code QUERY_PREFILTER_MAX_SELECTIVITY_RATIO} is set
+   * very low (e.g., 0.01), the pre-filter is skipped because the ratio of
+   * matching RIDs to link bag size exceeds the threshold, but correct results
+   * are still produced.
+   */
+  @Test
+  public void testAdaptiveAbortSkipsPreFilterWithLowSelectivityRatio() {
+    // Schema with indexed edge property
+    session.execute("CREATE class SRPerson extends V").close();
+    session.execute("CREATE property SRPerson.name STRING").close();
+
+    session.execute("CREATE class SRCompany extends V").close();
+    session.execute("CREATE property SRCompany.name STRING").close();
+
+    session.execute("CREATE class SRWorkAt extends E").close();
+    session.execute("CREATE property SRWorkAt.out LINK SRPerson").close();
+    session.execute("CREATE property SRWorkAt.in LINK SRCompany").close();
+    session.execute("CREATE property SRWorkAt.workFrom INTEGER").close();
+    session.execute(
+        "CREATE index SRWorkAt_workFrom on SRWorkAt (workFrom) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute("CREATE VERTEX SRCompany set name = 'megacorp'").close();
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX SRPerson set name = 'dev" + i + "'")
+          .close();
+      session.execute(
+          "CREATE EDGE SRWorkAt FROM"
+              + " (SELECT FROM SRPerson WHERE name = 'dev" + i + "')"
+              + " TO (SELECT FROM SRCompany WHERE name = 'megacorp')"
+              + " SET workFrom = " + (2010 + i))
+          .close();
+    }
+    session.commit();
+
+    // Override selectivity ratio to 0.01 — almost no filter is selective enough
+    GlobalConfiguration.QUERY_PREFILTER_MAX_SELECTIVITY_RATIO.setValue(0.01);
+
+    session.begin();
+    var query =
+        "MATCH {class: SRPerson, as: p}"
+            + ".outE('SRWorkAt'){where: (workFrom < 2013)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var result = session.query(query).toList();
+
+    // dev0 (2010), dev1 (2011), dev2 (2012) match
+    assertEquals(3, result.size());
+
+    Set<String> names = new HashSet<>();
+    for (var r : result) {
+      names.add(r.getProperty("p.name"));
+    }
+    assertEquals(Set.of("dev0", "dev1", "dev2"), names);
+
+    session.commit();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
@@ -10,6 +10,7 @@ import com.jetbrains.youtrackdb.internal.SequentialTest;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -30,11 +31,28 @@ import org.junit.experimental.categories.Category;
 @Category(SequentialTest.class)
 public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
 
+  private Object savedMaxRidSetSize;
+  private Object savedMaxSelectivityRatio;
+  private Object savedMinLinkBagSize;
+
+  @Before
+  public void saveConfigDefaults() {
+    savedMaxRidSetSize =
+        GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.getValue();
+    savedMaxSelectivityRatio =
+        GlobalConfiguration.QUERY_PREFILTER_MAX_SELECTIVITY_RATIO.getValue();
+    savedMinLinkBagSize =
+        GlobalConfiguration.QUERY_PREFILTER_MIN_LINKBAG_SIZE.getValue();
+  }
+
   @After
-  public void restoreDefaults() {
-    GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(100_000);
-    GlobalConfiguration.QUERY_PREFILTER_MAX_SELECTIVITY_RATIO.setValue(0.8);
-    GlobalConfiguration.QUERY_PREFILTER_MIN_LINKBAG_SIZE.setValue(50);
+  public void restoreConfigDefaults() {
+    GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE
+        .setValue(savedMaxRidSetSize);
+    GlobalConfiguration.QUERY_PREFILTER_MAX_SELECTIVITY_RATIO
+        .setValue(savedMaxSelectivityRatio);
+    GlobalConfiguration.QUERY_PREFILTER_MIN_LINKBAG_SIZE
+        .setValue(savedMinLinkBagSize);
   }
 
   // ---- Class inference: scheduling order ----
@@ -132,12 +150,19 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
 
     // Also verify the query produces correct results
     var result = session.query(query).toList();
-    // person5 has workFrom=2015, and has 20 tags -> 20 result rows
+    // person5 has workFrom=2015, and has 20 tags (tag100-tag119) -> 20 rows
     assertEquals(20, result.size());
+    Set<String> tags = new HashSet<>();
     for (var r : result) {
       assertEquals("person5", r.getProperty("person.name"));
       assertEquals("corpB", r.getProperty("company.name"));
+      tags.add(r.getProperty("tag.name"));
     }
+    Set<String> expectedTags = new HashSet<>();
+    for (int i = 100; i < 120; i++) {
+      expectedTags.add("tag" + i);
+    }
+    assertEquals(expectedTags, tags);
 
     session.commit();
   }
@@ -207,9 +232,21 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
             + "  where: (name = 'targetTag')}"
             + " RETURN post.title, broadTag.name, selectiveTag.name";
 
-    // Verify correct results
+    // Verify correct results: 10 posts x 5 broad tags = 50 rows
     var result = session.query(query).toList();
     assertEquals(50, result.size());
+
+    // Verify selectiveTag is always 'targetTag' and all 10 posts appear
+    Set<String> posts = new HashSet<>();
+    for (var r : result) {
+      assertEquals("targetTag", r.getProperty("selectiveTag.name"));
+      posts.add(r.getProperty("post.title"));
+    }
+    Set<String> expectedPosts = new HashSet<>();
+    for (int i = 0; i < 10; i++) {
+      expectedPosts.add("post" + i);
+    }
+    assertEquals(expectedPosts, posts);
 
     // Verify EXPLAIN shows index intersection on the selective tag alias,
     // proving the planner inferred VITag class and selected the index
@@ -279,29 +316,36 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
     }
     session.commit();
 
-    // Override maxRidSetSize to 1 — any index lookup with > 1 result aborts
-    GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(1);
-
-    session.begin();
     var query =
         "MATCH {class: AAPerson, as: p}"
             + ".outE('AAWorkAt'){where: (workFrom < 2015)}"
             + ".inV(){as: c}"
             + " RETURN p.name, c.name";
-    var result = session.query(query).toList();
 
-    // The query should still return correct results even without pre-filter
+    // Baseline: verify the planner DID attach an intersection descriptor
+    // (the adaptive abort happens at runtime, not plan time)
+    session.begin();
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertTrue(
+        "Baseline plan should show intersection descriptor, but was:\n" + plan,
+        plan.contains("(intersection:"));
+    session.commit();
+
+    // Override maxRidSetSize to 1 — any index lookup with > 1 result aborts
+    GlobalConfiguration.QUERY_PREFILTER_MAX_RIDSET_SIZE.setValue(1);
+
+    // The query should still return correct results via unfiltered fallback
+    session.begin();
+    var result = session.query(query).toList();
     assertEquals(5, result.size());
 
     Set<String> names = new HashSet<>();
     for (var r : result) {
       names.add(r.getProperty("p.name"));
     }
-    for (int i = 0; i < 5; i++) {
-      assertTrue(
-          "Should contain emp" + i,
-          names.contains("emp" + i));
-    }
+    assertEquals(
+        Set.of("emp0", "emp1", "emp2", "emp3", "emp4"), names);
 
     session.commit();
   }
@@ -350,15 +394,28 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
     }
     session.commit();
 
-    // Override minLinkBagSize to 999999 — all link bags are too small
-    GlobalConfiguration.QUERY_PREFILTER_MIN_LINKBAG_SIZE.setValue(999999);
-
-    session.begin();
     var query =
         "MATCH {class: MLForum, as: f}"
             + ".inE('MLHasMember'){where: (joinDate >= 1400)}"
             + ".outV(){as: p}"
             + " RETURN p.name, f.title";
+
+    // Baseline: verify the planner uses the MLHasMember_joinDate index
+    // (the plan uses SET/PREFETCH for the edge alias, not intersection,
+    // because the inE direction prefetches edges directly from the index)
+    session.begin();
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertTrue(
+        "Baseline plan should use MLHasMember_joinDate index, but was:\n"
+            + plan,
+        plan.contains("FETCH FROM INDEX MLHasMember_joinDate"));
+    session.commit();
+
+    // Override minLinkBagSize to 999999 — all link bags are too small
+    GlobalConfiguration.QUERY_PREFILTER_MIN_LINKBAG_SIZE.setValue(999999);
+
+    session.begin();
     var result = session.query(query).toList();
 
     // user4 (1400) and user5 (1500) match
@@ -410,15 +467,25 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
     }
     session.commit();
 
-    // Override selectivity ratio to 0.01 — almost no filter is selective enough
-    GlobalConfiguration.QUERY_PREFILTER_MAX_SELECTIVITY_RATIO.setValue(0.01);
-
-    session.begin();
     var query =
         "MATCH {class: SRPerson, as: p}"
             + ".outE('SRWorkAt'){where: (workFrom < 2013)}"
             + ".inV(){as: c}"
             + " RETURN p.name, c.name";
+
+    // Baseline: verify the planner DID attach an intersection descriptor
+    session.begin();
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertTrue(
+        "Baseline plan should show intersection descriptor, but was:\n" + plan,
+        plan.contains("(intersection:"));
+    session.commit();
+
+    // Override selectivity ratio to 0.01 — almost no filter is selective enough
+    GlobalConfiguration.QUERY_PREFILTER_MAX_SELECTIVITY_RATIO.setValue(0.01);
+
+    session.begin();
     var result = session.query(query).toList();
 
     // dev0 (2010), dev1 (2011), dev2 (2012) match

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
@@ -358,58 +358,58 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
    * <p>This tests the min-linkbag-size guard: link bags smaller than the
    * threshold skip pre-filtering entirely because loading a few records
    * is cheaper than building a RidSet.
+   *
+   * <p>Uses the outE direction so the planner produces an intersection
+   * descriptor (subject to the minLinkBagSize guard at runtime), rather
+   * than the inE direction which uses FETCH FROM INDEX (a plan-level step
+   * not affected by the guard).
    */
   @Test
   public void testAdaptiveAbortSkipsPreFilterWithLargeMinLinkBagSize() {
-    // Schema with indexed edge property
+    // Schema with indexed edge property — outE direction
     session.execute("CREATE class MLPerson extends V").close();
     session.execute("CREATE property MLPerson.name STRING").close();
 
-    session.execute("CREATE class MLForum extends V").close();
-    session.execute("CREATE property MLForum.title STRING").close();
+    session.execute("CREATE class MLCompany extends V").close();
+    session.execute("CREATE property MLCompany.name STRING").close();
 
-    session.execute("CREATE class MLHasMember extends E").close();
-    session.execute("CREATE property MLHasMember.out LINK MLPerson").close();
-    session.execute("CREATE property MLHasMember.in LINK MLForum").close();
-    session.execute("CREATE property MLHasMember.joinDate LONG").close();
+    session.execute("CREATE class MLWorkAt extends E").close();
+    session.execute("CREATE property MLWorkAt.out LINK MLPerson").close();
+    session.execute("CREATE property MLWorkAt.in LINK MLCompany").close();
+    session.execute("CREATE property MLWorkAt.workFrom INTEGER").close();
     session.execute(
-        "CREATE index MLHasMember_joinDate on MLHasMember (joinDate) NOTUNIQUE")
+        "CREATE index MLWorkAt_workFrom on MLWorkAt (workFrom) NOTUNIQUE")
         .close();
 
     session.begin();
-    // 3 forums, each with several members
-    for (int i = 0; i < 3; i++) {
-      session.execute("CREATE VERTEX MLForum set title = 'forum" + i + "'")
-          .close();
-    }
+    session.execute("CREATE VERTEX MLCompany set name = 'corp'").close();
     for (int i = 0; i < 6; i++) {
       session.execute("CREATE VERTEX MLPerson set name = 'user" + i + "'")
           .close();
       session.execute(
-          "CREATE EDGE MLHasMember FROM"
+          "CREATE EDGE MLWorkAt FROM"
               + " (SELECT FROM MLPerson WHERE name = 'user" + i + "')"
-              + " TO (SELECT FROM MLForum WHERE title = 'forum" + (i % 3) + "')"
-              + " SET joinDate = " + (1000 + i * 100))
+              + " TO (SELECT FROM MLCompany WHERE name = 'corp')"
+              + " SET workFrom = " + (2010 + i))
           .close();
     }
     session.commit();
 
     var query =
-        "MATCH {class: MLForum, as: f}"
-            + ".inE('MLHasMember'){where: (joinDate >= 1400)}"
-            + ".outV(){as: p}"
-            + " RETURN p.name, f.title";
+        "MATCH {class: MLPerson, as: p}"
+            + ".outE('MLWorkAt'){where: (workFrom >= 2014)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
 
-    // Baseline: verify the planner uses the MLHasMember_joinDate index
-    // (the plan uses SET/PREFETCH for the edge alias, not intersection,
-    // because the inE direction prefetches edges directly from the index)
+    // Baseline: verify the planner DID attach an intersection descriptor
+    // (the minLinkBagSize guard applies at runtime to intersection descriptors)
     session.begin();
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertTrue(
-        "Baseline plan should use MLHasMember_joinDate index, but was:\n"
+        "Baseline plan should show intersection descriptor, but was:\n"
             + plan,
-        plan.contains("FETCH FROM INDEX MLHasMember_joinDate"));
+        plan.contains("(intersection:"));
     session.commit();
 
     // Override minLinkBagSize to 999999 — all link bags are too small
@@ -418,7 +418,7 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
     session.begin();
     var result = session.query(query).toList();
 
-    // user4 (1400) and user5 (1500) match
+    // user4 (2014) and user5 (2015) match
     assertEquals(2, result.size());
 
     Set<String> names = new HashSet<>();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodLdbcPatternTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodLdbcPatternTest.java
@@ -1,7 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import java.util.HashSet;
@@ -83,11 +82,11 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
       pairs.add(r.getProperty("person.name") + "->"
           + r.getProperty("company.name"));
     }
+    Set<String> expected = new HashSet<>();
     for (int i = 0; i < 4; i++) {
-      assertTrue(
-          "Should contain alice" + i + "->corp" + (i % 4),
-          pairs.contains("alice" + i + "->corp" + (i % 4)));
+      expected.add("alice" + i + "->corp" + (i % 4));
     }
+    assertEquals(expected, pairs);
 
     session.commit();
   }
@@ -157,7 +156,7 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
    * {@code inE('HAS_MEMBER'){where: (joinDate >= ?)}.outV()}.
    *
    * <p>Graph: 6 persons, 3 forums. Each person is a member of one forum with
-   * a different joinDate. Query filters joinDate >= 1400 (3 matches).
+   * a different joinDate. Query filters joinDate >= 1400 (2 matches).
    */
   @Test
   public void testIC5HasMemberPattern() {
@@ -212,8 +211,7 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
       pairs.add(r.getProperty("person.name") + "->"
           + r.getProperty("forum.title"));
     }
-    assertTrue(pairs.contains("bob4->board1"));
-    assertTrue(pairs.contains("bob5->board2"));
+    assertEquals(Set.of("bob4->board1", "bob5->board2"), pairs);
 
     session.commit();
   }
@@ -227,10 +225,11 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
    *
    * <p>Graph structure:
    * <pre>
-   *   startPerson --KNOWS--> friend1, friend2, friend3
+   *   startPerson --KNOWS--> friend1, friend2, friend3, friend4
    *   friend1 --HAS_MEMBER(joinDate=1000)--> forumA
    *   friend2 --HAS_MEMBER(joinDate=2000)--> forumB
    *   friend3 --HAS_MEMBER(joinDate=3000)--> forumC
+   *   friend4 has NO HAS_MEMBER edge (dangling path — must be silently excluded)
    * </pre>
    *
    * <p>Query: starting from startPerson, traverse KNOWS to friends, then use
@@ -264,6 +263,8 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
     session.execute("CREATE VERTEX MCPerson set name = 'friend1'").close();
     session.execute("CREATE VERTEX MCPerson set name = 'friend2'").close();
     session.execute("CREATE VERTEX MCPerson set name = 'friend3'").close();
+    // friend4 has a KNOWS edge but NO HAS_MEMBER edge — dangling path
+    session.execute("CREATE VERTEX MCPerson set name = 'friend4'").close();
 
     // Create forums
     session.execute("CREATE VERTEX MCForum set title = 'forumA'").close();
@@ -286,8 +287,13 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
             + " (SELECT FROM MCPerson WHERE name = 'start')"
             + " TO (SELECT FROM MCPerson WHERE name = 'friend3')")
         .close();
+    session.execute(
+        "CREATE EDGE MCKnows FROM"
+            + " (SELECT FROM MCPerson WHERE name = 'start')"
+            + " TO (SELECT FROM MCPerson WHERE name = 'friend4')")
+        .close();
 
-    // HAS_MEMBER edges: each friend is in one forum with different joinDates
+    // HAS_MEMBER edges: friend1-3 each in one forum; friend4 has NO membership
     session.execute(
         "CREATE EDGE MCHasMember FROM"
             + " (SELECT FROM MCPerson WHERE name = 'friend1')"
@@ -326,12 +332,7 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
       pairs.add(r.getProperty("friend.name") + "->"
           + r.getProperty("forum.title"));
     }
-    assertTrue(
-        "Should contain friend2->forumB",
-        pairs.contains("friend2->forumB"));
-    assertTrue(
-        "Should contain friend3->forumC",
-        pairs.contains("friend3->forumC"));
+    assertEquals(Set.of("friend2->forumB", "friend3->forumC"), pairs);
 
     session.commit();
   }
@@ -434,8 +435,7 @@ public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
       assertEquals("techForum", r.getProperty("forum.title"));
       contents.add(r.getProperty("post.content"));
     }
-    assertTrue(contents.contains("post1"));
-    assertTrue(contents.contains("post2"));
+    assertEquals(Set.of("post1", "post2"), contents);
 
     session.commit();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodLdbcPatternTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodLdbcPatternTest.java
@@ -1,0 +1,442 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Integration tests that validate edge-method MATCH patterns modeled after LDBC
+ * Social Network Benchmark queries IC5 and IC11. These are real-world query
+ * shapes that natively use indexed edge properties for selective filtering.
+ *
+ * <p>IC11: Person→WORK_AT(workFrom < threshold)→Company
+ * <p>IC5: Person→KNOWS→...→HAS_MEMBER(joinDate >= threshold)→Forum→CONTAINER_OF→Post
+ *
+ * <p>Each test builds a simplified graph structure matching the LDBC pattern,
+ * then runs the MATCH query and verifies correctness.
+ */
+public class MatchEdgeMethodLdbcPatternTest extends DbTestBase {
+
+  // ---- IC11: Person→WORK_AT(workFrom < threshold)→Company ----
+
+  /**
+   * IC11-style pattern: find companies where a person has worked since before a
+   * given year, using {@code outE('WORK_AT'){where: (workFrom < ?)}.inV()}.
+   *
+   * <p>Graph: 8 persons, 4 companies. Each person works at one company with
+   * a different workFrom year. Query filters workFrom < 2014 (4 matches).
+   */
+  @Test
+  public void testIC11WorkAtPattern() {
+    // Schema
+    session.execute("CREATE class IC11Person extends V").close();
+    session.execute("CREATE property IC11Person.name STRING").close();
+
+    session.execute("CREATE class IC11Company extends V").close();
+    session.execute("CREATE property IC11Company.name STRING").close();
+
+    session.execute("CREATE class IC11WorkAt extends E").close();
+    session.execute("CREATE property IC11WorkAt.out LINK IC11Person").close();
+    session.execute("CREATE property IC11WorkAt.in LINK IC11Company").close();
+    session.execute("CREATE property IC11WorkAt.workFrom INTEGER").close();
+    session.execute(
+        "CREATE index IC11WorkAt_workFrom on IC11WorkAt (workFrom) NOTUNIQUE")
+        .close();
+
+    // Data: 8 persons, 4 companies
+    session.begin();
+    for (int i = 0; i < 4; i++) {
+      session.execute("CREATE VERTEX IC11Company set name = 'corp" + i + "'")
+          .close();
+    }
+    for (int i = 0; i < 8; i++) {
+      session.execute("CREATE VERTEX IC11Person set name = 'alice" + i + "'")
+          .close();
+      // workFrom: 2010, 2011, ..., 2017
+      session.execute(
+          "CREATE EDGE IC11WorkAt FROM"
+              + " (SELECT FROM IC11Person WHERE name = 'alice" + i + "')"
+              + " TO (SELECT FROM IC11Company WHERE name = 'corp" + (i % 4) + "')"
+              + " SET workFrom = " + (2010 + i))
+          .close();
+    }
+    session.commit();
+
+    // Query: find persons who started working before 2014
+    session.begin();
+    var query =
+        "MATCH {class: IC11Person, as: person}"
+            + ".outE('IC11WorkAt'){where: (workFrom < 2014)}"
+            + ".inV(){as: company}"
+            + " RETURN person.name, company.name";
+    var result = session.query(query).toList();
+
+    // persons alice0-alice3 have workFrom 2010-2013 (< 2014)
+    assertEquals(4, result.size());
+
+    Set<String> pairs = new HashSet<>();
+    for (var r : result) {
+      pairs.add(r.getProperty("person.name") + "->"
+          + r.getProperty("company.name"));
+    }
+    for (int i = 0; i < 4; i++) {
+      assertTrue(
+          "Should contain alice" + i + "->corp" + (i % 4),
+          pairs.contains("alice" + i + "->corp" + (i % 4)));
+    }
+
+    session.commit();
+  }
+
+  /**
+   * IC11 variation: query with ORDER BY on the edge property (workFrom) and
+   * LIMIT, mimicking the actual IC11 "top N earliest employers" pattern.
+   */
+  @Test
+  public void testIC11WorkAtWithOrderAndLimit() {
+    // Schema
+    session.execute("CREATE class IC11bPerson extends V").close();
+    session.execute("CREATE property IC11bPerson.name STRING").close();
+
+    session.execute("CREATE class IC11bCompany extends V").close();
+    session.execute("CREATE property IC11bCompany.name STRING").close();
+
+    session.execute("CREATE class IC11bWorkAt extends E").close();
+    session.execute("CREATE property IC11bWorkAt.out LINK IC11bPerson").close();
+    session.execute("CREATE property IC11bWorkAt.in LINK IC11bCompany").close();
+    session.execute("CREATE property IC11bWorkAt.workFrom INTEGER").close();
+    session.execute(
+        "CREATE index IC11bWorkAt_workFrom on IC11bWorkAt (workFrom) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    session.execute("CREATE VERTEX IC11bCompany set name = 'megacorp'").close();
+    // 6 persons all working at the same company with different years
+    for (int i = 0; i < 6; i++) {
+      session.execute(
+          "CREATE VERTEX IC11bPerson set name = 'emp" + i + "'").close();
+      session.execute(
+          "CREATE EDGE IC11bWorkAt FROM"
+              + " (SELECT FROM IC11bPerson WHERE name = 'emp" + i + "')"
+              + " TO (SELECT FROM IC11bCompany WHERE name = 'megacorp')"
+              + " SET workFrom = " + (2010 + i))
+          .close();
+    }
+    session.commit();
+
+    // Query: find the 3 earliest employees (workFrom < 2016, ORDER BY workFrom)
+    session.begin();
+    var query =
+        "MATCH {class: IC11bPerson, as: person}"
+            + ".outE('IC11bWorkAt'){as: wa, where: (workFrom < 2016)}"
+            + ".inV(){as: company}"
+            + " RETURN person.name, wa.workFrom"
+            + " ORDER BY wa.workFrom ASC LIMIT 3";
+    var result = session.query(query).toList();
+
+    assertEquals(3, result.size());
+    // Earliest 3: emp0 (2010), emp1 (2011), emp2 (2012)
+    assertEquals("emp0", result.get(0).getProperty("person.name"));
+    assertEquals(2010, (int) result.get(0).getProperty("wa.workFrom"));
+    assertEquals("emp1", result.get(1).getProperty("person.name"));
+    assertEquals(2011, (int) result.get(1).getProperty("wa.workFrom"));
+    assertEquals("emp2", result.get(2).getProperty("person.name"));
+    assertEquals(2012, (int) result.get(2).getProperty("wa.workFrom"));
+
+    session.commit();
+  }
+
+  // ---- IC5: Person→HAS_MEMBER(joinDate >= threshold)→Forum ----
+
+  /**
+   * IC5-style pattern: find forums a person joined after a given date, using
+   * {@code inE('HAS_MEMBER'){where: (joinDate >= ?)}.outV()}.
+   *
+   * <p>Graph: 6 persons, 3 forums. Each person is a member of one forum with
+   * a different joinDate. Query filters joinDate >= 1400 (3 matches).
+   */
+  @Test
+  public void testIC5HasMemberPattern() {
+    // Schema
+    session.execute("CREATE class IC5Person extends V").close();
+    session.execute("CREATE property IC5Person.name STRING").close();
+
+    session.execute("CREATE class IC5Forum extends V").close();
+    session.execute("CREATE property IC5Forum.title STRING").close();
+
+    session.execute("CREATE class IC5HasMember extends E").close();
+    session.execute("CREATE property IC5HasMember.out LINK IC5Person").close();
+    session.execute("CREATE property IC5HasMember.in LINK IC5Forum").close();
+    session.execute("CREATE property IC5HasMember.joinDate LONG").close();
+    session.execute(
+        "CREATE index IC5HasMember_joinDate on IC5HasMember (joinDate) NOTUNIQUE")
+        .close();
+
+    // Data: 6 persons, 3 forums
+    session.begin();
+    for (int i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX IC5Forum set title = 'board" + i + "'")
+          .close();
+    }
+    for (int i = 0; i < 6; i++) {
+      session.execute("CREATE VERTEX IC5Person set name = 'bob" + i + "'")
+          .close();
+      // joinDate: 1000, 1100, 1200, 1300, 1400, 1500
+      session.execute(
+          "CREATE EDGE IC5HasMember FROM"
+              + " (SELECT FROM IC5Person WHERE name = 'bob" + i + "')"
+              + " TO (SELECT FROM IC5Forum WHERE title = 'board" + (i % 3) + "')"
+              + " SET joinDate = " + (1000 + i * 100))
+          .close();
+    }
+    session.commit();
+
+    // Query from Forum side: find persons who joined on or after 1400
+    session.begin();
+    var query =
+        "MATCH {class: IC5Forum, as: forum}"
+            + ".inE('IC5HasMember'){where: (joinDate >= 1400)}"
+            + ".outV(){as: person}"
+            + " RETURN person.name, forum.title";
+    var result = session.query(query).toList();
+
+    // bob4 (1400) and bob5 (1500) match
+    assertEquals(2, result.size());
+
+    Set<String> pairs = new HashSet<>();
+    for (var r : result) {
+      pairs.add(r.getProperty("person.name") + "->"
+          + r.getProperty("forum.title"));
+    }
+    assertTrue(pairs.contains("bob4->board1"));
+    assertTrue(pairs.contains("bob5->board2"));
+
+    session.commit();
+  }
+
+  // ---- Multi-hop chain: edge-method traversal mixed with regular traversals ----
+
+  /**
+   * Multi-hop chain combining regular traversals with edge-method traversals,
+   * modeled after the IC5 pattern:
+   * {@code Person.out('KNOWS').inE('HAS_MEMBER'){where: joinDate >= ?}.outV()}.
+   *
+   * <p>Graph structure:
+   * <pre>
+   *   startPerson --KNOWS--> friend1, friend2, friend3
+   *   friend1 --HAS_MEMBER(joinDate=1000)--> forumA
+   *   friend2 --HAS_MEMBER(joinDate=2000)--> forumB
+   *   friend3 --HAS_MEMBER(joinDate=3000)--> forumC
+   * </pre>
+   *
+   * <p>Query: starting from startPerson, traverse KNOWS to friends, then use
+   * edge-method pattern to filter by joinDate >= 2000. Should return friend2
+   * and friend3 with their forums.
+   */
+  @Test
+  public void testMultiHopChainWithEdgeMethodTraversal() {
+    // Schema
+    session.execute("CREATE class MCPerson extends V").close();
+    session.execute("CREATE property MCPerson.name STRING").close();
+
+    session.execute("CREATE class MCForum extends V").close();
+    session.execute("CREATE property MCForum.title STRING").close();
+
+    session.execute("CREATE class MCKnows extends E").close();
+    session.execute("CREATE property MCKnows.out LINK MCPerson").close();
+    session.execute("CREATE property MCKnows.in LINK MCPerson").close();
+
+    session.execute("CREATE class MCHasMember extends E").close();
+    session.execute("CREATE property MCHasMember.out LINK MCPerson").close();
+    session.execute("CREATE property MCHasMember.in LINK MCForum").close();
+    session.execute("CREATE property MCHasMember.joinDate LONG").close();
+    session.execute(
+        "CREATE index MCHasMember_joinDate on MCHasMember (joinDate) NOTUNIQUE")
+        .close();
+
+    session.begin();
+    // Create persons
+    session.execute("CREATE VERTEX MCPerson set name = 'start'").close();
+    session.execute("CREATE VERTEX MCPerson set name = 'friend1'").close();
+    session.execute("CREATE VERTEX MCPerson set name = 'friend2'").close();
+    session.execute("CREATE VERTEX MCPerson set name = 'friend3'").close();
+
+    // Create forums
+    session.execute("CREATE VERTEX MCForum set title = 'forumA'").close();
+    session.execute("CREATE VERTEX MCForum set title = 'forumB'").close();
+    session.execute("CREATE VERTEX MCForum set title = 'forumC'").close();
+
+    // KNOWS edges: start -> friend1, friend2, friend3
+    session.execute(
+        "CREATE EDGE MCKnows FROM"
+            + " (SELECT FROM MCPerson WHERE name = 'start')"
+            + " TO (SELECT FROM MCPerson WHERE name = 'friend1')")
+        .close();
+    session.execute(
+        "CREATE EDGE MCKnows FROM"
+            + " (SELECT FROM MCPerson WHERE name = 'start')"
+            + " TO (SELECT FROM MCPerson WHERE name = 'friend2')")
+        .close();
+    session.execute(
+        "CREATE EDGE MCKnows FROM"
+            + " (SELECT FROM MCPerson WHERE name = 'start')"
+            + " TO (SELECT FROM MCPerson WHERE name = 'friend3')")
+        .close();
+
+    // HAS_MEMBER edges: each friend is in one forum with different joinDates
+    session.execute(
+        "CREATE EDGE MCHasMember FROM"
+            + " (SELECT FROM MCPerson WHERE name = 'friend1')"
+            + " TO (SELECT FROM MCForum WHERE title = 'forumA')"
+            + " SET joinDate = 1000")
+        .close();
+    session.execute(
+        "CREATE EDGE MCHasMember FROM"
+            + " (SELECT FROM MCPerson WHERE name = 'friend2')"
+            + " TO (SELECT FROM MCForum WHERE title = 'forumB')"
+            + " SET joinDate = 2000")
+        .close();
+    session.execute(
+        "CREATE EDGE MCHasMember FROM"
+            + " (SELECT FROM MCPerson WHERE name = 'friend3')"
+            + " TO (SELECT FROM MCForum WHERE title = 'forumC')"
+            + " SET joinDate = 3000")
+        .close();
+    session.commit();
+
+    // Multi-hop query: start -> KNOWS -> friend -> HAS_MEMBER(joinDate >= 2000) -> forum
+    session.begin();
+    var query =
+        "MATCH {class: MCPerson, as: person, where: (name = 'start')}"
+            + ".out('MCKnows'){as: friend}"
+            + ".outE('MCHasMember'){where: (joinDate >= 2000)}"
+            + ".inV(){as: forum}"
+            + " RETURN friend.name, forum.title";
+    var result = session.query(query).toList();
+
+    // friend2 (joinDate=2000) and friend3 (joinDate=3000) match
+    assertEquals(2, result.size());
+
+    Set<String> pairs = new HashSet<>();
+    for (var r : result) {
+      pairs.add(r.getProperty("friend.name") + "->"
+          + r.getProperty("forum.title"));
+    }
+    assertTrue(
+        "Should contain friend2->forumB",
+        pairs.contains("friend2->forumB"));
+    assertTrue(
+        "Should contain friend3->forumC",
+        pairs.contains("friend3->forumC"));
+
+    session.commit();
+  }
+
+  /**
+   * Multi-hop chain with a longer path: regular → edge-method → regular,
+   * combining three traversal types in sequence.
+   *
+   * <p>Pattern: Person→KNOWS→Friend→outE('HAS_MEMBER'){joinDate >= ?}→inV()
+   * as Forum→out('CONTAINER_OF')→Post
+   *
+   * <p>This exercises the planner's ability to handle edge-method patterns
+   * in the middle of a longer chain where regular traversals precede and
+   * follow.
+   */
+  @Test
+  public void testMultiHopChainRegularEdgeMethodRegular() {
+    // Schema
+    session.execute("CREATE class MC2Person extends V").close();
+    session.execute("CREATE property MC2Person.name STRING").close();
+
+    session.execute("CREATE class MC2Forum extends V").close();
+    session.execute("CREATE property MC2Forum.title STRING").close();
+
+    session.execute("CREATE class MC2Post extends V").close();
+    session.execute("CREATE property MC2Post.content STRING").close();
+
+    session.execute("CREATE class MC2Knows extends E").close();
+    session.execute("CREATE property MC2Knows.out LINK MC2Person").close();
+    session.execute("CREATE property MC2Knows.in LINK MC2Person").close();
+
+    session.execute("CREATE class MC2HasMember extends E").close();
+    session.execute("CREATE property MC2HasMember.out LINK MC2Person").close();
+    session.execute("CREATE property MC2HasMember.in LINK MC2Forum").close();
+    session.execute("CREATE property MC2HasMember.joinDate LONG").close();
+    session.execute(
+        "CREATE index MC2HasMember_joinDate on MC2HasMember (joinDate) NOTUNIQUE")
+        .close();
+
+    session.execute("CREATE class MC2ContainerOf extends E").close();
+    session.execute("CREATE property MC2ContainerOf.out LINK MC2Forum").close();
+    session.execute("CREATE property MC2ContainerOf.in LINK MC2Post").close();
+
+    session.begin();
+    // Persons
+    session.execute("CREATE VERTEX MC2Person set name = 'alice'").close();
+    session.execute("CREATE VERTEX MC2Person set name = 'bob'").close();
+
+    // Forum + posts
+    session.execute("CREATE VERTEX MC2Forum set title = 'techForum'").close();
+    session.execute("CREATE VERTEX MC2Post set content = 'post1'").close();
+    session.execute("CREATE VERTEX MC2Post set content = 'post2'").close();
+
+    // alice -> KNOWS -> bob
+    session.execute(
+        "CREATE EDGE MC2Knows FROM"
+            + " (SELECT FROM MC2Person WHERE name = 'alice')"
+            + " TO (SELECT FROM MC2Person WHERE name = 'bob')")
+        .close();
+
+    // bob -> HAS_MEMBER(joinDate=2000) -> techForum
+    session.execute(
+        "CREATE EDGE MC2HasMember FROM"
+            + " (SELECT FROM MC2Person WHERE name = 'bob')"
+            + " TO (SELECT FROM MC2Forum WHERE title = 'techForum')"
+            + " SET joinDate = 2000")
+        .close();
+
+    // techForum -> CONTAINER_OF -> post1, post2
+    session.execute(
+        "CREATE EDGE MC2ContainerOf FROM"
+            + " (SELECT FROM MC2Forum WHERE title = 'techForum')"
+            + " TO (SELECT FROM MC2Post WHERE content = 'post1')")
+        .close();
+    session.execute(
+        "CREATE EDGE MC2ContainerOf FROM"
+            + " (SELECT FROM MC2Forum WHERE title = 'techForum')"
+            + " TO (SELECT FROM MC2Post WHERE content = 'post2')")
+        .close();
+    session.commit();
+
+    // Query: alice -> KNOWS -> friend -> HAS_MEMBER(joinDate >= 1500) -> forum
+    //        -> CONTAINER_OF -> post
+    session.begin();
+    var query =
+        "MATCH {class: MC2Person, as: person, where: (name = 'alice')}"
+            + ".out('MC2Knows'){as: friend}"
+            + ".outE('MC2HasMember'){where: (joinDate >= 1500)}"
+            + ".inV(){as: forum}"
+            + ".out('MC2ContainerOf'){as: post}"
+            + " RETURN friend.name, forum.title, post.content";
+    var result = session.query(query).toList();
+
+    // bob (joinDate=2000 >= 1500) -> techForum -> post1, post2
+    assertEquals(2, result.size());
+
+    Set<String> contents = new HashSet<>();
+    for (var r : result) {
+      assertEquals("bob", r.getProperty("friend.name"));
+      assertEquals("techForum", r.getProperty("forum.title"));
+      contents.add(r.getProperty("post.content"));
+    }
+    assertTrue(contents.contains("post1"));
+    assertTrue(contents.contains("post2"));
+
+    session.commit();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -1,0 +1,344 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * End-to-end integration tests for index-assisted pre-filtering on edge-method
+ * MATCH patterns ({@code outE/inE} followed by {@code inV/outV}).
+ *
+ * <p>These tests verify that:
+ * <ul>
+ *   <li>Edge-method MATCH queries produce correct results identical to
+ *       equivalent non-edge-method queries</li>
+ *   <li>The planner applies pre-filter optimization when an indexed edge
+ *       property is used in a WHERE clause</li>
+ *   <li>Both {@code outE→inV} and {@code inE→outV} directions work</li>
+ *   <li>No pre-filter is applied when the edge property is not indexed</li>
+ * </ul>
+ */
+public class MatchEdgeMethodPreFilterTest extends DbTestBase {
+
+  /**
+   * Set up a graph with two edge classes that have indexed properties and typed
+   * LINK endpoints, enabling class inference from edge schema.
+   *
+   * <p>Schema:
+   * <pre>
+   *   Person --WORK_AT(workFrom: INTEGER, indexed)--> Company
+   *   Person --HAS_MEMBER(joinDate: LONG, indexed)--> Forum
+   * </pre>
+   *
+   * <p>Data: 10 persons, 5 companies, 3 forums.
+   * Each person works at one company (workFrom varies), and is a member of
+   * 1-3 forums (joinDate varies).
+   */
+  @Override
+  public void beforeTest() throws Exception {
+    super.beforeTest();
+
+    // Vertex classes
+    session.execute("CREATE class PFPerson extends V").close();
+    session.execute("CREATE property PFPerson.name STRING").close();
+
+    session.execute("CREATE class PFCompany extends V").close();
+    session.execute("CREATE property PFCompany.name STRING").close();
+
+    session.execute("CREATE class PFForum extends V").close();
+    session.execute("CREATE property PFForum.title STRING").close();
+
+    // Edge class: WORK_AT with indexed workFrom and typed endpoints
+    session.execute("CREATE class PFWorkAt extends E").close();
+    session.execute("CREATE property PFWorkAt.out LINK PFPerson").close();
+    session.execute("CREATE property PFWorkAt.in LINK PFCompany").close();
+    session.execute("CREATE property PFWorkAt.workFrom INTEGER").close();
+    session.execute(
+        "CREATE index PFWorkAt_workFrom on PFWorkAt (workFrom) NOTUNIQUE").close();
+
+    // Edge class: HAS_MEMBER with indexed joinDate and typed endpoints
+    session.execute("CREATE class PFHasMember extends E").close();
+    session.execute("CREATE property PFHasMember.out LINK PFPerson").close();
+    session.execute("CREATE property PFHasMember.in LINK PFForum").close();
+    session.execute("CREATE property PFHasMember.joinDate LONG").close();
+    session.execute(
+        "CREATE index PFHasMember_joinDate on PFHasMember (joinDate) NOTUNIQUE").close();
+
+    // Edge class without index — for negative test
+    session.execute("CREATE class PFLikes extends E").close();
+    session.execute("CREATE property PFLikes.out LINK PFPerson").close();
+    session.execute("CREATE property PFLikes.in LINK PFForum").close();
+    session.execute("CREATE property PFLikes.score INTEGER").close();
+    // No index on PFLikes.score
+
+    session.begin();
+
+    // Create companies
+    for (int i = 0; i < 5; i++) {
+      session.execute("CREATE VERTEX PFCompany set name = 'company" + i + "'")
+          .close();
+    }
+
+    // Create forums
+    for (int i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX PFForum set title = 'forum" + i + "'")
+          .close();
+    }
+
+    // Create 10 persons, each working at one company with different workFrom years
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX PFPerson set name = 'person" + i + "'")
+          .close();
+
+      // Person i works at company (i % 5), workFrom = 2010 + i
+      session.execute(
+          "CREATE EDGE PFWorkAt FROM"
+              + " (SELECT FROM PFPerson WHERE name = 'person" + i + "')"
+              + " TO (SELECT FROM PFCompany WHERE name = 'company" + (i % 5) + "')"
+              + " SET workFrom = " + (2010 + i))
+          .close();
+
+      // Person i is member of forum (i % 3), joinDate = 1000 + i * 100
+      session.execute(
+          "CREATE EDGE PFHasMember FROM"
+              + " (SELECT FROM PFPerson WHERE name = 'person" + i + "')"
+              + " TO (SELECT FROM PFForum WHERE title = 'forum" + (i % 3) + "')"
+              + " SET joinDate = " + (1000 + i * 100))
+          .close();
+
+      // Also create a Likes edge for negative tests (no index)
+      session.execute(
+          "CREATE EDGE PFLikes FROM"
+              + " (SELECT FROM PFPerson WHERE name = 'person" + i + "')"
+              + " TO (SELECT FROM PFForum WHERE title = 'forum" + (i % 3) + "')"
+              + " SET score = " + (i * 10))
+          .close();
+    }
+
+    session.commit();
+  }
+
+  // ---- Correctness tests ----
+
+  /**
+   * Verify that an outE→inV MATCH query with an indexed edge property filter
+   * produces the same results as the equivalent out() pattern.
+   *
+   * Pattern: Person -outE('PFWorkAt'){where: workFrom < 2015}-> inV() as company
+   * Expected: persons 0-4 (workFrom 2010-2014)
+   */
+  @Test
+  public void testOutEInVCorrectness() {
+    session.begin();
+
+    // Edge-method pattern
+    var edgeMethodQuery =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFWorkAt'){where: (workFrom < 2015)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var edgeResult = session.query(edgeMethodQuery).toList();
+
+    // Equivalent direct pattern for verification
+    var directQuery =
+        "SELECT FROM PFWorkAt WHERE workFrom < 2015";
+    var directResult = session.query(directQuery).toList();
+
+    assertEquals(
+        "Edge-method query should return same count as direct edge query",
+        directResult.size(), edgeResult.size());
+    assertEquals(5, edgeResult.size());
+
+    // Verify all person names are persons 0-4
+    Set<String> personNames = new HashSet<>();
+    for (var r : edgeResult) {
+      personNames.add(r.getProperty("p.name"));
+    }
+    for (int i = 0; i < 5; i++) {
+      assertTrue(
+          "Should contain person" + i,
+          personNames.contains("person" + i));
+    }
+
+    session.commit();
+  }
+
+  /**
+   * Verify that an inE→outV MATCH query with an indexed edge property filter
+   * produces correct results.
+   *
+   * Pattern: Forum -inE('PFHasMember'){where: joinDate >= 1500}-> outV() as person
+   * Expected: persons with joinDate >= 1500, i.e., persons 5-9
+   * (joinDate = 1000 + i*100, so >= 1500 means i >= 5)
+   */
+  @Test
+  public void testInEOutVCorrectness() {
+    session.begin();
+
+    var query =
+        "MATCH {class: PFForum, as: f}"
+            + ".inE('PFHasMember'){where: (joinDate >= 1500)}"
+            + ".outV(){as: p}"
+            + " RETURN p.name, f.title";
+    var result = session.query(query).toList();
+
+    assertEquals(5, result.size());
+
+    Set<String> personNames = new HashSet<>();
+    for (var r : result) {
+      personNames.add(r.getProperty("p.name"));
+    }
+    for (int i = 5; i < 10; i++) {
+      assertTrue(
+          "Should contain person" + i,
+          personNames.contains("person" + i));
+    }
+
+    session.commit();
+  }
+
+  // ---- Direction tests ----
+
+  /**
+   * Verify that both outE→inV and inE→outV directions produce correct results
+   * for the same logical relationship.
+   *
+   * outE from Person should yield the same companies as inE from Company yields
+   * persons — just viewed from different starting points.
+   */
+  @Test
+  public void testBothDirectionsConsistent() {
+    session.begin();
+
+    // outE from Person: find companies where workFrom = 2015
+    var outQuery =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFWorkAt'){where: (workFrom = 2015)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var outResult = session.query(outQuery).toList();
+    assertEquals(1, outResult.size());
+    assertEquals("person5", outResult.getFirst().getProperty("p.name"));
+    assertEquals("company0", outResult.getFirst().getProperty("c.name"));
+
+    // inE from Company: find persons where workFrom = 2015
+    var inQuery =
+        "MATCH {class: PFCompany, as: c}"
+            + ".inE('PFWorkAt'){where: (workFrom = 2015)}"
+            + ".outV(){as: p}"
+            + " RETURN p.name, c.name";
+    var inResult = session.query(inQuery).toList();
+    assertEquals(1, inResult.size());
+    assertEquals("person5", inResult.getFirst().getProperty("p.name"));
+    assertEquals("company0", inResult.getFirst().getProperty("c.name"));
+
+    session.commit();
+  }
+
+  // ---- EXPLAIN / pre-filter verification ----
+
+  /**
+   * Verify via EXPLAIN that the planner recognizes the edge class for
+   * outE('PFWorkAt') and includes it in the execution plan. The edge alias
+   * should appear in the plan, indicating class inference worked.
+   */
+  @Test
+  public void testExplainShowsEdgeClassInference() {
+    session.begin();
+
+    var query =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFWorkAt'){as: w, where: (workFrom < 2015)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    assertEquals(1, explainResult.size());
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
+
+    // The edge alias {w} should appear in the execution plan
+    assertTrue(
+        "Edge alias {w} should appear in execution plan, but plan was:\n" + plan,
+        plan.contains("{w}"));
+
+    session.commit();
+  }
+
+  /**
+   * Verify via EXPLAIN that the planner infers the vertex class for the inV()
+   * target from the edge schema's LINK property, even without an explicit
+   * class: constraint on the vertex alias.
+   *
+   * The vertex alias after inV() should get PFCompany inferred from
+   * PFWorkAt.in LINK PFCompany, affecting scheduling optimality.
+   */
+  @Test
+  public void testExplainInfersVertexClassFromEdgeSchema() {
+    session.begin();
+
+    // No explicit class: on the company alias — planner should infer it
+    var query =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFWorkAt'){as: w, where: (workFrom < 2015)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+
+    // Run the query and verify correct results (inference correctness)
+    var result = session.query(query).toList();
+    assertEquals(5, result.size());
+
+    // Verify EXPLAIN plan contains both aliases
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "Vertex alias {c} should appear in plan, but plan was:\n" + plan,
+        plan.contains("{c}"));
+
+    session.commit();
+  }
+
+  // ---- Negative test: no pre-filter without index ----
+
+  /**
+   * Verify that an edge class without an indexed property on the WHERE clause
+   * still produces correct results but does NOT benefit from pre-filtering.
+   *
+   * Uses PFLikes which has a score property but no index on it.
+   * The query should still work (correctness) but the execution plan should
+   * not show pre-filter optimization for the edge traversal.
+   */
+  @Test
+  public void testNoPreFilterWithoutIndex() {
+    session.begin();
+
+    // PFLikes.score has no index
+    var query =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFLikes'){where: (score >= 50)}"
+            + ".inV(){as: f}"
+            + " RETURN p.name, f.title";
+    var result = session.query(query).toList();
+
+    // persons 5-9 have score >= 50 (score = i * 10)
+    assertEquals(5, result.size());
+
+    Set<String> personNames = new HashSet<>();
+    for (var r : result) {
+      personNames.add(r.getProperty("p.name"));
+    }
+    for (int i = 5; i < 10; i++) {
+      assertTrue(
+          "Should contain person" + i,
+          personNames.contains("person" + i));
+    }
+
+    session.commit();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -243,9 +243,10 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
   /**
    * Verify via EXPLAIN that the planner recognizes the edge class for
-   * outE('PFWorkAt') and uses the PFWorkAt_workFrom index to fetch matching
-   * edges. The plan should contain a FETCH FROM INDEX step for the edge's
-   * workFrom index, proving class inference resolved PFWorkAt.
+   * outE('PFWorkAt') and uses the PFWorkAt_workFrom index as an
+   * intersection pre-filter on the edge traversal step. Inferred classes
+   * do not become prefetch roots (to avoid reversing while-traversal
+   * direction), but the index is still used as a pre-filter.
    */
   @Test
   public void testExplainShowsEdgeIndexUsage() {
@@ -267,11 +268,12 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
         "Edge alias {w} should appear in execution plan, but plan was:\n" + plan,
         plan.contains("{w}"));
 
-    // The plan should use the PFWorkAt_workFrom index to fetch edges,
-    // proving class inference resolved PFWorkAt and selected the index
+    // The plan should use the PFWorkAt_workFrom index as an intersection
+    // pre-filter on the edge traversal step
     assertTrue(
-        "Plan should use PFWorkAt_workFrom index, but plan was:\n" + plan,
-        plan.contains("FETCH FROM INDEX PFWorkAt_workFrom"));
+        "Plan should show intersection pre-filter using PFWorkAt_workFrom "
+            + "index, but plan was:\n" + plan,
+        plan.contains("intersection:"));
 
     session.commit();
   }
@@ -279,9 +281,9 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
   /**
    * Verify via EXPLAIN that the planner infers the vertex class for the inV()
    * target from the edge schema's LINK property, even without an explicit
-   * class: constraint. The plan should show a PREFETCH for the vertex alias
-   * fetching from the inferred class (PFCompany), and the edge index should
-   * be used for the edge alias.
+   * class: constraint. The inferred class is used for collection-ID filtering
+   * (shown as a class filter step in the plan) and the edge index is used as
+   * an intersection pre-filter.
    */
   @Test
   public void testExplainInfersVertexClassFromEdgeSchema() {
@@ -299,18 +301,17 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     var result = session.query(query).toList();
     assertEquals(5, result.size());
 
-    // Verify EXPLAIN plan shows the inferred vertex class PFCompany
-    // in a PREFETCH step — this proves the planner resolved the vertex
-    // class from the edge schema's LINK property
+    // Verify EXPLAIN plan shows the vertex alias and edge index pre-filter
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     assertTrue(
         "Vertex alias {c} should appear in plan, but plan was:\n" + plan,
         plan.contains("{c}"));
+    // The edge index should be used as intersection pre-filter
     assertTrue(
-        "Plan should fetch from inferred class PFCompany, but plan was:\n" + plan,
-        plan.contains("FETCH FROM CLASS PFCompany"));
+        "Plan should show intersection pre-filter, but plan was:\n" + plan,
+        plan.contains("intersection:"));
 
     session.commit();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -18,7 +19,7 @@ import org.junit.Test;
  *   <li>Edge-method MATCH queries produce correct results identical to
  *       equivalent non-edge-method queries</li>
  *   <li>The planner applies pre-filter optimization when an indexed edge
- *       property is used in a WHERE clause</li>
+ *       property is used in a WHERE clause (via EXPLAIN plan inspection)</li>
  *   <li>Both {@code outE→inV} and {@code inE→outV} directions work</li>
  *   <li>No pre-filter is applied when the edge property is not indexed</li>
  * </ul>
@@ -33,6 +34,7 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
    * <pre>
    *   Person --WORK_AT(workFrom: INTEGER, indexed)--> Company
    *   Person --HAS_MEMBER(joinDate: LONG, indexed)--> Forum
+   *   Person --LIKES(score: INTEGER, NOT indexed)--> Forum
    * </pre>
    *
    * <p>Data: 10 persons, 5 companies, 3 forums.
@@ -127,10 +129,10 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
   /**
    * Verify that an outE→inV MATCH query with an indexed edge property filter
-   * produces the same results as the equivalent out() pattern.
+   * produces correct results, checking both person names and person→company pairs.
    *
    * Pattern: Person -outE('PFWorkAt'){where: workFrom < 2015}-> inV() as company
-   * Expected: persons 0-4 (workFrom 2010-2014)
+   * Expected: persons 0-4 (workFrom 2010-2014), each at their assigned company
    */
   @Test
   public void testOutEInVCorrectness() {
@@ -154,15 +156,15 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
         directResult.size(), edgeResult.size());
     assertEquals(5, edgeResult.size());
 
-    // Verify all person names are persons 0-4
-    Set<String> personNames = new HashSet<>();
+    // Verify person→company pairs (not just person names)
+    Set<String> pairs = new HashSet<>();
     for (var r : edgeResult) {
-      personNames.add(r.getProperty("p.name"));
+      pairs.add(r.getProperty("p.name") + "->" + r.getProperty("c.name"));
     }
     for (int i = 0; i < 5; i++) {
       assertTrue(
-          "Should contain person" + i,
-          personNames.contains("person" + i));
+          "Should contain person" + i + "->company" + (i % 5),
+          pairs.contains("person" + i + "->company" + (i % 5)));
     }
 
     session.commit();
@@ -170,11 +172,10 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
   /**
    * Verify that an inE→outV MATCH query with an indexed edge property filter
-   * produces correct results.
+   * produces correct results, checking person→forum pairs.
    *
    * Pattern: Forum -inE('PFHasMember'){where: joinDate >= 1500}-> outV() as person
-   * Expected: persons with joinDate >= 1500, i.e., persons 5-9
-   * (joinDate = 1000 + i*100, so >= 1500 means i >= 5)
+   * Expected: persons 5-9 (joinDate = 1000 + i*100, so >= 1500 means i >= 5)
    */
   @Test
   public void testInEOutVCorrectness() {
@@ -189,14 +190,15 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
     assertEquals(5, result.size());
 
-    Set<String> personNames = new HashSet<>();
+    // Verify person→forum pairs
+    Set<String> pairs = new HashSet<>();
     for (var r : result) {
-      personNames.add(r.getProperty("p.name"));
+      pairs.add(r.getProperty("p.name") + "->" + r.getProperty("f.title"));
     }
     for (int i = 5; i < 10; i++) {
       assertTrue(
-          "Should contain person" + i,
-          personNames.contains("person" + i));
+          "Should contain person" + i + "->forum" + (i % 3),
+          pairs.contains("person" + i + "->forum" + (i % 3)));
     }
 
     session.commit();
@@ -206,10 +208,7 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
   /**
    * Verify that both outE→inV and inE→outV directions produce correct results
-   * for the same logical relationship.
-   *
-   * outE from Person should yield the same companies as inE from Company yields
-   * persons — just viewed from different starting points.
+   * for the same logical relationship: person5 works at company0 with workFrom=2015.
    */
   @Test
   public void testBothDirectionsConsistent() {
@@ -244,11 +243,12 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
   /**
    * Verify via EXPLAIN that the planner recognizes the edge class for
-   * outE('PFWorkAt') and includes it in the execution plan. The edge alias
-   * should appear in the plan, indicating class inference worked.
+   * outE('PFWorkAt') and uses the PFWorkAt_workFrom index to fetch matching
+   * edges. The plan should contain a FETCH FROM INDEX step for the edge's
+   * workFrom index, proving class inference resolved PFWorkAt.
    */
   @Test
-  public void testExplainShowsEdgeClassInference() {
+  public void testExplainShowsEdgeIndexUsage() {
     session.begin();
 
     var query =
@@ -267,25 +267,31 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
         "Edge alias {w} should appear in execution plan, but plan was:\n" + plan,
         plan.contains("{w}"));
 
+    // The plan should use the PFWorkAt_workFrom index to fetch edges,
+    // proving class inference resolved PFWorkAt and selected the index
+    assertTrue(
+        "Plan should use PFWorkAt_workFrom index, but plan was:\n" + plan,
+        plan.contains("FETCH FROM INDEX PFWorkAt_workFrom"));
+
     session.commit();
   }
 
   /**
    * Verify via EXPLAIN that the planner infers the vertex class for the inV()
    * target from the edge schema's LINK property, even without an explicit
-   * class: constraint on the vertex alias.
-   *
-   * The vertex alias after inV() should get PFCompany inferred from
-   * PFWorkAt.in LINK PFCompany, affecting scheduling optimality.
+   * class: constraint. The plan should show a PREFETCH for the vertex alias
+   * fetching from the inferred class (PFCompany), and the edge index should
+   * be used for the edge alias.
    */
   @Test
   public void testExplainInfersVertexClassFromEdgeSchema() {
     session.begin();
 
     // No explicit class: on the company alias — planner should infer it
+    // from PFWorkAt.in LINK PFCompany
     var query =
         "MATCH {class: PFPerson, as: p}"
-            + ".outE('PFWorkAt'){as: w, where: (workFrom < 2015)}"
+            + ".outE('PFWorkAt'){where: (workFrom < 2015)}"
             + ".inV(){as: c}"
             + " RETURN p.name, c.name";
 
@@ -293,13 +299,18 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     var result = session.query(query).toList();
     assertEquals(5, result.size());
 
-    // Verify EXPLAIN plan contains both aliases
+    // Verify EXPLAIN plan shows the inferred vertex class PFCompany
+    // in a PREFETCH step — this proves the planner resolved the vertex
+    // class from the edge schema's LINK property
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     assertTrue(
         "Vertex alias {c} should appear in plan, but plan was:\n" + plan,
         plan.contains("{c}"));
+    assertTrue(
+        "Plan should fetch from inferred class PFCompany, but plan was:\n" + plan,
+        plan.contains("FETCH FROM CLASS PFCompany"));
 
     session.commit();
   }
@@ -308,11 +319,8 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
   /**
    * Verify that an edge class without an indexed property on the WHERE clause
-   * still produces correct results but does NOT benefit from pre-filtering.
-   *
-   * Uses PFLikes which has a score property but no index on it.
-   * The query should still work (correctness) but the execution plan should
-   * not show pre-filter optimization for the edge traversal.
+   * still produces correct results but does NOT trigger pre-filtering. The
+   * EXPLAIN plan must not contain an index intersection descriptor for PFLikes.
    */
   @Test
   public void testNoPreFilterWithoutIndex() {
@@ -337,6 +345,151 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
       assertTrue(
           "Should contain person" + i,
           personNames.contains("person" + i));
+    }
+
+    // Verify EXPLAIN does NOT show index intersection for the non-indexed edge
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "Plan should NOT contain index intersection for non-indexed PFLikes,"
+            + " but plan was:\n" + plan,
+        plan.contains("(intersection: index"));
+
+    session.commit();
+  }
+
+  // ---- Boundary and edge cases ----
+
+  /**
+   * Verify that an outE→inV query returns zero results when the WHERE clause
+   * matches no edges (workFrom > 2999 matches nobody in the dataset).
+   */
+  @Test
+  public void testOutEInVReturnsEmptyWhenNoEdgesMatch() {
+    session.begin();
+
+    var query =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFWorkAt'){where: (workFrom > 2999)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var result = session.query(query).toList();
+
+    assertEquals(0, result.size());
+
+    session.commit();
+  }
+
+  /**
+   * Verify correctness when exactly one edge matches a range predicate,
+   * exercising a single-entry RID set in the pre-filter.
+   * workFrom = 2019 for person9, so >= 2019 matches exactly one edge.
+   */
+  @Test
+  public void testOutEInVSingleMatchRangePredicate() {
+    session.begin();
+
+    var query =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFWorkAt'){where: (workFrom >= 2019)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var result = session.query(query).toList();
+
+    assertEquals(1, result.size());
+    assertEquals("person9", result.getFirst().getProperty("p.name"));
+    assertEquals("company4", result.getFirst().getProperty("c.name"));
+
+    session.commit();
+  }
+
+  /**
+   * Verify that outE() without an edge class argument still returns correct
+   * results (traverses all edge types). Class inference cannot apply, so
+   * this exercises the null-currentEdgeClass path in addAliases.
+   */
+  @Test
+  public void testOutEWithoutClassArgument() {
+    session.begin();
+
+    // outE() without class name: traverses all edge types from PFPerson.
+    // Only PFWorkAt edges have the workFrom property; person5 has workFrom=2015.
+    var query =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE(){where: (workFrom = 2015)}"
+            + ".inV(){as: target}"
+            + " RETURN p.name, target.name";
+    var result = session.query(query).toList();
+
+    assertEquals(1, result.size());
+    assertEquals("person5", result.getFirst().getProperty("p.name"));
+
+    session.commit();
+  }
+
+  /**
+   * Verify that multiple edges of the same class between the same vertex pair
+   * are all returned when they match the WHERE clause. Exercises that the
+   * pre-filter operates on edge RIDs, not vertex RIDs.
+   */
+  @Test
+  public void testMultipleEdgesBetweenSameVertexPair() {
+    session.begin();
+
+    // person0 already works at company0 with workFrom=2010.
+    // Add a second PFWorkAt edge from person0 to company0 with workFrom=2011.
+    session.execute(
+        "CREATE EDGE PFWorkAt FROM"
+            + " (SELECT FROM PFPerson WHERE name = 'person0')"
+            + " TO (SELECT FROM PFCompany WHERE name = 'company0')"
+            + " SET workFrom = 2011")
+        .close();
+
+    var query =
+        "MATCH {class: PFPerson, as: p, where: (name = 'person0')}"
+            + ".outE('PFWorkAt'){where: (workFrom <= 2011)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var result = session.query(query).toList();
+
+    // Should return 2 results: both edges match workFrom <= 2011
+    assertEquals(2, result.size());
+    for (var r : result) {
+      assertEquals("person0", r.getProperty("p.name"));
+      assertEquals("company0", r.getProperty("c.name"));
+    }
+
+    session.commit();
+  }
+
+  /**
+   * Verify correctness when the WHERE clause matches all edges (workFrom >= 2010
+   * matches all 10 edges). Pre-filter should either be skipped (ratio too high)
+   * or produce correct results regardless.
+   */
+  @Test
+  public void testOutEInVWhereMatchesAllEdges() {
+    session.begin();
+
+    var query =
+        "MATCH {class: PFPerson, as: p}"
+            + ".outE('PFWorkAt'){where: (workFrom >= 2010)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var result = session.query(query).toList();
+
+    assertEquals(10, result.size());
+
+    // Verify all 10 person→company pairs
+    Set<String> pairs = new HashSet<>();
+    for (var r : result) {
+      pairs.add(r.getProperty("p.name") + "->" + r.getProperty("c.name"));
+    }
+    for (int i = 0; i < 10; i++) {
+      assertTrue(
+          "Should contain person" + i + "->company" + (i % 5),
+          pairs.contains("person" + i + "->company" + (i % 5)));
     }
 
     session.commit();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -161,11 +161,11 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     for (var r : edgeResult) {
       pairs.add(r.getProperty("p.name") + "->" + r.getProperty("c.name"));
     }
+    Set<String> expectedPairs = new HashSet<>();
     for (int i = 0; i < 5; i++) {
-      assertTrue(
-          "Should contain person" + i + "->company" + (i % 5),
-          pairs.contains("person" + i + "->company" + (i % 5)));
+      expectedPairs.add("person" + i + "->company" + (i % 5));
     }
+    assertEquals(expectedPairs, pairs);
 
     session.commit();
   }
@@ -195,11 +195,11 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     for (var r : result) {
       pairs.add(r.getProperty("p.name") + "->" + r.getProperty("f.title"));
     }
+    Set<String> expectedPairs = new HashSet<>();
     for (int i = 5; i < 10; i++) {
-      assertTrue(
-          "Should contain person" + i + "->forum" + (i % 3),
-          pairs.contains("person" + i + "->forum" + (i % 3)));
+      expectedPairs.add("person" + i + "->forum" + (i % 3));
     }
+    assertEquals(expectedPairs, pairs);
 
     session.commit();
   }
@@ -341,20 +341,20 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     for (var r : result) {
       personNames.add(r.getProperty("p.name"));
     }
+    Set<String> expectedNames = new HashSet<>();
     for (int i = 5; i < 10; i++) {
-      assertTrue(
-          "Should contain person" + i,
-          personNames.contains("person" + i));
+      expectedNames.add("person" + i);
     }
+    assertEquals(expectedNames, personNames);
 
     // Verify EXPLAIN does NOT show index intersection for the non-indexed edge
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     assertFalse(
-        "Plan should NOT contain index intersection for non-indexed PFLikes,"
-            + " but plan was:\n" + plan,
-        plan.contains("(intersection: index"));
+        "Plan should NOT contain any intersection descriptor for non-indexed"
+            + " PFLikes, but plan was:\n" + plan,
+        plan.contains("(intersection:"));
 
     session.commit();
   }
@@ -372,6 +372,30 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     var query =
         "MATCH {class: PFPerson, as: p}"
             + ".outE('PFWorkAt'){where: (workFrom > 2999)}"
+            + ".inV(){as: c}"
+            + " RETURN p.name, c.name";
+    var result = session.query(query).toList();
+
+    assertEquals(0, result.size());
+
+    session.commit();
+  }
+
+  /**
+   * Verify that a vertex with no outgoing edges of the traversed type
+   * produces zero results without errors, even when the pre-filter is active.
+   * Exercises the empty link bag path in applyPreFilter (size=0).
+   */
+  @Test
+  public void testOutEInVWithIsolatedVertexProducesEmptyResult() {
+    session.begin();
+
+    // Create an isolated person with no PFWorkAt edges
+    session.execute("CREATE VERTEX PFPerson set name = 'loner'").close();
+
+    var query =
+        "MATCH {class: PFPerson, as: p, where: (name = 'loner')}"
+            + ".outE('PFWorkAt'){where: (workFrom < 2015)}"
             + ".inV(){as: c}"
             + " RETURN p.name, c.name";
     var result = session.query(query).toList();
@@ -424,6 +448,7 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
     assertEquals(1, result.size());
     assertEquals("person5", result.getFirst().getProperty("p.name"));
+    assertEquals("company0", result.getFirst().getProperty("target.name"));
 
     session.commit();
   }
@@ -486,11 +511,46 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     for (var r : result) {
       pairs.add(r.getProperty("p.name") + "->" + r.getProperty("c.name"));
     }
+    Set<String> expectedPairs = new HashSet<>();
     for (int i = 0; i < 10; i++) {
-      assertTrue(
-          "Should contain person" + i + "->company" + (i % 5),
-          pairs.contains("person" + i + "->company" + (i % 5)));
+      expectedPairs.add("person" + i + "->company" + (i % 5));
     }
+    assertEquals(expectedPairs, pairs);
+
+    session.commit();
+  }
+
+  /**
+   * Verify that bothE() with an indexed edge property still produces correct
+   * results via unfiltered traversal. bothE() is intentionally out of scope
+   * for pre-filtering (returns ChainedIterable, not PreFilterableLinkBagIterable)
+   * and silently degrades to no-op. This test documents the intentional
+   * degradation and guards against regressions.
+   */
+  @Test
+  public void testBothEDegradesToNoPreFilterButReturnsCorrectResults() {
+    session.begin();
+
+    // bothE('PFWorkAt') from company0 should find persons working there.
+    // company0 has persons 0 and 5 (workFrom 2010, 2015).
+    // Filter workFrom < 2015 -> only person0 matches.
+    var query =
+        "MATCH {class: PFCompany, as: c, where: (name = 'company0')}"
+            + ".bothE('PFWorkAt'){where: (workFrom < 2015)}"
+            + ".outV(){as: p}"
+            + " RETURN p.name";
+    var result = session.query(query).toList();
+
+    assertEquals(1, result.size());
+    assertEquals("person0", result.getFirst().getProperty("p.name"));
+
+    // EXPLAIN should NOT show intersection descriptor for bothE
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertFalse(
+        "bothE should NOT trigger pre-filter intersection, but plan was:\n"
+            + plan,
+        plan.contains("(intersection:"));
 
     session.commit();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionTest.java
@@ -3479,6 +3479,72 @@ public class MatchStatementExecutionTest extends DbTestBase {
   }
 
   /**
+   * Boundary-depth diamond dedup: 0→1→3, 0→2→3. With {@code while: ($depth < 2)},
+   * the while condition fails at depth 2 (the leaf level where vertex 3 lives).
+   * Before the fix, {@code dedupVisited.add()} was inside the expansion block that
+   * only executes when the while condition holds, so leaf-level vertices were never
+   * marked as visited. Vertex 3 would appear twice — once from 1→3 and once from 2→3.
+   * After the fix, visited marking happens before the expansion check, so vertex 3
+   * is correctly deduplicated even at the boundary depth.
+   */
+  @Test
+  public void testWhileDeduplicatesLeafVerticesAtBoundaryDepth() {
+    session.begin();
+
+    // while: ($depth < 2) traverses depths 0, 1 from vertex 0:
+    //   depth 0: vertex 0 (while holds: 0 < 2)
+    //   depth 1: vertices 1, 2 (while holds: 1 < 2)
+    //   depth 2: vertex 3 via both 1 and 2 (while FAILS: 2 < 2 is false)
+    // Vertex 3 must appear exactly once despite being reachable from two parents.
+    var results = session.query(
+        "MATCH {class:DiamondV, as:start, where:(uid = 0)}"
+            + ".out('DiamondE'){as:reached, while:($depth < 2)}"
+            + " RETURN reached.uid as uid")
+        .stream().toList();
+
+    var uids = new ArrayList<Integer>();
+    for (var r : results) {
+      uids.add(((Number) r.getProperty("uid")).intValue());
+    }
+    Collections.sort(uids);
+
+    // Expect exactly 4 unique vertices: 0 (depth 0), 1 and 2 (depth 1), 3 (depth 2)
+    assertEquals(
+        "Boundary-depth diamond: each vertex must appear exactly once",
+        List.of(0, 1, 2, 3),
+        uids);
+    session.commit();
+  }
+
+  /**
+   * Same boundary-depth diamond as above, but with pathAlias declared. When pathAlias
+   * is present, dedup is disabled (dedupVisited is null) to preserve all distinct paths.
+   * Vertex 3 must appear twice — once for path 0→1→3 and once for path 0→2→3.
+   */
+  @Test
+  public void testWhileBoundaryDepthWithPathAliasPreservesAllPaths() {
+    session.begin();
+
+    var results = session.query(
+        "MATCH {class:DiamondV, as:start, where:(uid = 0)}"
+            + ".out('DiamondE'){as:reached, while:($depth < 2),"
+            + " pathAlias: p}"
+            + " RETURN reached.uid as uid, p")
+        .stream().toList();
+
+    // Count how many times vertex 3 appears — should be 2 (one per path)
+    var uid3Count = results.stream()
+        .filter(r -> ((Number) r.getProperty("uid")).intValue() == 3)
+        .count();
+    assertEquals(
+        "Boundary-depth vertex 3 should appear twice (once per path) with pathAlias",
+        2,
+        uid3Count);
+
+    session.commit();
+  }
+
+  /**
    * Verifies that MATCH ... RETURN $elements ORDER BY ... SKIP N LIMIT M uses the
    * bounded-heap optimization with buffer size = SKIP + LIMIT.
    */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ApplyPreFilterInterfaceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ApplyPreFilterInterfaceTest.java
@@ -1,0 +1,174 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.record.impl.PreFilterableLinkBagIterable;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchPathItem;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link MatchEdgeTraverser#applyPreFilter} dispatches on
+ * {@link PreFilterableLinkBagIterable} rather than the concrete
+ * {@code VertexFromLinkBagIterable} type, so both vertex and edge
+ * link-bag iterables receive class and RID filters.
+ *
+ * <p>Uses a lightweight stub that implements the interface directly,
+ * avoiding the need for a real database session or link bag.
+ */
+public class ApplyPreFilterInterfaceTest {
+
+  /**
+   * When applyPreFilter receives a PreFilterableLinkBagIterable (which
+   * both vertex and edge iterables implement), it should apply the class
+   * filter from the edge's acceptedCollectionIds. Before the interface
+   * change, only VertexFromLinkBagIterable was handled — any other
+   * implementor would pass through unfiltered.
+   */
+  @Test
+  public void applyPreFilterAcceptsAnyPreFilterableViaInterface() {
+    var collectionIds = IntOpenHashSet.of(20);
+    var edge = createEdgeTraversalWithClassFilter(collectionIds);
+    var traverser = createTraverser(edge);
+    var ctx = new BasicCommandContext();
+
+    var stub = new StubPreFilterable(100);
+    var result = traverser.applyPreFilter(stub, ctx);
+
+    assertThat(result).isInstanceOf(StubPreFilterable.class);
+    var filtered = (StubPreFilterable) result;
+    assertThat(filtered.appliedClassFilter).isEqualTo(collectionIds);
+    assertThat(filtered.appliedRidFilter).isNull();
+  }
+
+  /**
+   * When applyPreFilter receives a non-PreFilterableLinkBagIterable object
+   * (e.g. a plain String), it returns the object unchanged — no filtering
+   * is applied.
+   */
+  @Test
+  public void applyPreFilterPassesThroughNonInterfaceType() {
+    var edge = createEdgeTraversalWithClassFilter(IntOpenHashSet.of(10));
+    var traverser = createTraverser(edge);
+    var ctx = new BasicCommandContext();
+
+    var plainObject = "not a PreFilterableLinkBagIterable";
+    var result = traverser.applyPreFilter(plainObject, ctx);
+
+    assertThat(result).isSameAs(plainObject);
+  }
+
+  /**
+   * When the edge has no class filter and no intersection descriptor,
+   * applyPreFilter returns the iterable unchanged (no-op).
+   */
+  @Test
+  public void applyPreFilterNoOpWhenNoFiltersConfigured() {
+    var edge = createEdgeTraversal();
+    // No acceptedCollectionIds, no intersectionDescriptor
+    var traverser = createTraverser(edge);
+    var ctx = new BasicCommandContext();
+
+    var stub = new StubPreFilterable(100);
+    var result = traverser.applyPreFilter(stub, ctx);
+
+    // Same instance returned: no filters were applied
+    assertThat(result).isSameAs(stub);
+  }
+
+  /**
+   * When edge is null (path-item constructor), applyPreFilter returns the
+   * input unchanged regardless of its type.
+   */
+  @Test
+  public void applyPreFilterReturnsUnchangedWhenEdgeIsNull() {
+    var traverser = createTraverserWithNullEdge();
+    var ctx = new BasicCommandContext();
+    var stub = new StubPreFilterable(100);
+
+    var result = traverser.applyPreFilter(stub, ctx);
+
+    assertThat(result).isSameAs(stub);
+  }
+
+  // =========================================================================
+  // Helpers
+  // =========================================================================
+
+  private EdgeTraversal createEdgeTraversal() {
+    var nodeA = new PatternNode();
+    nodeA.alias = "a";
+    var nodeB = new PatternNode();
+    nodeB.alias = "b";
+    nodeA.addEdge(new SQLMatchPathItem(-1), nodeB);
+    var patternEdge = nodeA.out.iterator().next();
+    return new EdgeTraversal(patternEdge, true);
+  }
+
+  private EdgeTraversal createEdgeTraversalWithClassFilter(IntSet ids) {
+    var et = createEdgeTraversal();
+    et.setAcceptedCollectionIds(ids);
+    return et;
+  }
+
+  private MatchEdgeTraverser createTraverser(EdgeTraversal edge) {
+    return new MatchEdgeTraverser(null, edge);
+  }
+
+  private MatchEdgeTraverser createTraverserWithNullEdge() {
+    return new MatchEdgeTraverser(null, new SQLMatchPathItem(-1));
+  }
+
+  /**
+   * Lightweight stub implementing PreFilterableLinkBagIterable for testing
+   * filter dispatch without requiring a real LinkBag or database session.
+   * Records which filters were applied so tests can assert on them.
+   */
+  static class StubPreFilterable implements PreFilterableLinkBagIterable {
+    final int reportedSize;
+    IntSet appliedClassFilter;
+    Set<RID> appliedRidFilter;
+
+    StubPreFilterable(int size) {
+      this.reportedSize = size;
+    }
+
+    private StubPreFilterable(
+        int size, IntSet classFilter, Set<RID> ridFilter) {
+      this.reportedSize = size;
+      this.appliedClassFilter = classFilter;
+      this.appliedRidFilter = ridFilter;
+    }
+
+    @Override
+    public int size() {
+      return reportedSize;
+    }
+
+    @Override
+    public boolean isSizeable() {
+      return true;
+    }
+
+    @Nonnull
+    @Override
+    public PreFilterableLinkBagIterable withClassFilter(
+        @Nonnull IntSet collectionIds) {
+      return new StubPreFilterable(
+          reportedSize, collectionIds, appliedRidFilter);
+    }
+
+    @Nonnull
+    @Override
+    public PreFilterableLinkBagIterable withRidFilter(
+        @Nonnull Set<RID> ridSet) {
+      return new StubPreFilterable(
+          reportedSize, appliedClassFilter, ridSet);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ApplyPreFilterInterfaceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ApplyPreFilterInterfaceTest.java
@@ -8,6 +8,8 @@ import com.jetbrains.youtrackdb.internal.core.record.impl.PreFilterableLinkBagIt
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchPathItem;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.junit.Test;
@@ -143,6 +145,12 @@ public class ApplyPreFilterInterfaceTest {
       this.reportedSize = size;
       this.appliedClassFilter = classFilter;
       this.appliedRidFilter = ridFilter;
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<?> iterator() {
+      return Collections.emptyIterator();
     }
 
     @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversalCacheTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversalCacheTest.java
@@ -289,7 +289,7 @@ public class EdgeTraversalCacheTest {
     var rid = new RecordId(5, 1);
     when(expr.execute(nullable(Result.class), any())).thenReturn(rid);
 
-    var desc = new EdgeRidLookup("KNOWS", "out", expr);
+    var desc = new EdgeRidLookup("KNOWS", "out", expr, false);
     var key = desc.cacheKey(new BasicCommandContext());
 
     assertThat(key).isEqualTo(rid);
@@ -304,7 +304,7 @@ public class EdgeTraversalCacheTest {
     var expr = mock(SQLExpression.class);
     when(expr.execute(nullable(Result.class), any())).thenReturn(42);
 
-    var desc = new EdgeRidLookup("KNOWS", "out", expr);
+    var desc = new EdgeRidLookup("KNOWS", "out", expr, false);
     var key = desc.cacheKey(new BasicCommandContext());
 
     assertThat(key).isNull();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -19,10 +19,13 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.CostModel;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBaseExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIdentifier;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchExpression;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchFilter;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchPathItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMathExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMethodCall;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLModifier;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
@@ -1182,6 +1185,304 @@ public class MatchExecutionPlannerMutationTest {
     var patternEdge = nodeA.out.iterator().next();
 
     return new EdgeTraversal(patternEdge, out);
+  }
+
+  // =========================================================================
+  // addAliases (expression-level) — currentEdgeClass tracking
+  // =========================================================================
+
+  /**
+   * outE('KNOWS') item → aliasClasses should contain the edge alias mapped to "KNOWS".
+   * Verifies that outE sets currentEdgeClass and inference returns the edge class directly.
+   */
+  @Test
+  public void addAliases_outE_infersEdgeClass() {
+    var edgeAlias = "e";
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", edgeAlias));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses).containsEntry(edgeAlias, "KNOWS");
+  }
+
+  /**
+   * inE('HAS_MEMBER') item → aliasClasses should contain the edge alias mapped to
+   * "HAS_MEMBER".
+   */
+  @Test
+  public void addAliases_inE_infersEdgeClass() {
+    var edgeAlias = "e";
+    var expr = mockExpression(
+        mockPathItem("inE", "HAS_MEMBER", edgeAlias));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses).containsEntry(edgeAlias, "HAS_MEMBER");
+  }
+
+  /**
+   * outE('KNOWS') followed by inV() → aliasClasses should contain the edge alias
+   * mapped to "KNOWS" and the vertex alias mapped to the linked class from KNOWS.in.
+   * This verifies currentEdgeClass is propagated from outE to inV.
+   */
+  @Test
+  public void addAliases_outE_then_inV_infersVertexClass() {
+    var personClass = registerClass("Person", 100);
+    var edgeClass = registerClass("KNOWS", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", "e"),
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses)
+        .containsEntry("e", "KNOWS")
+        .containsEntry("v", "Person");
+  }
+
+  /**
+   * inE('WORK_AT') followed by outV() → aliasClasses should contain the edge alias
+   * mapped to "WORK_AT" and the vertex alias mapped to the linked class from
+   * WORK_AT.out.
+   */
+  @Test
+  public void addAliases_inE_then_outV_infersVertexClass() {
+    var personClass = registerClass("Person", 100);
+    var edgeClass = registerClass("WORK_AT", 300);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var expr = mockExpression(
+        mockPathItem("inE", "WORK_AT", "e"),
+        mockPathItem("outV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses)
+        .containsEntry("e", "WORK_AT")
+        .containsEntry("v", "Person");
+  }
+
+  /**
+   * inV() without a preceding outE → vertex alias should NOT be in aliasClasses
+   * (no currentEdgeClass to propagate).
+   */
+  @Test
+  public void addAliases_inV_withoutPrecedingOutE_noInference() {
+    var expr = mockExpression(
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses).doesNotContainKey("v");
+  }
+
+  /**
+   * outE('KNOWS') followed by inV() followed by another inV() →
+   * the second inV() should NOT infer a class because currentEdgeClass
+   * was reset after the first inV() consumed it.
+   */
+  @Test
+  public void addAliases_currentEdgeClass_resetAfterInV() {
+    var personClass = registerClass("Person", 100);
+    var edgeClass = registerClass("KNOWS", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", "e"),
+        mockPathItem("inV", null, "v1"),
+        mockPathItem("inV", null, "v2"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses)
+        .containsEntry("e", "KNOWS")
+        .containsEntry("v1", "Person")
+        .doesNotContainKey("v2");
+  }
+
+  /**
+   * Consecutive outE overwrites currentEdgeClass: outE('KNOWS') followed by
+   * outE('WORK_AT') followed by inV() → the inV should resolve from WORK_AT,
+   * not KNOWS.
+   */
+  @Test
+  public void addAliases_consecutiveOutE_overwritesCurrentEdgeClass() {
+    var personClass = registerClass("Person", 100);
+    var companyClass = registerClass("Company", 50);
+    var knowsEdge = registerClass("KNOWS", 500);
+    var workAtEdge = registerClass("WORK_AT", 300);
+
+    // KNOWS.in → Person
+    var knowsInProp = mock(SchemaPropertyInternal.class);
+    when(knowsInProp.getLinkedClass()).thenReturn(personClass);
+    when(knowsEdge.getPropertyInternal("in")).thenReturn(knowsInProp);
+
+    // WORK_AT.in → Company
+    var workAtInProp = mock(SchemaPropertyInternal.class);
+    when(workAtInProp.getLinkedClass()).thenReturn(companyClass);
+    when(workAtEdge.getPropertyInternal("in")).thenReturn(workAtInProp);
+
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", "e1"),
+        mockPathItem("outE", "WORK_AT", "e2"),
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses)
+        .containsEntry("e1", "KNOWS")
+        .containsEntry("e2", "WORK_AT")
+        .containsEntry("v", "Company");
+  }
+
+  /**
+   * bothE resets currentEdgeClass: outE('KNOWS') followed by bothE('X') followed by
+   * inV() → inV should NOT infer a class because bothE reset the state.
+   */
+  @Test
+  public void addAliases_bothE_resetsCurrentEdgeClass() {
+    registerClass("KNOWS", 500);
+
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", "e1"),
+        mockPathItem("bothE", "X", "e2"),
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses)
+        .containsEntry("e1", "KNOWS")
+        .doesNotContainKey("v");
+  }
+
+  /**
+   * skipClassInference=true → no class inference at all, even for edge methods.
+   */
+  @Test
+  public void addAliases_skipClassInference_noInference() {
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", "e"),
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), true);
+
+    assertThat(aliasClasses).isEmpty();
+  }
+
+  /**
+   * out('KNOWS') between outE and inV resets currentEdgeClass: outE('X') → out('Y') → inV()
+   * should NOT infer a class for inV because out() reset the edge state.
+   */
+  @Test
+  public void addAliases_outBetweenOutEAndInV_resetsCurrentEdgeClass() {
+    // Register KNOWS for the out('KNOWS') inference (vertex class)
+    var personClass = registerClass("Person", 100);
+    var knowsEdge = registerClass("KNOWS", 500);
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(knowsEdge.getPropertyInternal("in")).thenReturn(inProp);
+
+    registerClass("X", 100);
+
+    var expr = mockExpression(
+        mockPathItem("outE", "X", "e"),
+        mockPathItem("out", "KNOWS", "mid"),
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses)
+        .containsEntry("e", "X")
+        .containsEntry("mid", "Person")
+        .doesNotContainKey("v");
+  }
+
+  // ── addAliases helper methods ──
+
+  /**
+   * Creates a mock SQLMatchExpression with the given path items and an empty origin.
+   */
+  private SQLMatchExpression mockExpression(SQLMatchPathItem... items) {
+    var expr = mock(SQLMatchExpression.class);
+    var origin = mock(SQLMatchFilter.class);
+    when(origin.getAlias()).thenReturn(null);
+    when(expr.getOrigin()).thenReturn(origin);
+    when(expr.getItems()).thenReturn(List.of(items));
+    return expr;
+  }
+
+  /**
+   * Creates a mock SQLMatchPathItem with the given method name, optional edge class
+   * parameter, and filter alias.
+   *
+   * @param methodName the method name (e.g., "outE", "inV", "out")
+   * @param edgeClassParam the edge class parameter (e.g., "KNOWS"), or null for
+   *     parameterless methods like inV/outV
+   * @param alias the alias for the filter (e.g., "e", "v")
+   */
+  private SQLMatchPathItem mockPathItem(
+      String methodName, String edgeClassParam, String alias) {
+    var item = mock(SQLMatchPathItem.class);
+
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, methodName);
+    if (edgeClassParam != null) {
+      var param = mock(SQLExpression.class);
+      when(param.execute(nullable(Result.class), any(CommandContext.class)))
+          .thenReturn(edgeClassParam);
+      when(method.getParams()).thenReturn(List.of(param));
+    } else {
+      when(method.getParams()).thenReturn(List.of());
+    }
+    when(item.getMethod()).thenReturn(method);
+
+    var filter = mock(SQLMatchFilter.class);
+    when(filter.getAlias()).thenReturn(alias);
+    when(item.getFilter()).thenReturn(filter);
+
+    return item;
   }
 
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -764,7 +764,7 @@ public class MatchExecutionPlannerMutationTest {
     var method = mockMethodCallWithDirection("out", "HAS_CREATOR");
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isEqualTo("Person");
   }
 
@@ -784,7 +784,7 @@ public class MatchExecutionPlannerMutationTest {
     var method = mockMethodCallWithDirection("in", "CONTAINER_OF");
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isEqualTo("Forum");
   }
 
@@ -794,7 +794,7 @@ public class MatchExecutionPlannerMutationTest {
   @Test
   public void inferClassFromEdgeSchema_nullMethod_returnsNull() {
     var ctx = mockContext();
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(null, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(null, null, ctx))
         .isNull();
   }
 
@@ -808,19 +808,19 @@ public class MatchExecutionPlannerMutationTest {
     when(method.getParams()).thenReturn(List.of());
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isNull();
   }
 
   /**
-   * Non-traversal method (e.g., outE) → returns null (only in/out supported).
+   * Non-traversal method (e.g., both) → returns null.
    */
   @Test
   public void inferClassFromEdgeSchema_nonTraversalMethod_returnsNull() {
-    var method = mockMethodCallWithDirection("outE", "HAS_CREATOR");
+    var method = mockMethodCallWithDirection("both", "HAS_CREATOR");
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isNull();
   }
 
@@ -836,7 +836,7 @@ public class MatchExecutionPlannerMutationTest {
     var method = mockMethodCallWithDirection("out", "HAS_TAG");
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isNull();
   }
 
@@ -850,7 +850,7 @@ public class MatchExecutionPlannerMutationTest {
     var method = mockMethodCallWithDirection("out", "NONEXISTENT");
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isNull();
   }
 
@@ -870,7 +870,7 @@ public class MatchExecutionPlannerMutationTest {
     var method = mockMethodCallWithDirection("Out", "HAS_CREATOR");
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isEqualTo("Person");
   }
 
@@ -888,7 +888,175 @@ public class MatchExecutionPlannerMutationTest {
     when(method.getParams()).thenReturn(List.of(param));
     var ctx = mockContext();
 
-    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, ctx))
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isNull();
+  }
+
+  // ── inferClassFromEdgeSchema: outE/inE → edge class inference ──
+
+  /**
+   * outE('KNOWS') returns "KNOWS" — the edge class itself is the alias class.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_outE_returnsEdgeClass() {
+    var method = mockMethodCallWithDirection("outE", "KNOWS");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isEqualTo("KNOWS");
+  }
+
+  /**
+   * inE('HAS_MEMBER') returns "HAS_MEMBER" — the edge class itself is the alias class.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_inE_returnsEdgeClass() {
+    var method = mockMethodCallWithDirection("inE", "HAS_MEMBER");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isEqualTo("HAS_MEMBER");
+  }
+
+  /**
+   * outE() without params returns null — no edge class can be inferred.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_outE_noParams_returnsNull() {
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "outE");
+    when(method.getParams()).thenReturn(List.of());
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isNull();
+  }
+
+  /**
+   * inE() without params returns null.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_inE_noParams_returnsNull() {
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "inE");
+    when(method.getParams()).thenReturn(List.of());
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isNull();
+  }
+
+  // ── inferClassFromEdgeSchema: inV/outV → linked vertex class inference ──
+
+  /**
+   * inV() with currentEdgeClass "KNOWS" and KNOWS.in LINK Person → returns "Person".
+   * inV() reads the "in" property on the edge schema.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_inV_returnsLinkedVertexClass() {
+    var personClass = registerClass("Person", 100);
+    var edgeClass = registerClass("KNOWS", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "inV");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
+        .isEqualTo("Person");
+  }
+
+  /**
+   * outV() with currentEdgeClass "KNOWS" and KNOWS.out LINK Person → returns "Person".
+   * outV() reads the "out" property on the edge schema.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_outV_returnsLinkedVertexClass() {
+    var personClass = registerClass("Person", 100);
+    var edgeClass = registerClass("KNOWS", 500);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "outV");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
+        .isEqualTo("Person");
+  }
+
+  /**
+   * inV() without currentEdgeClass returns null — no preceding edge context.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_inV_noPrecedingEdge_returnsNull() {
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "inV");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isNull();
+  }
+
+  /**
+   * outV() without currentEdgeClass returns null.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_outV_noPrecedingEdge_returnsNull() {
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "outV");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isNull();
+  }
+
+  /**
+   * inV() with currentEdgeClass "UNKNOWN" (not in schema) returns null.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_inV_unknownEdgeClass_returnsNull() {
+    when(schema.getClassInternal("UNKNOWN")).thenReturn(null);
+
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "inV");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "UNKNOWN", ctx))
+        .isNull();
+  }
+
+  /**
+   * inV() with currentEdgeClass but no "in" LINK property on the edge → returns null.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_inV_noLinkProperty_returnsNull() {
+    registerClass("KNOWS", 500);
+    // No "in" property registered on KNOWS
+
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "inV");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
+        .isNull();
+  }
+
+  /**
+   * null method name → returns null regardless of currentEdgeClass.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_nullMethodName_returnsNull() {
+    var method = mock(SQLMethodCall.class);
+    when(method.getMethodNameString()).thenReturn(null);
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
         .isNull();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -29,6 +29,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLModifier;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -1205,7 +1206,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses).containsOnly(entry(edgeAlias, "KNOWS"));
   }
@@ -1223,7 +1224,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses).containsOnly(entry(edgeAlias, "HAS_MEMBER"));
   }
@@ -1257,7 +1258,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     // inV reads "in" property → Person, NOT "out" → Forum
     assertThat(aliasClasses)
@@ -1293,7 +1294,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     // outV reads "out" property → Person, NOT "in" → Company
     assertThat(aliasClasses)
@@ -1329,7 +1330,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     // inV reads "in" property → Person, NOT "out" → Company
     assertThat(aliasClasses)
@@ -1364,7 +1365,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     // outV reads "out" property → Person, NOT "in" → Message
     assertThat(aliasClasses)
@@ -1383,7 +1384,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses).isEmpty();
   }
@@ -1410,7 +1411,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses)
         .containsOnly(entry("e", "KNOWS"), entry("v1", "Person"));
@@ -1446,7 +1447,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses)
         .containsOnly(
@@ -1470,7 +1471,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses).containsOnly(entry("e1", "KNOWS"));
   }
@@ -1490,26 +1491,51 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses).containsOnly(entry("e", "PreExisting"));
   }
 
   /**
-   * skipClassInference=true → no class inference at all, even for edge methods.
+   * Aliases in whileAliases set → no class inference for those aliases,
+   * even for edge methods.
    */
   @Test
-  public void addAliases_skipClassInference_noInference() {
+  public void addAliases_whileAliases_noInferenceForRecursiveZone() {
     var expr = mockExpression(
         mockPathItem("outE", "KNOWS", "e"),
         mockPathItem("inV", null, "v"));
     var aliasClasses = new HashMap<String, String>();
 
+    // Both aliases are in the while set → no inference for either
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), true);
+        mockContext(), Set.of("e", "v"));
 
     assertThat(aliasClasses).isEmpty();
+  }
+
+  /**
+   * Only aliases in the whileAliases set are skipped; downstream aliases
+   * in the same expression still get inference.  Simulates IC5 pattern
+   * where 'person' is in the while zone but 'membership' is not.
+   */
+  @Test
+  public void addAliases_whileAliases_downstreamAliasesStillInferred() {
+    var expr = mockExpression(
+        mockPathItem("out", "KNOWS", "person"),
+        mockPathItem("inE", "HAS_MEMBER", "membership"));
+    var aliasClasses = new HashMap<String, String>();
+
+    // Only "person" is in the while set → "membership" should still be inferred
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), Set.of("person"));
+
+    // "person" should NOT be inferred (in while set)
+    assertThat(aliasClasses).doesNotContainKey("person");
+    // "membership" SHOULD be inferred to "HAS_MEMBER" (not in while set)
+    assertThat(aliasClasses).containsEntry("membership", "HAS_MEMBER");
   }
 
   /**
@@ -1535,7 +1561,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), false);
+        mockContext(), Set.of());
 
     assertThat(aliasClasses)
         .containsOnly(entry("e", "X"), entry("mid", "Person"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -949,45 +949,61 @@ public class MatchExecutionPlannerMutationTest {
   // ── inferClassFromEdgeSchema: inV/outV → linked vertex class inference ──
 
   /**
-   * inV() with currentEdgeClass "KNOWS" and KNOWS.in LINK Person → returns "Person".
-   * inV() reads the "in" property on the edge schema.
+   * inV() with currentEdgeClass "KNOWS" where KNOWS.in LINK Person and
+   * KNOWS.out LINK Forum → returns "Person" (the "in" side, not "out").
+   * Both properties are registered with different classes to kill a
+   * mutation that swaps the inV/outV property mapping.
    */
   @Test
   public void inferClassFromEdgeSchema_inV_returnsLinkedVertexClass() {
     var personClass = registerClass("Person", 100);
+    var forumClass = registerClass("Forum", 50);
     var edgeClass = registerClass("KNOWS", 500);
 
     var inProp = mock(SchemaPropertyInternal.class);
     when(inProp.getLinkedClass()).thenReturn(personClass);
     when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
 
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(forumClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
     var method = mock(SQLMethodCall.class);
     stubMethodName(method, "inV");
     var ctx = mockContext();
 
+    // inV must read the "in" property → Person, not Forum
     assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
         .isEqualTo("Person");
   }
 
   /**
-   * outV() with currentEdgeClass "KNOWS" and KNOWS.out LINK Person → returns "Person".
-   * outV() reads the "out" property on the edge schema.
+   * outV() with currentEdgeClass "KNOWS" where KNOWS.out LINK Forum and
+   * KNOWS.in LINK Person → returns "Forum" (the "out" side, not "in").
+   * Both properties are registered with different classes to kill a
+   * mutation that swaps the inV/outV property mapping.
    */
   @Test
   public void inferClassFromEdgeSchema_outV_returnsLinkedVertexClass() {
     var personClass = registerClass("Person", 100);
+    var forumClass = registerClass("Forum", 50);
     var edgeClass = registerClass("KNOWS", 500);
 
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
     var outProp = mock(SchemaPropertyInternal.class);
-    when(outProp.getLinkedClass()).thenReturn(personClass);
+    when(outProp.getLinkedClass()).thenReturn(forumClass);
     when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
 
     var method = mock(SQLMethodCall.class);
     stubMethodName(method, "outV");
     var ctx = mockContext();
 
+    // outV must read the "out" property → Forum, not Person
     assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
-        .isEqualTo("Person");
+        .isEqualTo("Forum");
   }
 
   /**
@@ -1057,6 +1073,64 @@ public class MatchExecutionPlannerMutationTest {
     var ctx = mockContext();
 
     assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
+        .isNull();
+  }
+
+  // ── inferClassFromEdgeSchema: case-insensitivity for new method types ──
+
+  /**
+   * OutE with mixed case resolves the edge class correctly —
+   * verifies toLowerCase(Locale.ROOT) works for the outE/inE branch.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_outE_caseInsensitive_returnsEdgeClass() {
+    var method = mockMethodCallWithDirection("OutE", "KNOWS");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
+        .isEqualTo("KNOWS");
+  }
+
+  /**
+   * INV with upper case resolves the linked vertex class correctly —
+   * verifies toLowerCase(Locale.ROOT) works for the inV/outV branch.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_inV_caseInsensitive_returnsLinkedVertexClass() {
+    var personClass = registerClass("Person", 100);
+    var edgeClass = registerClass("KNOWS", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "INV");
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, "KNOWS", ctx))
+        .isEqualTo("Person");
+  }
+
+  // ── inferClassFromEdgeSchema: outE/inE with non-string parameter ──
+
+  /**
+   * outE(123) with a non-string parameter returns null — extractEdgeClassName
+   * cannot resolve a non-string value to an edge class name.
+   */
+  @Test
+  public void inferClassFromEdgeSchema_outE_nonStringParam_returnsNull() {
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "outE");
+    var param = mock(SQLExpression.class);
+    when(param.execute(nullable(Result.class), any(CommandContext.class)))
+        .thenReturn(123);
+    // getMathExpression returns null → toString fallback also returns null
+    when(param.getMathExpression()).thenReturn(null);
+    when(method.getParams()).thenReturn(List.of(param));
+    var ctx = mockContext();
+
+    assertThat(MatchExecutionPlanner.inferClassFromEdgeSchema(method, null, ctx))
         .isNull();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1206,7 +1206,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses).containsOnly(entry(edgeAlias, "KNOWS"));
   }
@@ -1224,7 +1224,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses).containsOnly(entry(edgeAlias, "HAS_MEMBER"));
   }
@@ -1258,7 +1258,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     // inV reads "in" property → Person, NOT "out" → Forum
     assertThat(aliasClasses)
@@ -1294,7 +1294,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     // outV reads "out" property → Person, NOT "in" → Company
     assertThat(aliasClasses)
@@ -1330,7 +1330,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     // inV reads "in" property → Person, NOT "out" → Company
     assertThat(aliasClasses)
@@ -1365,7 +1365,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     // outV reads "out" property → Person, NOT "in" → Message
     assertThat(aliasClasses)
@@ -1384,7 +1384,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses).isEmpty();
   }
@@ -1411,7 +1411,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses)
         .containsOnly(entry("e", "KNOWS"), entry("v1", "Person"));
@@ -1447,7 +1447,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses)
         .containsOnly(
@@ -1471,7 +1471,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses).containsOnly(entry("e1", "KNOWS"));
   }
@@ -1491,7 +1491,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses).containsOnly(entry("e", "PreExisting"));
   }
@@ -1510,7 +1510,7 @@ public class MatchExecutionPlannerMutationTest {
     // Both aliases are in the while set → no inference for either
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of("e", "v"));
+        mockContext(), Set.of("e", "v"), new java.util.HashSet<>());
 
     assertThat(aliasClasses).isEmpty();
   }
@@ -1530,7 +1530,7 @@ public class MatchExecutionPlannerMutationTest {
     // Only "person" is in the while set → "membership" should still be inferred
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of("person"));
+        mockContext(), Set.of("person"), new java.util.HashSet<>());
 
     // "person" should NOT be inferred (in while set)
     assertThat(aliasClasses).doesNotContainKey("person");
@@ -1561,7 +1561,7 @@ public class MatchExecutionPlannerMutationTest {
 
     MatchExecutionPlanner.addAliases(
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
-        mockContext(), Set.of());
+        mockContext(), Set.of(), new java.util.HashSet<>());
 
     assertThat(aliasClasses)
         .containsOnly(entry("e", "X"), entry("mid", "Person"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -1206,7 +1207,7 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), false);
 
-    assertThat(aliasClasses).containsEntry(edgeAlias, "KNOWS");
+    assertThat(aliasClasses).containsOnly(entry(edgeAlias, "KNOWS"));
   }
 
   /**
@@ -1224,7 +1225,7 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), false);
 
-    assertThat(aliasClasses).containsEntry(edgeAlias, "HAS_MEMBER");
+    assertThat(aliasClasses).containsOnly(entry(edgeAlias, "HAS_MEMBER"));
   }
 
   /**
@@ -1251,8 +1252,7 @@ public class MatchExecutionPlannerMutationTest {
         mockContext(), false);
 
     assertThat(aliasClasses)
-        .containsEntry("e", "KNOWS")
-        .containsEntry("v", "Person");
+        .containsOnly(entry("e", "KNOWS"), entry("v", "Person"));
   }
 
   /**
@@ -1279,12 +1279,46 @@ public class MatchExecutionPlannerMutationTest {
         mockContext(), false);
 
     assertThat(aliasClasses)
-        .containsEntry("e", "WORK_AT")
-        .containsEntry("v", "Person");
+        .containsOnly(entry("e", "WORK_AT"), entry("v", "Person"));
   }
 
   /**
-   * inV() without a preceding outE → vertex alias should NOT be in aliasClasses
+   * outE('KNOWS') followed by outV() → aliasClasses should contain the edge alias
+   * mapped to "KNOWS" and the vertex alias mapped to KNOWS.out (the source vertex).
+   * Both in/out properties are registered with different classes to catch a
+   * direction-swap mutation in the inV/outV property mapping.
+   */
+  @Test
+  public void addAliases_outE_then_outV_infersSourceVertexClass() {
+    var personClass = registerClass("Person", 100);
+    var messageClass = registerClass("Message", 200);
+    var edgeClass = registerClass("KNOWS", 500);
+
+    // KNOWS.out → Person, KNOWS.in → Message
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(messageClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", "e"),
+        mockPathItem("outV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    // outV reads "out" property → Person, NOT "in" → Message
+    assertThat(aliasClasses)
+        .containsOnly(entry("e", "KNOWS"), entry("v", "Person"));
+  }
+
+  /**
+   * inV() without a preceding outE → aliasClasses should be empty
    * (no currentEdgeClass to propagate).
    */
   @Test
@@ -1297,7 +1331,7 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), false);
 
-    assertThat(aliasClasses).doesNotContainKey("v");
+    assertThat(aliasClasses).isEmpty();
   }
 
   /**
@@ -1325,9 +1359,7 @@ public class MatchExecutionPlannerMutationTest {
         mockContext(), false);
 
     assertThat(aliasClasses)
-        .containsEntry("e", "KNOWS")
-        .containsEntry("v1", "Person")
-        .doesNotContainKey("v2");
+        .containsOnly(entry("e", "KNOWS"), entry("v1", "Person"));
   }
 
   /**
@@ -1363,14 +1395,14 @@ public class MatchExecutionPlannerMutationTest {
         mockContext(), false);
 
     assertThat(aliasClasses)
-        .containsEntry("e1", "KNOWS")
-        .containsEntry("e2", "WORK_AT")
-        .containsEntry("v", "Company");
+        .containsOnly(
+            entry("e1", "KNOWS"), entry("e2", "WORK_AT"), entry("v", "Company"));
   }
 
   /**
    * bothE resets currentEdgeClass: outE('KNOWS') followed by bothE('X') followed by
-   * inV() → inV should NOT infer a class because bothE reset the state.
+   * inV() → inV should NOT infer a class because bothE reset the state. bothE('X')
+   * itself also gets no inference (not a recognized edge-method type).
    */
   @Test
   public void addAliases_bothE_resetsCurrentEdgeClass() {
@@ -1386,9 +1418,27 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), false);
 
-    assertThat(aliasClasses)
-        .containsEntry("e1", "KNOWS")
-        .doesNotContainKey("v");
+    assertThat(aliasClasses).containsOnly(entry("e1", "KNOWS"));
+  }
+
+  /**
+   * If aliasClasses already contains an entry for the alias (e.g., from an explicit
+   * class constraint), inference must not overwrite it.
+   */
+  @Test
+  public void addAliases_existingAliasClass_notOverwritten() {
+    registerClass("KNOWS", 500);
+
+    var expr = mockExpression(
+        mockPathItem("outE", "KNOWS", "e"));
+    var aliasClasses = new HashMap<String, String>();
+    aliasClasses.put("e", "PreExisting");
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    assertThat(aliasClasses).containsOnly(entry("e", "PreExisting"));
   }
 
   /**
@@ -1434,9 +1484,7 @@ public class MatchExecutionPlannerMutationTest {
         mockContext(), false);
 
     assertThat(aliasClasses)
-        .containsEntry("e", "X")
-        .containsEntry("mid", "Person")
-        .doesNotContainKey("v");
+        .containsOnly(entry("e", "X"), entry("mid", "Person"));
   }
 
   // ── addAliases helper methods ──

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1231,16 +1231,24 @@ public class MatchExecutionPlannerMutationTest {
   /**
    * outE('KNOWS') followed by inV() → aliasClasses should contain the edge alias
    * mapped to "KNOWS" and the vertex alias mapped to the linked class from KNOWS.in.
-   * This verifies currentEdgeClass is propagated from outE to inV.
+   * Both in/out properties are registered with different classes to catch a
+   * direction-swap mutation in the inV/outV property mapping.
    */
   @Test
   public void addAliases_outE_then_inV_infersVertexClass() {
     var personClass = registerClass("Person", 100);
+    var forumClass = registerClass("Forum", 50);
     var edgeClass = registerClass("KNOWS", 500);
 
     var inProp = mock(SchemaPropertyInternal.class);
     when(inProp.getLinkedClass()).thenReturn(personClass);
     when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    // Register "out" side with a different class so a direction swap
+    // returns "Forum" instead of null, making the failure diagnostic.
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(forumClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
 
     var expr = mockExpression(
         mockPathItem("outE", "KNOWS", "e"),
@@ -1251,6 +1259,7 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), false);
 
+    // inV reads "in" property → Person, NOT "out" → Forum
     assertThat(aliasClasses)
         .containsOnly(entry("e", "KNOWS"), entry("v", "Person"));
   }
@@ -1258,16 +1267,24 @@ public class MatchExecutionPlannerMutationTest {
   /**
    * inE('WORK_AT') followed by outV() → aliasClasses should contain the edge alias
    * mapped to "WORK_AT" and the vertex alias mapped to the linked class from
-   * WORK_AT.out.
+   * WORK_AT.out. Both in/out properties are registered with different classes to
+   * catch a direction-swap mutation.
    */
   @Test
   public void addAliases_inE_then_outV_infersVertexClass() {
     var personClass = registerClass("Person", 100);
+    var companyClass = registerClass("Company", 50);
     var edgeClass = registerClass("WORK_AT", 300);
 
     var outProp = mock(SchemaPropertyInternal.class);
     when(outProp.getLinkedClass()).thenReturn(personClass);
     when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    // Register "in" side with a different class so a direction swap
+    // returns "Company" instead of null, making the failure diagnostic.
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(companyClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
 
     var expr = mockExpression(
         mockPathItem("inE", "WORK_AT", "e"),
@@ -1278,6 +1295,43 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), false);
 
+    // outV reads "out" property → Person, NOT "in" → Company
+    assertThat(aliasClasses)
+        .containsOnly(entry("e", "WORK_AT"), entry("v", "Person"));
+  }
+
+  /**
+   * inE('WORK_AT') followed by inV() → aliasClasses should contain the edge alias
+   * mapped to "WORK_AT" and the vertex alias mapped to WORK_AT.in. Both in/out
+   * properties are registered with different classes to catch a direction-swap
+   * mutation. This completes the 4th direction combo (outE→inV, outE→outV,
+   * inE→outV, inE→inV), ensuring inV/outV property lookup is independent of
+   * whether the preceding method was outE or inE.
+   */
+  @Test
+  public void addAliases_inE_then_inV_infersTargetVertexClass() {
+    var personClass = registerClass("Person", 100);
+    var companyClass = registerClass("Company", 50);
+    var edgeClass = registerClass("WORK_AT", 300);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(companyClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var expr = mockExpression(
+        mockPathItem("inE", "WORK_AT", "e"),
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), false);
+
+    // inV reads "in" property → Person, NOT "out" → Company
     assertThat(aliasClasses)
         .containsOnly(entry("e", "WORK_AT"), entry("v", "Person"));
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
@@ -250,7 +250,8 @@ public class MatchStepUnitTest extends DbTestBase {
     var ctx = createCommandContext();
     var edge = createTestEdgeTraversal();
     edge.setIntersectionDescriptor(
-        new RidFilterDescriptor.EdgeRidLookup("Knows", "out", new SQLExpression(-1)));
+        new RidFilterDescriptor.EdgeRidLookup(
+            "Knows", "out", new SQLExpression(-1), false));
 
     var step = new MatchStep(ctx, edge, false);
     var result = step.prettyPrint(0, 2);
@@ -291,7 +292,7 @@ public class MatchStepUnitTest extends DbTestBase {
     var edge = createTestEdgeTraversal();
 
     var edgeDesc = new RidFilterDescriptor.EdgeRidLookup(
-        "Knows", "out", new SQLExpression(-1));
+        "Knows", "out", new SQLExpression(-1), false);
     var directDesc = new RidFilterDescriptor.DirectRid(new SQLExpression(-1));
     edge.setIntersectionDescriptor(
         new RidFilterDescriptor.Composite(java.util.List.of(edgeDesc, directDesc)));
@@ -314,7 +315,7 @@ public class MatchStepUnitTest extends DbTestBase {
     var edge = new EdgeTraversal(patternEdge, true);
     edge.setIntersectionDescriptor(
         new RidFilterDescriptor.EdgeRidLookup("HasCreator", "in",
-            new SQLExpression(-1)));
+            new SQLExpression(-1), false));
 
     var step = new OptionalMatchStep(ctx, edge, false);
     var result = step.prettyPrint(0, 2);

--- a/docs/adr/index-assisted-traversal/adr.md
+++ b/docs/adr/index-assisted-traversal/adr.md
@@ -1,0 +1,195 @@
+# Index-Assisted Traversal for Edge-Method MATCH Patterns — Architecture Decision Record
+
+## Summary
+
+MATCH queries using edge-method patterns (`outE`/`inE` followed by
+`inV`/`outV`) could not benefit from index intersection pre-filtering,
+even when indexed edge properties existed (e.g., `WORK_AT.workFrom`,
+`HAS_MEMBER.joinDate`). This forced full edge record loading for every
+link bag entry. This feature extends the existing pre-filter mechanism to
+edge-method patterns, enabling zero-I/O skipping of non-matching edges
+at the iterator level.
+
+The solution introduces a shared `PreFilterableLinkBagIterable` interface,
+a new `EdgeFromLinkBagIterable`/`EdgeFromLinkBagIterator` pair for
+edge-level filtering, extended class inference in the MATCH planner for
+six method types, and interface-based dispatch in the traverser and
+expand layers.
+
+## Goals
+
+- **Extend index pre-filtering to edge-method MATCH patterns** — achieved.
+  `outE`/`inE` patterns with indexed edge properties now skip non-matching
+  edge records without loading them from storage.
+- **Unified interface for pre-filterable iterables** — achieved.
+  `PreFilterableLinkBagIterable` provides a single dispatch point for both
+  vertex and edge iterables.
+- **Class inference for edge-method aliases** — achieved. The planner
+  infers edge classes from `outE`/`inE` parameters and vertex classes
+  from `inV`/`outV` via the edge's LINK schema.
+- **Adaptive abort guards apply identically** — achieved. The same
+  `maxRidSetSize`, `maxSelectivityRatio`, and `minLinkBagSize` knobs
+  govern edge pre-filtering.
+
+No goals were descoped or changed during implementation.
+
+## Constraints
+
+- **`bothE()` is out of scope** — unchanged. `bothE()` returns a
+  `ChainedIterable` which does not implement `PreFilterableLinkBagIterable`,
+  so it silently degrades to unfiltered iteration.
+- **No generated code changes** — upheld. All changes are planner-level
+  and runtime-level.
+- **Backward compatibility** — upheld. Pre-filter is strictly an
+  optimization; no query results change.
+
+No new constraints were discovered during implementation.
+
+## Architecture Notes
+
+### Component Map
+
+```mermaid
+flowchart TD
+    subgraph Planner ["MatchExecutionPlanner (plan-time)"]
+        CI["inferClassFromEdgeSchema<br/>(6 method types)"]
+        AA["addAliases loop<br/>(currentEdgeClass tracking)"]
+        OPT["optimizeScheduleWithIntersections"]
+        ACF["attachCollectionIdFilters"]
+    end
+
+    subgraph Traverser ["MatchEdgeTraverser (run-time)"]
+        APF["applyPreFilter<br/>(interface dispatch)"]
+    end
+
+    subgraph Expand ["ExpandStep (run-time)"]
+        EXP["expand() pre-filter<br/>(interface dispatch)"]
+    end
+
+    subgraph Iterator ["Record Iterables"]
+        PFI["PreFilterableLinkBagIterable<br/>(interface)"]
+        VFLI["VertexFromLinkBagIterable"]
+        EFLI["EdgeFromLinkBagIterable"]
+    end
+
+    subgraph Vertex ["VertexEntityImpl"]
+        GEI["getEdgesInternal<br/>(LinkBag -> EdgeFromLinkBagIterable)"]
+    end
+
+    AA -->|currentEdgeClass state| CI
+    CI -->|edge/vertex class| AA
+    AA -->|aliasClasses map| OPT
+    AA -->|aliasClasses map| ACF
+    OPT -->|IndexLookup descriptor| APF
+    ACF -->|IntSet collectionIds| APF
+    ACF -->|IntSet collectionIds| EXP
+    APF -->|withRidFilter / withClassFilter| PFI
+    EXP -->|withRidFilter / withClassFilter| PFI
+    PFI -.->|implements| VFLI
+    PFI -.->|implements| EFLI
+    GEI -->|LinkBag case| EFLI
+```
+
+- **`addAliases` loop**: Tracks `currentEdgeClass` state. `outE`/`inE` set
+  it; `inV`/`outV` consume and reset it; all other methods reset it.
+- **`inferClassFromEdgeSchema`**: Handles six method types (`out`, `in`,
+  `outE`, `inE`, `inV`, `outV`). Uses `extractEdgeClassName` for V2E and
+  `lookupLinkedVertexClass` for E2V inference.
+- **`optimizeScheduleWithIntersections`** and
+  **`attachCollectionIdFilters`**: No changes needed — once `aliasClasses`
+  has the correct class, existing logic finds indexes and resolves
+  collection IDs naturally.
+- **`applyPreFilter`**: Dispatches on `PreFilterableLinkBagIterable`
+  interface instead of concrete type. Inherited by
+  `MatchReverseEdgeTraverser`.
+- **`ExpandStep`**: Same interface-based dispatch.
+- **`getEdgesInternal`**: LinkBag case returns `EdgeFromLinkBagIterable`
+  instead of RID-projecting `EdgeIterable`.
+
+### Decision Records
+
+#### D1: Shared interface vs. multi-instanceof check
+- **Implemented as planned.** `PreFilterableLinkBagIterable` interface
+  extracted, both vertex and edge iterables implement it.
+- `iterator()` was added directly to the interface (returning
+  `Iterator<?>`) because Java does not allow `extends Iterable<?>`
+  with a wildcard supertype. Concrete implementations satisfy it
+  via covariant return types.
+
+#### D2: Edge class inference via forward-propagation in addAliases loop
+- **Implemented as planned.** Single-pass forward-propagation using
+  `currentEdgeClass` state variable. `outE`/`inE` set the state;
+  `inV`/`outV` consume and reset it; all other methods reset it.
+- `lookupLinkedVertexClass` was extracted as a shared helper for both
+  V2V and E2V schema lookups.
+- `extractEdgeClassName` was hardened with an empty-string guard.
+
+#### D3: EdgeFromLinkBagIterable filters on primary RIDs
+- **Implemented as planned.** New `EdgeFromLinkBagIterable` and
+  `EdgeFromLinkBagIterator` wrap LinkBag directly, filtering on
+  `primaryRid()` (edge RID) before loading from storage. Mirrors
+  the `VertexFromLinkBagIterable`/`VertexFromLinkBagIterator` pattern
+  but targets edge records instead of vertices.
+- `getEdgesInternal` returns `EdgeFromLinkBagIterable` for the LinkBag
+  case; non-LinkBag cases (`Identifiable`, `EntityLinkSetImpl`,
+  `EntityLinkListImpl`) continue using `EdgeIterable`.
+
+### Invariants
+
+- Pre-filter never excludes a record that would pass the WHERE clause.
+- Class filter collection IDs include all subclass collection IDs
+  (polymorphic), matching `collectionIdsForClass()` behavior.
+- Adaptive abort guards apply identically to edge and vertex
+  pre-filtering.
+- `EdgeFromLinkBagIterator` validates every `RidPair` via
+  `validateEdgePair()` and gracefully skips `RecordNotFoundException`
+  (dangling RID pattern).
+
+### Non-Goals
+
+- `bothE()` pre-filtering (deferred — requires
+  `PreFilterableChainedIterable` wrapper)
+- Multi-property-name edge cases: when `getEdgesInternal()` matches
+  multiple property names, it returns `chainedIterable(...)` which
+  doesn't implement the interface — silently degrades to unfiltered
+- `expand()` edge-method-specific behavior beyond the `instanceof`
+  type change
+- Index creation or schema changes — assumes indexes already exist
+
+## Key Discoveries
+
+- **Java wildcard supertype limitation**: `extends Iterable<?>` is not
+  allowed in Java interface declarations. Solved by declaring
+  `Iterator<?> iterator()` directly on the interface, with concrete
+  implementations providing covariant return types.
+
+- **Direction mapping asymmetry between V2V and E2V inference**: For V2V
+  (`out('X')`/`in('X')`), the direction is flipped (`out` reads the `in`
+  LINK property). For E2V (`inV()`/`outV()`), the direction is direct
+  (`inV()` reads the `in` property). This is because V2V traverses
+  *through* the edge to the opposite vertex, while E2V traverses *along*
+  the edge's own direction.
+
+- **Small-dataset adaptive abort**: With small datasets (e.g., 10 edges),
+  the runtime pre-filter's adaptive abort (`minLinkBagSize=50`) skips
+  intersection-based pre-filtering. The planner still attaches the index
+  via PREFETCH/SET steps. Integration test EXPLAIN assertions must check
+  for `FETCH FROM INDEX` and `FETCH FROM CLASS` rather than
+  `(intersection: index ...)` for small-dataset tests.
+
+- **Edge-method cost model interaction**: `outE`/`inE` patterns introduce
+  intermediate edge aliases that change the cost model's scheduling
+  behavior compared to direct V2V patterns. A 2-step edge-method chain
+  has different cost characteristics, which can affect scheduling order.
+  This is a pre-existing characteristic of the cost model, not a bug
+  introduced by this feature.
+
+- **Two existing tests depended on `EdgeIterator` concrete type**: Two
+  tests in `DoubleSidedEdgeLinkBagTest` explicitly cast the iterator to
+  `EdgeIterator` to test reset/multiValue behavior. These were
+  `EdgeIterator`-specific features that don't apply to
+  `EdgeFromLinkBagIterator`. Replaced with type verification tests.
+
+- **`extractEdgeClassName` edge cases**: The helper needed hardening for
+  empty strings, non-string parameters, and case-insensitivity. Added
+  during code review.

--- a/docs/adr/index-assisted-traversal/design-final.md
+++ b/docs/adr/index-assisted-traversal/design-final.md
@@ -1,0 +1,265 @@
+# Index-Assisted Traversal for Edge-Method MATCH Patterns — Final Design
+
+## Overview
+
+This feature extends the MATCH index intersection pre-filter — previously
+limited to `expand()` and vertex-to-vertex edges (`out`/`in`) — to
+edge-method patterns (`outE`/`inE` followed by `inV`/`outV`). This allows
+queries with indexed edge properties (e.g., `WORK_AT.workFrom`,
+`HAS_MEMBER.joinDate`) to skip non-matching edge records without loading
+them from storage.
+
+The implementation has three structural layers:
+
+1. **Iterator layer**: A shared `PreFilterableLinkBagIterable` interface and
+   a new `EdgeFromLinkBagIterable` that wraps a LinkBag and yields edge
+   records from primary RIDs with zero-I/O class and RID filtering.
+2. **Planner layer**: Extended class inference in `MatchExecutionPlanner`
+   that recognizes `outE('X')`/`inE('X')` as targeting edge class `X`, and
+   `inV()`/`outV()` as targeting the vertex class from the preceding edge's
+   LINK schema.
+3. **Traverser layer**: `applyPreFilter` in `MatchEdgeTraverser` and
+   `ExpandStep` generalized from the concrete `VertexFromLinkBagIterable`
+   type to the shared interface.
+
+No deviations from the original plan occurred. `bothE()` remains out of
+scope. All adaptive abort guards apply identically to edge pre-filtering.
+
+## Class Design
+
+```mermaid
+classDiagram
+    class Sizeable {
+        <<interface>>
+        +size() int
+        +isSizeable() boolean
+    }
+
+    class PreFilterableLinkBagIterable {
+        <<interface>>
+        +withClassFilter(IntSet collectionIds) PreFilterableLinkBagIterable
+        +withRidFilter(Set~RID~ ridSet) PreFilterableLinkBagIterable
+        +iterator() Iterator
+    }
+
+    Sizeable <|-- PreFilterableLinkBagIterable
+
+    class VertexFromLinkBagIterable {
+        -linkBag: LinkBag
+        -session: DatabaseSessionEmbedded
+        -acceptedCollectionIds: IntSet
+        -acceptedRids: Set~RID~
+        +withClassFilter(IntSet) VertexFromLinkBagIterable
+        +withRidFilter(Set~RID~) VertexFromLinkBagIterable
+        +iterator() Iterator~Vertex~
+        +size() int
+    }
+
+    class EdgeFromLinkBagIterable {
+        -linkBag: LinkBag
+        -session: DatabaseSessionEmbedded
+        -acceptedCollectionIds: IntSet
+        -acceptedRids: Set~RID~
+        +withClassFilter(IntSet) EdgeFromLinkBagIterable
+        +withRidFilter(Set~RID~) EdgeFromLinkBagIterable
+        +iterator() Iterator~EdgeInternal~
+        +size() int
+    }
+
+    class EdgeFromLinkBagIterator {
+        -ridPairIterator: Iterator~RidPair~
+        -session: DatabaseSessionEmbedded
+        -acceptedCollectionIds: IntSet
+        -acceptedRids: Set~RID~
+        -nextEdge: EdgeInternal
+        +hasNext() boolean
+        +next() EdgeInternal
+    }
+
+    class VertexFromLinkBagIterator {
+        -ridPairIterator: Iterator~RidPair~
+        -session: DatabaseSessionEmbedded
+        -acceptedCollectionIds: IntSet
+        -acceptedRids: Set~RID~
+        -nextVertex: Vertex
+        +hasNext() boolean
+        +next() Vertex
+    }
+
+    PreFilterableLinkBagIterable <|.. VertexFromLinkBagIterable
+    PreFilterableLinkBagIterable <|.. EdgeFromLinkBagIterable
+    EdgeFromLinkBagIterable --> EdgeFromLinkBagIterator : creates
+    VertexFromLinkBagIterable --> VertexFromLinkBagIterator : creates
+```
+
+`PreFilterableLinkBagIterable` extends `Sizeable` (inheriting `size()` and
+`isSizeable()`) and declares `withClassFilter()`, `withRidFilter()`, and
+`iterator()`. Java does not allow `extends Iterable<?>` with a wildcard
+supertype, so the `iterator()` method returning `Iterator<?>` is declared
+directly on the interface — concrete implementations satisfy it via
+covariant return types (`Iterator<Vertex>` and `Iterator<EdgeInternal>`).
+
+Both `withClassFilter` and `withRidFilter` return new instances with the
+filter applied (immutable-copy pattern). Filters compose: calling
+`withClassFilter` then `withRidFilter` produces an iterable that applies
+both. The underlying LinkBag is shared (not copied) across filtered
+instances.
+
+`EdgeFromLinkBagIterable` mirrors `VertexFromLinkBagIterable` structurally.
+The key difference is in the iterator: `VertexFromLinkBagIterator` reads
+`ridPair.secondaryRid()` (the opposite vertex), while
+`EdgeFromLinkBagIterator` reads `ridPair.primaryRid()` (the edge record
+itself). Both apply collection-ID and RID-set filters before loading from
+storage.
+
+## Workflow
+
+### Pre-filter attachment (plan time)
+
+```mermaid
+sequenceDiagram
+    participant MP as MatchExecutionPlanner
+    participant CI as inferClassFromEdgeSchema
+    participant AC as aliasClasses map
+    participant OPT as optimizeScheduleWithIntersections
+    participant TPH as TraversalPreFilterHelper
+
+    Note over MP: addAliases loop: currentEdgeClass = null
+    MP->>CI: item = outE('WORK_AT')
+    CI-->>MP: class = "WORK_AT"
+    MP->>AC: put("workEdge", "WORK_AT")
+    Note over MP: currentEdgeClass = "WORK_AT"
+
+    MP->>CI: item = inV(), currentEdgeClass = "WORK_AT"
+    CI-->>MP: class = "Organisation" (from WORK_AT.in LINK)
+    MP->>AC: put("company", "Organisation")
+    Note over MP: currentEdgeClass = null (reset)
+
+    Note over MP: After all aliases collected
+    MP->>OPT: schedule + aliasClasses + aliasFilters
+    OPT->>AC: get("workEdge") -> "WORK_AT"
+    OPT->>TPH: findIndexForFilter(WHERE workFrom < year, "WORK_AT")
+    TPH-->>OPT: IndexSearchDescriptor (WORK_AT.workFrom index)
+    OPT->>OPT: attach IndexLookup to edge alias
+```
+
+The `addAliases` loop processes MATCH expression items sequentially,
+tracking a `currentEdgeClass` variable:
+
+- **`outE('X')` / `inE('X')`**: `inferClassFromEdgeSchema` returns `X`
+  directly (the edge class name is the method parameter). `currentEdgeClass`
+  is set to `X`.
+- **`inV()` / `outV()`**: `inferClassFromEdgeSchema` uses `currentEdgeClass`
+  to look up the LINK property on the edge schema. `inV()` reads the `in`
+  property; `outV()` reads the `out` property. `currentEdgeClass` is reset
+  to null afterward.
+- **`out('X')` / `in('X')`** (existing V2V): direction is flipped — `out`
+  reads the `in` property because it traverses to the vertex on the `in`
+  side. `currentEdgeClass` is reset.
+- **Any other method**: `currentEdgeClass` is reset.
+
+Once `aliasClasses` is populated, `optimizeScheduleWithIntersections` and
+`attachCollectionIdFilters` work unchanged — they find the target alias
+class, query for matching indexes, and attach `IndexLookup` or
+`collectionIds` descriptors.
+
+### Pre-filter application (run time)
+
+```mermaid
+sequenceDiagram
+    participant MET as MatchEdgeTraverser
+    participant VEI as VertexEntityImpl
+    participant EFLI as EdgeFromLinkBagIterable
+    participant ET as EdgeTraversal
+    participant TPH as TraversalPreFilterHelper
+
+    MET->>VEI: getEdges(OUT, "WORK_AT")
+    VEI-->>MET: EdgeFromLinkBagIterable (wraps LinkBag)
+
+    MET->>MET: applyPreFilter(rawResult)
+    Note over MET: instanceof PreFilterableLinkBagIterable? YES
+    MET->>EFLI: size()
+    alt has acceptedCollectionIds
+        MET->>EFLI: withClassFilter(collectionIds)
+    end
+    alt has intersectionDescriptor AND size >= minLinkBagSize
+        MET->>ET: resolveWithCache(ctx, linkBagSize)
+        ET->>TPH: resolveIndexToRidSet(descriptor)
+        TPH-->>ET: RidSet (edge RIDs matching workFrom < year)
+        ET-->>MET: RidSet
+        MET->>MET: passesRatioCheck(ridSet.size, linkBagSize)?
+        MET->>EFLI: withRidFilter(ridSet)
+    end
+    MET-->>MET: filtered EdgeFromLinkBagIterable
+
+    Note over MET: Iterator skips non-matching primary RIDs (zero I/O)
+```
+
+At runtime, `applyPreFilter` checks the traversal result against the
+`PreFilterableLinkBagIterable` interface. For `outE('WORK_AT')`, the result
+is an `EdgeFromLinkBagIterable` (returned by
+`VertexEntityImpl.getEdgesInternal()` for the LinkBag case). The same
+adaptive abort guards apply:
+
+- **`minLinkBagSize`**: skip pre-filtering if the link bag is too small
+  (overhead exceeds benefit).
+- **`maxSelectivityRatio`**: skip if the RID set is too large relative to
+  the link bag (not selective enough).
+- **`maxRidSetSize`**: the index resolution itself aborts if the estimated
+  result set is too large (checked inside `resolveWithCache`).
+
+The `ExpandStep` operator uses the same interface-based dispatch for
+`expand()` expressions.
+
+## Primary vs Secondary RID Filtering
+
+The LinkBag stores `RidPair(primaryRid, secondaryRid)` entries where
+`primaryRid` is the edge record RID and `secondaryRid` is the opposite
+vertex RID.
+
+| Iterator | Filters on | Use case |
+|---|---|---|
+| `VertexFromLinkBagIterator` | `secondaryRid` | V2V traversal — skip vertices that don't match |
+| `EdgeFromLinkBagIterator` | `primaryRid` | V2E traversal — skip edges that don't match |
+
+Both filters operate before loading from storage (zero I/O), because the
+RID is in memory from the LinkBag entry. The collection-ID check
+(`acceptedCollectionIds.contains(rid.getCollectionId())`) and the RID-set
+check (`acceptedRids.contains(rid)`) are both O(1).
+
+This distinction is critical: an index on `WORK_AT.workFrom` returns edge
+RIDs, not vertex RIDs. `EdgeFromLinkBagIterator` filters primary RIDs
+against this set, ensuring only edges with matching `workFrom` values are
+loaded from storage.
+
+## Class Inference for Edge-Method Patterns
+
+`inferClassFromEdgeSchema` handles six method types in two categories:
+
+**V2E methods (`outE('X')`, `inE('X')`):** The alias represents an edge
+record. The inferred class is the edge class itself — the method parameter
+provides the class name directly. No schema lookup is needed.
+
+**E2V methods (`inV()`, `outV()`):** The alias represents a vertex reached
+via the preceding edge. The method has no parameters, so the edge class
+comes from the `currentEdgeClass` state variable set by the preceding
+`outE`/`inE`. The LINK property name matches the method direction directly
+(`inV()` reads `in`, `outV()` reads `out`). This differs from V2V inference
+where direction is flipped (`out('X')` reads `in`).
+
+Edge cases handled:
+- `currentEdgeClass` is null (no preceding `outE`/`inE`): inference skipped
+- Edge class not in schema: inference skipped
+- LINK property not declared: inference skipped
+- `extractEdgeClassName` returns null for empty strings, non-string
+  parameters, and missing parameters
+
+## Integration Points
+
+| Component | Change | File |
+|---|---|---|
+| `VertexEntityImpl.getEdgesInternal()` | LinkBag case returns `EdgeFromLinkBagIterable` instead of `EdgeIterable` | `VertexEntityImpl.java` |
+| `MatchEdgeTraverser.applyPreFilter()` | `instanceof PreFilterableLinkBagIterable` instead of concrete type | `MatchEdgeTraverser.java` |
+| `ExpandStep` | Same `instanceof` change for expand() expressions | `ExpandStep.java` |
+| `MatchExecutionPlanner.addAliases()` | `currentEdgeClass` tracking across items | `MatchExecutionPlanner.java` |
+| `MatchExecutionPlanner.inferClassFromEdgeSchema()` | Six method types, `lookupLinkedVertexClass` helper | `MatchExecutionPlanner.java` |

--- a/jmh-ldbc/src/main/resources/ldbc-queries/IC5.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-queries/IC5.sql
@@ -2,9 +2,12 @@
    Find Forums joined by friends/friends-of-friends after a given date,
    counting Posts by those friends.
 
-   Extends the MATCH pattern to traverse Forum -> CONTAINER_OF -> Post ->
-   HAS_CREATOR -> Person (matching the friend), avoiding the correlated
-   LET subquery that caused an N+1 scan over all forum posts. */
+   Reverse single-chain traversal: person -> Posts (via HAS_CREATOR) ->
+   Forum (via CONTAINER_OF) -> membership check (back-reference to person).
+   The single chain forces the scheduler to do person->posts FIRST (cheap:
+   ~100 posts per person), then check forum membership with a pre-filtered
+   O(1) EdgeRidLookup on the back-reference. This avoids the forward plan's
+   forum->CONTAINER_OF fan-out (~539 posts per forum x 15 forums/person). */
 SELECT forumTitle, forumId, count(post) as postCount
 FROM (
   SELECT DISTINCT forum.title as forumTitle,
@@ -14,11 +17,10 @@ FROM (
     MATCH {class: Person, as: start, where: (id = :personId)}
       .out('KNOWS'){while: ($depth < 2), as: person,
         where: (@rid <> $matched.start.@rid)}
-      .inE('HAS_MEMBER'){as: membership, where: (joinDate >= :minDate)}
-      .outV(){class: Forum, as: forum}
-      .out('CONTAINER_OF'){as: post}
-      .out('HAS_CREATOR'){as: creator,
-        where: (@rid = $matched.person.@rid)}
+      .in('HAS_CREATOR'){class: Post, as: post}
+      .in('CONTAINER_OF'){class: Forum, as: forum}
+      .outE('HAS_MEMBER'){as: membership, where: (joinDate >= :minDate)}
+      .inV(){as: personCheck, where: (@rid = $matched.person.@rid)}
     RETURN forum, post
   )
 )

--- a/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryExplainTest.java
+++ b/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryExplainTest.java
@@ -89,10 +89,14 @@ public class LdbcQueryExplainTest {
   // ==================== MATCH back-reference intersection ====================
 
   /**
-   * IC5: The MATCH pattern traverses Forum -> CONTAINER_OF -> Post ->
-   * HAS_CREATOR -> Person, filtering {@code creator.@rid = $matched.person.@rid}.
-   * The planner should detect the back-reference and set an intersection
-   * descriptor on the HAS_CREATOR edge traversal step.
+   * IC5: The reverse single-chain MATCH pattern traverses
+   * Person -> HAS_CREATOR -> Post -> CONTAINER_OF -> Forum ->
+   * outE(HAS_MEMBER) -> inV (back-ref to person).
+   *
+   * <p>The planner should detect the {@code .inV()} back-reference
+   * ({@code @rid = $matched.person.@rid}), propagate the edge class
+   * from the preceding {@code .outE('HAS_MEMBER')} step, and set an
+   * intersection descriptor on the HAS_MEMBER edge traversal step.
    */
   @Test
   public void testIC5_backReferenceIntersection() {
@@ -100,8 +104,8 @@ public class LdbcQueryExplainTest {
         "personId", 1L, "minDate", new Date(epochMillis(2010, 1, 1)),
         "limit", 10);
     assertTrue(
-        "IC5 plan should show intersection optimization on the HAS_CREATOR "
-            + "back-reference edge. Plan was:\n" + plan,
+        "IC5 plan should show intersection optimization on the HAS_MEMBER "
+            + "edge traversal step (back-ref from .inV()). Plan was:\n" + plan,
         plan.contains("intersection:"));
   }
 
@@ -133,6 +137,39 @@ public class LdbcQueryExplainTest {
         "IS7 plan should show intersection optimization on the KNOWS "
             + "optional back-reference edge. Plan was:\n" + plan,
         plan.contains("intersection:"));
+  }
+
+  // ==================== Index pre-filter on edge properties ====================
+
+  /**
+   * IC11: The MATCH pattern traverses Person -> KNOWS(depth<2) -> outE(WORK_AT)
+   * -> inV() -> out(IS_LOCATED_IN). The planner should:
+   * <ul>
+   *   <li>Infer class WORK_AT on the workEdge alias (from outE('WORK_AT'))</li>
+   *   <li>Infer class Organisation on the company alias (from WORK_AT.in LINK)</li>
+   *   <li>Infer class Place on the country alias (from IS_LOCATED_IN.in LINK)</li>
+   *   <li>Detect the WORK_AT.workFrom index for the {@code workFrom < :workFromYear}
+   *       condition and attach an IndexLookup pre-filter</li>
+   *   <li>Attach collection ID filters on company and country steps</li>
+   * </ul>
+   */
+  @Test
+  public void testIC11_indexPreFilterOnWorkAt() {
+    String plan = explain(LdbcQuerySql.IC11,
+        "personId", 1L, "countryName", "China",
+        "workFromYear", 2010, "limit", 10);
+
+    // Index pre-filter should detect WORK_AT.workFrom index on the workEdge step
+    assertTrue(
+        "IC11 plan should show index pre-filter on WORK_AT.workFrom. "
+            + "Plan was:\n" + plan,
+        plan.contains("index WORK_AT.workFrom"));
+
+    // Index pre-filter should detect Place.name index on the country step
+    assertTrue(
+        "IC11 plan should show index pre-filter on Place.name for the "
+            + "country filter. Plan was:\n" + plan,
+        plan.contains("index Place.name"));
   }
 
   // ==================== expand() predicate push-down ====================
@@ -297,6 +334,29 @@ public class LdbcQueryExplainTest {
       createEdge(ytg, "HAS_CREATOR", "Comment", 900, "Person", 2);
       createEdge(ytg, "IS_LOCATED_IN", "Comment", 900, "Place", 200);
       createEdge(ytg, "REPLY_OF", "Comment", 900, "Post", 800);
+
+      // ---- Companies (for IC11) ----
+      ytg.yql(
+          "INSERT INTO Company SET id = :id, name = :name, url = :url, type = :type",
+          "id", 1000L, "name", "Acme Corp", "url", "http://acme.com",
+          "type", "company").iterate();
+      ytg.yql(
+          "INSERT INTO Company SET id = :id, name = :name, url = :url, type = :type",
+          "id", 1001L, "name", "Globex Inc", "url", "http://globex.com",
+          "type", "company").iterate();
+      // Companies located in countries
+      createEdge(ytg, "IS_LOCATED_IN", "Company", 1000, "Place", 200); // China
+      createEdge(ytg, "IS_LOCATED_IN", "Company", 1001, "Place", 201); // India
+
+      // ---- WORK_AT edges (for IC11) ----
+      ytg.yql(
+          "CREATE EDGE WORK_AT FROM (SELECT FROM Person WHERE id = :from)"
+              + " TO (SELECT FROM Company WHERE id = :to) SET workFrom = :wf",
+          "from", 2L, "to", 1000L, "wf", 2008).iterate();
+      ytg.yql(
+          "CREATE EDGE WORK_AT FROM (SELECT FROM Person WHERE id = :from)"
+              + " TO (SELECT FROM Company WHERE id = :to) SET workFrom = :wf",
+          "from", 3L, "to", 1001L, "wf", 2012).iterate();
 
       // ---- LIKES ----
       ytg.yql(


### PR DESCRIPTION
#### Motivation:

MATCH queries using edge-method patterns (`outE`/`inE` followed by `inV`/`outV`) could not benefit from index intersection pre-filtering, even when indexed edge properties existed (e.g., `WORK_AT.workFrom`, `HAS_MEMBER.joinDate`). This forced full edge record loading for every link bag entry, making edge-method MATCH patterns significantly slower than their V2V counterparts on indexed properties.

This PR extends the existing pre-filter mechanism to edge-method patterns, enabling zero-I/O skipping of non-matching edges at the iterator level. It also fixes a while-loop leaf-level dedup bug that caused O(fan-out) duplication in `MATCH ... while` traversals.

## Summary

- **`PreFilterableLinkBagIterable` interface** — unified dispatch point for both vertex and edge iterables, replacing concrete type checks
- **`EdgeFromLinkBagIterable`/`EdgeFromLinkBagIterator`** — new iterator pair that filters edges on `primaryRid()` before loading from storage, mirroring the existing vertex pattern
- **Extended class inference in `MatchExecutionPlanner`** — `inferClassFromEdgeSchema` handles 6 method types (`out`, `in`, `outE`, `inE`, `inV`, `outV`); `addAliases` loop tracks `currentEdgeClass` state for forward-propagation through edge-method chains
- **Interface-based dispatch** in `MatchEdgeTraverser.applyPreFilter()` and `ExpandStep.expand()` — works with both vertex and edge iterables
- **`VertexEntityImpl.getEdgesInternal()`** returns `EdgeFromLinkBagIterable` for the LinkBag case instead of the previous `EdgeIterable`
- **While-loop dedup fix** — moved `dedupVisited.add()` outside the expansion block so leaf-level vertices at boundary depth are correctly deduplicated (was causing 6.1x duplication on IC11)
- **Edge RID propagation** — `collectEdgeRids` now propagates through `outE().inV()` chains

## Benchmark results (LDBC SF 1, Hetzner CCX33)

### IC11 (job referral — 2-hop KNOWS + WORK_AT join)

| Suite | Before | After | Change |
|---|---|---|---|
| Single-thread | ~19 ops/s | 31.2 ± 2.9 ops/s | **+64%** |
| Multi-thread (8T) | ~15.8 ops/s | 155.1 ± 15.4 ops/s | **~10x** |

The dedup fix eliminated 6.1x duplication (51K → 8.4K intermediate rows) in the while-loop traversal, with the improvement amplified on the multi-threaded suite.

## Constraints

- `bothE()` is out of scope — returns `ChainedIterable` which silently degrades to unfiltered iteration
- No generated code changes — all changes are planner-level and runtime-level
- Backward compatible — pre-filter is strictly an optimization, no query results change

## Test plan

- [x] Unit tests for `EdgeFromLinkBagIterable`/`EdgeFromLinkBagIterator` (RID filtering, class filtering, dangling RID handling)
- [x] Unit tests for `MatchExecutionPlanner` mutation (class inference for all 6 method types, `addAliases` edge class tracking)
- [x] Unit tests for `ExpandStep` and `MatchEdgeTraverser` interface dispatch
- [x] Integration tests for edge-method pre-filter end-to-end with EXPLAIN verification
- [x] LDBC IC5 and IC11 MATCH pattern validation tests
- [x] Class inference and adaptive abort integration tests
- [x] Existing `DoubleSidedEdgeLinkBagTest` updated for new iterator type
- [x] While-loop boundary-depth dedup regression tests (diamond graph with `$depth < 2`)
- [x] While-loop pathAlias preservation test at boundary depth
- [x] Full unit test suite passes (146 MATCH tests, 39 jmh-ldbc tests)