### PR TITLE
Replace Python/boto3 with static CLI tools in nightly benchmark workflow

### DIFF
--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -66,30 +66,42 @@ jobs:
             echo "load=csv" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install S3 tools
+      - name: Install CLI tools (mc, jq)
         run: |
-          pip3 install --break-system-packages boto3 -q 2>/dev/null || pip3 install boto3 -q
+          # Install MinIO client (static binary, no Python/pip needed)
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc \
+            || curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o "$HOME/mc"
+          chmod +x /usr/local/bin/mc 2>/dev/null || chmod +x "$HOME/mc"
+          # Ensure mc is on PATH
+          if ! command -v mc &>/dev/null; then
+            export PATH="$HOME:$PATH"
+            echo "$HOME" >> "$GITHUB_PATH"
+          fi
+
+          # Install jq if not present (needed for InfluxDB push)
+          if ! command -v jq &>/dev/null; then
+            curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 \
+              -o /usr/local/bin/jq \
+              || curl -fsSL https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 \
+                -o "$HOME/jq"
+            chmod +x /usr/local/bin/jq 2>/dev/null || chmod +x "$HOME/jq"
+            if ! command -v jq &>/dev/null; then
+              echo "$HOME" >> "$GITHUB_PATH"
+            fi
+          fi
+
+          mc alias set hetzner "${{ secrets.HETZNER_S3_ENDPOINT }}" \
+            "${{ secrets.HETZNER_S3_ACCESS_KEY }}" "${{ secrets.HETZNER_S3_SECRET_KEY }}"
+          mc ls hetzner/bench-cache/ldbc/ || echo "Warning: could not list S3 bucket"
 
       - name: Download LDBC CSV dataset from S3
         if: steps.mode.outputs.load == 'csv'
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
-          S3_ENDPOINT: ${{ secrets.HETZNER_S3_ENDPOINT }}
         run: |
