### PR TITLE
Fix nightly benchmark: use pip3 instead of pip

### DIFF
--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install S3 tools
         run: |
-          pip install --break-system-packages boto3 -q 2>/dev/null || pip install boto3 -q
+          pip3 install --break-system-packages boto3 -q 2>/dev/null || pip3 install boto3 -q
 
       - name: Download LDBC CSV dataset from S3
         if: steps.mode.outputs.load == 'csv'


### PR DESCRIPTION
## Motivation

The LDBC JMH nightly benchmark workflow ([run #23779828518](https://github.com/JetBrains/youtrackdb/actions/runs/23779828518)) fails at the "Install S3 tools" step with `pip: command not found` (exit code 127). The self-hosted benchmark runner (`agent-225`) has `python3`/`pip3` but not the unversioned `pip` command.

## Changes

- Replace `pip` with `pip3` in the `Install S3 tools` step of `ldbc-jmh-nightly.yml`

## Test plan

- [ ] Re-run the nightly benchmark workflow and verify the "Install S3 tools" step passes