### PR TITLE
Fix flaky histogram config tests caused by parallel GlobalConfiguration mutation

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/HistogramConfigurationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/HistogramConfigurationTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
 import com.jetbrains.youtrackdb.internal.core.db.record.CurrentStorageComponentsFactory;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.BinarySerializerFactory;
@@ -23,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests that histogram configuration parameters from
@@ -31,7 +33,12 @@ import org.junit.Test;
  *
  * <p>Each test temporarily overrides a config value, exercises the code
  * path that reads it, and then restores the original in {@link #tearDown()}.
+ *
+ * <p>Runs sequentially because it mutates {@link GlobalConfiguration},
+ * a JVM-wide singleton that would race with other test classes in the
+ * parallel surefire execution.
  */
+@Category(SequentialTest.class)
 public class HistogramConfigurationTest {
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IncrementalMaintenanceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IncrementalMaintenanceTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
 import com.jetbrains.youtrackdb.internal.core.db.record.CurrentStorageComponentsFactory;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.BinarySerializerFactory;
@@ -53,6 +54,7 @@ import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Incremental maintenance tests (Section 10.6 of the ADR).
@@ -62,7 +64,12 @@ import org.junit.Test;
  * rebalance triggers, concurrent operations, version-mismatch delta discard,
  * at-most-one rebalance guard, failure cooldown, resetOnClear, drift-biased
  * threshold halving, storage-level rebalance throttling, and checkpoint flush.
+ *
+ * <p>Runs sequentially because it mutates {@link GlobalConfiguration},
+ * a JVM-wide singleton that would race with other test classes in the
+ * parallel surefire execution.
  */
+@Category(SequentialTest.class)
 public class IncrementalMaintenanceTest {
 
   /** Generous timeout for CI environments where thread scheduling can be slow. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/RebalanceTriggerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/RebalanceTriggerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
 import com.jetbrains.youtrackdb.internal.core.db.record.CurrentStorageComponentsFactory;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.BinarySerializerFactory;
@@ -31,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests for the rebalance trigger and IO executor plumbing (Step 10).
@@ -42,7 +44,12 @@ import org.junit.Test;
  *   <li>Null executor safety (no scheduling when executor is absent)</li>
  *   <li>Rebalance scheduling when mutation threshold is exceeded</li>
  * </ul>
+ *
+ * <p>Runs sequentially because it mutates {@link GlobalConfiguration},
+ * a JVM-wide singleton that would race with other test classes in the
+ * parallel surefire execution.
  */
+@Category(SequentialTest.class)
 public class RebalanceTriggerTest {
 
   // GlobalConfiguration is JVM-global mutable state. Other test classes

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/ThreeTierTransitionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/ThreeTierTransitionTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
 import com.jetbrains.youtrackdb.internal.core.db.record.CurrentStorageComponentsFactory;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.BinarySerializerFactory;
@@ -44,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests for the three-tier estimation transition lifecycle (Section 10.5).
@@ -66,7 +68,12 @@ import org.junit.Test;
  *   <li>Uniform formulas produce reasonable estimates</li>
  *   <li>Histogram more accurate than uniform for skewed data</li>
  * </ul>
+ *
+ * <p>Runs sequentially because it mutates {@link GlobalConfiguration},
+ * a JVM-wide singleton that would race with other test classes in the
+ * parallel surefire execution.
  */
+@Category(SequentialTest.class)
 public class ThreeTierTransitionTest {
 
   // GlobalConfiguration is JVM-global mutable state. Other test classes


### PR DESCRIPTION
## Summary
- Four histogram test classes mutate `GlobalConfiguration` (a JVM-wide singleton) but ran in the parallel surefire execution, causing intermittent cross-class config races
- Added `@Category(SequentialTest.class)` to `HistogramConfigurationTest`, `IncrementalMaintenanceTest`, `RebalanceTriggerTest`, and `ThreeTierTransitionTest`
- Follows the existing pattern used by `IndexHistogramManagerUnitTest` and the pom.xml guideline for config-mutating tests

## Motivation
CI failures in PR #913 ([check run](https://github.com/JetBrains/youtrackdb/runs/69464168663)):
- `HistogramConfigurationTest.rebalanceThreshold_clampedByMaxMutations`
- `HistogramConfigurationTest.histogramMinSize_belowMinSize_doesNotSchedule`

Root cause: when test classes run in parallel, one class's `setConfig()` override gets clobbered by another class resetting to defaults between the config write and the `IndexHistogramManager` constructor read.

## Test plan
- [x] All 29 `HistogramConfigurationTest` tests pass
- [x] All 32 `IncrementalMaintenanceTest` tests pass
- [x] All 16 `RebalanceTriggerTest` tests pass
- [x] All 26 `ThreeTierTransitionTest` tests pass
- [x] Spotless clean
- [ ] CI passes with tests running in sequential phase