### PR TITLE
Fix nightly benchmark: pre-built DB nesting and result validation

### DIFF
--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -117,12 +117,19 @@ jobs:
           echo 'Downloaded from S3'
 
           mkdir -p jmh-ldbc/target/ldbc-bench-db
-          cd jmh-ldbc/target/ldbc-bench-db
           zstd -d /tmp/bench-db.tar.zst -o /tmp/bench-db.tar
-          tar xf /tmp/bench-db.tar
+          tar xf /tmp/bench-db.tar -C jmh-ldbc/target/ldbc-bench-db
           rm -f /tmp/bench-db.tar.zst /tmp/bench-db.tar
+          # The archive may contain a nested ldbc-bench-db/ directory.
+          # Flatten it so the DB files are directly under target/ldbc-bench-db/.
+          if [ -d jmh-ldbc/target/ldbc-bench-db/ldbc-bench-db ] && \
+             [ ! -f jmh-ldbc/target/ldbc-bench-db/database.ocf ]; then
+            echo "Flattening nested ldbc-bench-db directory"
+            mv jmh-ldbc/target/ldbc-bench-db/ldbc-bench-db/* jmh-ldbc/target/ldbc-bench-db/
+            rmdir jmh-ldbc/target/ldbc-bench-db/ldbc-bench-db
+          fi
           echo "Pre-built database extracted"
-          ls -la
+          ls -la jmh-ldbc/target/ldbc-bench-db/
 
       - name: Compile
         run: |
@@ -148,6 +155,20 @@ jobs:
             -Dspotless.check.skip=true -Dcentral.skip=true \
             -Djmh.args="-rf json -rff ${{ github.workspace }}/results.json" \
             2>&1 | tee bench.log
+
+      - name: Validate benchmark results
+        run: |
+          RESULTS="${{ github.workspace }}/results.json"
+          if [ ! -f "$RESULTS" ]; then
+            echo "::error::results.json not found — benchmarks did not produce output"
+            exit 1
+          fi
+          COUNT=$(jq 'length' "$RESULTS")
+          if [ "$COUNT" -eq 0 ] || [ "$COUNT" = "null" ]; then
+            echo "::error::results.json is empty — all benchmarks failed"
+            exit 1
+          fi
+          echo "Benchmark results contain $COUNT entries"
 
       - name: Upload built database to S3
         if: success() && steps.mode.outputs.load == 'csv'

--- a/jmh-ldbc/jmh-to-influxdb.sh
+++ b/jmh-ldbc/jmh-to-influxdb.sh
@@ -112,8 +112,9 @@ fi
 # Push to InfluxDB
 WRITE_URL="${INFLUXDB_URL%/}/api/v2/write?org=${INFLUXDB_ORG}&bucket=${INFLUXDB_BUCKET}&precision=ns"
 
-RESPONSE_FILE=$(mktemp)
-trap 'rm -f "$RESPONSE_FILE"' EXIT
+TMPDIR_RESP=$(mktemp -d)
+RESPONSE_FILE="$TMPDIR_RESP/response.txt"
+trap 'rm -rf "$TMPDIR_RESP"' EXIT
 
 HTTP_CODE=$(printf "%s" "$LINE_DATA" | curl -s -o "$RESPONSE_FILE" -w '%{http_code}' \
   -X POST "$WRITE_URL" \

--- a/jmh-ldbc/jmh-to-influxdb.sh
+++ b/jmh-ldbc/jmh-to-influxdb.sh
@@ -58,7 +58,7 @@ LINE_DATA=$(jq -r --arg branch "$BRANCH_ESC" \
                    --arg sha "$SHA_ESC" \
                    --arg ts "$TIMESTAMP_NS" '
   # Build benchmark lines
-  def esc: gsub("\\\\"; "\\\\") | gsub(" "; "\\ ") | gsub(","; "\\,") | gsub("="; "\\=");
+  def esc: split("\\") | join("\\\\") | split(" ") | join("\\ ") | split(",") | join("\\,") | split("=") | join("\\=");
   [ .[] |
     .benchmark as $bench |
     ($bench | split(".")[-2]) as $class |
@@ -99,6 +99,11 @@ NUM_BENCHMARKS=$(printf "%s\n" "$LINE_DATA" | grep -c '^jmh_benchmark,' || true)
 NUM_SCALABILITY=$(printf "%s\n" "$LINE_DATA" | grep -c '^scalability,' || true)
 echo "Parsed $NUM_BENCHMARKS benchmark results, $NUM_SCALABILITY scalability metrics"
 
+if [[ "$NUM_BENCHMARKS" -eq 0 ]]; then
+  echo "Error: no benchmark results parsed from $INPUT" >&2
+  exit 1
+fi
+
 if [ "$DRY_RUN" = true ]; then
   echo "$LINE_DATA"
   exit 0
@@ -107,17 +112,18 @@ fi
 # Push to InfluxDB
 WRITE_URL="${INFLUXDB_URL%/}/api/v2/write?org=${INFLUXDB_ORG}&bucket=${INFLUXDB_BUCKET}&precision=ns"
 
-HTTP_CODE=$(printf "%s" "$LINE_DATA" | curl -s -o /tmp/influxdb-response-$$.txt -w '%{http_code}' \
+RESPONSE_FILE=$(mktemp)
+trap 'rm -f "$RESPONSE_FILE"' EXIT
+
+HTTP_CODE=$(printf "%s" "$LINE_DATA" | curl -s -o "$RESPONSE_FILE" -w '%{http_code}' \
   -X POST "$WRITE_URL" \
   -H "Authorization: Token ${INFLUXDB_TOKEN}" \
   -H "Content-Type: text/plain; charset=utf-8" \
   --data-binary @-)
 
-if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+if [[ "${HTTP_CODE:-000}" -ge 200 && "${HTTP_CODE:-000}" -lt 300 ]]; then
   echo "InfluxDB write successful: $HTTP_CODE"
 else
-  echo "InfluxDB write failed: $HTTP_CODE - $(cat /tmp/influxdb-response-$$.txt)" >&2
-  rm -f /tmp/influxdb-response-$$.txt
+  echo "InfluxDB write failed: $HTTP_CODE - $(cat "$RESPONSE_FILE" 2>/dev/null || echo "No response body")" >&2
   exit 1
 fi
-rm -f /tmp/influxdb-response-$$.txt


### PR DESCRIPTION
## Motivation

The nightly JMH benchmark workflow ([run 23881448573](https://github.com/JetBrains/youtrackdb/actions/runs/23881448573/job/69635271618)) completed in ~7 minutes with zero results — all JMH forks failed with `LDBC dataset not found` but the job was marked as successful.

**Root cause**: The pre-built DB archive on S3 contains a nested `ldbc-bench-db/` directory. Extracting into `jmh-ldbc/target/ldbc-bench-db/` placed the actual DB files at `.../ldbc-bench-db/ldbc-bench-db/` — one level too deep for `LdbcBenchmarkState` to find.

**Silent success**: JMH exits 0 even when every fork fails, and the workflow had no validation of the output, so the job appeared green.

## Changes

1. **Fix pre-built DB extraction**: Detect the nested `ldbc-bench-db/` directory after extraction and flatten it so DB files are directly under `target/ldbc-bench-db/`.
2. **Add result validation step**: After benchmarks run, verify `results.json` exists and contains at least one entry. Fail the job with a clear error if benchmarks produced no results.

## Test plan

- [ ] Trigger manual workflow run with `use_prebuilt_db=true` and verify the DB is extracted correctly and benchmarks run to completion
- [ ] Verify the validation step would catch an empty `results.json` (visible in the step logic)