### PR TITLE
Add pre-flight compile check to JMH compare workflow

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -111,6 +111,14 @@ jobs:
           # Copy comparison script to /tmp/ so it survives git checkouts
           cp jmh-ldbc/jmh-compare.py /tmp/jmh-compare-${{ github.run_id }}.py
 
+      # Compile head first to fail fast — avoids wasting hours on base
+      # benchmarks only to discover the branch doesn't compile.
+      - name: 'Pre-flight: verify head compiles'
+        run: |
+          chmod +x mvnw
+          ./mvnw -pl jmh-ldbc -am compile -DskipTests \
+            -Dspotless.check.skip=true -q
+
       # ── Download data (once) ─────────────────────────────────────────────
       # Always download the CSV dataset as a fallback.
       # Download the pre-built DB too when requested (faster setup).


### PR DESCRIPTION
## Summary
- Adds a pre-flight compilation step for the head branch at the start of the JMH compare workflow, before downloading data or running base benchmarks.
- Prevents wasting hours of CCX33 compute when the branch has compilation errors (e.g. [run #23853915772](https://github.com/JetBrains/youtrackdb/actions/runs/23853915772) ran 8h of base benchmarks before discovering the head branch doesn't compile).

## Test plan
- [x] Verify workflow YAML is valid
- [ ] Trigger workflow on a branch with a known compilation error — should fail within minutes
- [ ] Trigger workflow on a healthy branch — pre-flight passes, benchmarks proceed normally