### PR TITLE
Fix flaky RatioTest.asyncRatio on Windows CI (#917)

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/RatioTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/metrics/RatioTest.java
@@ -18,44 +18,42 @@ public class RatioTest extends MetricsBaseTest {
 
   @Test
   public void zeroRatio() {
-    testRatioFunction("zero", 100, i -> ObjectDoublePair.of(new long[]{0, 0}, 0.0));
+    testRatioFunction("zero", 100, i -> ObjectDoublePair.of(new long[] {0, 0}, 0.0));
   }
 
   @Test
   public void oneRatio() {
-    testRatioFunction("one", 100, i -> ObjectDoublePair.of(new long[]{100, 100}, 1.0));
+    testRatioFunction("one", 100, i -> ObjectDoublePair.of(new long[] {100, 100}, 1.0));
   }
 
   @Test
   public void halfRatio() {
-    testRatioFunction("half", 100, i -> ObjectDoublePair.of(new long[]{50}, 0.5));
+    testRatioFunction("half", 100, i -> ObjectDoublePair.of(new long[] {50}, 0.5));
   }
 
   @Test
   public void halfRatio2() {
-    testRatioFunction("half2", 100, i -> ObjectDoublePair.of(new long[]{0, 100, 50}, 0.5));
+    testRatioFunction("half2", 100, i -> ObjectDoublePair.of(new long[] {0, 100, 50}, 0.5));
   }
 
   @Test
   public void discreteRatio() {
     testRatioFunction("discrete", ITERATIONS_COUNT,
         i -> ObjectDoublePair.of(
-            new long[]{i / 1000 % 2 == 0 ? i : 0},
-            i / 1000 % 2 == 0 ? (double) i / ITERATIONS_COUNT : 0
-        ));
+            new long[] {i / 1000 % 2 == 0 ? i : 0},
+            i / 1000 % 2 == 0 ? (double) i / ITERATIONS_COUNT : 0));
   }
 
   @Test
   public void linearRatio() {
     testRatioFunction("linear", ITERATIONS_COUNT,
-        i -> ObjectDoublePair.of(new long[]{i}, (double) i / ITERATIONS_COUNT));
+        i -> ObjectDoublePair.of(new long[] {i}, (double) i / ITERATIONS_COUNT));
   }
 
   private void testRatioFunction(
       String functionName,
       int base,
-      IntFunction<ObjectDoublePair<long[]>> ratioFunction
-  ) {
+      IntFunction<ObjectDoublePair<long[]>> ratioFunction) {
 
     final var ticker = new StubTicker(0, TICK.toNanos());
     // Use tickCheckInterval=1 so each record triggers a tick check, matching the test pattern
@@ -65,8 +63,7 @@ public class RatioTest extends MetricsBaseTest {
         TICK,
         TimeInterval.of(1, TimeUnit.SECONDS),
         1.0,
-        1
-    );
+        1);
 
     for (int i = 0; i < ITERATIONS_COUNT; i++) {
       final var e = ratioFunction.apply(i);
@@ -98,8 +95,7 @@ public class RatioTest extends MetricsBaseTest {
         TimeInterval.of(10, TimeUnit.MILLISECONDS),
         TimeInterval.of(1, TimeUnit.MINUTES),
         1.0,
-        1
-    );
+        1);
 
     final var expectedRate = 7.0 / 12;
 
@@ -144,8 +140,7 @@ public class RatioTest extends MetricsBaseTest {
     final var meter = Ratio.create(
         ticker,
         TimeInterval.of(1, TimeUnit.MILLISECONDS),
-        TimeInterval.of(1000, TimeUnit.MILLISECONDS)
-    );
+        TimeInterval.of(1000, TimeUnit.MILLISECONDS));
 
     // 10 threads producing 1 event every 500ns = 20_000 events per millisecond
     for (int i = 0; i < writerThreadCount; i++) {
@@ -156,8 +151,7 @@ public class RatioTest extends MetricsBaseTest {
               () -> {
                 meter.record(it.getValue() % successEveryNthIt == 0);
                 it.increment();
-              }, 0, eventPeriodNanos, TimeUnit.NANOSECONDS
-          );
+              }, 0, eventPeriodNanos, TimeUnit.NANOSECONDS);
     }
 
     // letting the rate stabilize
@@ -176,6 +170,8 @@ public class RatioTest extends MetricsBaseTest {
     final var expectedRatio = 1.0 / successEveryNthIt;
     final var avgRatio = total / iterations;
 
-    assertEquals(expectedRatio, avgRatio, 0.01 * expectedRatio);
+    // Use 5% tolerance because this test relies on real OS thread scheduling and Thread.sleep,
+    // which have higher jitter on Windows (observed ~2.4% drift on Windows CI runners).
+    assertEquals(expectedRatio, avgRatio, 0.05 * expectedRatio);
   }
 }


### PR DESCRIPTION
## Summary
- Widen assertion tolerance in `RatioTest.asyncRatio` from 1% to 5% of expected ratio to fix flaky Windows CI failures

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/23842433012

The `asyncRatio` test uses real OS thread scheduling (`ScheduledExecutorService` at 1μs period) and `Thread.sleep` for rate stabilization. On Windows CI runners, OS scheduling jitter caused the measured ratio to drift ~2.4% from the expected 1/3, exceeding the previous 1% tolerance:
```
expected:<0.3333333333333333> but was:<0.34146177329158134>
```

A 5% tolerance still validates that the ratio converges near 1/3 while accommodating platform scheduling variance.

## Test plan
- [x] Failing test `RatioTest#asyncRatio` passes locally
- [x] All 8 tests in `RatioTest` pass
- [x] Spotless formatting check passes