### PR TITLE
Switch scheduled workflows to CET and add EU location rotation

### DIFF
--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -32,6 +32,7 @@ jobs:
       - self-hosted
       - type-cpx42
       - image-x86-system-ubuntu-24.04
+      - in-nbg1-fsn1-hel1
     timeout-minutes: 360
     env:
       FAILED_RUN_URL: ${{ inputs.failed_run_url }}

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -37,6 +37,7 @@ jobs:
       - self-hosted
       - type-ccx33
       - image-x86-system-ubuntu-24.04
+      - in-nbg1-fsn1-hel1
     timeout-minutes: 1200
 
     steps:

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -6,8 +6,8 @@ permissions:
 
 on:
   schedule:
-    # Run at 3 AM UTC daily (after nightly integration tests)
-    - cron: '0 3 * * *'
+    # Run at 3 AM CET (2 AM UTC), after nightly integration tests
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -2,7 +2,8 @@ name: Java CI/CD Integration Tests Pipeline
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 2 * * *'
+    # Run at 2 AM CET (1 AM UTC)
+    - cron: '0 1 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,8 +70,9 @@ jobs:
     name: Linux ${{ matrix.arch }} - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
-    runs-on: [ self-hosted, '${{ matrix.arch == ''x86'' && ''type-cpx42'' || ''type-cax31'' }}',
-               'image-${{ matrix.arch == ''x86'' && ''x86-system'' || ''arm-system'' }}-ubuntu-24.04' ]
+    runs-on: [ self-hosted, '${{ matrix.arch == ''x86'' && ''type-cpx42'' || ''type-cax31-cax21'' }}',
+               'image-${{ matrix.arch == ''x86'' && ''x86-system'' || ''arm-system'' }}-ubuntu-24.04',
+               in-nbg1-fsn1-hel1 ]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -153,8 +153,9 @@ jobs:
     if: needs.detect-changes.outputs.should_build == 'true'
     runs-on:
       - self-hosted
-      - "${{ matrix.arch == 'x86' && 'type-cpx42' || 'type-cax31' }}"
+      - "${{ matrix.arch == 'x86' && 'type-cpx42' || 'type-cax31-cax21' }}"
       - "image-${{ matrix.arch == 'x86' && 'x86-system' || 'arm-system' }}-ubuntu-24.04"
+      - in-nbg1-fsn1-hel1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Motivation

Scheduled workflows were running on UTC times and all cloud runners were provisioned exclusively in Helsinki (hel1), causing potential capacity issues when that location is constrained.

## Summary

- Switch nightly cron schedules to CET: integration tests at 2 AM CET (1 AM UTC), LDBC JMH benchmarks at 3 AM CET (2 AM UTC)
- Add `in-nbg1-fsn1-hel1` location rotation labels to all self-hosted cloud runner jobs (maven-pipeline, integration tests, ldbc-jmh-compare, ci-failure-fix-agent) so testflows can provision servers across Nuremberg, Falkenstein, and Helsinki
- Add `cax21` as ARM server fallback (`type-cax31-cax21`) in maven-pipeline and integration tests, in case `cax31` is unavailable

[no-test-number-check]

## Test plan

- [ ] Verify nightly integration tests trigger at 2 AM CET
- [ ] Verify LDBC JMH nightly triggers at 3 AM CET
- [ ] Verify cloud runners are provisioned across multiple EU locations
- [ ] Verify ARM jobs fall back to cax21 when cax31 is unavailable