-          python3 - << 'PYEOF'
-          import boto3, os
-          s3 = boto3.client('s3',
-              endpoint_url=os.environ['S3_ENDPOINT'],
-              aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
-              aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
-          os.makedirs('jmh-ldbc/target/ldbc-dataset/sf1', exist_ok=True)
-          print('Downloading SF 1 CSV dataset from S3...')
-          s3.download_file('bench-cache', 'ldbc/ldbc-sf1-composite-merged-fk.tar.zst',
-              '/tmp/dataset.tar.zst')
-          print('Downloaded from S3')
-          PYEOF
+          echo 'Downloading SF 1 CSV dataset from S3...'
+          mc cp hetzner/bench-cache/ldbc/ldbc-sf1-composite-merged-fk.tar.zst /tmp/dataset.tar.zst
+          echo 'Downloaded from S3'
 
+          mkdir -p jmh-ldbc/target/ldbc-dataset/sf1
           cd jmh-ldbc/target/ldbc-dataset/sf1
           zstd -d /tmp/dataset.tar.zst -o /tmp/dataset.tar
           tar xf /tmp/dataset.tar
@@ -99,22 +111,10 @@ jobs:
 
       - name: Download pre-built LDBC database from S3
         if: steps.mode.outputs.load == 'prebuilt'
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
-          S3_ENDPOINT: ${{ secrets.HETZNER_S3_ENDPOINT }}
         run: |
-          python3 - << 'PYEOF'
-          import boto3, os
-          s3 = boto3.client('s3',
-              endpoint_url=os.environ['S3_ENDPOINT'],
-              aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
-              aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
-          print('Downloading pre-built SF 1 database from S3...')
-          s3.download_file('bench-cache', 'ldbc/ldbc-sf1-bench-db.tar.zst',
-              '/tmp/bench-db.tar.zst')
-          print('Downloaded from S3')
-          PYEOF
+          echo 'Downloading pre-built SF 1 database from S3...'
+          mc cp hetzner/bench-cache/ldbc/ldbc-sf1-bench-db.tar.zst /tmp/bench-db.tar.zst
+          echo 'Downloaded from S3'
 
           mkdir -p jmh-ldbc/target/ldbc-bench-db
           cd jmh-ldbc/target/ldbc-bench-db
@@ -151,10 +151,6 @@ jobs:
 
       - name: Upload built database to S3
         if: success() && steps.mode.outputs.load == 'csv'
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
-          S3_ENDPOINT: ${{ secrets.HETZNER_S3_ENDPOINT }}
         run: |
           set -euo pipefail
           cd jmh-ldbc/target/ldbc-bench-db
@@ -163,18 +159,9 @@ jobs:
           rm -f /tmp/bench-db.tar
           echo "Database archived: $(du -sh /tmp/bench-db.tar.zst | cut -f1)"
 
-          cd "$GITHUB_WORKSPACE"
-          python3 - << 'PYEOF'
-          import boto3, os
-          s3 = boto3.client('s3',
-              endpoint_url=os.environ['S3_ENDPOINT'],
-              aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
-              aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
-          print('Uploading built database to S3...')
-          s3.upload_file('/tmp/bench-db.tar.zst', 'bench-cache',
-              'ldbc/ldbc-sf1-bench-db.tar.zst')
-          print('Uploaded to S3: ldbc/ldbc-sf1-bench-db.tar.zst')
-          PYEOF
+          echo 'Uploading built database to S3...'
+          mc cp /tmp/bench-db.tar.zst hetzner/bench-cache/ldbc/ldbc-sf1-bench-db.tar.zst
+          echo 'Uploaded to S3: ldbc/ldbc-sf1-bench-db.tar.zst'
 
       - name: Push results to InfluxDB
         if: success()
@@ -182,7 +169,7 @@ jobs:
           INFLUXDB_URL: ${{ secrets.INFLUXDB_URL }}
           INFLUXDB_TOKEN: ${{ secrets.INFLUXDB_TOKEN }}
         run: |
-          python3 jmh-ldbc/jmh-to-influxdb.py \
+          bash jmh-ldbc/jmh-to-influxdb.sh \
             --input results.json \
             --influxdb-url "$INFLUXDB_URL" \
             --influxdb-token "$INFLUXDB_TOKEN" \

--- a/jmh-ldbc/jmh-to-influxdb.sh
+++ b/jmh-ldbc/jmh-to-influxdb.sh
@@ -47,7 +47,7 @@ TIMESTAMP_NS=$(( TIMESTAMP * 1000000000 ))
 
 # Escape InfluxDB tag value: backslash-escape spaces, commas, equals
 escape_tag() {
-  printf '%s' "$1" | sed 's/ /\\ /g; s/,/\\,/g; s/=/\\=/g'
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/ /\\ /g; s/,/\\,/g; s/=/\\=/g'
 }
 
 BRANCH_ESC=$(escape_tag "$BRANCH")
@@ -58,6 +58,7 @@ LINE_DATA=$(jq -r --arg branch "$BRANCH_ESC" \
                    --arg sha "$SHA_ESC" \
                    --arg ts "$TIMESTAMP_NS" '
   # Build benchmark lines
+  def esc: gsub("\\\\"; "\\\\") | gsub(" "; "\\ ") | gsub(","; "\\,") | gsub("="; "\\=");
   [ .[] |
     .benchmark as $bench |
     ($bench | split(".")[-2]) as $class |
@@ -69,7 +70,7 @@ LINE_DATA=$(jq -r --arg branch "$BRANCH_ESC" \
     ($pm.score // 0) as $score |
     ($pm.scoreError // 0) as $err |
     ($pm.scorePercentiles // {}) as $pct |
-    "jmh_benchmark,query=\($method | gsub(" "; "\\\\ ") | gsub(","; "\\\\,") | gsub("="; "\\\\=")),suite=\($suite | gsub(" "; "\\\\ ") | gsub(","; "\\\\,") | gsub("="; "\\\\=")),branch=\($branch),commit_sha=\($sha) score=\($score),score_error=\($err),score_p0_00=\($pct["0.0"] // 0),score_p50_00=\($pct["50.0"] // 0),score_p90_00=\($pct["90.0"] // 0),score_p95_00=\($pct["95.0"] // 0),score_p99_00=\($pct["99.0"] // 0),score_p99_99=\($pct["99.99"] // 0),score_p100_00=\($pct["100.0"] // 0) \($ts)"
+    "jmh_benchmark,query=\($method | esc),suite=\($suite | esc),branch=\($branch),commit_sha=\($sha) score=\($score),score_error=\($err),score_p0_00=\($pct["0.0"] // 0),score_p50_00=\($pct["50.0"] // 0),score_p90_00=\($pct["90.0"] // 0),score_p95_00=\($pct["95.0"] // 0),score_p99_00=\($pct["99.0"] // 0),score_p99_99=\($pct["99.99"] // 0),score_p100_00=\($pct["100.0"] // 0) \($ts)"
   ] +
   # Build scalability lines (MT/ST ratio per query)
   (
@@ -88,14 +89,14 @@ LINE_DATA=$(jq -r --arg branch "$BRANCH_ESC" \
       (map(select(.type == "ST")) | first // null) as $st |
       (map(select(.type == "MT")) | first // null) as $mt |
       select($st != null and $mt != null and $st.score > 0) |
-      "scalability,query=\($st.query | gsub(" "; "\\\\ ") | gsub(","; "\\\\,") | gsub("="; "\\\\=")),branch=\($branch),commit_sha=\($sha) ratio=\($mt.score / $st.score),st_score=\($st.score),mt_score=\($mt.score) \($ts)"
+      "scalability,query=\($st.query | esc),branch=\($branch),commit_sha=\($sha) ratio=\($mt.score / $st.score),st_score=\($st.score),mt_score=\($mt.score) \($ts)"
     )
   ) |
   .[]
 ' "$INPUT")
 
-NUM_BENCHMARKS=$(echo "$LINE_DATA" | grep -c '^jmh_benchmark,' || true)
-NUM_SCALABILITY=$(echo "$LINE_DATA" | grep -c '^scalability,' || true)
+NUM_BENCHMARKS=$(printf "%s\n" "$LINE_DATA" | grep -c '^jmh_benchmark,' || true)
+NUM_SCALABILITY=$(printf "%s\n" "$LINE_DATA" | grep -c '^scalability,' || true)
 echo "Parsed $NUM_BENCHMARKS benchmark results, $NUM_SCALABILITY scalability metrics"
 
 if [ "$DRY_RUN" = true ]; then
@@ -106,11 +107,11 @@ fi
 # Push to InfluxDB
 WRITE_URL="${INFLUXDB_URL%/}/api/v2/write?org=${INFLUXDB_ORG}&bucket=${INFLUXDB_BUCKET}&precision=ns"
 
-HTTP_CODE=$(curl -s -o /tmp/influxdb-response-$$.txt -w '%{http_code}' \
+HTTP_CODE=$(printf "%s" "$LINE_DATA" | curl -s -o /tmp/influxdb-response-$$.txt -w '%{http_code}' \
   -X POST "$WRITE_URL" \
   -H "Authorization: Token ${INFLUXDB_TOKEN}" \
   -H "Content-Type: text/plain; charset=utf-8" \
-  --data-binary "$LINE_DATA")
+  --data-binary @-)
 
 if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
   echo "InfluxDB write successful: $HTTP_CODE"

--- a/jmh-ldbc/jmh-to-influxdb.sh
+++ b/jmh-ldbc/jmh-to-influxdb.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Parse JMH JSON results and push to InfluxDB 2.x via line protocol.
+# Bash/jq/curl replacement for jmh-to-influxdb.py (no Python dependency).
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --input FILE --influxdb-url URL --influxdb-token TOKEN"
+  echo "       [--influxdb-org ORG] [--influxdb-bucket BUCKET]"
+  echo "       --branch BRANCH --commit-sha SHA --timestamp EPOCH_S"
+  echo "       [--dry-run]"
+  exit 1
+}
+
+# Defaults
+INFLUXDB_ORG="youtrackdb"
+INFLUXDB_BUCKET="jmh-benchmarks"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input)          INPUT="$2";          shift 2 ;;
+    --influxdb-url)   INFLUXDB_URL="$2";   shift 2 ;;
+    --influxdb-token) INFLUXDB_TOKEN="$2"; shift 2 ;;
+    --influxdb-org)   INFLUXDB_ORG="$2";   shift 2 ;;
+    --influxdb-bucket) INFLUXDB_BUCKET="$2"; shift 2 ;;
+    --branch)         BRANCH="$2";         shift 2 ;;
+    --commit-sha)     COMMIT_SHA="$2";     shift 2 ;;
+    --timestamp)      TIMESTAMP="$2";      shift 2 ;;
+    --dry-run)        DRY_RUN=true;        shift ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+: "${INPUT:?--input is required}"
+: "${INFLUXDB_URL:?--influxdb-url is required}"
+: "${INFLUXDB_TOKEN:?--influxdb-token is required}"
+: "${BRANCH:?--branch is required}"
+: "${COMMIT_SHA:?--commit-sha is required}"
+: "${TIMESTAMP:?--timestamp is required}"
+
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required but not found" >&2
+  exit 1
+fi
+
+TIMESTAMP_NS=$(( TIMESTAMP * 1000000000 ))
+
+# Escape InfluxDB tag value: backslash-escape spaces, commas, equals
+escape_tag() {
+  printf '%s' "$1" | sed 's/ /\\ /g; s/,/\\,/g; s/=/\\=/g'
+}
+
+BRANCH_ESC=$(escape_tag "$BRANCH")
+SHA_ESC=$(escape_tag "$COMMIT_SHA")
+
+# Parse JMH JSON and emit InfluxDB line protocol
+LINE_DATA=$(jq -r --arg branch "$BRANCH_ESC" \
+                   --arg sha "$SHA_ESC" \
+                   --arg ts "$TIMESTAMP_NS" '
+  # Build benchmark lines
+  [ .[] |
+    .benchmark as $bench |
+    ($bench | split(".")[-2]) as $class |
+    ($bench | split(".")[-1]) as $method |
+    (if ($class | test("SingleThread")) then "SingleThread"
+     elif ($class | test("MultiThread")) then "MultiThread"
+     else $class end) as $suite |
+    .primaryMetric as $pm |
+    ($pm.score // 0) as $score |
+    ($pm.scoreError // 0) as $err |
+    ($pm.scorePercentiles // {}) as $pct |
+    "jmh_benchmark,query=\($method | gsub(" "; "\\\\ ") | gsub(","; "\\\\,") | gsub("="; "\\\\=")),suite=\($suite | gsub(" "; "\\\\ ") | gsub(","; "\\\\,") | gsub("="; "\\\\=")),branch=\($branch),commit_sha=\($sha) score=\($score),score_error=\($err),score_p0_00=\($pct["0.0"] // 0),score_p50_00=\($pct["50.0"] // 0),score_p90_00=\($pct["90.0"] // 0),score_p95_00=\($pct["95.0"] // 0),score_p99_00=\($pct["99.0"] // 0),score_p99_99=\($pct["99.99"] // 0),score_p100_00=\($pct["100.0"] // 0) \($ts)"
+  ] +
+  # Build scalability lines (MT/ST ratio per query)
+  (
+    [ .[] |
+      .benchmark as $bench |
+      ($bench | split(".")[-2]) as $class |
+      ($bench | split(".")[-1]) as $method |
+      (if ($class | test("SingleThread")) then "ST"
+       elif ($class | test("MultiThread")) then "MT"
+       else null end) as $type |
+      select($type != null) |
+      { query: $method, type: $type, score: (.primaryMetric.score // 0) }
+    ] |
+    group_by(.query) |
+    map(
+      (map(select(.type == "ST")) | first // null) as $st |
+      (map(select(.type == "MT")) | first // null) as $mt |
+      select($st != null and $mt != null and $st.score > 0) |
+      "scalability,query=\($st.query | gsub(" "; "\\\\ ") | gsub(","; "\\\\,") | gsub("="; "\\\\=")),branch=\($branch),commit_sha=\($sha) ratio=\($mt.score / $st.score),st_score=\($st.score),mt_score=\($mt.score) \($ts)"
+    )
+  ) |
+  .[]
+' "$INPUT")
+
+NUM_BENCHMARKS=$(echo "$LINE_DATA" | grep -c '^jmh_benchmark,' || true)
+NUM_SCALABILITY=$(echo "$LINE_DATA" | grep -c '^scalability,' || true)
+echo "Parsed $NUM_BENCHMARKS benchmark results, $NUM_SCALABILITY scalability metrics"
+
+if [ "$DRY_RUN" = true ]; then
+  echo "$LINE_DATA"
+  exit 0
+fi
+
+# Push to InfluxDB
+WRITE_URL="${INFLUXDB_URL%/}/api/v2/write?org=${INFLUXDB_ORG}&bucket=${INFLUXDB_BUCKET}&precision=ns"
+
+HTTP_CODE=$(curl -s -o /tmp/influxdb-response-$$.txt -w '%{http_code}' \
+  -X POST "$WRITE_URL" \
+  -H "Authorization: Token ${INFLUXDB_TOKEN}" \
+  -H "Content-Type: text/plain; charset=utf-8" \
+  --data-binary "$LINE_DATA")
+
+if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+  echo "InfluxDB write successful: $HTTP_CODE"
+else
+  echo "InfluxDB write failed: $HTTP_CODE - $(cat /tmp/influxdb-response-$$.txt)" >&2
+  rm -f /tmp/influxdb-response-$$.txt
+  exit 1
+fi
+rm -f /tmp/influxdb-response-$$.txt


### PR DESCRIPTION
## Summary
- The bare-metal benchmark runner (`agent-225`) lacks `pip3`/Python, causing the nightly benchmark workflow to fail at the "Install S3 tools" step with `pip3: command not found` (exit code 127)
- Replaced all Python dependencies with static CLI binaries that need no runtime: MinIO client (`mc`) for S3 download/upload, `jq` + `curl` for InfluxDB push
- Added `jmh-ldbc/jmh-to-influxdb.sh` — a bash replacement for `jmh-to-influxdb.py` producing identical InfluxDB line protocol output

## Test plan
- [x] Verified `jmh-to-influxdb.sh` produces correct InfluxDB line protocol with sample JMH JSON (dry-run mode)
- [ ] Trigger manual workflow run to confirm end-to-end execution on bare-metal runner