### PR TITLE
Fix CSV extraction in JMH compare workflow

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -214,9 +214,7 @@ jobs:
           if [ "$DB_READY" = "false" ]; then
             echo "Extracting CSV dataset..."
             mkdir -p "$CSV_DIR"
-            cd "$CSV_DIR"
-            tar xf "$CSV_TAR"
-            cd "$GITHUB_WORKSPACE"
+            tar xf "$CSV_TAR" --strip-components=1 -C "$CSV_DIR"
 
             echo "=== Extracted CSV contents ==="
             ls -la "$CSV_DIR/" | head -20
@@ -349,9 +347,7 @@ jobs:
           if [ "$DB_READY" = "false" ]; then
             echo "Extracting CSV dataset..."
             mkdir -p "$CSV_DIR"
-            cd "$CSV_DIR"
-            tar xf "$CSV_TAR"
-            cd "$GITHUB_WORKSPACE"
+            tar xf "$CSV_TAR" --strip-components=1 -C "$CSV_DIR"
 
             echo "=== Extracted CSV contents ==="
             ls -la "$CSV_DIR/" | head -20


### PR DESCRIPTION
## Motivation

The `LDBC JMH Benchmark Compare` workflow fails at the "setup database" step when falling back to CSV dataset loading ([run #23829269302](https://github.com/JetBrains/youtrackdb/actions/runs/23829269302)).

The CSV tar archive (`ldbc-sf1-composite-merged-fk.tar.zst`) contains files under an `sf1/` prefix. The workflow extracts it into `$CSV_DIR` (`jmh-ldbc/target/ldbc-dataset/sf1`), creating a double-nested `sf1/sf1/dynamic` path. The validation then correctly fails because `static/` and `dynamic/` aren't at the expected level.

## Changes

Use `tar xf --strip-components=1 -C "$CSV_DIR"` instead of `cd`-ing into the directory, stripping the leading `sf1/` from archive paths. Applied to both Base and Head setup steps.

## Test plan

- [ ] Re-run the `LDBC JMH Benchmark Compare` workflow with `use_prebuilt_db: false` to confirm CSV fallback works