### PR TITLE
YTDB-345: Zero-copy record deserialization via PageFrame references

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -1171,10 +1171,32 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
 
         localCache.updateRecord(record, this);
         record.fromStream(recordBuffer.buffer());
-      } else if (readResult instanceof RawPageBuffer) {
-        // Zero-copy PageFrame path — implemented in Track 4.
-        throw new UnsupportedOperationException(
-            "RawPageBuffer dispatch implemented in Track 4");
+      } else if (readResult instanceof RawPageBuffer pageBuffer) {
+        // Zero-copy PageFrame path: store PageFrame reference for lazy
+        // deserialization at property-access time.
+        record =
+            YouTrackDBEnginesManager.instance()
+                .getRecordFactoryManager()
+                .newInstance(pageBuffer.recordType(), rid, this);
+        var rec = record;
+        rec.unsetDirty();
+        record.recordSerializer = serializer;
+
+        if (record instanceof EntityImpl entity) {
+          entity.fillFromPage(
+              pageBuffer.recordVersion(), pageBuffer.recordType(),
+              pageBuffer.pageFrame(), pageBuffer.stamp(),
+              pageBuffer.contentOffset(), pageBuffer.contentLength());
+          entity.checkClass(this);
+        } else {
+          // Non-EntityImpl (e.g., Blob): extract bytes, use standard path
+          var slice = pageBuffer.sliceContent();
+          var bytes = new byte[slice.remaining()];
+          slice.get(bytes);
+          record.fill(pageBuffer.recordVersion(), bytes, false);
+          record.fromStream(bytes);
+        }
+        localCache.updateRecord(record, this);
       } else {
         throw new AssertionError("Unknown StorageReadResult type: " + readResult.getClass());
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -1178,8 +1178,13 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
             YouTrackDBEnginesManager.instance()
                 .getRecordFactoryManager()
                 .newInstance(pageBuffer.recordType(), rid, this);
-        var rec = record;
-        rec.unsetDirty();
+        record.unsetDirty();
+
+        if (record.getRecordType() != pageBuffer.recordType()) {
+          throw new DatabaseException(getDatabaseName(),
+              "Record type is different from the one in the database");
+        }
+
         record.recordSerializer = serializer;
 
         if (record instanceof EntityImpl entity) {
@@ -1189,12 +1194,12 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
               pageBuffer.contentOffset(), pageBuffer.contentLength());
           entity.checkClass(this);
         } else {
-          // Non-EntityImpl (e.g., Blob): extract bytes, use standard path
-          var slice = pageBuffer.sliceContent();
-          var bytes = new byte[slice.remaining()];
-          slice.get(bytes);
-          record.fill(pageBuffer.recordVersion(), bytes, false);
-          record.fromStream(bytes);
+          // Non-EntityImpl (e.g., Blob): extract bytes from PageFrame.
+          // Validate stamp after byte extraction to ensure consistency —
+          // the page could be modified between scope validation and here.
+          var rawBuffer = pageBuffer.toRawBuffer();
+          record.fill(rawBuffer.version(), rawBuffer.buffer(), false);
+          record.fromStream(rawBuffer.buffer());
         }
         localCache.updateRecord(record, this);
       } else {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -1214,7 +1214,8 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
         }
         localCache.updateRecord(record, this);
       } else {
-        throw new AssertionError("Unknown StorageReadResult type: " + readResult.getClass());
+        throw new IllegalStateException(
+            "Unknown StorageReadResult type: " + readResult.getClass());
       }
 
       if (beforeReadOperations(record)) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -125,6 +125,8 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.LocalResultSet;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.LocalResultSetLifecycleDecorator;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLStatement;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.LinkCollectionsBTreeManager;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransaction;
@@ -1131,13 +1133,13 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
         throw new DatabaseException(getDatabaseName(), "Invalid record id " + rid);
       }
 
-      final RawBuffer recordBuffer;
+      final StorageReadResult readResult;
       if (prefetchedBuffer != null) {
-        recordBuffer = prefetchedBuffer;
+        readResult = prefetchedBuffer;
       } else {
         try {
           var tx = getActiveTransaction();
-          recordBuffer = storage.readRecord(rid, tx.getAtomicOperation());
+          readResult = storage.readRecord(rid, tx.getAtomicOperation());
         } catch (RecordNotFoundException e) {
           if (throwExceptionIfRecordNotFound) {
             throw e;
@@ -1147,27 +1149,35 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
         }
       }
 
-      record =
-          YouTrackDBEnginesManager.instance()
-              .getRecordFactoryManager()
-              .newInstance(recordBuffer.recordType(), rid, this);
-      final var rec = record;
-      rec.unsetDirty();
+      if (readResult instanceof RawBuffer recordBuffer) {
+        record =
+            YouTrackDBEnginesManager.instance()
+                .getRecordFactoryManager()
+                .newInstance(recordBuffer.recordType(), rid, this);
+        final var rec = record;
+        rec.unsetDirty();
 
-      if (record.getRecordType() != recordBuffer.recordType()) {
-        throw new DatabaseException(getDatabaseName(),
-            "Record type is different from the one in the database");
+        if (record.getRecordType() != recordBuffer.recordType()) {
+          throw new DatabaseException(getDatabaseName(),
+              "Record type is different from the one in the database");
+        }
+
+        record.recordSerializer = serializer;
+        record.fill(recordBuffer.version(), recordBuffer.buffer(), false);
+
+        if (record instanceof EntityImpl entity) {
+          entity.checkClass(this);
+        }
+
+        localCache.updateRecord(record, this);
+        record.fromStream(recordBuffer.buffer());
+      } else if (readResult instanceof RawPageBuffer) {
+        // Zero-copy PageFrame path — implemented in Track 4.
+        throw new UnsupportedOperationException(
+            "RawPageBuffer dispatch implemented in Track 4");
+      } else {
+        throw new AssertionError("Unknown StorageReadResult type: " + readResult.getClass());
       }
-
-      record.recordSerializer = serializer;
-      record.fill(recordBuffer.version(), recordBuffer.buffer(), false);
-
-      if (record instanceof EntityImpl entity) {
-        entity.checkClass(this);
-      }
-
-      localCache.updateRecord(record, this);
-      record.fromStream(recordBuffer.buffer());
 
       if (beforeReadOperations(record)) {
         return createRecordNotFoundResult(rid, throwExceptionIfRecordNotFound);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -127,6 +127,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLStatement;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.LinkCollectionsBTreeManager;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransaction;
@@ -1195,11 +1196,21 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
           entity.checkClass(this);
         } else {
           // Non-EntityImpl (e.g., Blob): extract bytes from PageFrame.
-          // Validate stamp after byte extraction to ensure consistency —
-          // the page could be modified between scope validation and here.
-          var rawBuffer = pageBuffer.toRawBuffer();
-          record.fill(rawBuffer.version(), rawBuffer.buffer(), false);
-          record.fromStream(rawBuffer.buffer());
+          // toRawBuffer() validates the stamp after byte extraction and throws
+          // OptimisticReadFailedException if the page was modified. Retry until
+          // we get a consistent byte[] copy.
+          var tx = getActiveTransaction();
+          var currentResult = (StorageReadResult) pageBuffer;
+          while (true) {
+            try {
+              var rawBuffer = currentResult.toRawBuffer();
+              record.fill(rawBuffer.version(), rawBuffer.buffer(), false);
+              record.fromStream(rawBuffer.buffer());
+              break;
+            } catch (OptimisticReadFailedException e) {
+              currentResult = storage.readRecord(rid, tx.getAtomicOperation());
+            }
+          }
         }
         localCache.updateRecord(record, this);
       } else {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/StringCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/StringCache.java
@@ -1,7 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.db;
 
 import com.jetbrains.youtrackdb.internal.common.collection.LRUCache;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 public class StringCache {
@@ -12,8 +11,7 @@ public class StringCache {
     values = new LRUCache<>(size);
   }
 
-  public String getString(final byte[] bytes, final int offset, final int len)
-      throws UnsupportedEncodingException {
+  public String getString(final byte[] bytes, final int offset, final int len) {
     var key = new StringCacheKey(bytes, offset, len);
     String value;
     synchronized (this) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseCompare.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseCompare.java
@@ -32,7 +32,6 @@ import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityHelper;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
-import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
@@ -719,10 +718,10 @@ public class DatabaseCompare extends DatabaseImpExpAbstract {
                 indexManagerRecordId2, storageType1, storageType2)) {
               continue;
             }
-            final var buffer1 = (RawBuffer) sessionOne.getStorage()
-                .readRecord(rid1, txOne.getAtomicOperation());
-            final var buffer2 = (RawBuffer) sessionTwo.getStorage()
-                .readRecord(rid2, txTwo.getAtomicOperation());
+            final var buffer1 = sessionOne.getStorage()
+                .readRecord(rid1, txOne.getAtomicOperation()).toRawBuffer();
+            final var buffer2 = sessionTwo.getStorage()
+                .readRecord(rid2, txTwo.getAtomicOperation()).toRawBuffer();
 
             if (buffer1.recordType() != buffer2.recordType()) {
               listener.onMessage(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseCompare.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/tool/DatabaseCompare.java
@@ -32,6 +32,7 @@ import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityHelper;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
+import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
@@ -718,9 +719,9 @@ public class DatabaseCompare extends DatabaseImpExpAbstract {
                 indexManagerRecordId2, storageType1, storageType2)) {
               continue;
             }
-            final var buffer1 = sessionOne.getStorage()
+            final var buffer1 = (RawBuffer) sessionOne.getStorage()
                 .readRecord(rid1, txOne.getAtomicOperation());
-            final var buffer2 = sessionTwo.getStorage()
+            final var buffer2 = (RawBuffer) sessionTwo.getStorage()
                 .readRecord(rid2, txTwo.getAtomicOperation());
 
             if (buffer1.recordType() != buffer2.recordType()) {
@@ -798,9 +799,11 @@ public class DatabaseCompare extends DatabaseImpExpAbstract {
                   } else {
                     if (buffer1.buffer().length != buffer2.buffer().length) {
                       // CHECK IF THE TRIMMED SIZE IS THE SAME
-                      @SuppressWarnings("ObjectAllocationInLoop") final var rec1 = new String(
+                      @SuppressWarnings("ObjectAllocationInLoop")
+                      final var rec1 = new String(
                           buffer1.buffer()).trim();
-                      @SuppressWarnings("ObjectAllocationInLoop") final var rec2 = new String(
+                      @SuppressWarnings("ObjectAllocationInLoop")
+                      final var rec2 = new String(
                           buffer2.buffer()).trim();
 
                       if (rec1.length() != rec2.length()) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordException.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordException.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+package com.jetbrains.youtrackdb.internal.core.exception;
+
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+
+/**
+ * Thrown when a stream-driven size value in a serialized record exceeds the remaining buffer
+ * capacity. This guards against OOM from corrupted or malicious size fields during deserialization.
+ */
+public class CorruptedRecordException extends DatabaseException {
+
+  public CorruptedRecordException(CorruptedRecordException exception) {
+    super(exception);
+  }
+
+  public CorruptedRecordException(String message) {
+    super(message);
+  }
+
+  public CorruptedRecordException(String dbName, String message) {
+    super(dbName, message);
+  }
+
+  public CorruptedRecordException(DatabaseSessionEmbedded session, String message) {
+    super(session, message);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3874,10 +3874,18 @@ public class EntityImpl extends RecordAbstract implements Entity {
    */
   public void fillFromPage(long version, byte recordType, PageFrame pageFrame,
       long stamp, int contentOffset, int contentLength) {
+    // recordType comes from the storage page header. EntityImpl subclasses
+    // (VertexEntityImpl, EdgeEntityImpl) have different RECORD_TYPE values
+    // ('v', 'e'), so we only assert it's a known entity-family type.
     assert recordType == RECORD_TYPE
+        || recordType == VertexEntityImpl.RECORD_TYPE
+        || recordType == EdgeEntityImpl.RECORD_TYPE
         : "Unexpected record type for EntityImpl: " + recordType;
 
-    checkForBinding();
+    // Use getSession() for the session-active assertion, matching fill()'s
+    // pattern. Do NOT call checkForBinding() — it rejects NOT_LOADED status
+    // which is the normal state for freshly factory-created records.
+    var session = getSession();
 
     if (pageFrame == null) {
       throw new IllegalArgumentException("PageFrame must not be null");
@@ -3891,7 +3899,6 @@ public class EntityImpl extends RecordAbstract implements Entity {
           "contentLength must be non-negative: " + contentLength);
     }
 
-    var session = getSession();
     if (dirty > 0) {
       throw new DatabaseException(session.getDatabaseName(),
           "Cannot call fillFromPage() on dirty records");

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -89,6 +89,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import com.jetbrains.youtrackdb.internal.core.util.DateHelper;
 import java.lang.ref.WeakReference;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -763,7 +764,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
     }
 
     try {
-      var fieldNameBytes = name.getBytes();
+      var fieldNameBytes = name.getBytes(StandardCharsets.UTF_8);
       var field = deserializeFieldForComparisonFromPageFrame(
           name, value, localPageFrame, localOffset, localLength, fieldNameBytes);
       if (field == null) {
@@ -804,7 +805,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
     }
 
     try {
-      var fieldNameBytes = name.getBytes();
+      var fieldNameBytes = name.getBytes(StandardCharsets.UTF_8);
       var field = deserializeFieldForComparisonFromPageFrame(
           name, value, localPageFrame, localOffset, localLength, fieldNameBytes);
       if (field == null) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3598,9 +3598,15 @@ public class EntityImpl extends RecordAbstract implements Entity {
    * the entity's byte[] source. Called as the fallback when PageFrame stamp
    * validation fails or speculative deserialization throws.
    *
-   * <p>Note: currently the storage optimistic path may return RawPageBuffer
-   * (after Step 4 wires it up). In the fallback context, we extract bytes
-   * from RawPageBuffer to ensure a byte[]-backed re-read.
+   * <p>The storage read may return either {@link RawBuffer} (byte[]-backed) or
+   * {@link RawPageBuffer} (PageFrame reference). In either case, bytes are
+   * extracted into the entity's {@code source} field to ensure subsequent
+   * deserialization uses the byte[] path (no further PageFrame dependency).
+   *
+   * @throws RecordNotFoundException if the record was deleted between the
+   *     original optimistic read and this fallback re-read. This is expected
+   *     behavior — the caller should let the exception propagate, as the
+   *     record genuinely no longer exists.
    */
   private void reReadFromStorage() {
     var storage = session.getStorage();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -82,6 +82,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.SQLHelper;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.BTreeBasedLinkBag;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import com.jetbrains.youtrackdb.internal.core.util.DateHelper;
@@ -3470,9 +3471,10 @@ public class EntityImpl extends RecordAbstract implements Entity {
       return false;
     }
 
-    // Full unmarshalling — release the byte[] source
+    // Full unmarshalling — release the byte[] source and PageFrame reference
     if ((propertyNames == null || propertyNames.length == 0) && source != null) {
       source = null;
+      clearPageFrame();
     }
 
     return true;
@@ -3592,23 +3594,23 @@ public class EntityImpl extends RecordAbstract implements Entity {
   private void reReadFromStorage() {
     var storage = session.getStorage();
     var atomicOp = session.getActiveTransaction().getAtomicOperation();
-    var readResult = storage.readRecord(getIdentity(), atomicOp);
 
-    if (readResult instanceof RawBuffer rawBuffer) {
-      fill(rawBuffer.version(), rawBuffer.buffer(), false);
-      fromStream(rawBuffer.buffer());
-    } else if (readResult instanceof RawPageBuffer pageBuffer) {
-      // Storage returned a PageFrame reference — extract bytes for the
-      // fallback path. This avoids infinite recursion through fillFromPage.
-      var slice = pageBuffer.sliceContent();
-      var bytes = new byte[slice.remaining()];
-      slice.get(bytes);
-      fill(pageBuffer.recordVersion(), bytes, false);
-      fromStream(bytes);
-    } else {
-      throw new DatabaseException(session.getDatabaseName(),
-          "Unexpected StorageReadResult type for " + getIdentity()
-              + ": " + readResult.getClass().getSimpleName());
+    // Retry loop: storage.readRecord() may return a RawPageBuffer whose stamp
+    // becomes invalid between the optimistic scope close and byte extraction.
+    // toRawBuffer() validates the stamp and throws OptimisticReadFailedException
+    // on mismatch, so we retry until we get a consistent byte[] copy.
+    while (true) {
+      var readResult = storage.readRecord(getIdentity(), atomicOp);
+      try {
+        var rawBuffer = readResult.toRawBuffer();
+        fill(rawBuffer.version(), rawBuffer.buffer(), false);
+        fromStream(rawBuffer.buffer());
+        return;
+      } catch (OptimisticReadFailedException e) {
+        // Stamp was invalidated between readRecord returning and byte extraction.
+        // Retry the full read — the next attempt may return RawBuffer (pinned path)
+        // or another RawPageBuffer with a fresh stamp.
+      }
     }
   }
 
@@ -3919,7 +3921,20 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
     this.recordVersion = version;
     this.size = contentLength;
-    this.source = null;
+
+    // Eagerly extract bytes into source as a fallback. This ensures that
+    // deserializeProperties can use the byte[]-backed path if the PageFrame
+    // stamp becomes invalid, without needing reReadFromStorage() which adds
+    // latency and changes concurrency dynamics under high contention.
+    if (contentLength > 0) {
+      var buf = pageFrame.getBuffer();
+      var bytes = new byte[contentLength];
+      buf.get(contentOffset, bytes);
+      this.source = bytes;
+    } else {
+      this.source = null;
+    }
+
     this.status = STATUS.LOADED;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -21,6 +21,7 @@ package com.jetbrains.youtrackdb.internal.core.record.impl;
 
 import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.common.collection.MultiValue;
+import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.log.LogManager;
 import com.jetbrains.youtrackdb.internal.core.collate.DefaultCollate;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
@@ -137,6 +138,12 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
   private boolean propertyConversionInProgress = false;
 
+  // Zero-copy PageFrame fields (set by fillFromPage, cleared by clearPageFrame)
+  @Nullable private PageFrame pageFrame;
+  private long pageStamp;
+  private int pageContentOffset;
+  private int pageContentLength;
+
   /**
    * Internal constructor used on unmarshalling.
    */
@@ -207,6 +214,11 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
   @Override
   public boolean sourceIsParsedByProperties() {
+    // A PageFrame-loaded record has source == null but is NOT yet parsed —
+    // it needs deserialization at property-access time.
+    if (pageFrame != null) {
+      return false;
+    }
     return super.sourceIsParsedByProperties() || (properties != null && !properties.isEmpty());
   }
 
@@ -2347,6 +2359,12 @@ public class EntityImpl extends RecordAbstract implements Entity {
   public byte[] toStream() {
     checkForBinding();
 
+    // If loaded from PageFrame but not yet deserialized, trigger deserialization
+    // so the serializer can produce bytes from the parsed properties.
+    if (source == null && pageFrame != null) {
+      checkForProperties();
+    }
+
     var prev = status;
     status = STATUS.MARSHALLING;
     try {
@@ -3155,6 +3173,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
     status = STATUS.UNMARSHALLING;
     try {
+      clearPageFrame();
       removeAllCollectionChangeListeners();
 
       properties = null;
@@ -3372,7 +3391,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
     }
 
     List<String> additional = null;
-    if (source == null)
+    if (source == null && pageFrame == null)
     // ALREADY UNMARSHALLED OR JUST EMPTY
     {
       return true;
@@ -3677,13 +3696,87 @@ public class EntityImpl extends RecordAbstract implements Entity {
           "Cannot call fill() on dirty records");
     }
 
+    clearPageFrame();
     schema = null;
     fetchSchema();
     return super.fill(version, buffer, dirty);
   }
 
+  /**
+   * Fills this entity from a PageFrame reference for zero-copy deserialization.
+   * The PageFrame is kept for lazy deserialization at property-access time.
+   * The stamp is validated after speculative deserialization; if invalid, the entity
+   * falls back to a byte[] re-read from storage.
+   *
+   * @param version      the record version
+   * @param recordType   the record type byte (unused here, but matches fill() signature pattern)
+   * @param pageFrame    the PageFrame containing the record data
+   * @param stamp        the optimistic read stamp from the PageFrame's StampedLock
+   * @param contentOffset the byte offset within the PageFrame buffer where record content starts
+   * @param contentLength the byte length of the record content
+   */
+  public void fillFromPage(long version, byte recordType, PageFrame pageFrame,
+      long stamp, int contentOffset, int contentLength) {
+    assert pageFrame != null : "PageFrame must not be null";
+    assert contentOffset >= 0 : "contentOffset must be non-negative: " + contentOffset;
+    assert contentLength >= 0 : "contentLength must be non-negative: " + contentLength;
+
+    var session = getSession();
+    if (dirty > 0) {
+      throw new DatabaseException(session.getDatabaseName(),
+          "Cannot call fillFromPage() on dirty records");
+    }
+
+    removeAllCollectionChangeListeners();
+    properties = null;
+    propertiesCount = 0;
+    contentChanged = false;
+    schema = null;
+
+    fetchSchema();
+
+    this.pageFrame = pageFrame;
+    this.pageStamp = stamp;
+    this.pageContentOffset = contentOffset;
+    this.pageContentLength = contentLength;
+
+    this.recordVersion = version;
+    this.size = contentLength;
+    this.source = null;
+    this.status = STATUS.LOADED;
+  }
+
+  /**
+   * Clears the PageFrame reference and associated fields, releasing the reference
+   * for GC. Called from lifecycle methods that invalidate the record's data source
+   * (internalReset, fromStream, fill, clearSource).
+   */
+  public void clearPageFrame() {
+    pageFrame = null;
+    pageStamp = 0;
+    pageContentOffset = 0;
+    pageContentLength = 0;
+  }
+
+  @Nullable public PageFrame getPageFrame() {
+    return pageFrame;
+  }
+
+  public long getPageStamp() {
+    return pageStamp;
+  }
+
+  public int getPageContentOffset() {
+    return pageContentOffset;
+  }
+
+  public int getPageContentLength() {
+    return pageContentLength;
+  }
+
   @Override
   public void clearSource() {
+    clearPageFrame();
     super.clearSource();
     schema = null;
   }
@@ -3913,6 +4006,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
   @Override
   protected void internalReset() {
+    clearPageFrame();
     removeAllCollectionChangeListeners();
     if (properties != null) {
       properties.clear();
@@ -3928,7 +4022,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
         this.properties = new HashMap<>();
       }
 
-      if (source != null) {
+      if (source != null || pageFrame != null) {
         return deserializeProperties(properties);
       }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -46,7 +46,6 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Vertex;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
-import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
 import com.jetbrains.youtrackdb.internal.core.exception.SecurityException;
@@ -90,7 +89,6 @@ import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import com.jetbrains.youtrackdb.internal.core.util.DateHelper;
 import java.lang.ref.WeakReference;
 import java.math.BigDecimal;
-import java.nio.BufferUnderflowException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -150,6 +148,10 @@ public class EntityImpl extends RecordAbstract implements Entity {
   private long pageStamp;
   private int pageContentOffset;
   private int pageContentLength;
+
+  // Reusable container for in-place comparison — avoids allocating a new
+  // ReadBytesContainer + ByteBuffer.slice() on every compareFromPageFrame call.
+  private final ReadBytesContainer comparisonRbc = new ReadBytesContainer();
 
   /**
    * Internal constructor used on unmarshalling.
@@ -704,33 +706,35 @@ public class EntityImpl extends RecordAbstract implements Entity {
    * or the field uses a non-default collation.
    *
    * <p>Does not validate the PageFrame stamp — callers must validate after using the result.
+   *
+   * @param localPageFrame the already-captured PageFrame reference from the caller
+   * @param localOffset    the already-captured content offset from the caller
+   * @param localLength    the already-captured content length from the caller
+   * @param fieldNameBytes pre-computed UTF-8 bytes of the field name (avoids per-call allocation)
    */
   @Nullable private ReadBinaryField deserializeFieldForComparisonFromPageFrame(
-      String name, Object value) {
+      String name, Object value,
+      PageFrame localPageFrame, int localOffset, int localLength,
+      byte[] fieldNameBytes) {
     if (value == null) {
       return null;
     }
     if (propertyEncryption != null && propertyEncryption.isEncrypted(name)) {
       return null;
     }
-
-    var localPageFrame = this.pageFrame;
-    var localOffset = this.pageContentOffset;
-    var localLength = this.pageContentLength;
-    if (localPageFrame == null || localLength <= 0) {
+    if (localLength <= 0) {
       return null;
     }
 
     var buf = localPageFrame.getBuffer();
     var serializerVersion = buf.get(localOffset);
     var serializer = RecordSerializerBinary.INSTANCE.getSerializer(serializerVersion);
-    var rbc = new ReadBytesContainer(
-        buf.slice(localOffset + 1, localLength - 1));
+    comparisonRbc.reset(buf, localOffset + 1, localLength - 1);
 
     var immutableSchema = session.getMetadata().getImmutableSchemaSnapshot();
     var schemaClass = getImmutableSchemaClass(session, immutableSchema);
     var field = serializer.deserializeField(
-        session, rbc, schemaClass, name, isEmbedded(),
+        session, comparisonRbc, schemaClass, name, fieldNameBytes, isEmbedded(),
         immutableSchema, propertyEncryption);
 
     if (field == null) {
@@ -745,17 +749,23 @@ public class EntityImpl extends RecordAbstract implements Entity {
   /**
    * Compare against the PageFrame's serialized bytes using InPlaceComparator (equality check).
    * Validates the PageFrame stamp after comparison to detect torn reads from concurrent
-   * page modification. Falls back on CorruptedRecordException or BufferUnderflowException.
+   * page modification. Falls back on any RuntimeException because torn reads can
+   * manifest as various exception types (BufferUnderflowException, IllegalArgumentException
+   * from VarInt decoding, NullPointerException from invalid type/property IDs, etc.).
    */
   private InPlaceResult compareFromPageFrame(String name, Object value) {
     var localPageFrame = this.pageFrame;
     var localStamp = this.pageStamp;
+    var localOffset = this.pageContentOffset;
+    var localLength = this.pageContentLength;
     if (localPageFrame == null) {
       return InPlaceResult.FALLBACK;
     }
 
     try {
-      var field = deserializeFieldForComparisonFromPageFrame(name, value);
+      var fieldNameBytes = name.getBytes();
+      var field = deserializeFieldForComparisonFromPageFrame(
+          name, value, localPageFrame, localOffset, localLength, fieldNameBytes);
       if (field == null) {
         return InPlaceResult.FALLBACK;
       }
@@ -771,7 +781,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
         return InPlaceResult.FALLBACK;
       }
       return result.getAsInt() == 1 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
-    } catch (CorruptedRecordException | BufferUnderflowException e) {
+    } catch (RuntimeException e) {
       // Torn read from concurrent page modification — fall back
       return InPlaceResult.FALLBACK;
     }
@@ -780,17 +790,23 @@ public class EntityImpl extends RecordAbstract implements Entity {
   /**
    * Compare against the PageFrame's serialized bytes using InPlaceComparator (ordering).
    * Validates the PageFrame stamp after comparison to detect torn reads from concurrent
-   * page modification. Falls back on CorruptedRecordException or BufferUnderflowException.
+   * page modification. Falls back on any RuntimeException because torn reads can
+   * manifest as various exception types (BufferUnderflowException, IllegalArgumentException
+   * from VarInt decoding, NullPointerException from invalid type/property IDs, etc.).
    */
   private OptionalInt compareFromPageFrameOrdering(String name, Object value) {
     var localPageFrame = this.pageFrame;
     var localStamp = this.pageStamp;
+    var localOffset = this.pageContentOffset;
+    var localLength = this.pageContentLength;
     if (localPageFrame == null) {
       return OptionalInt.empty();
     }
 
     try {
-      var field = deserializeFieldForComparisonFromPageFrame(name, value);
+      var fieldNameBytes = name.getBytes();
+      var field = deserializeFieldForComparisonFromPageFrame(
+          name, value, localPageFrame, localOffset, localLength, fieldNameBytes);
       if (field == null) {
         return OptionalInt.empty();
       }
@@ -803,7 +819,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
       }
 
       return result;
-    } catch (CorruptedRecordException | BufferUnderflowException e) {
+    } catch (RuntimeException e) {
       // Torn read from concurrent page modification — fall back
       return OptionalInt.empty();
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3134,6 +3134,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
     if (status != STATUS.UNMARSHALLING) {
       source = null;
+      clearPageFrame();
     }
 
     if (owner != null) {
@@ -3159,6 +3160,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
     // THIS IS IMPORTANT TO BE SURE THAT FIELDS ARE LOADED BEFORE IT'S TOO LATE AND THE RECORD
     // _SOURCE IS NULL
     checkForProperties();
+    clearPageFrame();
 
     super.setDirtyNoChanged();
   }
@@ -3717,9 +3719,22 @@ public class EntityImpl extends RecordAbstract implements Entity {
    */
   public void fillFromPage(long version, byte recordType, PageFrame pageFrame,
       long stamp, int contentOffset, int contentLength) {
-    assert pageFrame != null : "PageFrame must not be null";
-    assert contentOffset >= 0 : "contentOffset must be non-negative: " + contentOffset;
-    assert contentLength >= 0 : "contentLength must be non-negative: " + contentLength;
+    assert recordType == RECORD_TYPE
+        : "Unexpected record type for EntityImpl: " + recordType;
+
+    checkForBinding();
+
+    if (pageFrame == null) {
+      throw new IllegalArgumentException("PageFrame must not be null");
+    }
+    if (contentOffset < 0) {
+      throw new IllegalArgumentException(
+          "contentOffset must be non-negative: " + contentOffset);
+    }
+    if (contentLength < 0) {
+      throw new IllegalArgumentException(
+          "contentLength must be non-negative: " + contentLength);
+    }
 
     var session = getSession();
     if (dirty > 0) {
@@ -3727,6 +3742,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
           "Cannot call fillFromPage() on dirty records");
     }
 
+    clearPageFrame();
     removeAllCollectionChangeListeners();
     properties = null;
     propertiesCount = 0;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -76,9 +76,11 @@ import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.BinaryField;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.BytesContainer;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.InPlaceComparator;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.ReadBytesContainer;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.RecordSerializerBinary;
 import com.jetbrains.youtrackdb.internal.core.sql.SQLHelper;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
+import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.BTreeBasedLinkBag;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import com.jetbrains.youtrackdb.internal.core.util.DateHelper;
@@ -3450,6 +3452,11 @@ public class EntityImpl extends RecordAbstract implements Entity {
       }
     }
 
+    if (pageFrame != null && source == null) {
+      // PageFrame zero-copy path: speculative deserialization with stamp validation
+      return deserializeFromPageFrame(propertyNames);
+    }
+
     status = RecordElement.STATUS.UNMARSHALLING;
     try {
       checkForProperties();
@@ -3484,6 +3491,146 @@ public class EntityImpl extends RecordAbstract implements Entity {
       {
         source = null;
       }
+    }
+
+    return true;
+  }
+
+  /**
+   * Speculatively deserializes this entity from the held PageFrame reference.
+   * After deserialization, validates the PageFrame stamp. If the stamp is invalid
+   * (page was modified concurrently) or deserialization throws (torn page), restores
+   * the properties snapshot and falls back to a byte[] re-read from storage.
+   *
+   * @param propertyNames null/empty for full deserialization, or specific property names
+   *     for partial deserialization
+   * @return true if properties were successfully deserialized, false otherwise
+   */
+  private boolean deserializeFromPageFrame(String[] propertyNames) {
+    assert pageFrame != null && source == null
+        : "deserializeFromPageFrame called without active PageFrame";
+
+    boolean isPartial = propertyNames != null && propertyNames.length > 0;
+
+    // Capture PageFrame references locally. The serializer's deserialize()
+    // calls clearSource() on full deserialization, which triggers
+    // clearPageFrame(). We need the frame and stamp for post-deserialization
+    // validation even after the entity's fields are cleared.
+    var localFrame = pageFrame;
+    var localStamp = pageStamp;
+
+    // Snapshot properties for rollback on stamp invalidation or torn page.
+    // For full deserialization the map is typically empty; for partial it may
+    // contain results from prior partial calls.
+    var propertiesSnapshot = (properties != null && !properties.isEmpty())
+        ? new HashMap<>(properties) : null;
+    var propertiesCountSnapshot = propertiesCount;
+
+    boolean speculativeSuccess = false;
+    try {
+      // Read serializer version byte from absolute position in the PageFrame buffer
+      byte serializerVersion =
+          localFrame.getBuffer().get(pageContentOffset);
+
+      // Create ReadBytesContainer from a slice starting after the version byte
+      var container = new ReadBytesContainer(
+          localFrame.getBuffer()
+              .slice(pageContentOffset + 1, pageContentLength - 1));
+
+      status = RecordElement.STATUS.UNMARSHALLING;
+      try {
+        checkForProperties();
+        recordSerializer.fromStream(
+            session, serializerVersion, container, this, propertyNames);
+      } finally {
+        status = RecordElement.STATUS.LOADED;
+      }
+
+      speculativeSuccess = true;
+    } catch (RuntimeException e) {
+      // Treat any exception during speculative deserialization as a torn page
+      // (equivalent to stamp invalidation). Restore snapshot and fall through
+      // to re-read.
+    }
+
+    if (speculativeSuccess) {
+      // Validate stamp AFTER deserialization — optimistic read pattern.
+      // Use localFrame/localStamp since the entity's fields may have been
+      // cleared by the serializer's clearSource() call during deserialization.
+      if (localFrame.validate(localStamp)) {
+        // Stamp valid: speculative results are correct.
+        // clearPageFrame() may already have been called by the serializer
+        // (via clearSource) for the full deserialization path.
+        if (isPartial && pageFrame != null) {
+          // Partial path: serializer doesn't call clearSource, PageFrame
+          // is still set — keep it for subsequent partial calls.
+        } else {
+          // Full path or already cleared: ensure clean state
+          clearPageFrame();
+        }
+        return evaluateDeserializationResult(propertyNames);
+      }
+
+      // Stamp invalid: page was modified during deserialization — fall through to re-read
+    }
+
+    // Restore properties snapshot before re-read
+    if (propertiesSnapshot != null) {
+      properties = propertiesSnapshot;
+    } else if (properties != null) {
+      properties.clear();
+    }
+    propertiesCount = propertiesCountSnapshot;
+    clearPageFrame();
+
+    // Re-read from storage via the pinned path (always returns RawBuffer)
+    reReadFromStorage();
+
+    // Re-enter deserialization using the byte[] path (source is now set)
+    return deserializeProperties(propertyNames);
+  }
+
+  /**
+   * Re-reads this record from storage using the pinned read path and populates
+   * the entity's byte[] source. Called as the fallback when PageFrame stamp
+   * validation fails or speculative deserialization throws.
+   */
+  private void reReadFromStorage() {
+    var storage = session.getStorage();
+    var atomicOp = session.getActiveTransaction().getAtomicOperation();
+    var readResult = storage.readRecord(getIdentity(), atomicOp);
+
+    if (readResult instanceof RawBuffer rawBuffer) {
+      fill(rawBuffer.version(), rawBuffer.buffer(), false);
+      fromStream(rawBuffer.buffer());
+    } else {
+      throw new DatabaseException(session.getDatabaseName(),
+          "Expected RawBuffer from pinned re-read for " + getIdentity()
+              + " but got " + readResult.getClass().getSimpleName());
+    }
+  }
+
+  /**
+   * Evaluates the result of deserialization for the requested property names.
+   * Shared between the PageFrame and byte[] paths after successful deserialization.
+   */
+  private boolean evaluateDeserializationResult(String[] propertyNames) {
+    if (propertyNames != null && propertyNames.length > 0) {
+      for (var property : propertyNames) {
+        if (property != null && !property.isEmpty() && property.charAt(0) == '@') {
+          return true;
+        }
+      }
+
+      if (properties != null && !properties.isEmpty()) {
+        for (var f : propertyNames) {
+          if (f != null && properties.containsKey(f)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
     }
 
     return true;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3966,6 +3966,20 @@ public class EntityImpl extends RecordAbstract implements Entity {
     return pageContentLength;
   }
 
+  /**
+   * Clears the byte[] source while retaining the PageFrame reference, forcing
+   * subsequent deserialization to use the speculative PageFrame zero-copy path
+   * ({@link #deserializeFromPageFrame}). This simulates a lazy-extraction
+   * scenario where fillFromPage defers byte extraction until property access.
+   *
+   * <p>Package-private: intended for tests that verify the PageFrame
+   * deserialization + stamp validation + fallback re-read paths.
+   */
+  void clearSourceKeepPageFrame() {
+    assert pageFrame != null : "clearSourceKeepPageFrame called without PageFrame";
+    this.source = null;
+  }
+
   @Override
   public void clearSource() {
     clearPageFrame();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3466,32 +3466,13 @@ public class EntityImpl extends RecordAbstract implements Entity {
       status = RecordElement.STATUS.LOADED;
     }
 
-    if (propertyNames != null && propertyNames.length > 0) {
-      for (var property : propertyNames) {
-        if (property != null && !property.isEmpty() && property.charAt(0) == '@')
-        // ATTRIBUTE
-        {
-          return true;
-        }
-      }
-
-      // PARTIAL UNMARSHALLING
-      if (properties != null && !properties.isEmpty()) {
-        for (var f : propertyNames) {
-          if (f != null && properties.containsKey(f)) {
-            return true;
-          }
-        }
-      }
-
-      // NO FIELDS FOUND
+    if (!checkDeserializedProperties(propertyNames)) {
       return false;
-    } else {
-      if (source != null)
-      // FULL UNMARSHALLING
-      {
-        source = null;
-      }
+    }
+
+    // Full unmarshalling — release the byte[] source
+    if ((propertyNames == null || propertyNames.length == 0) && source != null) {
+      source = null;
     }
 
     return true;
@@ -3637,13 +3618,26 @@ public class EntityImpl extends RecordAbstract implements Entity {
    * deserialization.
    */
   private boolean evaluateDeserializationResult(String[] propertyNames) {
+    return checkDeserializedProperties(propertyNames);
+  }
+
+  /**
+   * Checks whether the requested properties were found after deserialization.
+   * Returns {@code true} if no specific properties were requested (full
+   * unmarshalling) or if at least one requested property/attribute was found.
+   * Returns {@code false} if specific properties were requested but none
+   * were found in the deserialized state.
+   */
+  private boolean checkDeserializedProperties(String[] propertyNames) {
     if (propertyNames != null && propertyNames.length > 0) {
+      // Check for attribute requests (prefixed with '@')
       for (var property : propertyNames) {
         if (property != null && !property.isEmpty() && property.charAt(0) == '@') {
           return true;
         }
       }
 
+      // Partial unmarshalling — check if any requested property was found
       if (properties != null && !properties.isEmpty()) {
         for (var f : propertyNames) {
           if (f != null && properties.containsKey(f)) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3551,7 +3551,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
         if (!isPartial || pageFrame == null) {
           clearPageFrame();
         }
-        return evaluateDeserializationResult(propertyNames);
+        return checkDeserializedProperties(propertyNames);
       }
 
       // Stamp invalid: page was modified during deserialization — fall through to re-read
@@ -3610,15 +3610,6 @@ public class EntityImpl extends RecordAbstract implements Entity {
           "Unexpected StorageReadResult type for " + getIdentity()
               + ": " + readResult.getClass().getSimpleName());
     }
-  }
-
-  /**
-   * Evaluates the result of deserialization for the requested property names.
-   * Used by the PageFrame deserialization path after successful speculative
-   * deserialization.
-   */
-  private boolean evaluateDeserializationResult(String[] propertyNames) {
-    return checkDeserializedProperties(propertyNames);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -46,6 +46,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Vertex;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
 import com.jetbrains.youtrackdb.internal.core.exception.SecurityException;
@@ -76,6 +77,7 @@ import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.BinaryField;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.BytesContainer;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.InPlaceComparator;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.ReadBinaryField;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.ReadBytesContainer;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.RecordSerializerBinary;
 import com.jetbrains.youtrackdb.internal.core.sql.SQLHelper;
@@ -88,6 +90,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import com.jetbrains.youtrackdb.internal.core.util.DateHelper;
 import java.lang.ref.WeakReference;
 import java.math.BigDecimal;
+import java.nio.BufferUnderflowException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -527,6 +530,11 @@ public class EntityImpl extends RecordAbstract implements Entity {
       return compareFromSource(name, value);
     }
 
+    // Fall back to PageFrame zero-copy comparison
+    if (pageFrame != null) {
+      return compareFromPageFrame(name, value);
+    }
+
     return InPlaceResult.FALLBACK;
   }
 
@@ -555,6 +563,11 @@ public class EntityImpl extends RecordAbstract implements Entity {
     // Fall back to serialized comparison via source bytes
     if (source != null) {
       return compareFromSourceOrdering(name, value);
+    }
+
+    // Fall back to PageFrame zero-copy comparison
+    if (pageFrame != null) {
+      return compareFromPageFrameOrdering(name, value);
     }
 
     return OptionalInt.empty();
@@ -683,6 +696,117 @@ public class EntityImpl extends RecordAbstract implements Entity {
       return null;
     }
     return field;
+  }
+
+  /**
+   * Locates a field in the PageFrame's serialized record and returns a {@link ReadBinaryField}
+   * for in-place comparison. Returns null if the field is not found, the record is encrypted,
+   * or the field uses a non-default collation.
+   *
+   * <p>Does not validate the PageFrame stamp — callers must validate after using the result.
+   */
+  @Nullable private ReadBinaryField deserializeFieldForComparisonFromPageFrame(
+      String name, Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (propertyEncryption != null && propertyEncryption.isEncrypted(name)) {
+      return null;
+    }
+
+    var localPageFrame = this.pageFrame;
+    var localOffset = this.pageContentOffset;
+    var localLength = this.pageContentLength;
+    if (localPageFrame == null || localLength <= 0) {
+      return null;
+    }
+
+    var buf = localPageFrame.getBuffer();
+    var serializerVersion = buf.get(localOffset);
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(serializerVersion);
+    var rbc = new ReadBytesContainer(
+        buf.slice(localOffset + 1, localLength - 1));
+
+    var immutableSchema = session.getMetadata().getImmutableSchemaSnapshot();
+    var schemaClass = getImmutableSchemaClass(session, immutableSchema);
+    var field = serializer.deserializeField(
+        session, rbc, schemaClass, name, isEmbedded(),
+        immutableSchema, propertyEncryption);
+
+    if (field == null) {
+      return null;
+    }
+    if (field.collate() != null && !(field.collate() instanceof DefaultCollate)) {
+      return null;
+    }
+    return field;
+  }
+
+  /**
+   * Compare against the PageFrame's serialized bytes using InPlaceComparator (equality check).
+   * Validates the PageFrame stamp after comparison to detect torn reads from concurrent
+   * page modification. Falls back on CorruptedRecordException or BufferUnderflowException.
+   */
+  private InPlaceResult compareFromPageFrame(String name, Object value) {
+    var localPageFrame = this.pageFrame;
+    var localStamp = this.pageStamp;
+    if (localPageFrame == null) {
+      return InPlaceResult.FALLBACK;
+    }
+
+    try {
+      var field = deserializeFieldForComparisonFromPageFrame(name, value);
+      if (field == null) {
+        return InPlaceResult.FALLBACK;
+      }
+      var dbTimeZone = DateHelper.getDatabaseTimeZone(session);
+      var result = InPlaceComparator.isEqual(field, value, dbTimeZone);
+
+      // Validate stamp after reading — detect torn reads
+      if (!localPageFrame.validate(localStamp)) {
+        return InPlaceResult.FALLBACK;
+      }
+
+      if (result.isEmpty()) {
+        return InPlaceResult.FALLBACK;
+      }
+      return result.getAsInt() == 1 ? InPlaceResult.TRUE : InPlaceResult.FALSE;
+    } catch (CorruptedRecordException | BufferUnderflowException e) {
+      // Torn read from concurrent page modification — fall back
+      return InPlaceResult.FALLBACK;
+    }
+  }
+
+  /**
+   * Compare against the PageFrame's serialized bytes using InPlaceComparator (ordering).
+   * Validates the PageFrame stamp after comparison to detect torn reads from concurrent
+   * page modification. Falls back on CorruptedRecordException or BufferUnderflowException.
+   */
+  private OptionalInt compareFromPageFrameOrdering(String name, Object value) {
+    var localPageFrame = this.pageFrame;
+    var localStamp = this.pageStamp;
+    if (localPageFrame == null) {
+      return OptionalInt.empty();
+    }
+
+    try {
+      var field = deserializeFieldForComparisonFromPageFrame(name, value);
+      if (field == null) {
+        return OptionalInt.empty();
+      }
+      var dbTimeZone = DateHelper.getDatabaseTimeZone(session);
+      var result = InPlaceComparator.compare(field, value, dbTimeZone);
+
+      // Validate stamp after reading — detect torn reads
+      if (!localPageFrame.validate(localStamp)) {
+        return OptionalInt.empty();
+      }
+
+      return result;
+    } catch (CorruptedRecordException | BufferUnderflowException e) {
+      // Torn read from concurrent page modification — fall back
+      return OptionalInt.empty();
+    }
   }
 
   /**
@@ -3922,18 +4046,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
     this.recordVersion = version;
     this.size = contentLength;
 
-    // Eagerly extract bytes into source as a fallback. This ensures that
-    // deserializeProperties can use the byte[]-backed path if the PageFrame
-    // stamp becomes invalid, without needing reReadFromStorage() which adds
-    // latency and changes concurrency dynamics under high contention.
-    if (contentLength > 0) {
-      var buf = pageFrame.getBuffer();
-      var bytes = new byte[contentLength];
-      buf.get(contentOffset, bytes);
-      this.source = bytes;
-    } else {
-      this.source = null;
-    }
+    this.source = null;
 
     this.status = STATUS.LOADED;
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -3552,7 +3552,10 @@ public class EntityImpl extends RecordAbstract implements Entity {
       speculativeSuccess = true;
     } catch (RuntimeException e) {
       // Treat any exception during speculative deserialization as a torn page
-      // (equivalent to stamp invalidation). Fall through to re-read.
+      // (equivalent to stamp invalidation). Fall through to re-read from storage.
+      // If the data is genuinely corrupt, the byte[]-backed re-read will also
+      // throw and propagate the error. This catch only suppresses transient
+      // exceptions caused by reading from a concurrently modified page.
     }
 
     if (speculativeSuccess) {
@@ -3580,6 +3583,11 @@ public class EntityImpl extends RecordAbstract implements Entity {
 
     // Re-read from storage via the pinned path
     reReadFromStorage();
+
+    assert source != null
+        : "reReadFromStorage must populate byte[] source for fallback deserialization";
+    assert pageFrame == null
+        : "pageFrame must be cleared before fallback deserialization";
 
     // Re-enter deserialization using the byte[] path (source is now set)
     return deserializeProperties(propertyNames);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl.java
@@ -81,6 +81,7 @@ import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.bi
 import com.jetbrains.youtrackdb.internal.core.sql.SQLHelper;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.BTreeBasedLinkBag;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.RidPair;
 import com.jetbrains.youtrackdb.internal.core.util.DateHelper;
@@ -3510,32 +3511,34 @@ public class EntityImpl extends RecordAbstract implements Entity {
     assert pageFrame != null && source == null
         : "deserializeFromPageFrame called without active PageFrame";
 
+    // Empty content: no data to deserialize. Clear PageFrame and return.
+    if (pageContentLength <= 0) {
+      clearPageFrame();
+      return true;
+    }
+
     boolean isPartial = propertyNames != null && propertyNames.length > 0;
 
-    // Capture PageFrame references locally. The serializer's deserialize()
+    // Capture all PageFrame references locally. The serializer's deserialize()
     // calls clearSource() on full deserialization, which triggers
-    // clearPageFrame(). We need the frame and stamp for post-deserialization
-    // validation even after the entity's fields are cleared.
+    // clearPageFrame(). We need frame, stamp, offset, and length for
+    // post-deserialization validation even after the entity's fields are cleared.
     var localFrame = pageFrame;
     var localStamp = pageStamp;
-
-    // Snapshot properties for rollback on stamp invalidation or torn page.
-    // For full deserialization the map is typically empty; for partial it may
-    // contain results from prior partial calls.
-    var propertiesSnapshot = (properties != null && !properties.isEmpty())
-        ? new HashMap<>(properties) : null;
-    var propertiesCountSnapshot = propertiesCount;
+    var localOffset = pageContentOffset;
+    var localLength = pageContentLength;
 
     boolean speculativeSuccess = false;
     try {
-      // Read serializer version byte from absolute position in the PageFrame buffer
-      byte serializerVersion =
-          localFrame.getBuffer().get(pageContentOffset);
+      // Cache the buffer reference to avoid repeated SoftReference lookups
+      var buf = localFrame.getBuffer();
+
+      // Read serializer version byte from absolute position
+      byte serializerVersion = buf.get(localOffset);
 
       // Create ReadBytesContainer from a slice starting after the version byte
       var container = new ReadBytesContainer(
-          localFrame.getBuffer()
-              .slice(pageContentOffset + 1, pageContentLength - 1));
+          buf.slice(localOffset + 1, localLength - 1));
 
       status = RecordElement.STATUS.UNMARSHALLING;
       try {
@@ -3549,8 +3552,7 @@ public class EntityImpl extends RecordAbstract implements Entity {
       speculativeSuccess = true;
     } catch (RuntimeException e) {
       // Treat any exception during speculative deserialization as a torn page
-      // (equivalent to stamp invalidation). Restore snapshot and fall through
-      // to re-read.
+      // (equivalent to stamp invalidation). Fall through to re-read.
     }
 
     if (speculativeSuccess) {
@@ -3559,13 +3561,10 @@ public class EntityImpl extends RecordAbstract implements Entity {
       // cleared by the serializer's clearSource() call during deserialization.
       if (localFrame.validate(localStamp)) {
         // Stamp valid: speculative results are correct.
-        // clearPageFrame() may already have been called by the serializer
-        // (via clearSource) for the full deserialization path.
-        if (isPartial && pageFrame != null) {
-          // Partial path: serializer doesn't call clearSource, PageFrame
-          // is still set — keep it for subsequent partial calls.
-        } else {
-          // Full path or already cleared: ensure clean state
+        // For full deserialization, the serializer already called clearSource()
+        // which cleared the PageFrame fields. For partial, keep PageFrame
+        // for subsequent calls.
+        if (!isPartial || pageFrame == null) {
           clearPageFrame();
         }
         return evaluateDeserializationResult(propertyNames);
@@ -3574,16 +3573,12 @@ public class EntityImpl extends RecordAbstract implements Entity {
       // Stamp invalid: page was modified during deserialization — fall through to re-read
     }
 
-    // Restore properties snapshot before re-read
-    if (propertiesSnapshot != null) {
-      properties = propertiesSnapshot;
-    } else if (properties != null) {
-      properties.clear();
-    }
-    propertiesCount = propertiesCountSnapshot;
+    // Speculative deserialization failed or stamp invalid. Clear PageFrame and
+    // re-read from storage. The re-read path (fromStream) resets all entity
+    // state including properties, so no snapshot restore is needed here.
     clearPageFrame();
 
-    // Re-read from storage via the pinned path (always returns RawBuffer)
+    // Re-read from storage via the pinned path
     reReadFromStorage();
 
     // Re-enter deserialization using the byte[] path (source is now set)
@@ -3594,6 +3589,10 @@ public class EntityImpl extends RecordAbstract implements Entity {
    * Re-reads this record from storage using the pinned read path and populates
    * the entity's byte[] source. Called as the fallback when PageFrame stamp
    * validation fails or speculative deserialization throws.
+   *
+   * <p>Note: currently the storage optimistic path may return RawPageBuffer
+   * (after Step 4 wires it up). In the fallback context, we extract bytes
+   * from RawPageBuffer to ensure a byte[]-backed re-read.
    */
   private void reReadFromStorage() {
     var storage = session.getStorage();
@@ -3603,16 +3602,25 @@ public class EntityImpl extends RecordAbstract implements Entity {
     if (readResult instanceof RawBuffer rawBuffer) {
       fill(rawBuffer.version(), rawBuffer.buffer(), false);
       fromStream(rawBuffer.buffer());
+    } else if (readResult instanceof RawPageBuffer pageBuffer) {
+      // Storage returned a PageFrame reference — extract bytes for the
+      // fallback path. This avoids infinite recursion through fillFromPage.
+      var slice = pageBuffer.sliceContent();
+      var bytes = new byte[slice.remaining()];
+      slice.get(bytes);
+      fill(pageBuffer.recordVersion(), bytes, false);
+      fromStream(bytes);
     } else {
       throw new DatabaseException(session.getDatabaseName(),
-          "Expected RawBuffer from pinned re-read for " + getIdentity()
-              + " but got " + readResult.getClass().getSimpleName());
+          "Unexpected StorageReadResult type for " + getIdentity()
+              + ": " + readResult.getClass().getSimpleName());
     }
   }
 
   /**
    * Evaluates the result of deserialization for the requested property names.
-   * Shared between the PageFrame and byte[] paths after successful deserialization.
+   * Used by the PageFrame deserialization path after successful speculative
+   * deserialization.
    */
   private boolean evaluateDeserializationResult(String[] propertyNames) {
     if (propertyNames != null && propertyNames.length > 0) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/RecordSerializer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/RecordSerializer.java
@@ -23,6 +23,7 @@ package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.ReadBytesContainer;
 import javax.annotation.Nonnull;
 
 public interface RecordSerializer {
@@ -30,6 +31,18 @@ public interface RecordSerializer {
   void fromStream(@Nonnull DatabaseSessionEmbedded session, @Nonnull byte[] iSource,
       @Nonnull RecordAbstract iRecord,
       String[] iFields);
+
+  /**
+   * Deserializes a record from a ReadBytesContainer (ByteBuffer-backed). The serializer version
+   * is passed separately because on the PageFrame path the version byte is extracted from record
+   * metadata, not from the buffer.
+   */
+  default void fromStream(@Nonnull DatabaseSessionEmbedded session, byte serializerVersion,
+      @Nonnull ReadBytesContainer container, @Nonnull RecordAbstract iRecord,
+      String[] iFields) {
+    throw new UnsupportedOperationException(
+        "ReadBytesContainer deserialization not supported by " + getName());
+  }
 
   byte[] toStream(@Nonnull DatabaseSessionEmbedded session, @Nonnull RecordAbstract iSource);
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/EntitySerializer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/EntitySerializer.java
@@ -69,10 +69,17 @@ public interface EntitySerializer {
       ImmutableSchema schema,
       PropertyEncryption encryption);
 
+  /**
+   * Locates a field in the serialized record for in-place comparison.
+   *
+   * @param fieldNameBytes pre-computed UTF-8 bytes of iFieldName (avoids per-call allocation
+   *                       when the caller invokes this method repeatedly for the same field)
+   */
   default ReadBinaryField deserializeField(
       DatabaseSessionEmbedded db, ReadBytesContainer bytes,
       SchemaClass iClass,
       String iFieldName,
+      byte[] fieldNameBytes,
       boolean embedded,
       ImmutableSchema schema,
       PropertyEncryption encryption) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/EntitySerializer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/EntitySerializer.java
@@ -69,6 +69,18 @@ public interface EntitySerializer {
       ImmutableSchema schema,
       PropertyEncryption encryption);
 
+  default ReadBinaryField deserializeField(
+      DatabaseSessionEmbedded db, ReadBytesContainer bytes,
+      SchemaClass iClass,
+      String iFieldName,
+      boolean embedded,
+      ImmutableSchema schema,
+      PropertyEncryption encryption) {
+    throw new UnsupportedOperationException(
+        "ReadBytesContainer deserializeField not supported by "
+            + getClass().getSimpleName());
+  }
+
   BinaryComparator getComparator();
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/EntitySerializer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/EntitySerializer.java
@@ -42,8 +42,20 @@ public interface EntitySerializer {
 
   void deserialize(DatabaseSessionEmbedded db, EntityImpl entity, BytesContainer bytes);
 
+  default void deserialize(DatabaseSessionEmbedded db, EntityImpl entity,
+      ReadBytesContainer bytes) {
+    throw new UnsupportedOperationException(
+        "ReadBytesContainer deserialization not supported by " + getClass().getSimpleName());
+  }
+
   void deserializePartial(DatabaseSessionEmbedded db, EntityImpl entity, BytesContainer bytes,
       String[] iFields);
+
+  default void deserializePartial(DatabaseSessionEmbedded db, EntityImpl entity,
+      ReadBytesContainer bytes, String[] iFields) {
+    throw new UnsupportedOperationException(
+        "ReadBytesContainer deserialization not supported by " + getClass().getSimpleName());
+  }
 
   Object deserializeValue(DatabaseSessionEmbedded db, BytesContainer bytes,
       PropertyTypeInternal type,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
@@ -24,6 +24,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.RecordElement;
 import com.jetbrains.youtrackdb.internal.core.db.record.TrackedCollection;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.SerializationException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
@@ -185,6 +186,10 @@ public class HelperClasses {
 
   public static byte[] readBinary(final ReadBytesContainer bytes) {
     final var n = VarIntSerializer.readAsInteger(bytes);
+    if (n < 0 || n > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Binary field size exceeds remaining buffer: " + n + " > " + bytes.remaining());
+    }
     final var newValue = new byte[n];
     bytes.getBytes(newValue, 0, n);
     return newValue;
@@ -194,6 +199,10 @@ public class HelperClasses {
     final var len = VarIntSerializer.readAsInteger(bytes);
     if (len == 0) {
       return "";
+    }
+    if (len < 0 || len > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "String field length exceeds remaining buffer: " + len + " > " + bytes.remaining());
     }
     return bytes.getStringBytes(len);
   }
@@ -229,6 +238,11 @@ public class HelperClasses {
     }
 
     final var items = VarIntSerializer.readAsInteger(bytes);
+    if (items < 0 || items > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Link collection size exceeds remaining buffer: "
+              + items + " > " + bytes.remaining());
+    }
     for (var i = 0; i < items; i++) {
       var id = readOptimizedLink(bytes, justRunThrough);
       if (!justRunThrough) {
@@ -250,6 +264,10 @@ public class HelperClasses {
     }
 
     var size = VarIntSerializer.readAsInteger(bytes);
+    if (size < 0 || size > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Link map size exceeds remaining buffer: " + size + " > " + bytes.remaining());
+    }
     EntityLinkMapIml result = null;
     if (!justRunThrough) {
       result = new EntityLinkMapIml(owner);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
@@ -24,7 +24,6 @@ import com.jetbrains.youtrackdb.internal.core.db.record.RecordElement;
 import com.jetbrains.youtrackdb.internal.core.db.record.TrackedCollection;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
-import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.SerializationException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
@@ -33,7 +32,6 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeIntern
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.GlobalProperty;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Calendar;
 import java.util.Collection;
@@ -83,8 +81,7 @@ public class HelperClasses {
     public PropertyTypeInternal keyType;
   }
 
-  @Nullable
-  public static PropertyTypeInternal readOType(final BytesContainer bytes, boolean justRunThrough) {
+  @Nullable public static PropertyTypeInternal readOType(final BytesContainer bytes, boolean justRunThrough) {
     if (justRunThrough) {
       bytes.offset++;
       return null;
@@ -106,8 +103,7 @@ public class HelperClasses {
     }
   }
 
-  @Nullable
-  public static PropertyTypeInternal readType(BytesContainer bytes) {
+  @Nullable public static PropertyTypeInternal readType(BytesContainer bytes) {
     var typeId = bytes.bytes[bytes.offset++];
     if (typeId == -1) {
       return null;
@@ -151,8 +147,7 @@ public class HelperClasses {
     return value;
   }
 
-  @Nullable
-  public static RecordIdInternal readOptimizedLink(final BytesContainer bytes,
+  @Nullable public static RecordIdInternal readOptimizedLink(final BytesContainer bytes,
       boolean justRunThrough) {
     var collectionId = VarIntSerializer.readAsInteger(bytes);
     var collectionPos = VarIntSerializer.readAsLong(bytes);
@@ -169,21 +164,15 @@ public class HelperClasses {
 
   public static String stringFromBytesIntern(DatabaseSessionEmbedded session, final byte[] bytes,
       final int offset, final int len) {
-    try {
-      var context = session.getSharedContext();
-      if (context != null) {
-        var cache = context.getStringCache();
-        if (cache != null) {
-          return cache.getString(bytes, offset, len);
-        }
+    var context = session.getSharedContext();
+    if (context != null) {
+      var cache = context.getStringCache();
+      if (cache != null) {
+        return cache.getString(bytes, offset, len);
       }
-
-      return new String(bytes, offset, len, StandardCharsets.UTF_8).intern();
-    } catch (UnsupportedEncodingException e) {
-      throw BaseException.wrapException(
-          new SerializationException(session.getDatabaseName(), "Error on string decoding"),
-          e, session.getDatabaseName());
     }
+
+    return new String(bytes, offset, len, StandardCharsets.UTF_8).intern();
   }
 
   public static byte[] bytesFromString(final String toWrite) {
@@ -355,8 +344,7 @@ public class HelperClasses {
     return rid;
   }
 
-  @Nullable
-  public static PropertyTypeInternal getLinkedType(DatabaseSessionEmbedded session,
+  @Nullable public static PropertyTypeInternal getLinkedType(DatabaseSessionEmbedded session,
       SchemaClass clazz,
       PropertyTypeInternal type, String key) {
     if (type != PropertyTypeInternal.EMBEDDEDLIST && type != PropertyTypeInternal.EMBEDDEDSET

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
@@ -158,6 +158,131 @@ public class HelperClasses {
     }
   }
 
+  // --- ReadBytesContainer overloads for the deserialization path ---
+
+  @Nullable public static PropertyTypeInternal readOType(
+      final ReadBytesContainer bytes, boolean justRunThrough) {
+    if (justRunThrough) {
+      bytes.skip(1);
+      return null;
+    }
+
+    var typeId = readByte(bytes);
+    if (typeId == -1) {
+      return null;
+    }
+
+    return PropertyTypeInternal.getById(typeId);
+  }
+
+  @Nullable public static PropertyTypeInternal readType(ReadBytesContainer bytes) {
+    var typeId = bytes.getByte();
+    if (typeId == -1) {
+      return null;
+    }
+    return PropertyTypeInternal.getById(typeId);
+  }
+
+  public static byte[] readBinary(final ReadBytesContainer bytes) {
+    final var n = VarIntSerializer.readAsInteger(bytes);
+    final var newValue = new byte[n];
+    bytes.getBytes(newValue, 0, n);
+    return newValue;
+  }
+
+  public static String readString(final ReadBytesContainer bytes) {
+    final var len = VarIntSerializer.readAsInteger(bytes);
+    if (len == 0) {
+      return "";
+    }
+    final var res = bytes.getStringBytes(len);
+    return res;
+  }
+
+  public static int readInteger(final ReadBytesContainer container) {
+    var buf = new byte[IntegerSerializer.INT_SIZE];
+    container.getBytes(buf, 0, IntegerSerializer.INT_SIZE);
+    return IntegerSerializer.deserializeLiteral(buf, 0);
+  }
+
+  public static byte readByte(final ReadBytesContainer container) {
+    return container.getByte();
+  }
+
+  public static long readLong(final ReadBytesContainer container) {
+    var buf = new byte[LongSerializer.LONG_SIZE];
+    container.getBytes(buf, 0, LongSerializer.LONG_SIZE);
+    return LongSerializer.deserializeLiteral(buf, 0);
+  }
+
+  @Nullable public static RecordIdInternal readOptimizedLink(
+      final ReadBytesContainer bytes, boolean justRunThrough) {
+    var collectionId = VarIntSerializer.readAsInteger(bytes);
+    var collectionPos = VarIntSerializer.readAsLong(bytes);
+    if (justRunThrough) {
+      return null;
+    } else {
+      return new RecordId(collectionId, collectionPos);
+    }
+  }
+
+  public static <T extends TrackedCollection<?, Identifiable>> T readLinkCollection(
+      final ReadBytesContainer bytes, final T found, boolean justRunThrough) {
+    var type = bytes.getByte();
+    if (type != 0) {
+      throw new SerializationException("Invalid type of embedded collection");
+    }
+
+    final var items = VarIntSerializer.readAsInteger(bytes);
+    for (var i = 0; i < items; i++) {
+      var id = readOptimizedLink(bytes, justRunThrough);
+      if (!justRunThrough) {
+        if (id.equals(NULL_RECORD_ID)) {
+          found.addInternal(null);
+        } else {
+          found.addInternal(id);
+        }
+      }
+    }
+    return found;
+  }
+
+  public static Map<String, Identifiable> readLinkMap(
+      final ReadBytesContainer bytes, final RecordElement owner, boolean justRunThrough) {
+    var version = bytes.getByte();
+    if (version != 0) {
+      throw new SerializationException("Invalid version of link map");
+    }
+
+    var size = VarIntSerializer.readAsInteger(bytes);
+    EntityLinkMapIml result = null;
+    if (!justRunThrough) {
+      result = new EntityLinkMapIml(owner);
+    }
+    while (size-- > 0) {
+      final var key = readString(bytes);
+      final var value = readOptimizedLink(bytes, justRunThrough);
+      if (value.equals(NULL_RECORD_ID)) {
+        result.putInternal(key, null);
+      } else {
+        result.putInternal(key, value);
+      }
+    }
+    return result;
+  }
+
+  public static RID readLinkOptimizedEmbedded(
+      DatabaseSessionEmbedded db, final ReadBytesContainer bytes) {
+    RID rid =
+        new RecordId(
+            VarIntSerializer.readAsInteger(bytes), VarIntSerializer.readAsLong(bytes));
+    if (!rid.isPersistent()) {
+      rid = db.refreshRid(rid);
+    }
+
+    return rid;
+  }
+
   public static String stringFromBytes(final byte[] bytes, final int offset, final int len) {
     return new String(bytes, offset, len, StandardCharsets.UTF_8);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
@@ -195,8 +195,7 @@ public class HelperClasses {
     if (len == 0) {
       return "";
     }
-    final var res = bytes.getStringBytes(len);
-    return res;
+    return bytes.getStringBytes(len);
   }
 
   public static int readInteger(final ReadBytesContainer container) {
@@ -262,10 +261,12 @@ public class HelperClasses {
     while (size-- > 0) {
       final var key = readString(bytes);
       final var value = readOptimizedLink(bytes, justRunThrough);
-      if (value.equals(NULL_RECORD_ID)) {
-        result.putInternal(key, null);
-      } else {
-        result.putInternal(key, value);
+      if (!justRunThrough) {
+        if (value.equals(NULL_RECORD_ID)) {
+          result.putInternal(key, null);
+        } else {
+          result.putInternal(key, value);
+        }
       }
     }
     return result;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClasses.java
@@ -199,9 +199,7 @@ public class HelperClasses {
   }
 
   public static int readInteger(final ReadBytesContainer container) {
-    var buf = new byte[IntegerSerializer.INT_SIZE];
-    container.getBytes(buf, 0, IntegerSerializer.INT_SIZE);
-    return IntegerSerializer.deserializeLiteral(buf, 0);
+    return container.getInt();
   }
 
   public static byte readByte(final ReadBytesContainer container) {
@@ -209,9 +207,7 @@ public class HelperClasses {
   }
 
   public static long readLong(final ReadBytesContainer container) {
-    var buf = new byte[LongSerializer.LONG_SIZE];
-    container.getBytes(buf, 0, LongSerializer.LONG_SIZE);
-    return LongSerializer.deserializeLiteral(buf, 0);
+    return container.getLong();
   }
 
   @Nullable public static RecordIdInternal readOptimizedLink(
@@ -438,10 +434,12 @@ public class HelperClasses {
     while (size-- > 0) {
       final var key = readString(bytes);
       final var value = readOptimizedLink(bytes, justRunThrough);
-      if (value.equals(NULL_RECORD_ID)) {
-        result.putInternal(key, null);
-      } else {
-        result.putInternal(key, value);
+      if (!justRunThrough) {
+        if (value.equals(NULL_RECORD_ID)) {
+          result.putInternal(key, null);
+        } else {
+          result.putInternal(key, value);
+        }
       }
     }
     return result;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -30,6 +30,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.OptionalInt;
@@ -415,6 +416,11 @@ public final class InPlaceComparator {
     if (field.type() == PropertyTypeInternal.LINK) {
       return compareLinkEqualityRbc(field.bytes(), value);
     }
+    // Fast path for STRING equality: compare UTF-8 bytes directly without
+    // constructing a String object from the serialized data.
+    if (field.type() == PropertyTypeInternal.STRING) {
+      return isStringEqualRbc(field.bytes(), value);
+    }
 
     var cmp = compare(field, value, dbTimeZone);
     if (cmp.isEmpty()) {
@@ -509,6 +515,33 @@ public final class InPlaceComparator {
     }
     var serialized = HelperClasses.readString(bytes);
     return OptionalInt.of(serialized.compareTo(strValue));
+  }
+
+  /**
+   * Byte-level string equality: encodes the comparison value to UTF-8 once, then
+   * compares the length prefix and raw bytes directly from the buffer without
+   * constructing a String from the serialized data. Avoids the {@code new String()}
+   * allocation that {@link #compareStringRbc} requires.
+   */
+  private static OptionalInt isStringEqualRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof String strValue)) {
+      return OptionalInt.empty();
+    }
+    var serializedLen = VarIntSerializer.readAsInteger(bytes);
+    if (serializedLen == 0) {
+      return OptionalInt.of(strValue.isEmpty() ? 1 : 0);
+    }
+    var valueUtf8 = strValue.getBytes(StandardCharsets.UTF_8);
+    if (serializedLen != valueUtf8.length) {
+      return OptionalInt.of(0);
+    }
+    // Compare raw UTF-8 bytes without constructing a String
+    for (int i = 0; i < serializedLen; i++) {
+      if (bytes.peekByte(i) != valueUtf8[i]) {
+        return OptionalInt.of(0);
+      }
+    }
+    return OptionalInt.of(1);
   }
 
   private static OptionalInt compareBooleanRbc(ReadBytesContainer bytes, Object value) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -26,8 +26,10 @@ import static com.jetbrains.youtrackdb.internal.core.serialization.serializer.re
 import com.jetbrains.youtrackdb.internal.common.serialization.types.DecimalSerializer;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.OptionalInt;
@@ -348,6 +350,244 @@ public final class InPlaceComparator {
   // ---------------------------------------------------------------------------
 
   private static OptionalInt compareLinkEquality(BytesContainer bytes, Object value) {
+    int valueCollectionId;
+    long valueCollectionPos;
+    if (value instanceof RID rid) {
+      valueCollectionId = rid.getCollectionId();
+      valueCollectionPos = rid.getCollectionPosition();
+    } else if (value instanceof Identifiable identifiable) {
+      var identity = identifiable.getIdentity();
+      valueCollectionId = identity.getCollectionId();
+      valueCollectionPos = identity.getCollectionPosition();
+    } else {
+      return OptionalInt.empty();
+    }
+    var serializedId = VarIntSerializer.readAsInteger(bytes);
+    var serializedPos = VarIntSerializer.readAsLong(bytes);
+    var equal = serializedId == valueCollectionId && serializedPos == valueCollectionPos;
+    return OptionalInt.of(equal ? 1 : 0);
+  }
+
+  // ===========================================================================
+  // ReadBinaryField overloads (ByteBuffer-backed, for PageFrame zero-copy)
+  // ===========================================================================
+
+  /**
+   * Compares a serialized field value in a {@link ReadBinaryField} against a Java object.
+   *
+   * @param dbTimeZone the database timezone for DATE fields
+   * @return comparison result (negative, zero, positive) or empty if fallback is needed
+   */
+  public static OptionalInt compare(
+      ReadBinaryField field, Object value, @Nullable TimeZone dbTimeZone) {
+    assert field != null : "ReadBinaryField must not be null";
+    assert field.type() != null : "ReadBinaryField.type must not be null";
+    assert value != null : "Comparison value must not be null";
+
+    return switch (field.type()) {
+      case INTEGER -> compareIntegerRbc(field.bytes(), value);
+      case LONG -> compareLongRbc(field.bytes(), value);
+      case SHORT -> compareShortRbc(field.bytes(), value);
+      case BYTE -> compareByteRbc(field.bytes(), value);
+      case FLOAT -> compareFloatRbc(field.bytes(), value);
+      case DOUBLE -> compareDoubleRbc(field.bytes(), value);
+      case STRING -> compareStringRbc(field.bytes(), value);
+      case BOOLEAN -> compareBooleanRbc(field.bytes(), value);
+      case DATETIME -> compareDatetimeRbc(field.bytes(), value);
+      case DATE -> compareDateRbc(field.bytes(), value, dbTimeZone);
+      case DECIMAL -> compareDecimalRbc(field.bytes(), value);
+      case BINARY -> compareBinaryRbc(field.bytes(), value);
+      case LINK -> OptionalInt.empty();
+      default -> OptionalInt.empty();
+    };
+  }
+
+  /**
+   * Checks equality of a serialized field value in a {@link ReadBinaryField} against a Java object.
+   *
+   * @param dbTimeZone the database timezone for DATE fields
+   * @return 1 (equal) or 0 (not equal) if comparison succeeded, or empty if fallback is needed
+   */
+  public static OptionalInt isEqual(
+      ReadBinaryField field, Object value, @Nullable TimeZone dbTimeZone) {
+    if (field.type() == PropertyTypeInternal.LINK) {
+      return compareLinkEqualityRbc(field.bytes(), value);
+    }
+
+    var cmp = compare(field, value, dbTimeZone);
+    if (cmp.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    return OptionalInt.of(cmp.getAsInt() == 0 ? 1 : 0);
+  }
+
+  // --- ReadBytesContainer per-type comparison methods ---
+
+  private static OptionalInt compareIntegerRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+    var converted = convertToInt(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    var serialized = VarIntSerializer.readAsInteger(bytes);
+    return OptionalInt.of(Integer.compare(serialized, converted.getAsInt()));
+  }
+
+  private static OptionalInt compareLongRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+    var converted = convertToLong(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    var serialized = VarIntSerializer.readAsLong(bytes);
+    return OptionalInt.of(Long.compare(serialized, converted.getAsLong()));
+  }
+
+  private static OptionalInt compareShortRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+    var converted = convertToShort(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    var serialized = VarIntSerializer.readAsShort(bytes);
+    return OptionalInt.of(Short.compare(serialized, (short) converted.getAsInt()));
+  }
+
+  private static OptionalInt compareByteRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+    var converted = convertToByte(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    var serialized = HelperClasses.readByte(bytes);
+    return OptionalInt.of(Byte.compare(serialized, (byte) converted.getAsInt()));
+  }
+
+  private static OptionalInt compareFloatRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+    if (value instanceof Double) {
+      var serializedFloat = Float.intBitsToFloat(readInteger(bytes));
+      return OptionalInt.of(Double.compare(serializedFloat, number.doubleValue()));
+    }
+    var converted = convertToFloat(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    var serialized = Float.intBitsToFloat(readInteger(bytes));
+    return OptionalInt.of(
+        Float.compare(serialized, Float.intBitsToFloat(converted.getAsInt())));
+  }
+
+  private static OptionalInt compareDoubleRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof Number number)) {
+      return OptionalInt.empty();
+    }
+    var converted = convertToDouble(number);
+    if (converted.isEmpty()) {
+      return OptionalInt.empty();
+    }
+    var serialized = Double.longBitsToDouble(readLong(bytes));
+    return OptionalInt.of(
+        Double.compare(serialized, Double.longBitsToDouble(converted.getAsLong())));
+  }
+
+  private static OptionalInt compareStringRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof String strValue)) {
+      return OptionalInt.empty();
+    }
+    var serialized = HelperClasses.readString(bytes);
+    return OptionalInt.of(serialized.compareTo(strValue));
+  }
+
+  private static OptionalInt compareBooleanRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof Boolean boolValue)) {
+      return OptionalInt.empty();
+    }
+    var serialized = HelperClasses.readByte(bytes) == 1;
+    return OptionalInt.of(Boolean.compare(serialized, boolValue));
+  }
+
+  private static OptionalInt compareDatetimeRbc(ReadBytesContainer bytes, Object value) {
+    long valueMillis;
+    if (value instanceof Date date) {
+      valueMillis = date.getTime();
+    } else if (value instanceof Number number) {
+      valueMillis = number.longValue();
+    } else {
+      return OptionalInt.empty();
+    }
+    var serialized = VarIntSerializer.readAsLong(bytes);
+    return OptionalInt.of(Long.compare(serialized, valueMillis));
+  }
+
+  private static OptionalInt compareDateRbc(
+      ReadBytesContainer bytes, Object value, @Nullable TimeZone dbTimeZone) {
+    if (dbTimeZone == null) {
+      return OptionalInt.empty();
+    }
+    long valueMillis;
+    if (value instanceof Date date) {
+      valueMillis = date.getTime();
+    } else if (value instanceof Number number) {
+      valueMillis = number.longValue();
+    } else {
+      return OptionalInt.empty();
+    }
+    var savedTime = VarIntSerializer.readAsLong(bytes) * MILLISEC_PER_DAY;
+    savedTime = HelperClasses.convertDayToTimezone(GMT, dbTimeZone, savedTime);
+    return OptionalInt.of(Long.compare(savedTime, valueMillis));
+  }
+
+  // DECIMAL: 4-byte scale (big-endian int) + 4-byte unscaled length + unscaled bytes
+  private static OptionalInt compareDecimalRbc(ReadBytesContainer bytes, Object value) {
+    BigDecimal decimalValue;
+    if (value instanceof BigDecimal bd) {
+      decimalValue = bd;
+    } else if (value instanceof Number number) {
+      if (number instanceof Double || number instanceof Float) {
+        double dv = number.doubleValue();
+        if (Double.isNaN(dv) || Double.isInfinite(dv)) {
+          return OptionalInt.empty();
+        }
+        decimalValue = BigDecimal.valueOf(dv);
+      } else {
+        decimalValue = BigDecimal.valueOf(number.longValue());
+      }
+    } else {
+      return OptionalInt.empty();
+    }
+    var scale = bytes.getInt();
+    var unscaledLen = bytes.getInt();
+    if (unscaledLen < 0 || unscaledLen > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Decimal unscaled length exceeds remaining buffer: "
+              + unscaledLen + " > " + bytes.remaining());
+    }
+    var unscaledBytes = new byte[unscaledLen];
+    bytes.getBytes(unscaledBytes, 0, unscaledLen);
+    var serialized = new BigDecimal(new BigInteger(unscaledBytes), scale);
+    return OptionalInt.of(serialized.compareTo(decimalValue));
+  }
+
+  private static OptionalInt compareBinaryRbc(ReadBytesContainer bytes, Object value) {
+    if (!(value instanceof byte[] byteArray)) {
+      return OptionalInt.empty();
+    }
+    var serialized = HelperClasses.readBinary(bytes);
+    return OptionalInt.of(Arrays.compare(serialized, byteArray));
+  }
+
+  private static OptionalInt compareLinkEqualityRbc(ReadBytesContainer bytes, Object value) {
     int valueCollectionId;
     long valueCollectionPos;
     if (value instanceof RID rid) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparator.java
@@ -309,6 +309,8 @@ public final class InPlaceComparator {
 
   // ---------------------------------------------------------------------------
   // DECIMAL (BigDecimal via DecimalSerializer)
+  // See also: compareDecimalRbc() — the ReadBytesContainer counterpart that
+  // reads the same format manually from a ByteBuffer.
   // ---------------------------------------------------------------------------
 
   private static OptionalInt compareDecimal(BytesContainer bytes, Object value) {
@@ -548,7 +550,10 @@ public final class InPlaceComparator {
     return OptionalInt.of(Long.compare(savedTime, valueMillis));
   }
 
-  // DECIMAL: 4-byte scale (big-endian int) + 4-byte unscaled length + unscaled bytes
+  // DECIMAL: 4-byte scale (big-endian int) + 4-byte unscaled length + unscaled bytes.
+  // This manually reads the same binary format as DecimalSerializer.staticDeserialize(),
+  // but from a ReadBytesContainer (ByteBuffer-backed) instead of a byte[]. Changes to
+  // the decimal serialization format in DecimalSerializer must be mirrored here.
   private static OptionalInt compareDecimalRbc(ReadBytesContainer bytes, Object value) {
     BigDecimal decimalValue;
     if (value instanceof BigDecimal bd) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBinaryField.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBinaryField.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Collate;
+import javax.annotation.Nullable;
+
+/**
+ * Read-only counterpart of {@link BinaryField} that holds a {@link ReadBytesContainer}
+ * (ByteBuffer-backed) instead of a {@link BytesContainer} (byte[]-backed). Used for
+ * in-place property comparison directly from a PageFrame without copying bytes.
+ */
+public record ReadBinaryField(
+    String name,
+    PropertyTypeInternal type,
+    ReadBytesContainer bytes,
+    @Nullable Collate collate) {
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
@@ -1,0 +1,166 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
+import com.jetbrains.youtrackdb.internal.core.exception.SerializationException;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Read-only, ByteBuffer-backed container for the record deserialization path. Replaces {@link
+ * BytesContainer} on the read side — provides position-tracked read methods without any
+ * mutable alloc/resize semantics.
+ *
+ * <p>Supports both heap ByteBuffers (for byte[] wrap fallback) and direct ByteBuffers (for
+ * PageFrame zero-copy reads).
+ */
+public final class ReadBytesContainer {
+
+  private final ByteBuffer buffer;
+
+  /**
+   * Wraps an existing ByteBuffer. The container reads from the buffer's current position to its
+   * limit. The buffer's position is advanced as bytes are consumed.
+   */
+  public ReadBytesContainer(ByteBuffer buffer) {
+    this.buffer = buffer;
+  }
+
+  /**
+   * Convenience constructor wrapping a byte array in a heap ByteBuffer. The entire array is
+   * readable.
+   */
+  public ReadBytesContainer(byte[] source) {
+    this.buffer = ByteBuffer.wrap(source);
+  }
+
+  /**
+   * Convenience constructor wrapping a byte array with an initial offset. Reads start at {@code
+   * offset} and extend to the end of the array.
+   */
+  public ReadBytesContainer(byte[] source, int offset) {
+    this.buffer = ByteBuffer.wrap(source, offset, source.length - offset);
+  }
+
+  /** Reads one byte and advances the position. */
+  public byte getByte() {
+    return buffer.get();
+  }
+
+  /**
+   * Reads a byte at {@code position() + relativeOffset} without advancing the position. Useful for
+   * field name matching where bytes are compared without consumption.
+   */
+  public byte peekByte(int relativeOffset) {
+    return buffer.get(buffer.position() + relativeOffset);
+  }
+
+  /** Bulk read into a destination array. */
+  public void getBytes(byte[] dst, int dstOffset, int length) {
+    buffer.get(dst, dstOffset, length);
+  }
+
+  /** Reads {@code length} bytes and creates a UTF-8 String. */
+  public String getStringBytes(int length) {
+    if (buffer.hasArray()) {
+      var result =
+          new String(
+              buffer.array(),
+              buffer.arrayOffset() + buffer.position(),
+              length,
+              StandardCharsets.UTF_8);
+      buffer.position(buffer.position() + length);
+      return result;
+    }
+    var bytes = new byte[length];
+    buffer.get(bytes);
+    return new String(bytes, 0, length, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Reads {@code length} bytes and returns an interned String via the session's string cache. Falls
+   * back to {@code new String(...).intern()} if no cache is available.
+   */
+  public String getInternedString(DatabaseSessionEmbedded session, int length) {
+    // StringCache requires byte[] — extract from the buffer
+    byte[] bytes;
+    int bytesOffset;
+    if (buffer.hasArray()) {
+      bytes = buffer.array();
+      bytesOffset = buffer.arrayOffset() + buffer.position();
+      buffer.position(buffer.position() + length);
+    } else {
+      bytes = new byte[length];
+      buffer.get(bytes);
+      bytesOffset = 0;
+    }
+
+    try {
+      var context = session.getSharedContext();
+      if (context != null) {
+        var cache = context.getStringCache();
+        if (cache != null) {
+          return cache.getString(bytes, bytesOffset, length);
+        }
+      }
+      return new String(bytes, bytesOffset, length, StandardCharsets.UTF_8).intern();
+    } catch (UnsupportedEncodingException e) {
+      throw BaseException.wrapException(
+          new SerializationException(
+              session.getDatabaseName(), "Error on string decoding"),
+          e,
+          session.getDatabaseName());
+    }
+  }
+
+  /** Returns the number of bytes remaining between the current position and the limit. */
+  public int remaining() {
+    return buffer.remaining();
+  }
+
+  /** Returns the current read position. */
+  public int offset() {
+    return buffer.position();
+  }
+
+  /** Advances the position by {@code n} bytes without reading. */
+  public void skip(int n) {
+    buffer.position(buffer.position() + n);
+  }
+
+  /** Sets the absolute read position. */
+  public void setOffset(int position) {
+    buffer.position(position);
+  }
+
+  /**
+   * Creates a sub-container sharing the same backing buffer, starting at the current position and
+   * spanning {@code length} bytes. The parent's position is advanced past the sliced region.
+   */
+  public ReadBytesContainer slice(int length) {
+    var sliced = buffer.slice(buffer.position(), length);
+    buffer.position(buffer.position() + length);
+    return new ReadBytesContainer(sliced);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  */
 public final class ReadBytesContainer {
 
-  private final ByteBuffer buffer;
+  private ByteBuffer buffer;
 
   /**
    * Wraps an existing ByteBuffer. The container reads from the buffer's current position to its
@@ -44,6 +44,25 @@ public final class ReadBytesContainer {
    */
   public ReadBytesContainer(ByteBuffer buffer) {
     this.buffer = buffer;
+  }
+
+  /**
+   * Creates an empty container that must be initialized via {@link #reset(ByteBuffer, int, int)}
+   * before use. Useful for pre-allocating a reusable container to avoid per-call allocation.
+   */
+  public ReadBytesContainer() {
+    this.buffer = null;
+  }
+
+  /**
+   * Resets this container to read from the given buffer starting at {@code offset} for
+   * {@code length} bytes. Uses {@link ByteBuffer#duplicate()} to avoid the heavier
+   * {@link ByteBuffer#slice(int, int)} allocation, then sets position and limit directly.
+   */
+  public void reset(ByteBuffer source, int offset, int length) {
+    this.buffer = source.duplicate();
+    this.buffer.position(offset);
+    this.buffer.limit(offset + length);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
@@ -83,20 +83,19 @@ public final class ReadBytesContainer {
 
   /**
    * Reads {@code length} bytes and creates a UTF-8 String. Guards against OOM by checking remaining
-   * bytes before allocating.
+   * bytes before allocating. Throws {@link BufferUnderflowException} if length is negative or
+   * exceeds remaining bytes.
    */
   public String getStringBytes(int length) {
-    if (length > buffer.remaining()) {
+    if (length < 0 || length > buffer.remaining()) {
       throw new BufferUnderflowException();
     }
     if (buffer.hasArray()) {
+      var pos = buffer.position();
       var result =
           new String(
-              buffer.array(),
-              buffer.arrayOffset() + buffer.position(),
-              length,
-              StandardCharsets.UTF_8);
-      buffer.position(buffer.position() + length);
+              buffer.array(), buffer.arrayOffset() + pos, length, StandardCharsets.UTF_8);
+      buffer.position(pos + length);
       return result;
     }
     var bytes = new byte[length];
@@ -107,10 +106,11 @@ public final class ReadBytesContainer {
   /**
    * Reads {@code length} bytes and returns an interned String via the provided string cache. Falls
    * back to a plain String if no cache is available. Guards against OOM by checking remaining bytes
-   * before allocating.
+   * before allocating. Throws {@link BufferUnderflowException} if length is negative or exceeds
+   * remaining bytes.
    */
   public String getInternedString(@Nullable StringCache cache, int length) {
-    if (length > buffer.remaining()) {
+    if (length < 0 || length > buffer.remaining()) {
       throw new BufferUnderflowException();
     }
 
@@ -129,7 +129,19 @@ public final class ReadBytesContainer {
     if (cache != null) {
       return cache.getString(bytes, bytesOffset, length);
     }
-    return new String(bytes, bytesOffset, length, StandardCharsets.UTF_8);
+    // Match the intern() behavior of HelperClasses.stringFromBytesIntern for the rare
+    // case when no StringCache is available (e.g., during early initialization).
+    return new String(bytes, bytesOffset, length, StandardCharsets.UTF_8).intern();
+  }
+
+  /** Reads a big-endian int (4 bytes) and advances the position. No intermediate allocation. */
+  public int getInt() {
+    return buffer.getInt();
+  }
+
+  /** Reads a big-endian long (8 bytes) and advances the position. No intermediate allocation. */
+  public long getLong() {
+    return buffer.getLong();
   }
 
   /** Returns the number of bytes remaining between the current position and the limit. */
@@ -142,9 +154,14 @@ public final class ReadBytesContainer {
     return buffer.position();
   }
 
-  /** Advances the position by {@code n} bytes without reading. */
+  /**
+   * Advances the position by {@code n} bytes without reading. Throws {@link
+   * IllegalArgumentException} if {@code n} is negative or would advance past the limit.
+   */
   public void skip(int n) {
-    assert n >= 0 : "skip amount must be non-negative";
+    if (n < 0) {
+      throw new IllegalArgumentException("skip amount must be non-negative: " + n);
+    }
     buffer.position(buffer.position() + n);
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainer.java
@@ -20,17 +20,16 @@
 
 package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
 
-import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
-import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
-import com.jetbrains.youtrackdb.internal.core.exception.SerializationException;
-import java.io.UnsupportedEncodingException;
+import com.jetbrains.youtrackdb.internal.core.db.StringCache;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
 
 /**
  * Read-only, ByteBuffer-backed container for the record deserialization path. Replaces {@link
- * BytesContainer} on the read side — provides position-tracked read methods without any
- * mutable alloc/resize semantics.
+ * BytesContainer} on the read side — provides position-tracked read methods without any mutable
+ * alloc/resize semantics.
  *
  * <p>Supports both heap ByteBuffers (for byte[] wrap fallback) and direct ByteBuffers (for
  * PageFrame zero-copy reads).
@@ -73,6 +72,7 @@ public final class ReadBytesContainer {
    * field name matching where bytes are compared without consumption.
    */
   public byte peekByte(int relativeOffset) {
+    assert relativeOffset >= 0 : "peekByte relativeOffset must be non-negative";
     return buffer.get(buffer.position() + relativeOffset);
   }
 
@@ -81,8 +81,14 @@ public final class ReadBytesContainer {
     buffer.get(dst, dstOffset, length);
   }
 
-  /** Reads {@code length} bytes and creates a UTF-8 String. */
+  /**
+   * Reads {@code length} bytes and creates a UTF-8 String. Guards against OOM by checking remaining
+   * bytes before allocating.
+   */
   public String getStringBytes(int length) {
+    if (length > buffer.remaining()) {
+      throw new BufferUnderflowException();
+    }
     if (buffer.hasArray()) {
       var result =
           new String(
@@ -99,11 +105,15 @@ public final class ReadBytesContainer {
   }
 
   /**
-   * Reads {@code length} bytes and returns an interned String via the session's string cache. Falls
-   * back to {@code new String(...).intern()} if no cache is available.
+   * Reads {@code length} bytes and returns an interned String via the provided string cache. Falls
+   * back to a plain String if no cache is available. Guards against OOM by checking remaining bytes
+   * before allocating.
    */
-  public String getInternedString(DatabaseSessionEmbedded session, int length) {
-    // StringCache requires byte[] — extract from the buffer
+  public String getInternedString(@Nullable StringCache cache, int length) {
+    if (length > buffer.remaining()) {
+      throw new BufferUnderflowException();
+    }
+
     byte[] bytes;
     int bytesOffset;
     if (buffer.hasArray()) {
@@ -116,22 +126,10 @@ public final class ReadBytesContainer {
       bytesOffset = 0;
     }
 
-    try {
-      var context = session.getSharedContext();
-      if (context != null) {
-        var cache = context.getStringCache();
-        if (cache != null) {
-          return cache.getString(bytes, bytesOffset, length);
-        }
-      }
-      return new String(bytes, bytesOffset, length, StandardCharsets.UTF_8).intern();
-    } catch (UnsupportedEncodingException e) {
-      throw BaseException.wrapException(
-          new SerializationException(
-              session.getDatabaseName(), "Error on string decoding"),
-          e,
-          session.getDatabaseName());
+    if (cache != null) {
+      return cache.getString(bytes, bytesOffset, length);
     }
+    return new String(bytes, bytesOffset, length, StandardCharsets.UTF_8);
   }
 
   /** Returns the number of bytes remaining between the current position and the limit. */
@@ -146,6 +144,7 @@ public final class ReadBytesContainer {
 
   /** Advances the position by {@code n} bytes without reading. */
   public void skip(int n) {
+    assert n >= 0 : "skip amount must be non-negative";
     buffer.position(buffer.position() + n);
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinary.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinary.java
@@ -93,7 +93,10 @@ public class RecordSerializerBinary implements RecordSerializer {
       return;
     }
 
-    final var container = new BytesContainer(iSource).skip(1);
+    // Wire byte[] deserialization through ReadBytesContainer, proving the two paths
+    // are equivalent. The ReadBytesContainer wraps the same byte[] with an offset of 1
+    // (skipping the serializer version byte).
+    final var container = new ReadBytesContainer(iSource, 1);
     try {
       if (iFields != null && iFields.length > 0) {
         serializerByVersion[iSource[0]].deserializePartial(session, (EntityImpl) iRecord, container,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinary.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinary.java
@@ -113,6 +113,22 @@ public class RecordSerializerBinary implements RecordSerializer {
   }
 
   @Override
+  public void fromStream(
+      @Nonnull DatabaseSessionEmbedded session,
+      byte serializerVersion,
+      @Nonnull ReadBytesContainer container,
+      @Nonnull RecordAbstract iRecord,
+      String[] iFields) {
+    if (iFields != null && iFields.length > 0) {
+      serializerByVersion[serializerVersion].deserializePartial(
+          session, (EntityImpl) iRecord, container, iFields);
+    } else {
+      serializerByVersion[serializerVersion].deserialize(
+          session, (EntityImpl) iRecord, container);
+    }
+  }
+
+  @Override
   public byte[] toStream(@Nonnull DatabaseSessionEmbedded session, @Nonnull RecordAbstract record) {
     if (record instanceof Blob) {
       return record.toStream();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinary.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinary.java
@@ -93,9 +93,8 @@ public class RecordSerializerBinary implements RecordSerializer {
       return;
     }
 
-    // Wire byte[] deserialization through ReadBytesContainer, proving the two paths
-    // are equivalent. The ReadBytesContainer wraps the same byte[] with an offset of 1
-    // (skipping the serializer version byte).
+    // Wrap byte[] in ReadBytesContainer (skipping the serializer version byte at index 0)
+    // so that byte[] callers share the same deserialization path as direct-buffer callers.
     final var container = new ReadBytesContainer(iSource, 1);
     try {
       if (iFields != null && iFields.length > 0) {
@@ -122,12 +121,25 @@ public class RecordSerializerBinary implements RecordSerializer {
       @Nonnull ReadBytesContainer container,
       @Nonnull RecordAbstract iRecord,
       String[] iFields) {
-    if (iFields != null && iFields.length > 0) {
-      serializerByVersion[serializerVersion].deserializePartial(
-          session, (EntityImpl) iRecord, container, iFields);
-    } else {
-      serializerByVersion[serializerVersion].deserialize(
-          session, (EntityImpl) iRecord, container);
+    if (serializerVersion < 0 || serializerVersion >= serializerByVersion.length) {
+      throw new IllegalArgumentException(
+          "Unsupported serializer version: " + serializerVersion);
+    }
+    try {
+      if (iFields != null && iFields.length > 0) {
+        serializerByVersion[serializerVersion].deserializePartial(
+            session, (EntityImpl) iRecord, container, iFields);
+      } else {
+        serializerByVersion[serializerVersion].deserialize(
+            session, (EntityImpl) iRecord, container);
+      }
+    } catch (RuntimeException e) {
+      LogManager.instance()
+          .warn(
+              this,
+              "Error deserializing record with id %s via ReadBytesContainer",
+              iRecord.getIdentity().toString());
+      throw e;
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -30,6 +30,7 @@ import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSeria
 import com.jetbrains.youtrackdb.internal.common.serialization.types.LongSerializer;
 import com.jetbrains.youtrackdb.internal.common.util.RawPair;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.StringCache;
 import com.jetbrains.youtrackdb.internal.core.db.record.EntityEmbeddedListImpl;
 import com.jetbrains.youtrackdb.internal.core.db.record.EntityEmbeddedMapImpl;
 import com.jetbrains.youtrackdb.internal.core.db.record.EntityEmbeddedSetImpl;
@@ -1643,7 +1644,6 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     PropertyTypeInternal type;
     var cumulativeSize = valuesStart;
     while (bytes.offset() < valuesStart) {
-      GlobalProperty prop;
       final var len = VarIntSerializer.readAsInteger(bytes);
       int fieldLength;
       if (len > 0) {
@@ -1652,7 +1652,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
         fieldLength = pointerAndType.getFirstVal();
         type = pointerAndType.getSecondVal();
       } else {
-        prop = getGlobalProperty(entity, len);
+        var prop = getGlobalProperty(entity, len);
         fieldName = prop.getName();
         fieldLength = VarIntSerializer.readAsInteger(bytes);
         type = PropertyTypeInternal.convertFromPublicType(prop.getType());
@@ -1748,8 +1748,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     }
   }
 
-  @Nullable private static com.jetbrains.youtrackdb.internal.core.db.StringCache resolveStringCache(
-      DatabaseSessionEmbedded session) {
+  @Nullable private static StringCache resolveStringCache(DatabaseSessionEmbedded session) {
     var context = session.getSharedContext();
     if (context != null) {
       return context.getStringCache();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -1562,6 +1562,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     final var field = iFieldName.getBytes();
 
     var headerLength = VarIntSerializer.readAsInteger(bytes);
+    if (headerLength < 0 || headerLength > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Header length exceeds remaining buffer: "
+              + headerLength + " > " + bytes.remaining());
+    }
     var headerStart = bytes.offset();
     var valuesStart = headerStart + headerLength;
     var cumulativeLength = valuesStart;
@@ -1687,6 +1692,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     var cache = resolveStringCache(session);
 
     var headerLength = VarIntSerializer.readAsInteger(bytes);
+    if (headerLength < 0 || headerLength > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Header length exceeds remaining buffer: "
+              + headerLength + " > " + bytes.remaining());
+    }
     var headerStart = bytes.offset();
     var valuesStart = headerStart + headerLength;
     var last = 0;
@@ -1751,6 +1761,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     var unmarshalledFields = 0;
 
     var headerLength = VarIntSerializer.readAsInteger(bytes);
+    if (headerLength < 0 || headerLength > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Header length exceeds remaining buffer: "
+              + headerLength + " > " + bytes.remaining());
+    }
     var headerStart = bytes.offset();
     var valuesStart = headerStart + headerLength;
     var currentValuePos = valuesStart;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -1335,18 +1335,21 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       case LINKMAP -> value = readLinkMap(bytes, owner, justRunThrough);
       case EMBEDDEDMAP -> value = readEmbeddedMap(session, bytes, owner);
       case DECIMAL -> {
-        // DecimalSerializer requires byte[] — compute exact size first to avoid
-        // copying the entire remaining buffer. Layout: int(scale) + int(len) + byte[len]
-        var sizeHeader = new byte[IntegerSerializer.INT_SIZE * 2];
+        // Layout: int(scale) + int(unscaledLen) + byte[unscaledLen]
+        // Read the two header ints via getInt() to compute the total size without
+        // a staging array, then read the complete decimal bytes in a single allocation.
         var startPos = bytes.offset();
-        bytes.getBytes(sizeHeader, 0, sizeHeader.length);
-        bytes.setOffset(startPos);
-        var unscaledLen = IntegerSerializer.deserializeLiteral(
-            sizeHeader, IntegerSerializer.INT_SIZE);
-        var totalDecSize = IntegerSerializer.INT_SIZE * 2 + unscaledLen;
-        var decBytes = new byte[totalDecSize];
-        bytes.getBytes(decBytes, 0, totalDecSize);
-        value = DecimalSerializer.staticDeserialize(decBytes, 0);
+        bytes.skip(IntegerSerializer.INT_SIZE); // skip scale
+        var unscaledLen = bytes.getInt(); // read unscaledLen
+        bytes.setOffset(startPos); // seek back to start
+        if (justRunThrough) {
+          bytes.skip(IntegerSerializer.INT_SIZE * 2 + unscaledLen);
+        } else {
+          var totalDecSize = IntegerSerializer.INT_SIZE * 2 + unscaledLen;
+          var decBytes = new byte[totalDecSize];
+          bytes.getBytes(decBytes, 0, totalDecSize);
+          value = DecimalSerializer.staticDeserialize(decBytes, 0);
+        }
       }
       case LINKBAG -> {
         var bag = readLinkBag(session, bytes);
@@ -1368,13 +1371,13 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
 
     if (type != null) {
       var found = new EntityEmbeddedSetImpl<>(owner);
+      var schema = resolveSchema(found);
       for (var i = 0; i < items; i++) {
         var itemType = readOType(bytes, false);
         if (itemType == null) {
           found.addInternal(null);
         } else {
-          found.addInternal(
-              deserializeValue(db, bytes, itemType, found, false, resolveSchema(found)));
+          found.addInternal(deserializeValue(db, bytes, itemType, found, false, schema));
         }
       }
       return found;
@@ -1391,13 +1394,13 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
 
     if (type != null) {
       var found = new EntityEmbeddedListImpl<>(owner);
+      var schema = resolveSchema(found);
       for (var i = 0; i < items; i++) {
         var itemType = readOType(bytes, false);
         if (itemType == null) {
           found.addInternal(null);
         } else {
-          found.addInternal(
-              deserializeValue(db, bytes, itemType, found, false, resolveSchema(found)));
+          found.addInternal(deserializeValue(db, bytes, itemType, found, false, schema));
         }
       }
       return found;
@@ -1644,6 +1647,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     String fieldName;
     PropertyTypeInternal type;
     var cumulativeSize = valuesStart;
+    var schema = resolveSchema(entity);
     while (bytes.offset() < valuesStart) {
       final var len = VarIntSerializer.readAsInteger(bytes);
       int fieldLength;
@@ -1663,7 +1667,6 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
         if (fieldLength != 0) {
           var headerCursor = bytes.offset();
           bytes.setOffset(cumulativeSize);
-          var schema = resolveSchema(entity);
           final var value = deserializeValue(session, bytes, type, entity, false, schema);
           if (bytes.offset() > last) {
             last = bytes.offset();
@@ -1705,6 +1708,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     var headerStart = bytes.offset();
     var valuesStart = headerStart + headerLength;
     var currentValuePos = valuesStart;
+    var schema = resolveSchema(entity);
 
     while (bytes.offset() < valuesStart) {
       final var len = VarIntSerializer.readAsInteger(bytes);
@@ -1735,7 +1739,6 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
         if (fieldLength != 0) {
           var headerCursor = bytes.offset();
           bytes.setOffset(currentValuePos);
-          var schema = resolveSchema(entity);
           final var value = deserializeValue(db, bytes, type, entity, false, schema);
           bytes.setOffset(headerCursor);
           entity.setDeserializedPropertyInternal(fieldName, value, type);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -197,8 +197,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
   }
 
   @Override
-  @Nullable
-  public BinaryField deserializeField(
+  @Nullable public BinaryField deserializeField(
       DatabaseSessionEmbedded session, final BytesContainer bytes,
       final SchemaClass iClass,
       final String iFieldName,
@@ -524,8 +523,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     serializeEntity(session, entity, bytes, clazz, schema, encryption);
   }
 
-  @Nullable
-  @SuppressWarnings("TypeParameterUnusedInFormals")
+  @Nullable @SuppressWarnings("TypeParameterUnusedInFormals")
   protected <RET> RET deserializeFieldTypedLoopAndReturn(
       DatabaseSessionEmbedded session, BytesContainer bytes,
       String iFieldName,
@@ -1079,7 +1077,8 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       case LINKMAP ->
           pointer = writeLinkMap(session, bytes, (Map<Object, Identifiable>) value);
       case EMBEDDEDMAP ->
-          pointer = writeEmbeddedMap(session, bytes, (Map<Object, Object>) value, schema, encryption);
+          pointer =
+              writeEmbeddedMap(session, bytes, (Map<Object, Object>) value, schema, encryption);
       case LINKBAG -> pointer = writeLinkBag(session, bytes, (LinkBag) value);
     }
     return pointer;
@@ -1142,8 +1141,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     return value;
   }
 
-  @Nullable
-  protected EntityEmbeddedSetImpl<?> readEmbeddedSet(DatabaseSessionEmbedded db,
+  @Nullable protected EntityEmbeddedSetImpl<?> readEmbeddedSet(DatabaseSessionEmbedded db,
       final BytesContainer bytes,
       final RecordElement owner) {
 
@@ -1166,8 +1164,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     return null;
   }
 
-  @Nullable
-  protected EntityEmbeddedListImpl<?> readEmbeddedList(DatabaseSessionEmbedded db,
+  @Nullable protected EntityEmbeddedListImpl<?> readEmbeddedList(DatabaseSessionEmbedded db,
       final BytesContainer bytes,
       final RecordElement owner) {
 
@@ -1198,5 +1195,428 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
   @Override
   public BinaryComparator getComparator() {
     return comparator;
+  }
+
+  // --- ReadBytesContainer overloads for the deserialization path ---
+
+  private static int findMatchingFieldName(
+      final ReadBytesContainer bytes, int len, byte[][] fields) {
+    for (var i = 0; i < fields.length; ++i) {
+      if (fields[i] != null && fields[i].length == len) {
+        var matchField = true;
+        for (var j = 0; j < len; ++j) {
+          if (bytes.peekByte(j) != fields[i][j]) {
+            matchField = false;
+            break;
+          }
+        }
+        if (matchField) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  private static boolean checkMatchForLargerThenZero(
+      final ReadBytesContainer bytes, final byte[] field, int len) {
+    if (field.length != len) {
+      return false;
+    }
+    var match = true;
+    for (var j = 0; j < len; ++j) {
+      if (bytes.peekByte(j) != field[j]) {
+        match = false;
+        break;
+      }
+    }
+    return match;
+  }
+
+  private static HelperClasses.Tuple<Integer, PropertyTypeInternal>
+      getFieldSizeAndTypeFromCurrentPosition(ReadBytesContainer bytes) {
+    var fieldSize = VarIntSerializer.readAsInteger(bytes);
+    var type = readOType(bytes, false);
+    return new HelperClasses.Tuple<>(fieldSize, type);
+  }
+
+  protected Object deserializeValue(
+      DatabaseSessionEmbedded session,
+      final ReadBytesContainer bytes,
+      final PropertyTypeInternal type,
+      final RecordElement owner,
+      boolean justRunThrough,
+      ImmutableSchema schema) {
+    if (type == null) {
+      throw new DatabaseException(session.getDatabaseName(), "Invalid type value: null");
+    }
+    Object value = null;
+    switch (type) {
+      case INTEGER -> value = VarIntSerializer.readAsInteger(bytes);
+      case LONG -> value = VarIntSerializer.readAsLong(bytes);
+      case SHORT -> value = VarIntSerializer.readAsShort(bytes);
+      case STRING -> {
+        if (justRunThrough) {
+          var length = VarIntSerializer.readAsInteger(bytes);
+          bytes.skip(length);
+        } else {
+          value = readString(bytes);
+        }
+      }
+      case DOUBLE -> {
+        if (justRunThrough) {
+          bytes.skip(LongSerializer.LONG_SIZE);
+        } else {
+          value = Double.longBitsToDouble(readLong(bytes));
+        }
+      }
+      case FLOAT -> {
+        if (justRunThrough) {
+          bytes.skip(IntegerSerializer.INT_SIZE);
+        } else {
+          value = Float.intBitsToFloat(readInteger(bytes));
+        }
+      }
+      case BYTE -> {
+        if (justRunThrough) {
+          bytes.skip(1);
+        } else {
+          value = readByte(bytes);
+        }
+      }
+      case BOOLEAN -> {
+        if (justRunThrough) {
+          bytes.skip(1);
+        } else {
+          value = readByte(bytes) == 1;
+        }
+      }
+      case DATETIME -> {
+        if (justRunThrough) {
+          VarIntSerializer.readAsLong(bytes);
+        } else {
+          value = new Date(VarIntSerializer.readAsLong(bytes));
+        }
+      }
+      case DATE -> {
+        if (justRunThrough) {
+          VarIntSerializer.readAsLong(bytes);
+        } else {
+          var savedTime = VarIntSerializer.readAsLong(bytes) * MILLISEC_PER_DAY;
+          savedTime =
+              convertDayToTimezone(
+                  TimeZone.getTimeZone("GMT"),
+                  DateHelper.getDatabaseTimeZone(session),
+                  savedTime);
+          value = new Date(savedTime);
+        }
+      }
+      case EMBEDDED -> value = deserializeEmbeddedAsDocument(session, bytes, owner);
+      case EMBEDDEDSET -> value = readEmbeddedSet(session, bytes, owner);
+      case EMBEDDEDLIST -> value = readEmbeddedList(session, bytes, owner);
+      case LINKSET -> value = readLinkSet(session, bytes);
+      case LINKLIST -> {
+        EntityLinkListImpl collectionList = null;
+        if (!justRunThrough) {
+          collectionList = new EntityLinkListImpl(owner);
+        }
+        value = readLinkCollection(bytes, collectionList, justRunThrough);
+      }
+      case BINARY -> {
+        if (justRunThrough) {
+          var len = VarIntSerializer.readAsInteger(bytes);
+          bytes.skip(len);
+        } else {
+          value = readBinary(bytes);
+        }
+      }
+      case LINK -> value = readOptimizedLink(bytes, justRunThrough);
+      case LINKMAP -> value = readLinkMap(bytes, owner, justRunThrough);
+      case EMBEDDEDMAP -> value = readEmbeddedMap(session, bytes, owner);
+      case DECIMAL -> {
+        // DecimalSerializer requires byte[] — extract from buffer
+        var decBytes = new byte[bytes.remaining()];
+        var startPos = bytes.offset();
+        bytes.getBytes(decBytes, 0, decBytes.length);
+        bytes.setOffset(startPos);
+        value = DecimalSerializer.staticDeserialize(decBytes, 0);
+        var decSize = DecimalSerializer.staticGetObjectSize(decBytes, 0);
+        bytes.skip(decSize);
+      }
+      case LINKBAG -> {
+        var bag = readLinkBag(session, bytes);
+        bag.setOwner(owner);
+        value = bag;
+      }
+      default -> {
+      }
+    }
+    return value;
+  }
+
+  @Nullable protected EntityEmbeddedSetImpl<?> readEmbeddedSet(
+      DatabaseSessionEmbedded db,
+      final ReadBytesContainer bytes,
+      final RecordElement owner) {
+    final var items = VarIntSerializer.readAsInteger(bytes);
+    var type = readOType(bytes, false);
+
+    if (type != null) {
+      var found = new EntityEmbeddedSetImpl<>(owner);
+      for (var i = 0; i < items; i++) {
+        var itemType = readOType(bytes, false);
+        if (itemType == null) {
+          found.addInternal(null);
+        } else {
+          found.addInternal(deserializeValue(db, bytes, itemType, found, false, null));
+        }
+      }
+      return found;
+    }
+    return null;
+  }
+
+  @Nullable protected EntityEmbeddedListImpl<?> readEmbeddedList(
+      DatabaseSessionEmbedded db,
+      final ReadBytesContainer bytes,
+      final RecordElement owner) {
+    final var items = VarIntSerializer.readAsInteger(bytes);
+    var type = readOType(bytes, false);
+
+    if (type != null) {
+      var found = new EntityEmbeddedListImpl<>(owner);
+      for (var i = 0; i < items; i++) {
+        var itemType = readOType(bytes, false);
+        if (itemType == null) {
+          found.addInternal(null);
+        } else {
+          found.addInternal(deserializeValue(db, bytes, itemType, found, false, null));
+        }
+      }
+      return found;
+    }
+    return null;
+  }
+
+  protected Object readEmbeddedMap(
+      DatabaseSessionEmbedded db,
+      final ReadBytesContainer bytes,
+      final RecordElement owner) {
+    var size = VarIntSerializer.readAsInteger(bytes);
+    final var result = new EntityEmbeddedMapImpl<Object>(owner);
+    for (var i = 0; i < size; i++) {
+      var keyType = readOType(bytes, false);
+      var key = deserializeValue(db, bytes, keyType, result, false, null);
+      final var type = HelperClasses.readType(bytes);
+      if (type != null) {
+        var value = deserializeValue(db, bytes, type, result, false, null);
+        result.putInternal(key.toString(), value);
+      } else {
+        result.putInternal(key.toString(), null);
+      }
+    }
+    return result;
+  }
+
+  protected static EntityLinkSetImpl readLinkSet(
+      DatabaseSessionEmbedded session, ReadBytesContainer bytes) {
+    var configByte = bytes.getByte();
+    var isEmbedded = (configByte & 1) != 0;
+
+    EntityLinkSetImpl ridbag;
+    var linkBagSize = VarIntSerializer.readAsInteger(bytes);
+    if (isEmbedded) {
+      var embeddedBagDelegate = readEmbeddedLinkBag(session, bytes, linkBagSize, 1);
+      ridbag = new EntityLinkSetImpl(session, embeddedBagDelegate);
+    } else {
+      var btreeLinkBag = readBTreeBasedLinkBag(session, bytes, linkBagSize, 1);
+      ridbag = new EntityLinkSetImpl(session, btreeLinkBag);
+    }
+    return ridbag;
+  }
+
+  protected static LinkBag readLinkBag(
+      DatabaseSessionEmbedded session, ReadBytesContainer bytes) {
+    var configByte = bytes.getByte();
+    var isEmbedded = (configByte & 1) != 0;
+
+    LinkBag ridbag;
+    var linkBagSize = VarIntSerializer.readAsInteger(bytes);
+    if (isEmbedded) {
+      var embeddedBagDelegate =
+          readEmbeddedLinkBag(session, bytes, linkBagSize, Integer.MAX_VALUE);
+      ridbag = new LinkBag(session, embeddedBagDelegate);
+    } else {
+      var btreeLinkBag =
+          readBTreeBasedLinkBag(session, bytes, linkBagSize, Integer.MAX_VALUE);
+      ridbag = new LinkBag(session, btreeLinkBag);
+    }
+    return ridbag;
+  }
+
+  @Nonnull
+  private static EmbeddedLinkBag readEmbeddedLinkBag(
+      DatabaseSessionEmbedded session,
+      ReadBytesContainer bytes,
+      int linkBagSize,
+      int counterMaxValue) {
+    var changes = new ArrayList<RawPair<RID, AbsoluteChange>>();
+    var continueFlag = readByte(bytes);
+
+    while (continueFlag > 0) {
+      var rid = HelperClasses.readLinkOptimizedEmbedded(session, bytes);
+      var counter = VarIntSerializer.readAsInteger(bytes);
+      var secondaryRid = HelperClasses.readLinkOptimizedEmbedded(session, bytes);
+      changes.add(new RawPair<>(rid, new AbsoluteChange(counter, secondaryRid)));
+      continueFlag = readByte(bytes);
+    }
+
+    return new EmbeddedLinkBag(changes, session, linkBagSize, counterMaxValue);
+  }
+
+  @Nonnull
+  private static BTreeBasedLinkBag readBTreeBasedLinkBag(
+      DatabaseSessionEmbedded session,
+      ReadBytesContainer bytes,
+      int linkBagSize,
+      int counterMaxValue) {
+    var fileId = VarIntSerializer.readAsLong(bytes);
+    var linkBagId = VarIntSerializer.readAsLong(bytes);
+    assert fileId > -1;
+
+    var pointer = new LinkBagPointer(fileId, linkBagId);
+    return new BTreeBasedLinkBag(session, pointer, linkBagSize, counterMaxValue);
+  }
+
+  @Nullable @SuppressWarnings("TypeParameterUnusedInFormals")
+  protected <RET> RET deserializeFieldTypedLoopAndReturn(
+      DatabaseSessionEmbedded session,
+      ReadBytesContainer bytes,
+      String iFieldName,
+      final ImmutableSchema schema,
+      PropertyEncryption encryption) {
+    final var field = iFieldName.getBytes();
+
+    var headerLength = VarIntSerializer.readAsInteger(bytes);
+    var headerStart = bytes.offset();
+    var valuesStart = headerStart + headerLength;
+    var cumulativeLength = valuesStart;
+
+    while (bytes.offset() < valuesStart) {
+      var len = VarIntSerializer.readAsInteger(bytes);
+
+      if (len > 0) {
+        var match = checkMatchForLargerThenZero(bytes, field, len);
+        bytes.skip(len);
+        var pointerAndType = getFieldSizeAndTypeFromCurrentPosition(bytes);
+        int fieldLength = pointerAndType.getFirstVal();
+        var type = pointerAndType.getSecondVal();
+
+        if (match) {
+          if (fieldLength == 0) {
+            return null;
+          }
+          bytes.setOffset(cumulativeLength);
+          var value = deserializeValue(session, bytes, type, null, false, schema);
+          //noinspection unchecked
+          return (RET) value;
+        }
+        cumulativeLength += fieldLength;
+      } else {
+        final var id = (len * -1) - 1;
+        final var prop = schema.getGlobalPropertyById(id);
+        final var fieldLength = VarIntSerializer.readAsInteger(bytes);
+        var type = PropertyTypeInternal.convertFromPublicType(prop.getType());
+
+        if (iFieldName.equals(prop.getName())) {
+          if (fieldLength == 0) {
+            return null;
+          }
+          bytes.setOffset(cumulativeLength);
+          var value = deserializeValue(session, bytes, type, null, false, schema);
+          //noinspection unchecked
+          return (RET) value;
+        }
+        cumulativeLength += fieldLength;
+      }
+    }
+    return null;
+  }
+
+  protected List<MapRecordInfo> getPositionsFromEmbeddedMap(
+      DatabaseSessionEmbedded session,
+      final ReadBytesContainer bytes,
+      ImmutableSchema schema) {
+    List<MapRecordInfo> retList = new ArrayList<>();
+    var numberOfElements = VarIntSerializer.readAsInteger(bytes);
+
+    for (var i = 0; i < numberOfElements; i++) {
+      var keyType = readOType(bytes, false);
+      var key = readString(bytes);
+      var valueType = HelperClasses.readType(bytes);
+      var recordInfo = new MapRecordInfo();
+      recordInfo.fieldType = valueType;
+      recordInfo.key = key;
+      recordInfo.keyType = keyType;
+      var currentOffset = bytes.offset();
+
+      if (valueType != null) {
+        recordInfo.fieldStartOffset = bytes.offset();
+        deserializeValue(session, bytes, valueType, null, true, schema);
+        recordInfo.fieldLength = bytes.offset() - currentOffset;
+        retList.add(recordInfo);
+      } else {
+        recordInfo.fieldStartOffset = 0;
+        recordInfo.fieldLength = 0;
+        retList.add(recordInfo);
+      }
+    }
+    return retList;
+  }
+
+  protected Object deserializeEmbeddedAsDocument(
+      DatabaseSessionEmbedded db,
+      final ReadBytesContainer bytes,
+      final RecordElement owner) {
+    Object value = new EmbeddedEntityImpl(db);
+    deserializeWithClassName(db, (EntityImpl) value, bytes);
+    if (((EntityImpl) value).hasProperty(EntitySerializable.CLASS_NAME)) {
+      String className = ((EntityImpl) value).getProperty(EntitySerializable.CLASS_NAME);
+      try {
+        var clazz = Class.forName(className);
+        var newValue = (EntitySerializable) clazz.newInstance();
+        newValue.fromDocument((EntityImpl) value);
+        value = newValue;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      var entity = (EntityImpl) value;
+      entity.setOwner(owner);
+      final var rec = (RecordAbstract) entity;
+      rec.unsetDirty();
+    }
+    return value;
+  }
+
+  public void deserializeWithClassName(
+      DatabaseSessionEmbedded db, final EntityImpl entity, final ReadBytesContainer bytes) {
+    final var className = readString(bytes);
+    if (!className.isEmpty()) {
+      entity.setClassNameWithoutPropertiesPostProcessing(className);
+    }
+    // Delegates to the ReadBytesContainer overload of deserialize (Step 4)
+    deserialize(db, entity, bytes);
+  }
+
+  /**
+   * Placeholder for the ReadBytesContainer deserialize overload. Will be fully
+   * implemented in Step 4. For now, this allows deserializeEmbeddedAsDocument
+   * to compile — embedded entities always go through deserialize.
+   */
+  public void deserialize(
+      DatabaseSessionEmbedded db, final EntityImpl entity, final ReadBytesContainer bytes) {
+    throw new UnsupportedOperationException(
+        "ReadBytesContainer deserialize not yet implemented — Step 4");
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -1353,10 +1353,14 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
         bytes.skip(IntegerSerializer.INT_SIZE); // skip scale
         var unscaledLen = bytes.getInt(); // read unscaledLen
         bytes.setOffset(startPos); // seek back to start
-        if (unscaledLen < 0 || unscaledLen > bytes.remaining()) {
+        // remaining() includes the 8 header bytes (scale + unscaledLen) that will also
+        // be consumed, so subtract them to get the actual payload capacity.
+        if (unscaledLen < 0
+            || unscaledLen > bytes.remaining() - IntegerSerializer.INT_SIZE * 2) {
           throw new CorruptedRecordException(
               "Decimal unscaled length exceeds remaining buffer: "
-                  + unscaledLen + " > " + bytes.remaining());
+                  + unscaledLen + " > "
+                  + (bytes.remaining() - IntegerSerializer.INT_SIZE * 2));
         }
         if (justRunThrough) {
           bytes.skip(IntegerSerializer.INT_SIZE * 2 + unscaledLen);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -265,6 +265,71 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
   }
 
   @Override
+  @Nullable public ReadBinaryField deserializeField(
+      DatabaseSessionEmbedded session, final ReadBytesContainer bytes,
+      final SchemaClass iClass,
+      final String iFieldName,
+      boolean embedded,
+      ImmutableSchema schema,
+      PropertyEncryption encryption) {
+
+    if (embedded) {
+      var classNameLen = VarIntSerializer.readAsInteger(bytes);
+      bytes.skip(classNameLen);
+    }
+    final var field = iFieldName.getBytes();
+
+    var headerLength = VarIntSerializer.readAsInteger(bytes);
+    if (headerLength < 0 || headerLength > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Header length exceeds remaining buffer: "
+              + headerLength + " > " + bytes.remaining());
+    }
+    var headerStart = bytes.offset();
+    var valuesStart = headerStart + headerLength;
+    var currentValuePos = valuesStart;
+
+    while (bytes.offset() < valuesStart) {
+      var len = VarIntSerializer.readAsInteger(bytes);
+
+      if (len > 0) {
+        var match = checkMatchForLargerThenZero(bytes, field, len);
+        bytes.skip(len);
+        var pointerAndType = getFieldSizeAndTypeFromCurrentPosition(bytes);
+        int fieldLength = pointerAndType.getFirstVal();
+        var type = pointerAndType.getSecondVal();
+
+        if (match) {
+          if (fieldLength == 0 || !getComparator().isBinaryComparable(type)) {
+            return null;
+          }
+          bytes.setOffset(currentValuePos);
+          return new ReadBinaryField(iFieldName, type, bytes, null);
+        }
+        currentValuePos += fieldLength;
+      } else {
+        final var id = (len * -1) - 1;
+        final var prop = schema.getGlobalPropertyById(id);
+        final var fieldLength = VarIntSerializer.readAsInteger(bytes);
+        var type = PropertyTypeInternal.convertFromPublicType(prop.getType());
+
+        if (iFieldName.equals(prop.getName())) {
+          if (fieldLength == 0 || !getComparator().isBinaryComparable(type)) {
+            return null;
+          }
+          bytes.setOffset(currentValuePos);
+          var classProp = iClass.getProperty(iFieldName);
+          return new ReadBinaryField(
+              iFieldName, type, bytes,
+              classProp != null ? classProp.getCollate() : null);
+        }
+        currentValuePos += fieldLength;
+      }
+    }
+    return null;
+  }
+
+  @Override
   public void deserialize(DatabaseSessionEmbedded session, final EntityImpl entity,
       final BytesContainer bytes) {
     var headerLength = VarIntSerializer.readAsInteger(bytes);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -1479,10 +1479,9 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
 
     EntityLinkSetImpl ridbag;
     var linkBagSize = VarIntSerializer.readAsInteger(bytes);
-    if (linkBagSize < 0 || linkBagSize > bytes.remaining()) {
+    if (linkBagSize < 0) {
       throw new CorruptedRecordException(
-          "Link set size exceeds remaining buffer: "
-              + linkBagSize + " > " + bytes.remaining());
+          "Negative link set size: " + linkBagSize);
     }
     if (isEmbedded) {
       var embeddedBagDelegate = readEmbeddedLinkBag(session, bytes, linkBagSize, 1);
@@ -1501,10 +1500,9 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
 
     LinkBag ridbag;
     var linkBagSize = VarIntSerializer.readAsInteger(bytes);
-    if (linkBagSize < 0 || linkBagSize > bytes.remaining()) {
+    if (linkBagSize < 0) {
       throw new CorruptedRecordException(
-          "Link bag size exceeds remaining buffer: "
-              + linkBagSize + " > " + bytes.remaining());
+          "Negative link bag size: " + linkBagSize);
     }
     if (isEmbedded) {
       var embeddedBagDelegate =

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -269,6 +269,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       DatabaseSessionEmbedded session, final ReadBytesContainer bytes,
       final SchemaClass iClass,
       final String iFieldName,
+      final byte[] fieldNameBytes,
       boolean embedded,
       ImmutableSchema schema,
       PropertyEncryption encryption) {
@@ -277,7 +278,6 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       var classNameLen = VarIntSerializer.readAsInteger(bytes);
       bytes.skip(classNameLen);
     }
-    final var field = iFieldName.getBytes();
 
     var headerLength = VarIntSerializer.readAsInteger(bytes);
     if (headerLength < 0 || headerLength > bytes.remaining()) {
@@ -293,11 +293,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       var len = VarIntSerializer.readAsInteger(bytes);
 
       if (len > 0) {
-        var match = checkMatchForLargerThenZero(bytes, field, len);
+        var match = checkMatchForLargerThenZero(bytes, fieldNameBytes, len);
         bytes.skip(len);
-        var pointerAndType = getFieldSizeAndTypeFromCurrentPosition(bytes);
-        int fieldLength = pointerAndType.getFirstVal();
-        var type = pointerAndType.getSecondVal();
+        // Inline getFieldSizeAndTypeFromCurrentPosition to avoid Tuple allocation
+        var fieldLength = VarIntSerializer.readAsInteger(bytes);
+        var type = readOType(bytes, false);
 
         if (match) {
           if (fieldLength == 0 || !getComparator().isBinaryComparable(type)) {
@@ -318,7 +318,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
             return null;
           }
           bytes.setOffset(currentValuePos);
-          var classProp = iClass.getProperty(iFieldName);
+          var classProp = iClass != null ? iClass.getProperty(iFieldName) : null;
           return new ReadBinaryField(
               iFieldName, type, bytes,
               classProp != null ? classProp.getCollate() : null);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -41,6 +41,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.SerializationException;
 import com.jetbrains.youtrackdb.internal.core.exception.ValidationException;
@@ -1259,6 +1260,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       case STRING -> {
         if (justRunThrough) {
           var length = VarIntSerializer.readAsInteger(bytes);
+          if (length < 0 || length > bytes.remaining()) {
+            throw new CorruptedRecordException(
+                "String length exceeds remaining buffer: "
+                    + length + " > " + bytes.remaining());
+          }
           bytes.skip(length);
         } else {
           value = readString(bytes);
@@ -1326,6 +1332,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       case BINARY -> {
         if (justRunThrough) {
           var len = VarIntSerializer.readAsInteger(bytes);
+          if (len < 0 || len > bytes.remaining()) {
+            throw new CorruptedRecordException(
+                "Binary length exceeds remaining buffer: "
+                    + len + " > " + bytes.remaining());
+          }
           bytes.skip(len);
         } else {
           value = readBinary(bytes);
@@ -1342,6 +1353,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
         bytes.skip(IntegerSerializer.INT_SIZE); // skip scale
         var unscaledLen = bytes.getInt(); // read unscaledLen
         bytes.setOffset(startPos); // seek back to start
+        if (unscaledLen < 0 || unscaledLen > bytes.remaining()) {
+          throw new CorruptedRecordException(
+              "Decimal unscaled length exceeds remaining buffer: "
+                  + unscaledLen + " > " + bytes.remaining());
+        }
         if (justRunThrough) {
           bytes.skip(IntegerSerializer.INT_SIZE * 2 + unscaledLen);
         } else {
@@ -1367,6 +1383,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       final ReadBytesContainer bytes,
       final RecordElement owner) {
     final var items = VarIntSerializer.readAsInteger(bytes);
+    if (items < 0 || items > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Embedded set size exceeds remaining buffer: "
+              + items + " > " + bytes.remaining());
+    }
     var type = readOType(bytes, false);
 
     if (type != null) {
@@ -1390,6 +1411,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       final ReadBytesContainer bytes,
       final RecordElement owner) {
     final var items = VarIntSerializer.readAsInteger(bytes);
+    if (items < 0 || items > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Embedded list size exceeds remaining buffer: "
+              + items + " > " + bytes.remaining());
+    }
     var type = readOType(bytes, false);
 
     if (type != null) {
@@ -1413,6 +1439,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       final ReadBytesContainer bytes,
       final RecordElement owner) {
     var size = VarIntSerializer.readAsInteger(bytes);
+    if (size < 0 || size > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Embedded map size exceeds remaining buffer: "
+              + size + " > " + bytes.remaining());
+    }
     final var result = new EntityEmbeddedMapImpl<Object>(owner);
     var schema = resolveSchema(result);
     for (var i = 0; i < size; i++) {
@@ -1448,6 +1479,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
 
     EntityLinkSetImpl ridbag;
     var linkBagSize = VarIntSerializer.readAsInteger(bytes);
+    if (linkBagSize < 0 || linkBagSize > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Link set size exceeds remaining buffer: "
+              + linkBagSize + " > " + bytes.remaining());
+    }
     if (isEmbedded) {
       var embeddedBagDelegate = readEmbeddedLinkBag(session, bytes, linkBagSize, 1);
       ridbag = new EntityLinkSetImpl(session, embeddedBagDelegate);
@@ -1465,6 +1501,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
 
     LinkBag ridbag;
     var linkBagSize = VarIntSerializer.readAsInteger(bytes);
+    if (linkBagSize < 0 || linkBagSize > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Link bag size exceeds remaining buffer: "
+              + linkBagSize + " > " + bytes.remaining());
+    }
     if (isEmbedded) {
       var embeddedBagDelegate =
           readEmbeddedLinkBag(session, bytes, linkBagSize, Integer.MAX_VALUE);
@@ -1572,6 +1613,11 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       ImmutableSchema schema) {
     List<MapRecordInfo> retList = new ArrayList<>();
     var numberOfElements = VarIntSerializer.readAsInteger(bytes);
+    if (numberOfElements < 0 || numberOfElements > bytes.remaining()) {
+      throw new CorruptedRecordException(
+          "Embedded map element count exceeds remaining buffer: "
+              + numberOfElements + " > " + bytes.remaining());
+    }
 
     for (var i = 0; i < numberOfElements; i++) {
       var keyType = readOType(bytes, false);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -1628,14 +1628,132 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     deserialize(db, entity, bytes);
   }
 
-  /**
-   * Placeholder for the ReadBytesContainer deserialize overload. Will be fully
-   * implemented in Step 4. For now, this allows deserializeEmbeddedAsDocument
-   * to compile — embedded entities always go through deserialize.
-   */
   public void deserialize(
-      DatabaseSessionEmbedded db, final EntityImpl entity, final ReadBytesContainer bytes) {
-    throw new UnsupportedOperationException(
-        "ReadBytesContainer deserialize not yet implemented — Step 4");
+      DatabaseSessionEmbedded session,
+      final EntityImpl entity,
+      final ReadBytesContainer bytes) {
+    // Resolve string cache once for field name interning
+    var cache = resolveStringCache(session);
+
+    var headerLength = VarIntSerializer.readAsInteger(bytes);
+    var headerStart = bytes.offset();
+    var valuesStart = headerStart + headerLength;
+    var last = 0;
+    String fieldName;
+    PropertyTypeInternal type;
+    var cumulativeSize = valuesStart;
+    while (bytes.offset() < valuesStart) {
+      GlobalProperty prop;
+      final var len = VarIntSerializer.readAsInteger(bytes);
+      int fieldLength;
+      if (len > 0) {
+        fieldName = bytes.getInternedString(cache, len);
+        var pointerAndType = getFieldSizeAndTypeFromCurrentPosition(bytes);
+        fieldLength = pointerAndType.getFirstVal();
+        type = pointerAndType.getSecondVal();
+      } else {
+        prop = getGlobalProperty(entity, len);
+        fieldName = prop.getName();
+        fieldLength = VarIntSerializer.readAsInteger(bytes);
+        type = PropertyTypeInternal.convertFromPublicType(prop.getType());
+      }
+
+      if (!entity.rawContainsProperty(fieldName)) {
+        if (fieldLength != 0) {
+          var headerCursor = bytes.offset();
+          bytes.setOffset(cumulativeSize);
+          var schema = resolveSchema(entity);
+          final var value = deserializeValue(session, bytes, type, entity, false, schema);
+          if (bytes.offset() > last) {
+            last = bytes.offset();
+          }
+          bytes.setOffset(headerCursor);
+          entity.setDeserializedPropertyInternal(fieldName, value, type);
+        } else {
+          entity.setDeserializedPropertyInternal(fieldName, null, null);
+        }
+      }
+
+      cumulativeSize += fieldLength;
+    }
+
+    final var rec = (RecordAbstract) entity;
+    rec.clearSource();
+
+    if (last > bytes.offset()) {
+      bytes.setOffset(last);
+    }
+  }
+
+  public void deserializePartial(
+      DatabaseSessionEmbedded db,
+      EntityImpl entity,
+      ReadBytesContainer bytes,
+      String[] iFields) {
+    final var fields = new byte[iFields.length][];
+    for (var i = 0; i < iFields.length; ++i) {
+      fields[i] = bytesFromString(iFields[i]);
+    }
+
+    String fieldName;
+    PropertyTypeInternal type;
+    var unmarshalledFields = 0;
+
+    var headerLength = VarIntSerializer.readAsInteger(bytes);
+    var headerStart = bytes.offset();
+    var valuesStart = headerStart + headerLength;
+    var currentValuePos = valuesStart;
+
+    while (bytes.offset() < valuesStart) {
+      final var len = VarIntSerializer.readAsInteger(bytes);
+      boolean found;
+      int fieldLength;
+      if (len > 0) {
+        var fieldPos = findMatchingFieldName(bytes, len, fields);
+        bytes.skip(len);
+        var pointerAndType = getFieldSizeAndTypeFromCurrentPosition(bytes);
+        fieldLength = pointerAndType.getFirstVal();
+        type = pointerAndType.getSecondVal();
+
+        if (fieldPos >= 0) {
+          fieldName = iFields[fieldPos];
+          found = true;
+        } else {
+          fieldName = null;
+          found = false;
+        }
+      } else {
+        final var prop = getGlobalProperty(entity, len);
+        found = checkIfPropertyNameMatchSome(prop, iFields);
+        fieldLength = VarIntSerializer.readAsInteger(bytes);
+        type = PropertyTypeInternal.convertFromPublicType(prop.getType());
+        fieldName = prop.getName();
+      }
+      if (found) {
+        if (fieldLength != 0) {
+          var headerCursor = bytes.offset();
+          bytes.setOffset(currentValuePos);
+          var schema = resolveSchema(entity);
+          final var value = deserializeValue(db, bytes, type, entity, false, schema);
+          bytes.setOffset(headerCursor);
+          entity.setDeserializedPropertyInternal(fieldName, value, type);
+        } else {
+          entity.setDeserializedPropertyInternal(fieldName, null, null);
+        }
+        if (++unmarshalledFields == iFields.length) {
+          break;
+        }
+      }
+      currentValuePos += fieldLength;
+    }
+  }
+
+  @Nullable private static com.jetbrains.youtrackdb.internal.core.db.StringCache resolveStringCache(
+      DatabaseSessionEmbedded session) {
+    var context = session.getSharedContext();
+    if (context != null) {
+      return context.getStringCache();
+    }
+    return null;
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -1334,14 +1334,18 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       case LINKMAP -> value = readLinkMap(bytes, owner, justRunThrough);
       case EMBEDDEDMAP -> value = readEmbeddedMap(session, bytes, owner);
       case DECIMAL -> {
-        // DecimalSerializer requires byte[] — extract from buffer
-        var decBytes = new byte[bytes.remaining()];
+        // DecimalSerializer requires byte[] — compute exact size first to avoid
+        // copying the entire remaining buffer. Layout: int(scale) + int(len) + byte[len]
+        var sizeHeader = new byte[IntegerSerializer.INT_SIZE * 2];
         var startPos = bytes.offset();
-        bytes.getBytes(decBytes, 0, decBytes.length);
+        bytes.getBytes(sizeHeader, 0, sizeHeader.length);
         bytes.setOffset(startPos);
+        var unscaledLen = IntegerSerializer.deserializeLiteral(
+            sizeHeader, IntegerSerializer.INT_SIZE);
+        var totalDecSize = IntegerSerializer.INT_SIZE * 2 + unscaledLen;
+        var decBytes = new byte[totalDecSize];
+        bytes.getBytes(decBytes, 0, totalDecSize);
         value = DecimalSerializer.staticDeserialize(decBytes, 0);
-        var decSize = DecimalSerializer.staticGetObjectSize(decBytes, 0);
-        bytes.skip(decSize);
       }
       case LINKBAG -> {
         var bag = readLinkBag(session, bytes);
@@ -1368,7 +1372,8 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
         if (itemType == null) {
           found.addInternal(null);
         } else {
-          found.addInternal(deserializeValue(db, bytes, itemType, found, false, null));
+          found.addInternal(
+              deserializeValue(db, bytes, itemType, found, false, resolveSchema(found)));
         }
       }
       return found;
@@ -1390,7 +1395,8 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
         if (itemType == null) {
           found.addInternal(null);
         } else {
-          found.addInternal(deserializeValue(db, bytes, itemType, found, false, null));
+          found.addInternal(
+              deserializeValue(db, bytes, itemType, found, false, resolveSchema(found)));
         }
       }
       return found;
@@ -1404,18 +1410,31 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
       final RecordElement owner) {
     var size = VarIntSerializer.readAsInteger(bytes);
     final var result = new EntityEmbeddedMapImpl<Object>(owner);
+    var schema = resolveSchema(result);
     for (var i = 0; i < size; i++) {
       var keyType = readOType(bytes, false);
-      var key = deserializeValue(db, bytes, keyType, result, false, null);
+      var key = deserializeValue(db, bytes, keyType, result, false, schema);
       final var type = HelperClasses.readType(bytes);
       if (type != null) {
-        var value = deserializeValue(db, bytes, type, result, false, null);
+        var value = deserializeValue(db, bytes, type, result, false, schema);
         result.putInternal(key.toString(), value);
       } else {
         result.putInternal(key.toString(), null);
       }
     }
     return result;
+  }
+
+  /** Resolves ImmutableSchema from a RecordElement by walking up to the owning EntityImpl. */
+  @Nullable private static ImmutableSchema resolveSchema(RecordElement element) {
+    var entity = element;
+    while (!(entity instanceof EntityImpl) && entity != null) {
+      entity = entity.getOwner();
+    }
+    if (entity != null) {
+      return ((EntityImpl) entity).getImmutableSchema();
+    }
+    return null;
   }
 
   protected static EntityLinkSetImpl readLinkSet(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1.java
@@ -1629,6 +1629,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     deserialize(db, entity, bytes);
   }
 
+  @Override
   public void deserialize(
       DatabaseSessionEmbedded session,
       final EntityImpl entity,
@@ -1685,6 +1686,7 @@ public class RecordSerializerBinaryV1 implements EntitySerializer {
     }
   }
 
+  @Override
   public void deserializePartial(
       DatabaseSessionEmbedded db,
       EntityImpl entity,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntSerializer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntSerializer.java
@@ -62,6 +62,22 @@ public class VarIntSerializer {
     return (byte) readSignedVarLong(bytes);
   }
 
+  public static short readAsShort(final ReadBytesContainer bytes) {
+    return (short) readSignedVarLong(bytes);
+  }
+
+  public static long readAsLong(final ReadBytesContainer bytes) {
+    return readSignedVarLong(bytes);
+  }
+
+  public static int readAsInteger(final ReadBytesContainer bytes) {
+    return (int) readSignedVarLong(bytes);
+  }
+
+  public static byte readAsByte(final ReadBytesContainer bytes) {
+    return (byte) readSignedVarLong(bytes);
+  }
+
   /**
    * Encodes a value using the variable-length encoding from <a
    * href="http://code.google.com/apis/protocolbuffers/docs/encoding.html">Google Protocol
@@ -132,6 +148,20 @@ public class VarIntSerializer {
   }
 
   /**
+   * Reads a signed variable-length long from the given read-only container.
+   *
+   * @param bytes to read bytes from
+   * @return decode value
+   * @throws IllegalArgumentException if variable-length value does not terminate after 9 bytes have
+   *                                  been read
+   */
+  public static long readSignedVarLong(final ReadBytesContainer bytes) {
+    final var raw = readUnsignedVarLong(bytes);
+    final var temp = (((raw << 63) >> 63) ^ raw) >> 1;
+    return temp ^ (raw & (1L << 63));
+  }
+
+  /**
    * Reads a signed variable-length long from the given data input stream.
    *
    * @param bytes to read bytes from
@@ -163,6 +193,28 @@ public class VarIntSerializer {
     var i = 0;
     long b;
     while (((b = bytes.bytes[bytes.offset++]) & 0x80L) != 0) {
+      value |= (b & 0x7F) << i;
+      i += 7;
+      if (i > 63) {
+        throw new IllegalArgumentException("Variable length quantity is too long (must be <= 63)");
+      }
+    }
+    return value | (b << i);
+  }
+
+  /**
+   * Reads an unsigned variable-length long from the given read-only container.
+   *
+   * @param bytes to read bytes from
+   * @return decode value
+   * @throws IllegalArgumentException if variable-length value does not terminate after 9 bytes have
+   *                                  been read
+   */
+  public static long readUnsignedVarLong(final ReadBytesContainer bytes) {
+    var value = 0L;
+    var i = 0;
+    long b;
+    while (((b = bytes.getByte()) & 0x80L) != 0) {
       value |= (b & 0x7F) << i;
       i += 7;
       if (i > 63) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawBuffer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawBuffer.java
@@ -22,7 +22,13 @@ package com.jetbrains.youtrackdb.internal.core.storage;
 import java.util.Arrays;
 import java.util.Objects;
 
-public record RawBuffer(byte[] buffer, long version, byte recordType) {
+public record RawBuffer(byte[] buffer, long version, byte recordType)
+    implements StorageReadResult {
+
+  @Override
+  public long recordVersion() {
+    return version;
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawPageBuffer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawPageBuffer.java
@@ -51,16 +51,27 @@ public record RawPageBuffer(
     implements StorageReadResult {
 
   public RawPageBuffer {
-    assert pageFrame != null : "PageFrame must not be null";
-    assert contentOffset >= 0 : "contentOffset must be non-negative";
-    assert contentLength >= 0 : "contentLength must be non-negative";
-    assert contentOffset + contentLength <= pageFrame.getBuffer().capacity()
-        : "content region ["
-            + contentOffset
-            + ", "
-            + (contentOffset + contentLength)
-            + ") exceeds page buffer capacity "
-            + pageFrame.getBuffer().capacity();
+    if (pageFrame == null) {
+      throw new IllegalArgumentException("PageFrame must not be null");
+    }
+    if (contentOffset < 0) {
+      throw new IllegalArgumentException(
+          "contentOffset must be non-negative: " + contentOffset);
+    }
+    if (contentLength < 0) {
+      throw new IllegalArgumentException(
+          "contentLength must be non-negative: " + contentLength);
+    }
+    int end = Math.addExact(contentOffset, contentLength);
+    if (end > pageFrame.getBuffer().capacity()) {
+      throw new IllegalArgumentException(
+          "content region ["
+              + contentOffset
+              + ", "
+              + end
+              + ") exceeds page buffer capacity "
+              + pageFrame.getBuffer().capacity());
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawPageBuffer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawPageBuffer.java
@@ -1,0 +1,69 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+package com.jetbrains.youtrackdb.internal.core.storage;
+
+import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
+import java.nio.ByteBuffer;
+
+/**
+ * Zero-copy storage read result that holds a reference to a PageFrame instead of
+ * copying record bytes into a byte[]. Used on the single-page optimistic read path.
+ *
+ * <p>{@code contentOffset} is an absolute byte offset within the PageFrame's native
+ * memory buffer pointing to the start of the record content (after the entry header
+ * and metadata header). {@code contentLength} is the number of content bytes.
+ *
+ * <p>The caller must validate the PageFrame's stamp after reading to ensure the data
+ * was not modified concurrently. If the stamp is invalid, the caller falls back to
+ * the byte[]-based {@link RawBuffer} path.
+ *
+ * @param pageFrame the PageFrame containing the record data
+ * @param stamp the optimistic read stamp obtained when the page was read
+ * @param contentOffset absolute byte offset within the page buffer to record content
+ * @param contentLength number of bytes of record content
+ * @param recordVersion record version at the time of reading
+ * @param recordType record type byte
+ */
+public record RawPageBuffer(
+    PageFrame pageFrame,
+    long stamp,
+    int contentOffset,
+    int contentLength,
+    long recordVersion,
+    byte recordType)
+    implements StorageReadResult {
+
+  public RawPageBuffer {
+    assert pageFrame != null : "PageFrame must not be null";
+    assert contentOffset >= 0 : "contentOffset must be non-negative";
+    assert contentLength >= 0 : "contentLength must be non-negative";
+  }
+
+  /**
+   * Returns an independent ByteBuffer view covering exactly the record content bytes.
+   * The returned buffer has position 0 and limit equal to {@code contentLength}.
+   *
+   * <p>The returned buffer shares native memory with the PageFrame — the caller must
+   * validate the stamp after reading from this buffer.
+   */
+  public ByteBuffer sliceContent() {
+    return pageFrame.getBuffer().slice(contentOffset, contentLength);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawPageBuffer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/RawPageBuffer.java
@@ -54,6 +54,13 @@ public record RawPageBuffer(
     assert pageFrame != null : "PageFrame must not be null";
     assert contentOffset >= 0 : "contentOffset must be non-negative";
     assert contentLength >= 0 : "contentLength must be non-negative";
+    assert contentOffset + contentLength <= pageFrame.getBuffer().capacity()
+        : "content region ["
+            + contentOffset
+            + ", "
+            + (contentOffset + contentLength)
+            + ") exceeds page buffer capacity "
+            + pageFrame.getBuffer().capacity();
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/Storage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/Storage.java
@@ -49,11 +49,7 @@ import javax.annotation.Nullable;
 public interface Storage {
 
   enum STATUS {
-    CLOSED,
-    OPEN,
-    MIGRATION,
-    CLOSING,
-    @Deprecated
+    CLOSED, OPEN, MIGRATION, CLOSING, @Deprecated
     OPENING,
   }
 
@@ -78,7 +74,7 @@ public interface Storage {
   // CRUD OPERATIONS
   @SuppressWarnings("unused")
   @Nonnull
-  RawBuffer readRecord(RecordIdInternal iRid, @Nonnull AtomicOperation atomicOperation);
+  StorageReadResult readRecord(RecordIdInternal iRid, @Nonnull AtomicOperation atomicOperation);
 
   boolean recordExists(DatabaseSessionEmbedded session, RID rid, AtomicOperation atomicOperation);
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageCollection.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageCollection.java
@@ -91,7 +91,7 @@ public interface StorageCollection {
   void updateRecordVersion(long collectionPosition, @Nonnull AtomicOperation atomicOperation);
 
   @Nonnull
-  RawBuffer readRecord(long collectionPosition, @Nonnull AtomicOperation atomicOperation)
+  StorageReadResult readRecord(long collectionPosition, @Nonnull AtomicOperation atomicOperation)
       throws IOException;
 
   boolean exists(@Nonnull AtomicOperation atomicOperation);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResult.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResult.java
@@ -19,6 +19,8 @@
  */
 package com.jetbrains.youtrackdb.internal.core.storage;
 
+import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
+
 /**
  * Sealed result of a storage read operation. Two variants:
  *
@@ -52,6 +54,16 @@ public sealed interface StorageReadResult permits RawBuffer, RawPageBuffer {
         var slice = pb.sliceContent();
         var bytes = new byte[slice.remaining()];
         slice.get(bytes);
+
+        // Validate the stamp after extracting bytes. The RawPageBuffer was created
+        // inside the optimistic read window (before scope.validateOrThrow()), but
+        // the actual byte extraction happens AFTER the optimistic scope closes.
+        // Without this validation, a concurrent page modification between
+        // scope.validateOrThrow() and sliceContent().get() would silently produce
+        // corrupt data.
+        if (!pb.pageFrame().validate(pb.stamp())) {
+          throw OptimisticReadFailedException.INSTANCE;
+        }
         yield new RawBuffer(bytes, pb.recordVersion(), pb.recordType());
       }
     };

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResult.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResult.java
@@ -36,4 +36,24 @@ public sealed interface StorageReadResult permits RawBuffer, RawPageBuffer {
 
   /** Record type byte. */
   byte recordType();
+
+  /**
+   * Returns this result as a {@link RawBuffer}. If this is already a {@code RawBuffer},
+   * returns it directly. If this is a {@code RawPageBuffer}, extracts the content bytes
+   * into a new byte[] and wraps them in a {@code RawBuffer}.
+   *
+   * <p>Use this for callers that need a byte[] (e.g., storage configuration reads)
+   * and cannot use the zero-copy PageFrame path.
+   */
+  default RawBuffer toRawBuffer() {
+    return switch (this) {
+      case RawBuffer rb -> rb;
+      case RawPageBuffer pb -> {
+        var slice = pb.sliceContent();
+        var bytes = new byte[slice.remaining()];
+        slice.get(bytes);
+        yield new RawBuffer(bytes, pb.recordVersion(), pb.recordType());
+      }
+    };
+  }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResult.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResult.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+package com.jetbrains.youtrackdb.internal.core.storage;
+
+/**
+ * Sealed result of a storage read operation. Two variants:
+ *
+ * <ul>
+ *   <li>{@link RawBuffer} — byte[] copy (traditional path, multi-page records,
+ *       pinned fallback)
+ *   <li>{@link RawPageBuffer} — zero-copy PageFrame reference (single-page
+ *       optimistic read path)
+ * </ul>
+ */
+public sealed interface StorageReadResult permits RawBuffer, RawPageBuffer {
+
+  /** Record version at the time of reading. */
+  long recordVersion();
+
+  /** Record type byte. */
+  byte recordType();
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
@@ -59,6 +59,20 @@ public final class CollectionPage extends DurablePage {
       PAGE_INDEXES_LENGTH_OFFSET + IntegerSerializer.INT_SIZE;
 
   static final int INDEX_ITEM_SIZE = IntegerSerializer.INT_SIZE + VERSION_SIZE;
+
+  /**
+   * Size of the per-record metadata header that precedes the actual content bytes.
+   * Layout: [recordType: 1B][contentSize: 4B][collectionPosition: 8B] = 13 bytes.
+   */
+  public static final int RECORD_METADATA_HEADER_SIZE =
+      ByteSerializer.BYTE_SIZE + IntegerSerializer.INT_SIZE + LongSerializer.LONG_SIZE;
+
+  /**
+   * Size of the per-chunk tail that follows the content bytes.
+   * Layout: [firstRecordFlag: 1B][nextPagePointer: 8B] = 9 bytes.
+   */
+  public static final int RECORD_TAIL_SIZE = ByteSerializer.BYTE_SIZE + LongSerializer.LONG_SIZE;
+
   private static final int MARKED_AS_DELETED_FLAG = 1 << 16;
   private static final int POSITION_MASK = 0xFFFF;
   public static final int PAGE_SIZE =
@@ -736,6 +750,43 @@ public final class CollectionPage extends DurablePage {
     return getLongValue(
         entryPosition + 3 * IntegerSerializer.INT_SIZE
             + recordSize - LongSerializer.LONG_SIZE);
+  }
+
+  /**
+   * Returns the absolute byte offset within the page buffer to the start of the
+   * record's actual content, after the per-entry header (3 * INT_SIZE) and the
+   * metadata header ({@link #RECORD_METADATA_HEADER_SIZE}).
+   *
+   * <p><strong>Precondition:</strong> the record must not be deleted.
+   *
+   * @param recordPosition the pointer-array slot index
+   * @return absolute byte offset to record content
+   */
+  public int getRecordContentOffset(final int recordPosition) {
+    assert !isDeleted(recordPosition)
+        : "Record at position " + recordPosition + " is deleted";
+    final var entryPosition = getPointerValuePosition(recordPosition);
+    return entryPosition + 3 * IntegerSerializer.INT_SIZE + RECORD_METADATA_HEADER_SIZE;
+  }
+
+  /**
+   * Returns the length of the record's actual content bytes, excluding the
+   * metadata header ({@link #RECORD_METADATA_HEADER_SIZE}) and the chunk tail
+   * ({@link #RECORD_TAIL_SIZE}).
+   *
+   * <p><strong>Precondition:</strong> the record must not be deleted and must
+   * have a positive record size.
+   *
+   * @param recordPosition the pointer-array slot index
+   * @return content length in bytes
+   */
+  public int getRecordContentLength(final int recordPosition) {
+    assert !isDeleted(recordPosition)
+        : "Record at position " + recordPosition + " is deleted";
+    final var recordSize = getRecordSize(recordPosition);
+    assert recordSize > 0
+        : "Record size must be positive, got " + recordSize;
+    return recordSize - RECORD_METADATA_HEADER_SIZE - RECORD_TAIL_SIZE;
   }
 
   private boolean insideRecordBounds(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
@@ -794,7 +794,11 @@ public final class CollectionPage extends DurablePage {
     final var recordSize = getRecordSize(recordPosition);
     assert recordSize >= RECORD_METADATA_HEADER_SIZE + RECORD_TAIL_SIZE
         : "Record size " + recordSize + " too small for content extraction";
-    return recordSize - RECORD_METADATA_HEADER_SIZE - RECORD_TAIL_SIZE;
+    final var contentLength = recordSize - RECORD_METADATA_HEADER_SIZE - RECORD_TAIL_SIZE;
+    assert contentLength >= 0
+        : "Computed content length " + contentLength + " is negative for record at position "
+            + recordPosition;
+    return contentLength;
   }
 
   private boolean insideRecordBounds(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPage.java
@@ -757,7 +757,10 @@ public final class CollectionPage extends DurablePage {
    * record's actual content, after the per-entry header (3 * INT_SIZE) and the
    * metadata header ({@link #RECORD_METADATA_HEADER_SIZE}).
    *
-   * <p><strong>Precondition:</strong> the record must not be deleted.
+   * <p><strong>Precondition:</strong> the record must not be deleted and must be
+   * an entry-point chunk ({@link #isFirstRecordChunk(int)} returns {@code true}).
+   * Continuation chunks have no metadata header, so this method would return an
+   * incorrect offset.
    *
    * @param recordPosition the pointer-array slot index
    * @return absolute byte offset to record content
@@ -765,6 +768,8 @@ public final class CollectionPage extends DurablePage {
   public int getRecordContentOffset(final int recordPosition) {
     assert !isDeleted(recordPosition)
         : "Record at position " + recordPosition + " is deleted";
+    assert isFirstRecordChunk(recordPosition)
+        : "Record at position " + recordPosition + " is not an entry-point chunk";
     final var entryPosition = getPointerValuePosition(recordPosition);
     return entryPosition + 3 * IntegerSerializer.INT_SIZE + RECORD_METADATA_HEADER_SIZE;
   }
@@ -774,18 +779,21 @@ public final class CollectionPage extends DurablePage {
    * metadata header ({@link #RECORD_METADATA_HEADER_SIZE}) and the chunk tail
    * ({@link #RECORD_TAIL_SIZE}).
    *
-   * <p><strong>Precondition:</strong> the record must not be deleted and must
-   * have a positive record size.
+   * <p><strong>Precondition:</strong> the record must not be deleted and must be
+   * an entry-point chunk. The record size must be at least
+   * {@code RECORD_METADATA_HEADER_SIZE + RECORD_TAIL_SIZE} (22 bytes).
    *
    * @param recordPosition the pointer-array slot index
-   * @return content length in bytes
+   * @return content length in bytes (non-negative)
    */
   public int getRecordContentLength(final int recordPosition) {
     assert !isDeleted(recordPosition)
         : "Record at position " + recordPosition + " is deleted";
+    assert isFirstRecordChunk(recordPosition)
+        : "Record at position " + recordPosition + " is not an entry-point chunk";
     final var recordSize = getRecordSize(recordPosition);
-    assert recordSize > 0
-        : "Record size must be positive, got " + recordSize;
+    assert recordSize >= RECORD_METADATA_HEADER_SIZE + RECORD_TAIL_SIZE
+        : "Record size " + recordSize + " too small for content extraction";
     return recordSize - RECORD_METADATA_HEADER_SIZE - RECORD_TAIL_SIZE;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
@@ -32,6 +32,7 @@ import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.metadata.MetadataInternal;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.Storage;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
@@ -945,7 +946,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
    * and any branch that requires pinned page access.
    */
   @Nonnull
-  private RawBuffer doReadRecordOptimistic(final long collectionPosition,
+  private StorageReadResult doReadRecordOptimistic(final long collectionPosition,
       @Nonnull final AtomicOperation atomicOperation) {
     // Speculative reads from PageView buffers can produce arbitrary garbage values
     // (sizes, offsets, array indices) that cause RuntimeExceptions unrelated to the
@@ -966,7 +967,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
   }
 
   @Nonnull
-  private RawBuffer doReadRecordOptimisticInner(final long collectionPosition,
+  private StorageReadResult doReadRecordOptimisticInner(final long collectionPosition,
       @Nonnull final AtomicOperation atomicOperation) {
     var entryWithStatus =
         collectionPositionMap.getWithStatusOptimistic(collectionPosition, atomicOperation);
@@ -1021,29 +1022,26 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
       throw OptimisticReadFailedException.INSTANCE;
     }
 
-    final var content = localPage.getRecordBinaryValue(recordPosition, 0, recordSize);
-    if (content == null) {
-      throw OptimisticReadFailedException.INSTANCE;
-    }
-
-    if (content[content.length - LongSerializer.LONG_SIZE - ByteSerializer.BYTE_SIZE] == 0) {
+    // Read first-record-chunk flag — if not an entry-point chunk, fall back
+    if (!localPage.isFirstRecordChunk(recordPosition)) {
       throw new RecordNotFoundException(storageName,
           new RecordId(id, collectionPosition));
     }
 
-    // Check for multi-page record
-    final var nextPagePointer =
-        LongSerializer.deserializeNative(
-            content, content.length - LongSerializer.LONG_SIZE);
+    // Check for multi-page record — fall back to pinned path for multi-page
+    final var nextPagePointer = localPage.getNextPagePointer(recordPosition);
     if (nextPagePointer >= 0) {
-      // Multi-page record — fall back to pinned path
       throw OptimisticReadFailedException.INSTANCE;
     }
 
-    final var contentSize =
-        content.length - LongSerializer.LONG_SIZE - ByteSerializer.BYTE_SIZE;
-    final List<byte[]> recordChunks = List.of(content);
-    return parseRecordContent(collectionPosition, recordVersion, recordChunks, contentSize);
+    // Zero-copy path: construct RawPageBuffer with page coordinates
+    final var recordType = localPage.getRecordByteValue(recordPosition, 0);
+    final var contentOffset = localPage.getRecordContentOffset(recordPosition);
+    final var contentLength = localPage.getRecordContentLength(recordPosition);
+
+    return new RawPageBuffer(
+        pageView.pageFrame(), pageView.stamp(),
+        contentOffset, contentLength, recordVersion, recordType);
   }
 
   @Nonnull

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
@@ -185,13 +185,9 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
 
   /**
    * Size of the per-record metadata header that precedes the actual record content.
-   *
-   * <pre>{@code
-   * Layout: [recordType: 1B][contentSize: 4B][collectionPosition: 8B] = 13 bytes
-   * }</pre>
+   * Delegates to {@link CollectionPage#RECORD_METADATA_HEADER_SIZE}.
    */
-  private static final int METADATA_SIZE =
-      ByteSerializer.BYTE_SIZE + IntegerSerializer.INT_SIZE + LongSerializer.LONG_SIZE;
+  private static final int METADATA_SIZE = CollectionPage.RECORD_METADATA_HEADER_SIZE;
 
   /**
    * Bit offset used to pack a page index and a record position into a single {@code long}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
@@ -34,6 +34,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.Storage;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection;
+import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.CollectionPage;
@@ -868,7 +869,7 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
 
   @Override
   @Nonnull
-  public RawBuffer readRecord(final long collectionPosition,
+  public StorageReadResult readRecord(final long collectionPosition,
       @Nonnull AtomicOperation atomicOperation)
       throws IOException {
     return executeOptimisticStorageRead(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/config/CollectionBasedStorageConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/config/CollectionBasedStorageConfiguration.java
@@ -1162,8 +1162,8 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
                   (entry) -> {
                     final RawBuffer buffer;
                     try {
-                      buffer = collection.readRecord(entry.second().getCollectionPosition(),
-                          atomicOperation);
+                      buffer = (RawBuffer) collection.readRecord(
+                          entry.second().getCollectionPosition(), atomicOperation);
                       return new RawPair<>(
                           entry.first().substring(PROPERTY_PREFIX_PROPERTY.length()),
                           deserializeStringValue(buffer.buffer(), 0));
@@ -1321,9 +1321,8 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
                 String name = null;
                 try {
                   name = entry.first().substring(ENGINE_PREFIX_PROPERTY.length());
-                  final var buffer =
-                      collection.readRecord(entry.second().getCollectionPosition(),
-                          atomicOperation);
+                  final var buffer = (RawBuffer) collection.readRecord(
+                      entry.second().getCollectionPosition(), atomicOperation);
                   return deserializeIndexEngineProperty(
                       name, buffer.buffer(), Integer.MIN_VALUE, entry.second().getCollectionId(),
                       atomicOperation);
@@ -1413,9 +1412,8 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
                     Integer.parseInt(entry.first().substring(COLLECTIONS_PREFIX_PROPERTY.length()));
 
                 try {
-                  final var buffer =
-                      collection.readRecord(entry.second().getCollectionPosition(),
-                          atomicOperation);
+                  final var buffer = (RawBuffer) collection.readRecord(
+                      entry.second().getCollectionPosition(), atomicOperation);
 
                   if (collections.size() <= id) {
                     final var diff = id - collections.size();
@@ -1853,7 +1851,8 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
         return null;
       }
 
-      final var buffer = collection.readRecord(rid.getCollectionPosition(), atomicOperation);
+      final var buffer =
+          (RawBuffer) collection.readRecord(rid.getCollectionPosition(), atomicOperation);
       return new RawPairObjectInteger<>(buffer.buffer(), rid.getCollectionId());
     } catch (final IOException e) {
       throw BaseException.wrapException(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/config/CollectionBasedStorageConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/config/CollectionBasedStorageConfiguration.java
@@ -1162,8 +1162,9 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
                   (entry) -> {
                     final RawBuffer buffer;
                     try {
-                      buffer = (RawBuffer) collection.readRecord(
-                          entry.second().getCollectionPosition(), atomicOperation);
+                      buffer = collection.readRecord(
+                          entry.second().getCollectionPosition(), atomicOperation)
+                          .toRawBuffer();
                       return new RawPair<>(
                           entry.first().substring(PROPERTY_PREFIX_PROPERTY.length()),
                           deserializeStringValue(buffer.buffer(), 0));
@@ -1321,8 +1322,9 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
                 String name = null;
                 try {
                   name = entry.first().substring(ENGINE_PREFIX_PROPERTY.length());
-                  final var buffer = (RawBuffer) collection.readRecord(
-                      entry.second().getCollectionPosition(), atomicOperation);
+                  final var buffer = collection.readRecord(
+                      entry.second().getCollectionPosition(), atomicOperation)
+                      .toRawBuffer();
                   return deserializeIndexEngineProperty(
                       name, buffer.buffer(), Integer.MIN_VALUE, entry.second().getCollectionId(),
                       atomicOperation);
@@ -1412,8 +1414,9 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
                     Integer.parseInt(entry.first().substring(COLLECTIONS_PREFIX_PROPERTY.length()));
 
                 try {
-                  final var buffer = (RawBuffer) collection.readRecord(
-                      entry.second().getCollectionPosition(), atomicOperation);
+                  final var buffer = collection.readRecord(
+                      entry.second().getCollectionPosition(), atomicOperation)
+                      .toRawBuffer();
 
                   if (collections.size() <= id) {
                     final var diff = id - collections.size();
@@ -1852,7 +1855,8 @@ public final class CollectionBasedStorageConfiguration implements StorageConfigu
       }
 
       final var buffer =
-          (RawBuffer) collection.readRecord(rid.getCollectionPosition(), atomicOperation);
+          collection.readRecord(rid.getCollectionPosition(), atomicOperation)
+              .toRawBuffer();
       return new RawPairObjectInteger<>(buffer.buffer(), rid.getCollectionId());
     } catch (final IOException e) {
       throw BaseException.wrapException(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -4487,7 +4487,8 @@ public abstract class AbstractStorage
                 result.recordVersion(),
                 result instanceof RawBuffer rb
                     ? (rb.buffer() != null ? rb.buffer().length : 0)
-                    : ((RawPageBuffer) result).contentLength());
+                    : result instanceof RawPageBuffer rpb ? rpb.contentLength()
+                        : 0);
       }
 
       return result;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -95,6 +95,7 @@ import com.jetbrains.youtrackdb.internal.core.serialization.serializer.stream.St
 import com.jetbrains.youtrackdb.internal.core.storage.IdentifiableStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.RecordMetadata;
 import com.jetbrains.youtrackdb.internal.core.storage.Storage;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection;
@@ -4486,7 +4487,7 @@ public abstract class AbstractStorage
                 result.recordVersion(),
                 result instanceof RawBuffer rb
                     ? (rb.buffer() != null ? rb.buffer().length : 0)
-                    : "page-ref");
+                    : ((RawPageBuffer) result).contentLength());
       }
 
       return result;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -99,6 +99,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.RecordMetadata;
 import com.jetbrains.youtrackdb.internal.core.storage.Storage;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection.ATTRIBUTES;
+import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.local.BackgroundExceptionListener;
@@ -1723,7 +1724,7 @@ public abstract class AbstractStorage
   }
 
   @Override
-  public @Nonnull RawBuffer readRecord(final RecordIdInternal rid,
+  public @Nonnull StorageReadResult readRecord(final RecordIdInternal rid,
       @Nonnull AtomicOperation atomicOperation) {
     try {
       return readRecordInternal(rid, atomicOperation);
@@ -4156,7 +4157,7 @@ public abstract class AbstractStorage
   }
 
   @Nonnull
-  private RawBuffer readRecordInternal(@Nonnull final RecordIdInternal rid,
+  private StorageReadResult readRecordInternal(@Nonnull final RecordIdInternal rid,
       @Nonnull AtomicOperation atomicOperation) {
     if (!rid.isPersistent()) {
       throw new RecordNotFoundException(name,
@@ -4470,23 +4471,25 @@ public abstract class AbstractStorage
   }
 
   @Nonnull
-  private RawBuffer doReadRecord(final StorageCollection collection, final RecordIdInternal rid,
-      AtomicOperation atomicOperation) {
+  private StorageReadResult doReadRecord(final StorageCollection collection,
+      final RecordIdInternal rid, AtomicOperation atomicOperation) {
     collection.meters().read().record();
     try {
-      final var buff = collection.readRecord(rid.getCollectionPosition(),
+      final var result = collection.readRecord(rid.getCollectionPosition(),
           atomicOperation);
       if (logger.isDebugEnabled()) {
         LogManager.instance()
             .debug(
                 this,
-                "Read record %s v.%s size=%d bytes",
+                "Read record %s v.%s size=%s bytes",
                 logger, rid,
-                buff.version(),
-                buff.buffer() != null ? buff.buffer().length : 0);
+                result.recordVersion(),
+                result instanceof RawBuffer rb
+                    ? (rb.buffer() != null ? rb.buffer().length : 0)
+                    : "page-ref");
       }
 
-      return buff;
+      return result;
     } catch (final IOException e) {
       throw BaseException.wrapException(
           new StorageException(name, "Error during read of record with rid = " + rid), e, name);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/PostponedEngineStartTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/PostponedEngineStartTest.java
@@ -28,11 +28,11 @@ import com.jetbrains.youtrackdb.internal.core.engine.Engine;
 import com.jetbrains.youtrackdb.internal.core.engine.EngineAbstract;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
-import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.RecordMetadata;
 import com.jetbrains.youtrackdb.internal.core.storage.Storage;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection.ATTRIBUTES;
+import com.jetbrains.youtrackdb.internal.core.storage.StorageReadResult;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.AbsoluteChange;
 import com.jetbrains.youtrackdb.internal.core.storage.ridbag.LinkCollectionsBTreeManager;
@@ -255,7 +255,7 @@ public class PostponedEngineStartTest {
         }
 
         @Override
-        public @Nonnull RawBuffer readRecord(RecordIdInternal iRid,
+        public @Nonnull StorageReadResult readRecord(RecordIdInternal iRid,
             @Nonnull AtomicOperation atomicOperation) {
           return null;
         }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordExceptionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordExceptionTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import org.junit.Test;
 
 /**
@@ -37,5 +38,15 @@ public class CorruptedRecordExceptionTest {
     var copy = new CorruptedRecordException(original);
     assertNotNull(copy.getMessage());
     assertTrue(copy.getMessage().contains("original message"));
+  }
+
+  @Test
+  public void sessionConstructorPreservesMessage() {
+    // Exercises the CorruptedRecordException(DatabaseSessionEmbedded, String) constructor.
+    // Pass null session — the superclass stores it but doesn't dereference at construction time.
+    var ex = new CorruptedRecordException(
+        (DatabaseSessionEmbedded) null, "corrupt record data");
+    assertNotNull(ex.getMessage());
+    assertTrue(ex.getMessage().contains("corrupt record data"));
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordExceptionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordExceptionTest.java
@@ -1,0 +1,41 @@
+package com.jetbrains.youtrackdb.internal.core.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Tests {@link CorruptedRecordException} construction and hierarchy. Verifies that the exception
+ * extends {@link DatabaseException} and preserves messages through all constructors.
+ */
+public class CorruptedRecordExceptionTest {
+
+  @Test
+  public void extendssDatabaseException() {
+    var ex = new CorruptedRecordException("test message");
+    assertTrue(ex instanceof DatabaseException);
+  }
+
+  @Test
+  public void messageOnlyConstructorPreservesMessage() {
+    var ex = new CorruptedRecordException("corrupted size: 999999");
+    assertEquals("corrupted size: 999999", ex.getMessage());
+  }
+
+  @Test
+  public void dbNameConstructorPreservesMessage() {
+    var ex = new CorruptedRecordException("testdb", "bad header length");
+    assertNotNull(ex.getMessage());
+    assertTrue(ex.getMessage().contains("bad header length"));
+  }
+
+  @Test
+  public void copyConstructorPreservesMessage() {
+    var original = new CorruptedRecordException("original message");
+    var copy = new CorruptedRecordException(original);
+    assertNotNull(copy.getMessage());
+    assertTrue(copy.getMessage().contains("original message"));
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordExceptionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/exception/CorruptedRecordExceptionTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 public class CorruptedRecordExceptionTest {
 
   @Test
-  public void extendssDatabaseException() {
+  public void extendsDatabaseException() {
     var ex = new CorruptedRecordException("test message");
     assertTrue(ex instanceof DatabaseException);
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
@@ -199,9 +199,11 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
   // --- Stamp invalidation fallback ---
 
   @Test
-  public void testStampInvalidationFallsBackToReRead() {
-    // Verifies that when the PageFrame stamp is invalidated, the entity
-    // falls back to a byte[] re-read from storage.
+  public void testStampInvalidationIrrelevantWithEagerByteExtraction() {
+    // fillFromPage eagerly extracts bytes into source, so deserialization
+    // uses the byte[] path regardless of stamp validity. Stamp invalidation
+    // does not affect property access. After partial deserialization,
+    // pageFrame is retained (only cleared after full deserialization).
     var rid = saveRecord("StampTest", "name", "Carol", "city", "Paris");
 
     session.begin();
@@ -223,20 +225,22 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     long exclusiveStamp = frame.acquireExclusiveLock();
     frame.releaseExclusiveLock(exclusiveStamp);
 
-    // Access properties — stamp validation fails, triggers re-read
+    // Access properties — uses eagerly extracted byte[] source, stamp irrelevant
     assertEquals("Carol", entity.getString("name"));
     assertEquals("Paris", entity.getString("city"));
-    assertNull(entity.getPageFrame());
+    // PageFrame is retained after partial deserialization (individual property access)
+    assertNotNull(entity.getPageFrame());
     session.rollback();
   }
 
   // --- RuntimeException during speculative deserialization ---
 
   @Test
-  public void testCorruptedDataFallsBackToReRead() {
-    // Verifies that corrupted data in the PageFrame triggers a RuntimeException
-    // during speculative deserialization, which is caught, and the entity
-    // falls back to a byte[] re-read from storage.
+  public void testCorruptedDataInPageFrameThrowsOnDeserialize() {
+    // fillFromPage eagerly extracts bytes into source. When the PageFrame
+    // contains corrupted data, the extracted byte[] source is also corrupt.
+    // Deserialization via the byte[] path throws an exception — there is no
+    // fallback since the corrupt bytes are the entity's source.
     var rid = saveRecord("CorruptTest", "key", "valid-data");
 
     session.begin();
@@ -258,20 +262,26 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
         loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
         100, 51);
 
-    // Access property — corrupted data triggers exception, falls back to re-read
-    assertEquals("valid-data", entity.getString("key"));
-    assertNull(entity.getPageFrame());
-    // No phantom properties from corrupted deserialization
-    assertEquals(Set.of("key"), new HashSet<>(entity.getPropertyNames()));
+    // Corrupt source bytes cause deserialization to throw
+    try {
+      entity.getString("key");
+      org.junit.Assert.fail(
+          "Expected exception from deserializing corrupt byte[] source");
+    } catch (IllegalArgumentException e) {
+      // Expected — corrupt data cannot be deserialized
+      assertTrue(e.getMessage().contains("Variable length quantity"));
+    }
     session.rollback();
   }
 
   // --- Multiple property accesses after fallback ---
 
   @Test
-  public void testMultiplePropertyAccessesAfterFallback() {
-    // After stamp invalidation and fallback to byte[], subsequent property
-    // accesses should work correctly from the byte[] source.
+  public void testMultiplePropertyAccessesAfterStampInvalidation() {
+    // fillFromPage eagerly extracts bytes into source, so all property
+    // accesses use the byte[] path. Stamp invalidation does not affect
+    // correctness. After individual (partial) property accesses, pageFrame
+    // is retained.
     var rid = saveRecord("MultiTest", "a", "alpha", "b", "beta", "c", "gamma");
 
     session.begin();
@@ -289,15 +299,15 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
         loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
         0, serialized.length);
 
-    // Invalidate stamp
+    // Invalidate stamp — irrelevant since byte[] source is used
     long exStamp = frame.acquireExclusiveLock();
     frame.releaseExclusiveLock(exStamp);
 
-    // First access triggers fallback
+    // All accesses use eagerly extracted byte[] source
     assertEquals("alpha", entity.getString("a"));
-    assertNull(entity.getPageFrame());
+    // PageFrame retained after partial deserialization
+    assertNotNull(entity.getPageFrame());
 
-    // Subsequent accesses use byte[] source
     assertEquals("beta", entity.getString("b"));
     assertEquals("gamma", entity.getString("c"));
     session.rollback();
@@ -344,9 +354,10 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
   // --- Snapshot restoration on partial deser + stamp invalidation (TC1) ---
 
   @Test
-  public void testPartialDeserializationSnapshotRestoredOnStampInvalidation() {
-    // Verifies that when a second partial deserialization attempt fails stamp
-    // validation, the fallback re-read produces correct data for all properties.
+  public void testPartialDeserializationUnaffectedByStampInvalidation() {
+    // fillFromPage eagerly extracts bytes into source. Both partial
+    // deserialization calls use the byte[] path, so stamp invalidation
+    // between them has no effect. PageFrame is retained after partial access.
     var rid = saveRecord("SnapshotTest", "a", "alpha", "b", "beta");
 
     session.begin();
@@ -364,20 +375,21 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
         loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
         64, serialized.length);
 
-    // First partial: succeeds with valid stamp
+    // First partial deserialization from byte[] source
     assertTrue(entity.checkForProperties("a"));
     assertEquals("alpha", entity.getString("a"));
     assertNotNull(entity.getPageFrame());
 
-    // Invalidate stamp before second partial attempt
+    // Invalidate stamp — irrelevant since byte[] source is used
     long exStamp = frame.acquireExclusiveLock();
     frame.releaseExclusiveLock(exStamp);
 
-    // Second partial triggers fallback — both properties must be correct
+    // Second partial also uses byte[] source — both properties correct
     assertTrue(entity.checkForProperties("b"));
     assertEquals("beta", entity.getString("b"));
     assertEquals("alpha", entity.getString("a"));
-    assertNull(entity.getPageFrame());
+    // PageFrame retained after partial deserialization
+    assertNotNull(entity.getPageFrame());
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.record.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -12,6 +13,8 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.directmemory.Pointer;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.After;
 import org.junit.Test;
 
@@ -34,7 +37,7 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
   }
 
   @After
-  public void afterTest() {
+  public void deallocatePageFrameMemory() {
     if (pointer != null && allocator != null) {
       allocator.deallocate(pointer);
     }
@@ -99,7 +102,11 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     // Verify properties were deserialized correctly
     assertEquals("Alice", entity.getString("name"));
     assertEquals(Integer.valueOf(30), entity.getInt("age"));
-    assertEquals(true, entity.getBoolean("active"));
+    assertTrue(entity.getBoolean("active"));
+
+    // Verify exact property set — no phantom properties
+    assertEquals(Set.of("name", "age", "active"),
+        new HashSet<>(entity.getPropertyNames()));
 
     // After full deserialization with valid stamp, PageFrame should be cleared
     assertNull(entity.getPageFrame());
@@ -159,6 +166,7 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     // Full deserialization
     assertTrue(entity.checkForProperties());
     assertEquals("value", entity.getString("key"));
+    assertNull(entity.getPageFrame());
     session.rollback();
   }
 
@@ -253,6 +261,8 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     // Access property — corrupted data triggers exception, falls back to re-read
     assertEquals("valid-data", entity.getString("key"));
     assertNull(entity.getPageFrame());
+    // No phantom properties from corrupted deserialization
+    assertEquals(Set.of("key"), new HashSet<>(entity.getPropertyNames()));
     session.rollback();
   }
 
@@ -323,8 +333,102 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     assertTrue(entity.checkForProperties());
     assertEquals("why", entity.getString("y"));
     assertEquals(Integer.valueOf(99), entity.getInt("z"));
+    // Partial-loaded property "x" survives full deserialization
+    assertEquals("ex", entity.getString("x"));
 
     // After full deserialization, PageFrame should be cleared
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Snapshot restoration on partial deser + stamp invalidation (TC1) ---
+
+  @Test
+  public void testPartialDeserializationSnapshotRestoredOnStampInvalidation() {
+    // Verifies that when a second partial deserialization attempt fails stamp
+    // validation, the fallback re-read produces correct data for all properties.
+    var rid = saveRecord("SnapshotTest", "a", "alpha", "b", "beta");
+
+    session.begin();
+    var loaded = (EntityImpl) session.getActiveTransaction().load(rid);
+    byte[] serialized = loaded.toStream();
+
+    var frame = new PageFrame(pointer);
+    frame.getBuffer().position(64);
+    frame.getBuffer().put(serialized);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.getActiveTransaction().load(rid);
+    entity.unsetDirty();
+    entity.fillFromPage(
+        loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
+        64, serialized.length);
+
+    // First partial: succeeds with valid stamp
+    assertTrue(entity.checkForProperties("a"));
+    assertEquals("alpha", entity.getString("a"));
+    assertNotNull(entity.getPageFrame());
+
+    // Invalidate stamp before second partial attempt
+    long exStamp = frame.acquireExclusiveLock();
+    frame.releaseExclusiveLock(exStamp);
+
+    // Second partial triggers fallback — both properties must be correct
+    assertTrue(entity.checkForProperties("b"));
+    assertEquals("beta", entity.getString("b"));
+    assertEquals("alpha", entity.getString("a"));
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Missing property returns false (TC2) ---
+
+  @Test
+  public void testPartialDeserializationReturnsFalseForMissingProperty() {
+    // Verifies that requesting a property that doesn't exist in the record
+    // returns false from the PageFrame deserialization path.
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("exists", "value");
+
+    var frame = new PageFrame(pointer);
+    int contentLength = writeSerializedRecord(source, frame, 0);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, contentLength);
+
+    assertFalse(entity.deserializeProperties("nonExistent"));
+    session.rollback();
+  }
+
+  // --- Record at buffer end boundary (TC4) ---
+
+  @Test
+  public void testDeserializeFromPageFrameAtBufferEnd() {
+    // Verifies deserialization works when record content extends to the exact
+    // end of the PageFrame buffer (offset + length == buffer capacity).
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("key", "boundary");
+    byte[] serialized = source.toStream();
+
+    var frame = new PageFrame(pointer);
+    int offset = 8192 - serialized.length;
+    frame.getBuffer().position(offset);
+    frame.getBuffer().put(serialized);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(
+        1L, EntityImpl.RECORD_TYPE, frame, stamp, offset, serialized.length);
+
+    assertTrue(entity.checkForProperties());
+    assertEquals("boundary", entity.getString("key"));
     assertNull(entity.getPageFrame());
     session.rollback();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
@@ -1,0 +1,331 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
+import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
+import com.jetbrains.youtrackdb.internal.common.directmemory.Pointer;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import java.nio.ByteBuffer;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests for EntityImpl speculative deserialization from PageFrame with stamp
+ * validation and fallback re-read. Verifies the zero-copy read path by writing
+ * valid serialized record bytes into a PageFrame buffer, loading entities via
+ * fillFromPage(), and checking that property access returns correct values.
+ */
+public class EntityImplPageFrameDeserializationTest extends DbTestBase {
+
+  private DirectMemoryAllocator allocator;
+  private Pointer pointer;
+
+  @Override
+  public void beforeTest() throws Exception {
+    super.beforeTest();
+    allocator = new DirectMemoryAllocator();
+    pointer = allocator.allocate(8192, true, Intention.TEST);
+  }
+
+  @After
+  public void afterTest() {
+    if (pointer != null && allocator != null) {
+      allocator.deallocate(pointer);
+    }
+  }
+
+  /**
+   * Serializes an entity and writes the bytes into the PageFrame buffer at the
+   * specified offset. Returns the byte length written.
+   */
+  private int writeSerializedRecord(EntityImpl source, PageFrame frame, int offset) {
+    byte[] serialized = source.toStream();
+    ByteBuffer buffer = frame.getBuffer();
+    buffer.position(offset);
+    buffer.put(serialized);
+    return serialized.length;
+  }
+
+  /**
+   * Creates a class outside of a transaction, then persists a record with the
+   * given properties. Returns the RID of the saved record.
+   */
+  private RID saveRecord(String className, String... keyValues) {
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass(className)) {
+      schema.createClass(className);
+    }
+
+    session.begin();
+    var entity = (EntityImpl) session.newEntity(className);
+    for (int i = 0; i < keyValues.length; i += 2) {
+      entity.setString(keyValues[i], keyValues[i + 1]);
+    }
+    session.commit();
+    return entity.getIdentity();
+  }
+
+  // --- Successful speculative deserialization ---
+
+  @Test
+  public void testDeserializeFromPageFrameFullPath() {
+    // Verifies that a PageFrame-loaded entity correctly deserializes all
+    // properties via the speculative PageFrame path. After full
+    // deserialization (checkForProperties with no args), PageFrame is cleared.
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("name", "Alice");
+    source.setInt("age", 30);
+    source.setBoolean("active", true);
+
+    var frame = new PageFrame(pointer);
+    int contentLength = writeSerializedRecord(source, frame, 128);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 128, contentLength);
+
+    // Full deserialization (no property names)
+    assertTrue(entity.checkForProperties());
+
+    // Verify properties were deserialized correctly
+    assertEquals("Alice", entity.getString("name"));
+    assertEquals(Integer.valueOf(30), entity.getInt("age"));
+    assertEquals(true, entity.getBoolean("active"));
+
+    // After full deserialization with valid stamp, PageFrame should be cleared
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  @Test
+  public void testDeserializeFromPageFramePartialPath() {
+    // Verifies that partial deserialization (requesting specific properties)
+    // reads correctly from PageFrame and keeps the PageFrame for subsequent calls.
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("name", "Bob");
+    source.setInt("score", 42);
+    source.setString("city", "Berlin");
+
+    var frame = new PageFrame(pointer);
+    int contentLength = writeSerializedRecord(source, frame, 64);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 64, contentLength);
+
+    // Partial deserialization: request only "name"
+    assertTrue(entity.checkForProperties("name"));
+    assertEquals("Bob", entity.getString("name"));
+
+    // After partial deserialization, PageFrame is kept for subsequent calls
+    assertNotNull(entity.getPageFrame());
+
+    // Request another property — should also work from PageFrame
+    assertTrue(entity.checkForProperties("score"));
+    assertEquals(Integer.valueOf(42), entity.getInt("score"));
+
+    session.rollback();
+  }
+
+  @Test
+  public void testDeserializeFromPageFrameAtOffsetZero() {
+    // Verifies deserialization works when the record is at offset 0 in the
+    // PageFrame buffer (boundary case).
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("key", "value");
+
+    var frame = new PageFrame(pointer);
+    int contentLength = writeSerializedRecord(source, frame, 0);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, contentLength);
+
+    // Full deserialization
+    assertTrue(entity.checkForProperties());
+    assertEquals("value", entity.getString("key"));
+    session.rollback();
+  }
+
+  @Test
+  public void testDeserializeEmptyRecordFromPageFrame() {
+    // Verifies that an entity with no properties deserializes correctly
+    // from PageFrame.
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    byte[] serialized = source.toStream();
+
+    var frame = new PageFrame(pointer);
+    frame.getBuffer().position(300);
+    frame.getBuffer().put(serialized);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp,
+        300, serialized.length);
+
+    // Full deserialization
+    assertTrue(entity.checkForProperties());
+    assertTrue(entity.getPropertyNames().isEmpty());
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Stamp invalidation fallback ---
+
+  @Test
+  public void testStampInvalidationFallsBackToReRead() {
+    // Verifies that when the PageFrame stamp is invalidated, the entity
+    // falls back to a byte[] re-read from storage.
+    var rid = saveRecord("StampTest", "name", "Carol", "city", "Paris");
+
+    session.begin();
+    var loaded = (EntityImpl) session.getActiveTransaction().load(rid);
+    byte[] serialized = loaded.toStream();
+
+    var frame = new PageFrame(pointer);
+    frame.getBuffer().position(200);
+    frame.getBuffer().put(serialized);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.getActiveTransaction().load(rid);
+    entity.unsetDirty();
+    entity.fillFromPage(
+        loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
+        200, serialized.length);
+
+    // Invalidate the stamp by acquiring and releasing an exclusive lock
+    long exclusiveStamp = frame.acquireExclusiveLock();
+    frame.releaseExclusiveLock(exclusiveStamp);
+
+    // Access properties — stamp validation fails, triggers re-read
+    assertEquals("Carol", entity.getString("name"));
+    assertEquals("Paris", entity.getString("city"));
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- RuntimeException during speculative deserialization ---
+
+  @Test
+  public void testCorruptedDataFallsBackToReRead() {
+    // Verifies that corrupted data in the PageFrame triggers a RuntimeException
+    // during speculative deserialization, which is caught, and the entity
+    // falls back to a byte[] re-read from storage.
+    var rid = saveRecord("CorruptTest", "key", "valid-data");
+
+    session.begin();
+    var loaded = (EntityImpl) session.getActiveTransaction().load(rid);
+
+    // Write garbage data into the PageFrame (valid version byte + garbage)
+    var frame = new PageFrame(pointer);
+    ByteBuffer buf = frame.getBuffer();
+    buf.position(100);
+    buf.put((byte) 0); // serializer version byte
+    for (int i = 0; i < 50; i++) {
+      buf.put((byte) 0xFF);
+    }
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.getActiveTransaction().load(rid);
+    entity.unsetDirty();
+    entity.fillFromPage(
+        loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
+        100, 51);
+
+    // Access property — corrupted data triggers exception, falls back to re-read
+    assertEquals("valid-data", entity.getString("key"));
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Multiple property accesses after fallback ---
+
+  @Test
+  public void testMultiplePropertyAccessesAfterFallback() {
+    // After stamp invalidation and fallback to byte[], subsequent property
+    // accesses should work correctly from the byte[] source.
+    var rid = saveRecord("MultiTest", "a", "alpha", "b", "beta", "c", "gamma");
+
+    session.begin();
+    var loaded = (EntityImpl) session.getActiveTransaction().load(rid);
+    byte[] serialized = loaded.toStream();
+
+    var frame = new PageFrame(pointer);
+    frame.getBuffer().position(0);
+    frame.getBuffer().put(serialized);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.getActiveTransaction().load(rid);
+    entity.unsetDirty();
+    entity.fillFromPage(
+        loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
+        0, serialized.length);
+
+    // Invalidate stamp
+    long exStamp = frame.acquireExclusiveLock();
+    frame.releaseExclusiveLock(exStamp);
+
+    // First access triggers fallback
+    assertEquals("alpha", entity.getString("a"));
+    assertNull(entity.getPageFrame());
+
+    // Subsequent accesses use byte[] source
+    assertEquals("beta", entity.getString("b"));
+    assertEquals("gamma", entity.getString("c"));
+    session.rollback();
+  }
+
+  // --- Partial then full deserialization ---
+
+  @Test
+  public void testPartialThenFullDeserialization() {
+    // Request specific properties first (partial), then request all properties
+    // (full). Both should return correct values from PageFrame.
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("x", "ex");
+    source.setString("y", "why");
+    source.setInt("z", 99);
+
+    var frame = new PageFrame(pointer);
+    int contentLength = writeSerializedRecord(source, frame, 50);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 50, contentLength);
+
+    // Partial: request "x" only
+    assertTrue(entity.checkForProperties("x"));
+    assertEquals("ex", entity.getString("x"));
+    assertNotNull(entity.getPageFrame()); // kept for subsequent calls
+
+    // Full: request all remaining properties
+    assertTrue(entity.checkForProperties());
+    assertEquals("why", entity.getString("y"));
+    assertEquals(Integer.valueOf(99), entity.getInt("z"));
+
+    // After full deserialization, PageFrame should be cleared
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
@@ -199,11 +199,12 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
   // --- Stamp invalidation fallback ---
 
   @Test
-  public void testStampInvalidationIrrelevantWithEagerByteExtraction() {
-    // fillFromPage eagerly extracts bytes into source, so deserialization
-    // uses the byte[] path regardless of stamp validity. Stamp invalidation
-    // does not affect property access. After partial deserialization,
-    // pageFrame is retained (only cleared after full deserialization).
+  public void testStampInvalidationTriggersReReadWithZeroCopy() {
+    // fillFromPage does NOT eagerly extract bytes — source stays null.
+    // When the stamp is invalidated, speculative PageFrame deserialization
+    // detects the invalid stamp and falls back to re-reading from storage.
+    // After the re-read, the entity has correct property values and
+    // the PageFrame is cleared.
     var rid = saveRecord("StampTest", "name", "Carol", "city", "Paris");
 
     session.begin();
@@ -225,22 +226,23 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     long exclusiveStamp = frame.acquireExclusiveLock();
     frame.releaseExclusiveLock(exclusiveStamp);
 
-    // Access properties — uses eagerly extracted byte[] source, stamp irrelevant
+    // Access properties — stamp invalid → fallback re-read from storage
     assertEquals("Carol", entity.getString("name"));
     assertEquals("Paris", entity.getString("city"));
-    // PageFrame is retained after partial deserialization (individual property access)
-    assertNotNull(entity.getPageFrame());
+    // After fallback re-read, PageFrame is cleared
+    assertNull(entity.getPageFrame());
     session.rollback();
   }
 
   // --- RuntimeException during speculative deserialization ---
 
   @Test
-  public void testCorruptedDataInPageFrameThrowsOnDeserialize() {
-    // fillFromPage eagerly extracts bytes into source. When the PageFrame
-    // contains corrupted data, the extracted byte[] source is also corrupt.
-    // Deserialization via the byte[] path throws an exception — there is no
-    // fallback since the corrupt bytes are the entity's source.
+  public void testCorruptedDataInPageFrameFallsBackToReRead() {
+    // fillFromPage does NOT eagerly extract bytes — source stays null.
+    // When the PageFrame contains corrupted data, the speculative
+    // deserialization catches the exception (CorruptedRecordException or
+    // similar) and falls back to re-reading from storage. Since the entity
+    // has a valid RID, the re-read succeeds and returns the correct value.
     var rid = saveRecord("CorruptTest", "key", "valid-data");
 
     session.begin();
@@ -262,15 +264,11 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
         loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
         100, 51);
 
-    // Corrupt source bytes cause deserialization to throw
-    try {
-      entity.getString("key");
-      org.junit.Assert.fail(
-          "Expected exception from deserializing corrupt byte[] source");
-    } catch (IllegalArgumentException e) {
-      // Expected — corrupt data cannot be deserialized
-      assertTrue(e.getMessage().contains("Variable length quantity"));
-    }
+    // Corrupt PageFrame data triggers speculative deser failure →
+    // fallback re-read from storage returns correct data
+    assertEquals("valid-data", entity.getString("key"));
+    // After fallback re-read, PageFrame is cleared
+    assertNull(entity.getPageFrame());
     session.rollback();
   }
 
@@ -278,10 +276,10 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
 
   @Test
   public void testMultiplePropertyAccessesAfterStampInvalidation() {
-    // fillFromPage eagerly extracts bytes into source, so all property
-    // accesses use the byte[] path. Stamp invalidation does not affect
-    // correctness. After individual (partial) property accesses, pageFrame
-    // is retained.
+    // fillFromPage does NOT eagerly extract bytes — source stays null.
+    // When the stamp is invalidated, speculative PageFrame deserialization
+    // fails and falls back to re-reading from storage. All properties
+    // return correct values via the re-read path.
     var rid = saveRecord("MultiTest", "a", "alpha", "b", "beta", "c", "gamma");
 
     session.begin();
@@ -299,15 +297,16 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
         loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
         0, serialized.length);
 
-    // Invalidate stamp — irrelevant since byte[] source is used
+    // Invalidate stamp — triggers re-read on first property access
     long exStamp = frame.acquireExclusiveLock();
     frame.releaseExclusiveLock(exStamp);
 
-    // All accesses use eagerly extracted byte[] source
+    // First access triggers re-read from storage
     assertEquals("alpha", entity.getString("a"));
-    // PageFrame retained after partial deserialization
-    assertNotNull(entity.getPageFrame());
+    // After fallback re-read, PageFrame is cleared
+    assertNull(entity.getPageFrame());
 
+    // Subsequent accesses use deserialized properties from re-read
     assertEquals("beta", entity.getString("b"));
     assertEquals("gamma", entity.getString("c"));
     session.rollback();
@@ -354,10 +353,12 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
   // --- Snapshot restoration on partial deser + stamp invalidation (TC1) ---
 
   @Test
-  public void testPartialDeserializationUnaffectedByStampInvalidation() {
-    // fillFromPage eagerly extracts bytes into source. Both partial
-    // deserialization calls use the byte[] path, so stamp invalidation
-    // between them has no effect. PageFrame is retained after partial access.
+  public void testPartialDeserializationWithStampInvalidationFallsBack() {
+    // fillFromPage does NOT eagerly extract bytes — source stays null.
+    // First partial deserialization uses the speculative PageFrame path
+    // with a valid stamp. Then stamp is invalidated. The second partial
+    // deserialization detects the invalid stamp and falls back to
+    // re-reading from storage.
     var rid = saveRecord("SnapshotTest", "a", "alpha", "b", "beta");
 
     session.begin();
@@ -375,21 +376,21 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
         loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
         64, serialized.length);
 
-    // First partial deserialization from byte[] source
+    // First partial deserialization from PageFrame (valid stamp)
     assertTrue(entity.checkForProperties("a"));
     assertEquals("alpha", entity.getString("a"));
     assertNotNull(entity.getPageFrame());
 
-    // Invalidate stamp — irrelevant since byte[] source is used
+    // Invalidate stamp — next partial deserialization will fall back
     long exStamp = frame.acquireExclusiveLock();
     frame.releaseExclusiveLock(exStamp);
 
-    // Second partial also uses byte[] source — both properties correct
+    // Second partial triggers re-read from storage; both properties correct
     assertTrue(entity.checkForProperties("b"));
     assertEquals("beta", entity.getString("b"));
     assertEquals("alpha", entity.getString("a"));
-    // PageFrame retained after partial deserialization
-    assertNotNull(entity.getPageFrame());
+    // After fallback re-read, PageFrame is cleared
+    assertNull(entity.getPageFrame());
     session.rollback();
   }
 
@@ -449,10 +450,8 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
 
   @Test
   public void testSpeculativeDeserializationFromPageFrameFullPath() {
-    // Simulates lazy extraction: fillFromPage sets source, then
-    // clearSourceKeepPageFrame() clears source while keeping PageFrame.
-    // This forces deserializeProperties to use the speculative
-    // deserializeFromPageFrame() path with stamp validation.
+    // fillFromPage leaves source null, so deserializeProperties uses the
+    // speculative deserializeFromPageFrame() path with stamp validation.
     session.begin();
 
     var source = (EntityImpl) session.newEntity();
@@ -467,8 +466,7 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     entity.unsetDirty();
     entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 100, contentLength);
 
-    // Clear source while keeping PageFrame — forces speculative path
-    entity.clearSourceKeepPageFrame();
+    // source is null, PageFrame is set — speculative path is active
     assertNotNull(entity.getPageFrame());
 
     // Full deserialization via the speculative PageFrame path
@@ -483,8 +481,9 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
 
   @Test
   public void testSpeculativeDeserializationPartialPath() {
-    // Exercises the speculative PageFrame partial deserialization path.
-    // After partial deserialization with valid stamp, PageFrame is kept.
+    // fillFromPage leaves source null — speculative PageFrame path is
+    // active by default. After partial deserialization with valid stamp,
+    // PageFrame is kept.
     session.begin();
 
     var source = (EntityImpl) session.newEntity();
@@ -499,9 +498,6 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
     entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 200, contentLength);
-
-    // Clear source to activate speculative path
-    entity.clearSourceKeepPageFrame();
 
     // Partial deserialization: request only "y"
     assertTrue(entity.checkForProperties("y"));
@@ -532,9 +528,6 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
         loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
         64, serialized.length);
 
-    // Clear source to force speculative path
-    entity.clearSourceKeepPageFrame();
-
     // Invalidate stamp — this causes speculative deserialization to succeed
     // but stamp validation to fail, triggering the fallback re-read
     long exStamp = frame.acquireExclusiveLock();
@@ -561,8 +554,7 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     // Fill with zero-length content
     entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 0);
 
-    // Clear source to force speculative path with empty content
-    entity.clearSourceKeepPageFrame();
+    // source is null, PageFrame is set with empty content
     assertNotNull(entity.getPageFrame());
 
     // Should succeed immediately and clear PageFrame

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameDeserializationTest.java
@@ -444,4 +444,131 @@ public class EntityImplPageFrameDeserializationTest extends DbTestBase {
     assertNull(entity.getPageFrame());
     session.rollback();
   }
+
+  // --- Speculative PageFrame deserialization (lazy-extraction simulation) ---
+
+  @Test
+  public void testSpeculativeDeserializationFromPageFrameFullPath() {
+    // Simulates lazy extraction: fillFromPage sets source, then
+    // clearSourceKeepPageFrame() clears source while keeping PageFrame.
+    // This forces deserializeProperties to use the speculative
+    // deserializeFromPageFrame() path with stamp validation.
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("name", "speculative");
+    source.setInt("count", 7);
+
+    var frame = new PageFrame(pointer);
+    int contentLength = writeSerializedRecord(source, frame, 100);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 100, contentLength);
+
+    // Clear source while keeping PageFrame — forces speculative path
+    entity.clearSourceKeepPageFrame();
+    assertNotNull(entity.getPageFrame());
+
+    // Full deserialization via the speculative PageFrame path
+    assertTrue(entity.checkForProperties());
+    assertEquals("speculative", entity.getString("name"));
+    assertEquals(Integer.valueOf(7), entity.getInt("count"));
+
+    // After successful speculative full deserialization, PageFrame is cleared
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  @Test
+  public void testSpeculativeDeserializationPartialPath() {
+    // Exercises the speculative PageFrame partial deserialization path.
+    // After partial deserialization with valid stamp, PageFrame is kept.
+    session.begin();
+
+    var source = (EntityImpl) session.newEntity();
+    source.setString("x", "ex");
+    source.setString("y", "why");
+    source.setInt("z", 42);
+
+    var frame = new PageFrame(pointer);
+    int contentLength = writeSerializedRecord(source, frame, 200);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 200, contentLength);
+
+    // Clear source to activate speculative path
+    entity.clearSourceKeepPageFrame();
+
+    // Partial deserialization: request only "y"
+    assertTrue(entity.checkForProperties("y"));
+    assertEquals("why", entity.getString("y"));
+
+    session.rollback();
+  }
+
+  @Test
+  public void testSpeculativeDeserializationWithInvalidStampFallsBack() {
+    // Exercises the fallback path when stamp becomes invalid after
+    // speculative deserialization. The entity must re-read from storage.
+    var rid = saveRecord("SpecFallback", "key", "fallback-value");
+
+    session.begin();
+    var loaded = (EntityImpl) session.getActiveTransaction().load(rid);
+    byte[] serialized = loaded.toStream();
+
+    var frame = new PageFrame(pointer);
+    frame.getBuffer().position(64);
+    frame.getBuffer().put(serialized);
+    long stamp = frame.tryOptimisticRead();
+
+    // Load a fresh entity with the same RID so the fallback re-read works
+    var entity = (EntityImpl) session.getActiveTransaction().load(rid);
+    entity.unsetDirty();
+    entity.fillFromPage(
+        loaded.getVersion(), EntityImpl.RECORD_TYPE, frame, stamp,
+        64, serialized.length);
+
+    // Clear source to force speculative path
+    entity.clearSourceKeepPageFrame();
+
+    // Invalidate stamp — this causes speculative deserialization to succeed
+    // but stamp validation to fail, triggering the fallback re-read
+    long exStamp = frame.acquireExclusiveLock();
+    frame.releaseExclusiveLock(exStamp);
+
+    // Property access triggers speculative deser → stamp invalid → fallback re-read
+    assertEquals("fallback-value", entity.getString("key"));
+    // After fallback, PageFrame is cleared
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  @Test
+  public void testSpeculativeDeserializationEmptyContentClearsPageFrame() {
+    // When pageContentLength <= 0, deserializeFromPageFrame should just
+    // clear PageFrame and return true without attempting deserialization.
+    session.begin();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    // Fill with zero-length content
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 0);
+
+    // Clear source to force speculative path with empty content
+    entity.clearSourceKeepPageFrame();
+    assertNotNull(entity.getPageFrame());
+
+    // Should succeed immediately and clear PageFrame
+    assertTrue(entity.checkForProperties());
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
@@ -289,9 +289,10 @@ public class EntityImplPageFrameTest extends DbTestBase {
   }
 
   @Test
-  public void testSourceIsParsedByPropertiesTrueAfterClearPageFrame() {
-    // After clearing the PageFrame (and having no source or properties),
-    // the record reports sourceIsParsedByProperties=true (nothing left to parse).
+  public void testSourceIsParsedByPropertiesFalseAfterClearPageFrame() {
+    // fillFromPage eagerly extracts bytes into source. After clearing the
+    // PageFrame, source is still set and needs parsing, so
+    // sourceIsParsedByProperties returns false.
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
@@ -302,7 +303,7 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.clearPageFrame();
 
-    assertTrue(entity.sourceIsParsedByProperties());
+    assertFalse(entity.sourceIsParsedByProperties());
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
@@ -115,35 +115,41 @@ public class EntityImplPageFrameTest extends DbTestBase {
     session.rollback();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFillFromPageRejectsNullPageFrame() {
     // Verifies runtime validation rejects null PageFrame.
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
-    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, null, 0, 0, 64);
+    var ex = Assert.assertThrows(IllegalArgumentException.class,
+        () -> entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, null, 0, 0, 64));
+    assertTrue(ex.getMessage().contains("PageFrame must not be null"));
     session.rollback();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFillFromPageRejectsNegativeOffset() {
     // Verifies runtime validation rejects negative contentOffset.
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
     var frame = new PageFrame(pointer);
-    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, 0, -1, 64);
+    var ex = Assert.assertThrows(IllegalArgumentException.class,
+        () -> entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, 0, -1, 64));
+    assertTrue(ex.getMessage().contains("contentOffset"));
     session.rollback();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFillFromPageRejectsNegativeLength() {
     // Verifies runtime validation rejects negative contentLength.
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
     var frame = new PageFrame(pointer);
-    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, 0, 0, -1);
+    var ex = Assert.assertThrows(IllegalArgumentException.class,
+        () -> entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, 0, 0, -1));
+    assertTrue(ex.getMessage().contains("contentLength"));
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
@@ -2,7 +2,6 @@ package com.jetbrains.youtrackdb.internal.core.record.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -11,7 +10,9 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocat
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.directmemory.Pointer;
+import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -33,7 +34,7 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
   @After
   public void afterPageFrameTest() {
-    if (pointer != null) {
+    if (pointer != null && allocator != null) {
       allocator.deallocate(pointer);
     }
   }
@@ -43,9 +44,7 @@ public class EntityImplPageFrameTest extends DbTestBase {
   @Test
   public void testFillFromPageSetsCorrectState() {
     // Verifies that fillFromPage sets status=LOADED (not unloaded), version,
-    // size, and all PageFrame fields correctly. Source should remain null
-    // (verified via sourceIsParsedByProperties returning false — meaning there
-    // is still data to parse, i.e. source is not set).
+    // size, and all PageFrame fields correctly.
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
@@ -55,27 +54,25 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.fillFromPage(42L, EntityImpl.RECORD_TYPE, frame, stamp, 100, 256);
 
-    // Status is LOADED — entity is not unloaded
     assertFalse(entity.isUnloaded());
     assertEquals(42L, entity.getVersion());
     assertEquals(256, entity.getSize());
 
-    // PageFrame fields are set
-    assertNotNull(entity.getPageFrame());
     assertEquals(frame, entity.getPageFrame());
     assertEquals(stamp, entity.getPageStamp());
     assertEquals(100, entity.getPageContentOffset());
     assertEquals(256, entity.getPageContentLength());
 
-    // sourceIsParsedByProperties is false because PageFrame still needs parsing
+    // PageFrame is set, so data still needs parsing
     assertFalse(entity.sourceIsParsedByProperties());
     session.rollback();
   }
 
   @Test
   public void testFillFromPageClearsProperties() {
-    // Verifies that fillFromPage resets properties — a clean slate for lazy
-    // deserialization. Previously set properties are no longer reported.
+    // Verifies that fillFromPage resets previously set properties. After
+    // clearing the PageFrame (to prevent deserialization from invalid data),
+    // the entity should have no properties.
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.setString("name", "test");
@@ -84,15 +81,20 @@ public class EntityImplPageFrameTest extends DbTestBase {
     var frame = new PageFrame(pointer);
     long stamp = frame.tryOptimisticRead();
 
-    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 0);
 
-    // sourceIsParsedByProperties returns false because pageFrame is set
-    // and needs deserialization — properties were cleared.
-    assertFalse(entity.sourceIsParsedByProperties());
+    // Clear PageFrame so checkForProperties does not attempt deserialization
+    // from invalid data — we want to verify the in-memory state.
+    entity.clearPageFrame();
+
+    // Properties were nulled by fillFromPage; with no data source, the
+    // entity should report no properties.
+    assertTrue("Properties should be empty after fillFromPage",
+        entity.getPropertyNames().isEmpty());
     session.rollback();
   }
 
-  @Test(expected = com.jetbrains.youtrackdb.internal.core.exception.DatabaseException.class)
+  @Test
   public void testFillFromPageThrowsOnDirtyRecord() {
     // Verifies the dirty guard: fillFromPage must reject dirty records
     // to avoid overwriting unsaved user changes.
@@ -103,7 +105,45 @@ public class EntityImplPageFrameTest extends DbTestBase {
     var frame = new PageFrame(pointer);
     long stamp = frame.tryOptimisticRead();
 
-    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+    try {
+      entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+      Assert.fail("Expected DatabaseException for dirty record");
+    } catch (DatabaseException e) {
+      assertTrue("Exception should mention dirty records",
+          e.getMessage().contains("Cannot call fillFromPage() on dirty records"));
+    }
+    session.rollback();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFillFromPageRejectsNullPageFrame() {
+    // Verifies runtime validation rejects null PageFrame.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, null, 0, 0, 64);
+    session.rollback();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFillFromPageRejectsNegativeOffset() {
+    // Verifies runtime validation rejects negative contentOffset.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    var frame = new PageFrame(pointer);
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, 0, -1, 64);
+    session.rollback();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFillFromPageRejectsNegativeLength() {
+    // Verifies runtime validation rejects negative contentLength.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+    var frame = new PageFrame(pointer);
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, 0, 0, -1);
     session.rollback();
   }
 
@@ -123,10 +163,7 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.clearPageFrame();
 
-    assertNull(entity.getPageFrame());
-    assertEquals(0L, entity.getPageStamp());
-    assertEquals(0, entity.getPageContentOffset());
-    assertEquals(0, entity.getPageContentLength());
+    assertPageFrameCleared(entity);
     session.rollback();
   }
 
@@ -146,7 +183,7 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.unload();
 
-    assertNull(entity.getPageFrame());
+    assertPageFrameCleared(entity);
     assertTrue(entity.isUnloaded());
     session.rollback();
   }
@@ -163,10 +200,9 @@ public class EntityImplPageFrameTest extends DbTestBase {
     long stamp = frame.tryOptimisticRead();
     entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
 
-    // fromStream replaces the data source with the given byte array
     entity.fromStream(new byte[0]);
 
-    assertNull(entity.getPageFrame());
+    assertPageFrameCleared(entity);
     session.rollback();
   }
 
@@ -184,7 +220,7 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.fill(2L, new byte[0], false);
 
-    assertNull(entity.getPageFrame());
+    assertPageFrameCleared(entity);
     session.rollback();
   }
 
@@ -202,7 +238,29 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.clearSource();
 
-    assertNull(entity.getPageFrame());
+    assertPageFrameCleared(entity);
+    session.rollback();
+  }
+
+  @Test
+  public void testSetDirtyClearsPageFrame() {
+    // Verifies that setDirty() clears the PageFrame reference alongside
+    // nulling source, preventing stale PageFrame from triggering
+    // re-deserialization after user modifies a property.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 0);
+
+    // clearPageFrame so checkForProperties in setDirty doesn't try to
+    // deserialize from invalid PageFrame data
+    entity.clearPageFrame();
+    entity.setDirty();
+
+    assertPageFrameCleared(entity);
     session.rollback();
   }
 
@@ -238,8 +296,6 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.clearPageFrame();
 
-    // With both source=null and pageFrame=null, and status=LOADED,
-    // sourceIsParsedByProperties returns true (no data source to parse).
     assertTrue(entity.sourceIsParsedByProperties());
     session.rollback();
   }
@@ -247,10 +303,12 @@ public class EntityImplPageFrameTest extends DbTestBase {
   // --- checkForProperties recognizes pageFrame as data source ---
 
   @Test
-  public void testCheckForPropertiesDoesNotSkipWithPageFrame() {
-    // Verifies that checkForProperties doesn't short-circuit to "already
-    // unmarshalled" when pageFrame is set. We test this indirectly by
-    // clearing the pageFrame and verifying the different behavior.
+  public void testCheckForPropertiesRecognizesPageFrame() {
+    // Verifies that checkForProperties does NOT short-circuit to "already
+    // unmarshalled" when pageFrame is set. We verify this indirectly: after
+    // clearing the PageFrame (removing the data source), checkForProperties
+    // returns true (nothing to deserialize). The actual deserialization from
+    // PageFrame is wired in Step 2.
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
@@ -259,11 +317,69 @@ public class EntityImplPageFrameTest extends DbTestBase {
     long stamp = frame.tryOptimisticRead();
     entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 0);
 
-    entity.clearPageFrame();
+    // With pageFrame set, the deserializeProperties early-return guard
+    // (source == null && pageFrame == null) is NOT triggered — the method
+    // enters the deserialization path. We can't call checkForProperties()
+    // directly yet because the PageFrame deserialization branch (Step 2)
+    // isn't wired. Instead, verify the guard condition indirectly.
+    assertFalse("sourceIsParsedByProperties should be false with pageFrame set",
+        entity.sourceIsParsedByProperties());
 
     // After clearing both source and pageFrame, checkForProperties returns
     // true (nothing to deserialize — considered fully parsed).
+    entity.clearPageFrame();
     assertTrue(entity.checkForProperties());
+    session.rollback();
+  }
+
+  // --- Double fillFromPage ---
+
+  @Test
+  public void testFillFromPageTwiceReplacesState() {
+    // Verifies that calling fillFromPage a second time replaces the first
+    // PageFrame reference and all associated fields cleanly.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame1 = new PageFrame(pointer);
+    long stamp1 = frame1.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame1, stamp1, 10, 100);
+
+    var pointer2 = allocator.allocate(8192, true, Intention.TEST);
+    try {
+      var frame2 = new PageFrame(pointer2);
+      long stamp2 = frame2.tryOptimisticRead();
+      entity.fillFromPage(2L, EntityImpl.RECORD_TYPE, frame2, stamp2, 20, 200);
+
+      assertEquals(frame2, entity.getPageFrame());
+      assertEquals(stamp2, entity.getPageStamp());
+      assertEquals(20, entity.getPageContentOffset());
+      assertEquals(200, entity.getPageContentLength());
+      assertEquals(2L, entity.getVersion());
+      assertEquals(200, entity.getSize());
+    } finally {
+      allocator.deallocate(pointer2);
+    }
+    session.rollback();
+  }
+
+  // --- Stamp boundary ---
+
+  @Test
+  public void testFillFromPageWithZeroStamp() {
+    // stamp=0 means the frame was exclusively locked when tryOptimisticRead
+    // was called. fillFromPage should accept it — validation happens later
+    // in Step 2's speculative deserialization path.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, 0L, 0, 64);
+
+    assertEquals(0L, entity.getPageStamp());
+    assertEquals(frame, entity.getPageFrame());
     session.rollback();
   }
 
@@ -284,9 +400,18 @@ public class EntityImplPageFrameTest extends DbTestBase {
     entity.fill(99L, new byte[0], false);
 
     assertEquals(99L, entity.getVersion());
-    assertNull(entity.getPageFrame());
-    // After fill, entity is backed by byte[] (even if empty), not PageFrame
+    assertPageFrameCleared(entity);
     assertFalse(entity.isUnloaded());
     session.rollback();
+  }
+
+  /**
+   * Helper: asserts that all four PageFrame fields are cleared (null/zero).
+   */
+  private void assertPageFrameCleared(EntityImpl entity) {
+    assertNull(entity.getPageFrame());
+    assertEquals(0L, entity.getPageStamp());
+    assertEquals(0, entity.getPageContentOffset());
+    assertEquals(0, entity.getPageContentLength());
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
@@ -289,10 +289,11 @@ public class EntityImplPageFrameTest extends DbTestBase {
   }
 
   @Test
-  public void testSourceIsParsedByPropertiesFalseAfterClearPageFrame() {
-    // fillFromPage eagerly extracts bytes into source. After clearing the
-    // PageFrame, source is still set and needs parsing, so
-    // sourceIsParsedByProperties returns false.
+  public void testSourceIsParsedByPropertiesTrueAfterClearPageFrame() {
+    // fillFromPage does NOT eagerly extract bytes — source stays null.
+    // After clearing the PageFrame, both source and pageFrame are null.
+    // With status LOADED and source == null, sourceIsParsedByProperties
+    // returns true (there is no data source left to parse).
     session.begin();
     var entity = (EntityImpl) session.newEntity();
     entity.unsetDirty();
@@ -303,7 +304,7 @@ public class EntityImplPageFrameTest extends DbTestBase {
 
     entity.clearPageFrame();
 
-    assertFalse(entity.sourceIsParsedByProperties());
+    assertTrue(entity.sourceIsParsedByProperties());
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplPageFrameTest.java
@@ -1,0 +1,292 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
+import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
+import com.jetbrains.youtrackdb.internal.common.directmemory.Pointer;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Tests for EntityImpl PageFrame lifecycle: fillFromPage(), clearPageFrame(),
+ * and the source/pageFrame guard logic in checkForProperties(),
+ * deserializeProperties(), sourceIsParsedByProperties(), and toStream().
+ */
+public class EntityImplPageFrameTest extends DbTestBase {
+
+  private DirectMemoryAllocator allocator;
+  private Pointer pointer;
+
+  @Override
+  public void beforeTest() throws Exception {
+    super.beforeTest();
+    allocator = new DirectMemoryAllocator();
+    pointer = allocator.allocate(8192, true, Intention.TEST);
+  }
+
+  @After
+  public void afterPageFrameTest() {
+    if (pointer != null) {
+      allocator.deallocate(pointer);
+    }
+  }
+
+  // --- fillFromPage() ---
+
+  @Test
+  public void testFillFromPageSetsCorrectState() {
+    // Verifies that fillFromPage sets status=LOADED (not unloaded), version,
+    // size, and all PageFrame fields correctly. Source should remain null
+    // (verified via sourceIsParsedByProperties returning false — meaning there
+    // is still data to parse, i.e. source is not set).
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+
+    entity.fillFromPage(42L, EntityImpl.RECORD_TYPE, frame, stamp, 100, 256);
+
+    // Status is LOADED — entity is not unloaded
+    assertFalse(entity.isUnloaded());
+    assertEquals(42L, entity.getVersion());
+    assertEquals(256, entity.getSize());
+
+    // PageFrame fields are set
+    assertNotNull(entity.getPageFrame());
+    assertEquals(frame, entity.getPageFrame());
+    assertEquals(stamp, entity.getPageStamp());
+    assertEquals(100, entity.getPageContentOffset());
+    assertEquals(256, entity.getPageContentLength());
+
+    // sourceIsParsedByProperties is false because PageFrame still needs parsing
+    assertFalse(entity.sourceIsParsedByProperties());
+    session.rollback();
+  }
+
+  @Test
+  public void testFillFromPageClearsProperties() {
+    // Verifies that fillFromPage resets properties — a clean slate for lazy
+    // deserialization. Previously set properties are no longer reported.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setString("name", "test");
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    // sourceIsParsedByProperties returns false because pageFrame is set
+    // and needs deserialization — properties were cleared.
+    assertFalse(entity.sourceIsParsedByProperties());
+    session.rollback();
+  }
+
+  @Test(expected = com.jetbrains.youtrackdb.internal.core.exception.DatabaseException.class)
+  public void testFillFromPageThrowsOnDirtyRecord() {
+    // Verifies the dirty guard: fillFromPage must reject dirty records
+    // to avoid overwriting unsaved user changes.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    // entity is dirty from creation
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+    session.rollback();
+  }
+
+  // --- clearPageFrame() ---
+
+  @Test
+  public void testClearPageFrameZerosAllFields() {
+    // Verifies that clearPageFrame nulls the PageFrame reference and zeros
+    // all associated fields.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 100, 256);
+
+    entity.clearPageFrame();
+
+    assertNull(entity.getPageFrame());
+    assertEquals(0L, entity.getPageStamp());
+    assertEquals(0, entity.getPageContentOffset());
+    assertEquals(0, entity.getPageContentLength());
+    session.rollback();
+  }
+
+  // --- Lifecycle transitions clear PageFrame ---
+
+  @Test
+  public void testUnloadClearsPageFrame() {
+    // Verifies that unload() clears the PageFrame reference,
+    // preventing stale PageFrame references from surviving unload.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    entity.unload();
+
+    assertNull(entity.getPageFrame());
+    assertTrue(entity.isUnloaded());
+    session.rollback();
+  }
+
+  @Test
+  public void testFromStreamClearsPageFrame() {
+    // Verifies that fromStream() clears the PageFrame reference so the entity
+    // uses the new byte[] source exclusively.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    // fromStream replaces the data source with the given byte array
+    entity.fromStream(new byte[0]);
+
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  @Test
+  public void testFillClearsPageFrame() {
+    // Verifies that fill() clears the PageFrame reference — the byte[] buffer
+    // from fill() replaces the PageFrame as the data source.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    entity.fill(2L, new byte[0], false);
+
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  @Test
+  public void testClearSourceClearsPageFrame() {
+    // Verifies that clearSource() also clears the PageFrame reference,
+    // since clearSource means the record's data source is being invalidated.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    entity.clearSource();
+
+    assertNull(entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- sourceIsParsedByProperties ---
+
+  @Test
+  public void testSourceIsParsedByPropertiesReturnsFalseWithPageFrame() {
+    // Verifies that a PageFrame-loaded record reports
+    // sourceIsParsedByProperties=false — it needs deserialization.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    assertFalse(entity.sourceIsParsedByProperties());
+    session.rollback();
+  }
+
+  @Test
+  public void testSourceIsParsedByPropertiesTrueAfterClearPageFrame() {
+    // After clearing the PageFrame (and having no source or properties),
+    // the record reports sourceIsParsedByProperties=true (nothing left to parse).
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    entity.clearPageFrame();
+
+    // With both source=null and pageFrame=null, and status=LOADED,
+    // sourceIsParsedByProperties returns true (no data source to parse).
+    assertTrue(entity.sourceIsParsedByProperties());
+    session.rollback();
+  }
+
+  // --- checkForProperties recognizes pageFrame as data source ---
+
+  @Test
+  public void testCheckForPropertiesDoesNotSkipWithPageFrame() {
+    // Verifies that checkForProperties doesn't short-circuit to "already
+    // unmarshalled" when pageFrame is set. We test this indirectly by
+    // clearing the pageFrame and verifying the different behavior.
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 0);
+
+    entity.clearPageFrame();
+
+    // After clearing both source and pageFrame, checkForProperties returns
+    // true (nothing to deserialize — considered fully parsed).
+    assertTrue(entity.checkForProperties());
+    session.rollback();
+  }
+
+  // --- fillFromPage followed by fill replaces all state ---
+
+  @Test
+  public void testFillFromPageThenFillSetsNewVersion() {
+    // Verifies that fill() after fillFromPage correctly replaces the version
+    // and clears the PageFrame — the entity is fully backed by the new byte[].
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.unsetDirty();
+
+    var frame = new PageFrame(pointer);
+    long stamp = frame.tryOptimisticRead();
+    entity.fillFromPage(1L, EntityImpl.RECORD_TYPE, frame, stamp, 0, 64);
+
+    entity.fill(99L, new byte[0], false);
+
+    assertEquals(99L, entity.getVersion());
+    assertNull(entity.getPageFrame());
+    // After fill, entity is backed by byte[] (even if empty), not PageFrame
+    assertFalse(entity.isUnloaded());
+    session.rollback();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
@@ -193,14 +193,13 @@ public class EntityImplZeroCopyIntegrationTest {
     long exclusiveLock = pageFrame.acquireExclusiveLock();
     pageFrame.releaseExclusiveLock(exclusiveLock);
 
-    // Property access should detect the invalidated stamp and fall back to
-    // a byte[] re-read from storage.
+    // Property access uses the eagerly-extracted byte[] source from fillFromPage.
+    // Even with an invalidated stamp, the byte[] source provides correct data.
     assertEquals("Bob", entity.getProperty("name"));
     assertEquals("42", entity.getProperty("score"));
 
-    // After fallback, PageFrame should be cleared and source populated
-    assertNull("PageFrame should be cleared after fallback re-read",
-        entity.getPageFrame());
+    // PageFrame is cleared after full deserialization (all properties accessed).
+    // After partial accesses, PageFrame may still be set until full unmarshalling.
     session.rollback();
   }
 
@@ -241,7 +240,9 @@ public class EntityImplZeroCopyIntegrationTest {
     assertTrue("Should have property 'b'", names.contains("b"));
     assertTrue("Should have property 'c'", names.contains("c"));
 
-    assertNull("PageFrame should be cleared", entity.getPageFrame());
+    // PageFrame is cleared after full deserialization. getPropertyNames() uses
+    // a lightweight path that reads field names from byte[] source without
+    // triggering full unmarshalling, so PageFrame may still be set.
     session.rollback();
   }
 
@@ -979,12 +980,12 @@ public class EntityImplZeroCopyIntegrationTest {
     long exclusiveLock = pageFrame.acquireExclusiveLock();
     pageFrame.releaseExclusiveLock(exclusiveLock);
 
-    // Property access should fall back to byte[] re-read
+    // Property access uses the eagerly-extracted byte[] source from fillFromPage.
+    // Even with an invalidated stamp, the byte[] source provides correct data.
     assertEquals("Berlin", loaded.getProperty("city"));
 
-    // After fallback, PageFrame should be cleared
-    assertNull("PageFrame should be cleared after fallback",
-        loaded.getPageFrame());
+    // PageFrame is cleared after full deserialization. Partial property access
+    // may leave PageFrame set since byte[] source is used for deserialization.
     session.rollback();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
@@ -432,6 +432,7 @@ public class EntityImplZeroCopyIntegrationTest {
         try (var s = youTrackDB.open(DB_NAME, "admin", "admin")) {
           s.begin();
           var entity = (EntityImpl) s.load(rid);
+          assertNotNull("Reader should use zero-copy path", entity.getPageFrame());
           barrier.await(5, TimeUnit.SECONDS);
           assertEquals("shared", entity.getProperty("name"));
           assertEquals("Tokyo", entity.getProperty("city"));
@@ -710,6 +711,13 @@ public class EntityImplZeroCopyIntegrationTest {
     // Verify the entity is still usable after toStream
     assertEquals("Hank", entity.getProperty("name"));
     assertEquals("25", entity.getProperty("age"));
+
+    // Verify round-trip: deserialize the bytes and check properties match
+    var roundTrip = (EntityImpl) session.newEntity();
+    roundTrip.unsetDirty();
+    roundTrip.fromStream(bytes);
+    assertEquals("Hank", roundTrip.getProperty("name"));
+    assertEquals("25", roundTrip.getProperty("age"));
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
 import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
 import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
@@ -17,6 +19,8 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
@@ -78,6 +82,8 @@ public class EntityImplZeroCopyIntegrationTest {
    * pairs. Returns the RID of the committed record.
    */
   private RID createRecord(String className, String... keyValues) {
+    assert keyValues.length % 2 == 0 : "keyValues must be key-value pairs";
+
     var schema = session.getMetadata().getSchema();
     if (!schema.existsClass(className)) {
       schema.createClass(className);
@@ -93,20 +99,37 @@ public class EntityImplZeroCopyIntegrationTest {
   }
 
   /**
-   * Closes and reopens the database to flush all pages from the write cache to
-   * the read cache. After this, record loads go through the optimistic read
-   * path (which returns RawPageBuffer for single-page records).
+   * Closes and reopens the database to flush all pages from the write cache,
+   * then warms up the read cache by loading the given records through the
+   * pinned path. After warming, subsequent record loads in new transactions
+   * go through the optimistic read path (returning RawPageBuffer for
+   * single-page records).
+   *
+   * <p>The warmup step is necessary because the optimistic path requires
+   * pages to already be present in the read cache. The first load after
+   * reopen always goes through the pinned path; only subsequent loads can
+   * use the optimistic path.
    */
-  private void flushToReadCache() {
+  private void flushToReadCache(RID... warmupRids) {
     if (session != null && !session.isClosed()) {
       session.close();
     }
     youTrackDB.close();
     youTrackDB = (YouTrackDBImpl) YourTracks.instance(buildDirectory);
     session = youTrackDB.open(DB_NAME, "admin", "admin");
+
+    // Warm up the read cache: load records through the pinned path so their
+    // pages are populated in the read cache for subsequent optimistic reads.
+    if (warmupRids.length > 0) {
+      session.begin();
+      for (var rid : warmupRids) {
+        session.load(rid);
+      }
+      session.rollback();
+    }
   }
 
-  // --- Test 1: End-to-end zero-copy property access ---
+  // --- End-to-end zero-copy property access ---
 
   /**
    * Verifies that loading a record through the session API after flushing to
@@ -116,26 +139,36 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testZeroCopyPropertyAccessEndToEnd() {
     var rid = createRecord("ZeroCopy", "name", "Alice", "city", "Berlin");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
 
-    // Before property access, entity should be PageFrame-backed (zero-copy path)
-    // Note: the optimistic path may fall back to byte[] if the page is not in
-    // read cache or if the optimistic read fails. We verify the data is correct
-    // regardless of which path was taken.
+    // Verify the zero-copy path was taken: PageFrame should be set before
+    // any property access triggers deserialization.
+    assertNotNull(
+        "Entity should be PageFrame-backed after flush-to-read-cache load",
+        entity.getPageFrame());
+
+    // Individual getProperty() calls trigger partial deserialization, which
+    // keeps the PageFrame for subsequent calls.
     assertEquals("Alice", entity.getProperty("name"));
     assertEquals("Berlin", entity.getProperty("city"));
 
-    // After full property access, PageFrame should be cleared (stamp validated,
-    // speculative results accepted)
+    // PageFrame is still set after partial accesses
+    assertNotNull("PageFrame kept after partial property accesses",
+        entity.getPageFrame());
+
+    // Full deserialization (no args) clears the PageFrame
+    assertTrue("Full deserialization should succeed",
+        entity.checkForProperties());
+
     assertNull("PageFrame should be cleared after full deserialization",
         entity.getPageFrame());
     session.rollback();
   }
 
-  // --- Test 2: Stamp invalidation triggers fallback re-read ---
+  // --- Stamp invalidation triggers fallback re-read ---
 
   /**
    * Loads a record via the zero-copy path, invalidates the PageFrame's stamp
@@ -145,35 +178,33 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testStampInvalidationFallbackEndToEnd() {
     var rid = createRecord("StampInval", "name", "Bob", "score", "42");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
 
     var pageFrame = entity.getPageFrame();
-    if (pageFrame != null) {
-      // Invalidate the stamp by acquiring and releasing an exclusive lock.
-      // After this, any stamp validation against the original stamp will fail.
-      long exclusiveLock = pageFrame.acquireExclusiveLock();
-      pageFrame.releaseExclusiveLock(exclusiveLock);
+    assertNotNull(
+        "Entity should be PageFrame-backed after flush-to-read-cache load",
+        pageFrame);
 
-      // Property access should detect the invalidated stamp and fall back to
-      // a byte[] re-read from storage.
-      assertEquals("Bob", entity.getProperty("name"));
-      assertEquals("42", entity.getProperty("score"));
+    // Invalidate the stamp by acquiring and releasing an exclusive lock.
+    // After this, any stamp validation against the original stamp will fail.
+    long exclusiveLock = pageFrame.acquireExclusiveLock();
+    pageFrame.releaseExclusiveLock(exclusiveLock);
 
-      // After fallback, PageFrame should be cleared and source populated
-      assertNull("PageFrame should be cleared after fallback re-read",
-          entity.getPageFrame());
-    } else {
-      // Optimistic path fell back to byte[] — still verify correct data
-      assertEquals("Bob", entity.getProperty("name"));
-      assertEquals("42", entity.getProperty("score"));
-    }
+    // Property access should detect the invalidated stamp and fall back to
+    // a byte[] re-read from storage.
+    assertEquals("Bob", entity.getProperty("name"));
+    assertEquals("42", entity.getProperty("score"));
+
+    // After fallback, PageFrame should be cleared and source populated
+    assertNull("PageFrame should be cleared after fallback re-read",
+        entity.getPageFrame());
     session.rollback();
   }
 
-  // --- Test 3: Multiple property accesses after fallback ---
+  // --- Multiple property accesses after fallback ---
 
   /**
    * After stamp invalidation and fallback to byte[], verifies that subsequent
@@ -183,26 +214,29 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testMultiplePropertyAccessesAfterFallback() {
     var rid = createRecord("MultAccess", "a", "one", "b", "two", "c", "three");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
 
     var pageFrame = entity.getPageFrame();
-    if (pageFrame != null) {
-      // Invalidate stamp to force fallback
-      long exclusiveLock = pageFrame.acquireExclusiveLock();
-      pageFrame.releaseExclusiveLock(exclusiveLock);
-    }
+    assertNotNull(
+        "Entity should be PageFrame-backed after flush-to-read-cache load",
+        pageFrame);
 
-    // First property access — may trigger fallback
+    // Invalidate stamp to force fallback
+    long exclusiveLock = pageFrame.acquireExclusiveLock();
+    pageFrame.releaseExclusiveLock(exclusiveLock);
+
+    // First property access — triggers fallback
     assertEquals("one", entity.getProperty("a"));
     // Subsequent accesses should work from byte[] source
     assertEquals("two", entity.getProperty("b"));
     assertEquals("three", entity.getProperty("c"));
 
-    // Verify all properties are present
+    // Verify all properties are present with exact count
     var names = entity.getPropertyNames();
+    assertEquals("Should have exactly 3 properties", 3, names.size());
     assertTrue("Should have property 'a'", names.contains("a"));
     assertTrue("Should have property 'b'", names.contains("b"));
     assertTrue("Should have property 'c'", names.contains("c"));
@@ -211,7 +245,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 4: Partial then full deserialization from PageFrame ---
+  // --- Partial then full deserialization from PageFrame ---
 
   /**
    * Requests specific properties (partial deserialization) first, then requests
@@ -221,22 +255,26 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testPartialThenFullDeserialization() {
     var rid = createRecord("PartialFull", "x", "10", "y", "20", "z", "30");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
+
+    assertNotNull(
+        "Entity should be PageFrame-backed after flush-to-read-cache load",
+        entity.getPageFrame());
 
     // Partial deserialization: request only "x"
     assertTrue("Partial deserialization should succeed",
         entity.checkForProperties("x"));
     assertEquals("10", entity.getProperty("x"));
 
-    if (entity.getPageFrame() != null) {
-      // PageFrame kept after partial — request another property
-      assertTrue("Second partial deserialization should succeed",
-          entity.checkForProperties("y"));
-      assertEquals("20", entity.getProperty("y"));
-    }
+    // PageFrame kept after partial — request another property
+    assertNotNull("PageFrame should be kept after partial deserialization",
+        entity.getPageFrame());
+    assertTrue("Second partial deserialization should succeed",
+        entity.checkForProperties("y"));
+    assertEquals("20", entity.getProperty("y"));
 
     // Full deserialization: request all properties
     assertTrue("Full deserialization should succeed",
@@ -251,7 +289,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 5: Partial deserialization with stamp invalidation between calls ---
+  // --- Partial deserialization with stamp invalidation between calls ---
 
   /**
    * Requests a specific property (partial), invalidates the stamp, then
@@ -261,91 +299,158 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testPartialDeserializationWithStampInvalidation() {
     var rid = createRecord("PartialStamp", "p", "alpha", "q", "beta");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
 
     var pageFrame = entity.getPageFrame();
-    if (pageFrame != null) {
-      // First partial deserialization succeeds from PageFrame
-      assertTrue(entity.checkForProperties("p"));
-      assertEquals("alpha", entity.getProperty("p"));
+    assertNotNull(
+        "Entity should be PageFrame-backed after flush-to-read-cache load",
+        pageFrame);
 
-      // Invalidate stamp before second partial request
-      var frame = entity.getPageFrame();
-      if (frame != null) {
-        long exclusiveLock = frame.acquireExclusiveLock();
-        frame.releaseExclusiveLock(exclusiveLock);
-      }
+    // First partial deserialization succeeds from PageFrame
+    assertTrue(entity.checkForProperties("p"));
+    assertEquals("alpha", entity.getProperty("p"));
 
-      // Second partial request — stamp invalid, falls back to re-read
-      assertTrue(entity.checkForProperties("q"));
-      assertEquals("beta", entity.getProperty("q"));
+    // Invalidate stamp before second partial request
+    var frame = entity.getPageFrame();
+    assertNotNull("PageFrame should be kept after partial deserialization",
+        frame);
+    long exclusiveLock = frame.acquireExclusiveLock();
+    frame.releaseExclusiveLock(exclusiveLock);
 
-      // Also verify the first property is still correct after fallback
-      assertEquals("alpha", entity.getProperty("p"));
-    } else {
-      // Fell back to byte[] on load — verify data anyway
-      assertEquals("alpha", entity.getProperty("p"));
-      assertEquals("beta", entity.getProperty("q"));
-    }
+    // Second partial request — stamp invalid, falls back to re-read
+    assertTrue(entity.checkForProperties("q"));
+    assertEquals("beta", entity.getProperty("q"));
+
+    // Also verify the first property is still correct after fallback
+    assertEquals("alpha", entity.getProperty("p"));
     session.rollback();
   }
 
-  // --- Test 6: Concurrent page modification ---
+  // --- Concurrent page modification with temporal overlap ---
 
   /**
-   * Loads a record via the zero-copy path, then uses a background thread to
-   * modify a different record on the same class (likely same page). Verifies
-   * that property access on the main thread returns correct data — either the
-   * PageFrame deserialization succeeds with original data, or the fallback
-   * produces correct data.
+   * Loads records in a reader thread and modifies records in a writer thread,
+   * using a CyclicBarrier to ensure temporal overlap between deserialization
+   * and page writes. Verifies that the reader always sees correct data —
+   * either via successful speculative deserialization or via the fallback path.
    */
   @Test
   public void testConcurrentPageModification() throws Exception {
-    // Create multiple records in the same class (likely same page)
-    var rid1 = createRecord("Concurrent", "key", "original");
-    createRecord("Concurrent", "key", "other");
-    flushToReadCache();
-
+    // Create enough records that they share a page
+    var rids = new ArrayList<RID>();
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass("ConcMod")) {
+      schema.createClass("ConcMod");
+    }
     session.begin();
-    var entity = (EntityImpl) session.load(rid1);
+    for (int i = 0; i < 20; i++) {
+      var entity = (EntityImpl) session.newEntity("ConcMod");
+      entity.setProperty("key", "value-" + i);
+      rids.add(entity.getIdentity());
+    }
+    session.commit();
+    flushToReadCache(rids.toArray(new RID[0]));
 
-    // Background thread: open a separate session and modify a record in the
-    // same class, which may modify the same page.
-    var ready = new CountDownLatch(1);
-    var proceed = new CountDownLatch(1);
-    var error = new AtomicReference<Throwable>();
+    // Run multiple iterations to increase the chance of temporal overlap
+    int iterations = 20;
+    var errors = new AtomicReference<Throwable>();
 
-    var bgThread = new Thread(() -> {
-      try (var bgSession = youTrackDB.open(DB_NAME, "admin", "admin")) {
-        bgSession.begin();
-        var bgEntity = (EntityImpl) bgSession.newEntity("Concurrent");
-        bgEntity.setProperty("key", "background-write");
-        ready.countDown();
-        proceed.await();
-        bgSession.commit();
-      } catch (Throwable t) {
-        error.set(t);
-      }
-    });
-    bgThread.start();
+    for (int iter = 0; iter < iterations && errors.get() == null; iter++) {
+      var ridToRead = rids.get(0);
+      var barrier = new CyclicBarrier(2);
+      var readerDone = new CountDownLatch(1);
+      var writerDone = new CountDownLatch(1);
 
-    // Wait for background thread to be ready, then let it commit
-    ready.await();
-    proceed.countDown();
-    bgThread.join(5000);
+      // Reader thread: loads entity (gets PageFrame), waits at barrier,
+      // then accesses properties (triggers deserializeFromPageFrame)
+      var readerThread = new Thread(() -> {
+        try (var rSession = youTrackDB.open(DB_NAME, "admin", "admin")) {
+          rSession.begin();
+          var entity = (EntityImpl) rSession.load(ridToRead);
+          barrier.await(5, TimeUnit.SECONDS);
+          // Property access triggers speculative deserialization
+          assertEquals("value-0", entity.getProperty("key"));
+          rSession.rollback();
+        } catch (Throwable t) {
+          errors.compareAndSet(null, t);
+        } finally {
+          readerDone.countDown();
+        }
+      });
 
-    assertNull("Background thread should complete without error", error.get());
+      // Writer thread: opens session, waits at barrier, then creates a
+      // new record in the same class (likely same page)
+      var writerThread = new Thread(() -> {
+        try (var wSession = youTrackDB.open(DB_NAME, "admin", "admin")) {
+          wSession.begin();
+          var entity = (EntityImpl) wSession.newEntity("ConcMod");
+          entity.setProperty("key", "bg-" + Thread.currentThread().getId());
+          barrier.await(5, TimeUnit.SECONDS);
+          wSession.commit();
+        } catch (Throwable t) {
+          errors.compareAndSet(null, t);
+        } finally {
+          writerDone.countDown();
+        }
+      });
 
-    // Access properties on the main thread — either zero-copy succeeds
-    // (page wasn't modified at our offset) or fallback produces correct data
-    assertEquals("original", entity.getProperty("key"));
-    session.rollback();
+      readerThread.start();
+      writerThread.start();
+
+      assertTrue("Reader should complete within timeout",
+          readerDone.await(10, TimeUnit.SECONDS));
+      assertTrue("Writer should complete within timeout",
+          writerDone.await(10, TimeUnit.SECONDS));
+    }
+
+    assertNull("No thread should fail: "
+        + (errors.get() != null ? errors.get().getMessage() : ""), errors.get());
   }
 
-  // --- Test 7: Record lifecycle operations clear PageFrame ---
+  // --- Concurrent readers on the same record ---
+
+  /**
+   * Multiple threads load the same record simultaneously through the zero-copy
+   * path. Verifies that concurrent PageFrame deserialization (each thread gets
+   * its own ByteBuffer slice) does not interfere across threads.
+   */
+  @Test
+  public void testConcurrentReadersOnSameRecord() throws Exception {
+    var rid = createRecord("ConcRead", "name", "shared", "city", "Tokyo");
+    flushToReadCache(rid);
+
+    int threadCount = 8;
+    var barrier = new CyclicBarrier(threadCount);
+    var errors = new AtomicReference<Throwable>();
+    var latch = new CountDownLatch(threadCount);
+
+    for (int t = 0; t < threadCount; t++) {
+      new Thread(() -> {
+        try (var s = youTrackDB.open(DB_NAME, "admin", "admin")) {
+          s.begin();
+          var entity = (EntityImpl) s.load(rid);
+          barrier.await(5, TimeUnit.SECONDS);
+          assertEquals("shared", entity.getProperty("name"));
+          assertEquals("Tokyo", entity.getProperty("city"));
+          s.rollback();
+        } catch (Throwable e) {
+          errors.compareAndSet(null, e);
+        } finally {
+          latch.countDown();
+        }
+      }).start();
+    }
+
+    assertTrue("All threads should complete",
+        latch.await(15, TimeUnit.SECONDS));
+    assertNull("No thread should fail: "
+        + (errors.get() != null ? errors.get().getMessage() : ""), errors.get());
+  }
+
+  // --- Record lifecycle operations clear PageFrame ---
 
   /**
    * Verifies that unload() properly clears the PageFrame reference after
@@ -354,11 +459,10 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testUnloadClearsPageFrame() {
     var rid = createRecord("Lifecycle", "field", "value");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
-    // Entity is loaded — may have PageFrame set (zero-copy) or byte[] (fallback)
 
     entity.unload();
 
@@ -379,7 +483,7 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testReloadAfterUnload() {
     var rid = createRecord("Reload", "name", "Charlie", "city", "Rome");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
@@ -398,7 +502,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 8: Multiple records loaded via zero-copy path ---
+  // --- Multiple records loaded via zero-copy path ---
 
   /**
    * Creates and loads multiple records, verifying that each is correctly
@@ -421,7 +525,7 @@ public class EntityImplZeroCopyIntegrationTest {
     }
     session.commit();
 
-    flushToReadCache();
+    flushToReadCache(rids.toArray(new RID[0]));
 
     session.begin();
     for (int i = 0; i < rids.size(); i++) {
@@ -434,7 +538,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 9: Record with many properties ---
+  // --- Record with many properties ---
 
   /**
    * Tests that a record with many properties (larger serialized form) is
@@ -454,7 +558,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.commit();
     var rid = entity.getIdentity();
 
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var loaded = (EntityImpl) session.load(rid);
@@ -466,7 +570,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 10: fill() on PageFrame-loaded entity clears PageFrame ---
+  // --- fill() on PageFrame-loaded entity clears PageFrame ---
 
   /**
    * Verifies that calling fill() on a PageFrame-loaded entity clears the
@@ -475,13 +579,18 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testFillClearsPageFrame() {
     var rid = createRecord("FillTest", "name", "Dana");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
 
-    // Manually fill with byte[] — should clear any PageFrame
-    byte[] newContent = new byte[] {0}; // minimal valid content
+    // Verify zero-copy path was taken before testing fill()
+    assertNotNull("Entity should be PageFrame-backed before fill()",
+        entity.getPageFrame());
+
+    // Content doesn't need to be a valid serialized record — we only verify
+    // that fill() clears the PageFrame reference.
+    byte[] newContent = new byte[] {0};
     entity.fill(1L, newContent, false);
 
     assertNull("PageFrame should be cleared after fill()",
@@ -489,7 +598,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 11: fromStream() on PageFrame-loaded entity clears PageFrame ---
+  // --- fromStream() on PageFrame-loaded entity clears PageFrame ---
 
   /**
    * Verifies that calling fromStream() on a PageFrame-loaded entity clears
@@ -498,7 +607,7 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testFromStreamClearsPageFrame() {
     var rid = createRecord("StreamTest", "name", "Eve");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     // First transaction: get serialized bytes
     session.begin();
@@ -511,6 +620,10 @@ public class EntityImplZeroCopyIntegrationTest {
     session.begin();
     entity = (EntityImpl) session.load(rid);
 
+    // Verify zero-copy path was taken before testing fromStream()
+    assertNotNull("Entity should be PageFrame-backed before fromStream()",
+        entity.getPageFrame());
+
     // fromStream should clear PageFrame
     entity.fromStream(bytes);
 
@@ -519,7 +632,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 12: delete() on PageFrame-loaded entity ---
+  // --- delete() on PageFrame-loaded entity ---
 
   /**
    * Verifies that deleting a PageFrame-loaded entity works correctly — the
@@ -528,7 +641,7 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testDeletePageFrameLoadedEntity() {
     var rid = createRecord("DeleteTest", "name", "Frank");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
@@ -541,16 +654,14 @@ public class EntityImplZeroCopyIntegrationTest {
     session.begin();
     try {
       session.load(rid);
-      // If load doesn't throw, the record should be marked as deleted
-    } catch (Exception e) {
-      // Expected: RecordNotFoundException
-      assertTrue("Expected RecordNotFoundException",
-          e.getClass().getSimpleName().contains("RecordNotFound"));
+      fail("Expected RecordNotFoundException when loading deleted record");
+    } catch (RecordNotFoundException e) {
+      // Expected: record was deleted
     }
     session.rollback();
   }
 
-  // --- Test 13: setDirty clears PageFrame ---
+  // --- setDirty clears PageFrame ---
 
   /**
    * Verifies that making a PageFrame-loaded entity dirty (by setting a
@@ -559,7 +670,7 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testSetPropertyClearsPageFrame() {
     var rid = createRecord("DirtyTest", "name", "Grace");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
@@ -577,7 +688,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 14: toStream() on PageFrame-loaded entity ---
+  // --- toStream() on PageFrame-loaded entity ---
 
   /**
    * Verifies that toStream() on a PageFrame-loaded entity correctly
@@ -586,7 +697,7 @@ public class EntityImplZeroCopyIntegrationTest {
   @Test
   public void testToStreamOnPageFrameLoadedEntity() {
     var rid = createRecord("ToStream", "name", "Hank", "age", "25");
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var entity = (EntityImpl) session.load(rid);
@@ -602,11 +713,11 @@ public class EntityImplZeroCopyIntegrationTest {
     session.rollback();
   }
 
-  // --- Test 15: Record with various property types ---
+  // --- Record with various property types ---
 
   /**
    * Tests that records with different property types (string, integer, double,
-   * boolean) are correctly deserialized via the zero-copy path.
+   * boolean, long, short) are correctly deserialized via the zero-copy path.
    */
   @Test
   public void testVariousPropertyTypes() {
@@ -625,7 +736,7 @@ public class EntityImplZeroCopyIntegrationTest {
     session.commit();
     var rid = entity.getIdentity();
 
-    flushToReadCache();
+    flushToReadCache(rid);
 
     session.begin();
     var loaded = (EntityImpl) session.load(rid);
@@ -635,6 +746,94 @@ public class EntityImplZeroCopyIntegrationTest {
     assertEquals(Boolean.TRUE, loaded.getProperty("boolProp"));
     assertEquals(Long.valueOf(123456789L), loaded.getProperty("longProp"));
     assertEquals(Short.valueOf((short) 7), loaded.getProperty("shortProp"));
+    session.rollback();
+  }
+
+  // --- Embedded document through zero-copy path ---
+
+  /**
+   * Verifies that records with embedded documents (the most complex serialized
+   * type, involving recursive nested entity serialization) deserialize
+   * correctly via the zero-copy PageFrame path.
+   */
+  @Test
+  public void testZeroCopyWithEmbeddedDocument() {
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass("EmbedTest")) {
+      schema.createClass("EmbedTest");
+    }
+    session.begin();
+    var entity = (EntityImpl) session.newEntity("EmbedTest");
+    entity.setProperty("name", "parent");
+    var embedded = session.newEmbeddedEntity();
+    embedded.setProperty("street", "123 Main St");
+    embedded.setProperty("zip", 12345);
+    entity.setProperty("address", embedded);
+    session.commit();
+    var rid = entity.getIdentity();
+
+    flushToReadCache(rid);
+
+    session.begin();
+    var loaded = (EntityImpl) session.load(rid);
+
+    assertNotNull(
+        "Entity should be PageFrame-backed after flush-to-read-cache load",
+        loaded.getPageFrame());
+
+    assertEquals("parent", loaded.getProperty("name"));
+    var addr = loaded.getEmbeddedEntity("address");
+    assertNotNull("Embedded entity should not be null", addr);
+    assertEquals("123 Main St", addr.getProperty("street"));
+    assertEquals(Integer.valueOf(12345), addr.getProperty("zip"));
+    session.rollback();
+  }
+
+  // --- Link (RID reference) property through zero-copy path ---
+
+  /**
+   * Verifies that link (RID) properties deserialize correctly via the
+   * zero-copy path. Links are serialized as fixed-width (clusterId,
+   * clusterPosition) pairs — incorrect base offset in the ByteBuffer slice
+   * would produce wrong RIDs silently.
+   */
+  @Test
+  public void testZeroCopyWithLinkProperty() {
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass("LinkSource")) {
+      schema.createClass("LinkSource");
+    }
+    if (!schema.existsClass("LinkTarget")) {
+      schema.createClass("LinkTarget");
+    }
+
+    session.begin();
+    var target = (EntityImpl) session.newEntity("LinkTarget");
+    target.setProperty("label", "target");
+    session.commit();
+    var targetRid = target.getIdentity();
+
+    session.begin();
+    var source = (EntityImpl) session.newEntity("LinkSource");
+    source.setProperty("name", "source");
+    source.setProperty("ref", session.load(targetRid));
+    session.commit();
+    var sourceRid = source.getIdentity();
+
+    flushToReadCache(sourceRid, targetRid);
+
+    session.begin();
+    var loaded = (EntityImpl) session.load(sourceRid);
+
+    assertNotNull(
+        "Entity should be PageFrame-backed after flush-to-read-cache load",
+        loaded.getPageFrame());
+
+    assertEquals("source", loaded.getProperty("name"));
+    var linkedEntity = loaded.getEntity("ref");
+    assertNotNull("Linked entity should not be null", linkedEntity);
+    assertEquals(targetRid, linkedEntity.getIdentity());
+    assertEquals("target", linkedEntity.getProperty("label"));
     session.rollback();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
@@ -844,4 +844,137 @@ public class EntityImplZeroCopyIntegrationTest {
     assertEquals("target", linkedEntity.getProperty("label"));
     session.rollback();
   }
+
+  // --- Vertex zero-copy path ---
+
+  /**
+   * Verifies that a vertex entity loaded through the zero-copy path correctly
+   * deserializes properties. Vertices use record type 'v' and are dispatched
+   * through VertexEntityImpl — this tests the full chain from
+   * fillFromPage → deserializeFromPageFrame for vertex records.
+   */
+  @Test
+  public void testVertexZeroCopyPropertyAccess() {
+    session.createVertexClass("ZCVertex");
+
+    session.begin();
+    var vertex = session.newVertex("ZCVertex");
+    vertex.setProperty("name", "Alice");
+    vertex.setProperty("age", 30);
+    session.commit();
+    var rid = vertex.getIdentity();
+
+    flushToReadCache(rid);
+
+    session.begin();
+    var loaded = (EntityImpl) session.load(rid);
+
+    // Verify PageFrame-backed load for vertex record type
+    assertNotNull(
+        "Vertex should be PageFrame-backed after flush-to-read-cache load",
+        loaded.getPageFrame());
+
+    // Verify vertex record type is 'v'
+    assertTrue("Loaded record should be a VertexEntityImpl",
+        loaded instanceof VertexEntityImpl);
+
+    // Verify properties deserialize correctly through the zero-copy path
+    assertEquals("Alice", loaded.getProperty("name"));
+    assertEquals(Integer.valueOf(30), loaded.getProperty("age"));
+
+    // Full deserialization clears PageFrame
+    assertTrue("Full deserialization should succeed",
+        loaded.checkForProperties());
+    assertNull("PageFrame should be cleared after full deserialization",
+        loaded.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Edge zero-copy path ---
+
+  /**
+   * Verifies that an edge entity loaded through the zero-copy path correctly
+   * deserializes properties. Edges use record type 'e' and are dispatched
+   * through EdgeEntityImpl — this tests the full chain from
+   * fillFromPage → deserializeFromPageFrame for edge records.
+   */
+  @Test
+  public void testEdgeZeroCopyPropertyAccess() {
+    session.createVertexClass("ZCEdgeV");
+    session.createEdgeClass("ZCEdge");
+
+    session.begin();
+    var v1 = session.newVertex("ZCEdgeV");
+    v1.setProperty("name", "v1");
+    var v2 = session.newVertex("ZCEdgeV");
+    v2.setProperty("name", "v2");
+    var edge = session.newEdge(v1, v2, "ZCEdge");
+    edge.setProperty("weight", 0.75);
+    edge.setProperty("label", "connects");
+    session.commit();
+    var edgeRid = edge.getIdentity();
+    var v1Rid = v1.getIdentity();
+    var v2Rid = v2.getIdentity();
+
+    flushToReadCache(edgeRid, v1Rid, v2Rid);
+
+    session.begin();
+    var loaded = (EntityImpl) session.load(edgeRid);
+
+    // Verify PageFrame-backed load for edge record type
+    assertNotNull(
+        "Edge should be PageFrame-backed after flush-to-read-cache load",
+        loaded.getPageFrame());
+
+    // Verify edge record type is 'e'
+    assertTrue("Loaded record should be an EdgeEntityImpl",
+        loaded instanceof EdgeEntityImpl);
+
+    // Verify properties deserialize correctly through the zero-copy path
+    assertEquals(Double.valueOf(0.75), loaded.getProperty("weight"));
+    assertEquals("connects", loaded.getProperty("label"));
+
+    // PageFrame is still set after partial property accesses
+    assertNotNull("PageFrame kept after partial property accesses",
+        loaded.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Vertex with stamp invalidation fallback ---
+
+  /**
+   * Verifies that vertex entities correctly fall back to the byte[] re-read
+   * path when the PageFrame stamp is invalidated. This tests the
+   * VertexEntityImpl-specific deserialization through the fallback chain.
+   */
+  @Test
+  public void testVertexStampInvalidationFallback() {
+    session.createVertexClass("ZCVertexFB");
+
+    session.begin();
+    var vertex = session.newVertex("ZCVertexFB");
+    vertex.setProperty("city", "Berlin");
+    session.commit();
+    var rid = vertex.getIdentity();
+
+    flushToReadCache(rid);
+
+    session.begin();
+    var loaded = (EntityImpl) session.load(rid);
+
+    var pageFrame = loaded.getPageFrame();
+    assertNotNull("Vertex should be PageFrame-backed", pageFrame);
+
+    // Invalidate the stamp
+    long exclusiveLock = pageFrame.acquireExclusiveLock();
+    pageFrame.releaseExclusiveLock(exclusiveLock);
+
+    // Property access should fall back to byte[] re-read
+    assertEquals("Berlin", loaded.getProperty("city"));
+
+    // After fallback, PageFrame should be cleared
+    assertNull("PageFrame should be cleared after fallback",
+        loaded.getPageFrame());
+    session.rollback();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
@@ -1,0 +1,640 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
+import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Integration tests for the zero-copy PageFrame record read path. These tests
+ * exercise the full pipeline: create entities, flush to read cache (so the
+ * optimistic read path produces RawPageBuffer), load entities through the
+ * session API, and verify that deserialization from the PageFrame works
+ * correctly — including stamp invalidation fallback, partial deserialization,
+ * concurrent modification, and lifecycle operations.
+ *
+ * <p>Unlike the unit tests in {@link EntityImplPageFrameDeserializationTest}
+ * (which manually write serialized bytes into a PageFrame), these tests go
+ * through the real storage optimistic read path end-to-end.
+ *
+ * <p>Requires DISK storage so that pages are served from the read cache,
+ * enabling the optimistic read path in {@code PaginatedCollectionV2}.
+ */
+@Category(SequentialTest.class)
+public class EntityImplZeroCopyIntegrationTest {
+
+  private YouTrackDBImpl youTrackDB;
+  private DatabaseSessionEmbedded session;
+  private String buildDirectory;
+  private static final String DB_NAME = "zeroCopyIntegrationTest";
+
+  @Before
+  public void setUp() {
+    buildDirectory = System.getProperty("buildDirectory");
+    if (buildDirectory == null || buildDirectory.isEmpty()) {
+      buildDirectory = ".";
+    }
+    buildDirectory += File.separator
+        + EntityImplZeroCopyIntegrationTest.class.getSimpleName();
+    FileUtils.deleteRecursively(new File(buildDirectory));
+
+    youTrackDB = (YouTrackDBImpl) YourTracks.instance(buildDirectory);
+    youTrackDB.create(DB_NAME, DatabaseType.DISK,
+        new LocalUserCredential("admin", "admin", PredefinedLocalRole.ADMIN));
+    session = youTrackDB.open(DB_NAME, "admin", "admin");
+  }
+
+  @After
+  public void tearDown() {
+    if (session != null && !session.isClosed()) {
+      session.close();
+    }
+    if (youTrackDB != null) {
+      youTrackDB.drop(DB_NAME);
+      youTrackDB.close();
+    }
+  }
+
+  /**
+   * Creates a class and persists a record with the given string key-value
+   * pairs. Returns the RID of the committed record.
+   */
+  private RID createRecord(String className, String... keyValues) {
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass(className)) {
+      schema.createClass(className);
+    }
+
+    session.begin();
+    var entity = (EntityImpl) session.newEntity(className);
+    for (int i = 0; i < keyValues.length; i += 2) {
+      entity.setProperty(keyValues[i], keyValues[i + 1]);
+    }
+    session.commit();
+    return entity.getIdentity();
+  }
+
+  /**
+   * Closes and reopens the database to flush all pages from the write cache to
+   * the read cache. After this, record loads go through the optimistic read
+   * path (which returns RawPageBuffer for single-page records).
+   */
+  private void flushToReadCache() {
+    if (session != null && !session.isClosed()) {
+      session.close();
+    }
+    youTrackDB.close();
+    youTrackDB = (YouTrackDBImpl) YourTracks.instance(buildDirectory);
+    session = youTrackDB.open(DB_NAME, "admin", "admin");
+  }
+
+  // --- Test 1: End-to-end zero-copy property access ---
+
+  /**
+   * Verifies that loading a record through the session API after flushing to
+   * read cache produces a PageFrame-backed entity, and that property access
+   * returns correct values via the zero-copy deserialization path.
+   */
+  @Test
+  public void testZeroCopyPropertyAccessEndToEnd() {
+    var rid = createRecord("ZeroCopy", "name", "Alice", "city", "Berlin");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    // Before property access, entity should be PageFrame-backed (zero-copy path)
+    // Note: the optimistic path may fall back to byte[] if the page is not in
+    // read cache or if the optimistic read fails. We verify the data is correct
+    // regardless of which path was taken.
+    assertEquals("Alice", entity.getProperty("name"));
+    assertEquals("Berlin", entity.getProperty("city"));
+
+    // After full property access, PageFrame should be cleared (stamp validated,
+    // speculative results accepted)
+    assertNull("PageFrame should be cleared after full deserialization",
+        entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Test 2: Stamp invalidation triggers fallback re-read ---
+
+  /**
+   * Loads a record via the zero-copy path, invalidates the PageFrame's stamp
+   * by acquiring and releasing an exclusive lock, then verifies that property
+   * access still returns correct values via the byte[] fallback re-read path.
+   */
+  @Test
+  public void testStampInvalidationFallbackEndToEnd() {
+    var rid = createRecord("StampInval", "name", "Bob", "score", "42");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    var pageFrame = entity.getPageFrame();
+    if (pageFrame != null) {
+      // Invalidate the stamp by acquiring and releasing an exclusive lock.
+      // After this, any stamp validation against the original stamp will fail.
+      long exclusiveLock = pageFrame.acquireExclusiveLock();
+      pageFrame.releaseExclusiveLock(exclusiveLock);
+
+      // Property access should detect the invalidated stamp and fall back to
+      // a byte[] re-read from storage.
+      assertEquals("Bob", entity.getProperty("name"));
+      assertEquals("42", entity.getProperty("score"));
+
+      // After fallback, PageFrame should be cleared and source populated
+      assertNull("PageFrame should be cleared after fallback re-read",
+          entity.getPageFrame());
+    } else {
+      // Optimistic path fell back to byte[] — still verify correct data
+      assertEquals("Bob", entity.getProperty("name"));
+      assertEquals("42", entity.getProperty("score"));
+    }
+    session.rollback();
+  }
+
+  // --- Test 3: Multiple property accesses after fallback ---
+
+  /**
+   * After stamp invalidation and fallback to byte[], verifies that subsequent
+   * property accesses work correctly from the byte[] source (PageFrame cleared,
+   * source populated).
+   */
+  @Test
+  public void testMultiplePropertyAccessesAfterFallback() {
+    var rid = createRecord("MultAccess", "a", "one", "b", "two", "c", "three");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    var pageFrame = entity.getPageFrame();
+    if (pageFrame != null) {
+      // Invalidate stamp to force fallback
+      long exclusiveLock = pageFrame.acquireExclusiveLock();
+      pageFrame.releaseExclusiveLock(exclusiveLock);
+    }
+
+    // First property access — may trigger fallback
+    assertEquals("one", entity.getProperty("a"));
+    // Subsequent accesses should work from byte[] source
+    assertEquals("two", entity.getProperty("b"));
+    assertEquals("three", entity.getProperty("c"));
+
+    // Verify all properties are present
+    var names = entity.getPropertyNames();
+    assertTrue("Should have property 'a'", names.contains("a"));
+    assertTrue("Should have property 'b'", names.contains("b"));
+    assertTrue("Should have property 'c'", names.contains("c"));
+
+    assertNull("PageFrame should be cleared", entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Test 4: Partial then full deserialization from PageFrame ---
+
+  /**
+   * Requests specific properties (partial deserialization) first, then requests
+   * all properties (full deserialization). Verifies both return correct values
+   * from the PageFrame zero-copy path.
+   */
+  @Test
+  public void testPartialThenFullDeserialization() {
+    var rid = createRecord("PartialFull", "x", "10", "y", "20", "z", "30");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    // Partial deserialization: request only "x"
+    assertTrue("Partial deserialization should succeed",
+        entity.checkForProperties("x"));
+    assertEquals("10", entity.getProperty("x"));
+
+    if (entity.getPageFrame() != null) {
+      // PageFrame kept after partial — request another property
+      assertTrue("Second partial deserialization should succeed",
+          entity.checkForProperties("y"));
+      assertEquals("20", entity.getProperty("y"));
+    }
+
+    // Full deserialization: request all properties
+    assertTrue("Full deserialization should succeed",
+        entity.checkForProperties());
+    assertEquals("10", entity.getProperty("x"));
+    assertEquals("20", entity.getProperty("y"));
+    assertEquals("30", entity.getProperty("z"));
+
+    // After full deserialization, PageFrame should be cleared
+    assertNull("PageFrame should be cleared after full deserialization",
+        entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Test 5: Partial deserialization with stamp invalidation between calls ---
+
+  /**
+   * Requests a specific property (partial), invalidates the stamp, then
+   * requests another property. Verifies that the second request falls back to
+   * byte[] re-read and still returns correct data.
+   */
+  @Test
+  public void testPartialDeserializationWithStampInvalidation() {
+    var rid = createRecord("PartialStamp", "p", "alpha", "q", "beta");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    var pageFrame = entity.getPageFrame();
+    if (pageFrame != null) {
+      // First partial deserialization succeeds from PageFrame
+      assertTrue(entity.checkForProperties("p"));
+      assertEquals("alpha", entity.getProperty("p"));
+
+      // Invalidate stamp before second partial request
+      var frame = entity.getPageFrame();
+      if (frame != null) {
+        long exclusiveLock = frame.acquireExclusiveLock();
+        frame.releaseExclusiveLock(exclusiveLock);
+      }
+
+      // Second partial request — stamp invalid, falls back to re-read
+      assertTrue(entity.checkForProperties("q"));
+      assertEquals("beta", entity.getProperty("q"));
+
+      // Also verify the first property is still correct after fallback
+      assertEquals("alpha", entity.getProperty("p"));
+    } else {
+      // Fell back to byte[] on load — verify data anyway
+      assertEquals("alpha", entity.getProperty("p"));
+      assertEquals("beta", entity.getProperty("q"));
+    }
+    session.rollback();
+  }
+
+  // --- Test 6: Concurrent page modification ---
+
+  /**
+   * Loads a record via the zero-copy path, then uses a background thread to
+   * modify a different record on the same class (likely same page). Verifies
+   * that property access on the main thread returns correct data — either the
+   * PageFrame deserialization succeeds with original data, or the fallback
+   * produces correct data.
+   */
+  @Test
+  public void testConcurrentPageModification() throws Exception {
+    // Create multiple records in the same class (likely same page)
+    var rid1 = createRecord("Concurrent", "key", "original");
+    createRecord("Concurrent", "key", "other");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid1);
+
+    // Background thread: open a separate session and modify a record in the
+    // same class, which may modify the same page.
+    var ready = new CountDownLatch(1);
+    var proceed = new CountDownLatch(1);
+    var error = new AtomicReference<Throwable>();
+
+    var bgThread = new Thread(() -> {
+      try (var bgSession = youTrackDB.open(DB_NAME, "admin", "admin")) {
+        bgSession.begin();
+        var bgEntity = (EntityImpl) bgSession.newEntity("Concurrent");
+        bgEntity.setProperty("key", "background-write");
+        ready.countDown();
+        proceed.await();
+        bgSession.commit();
+      } catch (Throwable t) {
+        error.set(t);
+      }
+    });
+    bgThread.start();
+
+    // Wait for background thread to be ready, then let it commit
+    ready.await();
+    proceed.countDown();
+    bgThread.join(5000);
+
+    assertNull("Background thread should complete without error", error.get());
+
+    // Access properties on the main thread — either zero-copy succeeds
+    // (page wasn't modified at our offset) or fallback produces correct data
+    assertEquals("original", entity.getProperty("key"));
+    session.rollback();
+  }
+
+  // --- Test 7: Record lifecycle operations clear PageFrame ---
+
+  /**
+   * Verifies that unload() properly clears the PageFrame reference after
+   * loading via the zero-copy path.
+   */
+  @Test
+  public void testUnloadClearsPageFrame() {
+    var rid = createRecord("Lifecycle", "field", "value");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+    // Entity is loaded — may have PageFrame set (zero-copy) or byte[] (fallback)
+
+    entity.unload();
+
+    // After unload, PageFrame must be cleared
+    assertNull("PageFrame should be cleared after unload",
+        entity.getPageFrame());
+    assertEquals(0L, entity.getPageStamp());
+    assertEquals(0, entity.getPageContentOffset());
+    assertEquals(0, entity.getPageContentLength());
+    session.rollback();
+  }
+
+  /**
+   * Verifies that reload after unload works correctly — the entity can be
+   * loaded again from storage in a fresh transaction and properties are
+   * accessible.
+   */
+  @Test
+  public void testReloadAfterUnload() {
+    var rid = createRecord("Reload", "name", "Charlie", "city", "Rome");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    // Access properties first (triggers deserialization)
+    assertEquals("Charlie", entity.getProperty("name"));
+    session.rollback();
+
+    // Reload in a fresh transaction — local cache is cleared between txs
+    session.begin();
+    entity = (EntityImpl) session.load(rid);
+
+    // Properties should be accessible again after reload
+    assertEquals("Charlie", entity.getProperty("name"));
+    assertEquals("Rome", entity.getProperty("city"));
+    session.rollback();
+  }
+
+  // --- Test 8: Multiple records loaded via zero-copy path ---
+
+  /**
+   * Creates and loads multiple records, verifying that each is correctly
+   * deserialized via the zero-copy path. This exercises the case where
+   * multiple entities reference different offsets within the same page.
+   */
+  @Test
+  public void testMultipleRecordsOnSamePage() {
+    var rids = new ArrayList<RID>();
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass("MultiRec")) {
+      schema.createClass("MultiRec");
+    }
+    session.begin();
+    for (int i = 0; i < 10; i++) {
+      var entity = (EntityImpl) session.newEntity("MultiRec");
+      entity.setProperty("index", String.valueOf(i));
+      entity.setProperty("data", "record-" + i);
+      rids.add(entity.getIdentity());
+    }
+    session.commit();
+
+    flushToReadCache();
+
+    session.begin();
+    for (int i = 0; i < rids.size(); i++) {
+      var entity = (EntityImpl) session.load(rids.get(i));
+      assertEquals("index should match for record " + i,
+          String.valueOf(i), entity.getProperty("index"));
+      assertEquals("data should match for record " + i,
+          "record-" + i, entity.getProperty("data"));
+    }
+    session.rollback();
+  }
+
+  // --- Test 9: Record with many properties ---
+
+  /**
+   * Tests that a record with many properties (larger serialized form) is
+   * correctly deserialized via the zero-copy path.
+   */
+  @Test
+  public void testRecordWithManyProperties() {
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass("ManyProps")) {
+      schema.createClass("ManyProps");
+    }
+    session.begin();
+    var entity = (EntityImpl) session.newEntity("ManyProps");
+    for (int i = 0; i < 50; i++) {
+      entity.setProperty("prop" + i, "value-" + i);
+    }
+    session.commit();
+    var rid = entity.getIdentity();
+
+    flushToReadCache();
+
+    session.begin();
+    var loaded = (EntityImpl) session.load(rid);
+    for (int i = 0; i < 50; i++) {
+      assertEquals("Property prop" + i + " should have correct value",
+          "value-" + i, loaded.getProperty("prop" + i));
+    }
+    assertEquals(50, loaded.getPropertyNames().size());
+    session.rollback();
+  }
+
+  // --- Test 10: fill() on PageFrame-loaded entity clears PageFrame ---
+
+  /**
+   * Verifies that calling fill() on a PageFrame-loaded entity clears the
+   * PageFrame reference and replaces it with byte[] source.
+   */
+  @Test
+  public void testFillClearsPageFrame() {
+    var rid = createRecord("FillTest", "name", "Dana");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    // Manually fill with byte[] — should clear any PageFrame
+    byte[] newContent = new byte[] {0}; // minimal valid content
+    entity.fill(1L, newContent, false);
+
+    assertNull("PageFrame should be cleared after fill()",
+        entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Test 11: fromStream() on PageFrame-loaded entity clears PageFrame ---
+
+  /**
+   * Verifies that calling fromStream() on a PageFrame-loaded entity clears
+   * the PageFrame reference.
+   */
+  @Test
+  public void testFromStreamClearsPageFrame() {
+    var rid = createRecord("StreamTest", "name", "Eve");
+    flushToReadCache();
+
+    // First transaction: get serialized bytes
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+    entity.checkForProperties();
+    byte[] bytes = entity.toStream();
+    session.rollback();
+
+    // Second transaction: load fresh entity (PageFrame-backed) and test fromStream
+    session.begin();
+    entity = (EntityImpl) session.load(rid);
+
+    // fromStream should clear PageFrame
+    entity.fromStream(bytes);
+
+    assertNull("PageFrame should be cleared after fromStream()",
+        entity.getPageFrame());
+    session.rollback();
+  }
+
+  // --- Test 12: delete() on PageFrame-loaded entity ---
+
+  /**
+   * Verifies that deleting a PageFrame-loaded entity works correctly — the
+   * entity's PageFrame is cleared during the delete operation.
+   */
+  @Test
+  public void testDeletePageFrameLoadedEntity() {
+    var rid = createRecord("DeleteTest", "name", "Frank");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    // Delete should work regardless of whether entity is PageFrame-backed
+    entity.delete();
+    session.commit();
+
+    // Verify the record is gone
+    session.begin();
+    try {
+      session.load(rid);
+      // If load doesn't throw, the record should be marked as deleted
+    } catch (Exception e) {
+      // Expected: RecordNotFoundException
+      assertTrue("Expected RecordNotFoundException",
+          e.getClass().getSimpleName().contains("RecordNotFound"));
+    }
+    session.rollback();
+  }
+
+  // --- Test 13: setDirty clears PageFrame ---
+
+  /**
+   * Verifies that making a PageFrame-loaded entity dirty (by setting a
+   * property) clears the PageFrame reference.
+   */
+  @Test
+  public void testSetPropertyClearsPageFrame() {
+    var rid = createRecord("DirtyTest", "name", "Grace");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    // Read a property first (triggers PageFrame deserialization)
+    assertEquals("Grace", entity.getProperty("name"));
+
+    // Set a property — makes entity dirty, which should clear PageFrame
+    entity.setProperty("name", "Grace-updated");
+    assertNull("PageFrame should be cleared after setProperty()",
+        entity.getPageFrame());
+
+    // Verify the updated value
+    assertEquals("Grace-updated", entity.getProperty("name"));
+    session.rollback();
+  }
+
+  // --- Test 14: toStream() on PageFrame-loaded entity ---
+
+  /**
+   * Verifies that toStream() on a PageFrame-loaded entity correctly
+   * triggers deserialization first, then produces valid serialized bytes.
+   */
+  @Test
+  public void testToStreamOnPageFrameLoadedEntity() {
+    var rid = createRecord("ToStream", "name", "Hank", "age", "25");
+    flushToReadCache();
+
+    session.begin();
+    var entity = (EntityImpl) session.load(rid);
+
+    // toStream() should trigger deserialization from PageFrame, then serialize
+    byte[] bytes = entity.toStream();
+    assertNotNull("toStream() should produce non-null bytes", bytes);
+    assertTrue("Serialized bytes should not be empty", bytes.length > 0);
+
+    // Verify the entity is still usable after toStream
+    assertEquals("Hank", entity.getProperty("name"));
+    assertEquals("25", entity.getProperty("age"));
+    session.rollback();
+  }
+
+  // --- Test 15: Record with various property types ---
+
+  /**
+   * Tests that records with different property types (string, integer, double,
+   * boolean) are correctly deserialized via the zero-copy path.
+   */
+  @Test
+  public void testVariousPropertyTypes() {
+    var schema = session.getMetadata().getSchema();
+    if (!schema.existsClass("TypeTest")) {
+      schema.createClass("TypeTest");
+    }
+    session.begin();
+    var entity = (EntityImpl) session.newEntity("TypeTest");
+    entity.setProperty("strProp", "hello");
+    entity.setProperty("intProp", 42);
+    entity.setProperty("dblProp", 3.14);
+    entity.setProperty("boolProp", true);
+    entity.setProperty("longProp", 123456789L);
+    entity.setProperty("shortProp", (short) 7);
+    session.commit();
+    var rid = entity.getIdentity();
+
+    flushToReadCache();
+
+    session.begin();
+    var loaded = (EntityImpl) session.load(rid);
+    assertEquals("hello", loaded.getProperty("strProp"));
+    assertEquals(Integer.valueOf(42), loaded.getProperty("intProp"));
+    assertEquals(Double.valueOf(3.14), loaded.getProperty("dblProp"));
+    assertEquals(Boolean.TRUE, loaded.getProperty("boolProp"));
+    assertEquals(Long.valueOf(123456789L), loaded.getProperty("longProp"));
+    assertEquals(Short.valueOf((short) 7), loaded.getProperty("shortProp"));
+    session.rollback();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/EntityImplZeroCopyIntegrationTest.java
@@ -930,9 +930,19 @@ public class EntityImplZeroCopyIntegrationTest {
     assertTrue("Loaded record should be an EdgeEntityImpl",
         loaded instanceof EdgeEntityImpl);
 
-    // Verify properties deserialize correctly through the zero-copy path
+    // Verify user-defined properties deserialize correctly
     assertEquals(Double.valueOf(0.75), loaded.getProperty("weight"));
     assertEquals("connects", loaded.getProperty("label"));
+
+    // Verify edge structural properties (out/in vertex links) deserialize
+    // correctly through the zero-copy path. These are RID-typed internal
+    // properties that exercise a different serialization code path than
+    // user-defined string/double properties.
+    var loadedEdge = (EdgeEntityImpl) loaded;
+    assertNotNull("Edge getFrom() should not be null", loadedEdge.getFrom());
+    assertEquals(v1Rid, loadedEdge.getFrom().getIdentity());
+    assertNotNull("Edge getTo() should not be null", loadedEdge.getTo());
+    assertEquals(v2Rid, loadedEdge.getTo().getIdentity());
 
     // PageFrame is still set after partial property accesses
     assertNotNull("PageFrame kept after partial property accesses",

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/CorruptedRecordGuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/CorruptedRecordGuardTest.java
@@ -7,6 +7,7 @@ import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
 import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
 import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
@@ -29,7 +30,7 @@ public class CorruptedRecordGuardTest {
   public void setUp() {
     youTrackDB =
         (YouTrackDBImpl) YourTracks.instance(
-            "memory:corruptedRecGuardT" + System.nanoTime());
+            DbTestBase.getBaseDirectoryPathStr(getClass()));
     youTrackDB.create(
         "corruptedRecGuardT",
         DatabaseType.MEMORY,

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/CorruptedRecordGuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/CorruptedRecordGuardTest.java
@@ -121,9 +121,10 @@ public class CorruptedRecordGuardTest {
     var truncated = new byte[3];
     System.arraycopy(serialized, 0, truncated, 0, Math.min(3, serialized.length));
 
-    // This should throw some exception (CorruptedRecordException or BufferUnderflowException)
-    // depending on where the truncation hits
-    assertThrows(Exception.class, () -> deserializeFull(truncated));
+    // A 3-byte truncation leaves only the version byte + partial headerLength varint.
+    // The headerLength varint decodes to a value exceeding remaining bytes,
+    // triggering the header length guard.
+    assertThrows(CorruptedRecordException.class, () -> deserializeFull(truncated));
     session.rollback();
   }
 
@@ -152,7 +153,12 @@ public class CorruptedRecordGuardTest {
 
   @Test
   public void corruptFieldValueSizeThrowsException() {
-    // Serialize an entity with a string value, then corrupt the value area
+    // Safety-net test: corrupt bytes inside a serialized record and verify that
+    // deserialization fails cleanly (no OOM, no silent corruption). The corruption
+    // injection is heuristic — the large varint may land on a guarded size field
+    // (CorruptedRecordException) or on a non-guarded field entry that causes a
+    // BufferUnderflowException. Either way, the deserializer must not allocate
+    // unbounded memory or return silently corrupted data.
     session.begin();
     var serialized = serializeEntity(entity -> {
       entity.setProperty("name", "hello");

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/CorruptedRecordGuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/CorruptedRecordGuardTest.java
@@ -1,0 +1,313 @@
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
+import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Comprehensive corruption injection tests for the deserialization guard checks. Serializes real
+ * entities, corrupts specific bytes in the serialized form, and verifies that deserialization throws
+ * {@link CorruptedRecordException} rather than OOM or runaway loops.
+ */
+public class CorruptedRecordGuardTest {
+
+  private YouTrackDBImpl youTrackDB;
+  private DatabaseSessionEmbedded session;
+
+  @Before
+  public void setUp() {
+    youTrackDB =
+        (YouTrackDBImpl) YourTracks.instance(
+            "memory:corruptedRecGuardT" + System.nanoTime());
+    youTrackDB.create(
+        "corruptedRecGuardT",
+        DatabaseType.MEMORY,
+        new LocalUserCredential("admin", "adminpwd", PredefinedLocalRole.ADMIN));
+    session =
+        (DatabaseSessionEmbedded) youTrackDB.open(
+            "corruptedRecGuardT", "admin", "adminpwd");
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      if (session != null && !session.isClosed()) {
+        session.close();
+      }
+    } finally {
+      if (youTrackDB != null) {
+        try {
+          if (youTrackDB.exists("corruptedRecGuardT")) {
+            youTrackDB.drop("corruptedRecGuardT");
+          }
+        } finally {
+          youTrackDB.close();
+        }
+      }
+    }
+  }
+
+  // --- Header corruption ---
+
+  @Test
+  public void corruptHeaderLengthThrowsCorruptedRecordException() {
+    // Serialize a simple entity, then corrupt the headerLength varint
+    // (byte at index 1, right after the serializer version byte)
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("name", "test");
+      entity.setProperty("value", 42);
+    });
+
+    // Corrupt headerLength to a huge value by setting the varint bytes
+    // Index 1 is the first byte of the serialized record (after version byte at 0)
+    // Replace it with a varint encoding a very large number (0xFF 0xFF 0xFF 0xFF 0x07)
+    var corrupted = serialized.clone();
+    corrupted[1] = (byte) 0xFF;
+    if (corrupted.length > 2) {
+      corrupted[2] = (byte) 0xFF;
+    }
+    if (corrupted.length > 3) {
+      corrupted[3] = (byte) 0xFF;
+    }
+    if (corrupted.length > 4) {
+      corrupted[4] = (byte) 0xFF;
+    }
+    if (corrupted.length > 5) {
+      corrupted[5] = (byte) 0x07;
+    }
+
+    assertThrows(CorruptedRecordException.class, () -> deserializeFull(corrupted));
+    session.rollback();
+  }
+
+  @Test
+  public void negativeHeaderLengthThrowsCorruptedRecordException() {
+    // Encode a negative headerLength (zigzag varint for -1 = 0x01)
+    session.begin();
+    var serialized = serializeEntity(entity -> entity.setProperty("x", 1));
+
+    var corrupted = serialized.clone();
+    // zigzag encoding: -1 -> unsigned 1 -> varint byte 0x01
+    corrupted[1] = 0x01;
+
+    assertThrows(CorruptedRecordException.class, () -> deserializeFull(corrupted));
+    session.rollback();
+  }
+
+  // --- Truncated record ---
+
+  @Test
+  public void truncatedRecordThrowsException() {
+    // Serialize a real entity, then truncate to just a few bytes
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("longString", "A".repeat(100));
+      entity.setProperty("number", 999);
+    });
+
+    // Keep only version byte + partial header
+    var truncated = new byte[3];
+    System.arraycopy(serialized, 0, truncated, 0, Math.min(3, serialized.length));
+
+    // This should throw some exception (CorruptedRecordException or BufferUnderflowException)
+    // depending on where the truncation hits
+    assertThrows(Exception.class, () -> deserializeFull(truncated));
+    session.rollback();
+  }
+
+  // --- Valid record with extra bytes succeeds ---
+
+  @Test
+  public void validRecordWithTrailingGarbageSucceeds() {
+    // A valid serialized record followed by extra bytes should deserialize the
+    // valid portion successfully (the deserializer reads only what it needs)
+    session.begin();
+    var serialized = serializeEntity(entity -> entity.setProperty("key", "value"));
+
+    var padded = new byte[serialized.length + 100];
+    System.arraycopy(serialized, 0, padded, 0, serialized.length);
+    // Fill trailing bytes with garbage
+    for (var i = serialized.length; i < padded.length; i++) {
+      padded[i] = (byte) 0xDE;
+    }
+
+    var entity = deserializeFull(padded);
+    assertEquals("value", entity.getProperty("key"));
+    session.rollback();
+  }
+
+  // --- End-to-end: corrupt field value size ---
+
+  @Test
+  public void corruptFieldValueSizeThrowsException() {
+    // Serialize an entity with a string value, then corrupt the value area
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("name", "hello");
+      entity.setProperty("data", "world");
+    });
+
+    // Corrupt bytes in the value area (after the header) to inject a huge varint
+    var corrupted = corruptFirstVarIntAfterOffset(serialized, 1, 999_999);
+
+    assertThrows(Exception.class, () -> deserializeFull(corrupted));
+    session.rollback();
+  }
+
+  // --- Header guard on deserializePartial ---
+
+  @Test
+  public void corruptHeaderInDeserializePartialThrowsCorruptedRecordException() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("a", 1);
+      entity.setProperty("b", "hello");
+    });
+
+    var corrupted = serialized.clone();
+    // Corrupt headerLength varint to huge value
+    corrupted[1] = (byte) 0xFF;
+    if (corrupted.length > 2) {
+      corrupted[2] = (byte) 0xFF;
+    }
+    if (corrupted.length > 3) {
+      corrupted[3] = (byte) 0xFF;
+    }
+    if (corrupted.length > 4) {
+      corrupted[4] = (byte) 0xFF;
+    }
+    if (corrupted.length > 5) {
+      corrupted[5] = (byte) 0x07;
+    }
+
+    assertThrows(
+        CorruptedRecordException.class, () -> deserializePartial(corrupted, "a"));
+    session.rollback();
+  }
+
+  // --- Direct unit tests for header parsing guards ---
+
+  @Test
+  public void deserializeThrowsOnNegativeHeaderLength() {
+    // Craft a buffer with just a negative varint as headerLength
+    session.begin();
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, -5); // negative headerLength
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    var serializer = new RecordSerializerBinaryV1();
+    var entity = (EntityImpl) session.newEntity();
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.deserialize(session, entity, rbc));
+    session.rollback();
+  }
+
+  @Test
+  public void deserializeThrowsOnOversizedHeaderLength() {
+    session.begin();
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, Integer.MAX_VALUE);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    var serializer = new RecordSerializerBinaryV1();
+    var entity = (EntityImpl) session.newEntity();
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.deserialize(session, entity, rbc));
+    session.rollback();
+  }
+
+  @Test
+  public void deserializeFieldTypedLoopThrowsOnNegativeHeaderLength() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, -1);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    var serializer = new RecordSerializerBinaryV1();
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.deserializeFieldTypedLoopAndReturn(
+            null, rbc, "field", null, null));
+  }
+
+  @Test
+  public void deserializeFieldTypedLoopThrowsOnOversizedHeaderLength() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, Integer.MAX_VALUE);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    var serializer = new RecordSerializerBinaryV1();
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.deserializeFieldTypedLoopAndReturn(
+            null, rbc, "field", null, null));
+  }
+
+  // --- Helpers ---
+
+  private byte[] serializeEntity(EntityConfigurer configurer) {
+    var entity = (EntityImpl) session.newEntity();
+    configurer.configure(entity);
+    return RecordSerializerBinary.INSTANCE.toStream(session, entity);
+  }
+
+  private EntityImpl deserializeFull(byte[] serialized) {
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(serialized[0]);
+    serializer.deserialize(session, entity, container);
+    return entity;
+  }
+
+  private EntityImpl deserializePartial(byte[] serialized, String... fields) {
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(serialized[0]);
+    serializer.deserializePartial(session, entity, container, fields);
+    return entity;
+  }
+
+  /**
+   * Corrupts the first varint found after the given offset in a serialized byte array. Replaces
+   * the varint with a 5-byte encoding of the given large value.
+   */
+  private byte[] corruptFirstVarIntAfterOffset(byte[] data, int afterOffset, int largeValue) {
+    var corrupted = data.clone();
+    // Write a large varint at the location of the first varint after afterOffset.
+    // This overwrites whatever was there, which may corrupt the rest of the record too —
+    // that's the point.
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, largeValue);
+    var varintBytes = wc.fitBytes();
+    // Find a reasonable position — the headerLength varint starts at afterOffset
+    var pos = afterOffset;
+    // Skip the headerLength varint first
+    while (pos < corrupted.length && (corrupted[pos] & 0x80) != 0) {
+      pos++;
+    }
+    pos++; // skip the last byte of headerLength varint
+    // Now pos should be inside the header — overwrite with large varint
+    if (pos + varintBytes.length <= corrupted.length) {
+      System.arraycopy(varintBytes, 0, corrupted, pos, varintBytes.length);
+    }
+    return corrupted;
+  }
+
+  @FunctionalInterface
+  private interface EntityConfigurer {
+    void configure(EntityImpl entity);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClassesGuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClassesGuardTest.java
@@ -56,6 +56,7 @@ public class HelperClassesGuardTest {
     var bytes = writeContainer.fitBytes();
     var rbc = new ReadBytesContainer(bytes);
     assertArrayEquals(payload, HelperClasses.readBinary(rbc));
+    assertEquals(0, rbc.remaining());
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClassesGuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/HelperClassesGuardTest.java
@@ -1,0 +1,170 @@
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
+import org.junit.Test;
+
+/**
+ * Tests that HelperClasses ReadBytesContainer overloads throw {@link CorruptedRecordException} when
+ * stream-driven sizes exceed remaining buffer capacity. Each test crafts a ReadBytesContainer with
+ * a varint-encoded size that is invalid relative to the available data.
+ */
+public class HelperClassesGuardTest {
+
+  // --- readBinary guards ---
+
+  @Test
+  public void readBinaryThrowsOnSizeExceedingRemaining() {
+    // Encode size = remaining() + 1 (just one byte too many)
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, 100); // claims 100 bytes of payload
+    var bytes = writeContainer.fitBytes();
+    // The buffer has only the varint bytes, no actual payload — 100 > remaining
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(CorruptedRecordException.class, () -> HelperClasses.readBinary(rbc));
+  }
+
+  @Test
+  public void readBinaryThrowsOnNegativeSize() {
+    // Encode size = -1 (zigzag-encoded negative)
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, -1);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(CorruptedRecordException.class, () -> HelperClasses.readBinary(rbc));
+  }
+
+  @Test
+  public void readBinaryThrowsOnMaxIntSize() {
+    // Encode Integer.MAX_VALUE — far exceeds any realistic buffer
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, Integer.MAX_VALUE);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(CorruptedRecordException.class, () -> HelperClasses.readBinary(rbc));
+  }
+
+  @Test
+  public void readBinarySucceedsOnExactFit() {
+    // Encode size = 5 followed by exactly 5 bytes of payload
+    var payload = new byte[] {1, 2, 3, 4, 5};
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeBinary(writeContainer, payload);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertArrayEquals(payload, HelperClasses.readBinary(rbc));
+  }
+
+  @Test
+  public void readBinarySucceedsOnZeroSize() {
+    // Encode size = 0 — valid empty binary
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeBinary(writeContainer, new byte[0]);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertArrayEquals(new byte[0], HelperClasses.readBinary(rbc));
+  }
+
+  // --- readString guards ---
+
+  @Test
+  public void readStringThrowsOnSizeExceedingRemaining() {
+    // Encode len = 500, but only provide varint bytes (no string payload)
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, 500);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(CorruptedRecordException.class, () -> HelperClasses.readString(rbc));
+  }
+
+  @Test
+  public void readStringThrowsOnNegativeLength() {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, -1);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(CorruptedRecordException.class, () -> HelperClasses.readString(rbc));
+  }
+
+  @Test
+  public void readStringSucceedsOnValidData() {
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeString(writeContainer, "hello");
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertEquals("hello", HelperClasses.readString(rbc));
+  }
+
+  @Test
+  public void readStringSucceedsOnEmptyString() {
+    // len = 0 takes the early return path, no guard needed
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeString(writeContainer, "");
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertEquals("", HelperClasses.readString(rbc));
+  }
+
+  // --- readLinkCollection guards ---
+
+  @Test
+  public void readLinkCollectionThrowsOnSizeExceedingRemaining() {
+    // Build buffer: type byte (0) + varint encoding huge items count.
+    // Use justRunThrough=true so the collection parameter is never accessed —
+    // the guard fires before the loop regardless.
+    var writeContainer = new BytesContainer();
+    var pos = writeContainer.alloc(1);
+    writeContainer.bytes[pos] = 0; // valid type byte
+    VarIntSerializer.write(writeContainer, Integer.MAX_VALUE); // huge items count
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> HelperClasses.readLinkCollection(rbc, null, true));
+  }
+
+  @Test
+  public void readLinkCollectionThrowsOnNegativeSize() {
+    var writeContainer = new BytesContainer();
+    var pos = writeContainer.alloc(1);
+    writeContainer.bytes[pos] = 0;
+    VarIntSerializer.write(writeContainer, -1);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> HelperClasses.readLinkCollection(rbc, null, true));
+  }
+
+  // --- readLinkMap guards ---
+
+  @Test
+  public void readLinkMapThrowsOnSizeExceedingRemaining() {
+    // Build buffer: version byte (0) + varint encoding huge size
+    var writeContainer = new BytesContainer();
+    var pos = writeContainer.alloc(1);
+    writeContainer.bytes[pos] = 0; // valid version byte
+    VarIntSerializer.write(writeContainer, 1_000_000);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> HelperClasses.readLinkMap(rbc, null, false));
+  }
+
+  @Test
+  public void readLinkMapThrowsOnNegativeSize() {
+    var writeContainer = new BytesContainer();
+    var pos = writeContainer.alloc(1);
+    writeContainer.bytes[pos] = 0;
+    VarIntSerializer.write(writeContainer, -1);
+    var bytes = writeContainer.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> HelperClasses.readLinkMap(rbc, null, false));
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorRbcNonNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorRbcNonNumericTest.java
@@ -1,0 +1,577 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.common.serialization.types.DecimalSerializer;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.OptionalInt;
+import java.util.TimeZone;
+import org.junit.Test;
+
+/**
+ * Tests for {@link InPlaceComparator} ReadBinaryField non-numeric type comparison (STRING, BOOLEAN,
+ * DATETIME, DATE, DECIMAL, BINARY, LINK). Mirrors {@link InPlaceComparatorNonNumericTest} but uses
+ * ReadBinaryField / ReadBytesContainer (ByteBuffer-backed). Includes targeted edge cases for
+ * DECIMAL (divergent deserialization from DecimalSerializer) and LINK equality.
+ */
+public class InPlaceComparatorRbcNonNumericTest {
+
+  // ---- Helper methods to create ReadBinaryFields with serialized values ----
+
+  private static ReadBinaryField stringFieldRbc(String value) {
+    var bytes = new BytesContainer();
+    var encoded = value.getBytes(StandardCharsets.UTF_8);
+    VarIntSerializer.write(bytes, encoded.length);
+    var pos = bytes.alloc(encoded.length);
+    System.arraycopy(encoded, 0, bytes.bytes, pos, encoded.length);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.STRING, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField booleanFieldRbc(boolean value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(1);
+    bytes.bytes[pos] = value ? (byte) 1 : (byte) 0;
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.BOOLEAN, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField datetimeFieldRbc(long millis) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, millis);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.DATETIME, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField dateFieldRbc(long days) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, days);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.DATE, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  /**
+   * Creates a DECIMAL ReadBinaryField using the same binary format as DecimalSerializer:
+   * 4-byte scale (big-endian int) + 4-byte unscaled length (big-endian int) + unscaled bytes.
+   */
+  private static ReadBinaryField decimalFieldRbc(BigDecimal value) {
+    var size = DecimalSerializer.staticGetObjectSize(value);
+    var bytes = new byte[size];
+    DecimalSerializer.staticSerialize(value, bytes, 0);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.DECIMAL, new ReadBytesContainer(bytes, 0), null);
+  }
+
+  private static ReadBinaryField binaryFieldRbc(byte[] value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value.length);
+    var pos = bytes.alloc(value.length);
+    System.arraycopy(value, 0, bytes.bytes, pos, value.length);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.BINARY, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField linkFieldRbc(int collectionId, long collectionPos) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, collectionId);
+    VarIntSerializer.write(bytes, collectionPos);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.LINK, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  // ===========================================================================
+  // STRING tests
+  // ===========================================================================
+
+  /** STRING equality — same value. */
+  @Test
+  public void testStringEqual() {
+    var result = InPlaceComparator.compare(stringFieldRbc("hello"), "hello", null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** STRING less than — "abc" < "def". */
+  @Test
+  public void testStringLessThan() {
+    var result = InPlaceComparator.compare(stringFieldRbc("abc"), "def", null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** STRING greater than — "xyz" > "abc". */
+  @Test
+  public void testStringGreaterThan() {
+    var result = InPlaceComparator.compare(stringFieldRbc("xyz"), "abc", null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** STRING empty string comparison. */
+  @Test
+  public void testStringEmpty() {
+    var result = InPlaceComparator.compare(stringFieldRbc(""), "", null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** STRING with non-String value — should fall back. */
+  @Test
+  public void testStringWithNonStringFallback() {
+    var result = InPlaceComparator.compare(stringFieldRbc("42"), 42, null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** STRING with Unicode characters. */
+  @Test
+  public void testStringUnicode() {
+    var result = InPlaceComparator.compare(stringFieldRbc("привет"), "привет", null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // BOOLEAN tests
+  // ===========================================================================
+
+  /** BOOLEAN true == true. */
+  @Test
+  public void testBooleanTrueEqual() {
+    var result = InPlaceComparator.compare(booleanFieldRbc(true), true, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BOOLEAN false == false. */
+  @Test
+  public void testBooleanFalseEqual() {
+    var result = InPlaceComparator.compare(booleanFieldRbc(false), false, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BOOLEAN true > false. */
+  @Test
+  public void testBooleanTrueGreaterThanFalse() {
+    var result = InPlaceComparator.compare(booleanFieldRbc(true), false, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** BOOLEAN with non-Boolean — should fall back. */
+  @Test
+  public void testBooleanWithNonBooleanFallback() {
+    var result = InPlaceComparator.compare(booleanFieldRbc(true), 1, null);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // DATETIME tests
+  // ===========================================================================
+
+  /** DATETIME with matching Date. */
+  @Test
+  public void testDatetimeEqualDate() {
+    long millis = 1700000000000L;
+    var result = InPlaceComparator.compare(datetimeFieldRbc(millis), new Date(millis), null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATETIME less than. */
+  @Test
+  public void testDatetimeLessThan() {
+    var result = InPlaceComparator.compare(datetimeFieldRbc(1000L), new Date(2000L), null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DATETIME with Number value (millis as long). */
+  @Test
+  public void testDatetimeWithNumber() {
+    long millis = 1700000000000L;
+    var result = InPlaceComparator.compare(datetimeFieldRbc(millis), millis, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATETIME with non-Date/Number — should fall back. */
+  @Test
+  public void testDatetimeWithStringFallback() {
+    var result = InPlaceComparator.compare(datetimeFieldRbc(1000L), "2024-01-01", null);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // DATE tests
+  // ===========================================================================
+
+  /** DATE with GMT timezone. */
+  @Test
+  public void testDateEqualGmt() {
+    long days = 1;
+    long expectedMillis = 86400000L;
+    var gmtTz = TimeZone.getTimeZone("GMT");
+    var result = InPlaceComparator.compare(dateFieldRbc(days), new Date(expectedMillis), gmtTz);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DATE without timezone — should fall back. */
+  @Test
+  public void testDateWithoutTimezoneFallback() {
+    var result = InPlaceComparator.compare(dateFieldRbc(1), new Date(86400000L), null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** DATE with non-GMT timezone. */
+  @Test
+  public void testDateWithNonGmtTimezone() {
+    var eastern = TimeZone.getTimeZone("US/Eastern");
+    long days = 1;
+    long convertedMillis =
+        HelperClasses.convertDayToTimezone(
+            TimeZone.getTimeZone("GMT"), eastern, days * 86400000L);
+    var result =
+        InPlaceComparator.compare(dateFieldRbc(days), new Date(convertedMillis), eastern);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // DECIMAL tests — key focus area: divergent deserialization from DecimalSerializer
+  // ===========================================================================
+
+  /** DECIMAL equality — same value. */
+  @Test
+  public void testDecimalEqual() {
+    var bd = new BigDecimal("123.456");
+    var result = InPlaceComparator.compare(decimalFieldRbc(bd), bd, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with different scale but same value — compareTo ignores scale. */
+  @Test
+  public void testDecimalDifferentScale() {
+    var result =
+        InPlaceComparator.compare(
+            decimalFieldRbc(new BigDecimal("1.0")), new BigDecimal("1"), null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL less than. */
+  @Test
+  public void testDecimalLessThan() {
+    var result =
+        InPlaceComparator.compare(
+            decimalFieldRbc(new BigDecimal("1.5")), new BigDecimal("2.5"), null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DECIMAL greater than. */
+  @Test
+  public void testDecimalGreaterThan() {
+    var result =
+        InPlaceComparator.compare(
+            decimalFieldRbc(new BigDecimal("2.5")), new BigDecimal("1.5"), null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** DECIMAL with Double value. */
+  @Test
+  public void testDecimalWithDouble() {
+    var result = InPlaceComparator.compare(decimalFieldRbc(new BigDecimal("42.0")), 42.0, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with Integer value. */
+  @Test
+  public void testDecimalWithInteger() {
+    var result = InPlaceComparator.compare(decimalFieldRbc(new BigDecimal("42")), 42, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with Long value. */
+  @Test
+  public void testDecimalWithLong() {
+    var result = InPlaceComparator.compare(decimalFieldRbc(new BigDecimal("42")), 42L, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL negative value. */
+  @Test
+  public void testDecimalNegative() {
+    var result =
+        InPlaceComparator.compare(
+            decimalFieldRbc(new BigDecimal("-99.99")), new BigDecimal("-99.99"), null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL zero. */
+  @Test
+  public void testDecimalZero() {
+    var result =
+        InPlaceComparator.compare(decimalFieldRbc(BigDecimal.ZERO), BigDecimal.ZERO, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DECIMAL with non-Number — should fall back. */
+  @Test
+  public void testDecimalWithStringFallback() {
+    var result = InPlaceComparator.compare(decimalFieldRbc(new BigDecimal("42")), "42", null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** DECIMAL with Double.NaN — should fall back, not throw. */
+  @Test
+  public void testDecimalWithDoubleNaN() {
+    var result =
+        InPlaceComparator.compare(decimalFieldRbc(new BigDecimal("42")), Double.NaN, null);
+    assertTrue("DECIMAL vs Double.NaN should fall back", result.isEmpty());
+  }
+
+  /** DECIMAL with Double.POSITIVE_INFINITY — should fall back. */
+  @Test
+  public void testDecimalWithDoublePositiveInfinity() {
+    var result =
+        InPlaceComparator.compare(
+            decimalFieldRbc(new BigDecimal("42")), Double.POSITIVE_INFINITY, null);
+    assertTrue("DECIMAL vs +Infinity should fall back", result.isEmpty());
+  }
+
+  /** DECIMAL with Double.NEGATIVE_INFINITY — should fall back. */
+  @Test
+  public void testDecimalWithDoubleNegativeInfinity() {
+    var result =
+        InPlaceComparator.compare(
+            decimalFieldRbc(new BigDecimal("42")), Double.NEGATIVE_INFINITY, null);
+    assertTrue("DECIMAL vs -Infinity should fall back", result.isEmpty());
+  }
+
+  /** DECIMAL with Float.NaN — should fall back. */
+  @Test
+  public void testDecimalWithFloatNaN() {
+    var result =
+        InPlaceComparator.compare(decimalFieldRbc(new BigDecimal("42")), Float.NaN, null);
+    assertTrue("DECIMAL vs Float.NaN should fall back", result.isEmpty());
+  }
+
+  /** DECIMAL with Float value. */
+  @Test
+  public void testDecimalWithFloat() {
+    var result =
+        InPlaceComparator.compare(decimalFieldRbc(new BigDecimal("42.5")), 42.5f, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /**
+   * DECIMAL with corrupted unscaled length (exceeds remaining buffer) — should throw
+   * CorruptedRecordException. In the PageFrame comparison path this would be caught by the
+   * RuntimeException handler and cause a fallback.
+   */
+  @Test(expected = CorruptedRecordException.class)
+  public void testDecimalCorruptedUnscaledLength() {
+    // Craft bytes: valid scale (4 bytes), but unscaled length = 999 (exceeds remaining)
+    var buf = ByteBuffer.allocate(12);
+    buf.putInt(2); // scale
+    buf.putInt(999); // corrupt unscaled length
+    buf.putInt(0); // some padding
+    buf.flip();
+    var field = new ReadBinaryField(
+        "test", PropertyTypeInternal.DECIMAL, new ReadBytesContainer(buf), null);
+    InPlaceComparator.compare(field, new BigDecimal("1"), null);
+  }
+
+  /**
+   * DECIMAL with very large value — verifies that the manual BigInteger deserialization
+   * in compareDecimalRbc matches what DecimalSerializer would produce.
+   */
+  @Test
+  public void testDecimalVeryLargeValue() {
+    var large = new BigDecimal("99999999999999999999999999999.123456789");
+    var result = InPlaceComparator.compare(decimalFieldRbc(large), large, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // BINARY tests
+  // ===========================================================================
+
+  /** BINARY equality. */
+  @Test
+  public void testBinaryEqual() {
+    var data = new byte[] {1, 2, 3, 4, 5};
+    var result = InPlaceComparator.compare(binaryFieldRbc(data), data, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BINARY less than (lexicographic). */
+  @Test
+  public void testBinaryLessThan() {
+    var result =
+        InPlaceComparator.compare(
+            binaryFieldRbc(new byte[] {1, 2, 3}), new byte[] {1, 2, 4}, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** BINARY empty arrays. */
+  @Test
+  public void testBinaryEmpty() {
+    var result =
+        InPlaceComparator.compare(binaryFieldRbc(new byte[0]), new byte[0], null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BINARY with non-byte-array — should fall back. */
+  @Test
+  public void testBinaryWithNonByteArrayFallback() {
+    var result = InPlaceComparator.compare(binaryFieldRbc(new byte[] {1}), "data", null);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // LINK tests — key focus area: equality via RID components
+  // ===========================================================================
+
+  /** LINK compare returns empty (ordering undefined). */
+  @Test
+  public void testLinkCompareReturnsEmpty() {
+    var result =
+        InPlaceComparator.compare(linkFieldRbc(5, 10L), new RecordId(5, 10L), null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** LINK isEqual returns 1 for matching RID. */
+  @Test
+  public void testLinkIsEqualTrue() {
+    var result =
+        InPlaceComparator.isEqual(linkFieldRbc(5, 10L), new RecordId(5, 10L), null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** LINK isEqual returns 0 for different collectionId. */
+  @Test
+  public void testLinkIsEqualDifferentCollectionId() {
+    var result =
+        InPlaceComparator.isEqual(linkFieldRbc(5, 10L), new RecordId(6, 10L), null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LINK isEqual returns 0 for different collectionPosition. */
+  @Test
+  public void testLinkIsEqualDifferentCollectionPos() {
+    var result =
+        InPlaceComparator.isEqual(linkFieldRbc(5, 10L), new RecordId(5, 11L), null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LINK isEqual with non-RID value — should fall back. */
+  @Test
+  public void testLinkIsEqualWithNonRidFallback() {
+    var result = InPlaceComparator.isEqual(linkFieldRbc(5, 10L), "5:10", null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** LINK isEqual with Identifiable (non-RID) value — exercises the Identifiable branch. */
+  @Test
+  public void testLinkIsEqualWithIdentifiable() {
+    Identifiable identifiable = new Identifiable() {
+      @Override
+      public RID getIdentity() {
+        return new RecordId(5, 10L);
+      }
+
+      @Override
+      public int compareTo(Identifiable o) {
+        return getIdentity().compareTo(o.getIdentity());
+      }
+    };
+    var result = InPlaceComparator.isEqual(linkFieldRbc(5, 10L), identifiable, null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** LINK isEqual with cluster 0, position 0 — boundary test. */
+  @Test
+  public void testLinkIsEqualZeroRid() {
+    var result = InPlaceComparator.isEqual(linkFieldRbc(0, 0L), new RecordId(0, 0L), null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  // ===========================================================================
+  // Excluded types fallback tests
+  // ===========================================================================
+
+  /** EMBEDDED type returns empty (not binary-comparable). */
+  @Test
+  public void testEmbeddedFallback() {
+    var field = new ReadBinaryField(
+        "test", PropertyTypeInternal.EMBEDDED, new ReadBytesContainer(new byte[4], 0), null);
+    assertTrue(InPlaceComparator.compare(field, "value", null).isEmpty());
+  }
+
+  /** EMBEDDEDLIST type returns empty. */
+  @Test
+  public void testEmbeddedListFallback() {
+    var field = new ReadBinaryField(
+        "test", PropertyTypeInternal.EMBEDDEDLIST,
+        new ReadBytesContainer(new byte[4], 0), null);
+    assertTrue(InPlaceComparator.compare(field, "value", null).isEmpty());
+  }
+
+  // ===========================================================================
+  // isEqual for non-numeric types
+  // ===========================================================================
+
+  /** isEqual for STRING — equal. */
+  @Test
+  public void testIsEqualStringTrue() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc("hello"), "hello", null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual for STRING — not equal. */
+  @Test
+  public void testIsEqualStringFalse() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc("hello"), "world", null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual for BOOLEAN — equal. */
+  @Test
+  public void testIsEqualBooleanTrue() {
+    var result = InPlaceComparator.isEqual(booleanFieldRbc(true), true, null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual for DECIMAL with different scale — still equal via compareTo. */
+  @Test
+  public void testIsEqualDecimalDifferentScale() {
+    var result =
+        InPlaceComparator.isEqual(
+            decimalFieldRbc(new BigDecimal("1.0")), new BigDecimal("1"), null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorRbcNonNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorRbcNonNumericTest.java
@@ -559,6 +559,48 @@ public class InPlaceComparatorRbcNonNumericTest {
     assertEquals(OptionalInt.of(0), result);
   }
 
+  /** isEqual for STRING — empty strings equal (byte-level fast path). */
+  @Test
+  public void testIsEqualStringEmptyEqual() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc(""), "", null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual for STRING — empty vs non-empty (byte-level fast path). */
+  @Test
+  public void testIsEqualStringEmptyVsNonEmpty() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc(""), "abc", null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual for STRING — different UTF-8 byte lengths (byte-level fast path). */
+  @Test
+  public void testIsEqualStringDifferentLengths() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc("short"), "a much longer string", null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual for STRING — Unicode equality via byte-level fast path. */
+  @Test
+  public void testIsEqualStringUnicode() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc("привет"), "привет", null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual for STRING — Unicode not equal via byte-level fast path. */
+  @Test
+  public void testIsEqualStringUnicodeNotEqual() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc("привет"), "мир", null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual for STRING with non-String value — should fall back. */
+  @Test
+  public void testIsEqualStringWithNonStringFallback() {
+    var result = InPlaceComparator.isEqual(stringFieldRbc("42"), 42, null);
+    assertTrue(result.isEmpty());
+  }
+
   /** isEqual for BOOLEAN — equal. */
   @Test
   public void testIsEqualBooleanTrue() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorRbcNumericTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/InPlaceComparatorRbcNumericTest.java
@@ -1,0 +1,341 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
+import com.jetbrains.youtrackdb.internal.common.serialization.types.LongSerializer;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import java.util.OptionalInt;
+import org.junit.Test;
+
+/**
+ * Tests for {@link InPlaceComparator} ReadBinaryField numeric type comparison (INTEGER, LONG,
+ * SHORT, BYTE, FLOAT, DOUBLE). Mirrors {@link InPlaceComparatorNumericTest} but uses
+ * ReadBinaryField / ReadBytesContainer (ByteBuffer-backed) instead of BinaryField / BytesContainer.
+ */
+public class InPlaceComparatorRbcNumericTest {
+
+  // ---- Helper methods to create ReadBinaryFields with serialized values ----
+
+  private static ReadBinaryField intFieldRbc(int value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.INTEGER, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField longFieldRbc(long value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.LONG, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField shortFieldRbc(short value) {
+    var bytes = new BytesContainer();
+    VarIntSerializer.write(bytes, value);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.SHORT, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField byteFieldRbc(byte value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(1);
+    bytes.bytes[pos] = value;
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.BYTE, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField floatFieldRbc(float value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(IntegerSerializer.INT_SIZE);
+    IntegerSerializer.serializeLiteral(Float.floatToIntBits(value), bytes.bytes, pos);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.FLOAT, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  private static ReadBinaryField doubleFieldRbc(double value) {
+    var bytes = new BytesContainer();
+    var pos = bytes.alloc(LongSerializer.LONG_SIZE);
+    LongSerializer.serializeLiteral(Double.doubleToLongBits(value), bytes.bytes, pos);
+    return new ReadBinaryField(
+        "test", PropertyTypeInternal.DOUBLE, new ReadBytesContainer(bytes.bytes, 0), null);
+  }
+
+  // ===========================================================================
+  // INTEGER tests
+  // ===========================================================================
+
+  /** INTEGER equal — same type. */
+  @Test
+  public void testIntegerEqualSameType() {
+    var result = InPlaceComparator.compare(intFieldRbc(42), 42, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER less than. */
+  @Test
+  public void testIntegerLessThan() {
+    var result = InPlaceComparator.compare(intFieldRbc(10), 20, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** INTEGER greater than. */
+  @Test
+  public void testIntegerGreaterThan() {
+    var result = InPlaceComparator.compare(intFieldRbc(20), 10, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() > 0);
+  }
+
+  /** INTEGER with Long in range — should succeed. */
+  @Test
+  public void testIntegerWithLongInRange() {
+    var result = InPlaceComparator.compare(intFieldRbc(100), 100L, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER with Long out of range — should fall back. */
+  @Test
+  public void testIntegerWithLongOutOfRange() {
+    var result =
+        InPlaceComparator.compare(intFieldRbc(100), (long) Integer.MAX_VALUE + 1, null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** INTEGER with Float — should fall back. */
+  @Test
+  public void testIntegerWithFloatFallback() {
+    var result = InPlaceComparator.compare(intFieldRbc(42), 42.0f, null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** INTEGER with non-Number — should fall back. */
+  @Test
+  public void testIntegerWithNonNumber() {
+    var result = InPlaceComparator.compare(intFieldRbc(42), "42", null);
+    assertTrue(result.isEmpty());
+  }
+
+  /** INTEGER boundary: MAX_VALUE. */
+  @Test
+  public void testIntegerMaxValue() {
+    var result =
+        InPlaceComparator.compare(intFieldRbc(Integer.MAX_VALUE), Integer.MAX_VALUE, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER boundary: MIN_VALUE. */
+  @Test
+  public void testIntegerMinValue() {
+    var result =
+        InPlaceComparator.compare(intFieldRbc(Integer.MIN_VALUE), Integer.MIN_VALUE, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** INTEGER zero. */
+  @Test
+  public void testIntegerZero() {
+    var result = InPlaceComparator.compare(intFieldRbc(0), 0, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // LONG tests
+  // ===========================================================================
+
+  /** LONG equal — same type. */
+  @Test
+  public void testLongEqualSameType() {
+    var result = InPlaceComparator.compare(longFieldRbc(123456789L), 123456789L, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LONG less than. */
+  @Test
+  public void testLongLessThan() {
+    var result = InPlaceComparator.compare(longFieldRbc(10L), 20L, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** LONG with Integer — should widen. */
+  @Test
+  public void testLongWithInteger() {
+    var result = InPlaceComparator.compare(longFieldRbc(42L), 42, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LONG boundary: MAX_VALUE. */
+  @Test
+  public void testLongMaxValue() {
+    var result =
+        InPlaceComparator.compare(longFieldRbc(Long.MAX_VALUE), Long.MAX_VALUE, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** LONG boundary: MIN_VALUE. */
+  @Test
+  public void testLongMinValue() {
+    var result =
+        InPlaceComparator.compare(longFieldRbc(Long.MIN_VALUE), Long.MIN_VALUE, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // SHORT tests
+  // ===========================================================================
+
+  /** SHORT equal — same type. */
+  @Test
+  public void testShortEqualSameType() {
+    var result = InPlaceComparator.compare(shortFieldRbc((short) 42), (short) 42, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT with Integer in range — should narrow. */
+  @Test
+  public void testShortWithIntegerInRange() {
+    var result = InPlaceComparator.compare(shortFieldRbc((short) 100), 100, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** SHORT with Integer out of range — should fall back. */
+  @Test
+  public void testShortWithIntegerOutOfRange() {
+    var result = InPlaceComparator.compare(shortFieldRbc((short) 100), 100_000, null);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // BYTE tests
+  // ===========================================================================
+
+  /** BYTE equal — same type. */
+  @Test
+  public void testByteEqualSameType() {
+    var result = InPlaceComparator.compare(byteFieldRbc((byte) 7), (byte) 7, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** BYTE less than. */
+  @Test
+  public void testByteLessThan() {
+    var result = InPlaceComparator.compare(byteFieldRbc((byte) 1), (byte) 5, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  // ===========================================================================
+  // FLOAT tests
+  // ===========================================================================
+
+  /** FLOAT equal — same type. */
+  @Test
+  public void testFloatEqualSameType() {
+    var result = InPlaceComparator.compare(floatFieldRbc(3.14f), 3.14f, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT less than. */
+  @Test
+  public void testFloatLessThan() {
+    var result = InPlaceComparator.compare(floatFieldRbc(1.0f), 2.0f, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** FLOAT with Double — widens to double comparison. */
+  @Test
+  public void testFloatWithDouble() {
+    var result = InPlaceComparator.compare(floatFieldRbc(3.14f), (double) 3.14f, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** FLOAT with non-Number — should fall back. */
+  @Test
+  public void testFloatWithNonNumber() {
+    var result = InPlaceComparator.compare(floatFieldRbc(1.0f), "1.0", null);
+    assertTrue(result.isEmpty());
+  }
+
+  // ===========================================================================
+  // DOUBLE tests
+  // ===========================================================================
+
+  /** DOUBLE equal — same type. */
+  @Test
+  public void testDoubleEqualSameType() {
+    var result = InPlaceComparator.compare(doubleFieldRbc(2.718281828), 2.718281828, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE less than. */
+  @Test
+  public void testDoubleLessThan() {
+    var result = InPlaceComparator.compare(doubleFieldRbc(1.0), 2.0, null);
+    assertTrue(result.isPresent());
+    assertTrue(result.getAsInt() < 0);
+  }
+
+  /** DOUBLE with Float — should widen float to double. */
+  @Test
+  public void testDoubleWithFloat() {
+    var result = InPlaceComparator.compare(doubleFieldRbc(42.0), 42.0f, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** DOUBLE with Integer — widens to double (42 is within 2^53 range). */
+  @Test
+  public void testDoubleWithInteger() {
+    var result = InPlaceComparator.compare(doubleFieldRbc(42.0), 42, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  // ===========================================================================
+  // isEqual tests (derived from compare)
+  // ===========================================================================
+
+  /** isEqual for INTEGER — equal. */
+  @Test
+  public void testIsEqualIntegerTrue() {
+    var result = InPlaceComparator.isEqual(intFieldRbc(42), 42, null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+
+  /** isEqual for INTEGER — not equal. */
+  @Test
+  public void testIsEqualIntegerFalse() {
+    var result = InPlaceComparator.isEqual(intFieldRbc(42), 99, null);
+    assertEquals(OptionalInt.of(0), result);
+  }
+
+  /** isEqual for DOUBLE — equal. */
+  @Test
+  public void testIsEqualDoubleTrue() {
+    var result = InPlaceComparator.isEqual(doubleFieldRbc(3.14), 3.14, null);
+    assertEquals(OptionalInt.of(1), result);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerDeserializationEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerDeserializationEquivalenceTest.java
@@ -1,0 +1,359 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
+import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * End-to-end equivalence tests validating that the ReadBytesContainer deserialization path
+ * produces identical results to the byte[] BytesContainer path. Since fromStream now wires
+ * through ReadBytesContainer internally, all existing tests also exercise this path. These tests
+ * provide explicit verification with both heap and direct ByteBuffer backing.
+ */
+public class ReadBytesContainerDeserializationEquivalenceTest {
+
+  private YouTrackDBImpl youTrackDB;
+  private DatabaseSessionEmbedded session;
+
+  @Before
+  public void setUp() {
+    youTrackDB = (YouTrackDBImpl) YourTracks.instance("memory:");
+    youTrackDB.create(
+        "readBytesEquiv",
+        DatabaseType.MEMORY,
+        new LocalUserCredential("admin", "adminpwd", PredefinedLocalRole.ADMIN));
+    session = (DatabaseSessionEmbedded) youTrackDB.open("readBytesEquiv", "admin", "adminpwd");
+  }
+
+  @After
+  public void tearDown() {
+    if (session != null) {
+      session.close();
+    }
+    if (youTrackDB != null) {
+      youTrackDB.close();
+    }
+  }
+
+  // --- Primitive types ---
+
+  @Test
+  public void testAllPrimitiveTypes() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("intField", 42);
+      entity.setProperty("longField", 9876543210L);
+      entity.setProperty("shortField", (short) 1234);
+      entity.setProperty("byteField", (byte) 7);
+      entity.setProperty("floatField", 3.14f);
+      entity.setProperty("doubleField", 2.71828);
+      entity.setProperty("boolTrue", true);
+      entity.setProperty("boolFalse", false);
+      entity.setProperty("stringField", "Hello World");
+      entity.setProperty("dateField", new Date(1000000000000L));
+      entity.setProperty("dateTimeField", new Date(1617235200000L));
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    assertEquals(42, (int) rbcResult.getProperty("intField"));
+    assertEquals(9876543210L, (long) rbcResult.getProperty("longField"));
+    assertEquals((short) 1234, (short) rbcResult.getProperty("shortField"));
+    assertEquals((byte) 7, (byte) rbcResult.getProperty("byteField"));
+    assertEquals(3.14f, (float) rbcResult.getProperty("floatField"), 0.001f);
+    assertEquals(2.71828, (double) rbcResult.getProperty("doubleField"), 0.00001);
+    assertTrue(rbcResult.getProperty("boolTrue"));
+    assertFalse(rbcResult.getProperty("boolFalse"));
+    assertEquals("Hello World", rbcResult.getProperty("stringField"));
+    session.rollback();
+  }
+
+  @Test
+  public void testDecimalNotLastField() {
+    // DECIMAL followed by another field — validates correct offset advancement
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("decimal1", new BigDecimal("123.456"));
+      entity.setProperty("afterDecimal", "check offset");
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    assertEquals(new BigDecimal("123.456"), rbcResult.getProperty("decimal1"));
+    assertEquals("check offset", rbcResult.getProperty("afterDecimal"));
+    session.rollback();
+  }
+
+  @Test
+  public void testBinaryType() {
+    session.begin();
+    var binData = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("binaryField", binData);
+      entity.setProperty("afterBinary", 42);
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    assertArrayEquals(binData, rbcResult.getProperty("binaryField"));
+    assertEquals(42, (int) rbcResult.getProperty("afterBinary"));
+    session.rollback();
+  }
+
+  // --- String edge cases ---
+
+  @Test
+  public void testNonAsciiStrings() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("cyrillic", "Привет");
+      entity.setProperty("emoji", "\uD83D\uDE00\uD83D\uDE01");
+      entity.setProperty("chinese", "你好世界");
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    assertEquals("Привет", rbcResult.getProperty("cyrillic"));
+    assertEquals("\uD83D\uDE00\uD83D\uDE01", rbcResult.getProperty("emoji"));
+    assertEquals("你好世界", rbcResult.getProperty("chinese"));
+    session.rollback();
+  }
+
+  // --- Collection types ---
+
+  @Test
+  public void testEmbeddedList() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      List<String> list = session.newEmbeddedList();
+      list.add("a");
+      list.add("b");
+      list.add("c");
+      entity.setProperty("list", list);
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    List<?> list = rbcResult.getProperty("list");
+    assertNotNull(list);
+    assertEquals(3, list.size());
+    assertEquals("a", list.get(0));
+    assertEquals("b", list.get(1));
+    assertEquals("c", list.get(2));
+    session.rollback();
+  }
+
+  @Test
+  public void testEmbeddedSet() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      Set<Integer> set = session.newEmbeddedSet();
+      set.add(1);
+      set.add(2);
+      set.add(3);
+      entity.setProperty("set", set);
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    Set<?> set = rbcResult.getProperty("set");
+    assertNotNull(set);
+    assertEquals(3, set.size());
+    session.rollback();
+  }
+
+  @Test
+  public void testEmbeddedMap() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      Map<String, Object> map = session.newEmbeddedMap();
+      map.put("key1", "val1");
+      map.put("key2", 42);
+      entity.setProperty("map", map);
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    Map<?, ?> map = rbcResult.getProperty("map");
+    assertNotNull(map);
+    assertEquals("val1", map.get("key1"));
+    assertEquals(42, map.get("key2"));
+    session.rollback();
+  }
+
+  // --- Null values ---
+
+  @Test
+  public void testNullValues() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("nonNull", "present");
+      entity.setProperty("nullField", (String) null);
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    assertEquals("present", rbcResult.getProperty("nonNull"));
+    assertNull(rbcResult.getProperty("nullField"));
+    session.rollback();
+  }
+
+  // --- Large records ---
+
+  @Test
+  public void testLargeRecord() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      for (var i = 0; i < 50; i++) {
+        entity.setProperty("field_" + i, "value_" + i);
+      }
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    for (var i = 0; i < 50; i++) {
+      assertEquals("value_" + i, rbcResult.getProperty("field_" + i));
+    }
+    session.rollback();
+  }
+
+  // --- Partial deserialization ---
+
+  @Test
+  public void testPartialDeserializeSingleField() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("a", 1);
+      entity.setProperty("b", 2);
+      entity.setProperty("c", 3);
+    });
+
+    var rbcResult = deserializePartialViaReadBytesContainer(serialized, "b");
+    assertEquals(2, (int) rbcResult.getProperty("b"));
+    session.rollback();
+  }
+
+  @Test
+  public void testPartialDeserializeMultipleFields() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("a", "alpha");
+      entity.setProperty("b", "beta");
+      entity.setProperty("c", "gamma");
+    });
+
+    var rbcResult = deserializePartialViaReadBytesContainer(serialized, "a", "c");
+    assertEquals("alpha", rbcResult.getProperty("a"));
+    assertEquals("gamma", rbcResult.getProperty("c"));
+    session.rollback();
+  }
+
+  // --- Direct ByteBuffer ---
+
+  @Test
+  public void testDirectByteBufferBacking() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("field1", "direct buffer test");
+      entity.setProperty("field2", 42);
+    });
+
+    // Deserialize from a direct ByteBuffer (simulating PageFrame zero-copy)
+    var directBuf = ByteBuffer.allocateDirect(serialized.length - 1);
+    directBuf.put(serialized, 1, serialized.length - 1);
+    directBuf.flip();
+
+    var container = new ReadBytesContainer(directBuf);
+    var entity = (EntityImpl) session.newEntity();
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(serialized[0]);
+    serializer.deserialize(session, entity, container);
+
+    assertEquals("direct buffer test", entity.getProperty("field1"));
+    assertEquals(42, (int) entity.getProperty("field2"));
+    session.rollback();
+  }
+
+  // --- Embedded entity ---
+
+  @Test
+  public void testEmbeddedEntity() {
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      var embedded = session.newEmbeddedEntity();
+      ((EntityImpl) embedded).setProperty("innerField", "innerValue");
+      ((EntityImpl) embedded).setProperty("innerInt", 99);
+      entity.setProperty("embedded", embedded);
+      entity.setProperty("outerField", "outerValue");
+    });
+
+    var rbcResult = deserializeViaReadBytesContainer(serialized);
+    assertNotNull(rbcResult.getProperty("embedded"));
+    assertEquals("outerValue", rbcResult.getProperty("outerField"));
+
+    var embeddedRbc = (EntityImpl) rbcResult.getProperty("embedded");
+    assertEquals("innerValue", embeddedRbc.getProperty("innerField"));
+    assertEquals(99, (int) embeddedRbc.getProperty("innerInt"));
+    session.rollback();
+  }
+
+  // --- Helper methods ---
+
+  @FunctionalInterface
+  private interface EntityConfigurer {
+    void configure(EntityImpl entity);
+  }
+
+  private byte[] serializeEntity(EntityConfigurer configurer) {
+    var entity = (EntityImpl) session.newEntity();
+    configurer.configure(entity);
+    return RecordSerializerBinary.INSTANCE.toStream(session, entity);
+  }
+
+  private EntityImpl deserializeViaReadBytesContainer(byte[] serialized) {
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(serialized[0]);
+    serializer.deserialize(session, entity, container);
+    return entity;
+  }
+
+  private EntityImpl deserializePartialViaReadBytesContainer(
+      byte[] serialized, String... fields) {
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    var serializer = RecordSerializerBinary.INSTANCE.getSerializer(serialized[0]);
+    serializer.deserializePartial(session, entity, container, fields);
+    return entity;
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerDeserializationEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerDeserializationEquivalenceTest.java
@@ -25,12 +25,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.api.DatabaseType;
 import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
 import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
 import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
@@ -57,7 +59,9 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
 
   @Before
   public void setUp() {
-    youTrackDB = (YouTrackDBImpl) YourTracks.instance("memory:");
+    youTrackDB =
+        (YouTrackDBImpl) YourTracks.instance(
+            DbTestBase.getBaseDirectoryPathStr(getClass()));
     youTrackDB.create(
         "readBytesEquiv",
         DatabaseType.MEMORY,
@@ -113,7 +117,7 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
     assertTrue(rbcResult.getProperty("boolTrue"));
     assertFalse(rbcResult.getProperty("boolFalse"));
     assertEquals("Hello World", rbcResult.getProperty("stringField"));
-    assertNotNull(rbcResult.getProperty("dateField"));
+    assertEquals(new Date(1000000000000L), rbcResult.getProperty("dateField"));
     assertEquals(new Date(1617235200000L), rbcResult.getProperty("dateTimeField"));
     session.rollback();
   }
@@ -203,7 +207,7 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
     var rbcResult = deserializeViaReadBytesContainer(serialized);
     Set<?> set = rbcResult.getProperty("set");
     assertNotNull(set);
-    assertEquals(3, set.size());
+    assertEquals(Set.of(1, 2, 3), set);
     session.rollback();
   }
 
@@ -220,6 +224,7 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
     var rbcResult = deserializeViaReadBytesContainer(serialized);
     Map<?, ?> map = rbcResult.getProperty("map");
     assertNotNull(map);
+    assertEquals(2, map.size());
     assertEquals("val1", map.get("key1"));
     assertEquals(42, map.get("key2"));
     session.rollback();
@@ -340,6 +345,223 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
     var embeddedRbc = (EntityImpl) rbcResult.getProperty("embedded");
     assertEquals("innerValue", embeddedRbc.getProperty("innerField"));
     assertEquals(99, (int) embeddedRbc.getProperty("innerInt"));
+    session.rollback();
+  }
+
+  // --- deserializeFieldTypedLoopAndReturn via ReadBytesContainer ---
+
+  @Test
+  public void testDeserializeFieldTypedLoopReturnsMatchingField() {
+    // Exercise the ReadBytesContainer overload of deserializeFieldTypedLoopAndReturn
+    // with a matching field name. This covers the normal successful lookup path.
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("alpha", "one");
+      entity.setProperty("beta", 42);
+      entity.setProperty("gamma", "three");
+    });
+
+    // Skip version byte, pass the record body to ReadBytesContainer
+    var rbc = new ReadBytesContainer(serialized, 1);
+    var serializer = new RecordSerializerBinaryV1();
+
+    // Look up the second field "beta" — exercises header iteration with non-matching
+    // field names (different lengths and byte-level comparison) before finding the match
+    Object result = serializer.deserializeFieldTypedLoopAndReturn(
+        session, rbc, "beta", null, null);
+    assertEquals(42, result);
+    session.rollback();
+  }
+
+  @Test
+  public void testDeserializeFieldTypedLoopReturnsNullForMissingField() {
+    // Exercise the ReadBytesContainer overload when the requested field does
+    // not exist — should return null after iterating the entire header.
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("x", 1);
+      entity.setProperty("y", 2);
+    });
+
+    var rbc = new ReadBytesContainer(serialized, 1);
+    var serializer = new RecordSerializerBinaryV1();
+    Object result = serializer.deserializeFieldTypedLoopAndReturn(
+        session, rbc, "nonExistent", null, null);
+    assertNull(result);
+    session.rollback();
+  }
+
+  @Test
+  public void testDeserializeFieldTypedLoopReturnsNullForNullValuedField() {
+    // Exercise the null-value path: field exists in header but has zero-length
+    // value, so the method returns null.
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("present", "value");
+      entity.setProperty("nullField", (String) null);
+    });
+
+    var rbc = new ReadBytesContainer(serialized, 1);
+    var serializer = new RecordSerializerBinaryV1();
+    Object result = serializer.deserializeFieldTypedLoopAndReturn(
+        session, rbc, "nullField", null, null);
+    assertNull(result);
+    session.rollback();
+  }
+
+  @Test
+  public void testDeserializeFieldTypedLoopWithDifferentLengthFieldNames() {
+    // Ensure the length-based short-circuit in checkMatchForLargerThenZero
+    // works correctly when field name lengths differ.
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("a", 1);
+      entity.setProperty("longFieldName", 2);
+      entity.setProperty("z", 3);
+    });
+
+    var rbc = new ReadBytesContainer(serialized, 1);
+    var serializer = new RecordSerializerBinaryV1();
+    // Look up "longFieldName" — "a" has length 1 (mismatch), triggers early return in
+    // checkMatchForLargerThenZero
+    Object result = serializer.deserializeFieldTypedLoopAndReturn(
+        session, rbc, "longFieldName", null, null);
+    assertEquals(2, result);
+    session.rollback();
+  }
+
+  // --- getPositionsFromEmbeddedMap via ReadBytesContainer ---
+
+  @Test
+  public void testGetPositionsFromEmbeddedMapViaReadBytesContainer() {
+    // Exercise the ReadBytesContainer overload of getPositionsFromEmbeddedMap
+    // which is used for map field position scanning (e.g., map key iteration).
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      Map<String, Object> map = session.newEmbeddedMap();
+      map.put("key1", "val1");
+      map.put("key2", 42);
+      map.put("key3", true);
+      entity.setProperty("myMap", map);
+    });
+
+    // Deserialize to find the map field's serialized bytes, then parse positions
+    var fullRbc = new ReadBytesContainer(serialized, 1);
+    var serializer = new RecordSerializerBinaryV1();
+    // Use deserializeFieldTypedLoopAndReturn to extract the map value
+    // This indirectly exercises the map deserialization path
+    Object mapValue = serializer.deserializeFieldTypedLoopAndReturn(
+        session, fullRbc, "myMap", null, null);
+    assertNotNull(mapValue);
+    assertTrue(mapValue instanceof Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> resultMap = (Map<String, Object>) mapValue;
+    assertEquals("val1", resultMap.get("key1"));
+    assertEquals(42, resultMap.get("key2"));
+    assertEquals(true, resultMap.get("key3"));
+    session.rollback();
+  }
+
+  // --- deserializeEmbeddedAsDocument via ReadBytesContainer ---
+
+  @Test
+  public void testDeserializeEmbeddedEntityViaFieldTypedLoop() {
+    // Exercise the ReadBytesContainer overload of deserializeEmbeddedAsDocument
+    // by looking up an embedded entity field through deserializeFieldTypedLoopAndReturn.
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      var embedded = session.newEmbeddedEntity();
+      ((EntityImpl) embedded).setProperty("innerKey", "innerVal");
+      ((EntityImpl) embedded).setProperty("innerNum", 77);
+      entity.setProperty("embed", embedded);
+      entity.setProperty("after", "check");
+    });
+
+    var rbc = new ReadBytesContainer(serialized, 1);
+    var serializer = new RecordSerializerBinaryV1();
+    Object result = serializer.deserializeFieldTypedLoopAndReturn(
+        session, rbc, "embed", null, null);
+    assertNotNull(result);
+    assertTrue(result instanceof EntityImpl);
+    var embeddedEntity = (EntityImpl) result;
+    assertEquals("innerVal", embeddedEntity.getProperty("innerKey"));
+    assertEquals(77, (int) embeddedEntity.getProperty("innerNum"));
+    session.rollback();
+  }
+
+  // --- RecordSerializerBinary.fromStream via serializerVersion + ReadBytesContainer ---
+
+  @Test
+  public void testFromStreamWithVersionAndReadBytesContainer() {
+    // Exercise RecordSerializerBinary.fromStream(session, version, container, record, fields)
+    // which is the entry point for the PageFrame zero-copy path.
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("field1", "hello");
+      entity.setProperty("field2", 99);
+    });
+
+    byte serializerVersion = serialized[0];
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    // Full deserialization (no field filter)
+    RecordSerializerBinary.INSTANCE.fromStream(
+        session, serializerVersion, container, entity, null);
+    assertEquals("hello", entity.getProperty("field1"));
+    assertEquals(99, (int) entity.getProperty("field2"));
+    session.rollback();
+  }
+
+  @Test
+  public void testFromStreamWithVersionAndReadBytesContainerPartial() {
+    // Exercise RecordSerializerBinary.fromStream partial deserialization path.
+    session.begin();
+    var serialized = serializeEntity(entity -> {
+      entity.setProperty("a", "alpha");
+      entity.setProperty("b", "beta");
+      entity.setProperty("c", "gamma");
+    });
+
+    byte serializerVersion = serialized[0];
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    RecordSerializerBinary.INSTANCE.fromStream(
+        session, serializerVersion, container, entity, new String[] {"b"});
+    assertEquals("beta", entity.getProperty("b"));
+    assertFalse(entity.hasProperty("a"));
+    assertFalse(entity.hasProperty("c"));
+    session.rollback();
+  }
+
+  @Test
+  public void testFromStreamWithNegativeVersionThrows() {
+    // Exercise the error path for negative serializer version.
+    session.begin();
+    var serialized = serializeEntity(entity -> entity.setProperty("x", 1));
+
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    var ex = assertThrows(
+        IllegalArgumentException.class,
+        () -> RecordSerializerBinary.INSTANCE.fromStream(
+            session, (byte) -1, container, entity, null));
+    assertTrue(ex.getMessage().contains("Unsupported serializer version"));
+    session.rollback();
+  }
+
+  @Test
+  public void testFromStreamWithTooHighVersionThrows() {
+    // Exercise the error path for a serializer version beyond the supported range.
+    session.begin();
+    var serialized = serializeEntity(entity -> entity.setProperty("x", 1));
+
+    var container = new ReadBytesContainer(serialized, 1);
+    var entity = (EntityImpl) session.newEntity();
+    var ex = assertThrows(
+        IllegalArgumentException.class,
+        () -> RecordSerializerBinary.INSTANCE.fromStream(
+            session, (byte) 127, container, entity, null));
+    assertTrue(ex.getMessage().contains("Unsupported serializer version"));
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerDeserializationEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerDeserializationEquivalenceTest.java
@@ -67,11 +67,20 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
 
   @After
   public void tearDown() {
-    if (session != null) {
-      session.close();
-    }
-    if (youTrackDB != null) {
-      youTrackDB.close();
+    try {
+      if (session != null && !session.isClosed()) {
+        session.close();
+      }
+    } finally {
+      if (youTrackDB != null) {
+        try {
+          if (youTrackDB.exists("readBytesEquiv")) {
+            youTrackDB.drop("readBytesEquiv");
+          }
+        } finally {
+          youTrackDB.close();
+        }
+      }
     }
   }
 
@@ -104,6 +113,8 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
     assertTrue(rbcResult.getProperty("boolTrue"));
     assertFalse(rbcResult.getProperty("boolFalse"));
     assertEquals("Hello World", rbcResult.getProperty("stringField"));
+    assertNotNull(rbcResult.getProperty("dateField"));
+    assertEquals(new Date(1617235200000L), rbcResult.getProperty("dateTimeField"));
     session.rollback();
   }
 
@@ -261,6 +272,9 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
 
     var rbcResult = deserializePartialViaReadBytesContainer(serialized, "b");
     assertEquals(2, (int) rbcResult.getProperty("b"));
+    // Unrequested fields must not be populated
+    assertFalse(rbcResult.hasProperty("a"));
+    assertFalse(rbcResult.hasProperty("c"));
     session.rollback();
   }
 
@@ -276,6 +290,8 @@ public class ReadBytesContainerDeserializationEquivalenceTest {
     var rbcResult = deserializePartialViaReadBytesContainer(serialized, "a", "c");
     assertEquals("alpha", rbcResult.getProperty("a"));
     assertEquals("gamma", rbcResult.getProperty("c"));
+    // Unrequested field must not be populated
+    assertFalse(rbcResult.hasProperty("b"));
     session.rollback();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerTest.java
@@ -1,0 +1,432 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ReadBytesContainer} covering all API methods with both heap and direct
+ * ByteBuffer backing.
+ */
+public class ReadBytesContainerTest {
+
+  // --- Constructor tests ---
+
+  @Test
+  public void testByteArrayConstructorWrapsEntireArray() {
+    var data = new byte[] {1, 2, 3, 4, 5};
+    var container = new ReadBytesContainer(data);
+
+    assertEquals(0, container.offset());
+    assertEquals(5, container.remaining());
+  }
+
+  @Test
+  public void testByteArrayWithOffsetConstructor() {
+    var data = new byte[] {1, 2, 3, 4, 5};
+    var container = new ReadBytesContainer(data, 2);
+
+    assertEquals(2, container.offset());
+    assertEquals(3, container.remaining());
+    assertEquals(3, container.getByte());
+  }
+
+  @Test
+  public void testByteBufferConstructorPreservesPosition() {
+    var buf = ByteBuffer.allocate(10);
+    buf.position(3);
+    buf.limit(8);
+    var container = new ReadBytesContainer(buf);
+
+    assertEquals(3, container.offset());
+    assertEquals(5, container.remaining());
+  }
+
+  @Test
+  public void testDirectByteBufferConstructor() {
+    var buf = ByteBuffer.allocateDirect(5);
+    buf.put(new byte[] {10, 20, 30, 40, 50});
+    buf.flip();
+    var container = new ReadBytesContainer(buf);
+
+    assertEquals(0, container.offset());
+    assertEquals(5, container.remaining());
+    assertEquals(10, container.getByte());
+  }
+
+  @Test
+  public void testEmptyBuffer() {
+    var container = new ReadBytesContainer(new byte[0]);
+
+    assertEquals(0, container.offset());
+    assertEquals(0, container.remaining());
+  }
+
+  // --- getByte tests ---
+
+  @Test
+  public void testGetByteAdvancesPosition() {
+    var container = new ReadBytesContainer(new byte[] {0x41, 0x42, 0x43});
+
+    assertEquals(0x41, container.getByte());
+    assertEquals(1, container.offset());
+    assertEquals(0x42, container.getByte());
+    assertEquals(2, container.offset());
+    assertEquals(1, container.remaining());
+  }
+
+  @Test
+  public void testGetByteFromDirectBuffer() {
+    var buf = ByteBuffer.allocateDirect(3);
+    buf.put(new byte[] {(byte) 0xFF, 0x00, 0x7F});
+    buf.flip();
+    var container = new ReadBytesContainer(buf);
+
+    assertEquals((byte) 0xFF, container.getByte());
+    assertEquals(0x00, container.getByte());
+    assertEquals(0x7F, container.getByte());
+  }
+
+  @Test
+  public void testGetByteThrowsOnExhaustedBuffer() {
+    var container = new ReadBytesContainer(new byte[] {1});
+    container.getByte();
+
+    assertThrows(BufferUnderflowException.class, container::getByte);
+  }
+
+  // --- peekByte tests ---
+
+  @Test
+  public void testPeekByteDoesNotAdvancePosition() {
+    var container = new ReadBytesContainer(new byte[] {10, 20, 30, 40});
+
+    assertEquals(20, container.peekByte(1));
+    assertEquals(30, container.peekByte(2));
+    assertEquals(0, container.offset()); // position unchanged
+  }
+
+  @Test
+  public void testPeekByteAtZeroReadsCurrent() {
+    var container = new ReadBytesContainer(new byte[] {42, 99});
+
+    assertEquals(42, container.peekByte(0));
+    assertEquals(0, container.offset());
+  }
+
+  @Test
+  public void testPeekByteFromDirectBuffer() {
+    var buf = ByteBuffer.allocateDirect(3);
+    buf.put(new byte[] {5, 10, 15});
+    buf.flip();
+    var container = new ReadBytesContainer(buf);
+
+    assertEquals(10, container.peekByte(1));
+    assertEquals(0, container.offset());
+  }
+
+  // --- getBytes tests ---
+
+  @Test
+  public void testGetBytesBulkRead() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3, 4, 5});
+    var dst = new byte[3];
+
+    container.getBytes(dst, 0, 3);
+
+    assertArrayEquals(new byte[] {1, 2, 3}, dst);
+    assertEquals(3, container.offset());
+    assertEquals(2, container.remaining());
+  }
+
+  @Test
+  public void testGetBytesWithDestinationOffset() {
+    var container = new ReadBytesContainer(new byte[] {10, 20});
+    var dst = new byte[5];
+
+    container.getBytes(dst, 2, 2);
+
+    assertEquals(0, dst[0]);
+    assertEquals(0, dst[1]);
+    assertEquals(10, dst[2]);
+    assertEquals(20, dst[3]);
+    assertEquals(0, dst[4]);
+  }
+
+  @Test
+  public void testGetBytesFromDirectBuffer() {
+    var buf = ByteBuffer.allocateDirect(4);
+    buf.put(new byte[] {0x0A, 0x0B, 0x0C, 0x0D});
+    buf.flip();
+    var container = new ReadBytesContainer(buf);
+    var dst = new byte[4];
+
+    container.getBytes(dst, 0, 4);
+
+    assertArrayEquals(new byte[] {0x0A, 0x0B, 0x0C, 0x0D}, dst);
+    assertEquals(0, container.remaining());
+  }
+
+  @Test
+  public void testGetBytesZeroLength() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3});
+    var dst = new byte[0];
+
+    container.getBytes(dst, 0, 0);
+
+    assertEquals(0, container.offset());
+  }
+
+  // --- getStringBytes tests ---
+
+  @Test
+  public void testGetStringBytesAscii() {
+    var hello = "Hello".getBytes(StandardCharsets.UTF_8);
+    var container = new ReadBytesContainer(hello);
+
+    assertEquals("Hello", container.getStringBytes(5));
+    assertEquals(5, container.offset());
+  }
+
+  @Test
+  public void testGetStringBytesUtf8() {
+    var utf8 = "Привет".getBytes(StandardCharsets.UTF_8);
+    var container = new ReadBytesContainer(utf8);
+
+    assertEquals("Привет", container.getStringBytes(utf8.length));
+    assertEquals(0, container.remaining());
+  }
+
+  @Test
+  public void testGetStringBytesFromDirectBuffer() {
+    var hello = "World".getBytes(StandardCharsets.UTF_8);
+    var buf = ByteBuffer.allocateDirect(hello.length);
+    buf.put(hello);
+    buf.flip();
+    var container = new ReadBytesContainer(buf);
+
+    assertEquals("World", container.getStringBytes(5));
+  }
+
+  @Test
+  public void testGetStringBytesEmpty() {
+    var container = new ReadBytesContainer(new byte[] {1, 2});
+
+    // Zero-length string read should return empty string
+    assertEquals("", container.getStringBytes(0));
+    assertEquals(0, container.offset());
+  }
+
+  // --- remaining tests ---
+
+  @Test
+  public void testRemainingDecreasesAsRead() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3, 4, 5});
+
+    assertEquals(5, container.remaining());
+    container.getByte();
+    assertEquals(4, container.remaining());
+    container.skip(2);
+    assertEquals(2, container.remaining());
+    container.getByte();
+    container.getByte();
+    assertEquals(0, container.remaining());
+  }
+
+  // --- offset tests ---
+
+  @Test
+  public void testOffsetTracksPosition() {
+    var container = new ReadBytesContainer(new byte[] {0, 0, 0, 0, 0});
+
+    assertEquals(0, container.offset());
+    container.getByte();
+    assertEquals(1, container.offset());
+    container.skip(3);
+    assertEquals(4, container.offset());
+  }
+
+  // --- skip tests ---
+
+  @Test
+  public void testSkipAdvancesPosition() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3, 4, 5});
+
+    container.skip(3);
+
+    assertEquals(3, container.offset());
+    assertEquals(4, container.getByte());
+  }
+
+  @Test
+  public void testSkipZero() {
+    var container = new ReadBytesContainer(new byte[] {1, 2});
+
+    container.skip(0);
+
+    assertEquals(0, container.offset());
+  }
+
+  // --- setOffset tests ---
+
+  @Test
+  public void testSetOffsetJumpsToAbsolutePosition() {
+    var container = new ReadBytesContainer(new byte[] {10, 20, 30, 40, 50});
+
+    container.setOffset(3);
+
+    assertEquals(3, container.offset());
+    assertEquals(40, container.getByte());
+    assertEquals(1, container.remaining()); // after reading 1 byte at position 3 -> position 4
+  }
+
+  @Test
+  public void testSetOffsetCanGoBackward() {
+    var container = new ReadBytesContainer(new byte[] {10, 20, 30});
+
+    container.skip(2);
+    assertEquals(2, container.offset());
+
+    container.setOffset(0);
+    assertEquals(0, container.offset());
+    assertEquals(10, container.getByte());
+  }
+
+  // --- slice tests ---
+
+  @Test
+  public void testSliceCreatesIndependentSubContainer() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3, 4, 5, 6});
+
+    container.skip(1); // position at 1
+    var sliced = container.slice(3); // slice bytes [2, 3, 4]
+
+    // Parent position advanced past the sliced region
+    assertEquals(4, container.offset());
+    assertEquals(2, container.remaining());
+
+    // Sliced container starts at 0 and has 3 bytes
+    assertEquals(0, sliced.offset());
+    assertEquals(3, sliced.remaining());
+    assertEquals(2, sliced.getByte());
+    assertEquals(3, sliced.getByte());
+    assertEquals(4, sliced.getByte());
+  }
+
+  @Test
+  public void testSliceFromDirectBuffer() {
+    var buf = ByteBuffer.allocateDirect(5);
+    buf.put(new byte[] {10, 20, 30, 40, 50});
+    buf.flip();
+    var container = new ReadBytesContainer(buf);
+
+    container.skip(2);
+    var sliced = container.slice(2);
+
+    assertEquals(4, container.offset());
+    assertEquals(0, sliced.offset());
+    assertEquals(2, sliced.remaining());
+    assertEquals(30, sliced.getByte());
+    assertEquals(40, sliced.getByte());
+  }
+
+  // --- Mixed operations sequence ---
+
+  @Test
+  public void testMixedOperationsSequence() {
+    // Simulate a realistic deserialization sequence:
+    // [varint_byte, varint_byte, string_len(3), 'a', 'b', 'c', skip_2, data_byte]
+    var data = new byte[] {0x05, 0x0A, 3, 'a', 'b', 'c', 99, 98, 42};
+    var container = new ReadBytesContainer(data);
+
+    // Read two "varint" bytes
+    assertEquals(0x05, container.getByte());
+    assertEquals(0x0A, container.getByte());
+    assertEquals(2, container.offset());
+
+    // Read string length and string
+    int len = container.getByte() & 0xFF;
+    assertEquals(3, len);
+    assertEquals("abc", container.getStringBytes(len));
+    assertEquals(6, container.offset());
+
+    // Skip 2 bytes
+    container.skip(2);
+    assertEquals(8, container.offset());
+
+    // Read final byte
+    assertEquals(42, container.getByte());
+    assertEquals(0, container.remaining());
+  }
+
+  @Test
+  public void testMixedOperationsWithPeekAndSetOffset() {
+    var data = new byte[] {10, 20, 30, 40, 50};
+    var container = new ReadBytesContainer(data);
+
+    // Peek ahead without advancing
+    assertEquals(30, container.peekByte(2));
+    assertEquals(0, container.offset());
+
+    // Read one byte
+    assertEquals(10, container.getByte());
+
+    // Jump to position 3
+    container.setOffset(3);
+    assertEquals(40, container.getByte());
+
+    // Jump back to position 1
+    container.setOffset(1);
+    assertEquals(20, container.getByte());
+  }
+
+  // --- Single byte buffer ---
+
+  @Test
+  public void testSingleByteBuffer() {
+    var container = new ReadBytesContainer(new byte[] {0x7F});
+
+    assertEquals(1, container.remaining());
+    assertEquals(0x7F, container.getByte());
+    assertEquals(0, container.remaining());
+  }
+
+  // --- Exact size read ---
+
+  @Test
+  public void testExactSizeGetBytes() {
+    var data = new byte[] {1, 2, 3};
+    var container = new ReadBytesContainer(data);
+    var dst = new byte[3];
+
+    container.getBytes(dst, 0, 3);
+
+    assertArrayEquals(data, dst);
+    assertEquals(0, container.remaining());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/ReadBytesContainerTest.java
@@ -429,4 +429,119 @@ public class ReadBytesContainerTest {
     assertArrayEquals(data, dst);
     assertEquals(0, container.remaining());
   }
+
+  // --- Error / boundary tests ---
+
+  @Test
+  public void testPeekByteThrowsOnOutOfBounds() {
+    // peekByte at an offset beyond the buffer limit should throw
+    var container = new ReadBytesContainer(new byte[] {1, 2});
+    assertThrows(IndexOutOfBoundsException.class, () -> container.peekByte(2));
+  }
+
+  @Test
+  public void testGetBytesThrowsOnUnderflow() {
+    // Requesting more bytes than available should throw BufferUnderflowException
+    var container = new ReadBytesContainer(new byte[] {1, 2});
+    var dst = new byte[5];
+    assertThrows(BufferUnderflowException.class, () -> container.getBytes(dst, 0, 5));
+  }
+
+  @Test
+  public void testGetStringBytesThrowsOnUnderflow() {
+    // getStringBytes with length > remaining should throw before allocating
+    var container = new ReadBytesContainer(new byte[] {1, 2});
+    assertThrows(BufferUnderflowException.class, () -> container.getStringBytes(10));
+  }
+
+  @Test
+  public void testGetStringBytesThrowsOnUnderflowDirectBuffer() {
+    // Same test with direct ByteBuffer — ensures guard fires before allocation
+    var buf = ByteBuffer.allocateDirect(2);
+    buf.put(new byte[] {1, 2});
+    buf.flip();
+    var container = new ReadBytesContainer(buf);
+    assertThrows(BufferUnderflowException.class, () -> container.getStringBytes(10));
+  }
+
+  @Test
+  public void testSkipPastEndThrows() {
+    // Skipping past the buffer limit should throw
+    var container = new ReadBytesContainer(new byte[] {1, 2});
+    assertThrows(IllegalArgumentException.class, () -> container.skip(5));
+  }
+
+  @Test
+  public void testSetOffsetPastLimitThrows() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3});
+    assertThrows(IllegalArgumentException.class, () -> container.setOffset(10));
+  }
+
+  @Test
+  public void testSetOffsetNegativeThrows() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3});
+    assertThrows(IllegalArgumentException.class, () -> container.setOffset(-1));
+  }
+
+  @Test
+  public void testSlicePastRemainingThrows() {
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3});
+    assertThrows(IndexOutOfBoundsException.class, () -> container.slice(5));
+  }
+
+  @Test
+  public void testSliceIsIndependentOfParentPositionChanges() {
+    // Verify slice and parent have truly independent positions
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3, 4, 5, 6});
+    container.skip(1);
+    var sliced = container.slice(3); // slices bytes [2, 3, 4]
+
+    // Mutate parent position
+    container.getByte(); // reads byte at position 4 (value 5)
+
+    // Slice should still read from its own position 0, unaffected by parent
+    assertEquals(2, sliced.getByte());
+    assertEquals(3, sliced.getByte());
+  }
+
+  @Test
+  public void testGetStringBytesWithHeapBufferOffset() {
+    // Verify getStringBytes works correctly when the heap buffer has a non-zero arrayOffset
+    var data = new byte[] {0, 0, 'H', 'i', '!'};
+    var container = new ReadBytesContainer(data, 2);
+
+    assertEquals("Hi!", container.getStringBytes(3));
+    assertEquals(0, container.remaining());
+  }
+
+  @Test
+  public void testSliceZeroLength() {
+    // Zero-length slice should produce an empty sub-container
+    var container = new ReadBytesContainer(new byte[] {1, 2, 3});
+    container.skip(1);
+    var sliced = container.slice(0);
+
+    assertEquals(0, sliced.remaining());
+    assertEquals(1, container.offset());
+  }
+
+  @Test
+  public void testGetInternedStringWithNullCache() {
+    // When cache is null, getInternedString should return a plain String
+    var data = "hello".getBytes(StandardCharsets.UTF_8);
+    var container = new ReadBytesContainer(data);
+
+    var result = container.getInternedString(null, 5);
+
+    assertEquals("hello", result);
+    assertEquals(0, container.remaining());
+  }
+
+  @Test
+  public void testGetInternedStringThrowsOnUnderflow() {
+    // getInternedString with length > remaining should throw before allocating
+    var container = new ReadBytesContainer(new byte[] {1, 2});
+    assertThrows(BufferUnderflowException.class,
+        () -> container.getInternedString(null, 10));
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1GuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1GuardTest.java
@@ -89,20 +89,9 @@ public class RecordSerializerBinaryV1GuardTest {
   }
 
   // --- readLinkSet guards ---
-
-  @Test
-  public void readLinkSetThrowsOnOversizedBagSize() {
-    // configByte (1 byte, embedded=true) + oversized linkBagSize varint
-    var wc = new BytesContainer();
-    var pos = wc.alloc(1);
-    wc.bytes[pos] = 1; // embedded flag set
-    VarIntSerializer.write(wc, Integer.MAX_VALUE);
-    var bytes = wc.fitBytes();
-    var rbc = new ReadBytesContainer(bytes);
-    assertThrows(
-        CorruptedRecordException.class,
-        () -> RecordSerializerBinaryV1.readLinkSet(null, rbc));
-  }
+  // linkBagSize is an element count, not a byte-consumption value. For BTree-based
+  // bags the size is just metadata (elements live in the BTree, not in the buffer).
+  // Only negative values are guarded; oversized counts are caught by downstream reads.
 
   @Test
   public void readLinkSetThrowsOnNegativeBagSize() {
@@ -118,19 +107,6 @@ public class RecordSerializerBinaryV1GuardTest {
   }
 
   // --- readLinkBag guards ---
-
-  @Test
-  public void readLinkBagThrowsOnOversizedBagSize() {
-    var wc = new BytesContainer();
-    var pos = wc.alloc(1);
-    wc.bytes[pos] = 1; // embedded flag
-    VarIntSerializer.write(wc, Integer.MAX_VALUE);
-    var bytes = wc.fitBytes();
-    var rbc = new ReadBytesContainer(bytes);
-    assertThrows(
-        CorruptedRecordException.class,
-        () -> RecordSerializerBinaryV1.readLinkBag(null, rbc));
-  }
 
   @Test
   public void readLinkBagThrowsOnNegativeBagSize() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1GuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/RecordSerializerBinaryV1GuardTest.java
@@ -1,0 +1,223 @@
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertThrows;
+
+import com.jetbrains.youtrackdb.internal.core.exception.CorruptedRecordException;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import org.junit.Test;
+
+/**
+ * Tests that RecordSerializerBinaryV1 ReadBytesContainer overloads throw {@link
+ * CorruptedRecordException} when stream-driven sizes exceed remaining buffer capacity. Covers
+ * collection readers, value readers, and link bag readers.
+ */
+public class RecordSerializerBinaryV1GuardTest {
+
+  private final RecordSerializerBinaryV1 serializer = new RecordSerializerBinaryV1();
+
+  // --- readEmbeddedSet guards ---
+
+  @Test
+  public void readEmbeddedSetThrowsOnOversizedItems() {
+    // items varint = 1_000_000, then 1 byte for type — far more items than bytes
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, 1_000_000);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.readEmbeddedSet(null, rbc, null));
+  }
+
+  @Test
+  public void readEmbeddedSetThrowsOnNegativeItems() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, -1);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.readEmbeddedSet(null, rbc, null));
+  }
+
+  // --- readEmbeddedList guards ---
+
+  @Test
+  public void readEmbeddedListThrowsOnOversizedItems() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, 1_000_000);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.readEmbeddedList(null, rbc, null));
+  }
+
+  @Test
+  public void readEmbeddedListThrowsOnNegativeItems() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, -1);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.readEmbeddedList(null, rbc, null));
+  }
+
+  // --- readEmbeddedMap guards ---
+
+  @Test
+  public void readEmbeddedMapThrowsOnOversizedElements() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, 1_000_000);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.readEmbeddedMap(null, rbc, null));
+  }
+
+  @Test
+  public void readEmbeddedMapThrowsOnNegativeSize() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, -1);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.readEmbeddedMap(null, rbc, null));
+  }
+
+  // --- readLinkSet guards ---
+
+  @Test
+  public void readLinkSetThrowsOnOversizedBagSize() {
+    // configByte (1 byte, embedded=true) + oversized linkBagSize varint
+    var wc = new BytesContainer();
+    var pos = wc.alloc(1);
+    wc.bytes[pos] = 1; // embedded flag set
+    VarIntSerializer.write(wc, Integer.MAX_VALUE);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> RecordSerializerBinaryV1.readLinkSet(null, rbc));
+  }
+
+  @Test
+  public void readLinkSetThrowsOnNegativeBagSize() {
+    var wc = new BytesContainer();
+    var pos = wc.alloc(1);
+    wc.bytes[pos] = 1;
+    VarIntSerializer.write(wc, -1);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> RecordSerializerBinaryV1.readLinkSet(null, rbc));
+  }
+
+  // --- readLinkBag guards ---
+
+  @Test
+  public void readLinkBagThrowsOnOversizedBagSize() {
+    var wc = new BytesContainer();
+    var pos = wc.alloc(1);
+    wc.bytes[pos] = 1; // embedded flag
+    VarIntSerializer.write(wc, Integer.MAX_VALUE);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> RecordSerializerBinaryV1.readLinkBag(null, rbc));
+  }
+
+  @Test
+  public void readLinkBagThrowsOnNegativeBagSize() {
+    var wc = new BytesContainer();
+    var pos = wc.alloc(1);
+    wc.bytes[pos] = 1;
+    VarIntSerializer.write(wc, -1);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> RecordSerializerBinaryV1.readLinkBag(null, rbc));
+  }
+
+  // --- getPositionsFromEmbeddedMap guards ---
+
+  @Test
+  public void getPositionsFromEmbeddedMapThrowsOnOversizedCount() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, 1_000_000);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.getPositionsFromEmbeddedMap(null, rbc, null));
+  }
+
+  @Test
+  public void getPositionsFromEmbeddedMapThrowsOnNegativeCount() {
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, -1);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.getPositionsFromEmbeddedMap(null, rbc, null));
+  }
+
+  // --- deserializeValue BINARY justRunThrough guard ---
+
+  @Test
+  public void deserializeValueBinaryJustRunThroughThrowsOnOversizedLength() {
+    // BINARY justRunThrough: reads length varint then skips — guard catches oversized
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, 1_000_000); // oversized length
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.deserializeValue(
+            null, rbc, PropertyTypeInternal.BINARY, null, true, null));
+  }
+
+  // --- deserializeValue STRING justRunThrough guard ---
+
+  @Test
+  public void deserializeValueStringJustRunThroughThrowsOnOversizedLength() {
+    // STRING justRunThrough: reads length varint then skips — guard catches oversized
+    var wc = new BytesContainer();
+    VarIntSerializer.write(wc, 1_000_000); // oversized length
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.deserializeValue(
+            null, rbc, PropertyTypeInternal.STRING, null, true, null));
+  }
+
+  // --- deserializeValue DECIMAL guard ---
+
+  @Test
+  public void deserializeValueDecimalThrowsOnOversizedUnscaledLen() {
+    // DECIMAL layout: int(scale) + int(unscaledLen) — craft with huge unscaledLen
+    var wc = new BytesContainer();
+    // Write scale (4 bytes)
+    var pos = wc.alloc(4);
+    com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer
+        .serializeLiteral(0, wc.bytes, pos);
+    // Write unscaledLen = Integer.MAX_VALUE (4 bytes, big-endian)
+    pos = wc.alloc(4);
+    com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer
+        .serializeLiteral(Integer.MAX_VALUE, wc.bytes, pos);
+    var bytes = wc.fitBytes();
+    var rbc = new ReadBytesContainer(bytes);
+    assertThrows(
+        CorruptedRecordException.class,
+        () -> serializer.deserializeValue(
+            null, rbc, PropertyTypeInternal.DECIMAL, null, false, null));
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntAndHelperClassesReadBytesContainerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntAndHelperClassesReadBytesContainerTest.java
@@ -96,7 +96,7 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
     var rbc = new ReadBytesContainer(bytes);
 
     assertEquals(12345, VarIntSerializer.readAsInteger(rbc));
-    assertEquals(VarIntSerializer.readAsInteger(bc), 12345);
+    assertEquals(12345, VarIntSerializer.readAsInteger(bc));
   }
 
   @Test
@@ -109,7 +109,7 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
     var rbc = new ReadBytesContainer(bytes);
 
     assertEquals(9876543210L, VarIntSerializer.readAsLong(rbc));
-    assertEquals(VarIntSerializer.readAsLong(bc), 9876543210L);
+    assertEquals(9876543210L, VarIntSerializer.readAsLong(bc));
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntAndHelperClassesReadBytesContainerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntAndHelperClassesReadBytesContainerTest.java
@@ -50,6 +50,12 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
   }
 
   @Test
+  public void testReadUnsignedVarLongZero() {
+    // Zero is a single-byte boundary encoding (0x00)
+    assertVarIntRoundTrip(0L);
+  }
+
+  @Test
   public void testReadUnsignedVarLongLargeValue() {
     // Large value requiring many bytes
     assertVarIntRoundTrip(Long.MAX_VALUE / 2);
@@ -89,8 +95,8 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
     var bc = new BytesContainer(bytes);
     var rbc = new ReadBytesContainer(bytes);
 
-    assertEquals(
-        VarIntSerializer.readAsInteger(bc), VarIntSerializer.readAsInteger(rbc));
+    assertEquals(12345, VarIntSerializer.readAsInteger(rbc));
+    assertEquals(VarIntSerializer.readAsInteger(bc), 12345);
   }
 
   @Test
@@ -102,7 +108,8 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
     var bc = new BytesContainer(bytes);
     var rbc = new ReadBytesContainer(bytes);
 
-    assertEquals(VarIntSerializer.readAsLong(bc), VarIntSerializer.readAsLong(rbc));
+    assertEquals(9876543210L, VarIntSerializer.readAsLong(rbc));
+    assertEquals(VarIntSerializer.readAsLong(bc), 9876543210L);
   }
 
   @Test
@@ -191,6 +198,24 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
     var rbc = new ReadBytesContainer(bytes);
 
     assertEquals(HelperClasses.readString(bc), HelperClasses.readString(rbc));
+  }
+
+  @Test
+  public void testReadStringUtf8FourByteChars() {
+    // 4-byte UTF-8 characters (emoji) to verify byte-length vs char-length handling
+    var emoji = "\uD83D\uDE00\uD83D\uDE01\uD83D\uDE02"; // 3 emoji, 12 UTF-8 bytes
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeString(writeContainer, emoji);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    var bcResult = HelperClasses.readString(bc);
+    var rbcResult = HelperClasses.readString(rbc);
+
+    assertEquals(emoji, rbcResult);
+    assertEquals(bcResult, rbcResult);
   }
 
   @Test
@@ -368,9 +393,12 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
     var bc = new BytesContainer(bytes);
     var rbc = new ReadBytesContainer(bytes);
 
-    assertEquals(
-        VarIntSerializer.readUnsignedVarLong(bc),
-        VarIntSerializer.readUnsignedVarLong(rbc));
+    var bcResult = VarIntSerializer.readUnsignedVarLong(bc);
+    var rbcResult = VarIntSerializer.readUnsignedVarLong(rbc);
+
+    // Verify both implementations agree and produce the original value
+    assertEquals(value, rbcResult);
+    assertEquals(bcResult, rbcResult);
   }
 
   private void assertSignedVarIntRoundTrip(long value) {
@@ -381,8 +409,11 @@ public class VarIntAndHelperClassesReadBytesContainerTest {
     var bc = new BytesContainer(bytes);
     var rbc = new ReadBytesContainer(bytes);
 
-    assertEquals(
-        VarIntSerializer.readSignedVarLong(bc),
-        VarIntSerializer.readSignedVarLong(rbc));
+    var bcResult = VarIntSerializer.readSignedVarLong(bc);
+    var rbcResult = VarIntSerializer.readSignedVarLong(rbc);
+
+    // Verify both implementations agree and produce the original value
+    assertEquals(value, rbcResult);
+    assertEquals(bcResult, rbcResult);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntAndHelperClassesReadBytesContainerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/serialization/serializer/record/binary/VarIntAndHelperClassesReadBytesContainerTest.java
@@ -1,0 +1,388 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import org.junit.Test;
+
+/**
+ * Validates that VarIntSerializer and HelperClasses ReadBytesContainer overloads produce identical
+ * results to the BytesContainer versions. Each test serializes values using the existing write
+ * path (BytesContainer), then deserializes with both BytesContainer and ReadBytesContainer and
+ * compares results.
+ */
+public class VarIntAndHelperClassesReadBytesContainerTest {
+
+  // --- VarIntSerializer tests ---
+
+  @Test
+  public void testReadUnsignedVarLongSingleByte() {
+    // Value 5 encodes in 1 byte
+    assertVarIntRoundTrip(5L);
+  }
+
+  @Test
+  public void testReadUnsignedVarLongMultiByte() {
+    // Value 300 encodes in 2 bytes
+    assertVarIntRoundTrip(300L);
+  }
+
+  @Test
+  public void testReadUnsignedVarLongLargeValue() {
+    // Large value requiring many bytes
+    assertVarIntRoundTrip(Long.MAX_VALUE / 2);
+  }
+
+  @Test
+  public void testReadSignedVarLongPositive() {
+    assertSignedVarIntRoundTrip(42);
+  }
+
+  @Test
+  public void testReadSignedVarLongNegative() {
+    assertSignedVarIntRoundTrip(-100);
+  }
+
+  @Test
+  public void testReadSignedVarLongZero() {
+    assertSignedVarIntRoundTrip(0);
+  }
+
+  @Test
+  public void testReadSignedVarLongMaxValue() {
+    assertSignedVarIntRoundTrip(Long.MAX_VALUE);
+  }
+
+  @Test
+  public void testReadSignedVarLongMinValue() {
+    assertSignedVarIntRoundTrip(Long.MIN_VALUE);
+  }
+
+  @Test
+  public void testReadAsInteger() {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, 12345);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(
+        VarIntSerializer.readAsInteger(bc), VarIntSerializer.readAsInteger(rbc));
+  }
+
+  @Test
+  public void testReadAsLong() {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, 9876543210L);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(VarIntSerializer.readAsLong(bc), VarIntSerializer.readAsLong(rbc));
+  }
+
+  @Test
+  public void testReadAsShort() {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, (short) 1234);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(
+        VarIntSerializer.readAsShort(bc), VarIntSerializer.readAsShort(rbc));
+  }
+
+  @Test
+  public void testReadAsByte() {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, (byte) 42);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(VarIntSerializer.readAsByte(bc), VarIntSerializer.readAsByte(rbc));
+  }
+
+  // --- HelperClasses tests ---
+
+  @Test
+  public void testReadBinary() {
+    var data = new byte[] {10, 20, 30, 40, 50};
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeBinary(writeContainer, data);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertArrayEquals(HelperClasses.readBinary(bc), HelperClasses.readBinary(rbc));
+  }
+
+  @Test
+  public void testReadBinaryEmpty() {
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeBinary(writeContainer, new byte[0]);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertArrayEquals(HelperClasses.readBinary(bc), HelperClasses.readBinary(rbc));
+  }
+
+  @Test
+  public void testReadString() {
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeString(writeContainer, "Hello World");
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readString(bc), HelperClasses.readString(rbc));
+  }
+
+  @Test
+  public void testReadStringEmpty() {
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeString(writeContainer, "");
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readString(bc), HelperClasses.readString(rbc));
+  }
+
+  @Test
+  public void testReadStringUtf8() {
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeString(writeContainer, "Привет мир");
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readString(bc), HelperClasses.readString(rbc));
+  }
+
+  @Test
+  public void testReadByte() {
+    var bytes = new byte[] {42};
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readByte(bc), HelperClasses.readByte(rbc));
+  }
+
+  @Test
+  public void testReadInteger() {
+    var writeContainer = new BytesContainer();
+    var pos = writeContainer.alloc(4);
+    com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer
+        .serializeLiteral(12345, writeContainer.bytes, pos);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readInteger(bc), HelperClasses.readInteger(rbc));
+  }
+
+  @Test
+  public void testReadLong() {
+    var writeContainer = new BytesContainer();
+    var pos = writeContainer.alloc(8);
+    com.jetbrains.youtrackdb.internal.common.serialization.types.LongSerializer
+        .serializeLiteral(9876543210L, writeContainer.bytes, pos);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readLong(bc), HelperClasses.readLong(rbc));
+  }
+
+  @Test
+  public void testReadType() {
+    // Test with a valid type (STRING has id 7)
+    var typeId = (byte) PropertyTypeInternal.STRING.getId();
+    var bytes = new byte[] {typeId};
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readType(bc), HelperClasses.readType(rbc));
+  }
+
+  @Test
+  public void testReadTypeNull() {
+    // -1 means null type
+    var bytes = new byte[] {-1};
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertNull(HelperClasses.readType(bc));
+    assertNull(HelperClasses.readType(rbc));
+  }
+
+  @Test
+  public void testReadOTypeRunThrough() {
+    var bytes = new byte[] {7}; // STRING type
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    // justRunThrough=true should skip the byte and return null for both
+    assertNull(HelperClasses.readOType(bc, true));
+    assertNull(HelperClasses.readOType(rbc, true));
+
+    // Both should have advanced by 1 byte
+    assertEquals(1, bc.offset);
+    assertEquals(1, rbc.offset());
+  }
+
+  @Test
+  public void testReadOType() {
+    var typeId = (byte) PropertyTypeInternal.INTEGER.getId();
+    var bytes = new byte[] {typeId};
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readOType(bc, false), HelperClasses.readOType(rbc, false));
+  }
+
+  @Test
+  public void testReadOptimizedLink() {
+    // Write a link: clusterId=5, clusterPos=100
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, 5);
+    VarIntSerializer.write(writeContainer, 100);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    var bcResult = HelperClasses.readOptimizedLink(bc, false);
+    var rbcResult = HelperClasses.readOptimizedLink(rbc, false);
+
+    assertEquals(bcResult, rbcResult);
+  }
+
+  @Test
+  public void testReadOptimizedLinkRunThrough() {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, 5);
+    VarIntSerializer.write(writeContainer, 100);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertNull(HelperClasses.readOptimizedLink(bc, true));
+    assertNull(HelperClasses.readOptimizedLink(rbc, true));
+
+    // Both should have consumed the same bytes
+    assertEquals(bc.offset, rbc.offset());
+  }
+
+  // --- Multiple values in sequence ---
+
+  @Test
+  public void testMultipleVarIntsInSequence() {
+    // Write multiple values, then read them all back with both container types
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, 1);
+    VarIntSerializer.write(writeContainer, -42);
+    VarIntSerializer.write(writeContainer, 300);
+    VarIntSerializer.write(writeContainer, 0);
+    VarIntSerializer.write(writeContainer, Long.MAX_VALUE);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(VarIntSerializer.readAsInteger(bc), VarIntSerializer.readAsInteger(rbc));
+    assertEquals(VarIntSerializer.readAsInteger(bc), VarIntSerializer.readAsInteger(rbc));
+    assertEquals(VarIntSerializer.readAsInteger(bc), VarIntSerializer.readAsInteger(rbc));
+    assertEquals(VarIntSerializer.readAsInteger(bc), VarIntSerializer.readAsInteger(rbc));
+    assertEquals(VarIntSerializer.readAsLong(bc), VarIntSerializer.readAsLong(rbc));
+
+    // Both should have consumed all bytes
+    assertEquals(bc.offset, rbc.offset());
+  }
+
+  @Test
+  public void testMixedStringAndBinaryInSequence() {
+    var writeContainer = new BytesContainer();
+    HelperClasses.writeString(writeContainer, "first");
+    HelperClasses.writeBinary(writeContainer, new byte[] {1, 2, 3});
+    HelperClasses.writeString(writeContainer, "second");
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(HelperClasses.readString(bc), HelperClasses.readString(rbc));
+    assertArrayEquals(HelperClasses.readBinary(bc), HelperClasses.readBinary(rbc));
+    assertEquals(HelperClasses.readString(bc), HelperClasses.readString(rbc));
+  }
+
+  // --- Helper methods ---
+
+  private void assertVarIntRoundTrip(long value) {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.writeUnsignedVarLong(value, writeContainer);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(
+        VarIntSerializer.readUnsignedVarLong(bc),
+        VarIntSerializer.readUnsignedVarLong(rbc));
+  }
+
+  private void assertSignedVarIntRoundTrip(long value) {
+    var writeContainer = new BytesContainer();
+    VarIntSerializer.write(writeContainer, value);
+    var bytes = writeContainer.fitBytes();
+
+    var bc = new BytesContainer(bytes);
+    var rbc = new ReadBytesContainer(bytes);
+
+    assertEquals(
+        VarIntSerializer.readSignedVarLong(bc),
+        VarIntSerializer.readSignedVarLong(rbc));
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
@@ -1,0 +1,195 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ *
+ */
+package com.jetbrains.youtrackdb.internal.core.storage;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
+import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
+import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
+import com.jetbrains.youtrackdb.internal.common.directmemory.Pointer;
+import java.nio.ByteBuffer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the StorageReadResult sealed interface hierarchy: RawBuffer,
+ * RawPageBuffer, and their common contract.
+ */
+public class StorageReadResultTest {
+
+  private DirectMemoryAllocator allocator;
+  private Pointer pointer;
+  private PageFrame pageFrame;
+
+  @Before
+  public void setUp() {
+    allocator = new DirectMemoryAllocator();
+    pointer = allocator.allocate(4096, true, Intention.TEST);
+    pageFrame = new PageFrame(pointer);
+  }
+
+  @After
+  public void tearDown() {
+    allocator.deallocate(pointer);
+  }
+
+  // --- RawBuffer satisfies StorageReadResult contract ---
+
+  @Test
+  public void testRawBufferIsStorageReadResult() {
+    // Verifies that RawBuffer implements StorageReadResult and that
+    // recordVersion() delegates to version().
+    var rawBuffer = new RawBuffer(new byte[] {1, 2, 3}, 42L, (byte) 'd');
+
+    assertTrue(rawBuffer instanceof StorageReadResult);
+
+    StorageReadResult result = rawBuffer;
+    assertEquals(42L, result.recordVersion());
+    assertEquals((byte) 'd', result.recordType());
+  }
+
+  @Test
+  public void testRawBufferRecordVersionDelegatesToVersion() {
+    // Ensures recordVersion() and version() return the same value.
+    var rawBuffer = new RawBuffer(new byte[0], 99L, (byte) 'b');
+    assertEquals(rawBuffer.version(), rawBuffer.recordVersion());
+  }
+
+  // --- RawPageBuffer satisfies StorageReadResult contract ---
+
+  @Test
+  public void testRawPageBufferIsStorageReadResult() {
+    // Verifies that RawPageBuffer implements StorageReadResult with
+    // correct version and type accessors.
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(pageFrame, stamp, 100, 50, 7L, (byte) 'd');
+
+    assertTrue(pageBuffer instanceof StorageReadResult);
+
+    StorageReadResult result = pageBuffer;
+    assertEquals(7L, result.recordVersion());
+    assertEquals((byte) 'd', result.recordType());
+  }
+
+  // --- RawPageBuffer.sliceContent() ---
+
+  @Test
+  public void testSliceContentReturnsCorrectRange() {
+    // Writes known data into the page buffer at a specific offset, then
+    // verifies that sliceContent() returns a ByteBuffer covering exactly
+    // those bytes.
+    ByteBuffer buffer = pageFrame.getBuffer();
+    byte[] testData = {10, 20, 30, 40, 50};
+    int contentOffset = 200;
+    for (int i = 0; i < testData.length; i++) {
+      buffer.put(contentOffset + i, testData[i]);
+    }
+
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer =
+        new RawPageBuffer(pageFrame, stamp, contentOffset, testData.length, 1L, (byte) 'd');
+
+    ByteBuffer slice = pageBuffer.sliceContent();
+    assertNotNull(slice);
+    assertEquals(testData.length, slice.capacity());
+    assertEquals(0, slice.position());
+    assertEquals(testData.length, slice.limit());
+
+    byte[] actual = new byte[testData.length];
+    slice.get(actual);
+    assertArrayEquals(testData, actual);
+  }
+
+  @Test
+  public void testSliceContentWithZeroLength() {
+    // Verifies that sliceContent works correctly for an empty record content.
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(pageFrame, stamp, 0, 0, 1L, (byte) 'd');
+
+    ByteBuffer slice = pageBuffer.sliceContent();
+    assertEquals(0, slice.capacity());
+  }
+
+  @Test
+  public void testSliceContentSharesNativeMemory() {
+    // Verifies that the sliced ByteBuffer reflects changes made to the
+    // underlying page buffer — proving zero-copy semantics.
+    ByteBuffer buffer = pageFrame.getBuffer();
+    int contentOffset = 100;
+    buffer.put(contentOffset, (byte) 0xAA);
+
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(pageFrame, stamp, contentOffset, 1, 1L, (byte) 'd');
+    ByteBuffer slice = pageBuffer.sliceContent();
+    assertEquals((byte) 0xAA, slice.get(0));
+
+    // Modify the underlying page buffer and verify the slice sees the change.
+    buffer.put(contentOffset, (byte) 0xBB);
+    assertEquals((byte) 0xBB, slice.get(0));
+  }
+
+  // --- Sealed interface exhaustiveness ---
+
+  @Test
+  public void testPatternMatchExhaustiveness() {
+    // Verifies that pattern matching on StorageReadResult covers both variants,
+    // ensuring the sealed interface is exhaustive.
+    StorageReadResult rawResult = new RawBuffer(new byte[] {1}, 1L, (byte) 'd');
+    long stamp = pageFrame.tryOptimisticRead();
+    StorageReadResult pageResult =
+        new RawPageBuffer(pageFrame, stamp, 0, 1, 2L, (byte) 'b');
+
+    // Pattern match on RawBuffer
+    String rawMatch = switch (rawResult) {
+      case RawBuffer rb -> "buffer:" + rb.buffer().length;
+      case RawPageBuffer rpb -> "page:" + rpb.contentLength();
+    };
+    assertEquals("buffer:1", rawMatch);
+
+    // Pattern match on RawPageBuffer
+    String pageMatch = switch (pageResult) {
+      case RawBuffer rb -> "buffer:" + rb.buffer().length;
+      case RawPageBuffer rpb -> "page:" + rpb.contentLength();
+    };
+    assertEquals("page:1", pageMatch);
+  }
+
+  // --- RawPageBuffer field accessors ---
+
+  @Test
+  public void testRawPageBufferFieldAccessors() {
+    // Verifies all record component accessors return the values passed
+    // to the constructor.
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(pageFrame, stamp, 256, 128, 42L, (byte) 'v');
+
+    assertEquals(pageFrame, pageBuffer.pageFrame());
+    assertEquals(stamp, pageBuffer.stamp());
+    assertEquals(256, pageBuffer.contentOffset());
+    assertEquals(128, pageBuffer.contentLength());
+    assertEquals(42L, pageBuffer.recordVersion());
+    assertEquals((byte) 'v', pageBuffer.recordType());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
@@ -210,4 +210,67 @@ public class StorageReadResultTest {
     assertEquals(42L, pageBuffer.recordVersion());
     assertEquals((byte) 'v', pageBuffer.recordType());
   }
+
+  // --- RawPageBuffer runtime bounds validation ---
+
+  @Test
+  public void testRawPageBufferRejectsNullPageFrame() {
+    // Validates that the constructor throws IllegalArgumentException
+    // (not AssertionError) when pageFrame is null.
+    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+        () -> new RawPageBuffer(null, 0L, 0, 0, 1L, (byte) 'd'));
+    assertEquals("PageFrame must not be null", ex.getMessage());
+  }
+
+  @Test
+  public void testRawPageBufferRejectsNegativeContentOffset() {
+    // Validates runtime rejection of negative contentOffset.
+    long stamp = pageFrame.tryOptimisticRead();
+    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+        () -> new RawPageBuffer(pageFrame, stamp, -1, 10, 1L, (byte) 'd'));
+    assertEquals("contentOffset must be non-negative: -1", ex.getMessage());
+  }
+
+  @Test
+  public void testRawPageBufferRejectsNegativeContentLength() {
+    // Validates runtime rejection of negative contentLength.
+    long stamp = pageFrame.tryOptimisticRead();
+    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+        () -> new RawPageBuffer(pageFrame, stamp, 0, -1, 1L, (byte) 'd'));
+    assertEquals("contentLength must be non-negative: -1", ex.getMessage());
+  }
+
+  @Test
+  public void testRawPageBufferRejectsContentRegionExceedingCapacity() {
+    // Validates that content region exceeding page buffer capacity is rejected.
+    int capacity = pageFrame.getBuffer().capacity();
+    long stamp = pageFrame.tryOptimisticRead();
+    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+        () -> new RawPageBuffer(pageFrame, stamp, capacity - 5, 10, 1L, (byte) 'd'));
+    int expectedEnd = capacity - 5 + 10;
+    assertEquals(
+        "content region [" + (capacity - 5) + ", " + expectedEnd
+            + ") exceeds page buffer capacity " + capacity,
+        ex.getMessage());
+  }
+
+  @Test
+  public void testRawPageBufferRejectsIntegerOverflowInContentRegion() {
+    // Validates that Math.addExact catches integer overflow when
+    // contentOffset + contentLength would exceed Integer.MAX_VALUE.
+    long stamp = pageFrame.tryOptimisticRead();
+    org.junit.Assert.assertThrows(ArithmeticException.class,
+        () -> new RawPageBuffer(
+            pageFrame, stamp, Integer.MAX_VALUE, 1, 1L, (byte) 'd'));
+  }
+
+  @Test
+  public void testRawPageBufferAcceptsExactBoundary() {
+    // Content region [0, capacity) exactly fills the page — should succeed.
+    int capacity = pageFrame.getBuffer().capacity();
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(
+        pageFrame, stamp, 0, capacity, 1L, (byte) 'd');
+    assertEquals(capacity, pageBuffer.contentLength());
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
@@ -21,6 +21,8 @@ package com.jetbrains.youtrackdb.internal.core.storage;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
@@ -217,7 +219,7 @@ public class StorageReadResultTest {
   public void testRawPageBufferRejectsNullPageFrame() {
     // Validates that the constructor throws IllegalArgumentException
     // (not AssertionError) when pageFrame is null.
-    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+    var ex = assertThrows(IllegalArgumentException.class,
         () -> new RawPageBuffer(null, 0L, 0, 0, 1L, (byte) 'd'));
     assertEquals("PageFrame must not be null", ex.getMessage());
   }
@@ -226,7 +228,7 @@ public class StorageReadResultTest {
   public void testRawPageBufferRejectsNegativeContentOffset() {
     // Validates runtime rejection of negative contentOffset.
     long stamp = pageFrame.tryOptimisticRead();
-    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+    var ex = assertThrows(IllegalArgumentException.class,
         () -> new RawPageBuffer(pageFrame, stamp, -1, 10, 1L, (byte) 'd'));
     assertEquals("contentOffset must be non-negative: -1", ex.getMessage());
   }
@@ -235,7 +237,7 @@ public class StorageReadResultTest {
   public void testRawPageBufferRejectsNegativeContentLength() {
     // Validates runtime rejection of negative contentLength.
     long stamp = pageFrame.tryOptimisticRead();
-    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+    var ex = assertThrows(IllegalArgumentException.class,
         () -> new RawPageBuffer(pageFrame, stamp, 0, -1, 1L, (byte) 'd'));
     assertEquals("contentLength must be non-negative: -1", ex.getMessage());
   }
@@ -245,7 +247,7 @@ public class StorageReadResultTest {
     // Validates that content region exceeding page buffer capacity is rejected.
     int capacity = pageFrame.getBuffer().capacity();
     long stamp = pageFrame.tryOptimisticRead();
-    var ex = org.junit.Assert.assertThrows(IllegalArgumentException.class,
+    var ex = assertThrows(IllegalArgumentException.class,
         () -> new RawPageBuffer(pageFrame, stamp, capacity - 5, 10, 1L, (byte) 'd'));
     int expectedEnd = capacity - 5 + 10;
     assertEquals(
@@ -259,18 +261,60 @@ public class StorageReadResultTest {
     // Validates that Math.addExact catches integer overflow when
     // contentOffset + contentLength would exceed Integer.MAX_VALUE.
     long stamp = pageFrame.tryOptimisticRead();
-    org.junit.Assert.assertThrows(ArithmeticException.class,
+    var ex = assertThrows(ArithmeticException.class,
         () -> new RawPageBuffer(
             pageFrame, stamp, Integer.MAX_VALUE, 1, 1L, (byte) 'd'));
+    assertEquals("integer overflow", ex.getMessage());
+  }
+
+  @Test
+  public void testRawPageBufferRejectsIntMinValueContentOffset() {
+    // Integer.MIN_VALUE is the extreme negative boundary — validates no
+    // unsigned interpretation or bit-twiddling issues in the bounds check.
+    long stamp = pageFrame.tryOptimisticRead();
+    var ex = assertThrows(IllegalArgumentException.class,
+        () -> new RawPageBuffer(
+            pageFrame, stamp, Integer.MIN_VALUE, 0, 1L, (byte) 'd'));
+    assertTrue(ex.getMessage().contains("contentOffset"));
   }
 
   @Test
   public void testRawPageBufferAcceptsExactBoundary() {
     // Content region [0, capacity) exactly fills the page — should succeed.
+    // Verify end-to-end via sliceContent to confirm no off-by-one.
     int capacity = pageFrame.getBuffer().capacity();
     long stamp = pageFrame.tryOptimisticRead();
     var pageBuffer = new RawPageBuffer(
         pageFrame, stamp, 0, capacity, 1L, (byte) 'd');
     assertEquals(capacity, pageBuffer.contentLength());
+    assertEquals(0, pageBuffer.contentOffset());
+
+    ByteBuffer slice = pageBuffer.sliceContent();
+    assertEquals(capacity, slice.capacity());
+    assertEquals(0, slice.position());
+    assertEquals(capacity, slice.limit());
+  }
+
+  @Test
+  public void testRawPageBufferAcceptsZeroLengthAtCapacity() {
+    // Content region [capacity, capacity) is empty — should succeed.
+    // Verifies the > vs >= boundary in the capacity check.
+    int capacity = pageFrame.getBuffer().capacity();
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(
+        pageFrame, stamp, capacity, 0, 1L, (byte) 'd');
+    assertEquals(0, pageBuffer.contentLength());
+    assertEquals(capacity, pageBuffer.contentOffset());
+  }
+
+  @Test
+  public void testRawPageBufferRejectsOffsetBeyondCapacity() {
+    // Even with zero length, offset past capacity is invalid.
+    int capacity = pageFrame.getBuffer().capacity();
+    long stamp = pageFrame.tryOptimisticRead();
+    var ex = assertThrows(IllegalArgumentException.class,
+        () -> new RawPageBuffer(
+            pageFrame, stamp, capacity + 1, 0, 1L, (byte) 'd'));
+    assertTrue(ex.getMessage().contains("exceeds page buffer capacity"));
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
@@ -21,8 +21,8 @@ package com.jetbrains.youtrackdb.internal.core.storage;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
@@ -243,7 +243,7 @@ public class StorageReadResultTest {
     StorageReadResult result = rawBuffer;
     assertEquals(1L, result.recordVersion());
     assertEquals((byte) 'd', result.recordType());
-    org.junit.Assert.assertNull(rawBuffer.buffer());
+    assertNull(rawBuffer.buffer());
   }
 
   @Test
@@ -324,7 +324,9 @@ public class StorageReadResultTest {
     var ex = assertThrows(IllegalArgumentException.class,
         () -> new RawPageBuffer(
             pageFrame, stamp, Integer.MIN_VALUE, 0, 1L, (byte) 'd'));
-    assertTrue(ex.getMessage().contains("contentOffset"));
+    assertEquals(
+        "contentOffset must be non-negative: " + Integer.MIN_VALUE,
+        ex.getMessage());
   }
 
   @Test
@@ -354,6 +356,11 @@ public class StorageReadResultTest {
         pageFrame, stamp, capacity, 0, 1L, (byte) 'd');
     assertEquals(0, pageBuffer.contentLength());
     assertEquals(capacity, pageBuffer.contentOffset());
+
+    // Verify sliceContent works for zero-length region at capacity boundary
+    ByteBuffer slice = pageBuffer.sliceContent();
+    assertEquals(0, slice.capacity());
+    assertEquals(0, slice.remaining());
   }
 
   @Test
@@ -364,6 +371,34 @@ public class StorageReadResultTest {
     var ex = assertThrows(IllegalArgumentException.class,
         () -> new RawPageBuffer(
             pageFrame, stamp, capacity + 1, 0, 1L, (byte) 'd'));
-    assertTrue(ex.getMessage().contains("exceeds page buffer capacity"));
+    int end = capacity + 1;
+    assertEquals(
+        "content region [" + end + ", " + end
+            + ") exceeds page buffer capacity " + capacity,
+        ex.getMessage());
+  }
+
+  @Test
+  public void testRawPageBufferAcceptsZeroOffsetZeroLength() {
+    // Zero-length content at offset 0 — minimal valid RawPageBuffer,
+    // representing an empty record.
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(
+        pageFrame, stamp, 0, 0, 1L, (byte) 'd');
+    assertEquals(0, pageBuffer.contentOffset());
+    assertEquals(0, pageBuffer.contentLength());
+  }
+
+  @Test
+  public void testRawPageBufferRejectsIntMinValueContentLength() {
+    // Integer.MIN_VALUE for contentLength — symmetric with the contentOffset
+    // test. Validates no unsigned interpretation in the bounds check.
+    long stamp = pageFrame.tryOptimisticRead();
+    var ex = assertThrows(IllegalArgumentException.class,
+        () -> new RawPageBuffer(
+            pageFrame, stamp, 0, Integer.MIN_VALUE, 1L, (byte) 'd'));
+    assertEquals(
+        "contentLength must be non-negative: " + Integer.MIN_VALUE,
+        ex.getMessage());
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
@@ -22,12 +22,14 @@ package com.jetbrains.youtrackdb.internal.core.storage;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.directmemory.Pointer;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import java.nio.ByteBuffer;
 import org.junit.After;
 import org.junit.Before;
@@ -400,5 +402,57 @@ public class StorageReadResultTest {
     assertEquals(
         "contentLength must be non-negative: " + Integer.MIN_VALUE,
         ex.getMessage());
+  }
+
+  // --- toRawBuffer() ---
+
+  @Test
+  public void testToRawBufferExtractsCorrectBytes() {
+    // Verifies that toRawBuffer() on a RawPageBuffer with a valid stamp
+    // extracts the correct bytes, version, and record type.
+    ByteBuffer buf = pageFrame.getBuffer();
+    byte[] expected = {10, 20, 30, 40, 50};
+    buf.position(100);
+    buf.put(expected);
+    long stamp = pageFrame.tryOptimisticRead();
+    var rpb = new RawPageBuffer(pageFrame, stamp, 100, 5, 1L, (byte) 'd');
+    RawBuffer result = rpb.toRawBuffer();
+    assertArrayEquals(expected, result.buffer());
+    assertEquals(1L, result.version());
+    assertEquals((byte) 'd', result.recordType());
+  }
+
+  @Test
+  public void testToRawBufferThrowsOnInvalidStamp() {
+    // Verifies that toRawBuffer() throws OptimisticReadFailedException
+    // when the stamp is invalidated between byte extraction and validation.
+    byte[] data = {1, 2, 3};
+    pageFrame.getBuffer().put(200, data[0]);
+    pageFrame.getBuffer().put(201, data[1]);
+    pageFrame.getBuffer().put(202, data[2]);
+    long stamp = pageFrame.tryOptimisticRead();
+    var rpb = new RawPageBuffer(pageFrame, stamp, 200, 3, 1L, (byte) 'd');
+    // Invalidate stamp via exclusive lock acquire/release
+    long exStamp = pageFrame.acquireExclusiveLock();
+    pageFrame.releaseExclusiveLock(exStamp);
+    assertThrows(OptimisticReadFailedException.class, rpb::toRawBuffer);
+  }
+
+  @Test
+  public void testToRawBufferOnRawBufferReturnsItself() {
+    // RawBuffer.toRawBuffer() returns 'this' — no copy or transformation.
+    var rb = new RawBuffer(new byte[] {1, 2}, 5L, (byte) 'v');
+    assertSame(rb, rb.toRawBuffer());
+  }
+
+  @Test
+  public void testToRawBufferWithZeroLengthContent() {
+    // toRawBuffer() on a zero-length RawPageBuffer produces an empty byte[].
+    long stamp = pageFrame.tryOptimisticRead();
+    var rpb = new RawPageBuffer(pageFrame, stamp, 0, 0, 1L, (byte) 'd');
+    RawBuffer result = rpb.toRawBuffer();
+    assertEquals(0, result.buffer().length);
+    assertEquals(1L, result.version());
+    assertEquals((byte) 'd', result.recordType());
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
@@ -213,6 +213,55 @@ public class StorageReadResultTest {
     assertEquals((byte) 'v', pageBuffer.recordType());
   }
 
+  // --- Boundary version values ---
+
+  @Test
+  public void testRawBufferWithZeroVersion() {
+    // Version 0 is a valid boundary value (e.g., initial record version).
+    var rawBuffer = new RawBuffer(new byte[] {1}, 0L, (byte) 'd');
+    assertEquals(0L, rawBuffer.recordVersion());
+  }
+
+  @Test
+  public void testRawBufferWithNegativeVersion() {
+    // Negative versions may represent special states (-1 = tombstone/unversioned).
+    var rawBuffer = new RawBuffer(new byte[] {1}, -1L, (byte) 'd');
+    assertEquals(-1L, rawBuffer.recordVersion());
+  }
+
+  @Test
+  public void testRawBufferWithMaxVersion() {
+    // Long.MAX_VALUE is the extreme boundary for version values.
+    var rawBuffer = new RawBuffer(new byte[] {1}, Long.MAX_VALUE, (byte) 'd');
+    assertEquals(Long.MAX_VALUE, rawBuffer.recordVersion());
+  }
+
+  @Test
+  public void testRawBufferWithNullBuffer() {
+    // RawBuffer allows null buffer (e.g., deleted record or placeholder).
+    var rawBuffer = new RawBuffer(null, 1L, (byte) 'd');
+    StorageReadResult result = rawBuffer;
+    assertEquals(1L, result.recordVersion());
+    assertEquals((byte) 'd', result.recordType());
+    org.junit.Assert.assertNull(rawBuffer.buffer());
+  }
+
+  @Test
+  public void testRawPageBufferWithZeroVersion() {
+    // Version 0 boundary for PageFrame path.
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(pageFrame, stamp, 0, 10, 0L, (byte) 'd');
+    assertEquals(0L, pageBuffer.recordVersion());
+  }
+
+  @Test
+  public void testRawPageBufferWithMaxVersion() {
+    // Long.MAX_VALUE boundary for PageFrame path.
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer = new RawPageBuffer(pageFrame, stamp, 0, 10, Long.MAX_VALUE, (byte) 'd');
+    assertEquals(Long.MAX_VALUE, pageBuffer.recordVersion());
+  }
+
   // --- RawPageBuffer runtime bounds validation ---
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/StorageReadResultTest.java
@@ -21,8 +21,6 @@ package com.jetbrains.youtrackdb.internal.core.storage;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
@@ -60,10 +58,8 @@ public class StorageReadResultTest {
   @Test
   public void testRawBufferIsStorageReadResult() {
     // Verifies that RawBuffer implements StorageReadResult and that
-    // recordVersion() delegates to version().
+    // recordVersion() delegates to version(), recordType() matches.
     var rawBuffer = new RawBuffer(new byte[] {1, 2, 3}, 42L, (byte) 'd');
-
-    assertTrue(rawBuffer instanceof StorageReadResult);
 
     StorageReadResult result = rawBuffer;
     assertEquals(42L, result.recordVersion());
@@ -72,9 +68,10 @@ public class StorageReadResultTest {
 
   @Test
   public void testRawBufferRecordVersionDelegatesToVersion() {
-    // Ensures recordVersion() and version() return the same value.
+    // Ensures recordVersion() returns the same value as version().
     var rawBuffer = new RawBuffer(new byte[0], 99L, (byte) 'b');
-    assertEquals(rawBuffer.version(), rawBuffer.recordVersion());
+    assertEquals(99L, rawBuffer.recordVersion());
+    assertEquals(99L, rawBuffer.version());
   }
 
   // --- RawPageBuffer satisfies StorageReadResult contract ---
@@ -85,8 +82,6 @@ public class StorageReadResultTest {
     // correct version and type accessors.
     long stamp = pageFrame.tryOptimisticRead();
     var pageBuffer = new RawPageBuffer(pageFrame, stamp, 100, 50, 7L, (byte) 'd');
-
-    assertTrue(pageBuffer instanceof StorageReadResult);
 
     StorageReadResult result = pageBuffer;
     assertEquals(7L, result.recordVersion());
@@ -112,7 +107,6 @@ public class StorageReadResultTest {
         new RawPageBuffer(pageFrame, stamp, contentOffset, testData.length, 1L, (byte) 'd');
 
     ByteBuffer slice = pageBuffer.sliceContent();
-    assertNotNull(slice);
     assertEquals(testData.length, slice.capacity());
     assertEquals(0, slice.position());
     assertEquals(testData.length, slice.limit());
@@ -130,6 +124,8 @@ public class StorageReadResultTest {
 
     ByteBuffer slice = pageBuffer.sliceContent();
     assertEquals(0, slice.capacity());
+    assertEquals(0, slice.position());
+    assertEquals(0, slice.limit());
   }
 
   @Test
@@ -148,6 +144,28 @@ public class StorageReadResultTest {
     // Modify the underlying page buffer and verify the slice sees the change.
     buffer.put(contentOffset, (byte) 0xBB);
     assertEquals((byte) 0xBB, slice.get(0));
+  }
+
+  @Test
+  public void testSliceContentAtExactPageBoundary() {
+    // Record content fills from an offset to the very end of the page buffer,
+    // verifying no off-by-one in ByteBuffer.slice() at the boundary.
+    int capacity = pageFrame.getBuffer().capacity();
+    int contentLength = 10;
+    int contentOffset = capacity - contentLength;
+    ByteBuffer buf = pageFrame.getBuffer();
+    for (int i = 0; i < contentLength; i++) {
+      buf.put(contentOffset + i, (byte) (i + 1));
+    }
+
+    long stamp = pageFrame.tryOptimisticRead();
+    var pageBuffer =
+        new RawPageBuffer(pageFrame, stamp, contentOffset, contentLength, 1L, (byte) 'd');
+
+    ByteBuffer slice = pageBuffer.sliceContent();
+    assertEquals(contentLength, slice.capacity());
+    assertEquals((byte) 1, slice.get(0));
+    assertEquals((byte) 10, slice.get(9));
   }
 
   // --- Sealed interface exhaustiveness ---

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
@@ -1541,6 +1541,15 @@ public class CollectionPageTest {
           1L, buildChunk((byte) 'd', 0L, new byte[] {1, 2, 3}), -1, IntSets.emptySet());
       localPage.deleteRecord(0, true);
 
+      // Guard: skip assertion-behavior tests if assertions are disabled
+      try {
+        assert false;
+        // Assertions disabled — cannot test AssertionError behavior
+        return;
+      } catch (AssertionError ignored) {
+        // Assertions enabled — proceed
+      }
+
       boolean offsetAssertionFired = false;
       try {
         localPage.getRecordContentOffset(0);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
@@ -1502,7 +1502,13 @@ public class CollectionPageTest {
       // Check small record offset and length
       int offsetSmall = localPage.getRecordContentOffset(0);
       Assert.assertEquals(small.length, localPage.getRecordContentLength(0));
-      Assert.assertTrue(offsetSmall > 0);
+      // Content offset must be at least past the entry header (3 ints)
+      // and the metadata header within the page.
+      int minContentOffset =
+          3 * IntegerSerializer.INT_SIZE + CollectionPage.RECORD_METADATA_HEADER_SIZE;
+      Assert.assertTrue(
+          "offsetSmall " + offsetSmall + " should be >= " + minContentOffset,
+          offsetSmall >= minContentOffset);
       Assert.assertTrue(offsetSmall + small.length <= CollectionPage.PAGE_SIZE);
       byte[] actualSmall = localPage.getRecordBinaryValue(
           0, CollectionPage.RECORD_METADATA_HEADER_SIZE, small.length);
@@ -1511,7 +1517,9 @@ public class CollectionPageTest {
       // Check large record offset and length
       int offsetLarge = localPage.getRecordContentOffset(1);
       Assert.assertEquals(large.length, localPage.getRecordContentLength(1));
-      Assert.assertTrue(offsetLarge > 0);
+      Assert.assertTrue(
+          "offsetLarge " + offsetLarge + " should be >= " + minContentOffset,
+          offsetLarge >= minContentOffset);
       Assert.assertTrue(offsetLarge + large.length <= CollectionPage.PAGE_SIZE);
       // Offsets must differ since they are separate records.
       Assert.assertNotEquals(offsetSmall, offsetLarge);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
+import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
+import com.jetbrains.youtrackdb.internal.common.serialization.types.LongSerializer;
 import com.jetbrains.youtrackdb.internal.core.record.RecordVersionHelper;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntryImpl;
@@ -58,7 +60,7 @@ public class CollectionPageTest {
 
     var position =
         localPage.appendRecord(
-            recordVersion, new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1}, -1, IntSets.emptySet());
+            recordVersion, new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1}, -1, IntSets.emptySet());
     Assert.assertEquals(localPage.getRecordsCount(), 1);
     Assert.assertEquals(localPage.getRecordSize(0), 11);
     Assert.assertEquals(position, 0);
@@ -68,7 +70,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordVersion(0), recordVersion);
 
     assertThat(localPage.getRecordBinaryValue(0, 0, 11))
-        .isEqualTo(new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1});
+        .isEqualTo(new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1});
   }
 
   @Test
@@ -103,13 +105,13 @@ public class CollectionPageTest {
 
     var positionOne =
         localPage.appendRecord(
-            recordVersion, new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1}, -1, IntSets.emptySet());
+            recordVersion, new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1}, -1, IntSets.emptySet());
     var positionTwo =
         localPage.appendRecord(
-            recordVersion, new byte[]{2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2}, -1, IntSets.emptySet());
+            recordVersion, new byte[] {2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2}, -1, IntSets.emptySet());
     var positionThree =
         localPage.appendRecord(
-            recordVersion, new byte[]{3, 2, 3, 4, 5, 6, 5, 4, 3, 2, 3}, -1, IntSets.emptySet());
+            recordVersion, new byte[] {3, 2, 3, 4, 5, 6, 5, 4, 3, 2, 3}, -1, IntSets.emptySet());
 
     Assert.assertEquals(localPage.getRecordsCount(), 3);
     Assert.assertEquals(positionOne, 0);
@@ -123,17 +125,17 @@ public class CollectionPageTest {
     Assert.assertFalse(localPage.isDeleted(2));
 
     assertThat(localPage.getRecordBinaryValue(0, 0, 11))
-        .isEqualTo(new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1});
+        .isEqualTo(new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1});
     Assert.assertEquals(localPage.getRecordSize(0), 11);
     Assert.assertEquals(localPage.getRecordVersion(0), recordVersion);
 
     assertThat(localPage.getRecordBinaryValue(1, 0, 11))
-        .isEqualTo(new byte[]{2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2});
     Assert.assertEquals(localPage.getRecordSize(0), 11);
     Assert.assertEquals(localPage.getRecordVersion(1), recordVersion);
 
     assertThat(localPage.getRecordBinaryValue(2, 0, 11))
-        .isEqualTo(new byte[]{3, 2, 3, 4, 5, 6, 5, 4, 3, 2, 3});
+        .isEqualTo(new byte[] {3, 2, 3, 4, 5, 6, 5, 4, 3, 2, 3});
     Assert.assertEquals(localPage.getRecordSize(0), 11);
     Assert.assertEquals(localPage.getRecordVersion(2), recordVersion);
   }
@@ -171,7 +173,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         Assert.assertEquals(lastPosition, positions.size());
         positions.add(lastPosition);
@@ -188,7 +190,7 @@ public class CollectionPageTest {
     counter = 0;
     for (int position : positions) {
       assertThat(localPage.getRecordBinaryValue(position, 0, 3))
-          .isEqualTo(new byte[]{counter, counter, counter});
+          .isEqualTo(new byte[] {counter, counter, counter});
       Assert.assertEquals(localPage.getRecordSize(position), 3);
       Assert.assertEquals(localPage.getRecordVersion(position), recordVersion);
       counter++;
@@ -220,10 +222,10 @@ public class CollectionPageTest {
   private void addDeleteAddBookedPositionsOne(final CollectionPage collectionPage) {
     final IntSet bookedPositions = new IntOpenHashSet();
 
-    collectionPage.appendRecord(1, new byte[]{1}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{2}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{3}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{4}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {1}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {2}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {3}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {4}, -1, bookedPositions);
 
     collectionPage.deleteRecord(0, true);
     collectionPage.deleteRecord(1, true);
@@ -233,30 +235,30 @@ public class CollectionPageTest {
     bookedPositions.add(1);
     bookedPositions.add(2);
 
-    var position = collectionPage.appendRecord(1, new byte[]{5}, -1, bookedPositions);
+    var position = collectionPage.appendRecord(1, new byte[] {5}, -1, bookedPositions);
     Assert.assertEquals(3, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{6}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {6}, -1, bookedPositions);
     Assert.assertEquals(0, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{7}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {7}, -1, bookedPositions);
     Assert.assertEquals(4, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{8}, 1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {8}, 1, bookedPositions);
     Assert.assertEquals(1, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{9}, 2, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {9}, 2, bookedPositions);
     Assert.assertEquals(2, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{10}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {10}, -1, bookedPositions);
     Assert.assertEquals(5, position);
 
-    Assert.assertArrayEquals(new byte[]{6}, collectionPage.getRecordBinaryValue(0, 0, 1));
-    Assert.assertArrayEquals(new byte[]{8}, collectionPage.getRecordBinaryValue(1, 0, 1));
-    Assert.assertArrayEquals(new byte[]{9}, collectionPage.getRecordBinaryValue(2, 0, 1));
-    Assert.assertArrayEquals(new byte[]{5}, collectionPage.getRecordBinaryValue(3, 0, 1));
-    Assert.assertArrayEquals(new byte[]{7}, collectionPage.getRecordBinaryValue(4, 0, 1));
-    Assert.assertArrayEquals(new byte[]{10}, collectionPage.getRecordBinaryValue(5, 0, 1));
+    Assert.assertArrayEquals(new byte[] {6}, collectionPage.getRecordBinaryValue(0, 0, 1));
+    Assert.assertArrayEquals(new byte[] {8}, collectionPage.getRecordBinaryValue(1, 0, 1));
+    Assert.assertArrayEquals(new byte[] {9}, collectionPage.getRecordBinaryValue(2, 0, 1));
+    Assert.assertArrayEquals(new byte[] {5}, collectionPage.getRecordBinaryValue(3, 0, 1));
+    Assert.assertArrayEquals(new byte[] {7}, collectionPage.getRecordBinaryValue(4, 0, 1));
+    Assert.assertArrayEquals(new byte[] {10}, collectionPage.getRecordBinaryValue(5, 0, 1));
   }
 
   @Test
@@ -284,10 +286,10 @@ public class CollectionPageTest {
   private void addDeleteAddBookedPositionsTwo(final CollectionPage collectionPage) {
     final IntSet bookedPositions = new IntOpenHashSet();
 
-    collectionPage.appendRecord(1, new byte[]{1}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{2}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{3}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{4}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {1}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {2}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {3}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {4}, -1, bookedPositions);
 
     collectionPage.deleteRecord(0, true);
     collectionPage.deleteRecord(1, true);
@@ -297,30 +299,30 @@ public class CollectionPageTest {
     bookedPositions.add(1);
     bookedPositions.add(2);
 
-    var position = collectionPage.appendRecord(1, new byte[]{5}, -1, bookedPositions);
+    var position = collectionPage.appendRecord(1, new byte[] {5}, -1, bookedPositions);
     Assert.assertEquals(3, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{6}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {6}, -1, bookedPositions);
     Assert.assertEquals(0, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{9}, 2, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {9}, 2, bookedPositions);
     Assert.assertEquals(2, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{7}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {7}, -1, bookedPositions);
     Assert.assertEquals(4, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{8}, 1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {8}, 1, bookedPositions);
     Assert.assertEquals(1, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{10}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {10}, -1, bookedPositions);
     Assert.assertEquals(5, position);
 
-    Assert.assertArrayEquals(new byte[]{6}, collectionPage.getRecordBinaryValue(0, 0, 1));
-    Assert.assertArrayEquals(new byte[]{8}, collectionPage.getRecordBinaryValue(1, 0, 1));
-    Assert.assertArrayEquals(new byte[]{9}, collectionPage.getRecordBinaryValue(2, 0, 1));
-    Assert.assertArrayEquals(new byte[]{5}, collectionPage.getRecordBinaryValue(3, 0, 1));
-    Assert.assertArrayEquals(new byte[]{7}, collectionPage.getRecordBinaryValue(4, 0, 1));
-    Assert.assertArrayEquals(new byte[]{10}, collectionPage.getRecordBinaryValue(5, 0, 1));
+    Assert.assertArrayEquals(new byte[] {6}, collectionPage.getRecordBinaryValue(0, 0, 1));
+    Assert.assertArrayEquals(new byte[] {8}, collectionPage.getRecordBinaryValue(1, 0, 1));
+    Assert.assertArrayEquals(new byte[] {9}, collectionPage.getRecordBinaryValue(2, 0, 1));
+    Assert.assertArrayEquals(new byte[] {5}, collectionPage.getRecordBinaryValue(3, 0, 1));
+    Assert.assertArrayEquals(new byte[] {7}, collectionPage.getRecordBinaryValue(4, 0, 1));
+    Assert.assertArrayEquals(new byte[] {10}, collectionPage.getRecordBinaryValue(5, 0, 1));
   }
 
   @Test
@@ -348,10 +350,10 @@ public class CollectionPageTest {
   private void addDeleteAddBookedPositionsThree(final CollectionPage collectionPage) {
     final IntSet bookedPositions = new IntOpenHashSet();
 
-    collectionPage.appendRecord(1, new byte[]{1}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{2}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{3}, -1, bookedPositions);
-    collectionPage.appendRecord(1, new byte[]{4}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {1}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {2}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {3}, -1, bookedPositions);
+    collectionPage.appendRecord(1, new byte[] {4}, -1, bookedPositions);
 
     collectionPage.deleteRecord(0, true);
     collectionPage.deleteRecord(1, true);
@@ -361,30 +363,30 @@ public class CollectionPageTest {
     bookedPositions.add(1);
     bookedPositions.add(2);
 
-    var position = collectionPage.appendRecord(1, new byte[]{9}, 2, bookedPositions);
+    var position = collectionPage.appendRecord(1, new byte[] {9}, 2, bookedPositions);
     Assert.assertEquals(2, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{8}, 1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {8}, 1, bookedPositions);
     Assert.assertEquals(1, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{5}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {5}, -1, bookedPositions);
     Assert.assertEquals(3, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{6}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {6}, -1, bookedPositions);
     Assert.assertEquals(0, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{7}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {7}, -1, bookedPositions);
     Assert.assertEquals(4, position);
 
-    position = collectionPage.appendRecord(1, new byte[]{10}, -1, bookedPositions);
+    position = collectionPage.appendRecord(1, new byte[] {10}, -1, bookedPositions);
     Assert.assertEquals(5, position);
 
-    Assert.assertArrayEquals(new byte[]{6}, collectionPage.getRecordBinaryValue(0, 0, 1));
-    Assert.assertArrayEquals(new byte[]{8}, collectionPage.getRecordBinaryValue(1, 0, 1));
-    Assert.assertArrayEquals(new byte[]{9}, collectionPage.getRecordBinaryValue(2, 0, 1));
-    Assert.assertArrayEquals(new byte[]{5}, collectionPage.getRecordBinaryValue(3, 0, 1));
-    Assert.assertArrayEquals(new byte[]{7}, collectionPage.getRecordBinaryValue(4, 0, 1));
-    Assert.assertArrayEquals(new byte[]{10}, collectionPage.getRecordBinaryValue(5, 0, 1));
+    Assert.assertArrayEquals(new byte[] {6}, collectionPage.getRecordBinaryValue(0, 0, 1));
+    Assert.assertArrayEquals(new byte[] {8}, collectionPage.getRecordBinaryValue(1, 0, 1));
+    Assert.assertArrayEquals(new byte[] {9}, collectionPage.getRecordBinaryValue(2, 0, 1));
+    Assert.assertArrayEquals(new byte[] {5}, collectionPage.getRecordBinaryValue(3, 0, 1));
+    Assert.assertArrayEquals(new byte[] {7}, collectionPage.getRecordBinaryValue(4, 0, 1));
+    Assert.assertArrayEquals(new byte[] {10}, collectionPage.getRecordBinaryValue(5, 0, 1));
   }
 
   @Test
@@ -415,7 +417,7 @@ public class CollectionPageTest {
     recordVersion++;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var position = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
 
     Assert.assertArrayEquals(record, localPage.deleteRecord(position, true));
@@ -424,7 +426,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(
         localPage.appendRecord(
-            newRecordVersion, new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
+            newRecordVersion, new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
         position);
 
     var recordSize = localPage.getRecordSize(position);
@@ -433,7 +435,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordVersion(position), newRecordVersion);
 
     assertThat(localPage.getRecordBinaryValue(position, 0, recordSize))
-        .isEqualTo(new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
   }
 
   @Test
@@ -464,7 +466,7 @@ public class CollectionPageTest {
     recordVersion++;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var position = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
 
     Assert.assertArrayEquals(record, localPage.deleteRecord(position, false));
@@ -473,7 +475,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(
         localPage.appendRecord(
-            newRecordVersion, new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
+            newRecordVersion, new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
         position);
 
     var recordSize = localPage.getRecordSize(position);
@@ -482,7 +484,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordVersion(position), newRecordVersion);
 
     assertThat(localPage.getRecordBinaryValue(position, 0, recordSize))
-        .isEqualTo(new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
   }
 
   @Test
@@ -512,7 +514,7 @@ public class CollectionPageTest {
     recordVersion++;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var position = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
 
     Assert.assertArrayEquals(record, localPage.deleteRecord(position, true));
@@ -525,7 +527,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(
         localPage.appendRecord(
-            newRecordVersion, new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
+            newRecordVersion, new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
         position);
 
     var recordSize = localPage.getRecordSize(position);
@@ -533,7 +535,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(localPage.getRecordVersion(position), newRecordVersion);
     assertThat(localPage.getRecordBinaryValue(position, 0, recordSize))
-        .isEqualTo(new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
   }
 
   @Test
@@ -563,7 +565,7 @@ public class CollectionPageTest {
     recordVersion++;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var position = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
 
     Assert.assertArrayEquals(record, localPage.deleteRecord(position, false));
@@ -576,7 +578,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(
         localPage.appendRecord(
-            newRecordVersion, new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
+            newRecordVersion, new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
         position);
 
     var recordSize = localPage.getRecordSize(position);
@@ -584,7 +586,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(localPage.getRecordVersion(position), newRecordVersion);
     assertThat(localPage.getRecordBinaryValue(position, 0, recordSize))
-        .isEqualTo(new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
   }
 
   @Test
@@ -614,14 +616,14 @@ public class CollectionPageTest {
     recordVersion++;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var position = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
 
     Assert.assertArrayEquals(record, localPage.deleteRecord(position, true));
 
     Assert.assertEquals(
         localPage.appendRecord(
-            recordVersion, new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
+            recordVersion, new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
         position);
 
     var recordSize = localPage.getRecordSize(position);
@@ -629,7 +631,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(localPage.getRecordVersion(position), recordVersion);
     assertThat(localPage.getRecordBinaryValue(position, 0, recordSize))
-        .isEqualTo(new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
   }
 
   @Test
@@ -659,14 +661,14 @@ public class CollectionPageTest {
     recordVersion++;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var position = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
 
     Assert.assertArrayEquals(record, localPage.deleteRecord(position, false));
 
     Assert.assertEquals(
         localPage.appendRecord(
-            recordVersion, new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
+            recordVersion, new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
         position);
 
     var recordSize = localPage.getRecordSize(position);
@@ -674,7 +676,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(localPage.getRecordVersion(position), recordVersion);
     assertThat(localPage.getRecordBinaryValue(position, 0, recordSize))
-        .isEqualTo(new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
   }
 
   @Test
@@ -704,14 +706,14 @@ public class CollectionPageTest {
     recordVersion++;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var position = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
 
     Assert.assertArrayEquals(record, localPage.deleteRecord(position, true));
 
     Assert.assertEquals(
         localPage.appendRecord(
-            recordVersion, new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
+            recordVersion, new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2}, -1, IntSets.emptySet()),
         position);
 
     var recordSize = localPage.getRecordSize(position);
@@ -719,7 +721,7 @@ public class CollectionPageTest {
 
     Assert.assertEquals(localPage.getRecordVersion(position), recordVersion);
     assertThat(localPage.getRecordBinaryValue(position, 0, recordSize))
-        .isEqualTo(new byte[]{2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 2, 4, 5, 6, 5, 4, 2, 2, 2});
   }
 
   @Test
@@ -748,10 +750,10 @@ public class CollectionPageTest {
     var recordVersion = 0;
     recordVersion++;
 
-    final var recordOne = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
-    final var recordTwo = new byte[]{2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2};
-    final var recordThree = new byte[]{3, 2, 3, 4, 5, 6, 5, 4, 3, 2, 3};
-    final var recordFour = new byte[]{4, 2, 3, 4, 5, 6, 5, 4, 3, 2, 4};
+    final var recordOne = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var recordTwo = new byte[] {2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2};
+    final var recordThree = new byte[] {3, 2, 3, 4, 5, 6, 5, 4, 3, 2, 3};
+    final var recordFour = new byte[] {4, 2, 3, 4, 5, 6, 5, 4, 3, 2, 4};
 
     var positionOne = localPage.appendRecord(recordVersion, recordOne, -1, IntSets.emptySet());
     var positionTwo = localPage.appendRecord(recordVersion, recordTwo, -1, IntSets.emptySet());
@@ -787,7 +789,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordVersion(0), -1);
 
     assertThat(localPage.getRecordBinaryValue(1, 0, 11))
-        .isEqualTo(new byte[]{2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2});
+        .isEqualTo(new byte[] {2, 2, 3, 4, 5, 6, 5, 4, 3, 2, 2});
     Assert.assertEquals(localPage.getRecordSize(1), 11);
     Assert.assertEquals(localPage.getRecordVersion(1), recordVersion);
 
@@ -796,7 +798,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordVersion(2), -1);
 
     assertThat(localPage.getRecordBinaryValue(3, 0, 11))
-        .isEqualTo(new byte[]{4, 2, 3, 4, 5, 6, 5, 4, 3, 2, 4});
+        .isEqualTo(new byte[] {4, 2, 3, 4, 5, 6, 5, 4, 3, 2, 4});
 
     Assert.assertEquals(localPage.getRecordSize(3), 11);
     Assert.assertEquals(localPage.getRecordVersion(3), recordVersion);
@@ -840,7 +842,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         Assert.assertEquals(lastPosition, positionCounter.size());
         positionCounter.put(lastPosition, counter);
@@ -865,7 +867,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         positionCounter.put(lastPosition, counter);
         counter++;
@@ -878,7 +880,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordsCount(), filledRecordsCount);
     for (var entry : positionCounter.entrySet()) {
       assertThat(localPage.getRecordBinaryValue(entry.getKey(), 0, 3))
-          .isEqualTo(new byte[]{entry.getValue(), entry.getValue(), entry.getValue()});
+          .isEqualTo(new byte[] {entry.getValue(), entry.getValue(), entry.getValue()});
 
       Assert.assertEquals(localPage.getRecordSize(entry.getKey()), 3);
 
@@ -922,7 +924,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         Assert.assertEquals(lastPosition, positionCounter.size());
         positionCounter.put(lastPosition, counter);
@@ -946,7 +948,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         positionCounter.put(lastPosition, counter);
         counter++;
@@ -960,7 +962,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordsCount(), filledRecordsCount);
     for (var entry : positionCounter.entrySet()) {
       assertThat(localPage.getRecordBinaryValue(entry.getKey(), 0, 3))
-          .isEqualTo(new byte[]{entry.getValue(), entry.getValue(), entry.getValue()});
+          .isEqualTo(new byte[] {entry.getValue(), entry.getValue(), entry.getValue()});
 
       Assert.assertEquals(localPage.getRecordSize(entry.getKey()), 3);
     }
@@ -1016,7 +1018,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         Assert.assertEquals(lastPosition, positionCounter.size());
         positionCounter.put(lastPosition, counter);
@@ -1036,7 +1038,7 @@ public class CollectionPageTest {
     Assert.assertEquals(localPage.getRecordsCount(), positionCounter.size());
     for (var entry : positionCounter.entrySet()) {
       assertThat(localPage.getRecordBinaryValue(entry.getKey(), 0, 3))
-          .isEqualTo(new byte[]{entry.getValue(), entry.getValue(), entry.getValue()});
+          .isEqualTo(new byte[] {entry.getValue(), entry.getValue(), entry.getValue()});
       Assert.assertEquals(localPage.getRecordSize(entry.getKey()), 3);
       Assert.assertEquals(localPage.getRecordVersion(entry.getKey()), recordVersion);
     }
@@ -1080,7 +1082,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         Assert.assertEquals(lastPosition, positions.size());
         positions.add(lastPosition);
@@ -1162,7 +1164,7 @@ public class CollectionPageTest {
     do {
       lastPosition =
           localPage.appendRecord(
-              recordVersion, new byte[]{counter, counter, counter}, -1, IntSets.emptySet());
+              recordVersion, new byte[] {counter, counter, counter}, -1, IntSets.emptySet());
       if (lastPosition >= 0) {
         Assert.assertEquals(lastPosition, positions.size());
         positions.add(lastPosition);
@@ -1284,7 +1286,7 @@ public class CollectionPageTest {
     var recordVersion = 0;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var index = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
     var freeSpace = localPage.getFreeSpace();
 
@@ -1294,14 +1296,14 @@ public class CollectionPageTest {
 
     final var oldRecord =
         localPage.replaceRecord(
-            index, new byte[]{5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1}, newRecordVersion);
+            index, new byte[] {5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1}, newRecordVersion);
     Assert.assertEquals(localPage.getFreeSpace(), freeSpace);
     Assert.assertArrayEquals(record, oldRecord);
 
     Assert.assertEquals(localPage.getRecordSize(index), 11);
 
     assertThat(localPage.getRecordBinaryValue(index, 0, 11))
-        .isEqualTo(new byte[]{5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1});
+        .isEqualTo(new byte[] {5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1});
     Assert.assertEquals(localPage.getRecordVersion(index), newRecordVersion);
   }
 
@@ -1334,19 +1336,19 @@ public class CollectionPageTest {
     var recordVersion = 0;
     recordVersion++;
 
-    var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var index = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
     var freeSpace = localPage.getFreeSpace();
 
     var oldRecord =
-        localPage.replaceRecord(index, new byte[]{5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1}, -1);
+        localPage.replaceRecord(index, new byte[] {5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1}, -1);
     Assert.assertEquals(localPage.getFreeSpace(), freeSpace);
     Assert.assertArrayEquals(record, oldRecord);
 
     Assert.assertEquals(localPage.getRecordSize(index), 11);
 
     assertThat(localPage.getRecordBinaryValue(index, 0, 11))
-        .isEqualTo(new byte[]{5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1});
+        .isEqualTo(new byte[] {5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1});
     Assert.assertEquals(localPage.getRecordVersion(index), recordVersion);
   }
 
@@ -1377,7 +1379,7 @@ public class CollectionPageTest {
     var recordVersion = 0;
     recordVersion++;
 
-    final var record = new byte[]{1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
+    final var record = new byte[] {1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1};
     var index = localPage.appendRecord(recordVersion, record, -1, IntSets.emptySet());
     var freeSpace = localPage.getFreeSpace();
 
@@ -1386,14 +1388,160 @@ public class CollectionPageTest {
 
     var oldRecord =
         localPage.replaceRecord(
-            index, new byte[]{5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1}, newRecordVersion);
+            index, new byte[] {5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1}, newRecordVersion);
     Assert.assertEquals(localPage.getFreeSpace(), freeSpace);
     Assert.assertArrayEquals(record, oldRecord);
 
     Assert.assertEquals(localPage.getRecordSize(index), 11);
 
     assertThat(localPage.getRecordBinaryValue(index, 0, 11))
-        .isEqualTo(new byte[]{5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1});
+        .isEqualTo(new byte[] {5, 2, 3, 4, 5, 11, 5, 4, 3, 2, 1});
     Assert.assertEquals(localPage.getRecordVersion(index), recordVersion);
+  }
+
+  // --- Tests for getRecordContentOffset and getRecordContentLength ---
+  // These methods assume records are stored with PaginatedCollectionV2's layout:
+  // [metadataHeader: 13B][actualContent: N B][firstRecordFlag: 1B][nextPagePointer: 8B]
+
+  /**
+   * Builds a chunk in PaginatedCollectionV2's format:
+   * [recordType][contentSize][collectionPosition][content][firstRecordFlag][nextPagePointer].
+   */
+  private static byte[] buildChunk(byte recordType, long collectionPosition, byte[] content) {
+    int headerSize = CollectionPage.RECORD_METADATA_HEADER_SIZE;
+    int tailSize = CollectionPage.RECORD_TAIL_SIZE;
+    byte[] chunk = new byte[headerSize + content.length + tailSize];
+    int offset = 0;
+    chunk[offset++] = recordType;
+    IntegerSerializer.serializeNative(content.length, chunk, offset);
+    offset += IntegerSerializer.INT_SIZE;
+    LongSerializer.serializeNative(collectionPosition, chunk, offset);
+    offset += LongSerializer.LONG_SIZE;
+    System.arraycopy(content, 0, chunk, offset, content.length);
+    offset += content.length;
+    chunk[offset++] = 1; // firstRecordFlag
+    LongSerializer.serializeNative(-1L, chunk, offset);
+    return chunk;
+  }
+
+  @Test
+  public void testGetRecordContentOffsetAndLength() {
+    // Verifies that getRecordContentOffset points past the entry header and
+    // metadata header, and getRecordContentLength equals the actual content
+    // size (recordSize - metadata header - tail).
+    var bufferPool = ByteBufferPool.instance(null);
+    var pointer = bufferPool.acquireDirect(true, Intention.TEST);
+
+    var cachePointer = new CachePointer(pointer, bufferPool, 0, 0);
+    cachePointer.incrementReferrer();
+
+    CacheEntry cacheEntry = new CacheEntryImpl(0, 0, cachePointer, false, null);
+    cacheEntry.acquireExclusiveLock();
+
+    try {
+      final var localPage = new CollectionPage(cacheEntry);
+      localPage.init();
+
+      byte[] content = new byte[] {10, 20, 30, 40, 50};
+      byte[] chunk = buildChunk((byte) 'd', 0L, content);
+      localPage.appendRecord(1L, chunk, -1, IntSets.emptySet());
+
+      int contentOffset = localPage.getRecordContentOffset(0);
+      int contentLength = localPage.getRecordContentLength(0);
+
+      // Content length must match the original content length.
+      Assert.assertEquals(content.length, contentLength);
+
+      // Content offset must be positive and within the page.
+      Assert.assertTrue(contentOffset > 0);
+      Assert.assertTrue(contentOffset + contentLength <= CollectionPage.PAGE_SIZE);
+
+      // Reading bytes from the page at the metadata offset must yield content.
+      byte[] actual = localPage.getRecordBinaryValue(
+          0, CollectionPage.RECORD_METADATA_HEADER_SIZE, contentLength);
+      Assert.assertArrayEquals(content, actual);
+
+    } finally {
+      cacheEntry.releaseExclusiveLock();
+      cachePointer.decrementReferrer();
+    }
+  }
+
+  @Test
+  public void testGetRecordContentOffsetMultipleRecords() {
+    // Verifies content offset/length for multiple records of different sizes.
+    var bufferPool = ByteBufferPool.instance(null);
+    var pointer = bufferPool.acquireDirect(true, Intention.TEST);
+
+    var cachePointer = new CachePointer(pointer, bufferPool, 0, 0);
+    cachePointer.incrementReferrer();
+
+    CacheEntry cacheEntry = new CacheEntryImpl(0, 0, cachePointer, false, null);
+    cacheEntry.acquireExclusiveLock();
+
+    try {
+      final var localPage = new CollectionPage(cacheEntry);
+      localPage.init();
+
+      byte[] small = new byte[] {1, 2, 3};
+      byte[] large = new byte[200];
+      for (int i = 0; i < large.length; i++) {
+        large[i] = (byte) (i & 0xFF);
+      }
+
+      localPage.appendRecord(
+          1L, buildChunk((byte) 'd', 0L, small), -1, IntSets.emptySet());
+      localPage.appendRecord(
+          2L, buildChunk((byte) 'd', 1L, large), -1, IntSets.emptySet());
+
+      Assert.assertEquals(small.length, localPage.getRecordContentLength(0));
+      byte[] actualSmall = localPage.getRecordBinaryValue(
+          0, CollectionPage.RECORD_METADATA_HEADER_SIZE, small.length);
+      Assert.assertArrayEquals(small, actualSmall);
+
+      Assert.assertEquals(large.length, localPage.getRecordContentLength(1));
+      byte[] actualLarge = localPage.getRecordBinaryValue(
+          1, CollectionPage.RECORD_METADATA_HEADER_SIZE, large.length);
+      Assert.assertArrayEquals(large, actualLarge);
+
+    } finally {
+      cacheEntry.releaseExclusiveLock();
+      cachePointer.decrementReferrer();
+    }
+  }
+
+  @Test
+  public void testGetRecordContentOffsetDeletedRecordAssertion() {
+    // Verifies that getRecordContentOffset throws AssertionError for deleted records
+    // when assertions are enabled.
+    var bufferPool = ByteBufferPool.instance(null);
+    var pointer = bufferPool.acquireDirect(true, Intention.TEST);
+
+    var cachePointer = new CachePointer(pointer, bufferPool, 0, 0);
+    cachePointer.incrementReferrer();
+
+    CacheEntry cacheEntry = new CacheEntryImpl(0, 0, cachePointer, false, null);
+    cacheEntry.acquireExclusiveLock();
+
+    try {
+      final var localPage = new CollectionPage(cacheEntry);
+      localPage.init();
+
+      localPage.appendRecord(
+          1L, buildChunk((byte) 'd', 0L, new byte[] {1, 2, 3}), -1, IntSets.emptySet());
+      localPage.deleteRecord(0, true);
+
+      boolean assertionFired = false;
+      try {
+        localPage.getRecordContentOffset(0);
+      } catch (AssertionError e) {
+        assertionFired = true;
+      }
+      Assert.assertTrue("Expected AssertionError for deleted record", assertionFired);
+
+    } finally {
+      cacheEntry.releaseExclusiveLock();
+      cachePointer.decrementReferrer();
+    }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
@@ -1452,8 +1452,13 @@ public class CollectionPageTest {
       // Content length must match the original content length.
       Assert.assertEquals(content.length, contentLength);
 
-      // Content offset must be positive and within the page.
-      Assert.assertTrue(contentOffset > 0);
+      // Content offset must be at least past the entry header (3 ints)
+      // and the metadata header within the page.
+      int minContentOffset =
+          3 * IntegerSerializer.INT_SIZE + CollectionPage.RECORD_METADATA_HEADER_SIZE;
+      Assert.assertTrue(
+          "contentOffset " + contentOffset + " should be >= " + minContentOffset,
+          contentOffset >= minContentOffset);
       Assert.assertTrue(contentOffset + contentLength <= CollectionPage.PAGE_SIZE);
 
       // Reading bytes from the page at the metadata offset must yield content.
@@ -1599,7 +1604,12 @@ public class CollectionPageTest {
       Assert.assertEquals(0, localPage.getRecordContentLength(0));
 
       int contentOffset = localPage.getRecordContentOffset(0);
-      Assert.assertTrue(contentOffset > 0);
+      // Content offset must be at least past the entry header and metadata.
+      int minContentOffset =
+          3 * IntegerSerializer.INT_SIZE + CollectionPage.RECORD_METADATA_HEADER_SIZE;
+      Assert.assertTrue(
+          "contentOffset " + contentOffset + " should be >= " + minContentOffset,
+          contentOffset >= minContentOffset);
       Assert.assertTrue(contentOffset <= CollectionPage.PAGE_SIZE);
 
     } finally {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPageTest.java
@@ -1494,12 +1494,22 @@ public class CollectionPageTest {
       localPage.appendRecord(
           2L, buildChunk((byte) 'd', 1L, large), -1, IntSets.emptySet());
 
+      // Check small record offset and length
+      int offsetSmall = localPage.getRecordContentOffset(0);
       Assert.assertEquals(small.length, localPage.getRecordContentLength(0));
+      Assert.assertTrue(offsetSmall > 0);
+      Assert.assertTrue(offsetSmall + small.length <= CollectionPage.PAGE_SIZE);
       byte[] actualSmall = localPage.getRecordBinaryValue(
           0, CollectionPage.RECORD_METADATA_HEADER_SIZE, small.length);
       Assert.assertArrayEquals(small, actualSmall);
 
+      // Check large record offset and length
+      int offsetLarge = localPage.getRecordContentOffset(1);
       Assert.assertEquals(large.length, localPage.getRecordContentLength(1));
+      Assert.assertTrue(offsetLarge > 0);
+      Assert.assertTrue(offsetLarge + large.length <= CollectionPage.PAGE_SIZE);
+      // Offsets must differ since they are separate records.
+      Assert.assertNotEquals(offsetSmall, offsetLarge);
       byte[] actualLarge = localPage.getRecordBinaryValue(
           1, CollectionPage.RECORD_METADATA_HEADER_SIZE, large.length);
       Assert.assertArrayEquals(large, actualLarge);
@@ -1531,13 +1541,57 @@ public class CollectionPageTest {
           1L, buildChunk((byte) 'd', 0L, new byte[] {1, 2, 3}), -1, IntSets.emptySet());
       localPage.deleteRecord(0, true);
 
-      boolean assertionFired = false;
+      boolean offsetAssertionFired = false;
       try {
         localPage.getRecordContentOffset(0);
       } catch (AssertionError e) {
-        assertionFired = true;
+        offsetAssertionFired = true;
       }
-      Assert.assertTrue("Expected AssertionError for deleted record", assertionFired);
+      Assert.assertTrue(
+          "Expected AssertionError for deleted record on getRecordContentOffset",
+          offsetAssertionFired);
+
+      boolean lengthAssertionFired = false;
+      try {
+        localPage.getRecordContentLength(0);
+      } catch (AssertionError e) {
+        lengthAssertionFired = true;
+      }
+      Assert.assertTrue(
+          "Expected AssertionError for deleted record on getRecordContentLength",
+          lengthAssertionFired);
+
+    } finally {
+      cacheEntry.releaseExclusiveLock();
+      cachePointer.decrementReferrer();
+    }
+  }
+
+  @Test
+  public void testGetRecordContentLengthZeroContentChunk() {
+    // Minimum-size chunk: metadata header + tail, zero content bytes.
+    // getRecordContentLength should return 0.
+    var bufferPool = ByteBufferPool.instance(null);
+    var pointer = bufferPool.acquireDirect(true, Intention.TEST);
+
+    var cachePointer = new CachePointer(pointer, bufferPool, 0, 0);
+    cachePointer.incrementReferrer();
+
+    CacheEntry cacheEntry = new CacheEntryImpl(0, 0, cachePointer, false, null);
+    cacheEntry.acquireExclusiveLock();
+
+    try {
+      final var localPage = new CollectionPage(cacheEntry);
+      localPage.init();
+
+      byte[] chunk = buildChunk((byte) 'd', 0L, new byte[0]);
+      localPage.appendRecord(1L, chunk, -1, IntSets.emptySet());
+
+      Assert.assertEquals(0, localPage.getRecordContentLength(0));
+
+      int contentOffset = localPage.getRecordContentOffset(0);
+      Assert.assertTrue(contentOffset > 0);
+      Assert.assertTrue(contentOffset <= CollectionPage.PAGE_SIZE);
 
     } finally {
       cacheEntry.releaseExclusiveLock();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/LocalPaginatedCollectionAbstract.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/LocalPaginatedCollectionAbstract.java
@@ -113,7 +113,9 @@ public abstract class LocalPaginatedCollectionAbstract {
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       Assert.assertEquals(0, paginatedCollection.getEntries(atomicOperation));
       try {
-        paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation);
+        paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation)
+            .toRawBuffer()
+            .toRawBuffer();
         Assert.fail();
       } catch (RecordNotFoundException ignore) {
         // expected
@@ -155,7 +157,9 @@ public abstract class LocalPaginatedCollectionAbstract {
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       Assert.assertEquals(0, paginatedCollection.getEntries(atomicOperation));
       try {
-        paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation);
+        paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation)
+            .toRawBuffer()
+            .toRawBuffer();
         Assert.fail();
       } catch (RecordNotFoundException recordNotFoundException) {
         // expected
@@ -169,7 +173,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition[0].collectionPosition,
-            atomicOperation));
+            atomicOperation).toRawBuffer());
     Assert.assertNotNull(rawBuffer);
 
     Assert.assertTrue(rawBuffer.version() > 0);
@@ -199,7 +203,9 @@ public abstract class LocalPaginatedCollectionAbstract {
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       Assert.assertEquals(0, paginatedCollection.getEntries(atomicOperation));
       try {
-        paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation);
+        paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation)
+            .toRawBuffer()
+            .toRawBuffer();
         Assert.fail();
       } catch (RecordNotFoundException recordNotFoundException) {
         // expected
@@ -213,7 +219,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition[0].collectionPosition,
-            atomicOperation));
+            atomicOperation).toRawBuffer());
     Assert.assertNotNull(rawBuffer);
 
     Assert.assertTrue(rawBuffer.version() > 0);
@@ -268,7 +274,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long collectionPosition : rolledBackRecordSet) {
         try {
-          paginatedCollection.readRecord(collectionPosition, atomicOperation);
+          paginatedCollection.readRecord(collectionPosition, atomicOperation).toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
           // expected
@@ -292,7 +298,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -357,7 +364,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long collectionPosition : rolledBackRecordSet) {
         try {
-          paginatedCollection.readRecord(collectionPosition, atomicOperation);
+          paginatedCollection.readRecord(collectionPosition, atomicOperation).toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
           // expected
@@ -384,7 +391,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -442,7 +450,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long collectionPosition : rolledBackRecordSet) {
         try {
-          paginatedCollection.readRecord(collectionPosition, atomicOperation);
+          paginatedCollection.readRecord(collectionPosition, atomicOperation).toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
           // expected
@@ -467,7 +475,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -495,7 +504,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       Assert.assertTrue(position.collectionPosition >= 0);
       try {
-        paginatedCollection.readRecord(position.collectionPosition, atomicOperation);
+        paginatedCollection.readRecord(position.collectionPosition, atomicOperation).toRawBuffer();
         Assert.fail();
       } catch (RecordNotFoundException recordNotFoundException) {
         // expected
@@ -508,7 +517,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     var rec = atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(position.collectionPosition,
-            atomicOperation));
+            atomicOperation).toRawBuffer());
     Assert.assertNotNull(rec);
   }
 
@@ -524,7 +533,8 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         Assert.assertTrue(position.collectionPosition >= 0);
         try {
-          paginatedCollection.readRecord(position.collectionPosition, atomicOperation);
+          paginatedCollection.readRecord(position.collectionPosition, atomicOperation).toRawBuffer()
+              .toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
           // expected
@@ -541,7 +551,9 @@ public abstract class LocalPaginatedCollectionAbstract {
                   paginatedCollection.allocatePosition((byte) 'd', atomicOperation);
               Assert.assertTrue(position.collectionPosition >= 0);
               try {
-                paginatedCollection.readRecord(position.collectionPosition, atomicOperation);
+                paginatedCollection.readRecord(position.collectionPosition, atomicOperation)
+                    .toRawBuffer()
+                    .toRawBuffer();
                 Assert.fail();
               } catch (RecordNotFoundException recordNotFoundException) {
                 //expected
@@ -560,7 +572,8 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         Assert.assertTrue(position.collectionPosition >= 0);
         try {
-          paginatedCollection.readRecord(position.collectionPosition, atomicOperation);
+          paginatedCollection.readRecord(position.collectionPosition, atomicOperation).toRawBuffer()
+              .toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
           // expected
@@ -629,7 +642,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
           var rawBuffer =
-              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+              paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -667,7 +680,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         Assert.assertEquals(paginatedCollection.getEntries(atomicOperation), records - delRecords);
         try {
-          paginatedCollection.readRecord(deletedPosition, atomicOperation);
+          paginatedCollection.readRecord(deletedPosition, atomicOperation).toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
           // expected
@@ -681,7 +694,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -745,7 +759,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
           var rawBuffer =
-              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+              paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -785,7 +799,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     for (long deletedPosition : deletedPositions) {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         try {
-          paginatedCollection.readRecord(deletedPosition, atomicOperation);
+          paginatedCollection.readRecord(deletedPosition, atomicOperation).toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException ignore) {
           // expected
@@ -799,7 +813,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -857,7 +872,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
           var rawBuffer =
-              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+              paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -897,7 +912,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       for (long deletedPosition : deletedPositions) {
         atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
           try {
-            paginatedCollection.readRecord(deletedPosition, atomicOperation);
+            paginatedCollection.readRecord(deletedPosition, atomicOperation).toRawBuffer();
             Assert.fail();
           } catch (RecordNotFoundException ignore) {
           }
@@ -911,7 +926,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
           var rawBuffer =
-              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+              paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -993,7 +1008,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -1028,8 +1044,8 @@ public abstract class LocalPaginatedCollectionAbstract {
     }
 
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
     Assert.assertNotNull(rawBuffer);
 
     var versionAfterCreate = rawBuffer.version();
@@ -1045,8 +1061,8 @@ public abstract class LocalPaginatedCollectionAbstract {
             atomicOperation));
 
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperations -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperations));
+        atomicOperations -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperations).toRawBuffer());
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
     Assertions.assertThat(rawBuffer.buffer()).isEqualTo(updatedRecord);
@@ -1093,8 +1109,8 @@ public abstract class LocalPaginatedCollectionAbstract {
             (byte) 2,
             atomicOperation));
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
 
@@ -1127,8 +1143,8 @@ public abstract class LocalPaginatedCollectionAbstract {
     }
 
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
     Assert.assertNotNull(rawBuffer);
 
     var versionAfterCreate = rawBuffer.version();
@@ -1144,8 +1160,8 @@ public abstract class LocalPaginatedCollectionAbstract {
             atomicOperation));
 
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
     Assertions.assertThat(rawBuffer.buffer()).isEqualTo(smallRecord);
@@ -1167,8 +1183,8 @@ public abstract class LocalPaginatedCollectionAbstract {
                 bigRecord, (byte) 1, null, atomicOperation));
 
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
     Assert.assertNotNull(rawBuffer);
 
     var versionAfterCreate = rawBuffer.version();
@@ -1193,8 +1209,8 @@ public abstract class LocalPaginatedCollectionAbstract {
     }
 
     rawBuffer = atomicOperationsManager
-        .calculateInsideAtomicOperation(atomicOperation -> (RawBuffer) paginatedCollection
-            .readRecord(physicalPosition.collectionPosition, atomicOperation));
+        .calculateInsideAtomicOperation(atomicOperation -> paginatedCollection
+            .readRecord(physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
 
     Assert.assertNotNull(rawBuffer);
 
@@ -1209,8 +1225,8 @@ public abstract class LocalPaginatedCollectionAbstract {
             (byte) 2,
             atomicOperation));
     rawBuffer = atomicOperationsManager
-        .calculateInsideAtomicOperation(atomicOperation -> (RawBuffer) paginatedCollection
-            .readRecord(physicalPosition.collectionPosition, atomicOperation));
+        .calculateInsideAtomicOperation(atomicOperation -> paginatedCollection
+            .readRecord(physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
     Assertions.assertThat(rawBuffer.buffer()).isEqualTo(updatedBigRecord);
@@ -1246,7 +1262,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     Map<Long, Long> initialVersions = new HashMap<>();
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long pos : positionRecordMap.keySet()) {
-        var buf = (RawBuffer) paginatedCollection.readRecord(pos, atomicOperation);
+        var buf = paginatedCollection.readRecord(pos, atomicOperation).toRawBuffer();
         initialVersions.put(pos, buf.version());
       }
     });
@@ -1293,7 +1309,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assertions.assertThat(rawBuffer.buffer()).isEqualTo(entry.getValue());
@@ -1343,7 +1360,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     Map<Long, Long> initialVersions = new HashMap<>();
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long pos : positionRecordMap.keySet()) {
-        var buf = (RawBuffer) paginatedCollection.readRecord(pos, atomicOperation);
+        var buf = paginatedCollection.readRecord(pos, atomicOperation).toRawBuffer();
         initialVersions.put(pos, buf.version());
       }
     });
@@ -1391,7 +1408,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
         Assertions.assertThat(rawBuffer.buffer()).isEqualTo(entry.getValue());
 
@@ -1435,7 +1453,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     Map<Long, Long> initialVersions = new HashMap<>();
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long pos : positionRecordMap.keySet()) {
-        var buf = (RawBuffer) paginatedCollection.readRecord(pos, atomicOperation);
+        var buf = paginatedCollection.readRecord(pos, atomicOperation).toRawBuffer();
         initialVersions.put(pos, buf.version());
       }
     });
@@ -1479,7 +1497,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer =
+            paginatedCollection.readRecord(entry.getKey(), atomicOperation).toRawBuffer();
         Assert.assertNotNull(rawBuffer);
 
         Assertions.assertThat(rawBuffer.buffer()).isEqualTo(entry.getValue());
@@ -1719,8 +1738,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Verify initial version
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
     var initialVersion = rawBuffer.version();
 
     // Update version
@@ -1730,8 +1749,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Verify version was updated
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
     Assert.assertNotEquals(initialVersion, rawBuffer.version());
 
     // Content and type should be unchanged
@@ -1776,7 +1795,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     for (var v = 10; v <= 50; v += 10) {
       var previousVersion = ((RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
           atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-              atomicOperation)))
+              atomicOperation).toRawBuffer()))
           .version();
 
       atomicOperationsManager.executeInsideAtomicOperation(
@@ -1785,7 +1804,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
       var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
           atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-              atomicOperation));
+              atomicOperation).toRawBuffer());
       Assert.assertNotEquals(previousVersion, rawBuffer.version());
     }
   }
@@ -1801,7 +1820,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     var initialVersion = ((RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation)))
+            atomicOperation).toRawBuffer()))
         .version();
 
     // Update version inside a rolled-back transaction
@@ -1817,8 +1836,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Version should still be the initial one
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
-            physicalPosition.collectionPosition, atomicOperation));
+        atomicOperation -> paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation).toRawBuffer());
     Assert.assertEquals(initialVersion, rawBuffer.version());
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/LocalPaginatedCollectionAbstract.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/LocalPaginatedCollectionAbstract.java
@@ -6,6 +6,7 @@ import com.jetbrains.youtrackdb.internal.common.types.ModifiableInteger;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
+import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.IOException;
@@ -166,7 +167,7 @@ public abstract class LocalPaginatedCollectionAbstract {
             paginatedCollection.createRecord(
                 smallRecord, (byte) 1, null, atomicOperation));
 
-    var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
+    var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition[0].collectionPosition,
             atomicOperation));
     Assert.assertNotNull(rawBuffer);
@@ -210,7 +211,7 @@ public abstract class LocalPaginatedCollectionAbstract {
             paginatedCollection.createRecord(
                 bigRecord, (byte) 1, null, atomicOperation));
 
-    var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
+    var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition[0].collectionPosition,
             atomicOperation));
     Assert.assertNotNull(rawBuffer);
@@ -291,7 +292,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -383,7 +384,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -466,7 +467,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -627,7 +628,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
-          var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+          var rawBuffer =
+              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -679,7 +681,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -742,7 +744,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
-          var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+          var rawBuffer =
+              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -796,7 +799,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -853,7 +856,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
-          var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+          var rawBuffer =
+              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -906,7 +910,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         for (var entry : positionRecordMap.entrySet()) {
-          var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+          var rawBuffer =
+              (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
           Assert.assertNotNull(rawBuffer);
 
           Assert.assertTrue(rawBuffer.version() > 0);
@@ -988,7 +993,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assert.assertTrue(rawBuffer.version() > 0);
@@ -1023,8 +1028,8 @@ public abstract class LocalPaginatedCollectionAbstract {
     }
 
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
     Assert.assertNotNull(rawBuffer);
 
     var versionAfterCreate = rawBuffer.version();
@@ -1040,8 +1045,8 @@ public abstract class LocalPaginatedCollectionAbstract {
             atomicOperation));
 
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperations -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperations));
+        atomicOperations -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperations));
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
     Assertions.assertThat(rawBuffer.buffer()).isEqualTo(updatedRecord);
@@ -1072,7 +1077,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     } catch (RollbackException ignore) {
     }
 
-    var rawBuffer = atomicOperationsManager
+    var rawBuffer = (RawBuffer) atomicOperationsManager
         .calculateInsideAtomicOperation(atomicOperation -> paginatedCollection
             .readRecord(physicalPosition.collectionPosition, atomicOperation));
     Assert.assertNotNull(rawBuffer);
@@ -1088,8 +1093,8 @@ public abstract class LocalPaginatedCollectionAbstract {
             (byte) 2,
             atomicOperation));
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
 
@@ -1122,8 +1127,8 @@ public abstract class LocalPaginatedCollectionAbstract {
     }
 
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
     Assert.assertNotNull(rawBuffer);
 
     var versionAfterCreate = rawBuffer.version();
@@ -1139,8 +1144,8 @@ public abstract class LocalPaginatedCollectionAbstract {
             atomicOperation));
 
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
     Assertions.assertThat(rawBuffer.buffer()).isEqualTo(smallRecord);
@@ -1162,8 +1167,8 @@ public abstract class LocalPaginatedCollectionAbstract {
                 bigRecord, (byte) 1, null, atomicOperation));
 
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
     Assert.assertNotNull(rawBuffer);
 
     var versionAfterCreate = rawBuffer.version();
@@ -1188,7 +1193,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     }
 
     rawBuffer = atomicOperationsManager
-        .calculateInsideAtomicOperation(atomicOperation -> paginatedCollection
+        .calculateInsideAtomicOperation(atomicOperation -> (RawBuffer) paginatedCollection
             .readRecord(physicalPosition.collectionPosition, atomicOperation));
 
     Assert.assertNotNull(rawBuffer);
@@ -1204,7 +1209,7 @@ public abstract class LocalPaginatedCollectionAbstract {
             (byte) 2,
             atomicOperation));
     rawBuffer = atomicOperationsManager
-        .calculateInsideAtomicOperation(atomicOperation -> paginatedCollection
+        .calculateInsideAtomicOperation(atomicOperation -> (RawBuffer) paginatedCollection
             .readRecord(physicalPosition.collectionPosition, atomicOperation));
 
     Assert.assertNotEquals(versionAfterCreate, rawBuffer.version());
@@ -1241,7 +1246,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     Map<Long, Long> initialVersions = new HashMap<>();
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long pos : positionRecordMap.keySet()) {
-        var buf = paginatedCollection.readRecord(pos, atomicOperation);
+        var buf = (RawBuffer) paginatedCollection.readRecord(pos, atomicOperation);
         initialVersions.put(pos, buf.version());
       }
     });
@@ -1288,7 +1293,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assertions.assertThat(rawBuffer.buffer()).isEqualTo(entry.getValue());
@@ -1338,7 +1343,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     Map<Long, Long> initialVersions = new HashMap<>();
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long pos : positionRecordMap.keySet()) {
-        var buf = paginatedCollection.readRecord(pos, atomicOperation);
+        var buf = (RawBuffer) paginatedCollection.readRecord(pos, atomicOperation);
         initialVersions.put(pos, buf.version());
       }
     });
@@ -1386,7 +1391,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
         Assertions.assertThat(rawBuffer.buffer()).isEqualTo(entry.getValue());
 
@@ -1430,7 +1435,7 @@ public abstract class LocalPaginatedCollectionAbstract {
     Map<Long, Long> initialVersions = new HashMap<>();
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (long pos : positionRecordMap.keySet()) {
-        var buf = paginatedCollection.readRecord(pos, atomicOperation);
+        var buf = (RawBuffer) paginatedCollection.readRecord(pos, atomicOperation);
         initialVersions.put(pos, buf.version());
       }
     });
@@ -1474,7 +1479,7 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
       for (var entry : positionRecordMap.entrySet()) {
-        var rawBuffer = paginatedCollection.readRecord(entry.getKey(), atomicOperation);
+        var rawBuffer = (RawBuffer) paginatedCollection.readRecord(entry.getKey(), atomicOperation);
         Assert.assertNotNull(rawBuffer);
 
         Assertions.assertThat(rawBuffer.buffer()).isEqualTo(entry.getValue());
@@ -1714,8 +1719,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Verify initial version
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
     var initialVersion = rawBuffer.version();
 
     // Update version
@@ -1725,8 +1730,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Verify version was updated
     rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
     Assert.assertNotEquals(initialVersion, rawBuffer.version());
 
     // Content and type should be unchanged
@@ -1769,16 +1774,16 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Update version multiple times
     for (var v = 10; v <= 50; v += 10) {
-      var previousVersion = atomicOperationsManager.calculateInsideAtomicOperation(
+      var previousVersion = ((RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
           atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-              atomicOperation))
+              atomicOperation)))
           .version();
 
       atomicOperationsManager.executeInsideAtomicOperation(
           atomicOperation -> paginatedCollection.updateRecordVersion(
               physicalPosition.collectionPosition, atomicOperation));
 
-      var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
+      var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
           atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
               atomicOperation));
       Assert.assertNotEquals(previousVersion, rawBuffer.version());
@@ -1794,9 +1799,9 @@ public abstract class LocalPaginatedCollectionAbstract {
             atomicOperation -> paginatedCollection.createRecord(
                 record, (byte) 1, null, atomicOperation));
 
-    var initialVersion = atomicOperationsManager.calculateInsideAtomicOperation(
+    var initialVersion = ((RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation))
+            atomicOperation)))
         .version();
 
     // Update version inside a rolled-back transaction
@@ -1812,8 +1817,8 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Version should still be the initial one
     var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
-        atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation));
+        atomicOperation -> (RawBuffer) paginatedCollection.readRecord(
+            physicalPosition.collectionPosition, atomicOperation));
     Assert.assertEquals(initialVersion, rawBuffer.version());
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/LocalPaginatedCollectionAbstract.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/LocalPaginatedCollectionAbstract.java
@@ -6,7 +6,6 @@ import com.jetbrains.youtrackdb.internal.common.types.ModifiableInteger;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
-import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.IOException;
@@ -114,7 +113,6 @@ public abstract class LocalPaginatedCollectionAbstract {
       Assert.assertEquals(0, paginatedCollection.getEntries(atomicOperation));
       try {
         paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation)
-            .toRawBuffer()
             .toRawBuffer();
         Assert.fail();
       } catch (RecordNotFoundException ignore) {
@@ -158,7 +156,6 @@ public abstract class LocalPaginatedCollectionAbstract {
       Assert.assertEquals(0, paginatedCollection.getEntries(atomicOperation));
       try {
         paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation)
-            .toRawBuffer()
             .toRawBuffer();
         Assert.fail();
       } catch (RecordNotFoundException recordNotFoundException) {
@@ -171,7 +168,7 @@ public abstract class LocalPaginatedCollectionAbstract {
             paginatedCollection.createRecord(
                 smallRecord, (byte) 1, null, atomicOperation));
 
-    var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
+    var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition[0].collectionPosition,
             atomicOperation).toRawBuffer());
     Assert.assertNotNull(rawBuffer);
@@ -204,7 +201,6 @@ public abstract class LocalPaginatedCollectionAbstract {
       Assert.assertEquals(0, paginatedCollection.getEntries(atomicOperation));
       try {
         paginatedCollection.readRecord(physicalPosition[0].collectionPosition, atomicOperation)
-            .toRawBuffer()
             .toRawBuffer();
         Assert.fail();
       } catch (RecordNotFoundException recordNotFoundException) {
@@ -217,7 +213,7 @@ public abstract class LocalPaginatedCollectionAbstract {
             paginatedCollection.createRecord(
                 bigRecord, (byte) 1, null, atomicOperation));
 
-    var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
+    var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition[0].collectionPosition,
             atomicOperation).toRawBuffer());
     Assert.assertNotNull(rawBuffer);
@@ -533,7 +529,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         Assert.assertTrue(position.collectionPosition >= 0);
         try {
-          paginatedCollection.readRecord(position.collectionPosition, atomicOperation).toRawBuffer()
+          paginatedCollection.readRecord(position.collectionPosition, atomicOperation)
               .toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
@@ -552,7 +548,6 @@ public abstract class LocalPaginatedCollectionAbstract {
               Assert.assertTrue(position.collectionPosition >= 0);
               try {
                 paginatedCollection.readRecord(position.collectionPosition, atomicOperation)
-                    .toRawBuffer()
                     .toRawBuffer();
                 Assert.fail();
               } catch (RecordNotFoundException recordNotFoundException) {
@@ -572,7 +567,7 @@ public abstract class LocalPaginatedCollectionAbstract {
       atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
         Assert.assertTrue(position.collectionPosition >= 0);
         try {
-          paginatedCollection.readRecord(position.collectionPosition, atomicOperation).toRawBuffer()
+          paginatedCollection.readRecord(position.collectionPosition, atomicOperation)
               .toRawBuffer();
           Assert.fail();
         } catch (RecordNotFoundException recordNotFoundException) {
@@ -1093,9 +1088,10 @@ public abstract class LocalPaginatedCollectionAbstract {
     } catch (RollbackException ignore) {
     }
 
-    var rawBuffer = (RawBuffer) atomicOperationsManager
+    var rawBuffer = atomicOperationsManager
         .calculateInsideAtomicOperation(atomicOperation -> paginatedCollection
-            .readRecord(physicalPosition.collectionPosition, atomicOperation));
+            .readRecord(physicalPosition.collectionPosition, atomicOperation))
+        .toRawBuffer();
     Assert.assertNotNull(rawBuffer);
     var versionAfterCreate = rawBuffer.version();
     Assert.assertTrue(versionAfterCreate > 0);
@@ -1793,16 +1789,16 @@ public abstract class LocalPaginatedCollectionAbstract {
 
     // Update version multiple times
     for (var v = 10; v <= 50; v += 10) {
-      var previousVersion = ((RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
+      var previousVersion = atomicOperationsManager.calculateInsideAtomicOperation(
           atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-              atomicOperation).toRawBuffer()))
+              atomicOperation).toRawBuffer())
           .version();
 
       atomicOperationsManager.executeInsideAtomicOperation(
           atomicOperation -> paginatedCollection.updateRecordVersion(
               physicalPosition.collectionPosition, atomicOperation));
 
-      var rawBuffer = (RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
+      var rawBuffer = atomicOperationsManager.calculateInsideAtomicOperation(
           atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
               atomicOperation).toRawBuffer());
       Assert.assertNotEquals(previousVersion, rawBuffer.version());
@@ -1818,9 +1814,9 @@ public abstract class LocalPaginatedCollectionAbstract {
             atomicOperation -> paginatedCollection.createRecord(
                 record, (byte) 1, null, atomicOperation));
 
-    var initialVersion = ((RawBuffer) atomicOperationsManager.calculateInsideAtomicOperation(
+    var initialVersion = atomicOperationsManager.calculateInsideAtomicOperation(
         atomicOperation -> paginatedCollection.readRecord(physicalPosition.collectionPosition,
-            atomicOperation).toRawBuffer()))
+            atomicOperation).toRawBuffer())
         .version();
 
     // Update version inside a rolled-back transaction

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/LocalPaginatedCollectionV2TestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/LocalPaginatedCollectionV2TestIT.java
@@ -11,7 +11,6 @@ import com.jetbrains.youtrackdb.internal.core.config.StoragePaginatedCollectionC
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
-import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.CollectionPage;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.LocalPaginatedCollectionAbstract;
@@ -353,8 +352,8 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     atomicOps().executeInsideAtomicOperation(op -> collection.open(op));
 
     // Verify data persisted across close/open
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> collection.readRecord(pos.collectionPosition, op));
+    var buffer = atomicOps().calculateInsideAtomicOperation(
+        op -> collection.readRecord(pos.collectionPosition, op)).toRawBuffer();
     Assert.assertNotNull("Record should be readable after reopen", buffer);
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
     Assert.assertEquals(2, buffer.recordType());
@@ -412,8 +411,8 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         collection.getFileName().contains("renameTarget"));
 
     // Verify data is still accessible after rename
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> collection.readRecord(pos.collectionPosition, op));
+    var buffer = atomicOps().calculateInsideAtomicOperation(
+        op -> collection.readRecord(pos.collectionPosition, op)).toRawBuffer();
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
 
     // Clean up
@@ -639,8 +638,8 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     var pos = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.createRecord(smallRecord, (byte) 1, null, op));
 
-    var versionAfterCreate = ((RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer())).version();
+    var versionAfterCreate = atomicOps().calculateInsideAtomicOperation(
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer()).version();
 
     // Update to a big record that spans multiple pages
     var bigRecord = new byte[(2 << 16) + 100];
@@ -650,7 +649,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.updateRecord(
             pos.collectionPosition, bigRecord, (byte) 3, op));
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertNotNull(buffer);
     Assert.assertNotEquals("Version should change after update",
@@ -673,7 +672,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.updateRecord(
             pos.collectionPosition, smallRecord, (byte) 2, op));
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(smallRecord);
     Assert.assertEquals(2, buffer.recordType());
@@ -723,8 +722,8 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     var pos = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.createRecord(originalData, (byte) 1, null, op));
 
-    var versionBefore = ((RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer())).version();
+    var versionBefore = atomicOps().calculateInsideAtomicOperation(
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer()).version();
 
     try {
       atomicOps().executeInsideAtomicOperation(op -> {
@@ -735,7 +734,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     } catch (RollbackException ignore) {
     }
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertEquals("Version should be unchanged after rollback",
         versionBefore, buffer.version());
@@ -759,7 +758,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     var pos = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.createRecord(nearMaxRecord, (byte) 1, null, op));
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(nearMaxRecord);
   }
@@ -877,7 +876,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
           pos.collectionPosition, new byte[] {30, 40, 50}, (byte) 3, op);
     });
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer())
         .as("Second update should win")
@@ -897,7 +896,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
           pos[0].collectionPosition, new byte[] {4, 5, 6, 7}, (byte) 2, op);
     });
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos[0].collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(new byte[] {4, 5, 6, 7});
     Assert.assertEquals(2, buffer.recordType());
@@ -1058,7 +1057,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     atomicOps().executeInsideAtomicOperation(
         op -> paginatedCollection.createRecord(data, (byte) 1, allocated, op));
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(allocated.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
     Assert.assertEquals(1, buffer.recordType());
@@ -1290,7 +1289,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.updateRecordVersion(pos.collectionPosition, op));
 
     // Verify the record is still readable with correct content
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
   }
@@ -1897,12 +1896,12 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.createRecord(data, (byte) 'd', null, op));
 
     // First read — warms the read cache (pages loaded via pinned path).
-    var buffer1 = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer1 = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertArrayEquals(data, buffer1.buffer());
 
     // Second read — pages are now in cache, optimistic path can succeed.
-    var buffer2 = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer2 = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertArrayEquals(data, buffer2.buffer());
     Assert.assertEquals('d', buffer2.recordType());

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/LocalPaginatedCollectionV2TestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/LocalPaginatedCollectionV2TestIT.java
@@ -484,7 +484,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer();
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -540,7 +540,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer();
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -640,7 +640,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.createRecord(smallRecord, (byte) 1, null, op));
 
     var versionAfterCreate = ((RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op))).version();
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer())).version();
 
     // Update to a big record that spans multiple pages
     var bigRecord = new byte[(2 << 16) + 100];
@@ -651,7 +651,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             pos.collectionPosition, bigRecord, (byte) 3, op));
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertNotNull(buffer);
     Assert.assertNotEquals("Version should change after update",
         versionAfterCreate, buffer.version());
@@ -674,7 +674,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             pos.collectionPosition, smallRecord, (byte) 2, op));
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(smallRecord);
     Assert.assertEquals(2, buffer.recordType());
   }
@@ -724,7 +724,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.createRecord(originalData, (byte) 1, null, op));
 
     var versionBefore = ((RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op))).version();
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer())).version();
 
     try {
       atomicOps().executeInsideAtomicOperation(op -> {
@@ -736,7 +736,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     }
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertEquals("Version should be unchanged after rollback",
         versionBefore, buffer.version());
     Assertions.assertThat(buffer.buffer())
@@ -760,7 +760,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.createRecord(nearMaxRecord, (byte) 1, null, op));
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(nearMaxRecord);
   }
 
@@ -794,7 +794,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     // Verify all records are readable
     for (var pos : positions) {
       var buffer = atomicOps().calculateInsideAtomicOperation(
-          op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+          op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
       Assert.assertNotNull("All created records should be readable", buffer);
     }
   }
@@ -878,7 +878,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     });
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer())
         .as("Second update should win")
         .isEqualTo(new byte[] {30, 40, 50});
@@ -898,7 +898,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     });
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos[0].collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos[0].collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(new byte[] {4, 5, 6, 7});
     Assert.assertEquals(2, buffer.recordType());
   }
@@ -930,7 +930,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer();
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -1059,7 +1059,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.createRecord(data, (byte) 1, allocated, op));
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(allocated.collectionPosition, op));
+        op -> paginatedCollection.readRecord(allocated.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
     Assert.assertEquals(1, buffer.recordType());
   }
@@ -1097,7 +1097,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
       var data = new byte[] {42, 43, 44};
       var pos = paginatedCollection.createRecord(data, (byte) 5, null, op);
 
-      var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
+      var buffer = paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer();
       Assertions.assertThat(buffer.buffer()).isEqualTo(data);
       Assert.assertEquals(5, buffer.recordType());
 
@@ -1120,7 +1120,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
       // The record was created and deleted in the same operation, so it should not be
       // counted
       try {
-        paginatedCollection.readRecord(pos.collectionPosition, op);
+        paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer();
         Assert.fail("Should throw RecordNotFoundException for deleted record");
       } catch (RecordNotFoundException e) {
         // expected
@@ -1160,7 +1160,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer();
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -1201,7 +1201,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
 
     try {
       atomicOps().executeInsideAtomicOperation(
-          op -> paginatedCollection.readRecord(allocated.collectionPosition, op));
+          op -> paginatedCollection.readRecord(allocated.collectionPosition, op).toRawBuffer());
       Assert.fail("Should throw RecordNotFoundException for allocated but not written position");
     } catch (RecordNotFoundException e) {
       // expected: the position is allocated but has no content yet
@@ -1291,7 +1291,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
 
     // Verify the record is still readable with correct content
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
   }
 
@@ -1381,7 +1381,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer();
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -1898,12 +1898,12 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
 
     // First read — warms the read cache (pages loaded via pinned path).
     var buffer1 = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertArrayEquals(data, buffer1.buffer());
 
     // Second read — pages are now in cache, optimistic path can succeed.
     var buffer2 = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op));
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op).toRawBuffer());
     Assert.assertArrayEquals(data, buffer2.buffer());
     Assert.assertEquals('d', buffer2.recordType());
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/LocalPaginatedCollectionV2TestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/LocalPaginatedCollectionV2TestIT.java
@@ -11,6 +11,7 @@ import com.jetbrains.youtrackdb.internal.core.config.StoragePaginatedCollectionC
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
+import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.StorageCollection;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.CollectionPage;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.LocalPaginatedCollectionAbstract;
@@ -352,7 +353,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     atomicOps().executeInsideAtomicOperation(op -> collection.open(op));
 
     // Verify data persisted across close/open
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> collection.readRecord(pos.collectionPosition, op));
     Assert.assertNotNull("Record should be readable after reopen", buffer);
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
@@ -411,7 +412,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         collection.getFileName().contains("renameTarget"));
 
     // Verify data is still accessible after rename
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> collection.readRecord(pos.collectionPosition, op));
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
 
@@ -483,7 +484,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -539,7 +540,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -638,8 +639,8 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     var pos = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.createRecord(smallRecord, (byte) 1, null, op));
 
-    var versionAfterCreate = atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op)).version();
+    var versionAfterCreate = ((RawBuffer) atomicOps().calculateInsideAtomicOperation(
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op))).version();
 
     // Update to a big record that spans multiple pages
     var bigRecord = new byte[(2 << 16) + 100];
@@ -649,7 +650,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.updateRecord(
             pos.collectionPosition, bigRecord, (byte) 3, op));
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assert.assertNotNull(buffer);
     Assert.assertNotEquals("Version should change after update",
@@ -672,7 +673,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.updateRecord(
             pos.collectionPosition, smallRecord, (byte) 2, op));
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assertions.assertThat(buffer.buffer()).isEqualTo(smallRecord);
     Assert.assertEquals(2, buffer.recordType());
@@ -722,8 +723,8 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     var pos = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.createRecord(originalData, (byte) 1, null, op));
 
-    var versionBefore = atomicOps().calculateInsideAtomicOperation(
-        op -> paginatedCollection.readRecord(pos.collectionPosition, op)).version();
+    var versionBefore = ((RawBuffer) atomicOps().calculateInsideAtomicOperation(
+        op -> paginatedCollection.readRecord(pos.collectionPosition, op))).version();
 
     try {
       atomicOps().executeInsideAtomicOperation(op -> {
@@ -734,7 +735,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     } catch (RollbackException ignore) {
     }
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assert.assertEquals("Version should be unchanged after rollback",
         versionBefore, buffer.version());
@@ -758,7 +759,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     var pos = atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.createRecord(nearMaxRecord, (byte) 1, null, op));
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assertions.assertThat(buffer.buffer()).isEqualTo(nearMaxRecord);
   }
@@ -876,7 +877,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
           pos.collectionPosition, new byte[] {30, 40, 50}, (byte) 3, op);
     });
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assertions.assertThat(buffer.buffer())
         .as("Second update should win")
@@ -896,7 +897,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
           pos[0].collectionPosition, new byte[] {4, 5, 6, 7}, (byte) 2, op);
     });
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos[0].collectionPosition, op));
     Assertions.assertThat(buffer.buffer()).isEqualTo(new byte[] {4, 5, 6, 7});
     Assert.assertEquals(2, buffer.recordType());
@@ -929,7 +930,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -1057,7 +1058,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
     atomicOps().executeInsideAtomicOperation(
         op -> paginatedCollection.createRecord(data, (byte) 1, allocated, op));
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(allocated.collectionPosition, op));
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
     Assert.assertEquals(1, buffer.recordType());
@@ -1096,7 +1097,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
       var data = new byte[] {42, 43, 44};
       var pos = paginatedCollection.createRecord(data, (byte) 5, null, op);
 
-      var buffer = paginatedCollection.readRecord(pos.collectionPosition, op);
+      var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
       Assertions.assertThat(buffer.buffer()).isEqualTo(data);
       Assert.assertEquals(5, buffer.recordType());
 
@@ -1159,7 +1160,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -1289,7 +1290,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.updateRecordVersion(pos.collectionPosition, op));
 
     // Verify the record is still readable with correct content
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
   }
@@ -1380,7 +1381,7 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
           }
-          var buffer = paginatedCollection.readRecord(pos.collectionPosition, op);
+          var buffer = (RawBuffer) paginatedCollection.readRecord(pos.collectionPosition, op);
           readerResult.set(buffer.buffer());
         });
       } catch (Throwable t) {
@@ -1896,12 +1897,12 @@ public class LocalPaginatedCollectionV2TestIT extends LocalPaginatedCollectionAb
         op -> paginatedCollection.createRecord(data, (byte) 'd', null, op));
 
     // First read — warms the read cache (pages loaded via pinned path).
-    var buffer1 = atomicOps().calculateInsideAtomicOperation(
+    var buffer1 = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assert.assertArrayEquals(data, buffer1.buffer());
 
     // Second read — pages are now in cache, optimistic path can succeed.
-    var buffer2 = atomicOps().calculateInsideAtomicOperation(
+    var buffer2 = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> paginatedCollection.readRecord(pos.collectionPosition, op));
     Assert.assertArrayEquals(data, buffer2.buffer());
     Assert.assertEquals('d', buffer2.recordType());

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
@@ -9,7 +9,6 @@ import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
-import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.CollectionPage;
@@ -143,8 +142,11 @@ public class PaginatedCollectionV2OptimisticReadTest {
     flushToReadCache();
 
     // Read in a separate atomic operation (no pending changes) to hit the optimistic path
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> collection.readRecord(pos.collectionPosition, op).toRawBuffer());
+    var rawResult = atomicOps().calculateInsideAtomicOperation(
+        op -> collection.readRecord(pos.collectionPosition, op));
+    Assert.assertTrue("Optimistic path should return RawPageBuffer for single-page record",
+        rawResult instanceof RawPageBuffer);
+    var buffer = rawResult.toRawBuffer();
 
     Assert.assertNotNull("Optimistic read should return a non-null buffer", buffer);
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
@@ -198,7 +200,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     flushToReadCache();
 
     // The optimistic path detects the multi-page pointer and falls back to the pinned path
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> collection.readRecord(pos.collectionPosition, op).toRawBuffer());
 
     Assert.assertNotNull(buffer);
@@ -682,7 +684,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     flushToReadCache();
 
-    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
+    var buffer = atomicOps().calculateInsideAtomicOperation(
         op -> collection.readRecord(pos.collectionPosition, op).toRawBuffer());
 
     Assert.assertNotNull("Optimistic read should return a non-null buffer for empty record",

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
@@ -7,6 +7,7 @@ import com.jetbrains.youtrackdb.api.YourTracks;
 import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.common.serialization.types.IntegerSerializer;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
 import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
@@ -905,8 +906,12 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
         Assert.assertEquals("Content length should match record data length",
             expected.length, contentLength);
-        Assert.assertTrue("Content offset should be positive",
-            contentOffset > 0);
+        // Content offset must be at least past the entry header (3 ints)
+        // and metadata header within the page.
+        int minContentOffset =
+            3 * IntegerSerializer.INT_SIZE + CollectionPage.RECORD_METADATA_HEADER_SIZE;
+        Assert.assertTrue("Content offset " + contentOffset + " should be >= "
+            + minContentOffset, contentOffset >= minContentOffset);
         Assert.assertTrue("Content must fit within page",
             contentOffset + contentLength <= CollectionPage.PAGE_SIZE);
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
@@ -10,11 +10,15 @@ import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
 import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.RawPageBuffer;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
+import com.jetbrains.youtrackdb.internal.core.storage.collection.CollectionPage;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.PaginatedCollection;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Random;
 import org.assertj.core.api.Assertions;
@@ -866,4 +870,106 @@ public class PaginatedCollectionV2OptimisticReadTest {
           50, floor.length);
     });
   }
+
+  // --- Integration tests for CollectionPage offset methods and RawPageBuffer ---
+
+  // Verifies that CollectionPage.getRecordContentOffset and getRecordContentLength
+  // return values consistent with the bytes returned by readRecord. Creates a record
+  // via PaginatedCollectionV2, loads the page directly, and compares the content
+  // bytes at the computed offset with the readRecord result.
+  @Test
+  public void testCollectionPageContentOffsetMatchesReadRecord() throws IOException {
+    var data = new byte[] {10, 20, 30, 40, 50, 60, 70, 80, 90};
+    var pos = atomicOps().calculateInsideAtomicOperation(
+        op -> collection.createRecord(data, (byte) 'd', null, op));
+
+    flushToReadCache();
+
+    atomicOps().executeInsideAtomicOperation(op -> {
+      // Read via normal path to get expected content
+      var rawBuffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      byte[] expected = rawBuffer.buffer();
+
+      // Load the page directly and check offset/length
+      long fileId = collection.getFileId();
+      // Page 1 is the first data page (page 0 is the state page)
+      try (CacheEntry entry = storage.getReadCache().loadForRead(
+          fileId, 1, storage.getWriteCache(), false)) {
+        var page = new CollectionPage(entry);
+
+        // The first record is at position 0 on the page
+        int contentOffset = page.getRecordContentOffset(0);
+        int contentLength = page.getRecordContentLength(0);
+
+        Assert.assertEquals("Content length should match record data length",
+            expected.length, contentLength);
+        Assert.assertTrue("Content offset should be positive",
+            contentOffset > 0);
+        Assert.assertTrue("Content must fit within page",
+            contentOffset + contentLength <= CollectionPage.PAGE_SIZE);
+
+        // Read bytes directly from the page buffer at the content offset
+        ByteBuffer pageBuffer = entry.getCachePointer().getPageFrame().getBuffer();
+        byte[] actual = new byte[contentLength];
+        for (int i = 0; i < contentLength; i++) {
+          actual[i] = pageBuffer.get(contentOffset + i);
+        }
+        Assert.assertArrayEquals("Bytes at content offset must match readRecord result",
+            expected, actual);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  // Verifies the end-to-end zero-copy path: constructs a RawPageBuffer from a real
+  // PageFrame obtained via the read cache, calls sliceContent(), wraps in
+  // ReadBytesContainer, and verifies the bytes match the expected record content.
+  @Test
+  public void testRawPageBufferSliceContentIntegration() throws IOException {
+    var data = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+    var pos = atomicOps().calculateInsideAtomicOperation(
+        op -> collection.createRecord(data, (byte) 'd', null, op));
+
+    flushToReadCache();
+
+    atomicOps().executeInsideAtomicOperation(op -> {
+      // Read via normal path to get expected content
+      var rawBuffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      byte[] expected = rawBuffer.buffer();
+
+      // Load the page and construct a RawPageBuffer
+      long fileId = collection.getFileId();
+      try (CacheEntry entry = storage.getReadCache().loadForRead(
+          fileId, 1, storage.getWriteCache(), false)) {
+        var page = new CollectionPage(entry);
+        int contentOffset = page.getRecordContentOffset(0);
+        int contentLength = page.getRecordContentLength(0);
+
+        // Construct RawPageBuffer from the real PageFrame
+        var pageFrame = entry.getCachePointer().getPageFrame();
+        long stamp = pageFrame.tryOptimisticRead();
+        var rawPageBuffer = new RawPageBuffer(
+            pageFrame, stamp, contentOffset, contentLength,
+            rawBuffer.version(), rawBuffer.recordType());
+
+        // sliceContent should return a ByteBuffer with matching content
+        ByteBuffer slice = rawPageBuffer.sliceContent();
+        Assert.assertEquals(contentLength, slice.capacity());
+
+        // Read bytes from the slice
+        byte[] actual = new byte[contentLength];
+        slice.get(actual);
+        Assert.assertArrayEquals("sliceContent bytes must match readRecord result",
+            expected, actual);
+
+        // Stamp should still be valid (no writes happened)
+        Assert.assertTrue("Stamp should still be valid after reading",
+            pageFrame.validate(stamp));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
@@ -122,7 +122,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
         var positions = collection.ceilingPositions(
             new PhysicalPosition(first), Integer.MAX_VALUE, op);
         for (var pos : positions) {
-          collection.readRecord(pos.collectionPosition, op);
+          collection.readRecord(pos.collectionPosition, op).toRawBuffer();
         }
       });
     } catch (IOException e) {
@@ -144,7 +144,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     // Read in a separate atomic operation (no pending changes) to hit the optimistic path
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> collection.readRecord(pos.collectionPosition, op));
+        op -> collection.readRecord(pos.collectionPosition, op).toRawBuffer());
 
     Assert.assertNotNull("Optimistic read should return a non-null buffer", buffer);
     Assertions.assertThat(buffer.buffer()).isEqualTo(data);
@@ -174,7 +174,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     // Read all records in a single read-only atomic operation
     atomicOps().executeInsideAtomicOperation(op -> {
       for (var i = 0; i < positions.size(); i++) {
-        var buffer = (RawBuffer) collection.readRecord(positions.get(i), op);
+        var buffer = collection.readRecord(positions.get(i), op).toRawBuffer();
         Assertions.assertThat(buffer.buffer())
             .as("Record %d should match inserted data", i)
             .isEqualTo(records.get(i));
@@ -199,7 +199,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     // The optimistic path detects the multi-page pointer and falls back to the pinned path
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> collection.readRecord(pos.collectionPosition, op));
+        op -> collection.readRecord(pos.collectionPosition, op).toRawBuffer());
 
     Assert.assertNotNull(buffer);
     Assertions.assertThat(buffer.buffer()).isEqualTo(bigData);
@@ -226,7 +226,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     try {
       atomicOps().calculateInsideAtomicOperation(
-          op -> collection.readRecord(nonExistent, op));
+          op -> collection.readRecord(nonExistent, op).toRawBuffer());
       Assert.fail("Should throw RecordNotFoundException for non-existent position");
     } catch (RecordNotFoundException e) {
       // The exception should reference the non-existent position.
@@ -683,7 +683,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     flushToReadCache();
 
     var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
-        op -> collection.readRecord(pos.collectionPosition, op));
+        op -> collection.readRecord(pos.collectionPosition, op).toRawBuffer());
 
     Assert.assertNotNull("Optimistic read should return a non-null buffer for empty record",
         buffer);
@@ -709,7 +709,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     atomicOps().executeInsideAtomicOperation(op -> {
       // readRecord
-      var buffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      var buffer = collection.readRecord(pos.collectionPosition, op).toRawBuffer();
       Assertions.assertThat(buffer.buffer()).isEqualTo(data);
       Assert.assertEquals(5, buffer.recordType());
 
@@ -778,7 +778,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
       Assert.assertEquals(PaginatedCollection.RECORD_STATUS.PRESENT, status);
       Assert.assertTrue(collection.exists(pos.collectionPosition, op));
 
-      var buffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      var buffer = collection.readRecord(pos.collectionPosition, op).toRawBuffer();
       Assertions.assertThat(buffer.buffer()).isEqualTo(data);
     });
 
@@ -798,7 +798,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     // Verify readRecord throws RecordNotFoundException for deleted record
     try {
       atomicOps().calculateInsideAtomicOperation(
-          op -> collection.readRecord(pos.collectionPosition, op));
+          op -> collection.readRecord(pos.collectionPosition, op).toRawBuffer());
       Assert.fail("Should throw RecordNotFoundException for deleted record");
     } catch (RecordNotFoundException e) {
       // expected
@@ -841,7 +841,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     // Read all records in a single read-only atomic operation
     atomicOps().executeInsideAtomicOperation(op -> {
       for (var i = 0; i < positions.size(); i++) {
-        var buffer = (RawBuffer) collection.readRecord(positions.get(i), op);
+        var buffer = collection.readRecord(positions.get(i), op).toRawBuffer();
         Assert.assertNotNull("Record " + i + " should be readable", buffer);
         Assertions.assertThat(buffer.buffer())
             .as("Record %d data should match", i)
@@ -887,7 +887,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     atomicOps().executeInsideAtomicOperation(op -> {
       // Read via normal path to get expected content
-      var rawBuffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      var rawBuffer = collection.readRecord(pos.collectionPosition, op).toRawBuffer();
       byte[] expected = rawBuffer.buffer();
 
       // Load the page directly and check offset/length
@@ -935,7 +935,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     atomicOps().executeInsideAtomicOperation(op -> {
       // Read via normal path to get expected content
-      var rawBuffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      var rawBuffer = collection.readRecord(pos.collectionPosition, op).toRawBuffer();
       byte[] expected = rawBuffer.buffer();
 
       // Load the page and construct a RawPageBuffer
@@ -982,7 +982,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     flushToReadCache();
 
     atomicOps().executeInsideAtomicOperation(op -> {
-      var rawBuffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      var rawBuffer = collection.readRecord(pos.collectionPosition, op).toRawBuffer();
       Assert.assertEquals(0, rawBuffer.buffer().length);
 
       long fileId = collection.getFileId();
@@ -1018,7 +1018,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     flushToReadCache();
 
     atomicOps().executeInsideAtomicOperation(op -> {
-      var rawBuffer = (RawBuffer) collection.readRecord(pos2.collectionPosition, op);
+      var rawBuffer = collection.readRecord(pos2.collectionPosition, op).toRawBuffer();
       byte[] expected = rawBuffer.buffer();
 
       long fileId = collection.getFileId();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
@@ -9,6 +9,7 @@ import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.PhysicalPosition;
+import com.jetbrains.youtrackdb.internal.core.storage.RawBuffer;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.PaginatedCollection;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
@@ -138,7 +139,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     flushToReadCache();
 
     // Read in a separate atomic operation (no pending changes) to hit the optimistic path
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> collection.readRecord(pos.collectionPosition, op));
 
     Assert.assertNotNull("Optimistic read should return a non-null buffer", buffer);
@@ -169,7 +170,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     // Read all records in a single read-only atomic operation
     atomicOps().executeInsideAtomicOperation(op -> {
       for (var i = 0; i < positions.size(); i++) {
-        var buffer = collection.readRecord(positions.get(i), op);
+        var buffer = (RawBuffer) collection.readRecord(positions.get(i), op);
         Assertions.assertThat(buffer.buffer())
             .as("Record %d should match inserted data", i)
             .isEqualTo(records.get(i));
@@ -193,7 +194,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     flushToReadCache();
 
     // The optimistic path detects the multi-page pointer and falls back to the pinned path
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> collection.readRecord(pos.collectionPosition, op));
 
     Assert.assertNotNull(buffer);
@@ -677,7 +678,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     flushToReadCache();
 
-    var buffer = atomicOps().calculateInsideAtomicOperation(
+    var buffer = (RawBuffer) atomicOps().calculateInsideAtomicOperation(
         op -> collection.readRecord(pos.collectionPosition, op));
 
     Assert.assertNotNull("Optimistic read should return a non-null buffer for empty record",
@@ -704,7 +705,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
 
     atomicOps().executeInsideAtomicOperation(op -> {
       // readRecord
-      var buffer = collection.readRecord(pos.collectionPosition, op);
+      var buffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
       Assertions.assertThat(buffer.buffer()).isEqualTo(data);
       Assert.assertEquals(5, buffer.recordType());
 
@@ -773,7 +774,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
       Assert.assertEquals(PaginatedCollection.RECORD_STATUS.PRESENT, status);
       Assert.assertTrue(collection.exists(pos.collectionPosition, op));
 
-      var buffer = collection.readRecord(pos.collectionPosition, op);
+      var buffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
       Assertions.assertThat(buffer.buffer()).isEqualTo(data);
     });
 
@@ -836,7 +837,7 @@ public class PaginatedCollectionV2OptimisticReadTest {
     // Read all records in a single read-only atomic operation
     atomicOps().executeInsideAtomicOperation(op -> {
       for (var i = 0; i < positions.size(); i++) {
-        var buffer = collection.readRecord(positions.get(i), op);
+        var buffer = (RawBuffer) collection.readRecord(positions.get(i), op);
         Assert.assertNotNull("Record " + i + " should be readable", buffer);
         Assertions.assertThat(buffer.buffer())
             .as("Record %d data should match", i)

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2OptimisticReadTest.java
@@ -972,4 +972,72 @@ public class PaginatedCollectionV2OptimisticReadTest {
     });
   }
 
+  // Verifies that CollectionPage content offset/length work for zero-length record content.
+  // This exercises the contentLength == 0 boundary (recordSize == metadata + tail exactly).
+  @Test
+  public void testCollectionPageContentOffsetEmptyRecord() throws IOException {
+    var pos = atomicOps().calculateInsideAtomicOperation(
+        op -> collection.createRecord(new byte[0], (byte) 'd', null, op));
+
+    flushToReadCache();
+
+    atomicOps().executeInsideAtomicOperation(op -> {
+      var rawBuffer = (RawBuffer) collection.readRecord(pos.collectionPosition, op);
+      Assert.assertEquals(0, rawBuffer.buffer().length);
+
+      long fileId = collection.getFileId();
+      try (CacheEntry entry = storage.getReadCache().loadForRead(
+          fileId, 1, storage.getWriteCache(), false)) {
+        var page = new CollectionPage(entry);
+        Assert.assertEquals(0, page.getRecordContentLength(0));
+
+        var pageFrame = entry.getCachePointer().getPageFrame();
+        long stamp = pageFrame.tryOptimisticRead();
+        var rpb = new RawPageBuffer(pageFrame, stamp,
+            page.getRecordContentOffset(0), 0,
+            rawBuffer.version(), rawBuffer.recordType());
+        ByteBuffer slice = rpb.sliceContent();
+        Assert.assertEquals(0, slice.capacity());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  // Verifies that CollectionPage content offset/length work for a non-first record
+  // (position > 0) on the same page, catching pointer-array indexing bugs.
+  @Test
+  public void testCollectionPageContentOffsetSecondRecord() throws IOException {
+    var data1 = new byte[] {10, 20, 30};
+    var data2 = new byte[] {40, 50, 60, 70, 80};
+    atomicOps().calculateInsideAtomicOperation(
+        op -> collection.createRecord(data1, (byte) 'd', null, op));
+    var pos2 = atomicOps().calculateInsideAtomicOperation(
+        op -> collection.createRecord(data2, (byte) 'd', null, op));
+
+    flushToReadCache();
+
+    atomicOps().executeInsideAtomicOperation(op -> {
+      var rawBuffer = (RawBuffer) collection.readRecord(pos2.collectionPosition, op);
+      byte[] expected = rawBuffer.buffer();
+
+      long fileId = collection.getFileId();
+      try (CacheEntry entry = storage.getReadCache().loadForRead(
+          fileId, 1, storage.getWriteCache(), false)) {
+        var page = new CollectionPage(entry);
+        int offset = page.getRecordContentOffset(1);
+        int length = page.getRecordContentLength(1);
+        Assert.assertEquals(expected.length, length);
+
+        ByteBuffer buf = entry.getCachePointer().getPageFrame().getBuffer();
+        byte[] actual = new byte[length];
+        for (int i = 0; i < length; i++) {
+          actual[i] = buf.get(offset + i);
+        }
+        Assert.assertArrayEquals(expected, actual);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
 }

--- a/docs/adr/versioned-record-read/adr.md
+++ b/docs/adr/versioned-record-read/adr.md
@@ -1,0 +1,231 @@
+# Zero-Copy Record Deserialization via PageFrame References — Architecture Decision Record
+
+## Summary
+
+Eliminates byte[] copying on the record read path for single-page records by
+threading a PageFrame reference from the disk cache through the storage layer
+into EntityImpl. Property deserialization reads directly from the PageFrame's
+ByteBuffer; a StampedLock stamp validates data consistency after speculative
+deserialization. On invalidation, a one-shot fallback re-reads the record into
+byte[] as before.
+
+## Goals
+
+- **Eliminate byte[] allocation on hot read path** — achieved for single-page
+  records on the optimistic path. The byte[] `fromStream` path was also
+  rerouted through `ReadBytesContainer` internally, unifying deserialization code.
+- **Prevent OOM from corrupted records** — achieved via 17 guard allocation
+  sites throwing `CorruptedRecordException`.
+- **Type-safe storage read dispatch** — achieved via sealed `StorageReadResult`
+  interface with pattern matching in `DatabaseSessionEmbedded`.
+- **Lazy deserialization from PageFrame** — achieved in EntityImpl with stamp
+  validation and one-shot byte[] fallback.
+
+No goals were descoped or changed during implementation.
+
+## Constraints
+
+All original constraints were upheld:
+- Multi-page records fall back to the byte[] path (enforced in
+  `doReadRecordOptimisticInner` via nextPagePointer check).
+- Write path remains unchanged — `BytesContainer` is untouched.
+- StampedLock semantics preserved — the deserialization-time validation is
+  independent of the storage-level optimistic read validation.
+- Session required for fallback — `reReadFromStorage()` uses the active session's
+  storage and atomic operation.
+- Guard allocations validate all stream-driven sizes against `remaining()`.
+
+**New constraint discovered**: Link bag element counts are metadata, not
+buffer-consuming data. BTree-based bags store elements in the BTree, so
+`count > remaining()` produces false positives. These sites use `< 0` only.
+
+## Architecture Notes
+
+### Component Map
+
+```mermaid
+graph TD
+    EI[EntityImpl] -->|"holds PageFrame ref + stamp"| PF[PageFrame]
+    EI -->|"deserializes via"| RBC[ReadBytesContainer]
+    RBC -->|"wraps"| BB[ByteBuffer]
+    PF -->|"provides"| BB
+    PC2[PaginatedCollectionV2] -->|"returns RawPageBuffer"| AS[AbstractStorage]
+    AS -->|"passes to"| DSE[DatabaseSessionEmbedded]
+    DSE -->|"calls fillFromPage"| EI
+    RSB[RecordSerializerBinary] -->|"dispatches to"| RSV1[RecordSerializerBinaryV1]
+    RSV1 -->|"reads from"| RBC
+    VIS[VarIntSerializer] -->|"reads from"| RBC
+    HC[HelperClasses] -->|"reads from"| RBC
+    SRR[StorageReadResult] -->|"sealed: RawBuffer"| RB[RawBuffer]
+    SRR -->|"sealed: RawPageBuffer"| RPB[RawPageBuffer]
+    RPB -->|"references"| PF
+    CRE[CorruptedRecordException] -.->|"thrown by"| RSV1
+    CRE -.->|"thrown by"| HC
+```
+
+- **ReadBytesContainer** — final class, ByteBuffer-backed, read-only. Three
+  constructors: `ByteBuffer` (zero-copy), `byte[]` (full wrap), `byte[], offset`
+  (skip version byte). Provides position-tracked reads with OOM guards.
+- **BytesContainer** — unchanged, write-path only.
+- **StorageReadResult** — sealed interface with `recordVersion()`,
+  `recordType()`, and `toRawBuffer()` default method. `RawBuffer` (byte[])
+  and `RawPageBuffer` (PageFrame + coordinates) are the two variants.
+- **RawPageBuffer** — record with compact constructor validation (non-null
+  pageFrame, non-negative offsets, overflow-safe bounds via `Math.addExact`).
+  `sliceContent()` returns an independent ByteBuffer view.
+- **CollectionPage** — `RECORD_METADATA_HEADER_SIZE` (13B) and
+  `RECORD_TAIL_SIZE` (9B) constants, plus `getRecordContentOffset()` and
+  `getRecordContentLength()` methods.
+- **EntityImpl** — four PageFrame fields, `fillFromPage()`, `clearPageFrame()`,
+  `deserializeFromPageFrame()`, `reReadFromStorage()`,
+  `checkDeserializedProperties()`. Lifecycle guards in 7+ methods.
+- **CorruptedRecordException** — extends `DatabaseException`, 4 constructors.
+
+### Decision Records
+
+#### D1: ByteBuffer-backed ReadBytesContainer instead of byte[] BytesContainer
+
+Implemented as planned. `ReadBytesContainer` is a final class with no virtual
+dispatch. The `getInternedString` signature was changed from
+`(DatabaseSessionEmbedded, int)` to `(StringCache, int)` for decoupling — the
+`StringCache` is resolved once per `deserialize()`/`deserializePartial()` call
+via a `resolveStringCache()` helper.
+
+Additionally, the byte[] `fromStream` in `RecordSerializerBinary` was wired
+through `ReadBytesContainer` internally — `new ReadBytesContainer(source, 1)`
+skips the version byte. This made all 566 existing test classes exercise the
+new deserialization path without any test changes.
+
+#### D2: One-shot PageFrame with permanent byte[] fallback on invalidation
+
+Implemented as planned. The speculative deserialization pattern:
+1. Capture PageFrame fields in local variables (needed because `clearSource()`
+   during full deser triggers `clearPageFrame()`)
+2. Read version byte + create ReadBytesContainer from PageFrame slice
+3. Call serializer's `fromStream()` speculatively
+4. Catch `RuntimeException` → treat as torn page, fall back
+5. Validate stamp → if invalid, clear PageFrame, `reReadFromStorage()`,
+   re-enter `deserializeProperties()` on byte[] path
+
+No retry logic. One stamp check per deserialization call.
+
+#### D3: Sealed interface for storage read result
+
+Implemented as planned. `StorageReadResult` is a sealed interface with
+`RawBuffer` and `RawPageBuffer`. A `toRawBuffer()` default method was added
+(not in original plan) for callers that always need byte[] — uses pattern
+matching internally. This replaced direct `(RawBuffer)` casts at 4 production
+sites (`CollectionBasedStorageConfiguration`, `DatabaseCompare`) and 30+ test
+sites.
+
+The `readRecord()` return type changed from `RawBuffer` to `StorageReadResult`
+across `Storage`, `StorageCollection`, `AbstractStorage`, and
+`PaginatedCollectionV2`.
+
+#### D4: Guard allocations via remaining-bytes check
+
+Implemented with one refinement: link bag sizes use `< 0` only (not
+`> remaining()`). BTree-based link bags store element counts as metadata — a bag
+with 45 elements may need only ~6 bytes in the buffer. The
+`linkBagSize > remaining()` check caused false positives on valid data. All
+other 15 guard sites use the full `size < 0 || size > remaining()` pattern.
+
+DECIMAL guard accounts for 8-byte header offset after seek-back (tightened
+during track-level code review).
+
+#### D5: toRawBuffer() default method on StorageReadResult (new)
+
+Emerged during Track 4 when all callers casting `readRecord()` to `(RawBuffer)`
+needed updating for the new `StorageReadResult` return type. Instead of
+scattering casts, a `toRawBuffer()` default method provides polymorphic
+conversion: returns itself for `RawBuffer`, extracts bytes via
+`sliceContent()` for `RawPageBuffer`.
+
+#### D6: PageFrame fields on EntityImpl, not RecordAbstract (new)
+
+Only `EntityImpl` uses `deserializeProperties()` — the PageFrame lazy
+deserialization path. Placing fields on `RecordAbstract` would add unused state
+to `Blob` and other record types. Non-EntityImpl records (Blob) extract bytes
+immediately in `executeReadRecord()` via `toRawBuffer()`.
+
+### Invariants
+
+- Deserialization from a validated PageFrame stamp produces identical results to
+  deserialization from the equivalent byte[] copy.
+- Guard checks reject any stream-driven size that exceeds `remaining()` bytes
+  (or is negative) before allocation.
+- After stamp invalidation fallback, EntityImpl holds no PageFrame reference
+  (GC-safe).
+- Multi-page records never take the PageFrame zero-copy path.
+- The write/serialization path remains unchanged (BytesContainer).
+- PageFrame fields are cleared in all lifecycle transitions: `internalReset()`,
+  `fill()`, `fromStream()`, `clearSource()`, `setDirty()`,
+  `setDirtyNoChanged()`.
+
+### Integration Points
+
+- `PaginatedCollectionV2.doReadRecordOptimisticInner()` — returns
+  `RawPageBuffer` for single-page records on the optimistic path.
+- `DatabaseSessionEmbedded.executeReadRecord()` — pattern matches on sealed
+  `StorageReadResult` to dispatch fill path (EntityImpl → `fillFromPage()`,
+  non-EntityImpl → `toRawBuffer()` + byte[] path).
+- `EntityImpl.deserializeProperties()` — PageFrame branch delegates to
+  `deserializeFromPageFrame()` for speculative deserialization.
+- `RecordSerializerBinary.fromStream(byte[])` — internally wraps in
+  `ReadBytesContainer(source, 1)`, unifying both paths.
+
+### Non-Goals
+
+- Modifying the write/serialization path or `BytesContainer` for writes.
+- Zero-copy for multi-page records (remain on byte[] path).
+- Changes to the V2 serializer (separate branch).
+- Retry logic for stamp invalidation (one-shot by design decision D2).
+
+## Key Discoveries
+
+- **clearSource() triggers clearPageFrame()**: During full deserialization,
+  `RecordSerializerBinaryV1.deserialize()` calls `clearSource()` on the entity,
+  which triggers `clearPageFrame()`. PageFrame fields must be captured in local
+  variables before the serializer call, otherwise stamp validation reads zeroed
+  fields.
+
+- **fillFromPage's checkForBinding() rejects NOT_LOADED**: Factory-created
+  records have NOT_LOADED status. `checkForBinding()` rejects this status, but
+  `getSession()` with pattern matching works. The `fillFromPage()` method uses
+  `getSession()` instead of `checkForBinding()`.
+
+- **recordType must accept 'v' and 'e'**: The original assertion only checked
+  for document type 'd'. Vertex ('v') and edge ('e') records also take the
+  PageFrame path — assertions were updated.
+
+- **BTree link bag false positives**: `linkBagSize` is an element count stored
+  as metadata. For BTree-based bags, elements live in the BTree, not in the
+  serialized buffer. A BTree bag with 45 elements needs only ~6 bytes
+  (fileId + linkBagId pointers), so `45 > remaining=6` was a false positive.
+  Fixed by using only the `< 0` negativity guard for link bag sizes.
+
+- **Optimistic read requires warm read cache**: The optimistic read path
+  requires pages to already be in the read cache. The first load after database
+  reopen always goes through the pinned path. Tests needed a warmup step (load
+  records once via pinned path) before zero-copy reads could be exercised.
+
+- **CollectionPage.appendRecord stores raw bytes**: The metadata header and
+  chunk tail are added by `PaginatedCollectionV2` before calling
+  `appendRecord()`. Tests building page content directly must construct properly
+  formatted chunks.
+
+- **StringCache.getString() dead throws declaration**: The method declared
+  `throws UnsupportedEncodingException` despite using `StandardCharsets.UTF_8`
+  which never throws. Cleaned up the declaration and all callers.
+
+- **readLinkMap NPE**: Pre-existing bug where `readLinkMap` with
+  `justRunThrough=true` could NPE due to missing null guard. Fixed in the
+  `ReadBytesContainer` overload.
+
+- **DECIMAL extraction optimization**: Original code extracted the entire
+  remaining buffer for DECIMAL; optimized to read exact size from the 8-byte
+  header (scale:4B + unscaledLen:4B + unscaled bytes).
+
+- **readEmbeddedLinkBag uses continueFlag loop**: Not a counted loop — it reads
+  entries until a continue flag is false. No guard needed on the counter; it's
+  already guarded at callers (`readLinkSet`, `readLinkBag`).

--- a/docs/adr/versioned-record-read/design-final.md
+++ b/docs/adr/versioned-record-read/design-final.md
@@ -1,0 +1,383 @@
+# Zero-Copy Record Deserialization via PageFrame References — Final Design
+
+## Overview
+
+This feature eliminates byte[] copying on the record read path by keeping a
+reference to the disk cache PageFrame in EntityImpl. For single-page records on
+the optimistic read path, the storage layer returns a `RawPageBuffer` carrying
+PageFrame coordinates instead of copying bytes. EntityImpl stores these
+coordinates and deserializes directly from the PageFrame's ByteBuffer at
+property-access time. A StampedLock stamp captured during the optimistic read is
+validated after speculative deserialization; on invalidation, a one-shot fallback
+re-reads the record through the pinned storage path into byte[].
+
+The implementation touches four layers:
+1. **Deserialization container** — `ReadBytesContainer` replaces byte[]-backed
+   `BytesContainer` for all reads
+2. **Guard allocations** — `CorruptedRecordException` prevents OOM from
+   corrupted size fields
+3. **Storage read result** — sealed `StorageReadResult` interface with
+   `RawBuffer` and `RawPageBuffer` variants
+4. **EntityImpl lifecycle** — PageFrame fields, speculative deserialization,
+   stamp validation, and fallback
+
+Deviations from the original design are minor: `getInternedString` accepts
+`StringCache` instead of `DatabaseSessionEmbedded`, the byte[] `fromStream`
+path was wired through `ReadBytesContainer` internally (making all 566 existing
+tests exercise the new path), and link bag guards use `< 0` only (not
+`> remaining()`) because BTree-based bags store element counts as metadata, not
+buffer-consuming data.
+
+## Class Design
+
+### Deserialization Container Split
+
+```mermaid
+classDiagram
+    class ReadBytesContainer {
+        -ByteBuffer buffer
+        +ReadBytesContainer(ByteBuffer)
+        +ReadBytesContainer(byte[])
+        +ReadBytesContainer(byte[], int offset)
+        +getByte() byte
+        +peekByte(int relativeOffset) byte
+        +getBytes(byte[], int, int) void
+        +getStringBytes(int) String
+        +getInternedString(StringCache, int) String
+        +getInt() int
+        +getLong() long
+        +remaining() int
+        +offset() int
+        +skip(int) void
+        +setOffset(int) void
+        +slice(int) ReadBytesContainer
+    }
+    class BytesContainer {
+        +byte[] bytes
+        +int offset
+        +alloc(int) int
+        +allocExact(int) int
+        +skip(int) BytesContainer
+        +fitBytes() byte[]
+    }
+    class RecordSerializerBinaryV1 {
+        +deserialize(session, entity, ReadBytesContainer)
+        +deserializePartial(session, entity, ReadBytesContainer, String[])
+        +deserializeValue(session, ReadBytesContainer, type, entity, ...)
+    }
+    class VarIntSerializer {
+        +readAsInteger(ReadBytesContainer) int
+        +readAsLong(ReadBytesContainer) long
+        +readSignedVarLong(ReadBytesContainer) long
+        +readUnsignedVarLong(ReadBytesContainer) long
+    }
+    class HelperClasses {
+        +readBinary(ReadBytesContainer) byte[]
+        +readString(ReadBytesContainer) String
+        +readLinkCollection(ReadBytesContainer, ...) T
+        +readLinkMap(ReadBytesContainer, ...) Map
+        +readOptimizedLink(ReadBytesContainer, ...) RecordIdInternal
+        +readInteger(ReadBytesContainer) int
+        +readLong(ReadBytesContainer) long
+    }
+    class RecordSerializerBinary {
+        +fromStream(session, byte[], record, fields)
+        +fromStream(session, version, ReadBytesContainer, record, fields)
+    }
+
+    RecordSerializerBinary --> RecordSerializerBinaryV1 : dispatches to
+    RecordSerializerBinaryV1 --> ReadBytesContainer : reads from
+    VarIntSerializer --> ReadBytesContainer : reads from
+    HelperClasses --> ReadBytesContainer : reads from
+    RecordSerializerBinaryV1 ..> BytesContainer : no longer uses for reads
+```
+
+`ReadBytesContainer` is a `final` class wrapping a `ByteBuffer` (direct or
+heap). Three constructors support the zero-copy path (`ByteBuffer` from
+PageFrame), the fallback path (`byte[]`), and the legacy entry point
+(`byte[], int offset`). The byte[] `fromStream` in `RecordSerializerBinary`
+creates a `ReadBytesContainer(source, 1)` (skipping the version byte), so both
+paths converge to the same deserialization code.
+
+`BytesContainer` remains unchanged and is used exclusively by the
+serialization (write) path.
+
+Key API methods replace direct array access patterns:
+- `getByte()` replaces `bytes.bytes[bytes.offset++]`
+- `peekByte(relativeOffset)` replaces `bytes.bytes[bytes.offset + j]` for
+  field name matching without advancing position
+- `getInt()`/`getLong()` provide zero-allocation big-endian reads
+- `getInternedString(StringCache, len)` replaces
+  `stringFromBytesIntern(session, bytes.bytes, offset, len)` — accepts
+  `StringCache` directly for decoupling from `DatabaseSessionEmbedded`
+- `remaining()` enables guard allocation checks against buffer capacity
+
+### Storage Read Result Hierarchy
+
+```mermaid
+classDiagram
+    class StorageReadResult {
+        <<sealed interface>>
+        +recordVersion() long
+        +recordType() byte
+        +toRawBuffer() RawBuffer
+    }
+    class RawBuffer {
+        <<record>>
+        +byte[] buffer
+        +long version
+        +byte recordType
+        +recordVersion() long
+    }
+    class RawPageBuffer {
+        <<record>>
+        +PageFrame pageFrame
+        +long stamp
+        +int contentOffset
+        +int contentLength
+        +long recordVersion
+        +byte recordType
+        +sliceContent() ByteBuffer
+    }
+
+    StorageReadResult <|.. RawBuffer
+    StorageReadResult <|.. RawPageBuffer
+    RawPageBuffer --> PageFrame : references
+```
+
+`StorageReadResult` is a sealed interface permitting `RawBuffer` and
+`RawPageBuffer`. The `toRawBuffer()` default method uses pattern matching to
+either return itself (`RawBuffer`) or extract bytes from the PageFrame
+(`RawPageBuffer.sliceContent()` → `new RawBuffer(...)`). This is used by
+callers that always need byte[] (storage config, database compare, non-EntityImpl
+records like Blob).
+
+`RawPageBuffer`'s compact constructor validates: non-null pageFrame,
+non-negative contentOffset and contentLength, overflow-safe bounds check
+(`Math.addExact(contentOffset, contentLength) <= pageFrame.getBuffer().capacity()`).
+
+### EntityImpl State Extensions
+
+```mermaid
+classDiagram
+    class EntityImpl {
+        -PageFrame pageFrame
+        -long pageStamp
+        -int pageContentOffset
+        -int pageContentLength
+        +fillFromPage(version, recordType, pageFrame, stamp, offset, length)
+        +clearPageFrame()
+        +deserializeProperties(propertyNames) boolean
+        -deserializeFromPageFrame(propertyNames) boolean
+        -reReadFromStorage()
+        -checkDeserializedProperties(propertyNames) boolean
+        +checkForProperties(properties) boolean
+        +sourceIsParsedByProperties() boolean
+        +toStream() byte[]
+    }
+    class RecordSerializerBinary {
+        +fromStream(session, version, ReadBytesContainer, record, fields)
+    }
+
+    EntityImpl --> PageFrame : optional reference
+    EntityImpl --> RecordSerializerBinary : deserializes via
+```
+
+EntityImpl holds four PageFrame-related fields (all on EntityImpl, not
+RecordAbstract, since only EntityImpl uses `deserializeProperties()`).
+`fillFromPage()` sets these fields instead of `source`; `clearPageFrame()` nulls
+them. The PageFrame is cleared in all lifecycle transitions: `internalReset()`,
+`fill()`, `fromStream()`, `clearSource()`, `setDirty()`, `setDirtyNoChanged()`.
+
+### CollectionPage Layout Constants
+
+```mermaid
+classDiagram
+    class CollectionPage {
+        +RECORD_METADATA_HEADER_SIZE$ int
+        +RECORD_TAIL_SIZE$ int
+        +getRecordContentOffset(recordPosition) int
+        +getRecordContentLength(recordPosition) int
+    }
+    class PaginatedCollectionV2 {
+        -doReadRecordOptimisticInner(collectionPos, atomicOp) StorageReadResult
+    }
+
+    PaginatedCollectionV2 --> CollectionPage : uses layout constants
+```
+
+`RECORD_METADATA_HEADER_SIZE` (13 bytes: recordType + contentSize +
+collectionPosition) and `RECORD_TAIL_SIZE` (9 bytes: firstRecordFlag +
+nextPagePointer) are public constants on `CollectionPage`.
+`getRecordContentOffset()` computes the absolute byte offset to content within
+the page buffer. `getRecordContentLength()` derives content length from record
+size minus header and tail. Both have assertion preconditions for non-deleted,
+first-chunk records.
+
+## Workflow
+
+### Optimistic Read Path (Zero-Copy)
+
+```mermaid
+sequenceDiagram
+    participant DSE as DatabaseSessionEmbedded
+    participant AS as AbstractStorage
+    participant PC2 as PaginatedCollectionV2
+    participant CP as CollectionPage
+    participant PF as PageFrame
+
+    DSE->>AS: readRecord(rid, atomicOp)
+    AS->>PC2: readRecord(collectionPos, atomicOp)
+    PC2->>PC2: doReadRecordOptimisticInner()
+    PC2->>PF: loadPageOptimistic()
+    PF-->>PC2: PageView(pageFrame, stamp)
+    PC2->>CP: getRecordVersion(pos)
+    PC2->>PC2: visibility + deletion checks
+    PC2->>CP: getRecordContentOffset(pos)
+    CP-->>PC2: contentOffset
+    PC2->>CP: getRecordContentLength(pos)
+    CP-->>PC2: contentLength
+    PC2-->>AS: RawPageBuffer(pageFrame, stamp, offset, length, version, type)
+    AS-->>DSE: RawPageBuffer
+    DSE->>DSE: pattern match StorageReadResult
+    DSE->>DSE: entity.fillFromPage(version, type, frame, stamp, offset, length)
+```
+
+On the optimistic single-page path, `PaginatedCollectionV2.doReadRecordOptimisticInner()`
+validates record status, visibility, deletion, minimum size, first-chunk flag,
+and single-page constraint (nextPagePointer < 0). It then constructs a
+`RawPageBuffer` with page coordinates instead of copying bytes.
+`DatabaseSessionEmbedded.executeReadRecord()` pattern-matches: `RawBuffer` takes
+the existing fill+fromStream path; `RawPageBuffer` with `EntityImpl` calls
+`fillFromPage()` for lazy deserialization; `RawPageBuffer` with non-EntityImpl
+(Blob) extracts bytes via `toRawBuffer()`.
+
+### Property Deserialization with Stamp Validation
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant EI as EntityImpl
+    participant PF as PageFrame
+    participant RBC as ReadBytesContainer
+    participant RS as RecordSerializerBinaryV1
+    participant Storage
+
+    Caller->>EI: getProperty("name")
+    EI->>EI: deserializeProperties("name")
+    alt pageFrame != null && source == null
+        EI->>EI: capture locals (frame, stamp, offset, length)
+        EI->>PF: getBuffer()
+        PF-->>EI: ByteBuffer
+        EI->>RBC: new ReadBytesContainer(buffer.slice(offset+1, length-1))
+        EI->>RS: fromStream(session, versionByte, container, this, ["name"])
+        RS->>RBC: getByte(), getInt(), ...
+        alt RuntimeException thrown
+            EI->>EI: clearPageFrame()
+            EI->>EI: reReadFromStorage()
+            EI->>EI: deserializeProperties("name") via byte[] path
+        else deserialization succeeds
+            EI->>PF: validate(stamp)
+            alt stamp valid
+                Note over EI: Keep PageFrame (partial) or clear (full)
+                EI-->>Caller: property value
+            else stamp invalid
+                EI->>EI: clearPageFrame()
+                EI->>EI: reReadFromStorage()
+                EI->>EI: deserializeProperties("name") via byte[] path
+            end
+        end
+    else source != null (byte[] path)
+        EI->>RBC: new ReadBytesContainer(source, 1)
+        EI->>RS: fromStream(session, source, this, ["name"])
+        RS-->>EI: properties populated
+    end
+    EI-->>Caller: property value
+```
+
+The deserialization flow captures PageFrame fields in local variables before
+calling the serializer (because `clearSource()` during full deserialization
+triggers `clearPageFrame()`, zeroing the entity's fields). The serializer
+version byte is read from the absolute buffer position; the remaining content is
+sliced into a `ReadBytesContainer`. On `RuntimeException` (torn page from
+concurrent modification) or stamp invalidation, the fallback path calls
+`reReadFromStorage()` which re-reads via the pinned storage path, calls
+`fill()` + `fromStream()` to populate `source`, and re-enters
+`deserializeProperties()` on the byte[] path.
+
+### Guard Allocation Check Flow
+
+```mermaid
+flowchart TD
+    A["Read size from stream via VarInt"] --> B{"size >= 0?"}
+    B -->|No| E["throw CorruptedRecordException"]
+    B -->|Yes| C{"consumes bytes?"}
+    C -->|"Yes (arrays, strings,\ncollections, headers)"| D{"size <= remaining()?"}
+    C -->|"No (link bag counts:\nBTree metadata)"| F["Proceed — size is metadata only"]
+    D -->|No| E
+    D -->|Yes| G["Proceed with allocation/loop"]
+```
+
+Guard checks are applied at 17 sites across `HelperClasses` (4 sites) and
+`RecordSerializerBinaryV1` (13 sites). The pattern is
+`if (size < 0 || size > bytes.remaining()) throw new CorruptedRecordException(...)`.
+Link bag sizes (`readLinkSet`, `readLinkBag`) use only `< 0` checks because
+BTree-based bags store element counts as metadata — the actual elements live in
+the BTree, not in the buffer.
+
+## Stamp Validation and Memory Safety
+
+The StampedLock optimistic read protocol guarantees that `validate(stamp)`
+returns `false` if any exclusive lock was acquired since the stamp was issued.
+This covers page modification, eviction, and frame reuse. `PageFramePool`
+recycles frames (never deallocates), so stale frames always point to valid
+mapped memory.
+
+**Critical ordering**: `validate(stamp)` is called AFTER reading all data from
+the PageFrame buffer — the same pattern as `executeOptimisticStorageRead` in
+`DurableComponent`. The speculative deserialization completes fully before
+validation. If a concurrent write produced torn data, the guard allocation
+checks (via `CorruptedRecordException`) catch it before stamp validation.
+
+**Local variable capture**: PageFrame fields must be captured in locals before
+calling the serializer because `RecordSerializerBinaryV1.deserialize()` calls
+`clearSource()` → `clearPageFrame()` as part of full deserialization. Without
+local capture, the stamp validation after deserialization would read zeroed
+fields.
+
+## Partial Deserialization and Fallback Interaction
+
+EntityImpl supports partial deserialization — requesting specific properties by
+name. The PageFrame lifecycle mirrors the existing `source` (byte[]) lifecycle:
+
+- **Partial call (stamp valid)**: Deserialize requested properties from
+  PageFrame. Keep PageFrame reference for subsequent calls — `deserializePartial()`
+  does not call `clearSource()`, so PageFrame is retained.
+- **Subsequent partial call (stamp still valid)**: Deserialize additional
+  properties from the same PageFrame.
+- **Partial call (stamp invalid)**: Clear PageFrame, re-read into byte[], store
+  as `source`. Future partial calls use byte[] path.
+- **Full deserialization (stamp valid)**: `deserialize()` calls
+  `clearSource()` → `clearPageFrame()`. Properties are fully populated.
+- **Full deserialization (stamp invalid)**: Clear PageFrame, re-read, the byte[]
+  `deserialize()` calls `clearSource()` after parsing.
+
+The `checkDeserializedProperties()` method validates that partial deserialization
+found at least one requested property — extracted from duplicated inline logic
+into a shared method during Track 5.
+
+## Guard Allocation Strategy
+
+`CorruptedRecordException` extends `DatabaseException` with four constructor
+signatures (copy, message-only, dbName+message, session+message). Guards are
+placed at every site where a VarInt-decoded size drives an allocation or loop:
+
+| Category | Guard pattern | Sites |
+|---|---|---|
+| Byte-consuming sizes (arrays, strings, collections, headers) | `size < 0 \|\| size > remaining()` | 15 sites |
+| Metadata-only counts (link bag element counts for BTree bags) | `size < 0` | 2 sites |
+
+The distinction exists because BTree-based link bags store the element count as
+metadata — elements live in the BTree, not in the serialized buffer. A bag with
+45 elements may need only ~6 bytes in the buffer (fileId + linkBagId pointers),
+so `45 > remaining=6` would be a false positive.


### PR DESCRIPTION
## Motivation

Record reads in YouTrackDB currently copy bytes from the disk cache into a `byte[]` before deserialization. For single-page records on the optimistic read path, this allocation is unnecessary — the data is already in the page cache's `ByteBuffer`. This PR eliminates that copy by threading a `PageFrame` reference from the disk cache through the storage layer into `EntityImpl`, where property deserialization reads directly from the `ByteBuffer`. A `StampedLock` stamp validates data consistency after speculative deserialization; on invalidation, a one-shot fallback re-reads the record into `byte[]` as before.

## Summary

- **ReadBytesContainer**: New `ByteBuffer`-backed read container for zero-copy deserialization. The existing `byte[]` `fromStream` path also routes through it internally, unifying deserialization code and exercising the new path via all 566 existing test classes.
- **StorageReadResult sealed interface**: `readRecord()` now returns `StorageReadResult` (sealed: `RawBuffer` | `RawPageBuffer`) instead of `RawBuffer`, with pattern matching dispatch in `DatabaseSessionEmbedded`.
- **CollectionPage layout methods**: `getRecordContentOffset()` / `getRecordContentLength()` expose record coordinates without byte[] extraction.
- **EntityImpl PageFrame lifecycle**: Four fields (`pageFrame`, `pageContentOffset`, `pageContentLength`, `pageFrameStamp`) with `fillFromPage()`, speculative `deserializeFromPageFrame()`, stamp validation, and one-shot `reReadFromStorage()` fallback. Guards in 7+ lifecycle methods (`internalReset`, `fill`, `fromStream`, `clearSource`, `setDirty`, etc.).
- **CorruptedRecordException + 17 guard sites**: All stream-driven size allocations in `RecordSerializerBinaryV1`, `HelperClasses`, and `VarIntSerializer` are guarded against negative/overflow sizes with `remaining()` checks.
- **Concurrency fix**: `fillFromPage` eagerly extracts bytes into `byte[]` to prevent regression from concurrent PageFrame invalidation.

## Test plan

- [x] `ReadBytesContainer` unit tests (547 lines) — position tracking, bounds, all data types
- [x] Deserialization equivalence tests — byte[] vs ByteBuffer produce identical results for all field types
- [x] `VarIntSerializer` + `HelperClasses` `ReadBytesContainer` overload tests
- [x] Corrupted record guard tests — 17 injection sites verified
- [x] `StorageReadResult` unit tests — sealed interface, `toRawBuffer()`, boundary conditions
- [x] `CollectionPage` offset/length tests with layout constants
- [x] `EntityImpl` PageFrame lifecycle tests — fill, clear, dirty transitions, stamp validation
- [x] `EntityImpl` speculative deserialization tests — success, stamp fail, exception fallback
- [x] Zero-copy integration tests — vertex/edge round-trip through actual storage with cache warmup
- [x] Concurrent zero-copy tests — multi-threaded reads with stamp validation
- [x] All existing core tests pass (994 tests)