### PR TITLE
Fix curated parameter desync in JMH benchmark comparison

### DIFF
--- a/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
+++ b/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
@@ -131,7 +131,7 @@ ssh root@<IP> "curl -sS -o /tmp/curated-params-v3.json '<CURATED_PARAMS_URL>' &&
   curl -sS -o /tmp/factor-tables.json '<FACTOR_TABLES_URL>'"
 ```
 
-Replace `<module>` with the benchmark module (e.g. `jmh-ldbc`) and `<PRESIGNED_URL>` with the URL from Step 1.
+Replace `<module>` with the benchmark module (e.g. `jmh-ldbc`), `<CSV_PRESIGNED_URL>` with the CSV dataset URL, and `<CURATED_PARAMS_URL>` / `<FACTOR_TABLES_URL>` with the corresponding URLs from Step 1.
 
 **Important**: Use presigned HTTPS URLs + curl for S3 downloads. Do NOT use boto3 or awscli on the server — pip install is slow and boto3 downloads can hang over HTTP (port 80 is often blocked). The presigned URL approach is faster and more reliable.
 

--- a/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
+++ b/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
@@ -125,10 +125,13 @@ ssh root@<IP> "apt-get install -y -qq zstd > /dev/null 2>&1 && \
 
 The CSV dataset uses LDBC datagen v1.0.0 CsvCompositeMergeForeign format. The DB will be created from CSVs during the pre-load step (Step 4b), which takes ~21 minutes for SF 1.
 
-**Step 3**: Download canonical curated parameters (install after DB is created in Step 4b):
+**Step 3**: Download canonical curated parameters and install into the DB directory (created here so they are available before the pre-load fork in Step 4b):
 ```bash
-ssh root@<IP> "curl -sS -o /tmp/curated-params-v3.json '<CURATED_PARAMS_URL>' && \
-  curl -sS -o /tmp/factor-tables.json '<FACTOR_TABLES_URL>'"
+ssh root@<IP> "mkdir -p /root/ytdb/<module>/target/ldbc-bench-db && \
+  curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json '<CURATED_PARAMS_URL>' && \
+  curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/factor-tables.json '<FACTOR_TABLES_URL>' && \
+  touch /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json && \
+  echo 'Canonical curated params installed'"
 ```
 
 Replace `<module>` with the benchmark module (e.g. `jmh-ldbc`), `<CSV_PRESIGNED_URL>` with the CSV dataset URL, and `<CURATED_PARAMS_URL>` / `<FACTOR_TABLES_URL>` with the corresponding URLs from Step 1.
@@ -148,9 +151,9 @@ Replace `<module>` with the target benchmark module (e.g. `jmh-ldbc`).
 
 Wait for BUILD SUCCESS (typically ~60-90 seconds on CCX33).
 
-### Step 4b: Pre-load and curate parameters (jmh-ldbc only)
+### Step 4b: Pre-load database (jmh-ldbc only)
 
-**Critical for jmh-ldbc**: The first JMH fork triggers DB loading (if using CSV) and parameter curation inside `@Setup(Level.Trial)`. For multi-threaded benchmarks, threads start executing queries on a partially-loaded database, producing wildly inaccurate results.
+**Critical for jmh-ldbc**: The first JMH fork triggers DB loading (if using CSV) and parameter loading inside `@Setup(Level.Trial)`. For multi-threaded benchmarks, threads start executing queries on a partially-loaded database, producing wildly inaccurate results.
 
 **Always run a pre-load fork** before the real benchmarks to ensure the DB is ready and curated parameters are cached:
 
@@ -161,15 +164,7 @@ ssh root@<IP> 'cd /root/ytdb && ./mvnw -pl <module> -am verify -P bench -DskipTe
 
 This runs a single fork (`-f 1`) that triggers:
 1. DB creation from CSV files — ~21 min for SF 1
-2. Factor table computation and caching to `factor-tables.json`
-3. Parameter curation (including IC4 oldPost-count difficulty sampling) and caching to `curated-params-v<N>.json` (versioned filename — bumped when curation logic changes)
-
-After the pre-load completes, install canonical curated parameters to override any locally-generated ones:
-```bash
-ssh root@<IP> "cp /tmp/curated-params-v3.json /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json && \
-  cp /tmp/factor-tables.json /root/ytdb/<module>/target/ldbc-bench-db/factor-tables.json && \
-  echo 'Canonical curated params installed'"
-```
+2. Loading canonical curated parameters and factor tables from the cache files installed in Step 3 (no regeneration needed)
 
 Subsequent forked runs will find the existing DB and load curated parameters from the JSON cache — zero SQL queries needed.
 
@@ -276,8 +271,8 @@ Changes within ~5-7% are typically measurement noise for multi-threaded benchmar
 
 - **Server type**: CCX33 provides 8 dedicated AMD EPYC vCPUs — dedicated (not shared) cores ensure consistent benchmark results. For heavier benchmarks, consider CCX43 (16 vCPUs) or CCX53 (32 vCPUs).
 - **jmh-ldbc Threads.MAX**: The multi-threaded LDBC benchmark uses `@Threads(Threads.MAX)` — one thread per available processor. On CCX33 this means 8 threads.
-- **jmh-ldbc dataset loading**: Always load from the CSV dataset (see Step 3b). Pre-load with `-f 1` before real benchmarks (see Step 4b), then install canonical curated params. The DB path is `./target/ldbc-bench-db`.
-- **jmh-ldbc curated params**: Canonical curated parameters are stored in S3 as separate objects (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`). **Always download and install them after DB creation** — never let the benchmark regenerate params independently, as different code versions produce different iteration orders, which cause the stride-based parameter sampling to select different query parameter sets, making results incomparable. See `jmh-ldbc/README.md` for the regeneration procedure (only needed when curation algorithm changes).
+- **jmh-ldbc dataset loading**: Always load from the CSV dataset (see Step 3b). Install canonical curated params into the DB directory (Step 3b, Step 3), then pre-load with `-f 1` (Step 4b). The DB path is `./target/ldbc-bench-db`.
+- **jmh-ldbc curated params**: Canonical curated parameters are stored in S3 as separate objects (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`). **Always download and install them before the pre-load fork** — never let the benchmark regenerate params independently, as different code versions produce different iteration orders, which cause the stride-based parameter sampling to select different query parameter sets, making results incomparable. See `jmh-ldbc/README.md` for the regeneration procedure (only needed when curation algorithm changes).
 - **Never run benchmarks concurrently**: Multiple JMH processes on the same server will contend for CPU and produce unreliable numbers. Always run one at a time.
 - **Ubuntu apt lock on fresh servers**: Newly provisioned Ubuntu 24.04 servers run `unattended-upgrades` on first boot. If `apt-get install` fails with "Could not get lock", wait 30 seconds and retry.
 - **Memory file**: For LDBC benchmarks, update `ldbc-jmh-benchmarks.md` in the auto-memory directory with new results after each run.

--- a/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
+++ b/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
@@ -128,9 +128,8 @@ The CSV dataset uses LDBC datagen v1.0.0 CsvCompositeMergeForeign format. The DB
 **Step 3**: Download canonical curated parameters and install into the DB directory (created here so they are available before the pre-load fork in Step 4b):
 ```bash
 ssh root@<IP> "mkdir -p /root/ytdb/<module>/target/ldbc-bench-db && \
-  curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json '<CURATED_PARAMS_URL>' && \
   curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/factor-tables.json '<FACTOR_TABLES_URL>' && \
-  touch /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json && \
+  curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json '<CURATED_PARAMS_URL>' && \
   echo 'Canonical curated params installed'"
 ```
 

--- a/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
+++ b/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
@@ -84,79 +84,38 @@ ssh root@<IP> 'git config --global --add safe.directory /root/ytdb && \
 
 ### Step 3b: Download LDBC data from Hetzner S3 (jmh-ldbc only — MANDATORY)
 
-The LDBC SF 1 data must be available before running benchmarks. Download from Hetzner Object Storage (S3 bucket `bench-cache`).
+The LDBC SF 1 CSV dataset and canonical curated parameters must be available before running benchmarks. Download from Hetzner Object Storage (S3 bucket `bench-cache`).
 
 **Available S3 artifacts:**
 | Key | Size | Description |
 |-----|------|-------------|
-| `ldbc/ldbc-sf1-bench-db.tar.zst` | ~1.3 GB | Pre-built YouTrackDB database (SF 1) — **default** |
-| `ldbc/ldbc-sf1-composite-merged-fk.tar.zst` | ~195 MB | Raw CSV dataset (SF 1) — use when user explicitly asks (e.g. testing storage format changes) |
-| `ldbc/ldbc-sf0.1-composite-merged-fk.tar.zst` | ~19 MB | Raw CSV dataset (SF 0.1) — for quick smoke tests only |
+| `ldbc/ldbc-sf1-composite-merged-fk.tar.zst` | ~195 MB | CSV dataset (SF 1) |
+| `ldbc/ldbc-sf0.1-composite-merged-fk.tar.zst` | ~19 MB | CSV dataset (SF 0.1) — for quick smoke tests only |
+| `ldbc/curated-params-v3.json` | — | Canonical curated parameters |
+| `ldbc/factor-tables.json` | — | Canonical factor tables |
 
-**Default: Use the pre-built database.** This skips the ~21 min CSV loading step. Only fall back to the CSV dataset when the user explicitly asks — e.g. when testing storage format changes, serializer changes, or any code that affects how data is written to disk.
-
-**Step 1**: Generate a presigned HTTPS URL locally (boto3 required on the local machine):
+**Step 1**: Generate presigned HTTPS URLs locally (boto3 required on the local machine):
 ```bash
-# For pre-built DB (default):
-S3_KEY="ldbc/ldbc-sf1-bench-db.tar.zst"
-
-# For CSV dataset (only when user explicitly asks):
-# S3_KEY="ldbc/ldbc-sf1-composite-merged-fk.tar.zst"
-
+# CSV dataset
 python3 -c "
 import boto3, os
 s3 = boto3.client('s3',
     endpoint_url='https://nbg1.your-objectstorage.com',
     aws_access_key_id=os.environ['HETZNER_S3_ACCESS_KEY'],
     aws_secret_access_key=os.environ['HETZNER_S3_SECRET_KEY'])
-url = s3.generate_presigned_url('get_object',
-    Params={'Bucket': 'bench-cache', 'Key': '$S3_KEY'},
-    ExpiresIn=7200)
-print(url)
+for key in ['ldbc/ldbc-sf1-composite-merged-fk.tar.zst', 'ldbc/curated-params-v3.json', 'ldbc/factor-tables.json']:
+    url = s3.generate_presigned_url('get_object',
+        Params={'Bucket': 'bench-cache', 'Key': key},
+        ExpiresIn=7200)
+    print(f'{key}: {url}')
 "
 ```
 
-**Step 2a — Pre-built DB (default)**: Download and extract:
-```bash
-ssh root@<IP> "apt-get install -y -qq zstd > /dev/null 2>&1 && \
-  mkdir -p /root/ytdb/<module>/target && \
-  curl -sS -o /tmp/bench-db.tar.zst '<PRESIGNED_URL>' && \
-  cd /root/ytdb/<module>/target && \
-  zstd -d /tmp/bench-db.tar.zst -o /tmp/bench-db.tar && \
-  tar xf /tmp/bench-db.tar && \
-  rm -f /tmp/bench-db.tar.zst /tmp/bench-db.tar && \
-  echo 'DB ready' && du -sh ldbc-bench-db/"
-```
-
-The pre-built DB tar includes canonical curated parameters (`curated-params-v3.json` and `factor-tables.json`). **Do NOT delete them.** All runs must use the same canonical parameters to ensure comparable results — see the [jmh-ldbc README](jmh-ldbc/README.md#canonical-curated-parameters) for details.
-
-If the pre-built DB is missing curated params (e.g., old tar), download them separately:
-```bash
-# Generate presigned URLs for canonical params (locally)
-for KEY in curated-params-v3.json factor-tables.json; do
-  python3 -c "
-import boto3, os
-s3 = boto3.client('s3',
-    endpoint_url='https://nbg1.your-objectstorage.com',
-    aws_access_key_id=os.environ['HETZNER_S3_ACCESS_KEY'],
-    aws_secret_access_key=os.environ['HETZNER_S3_SECRET_KEY'])
-url = s3.generate_presigned_url('get_object',
-    Params={'Bucket': 'bench-cache', 'Key': 'ldbc/$KEY'},
-    ExpiresIn=7200)
-print(url)
-"
-done
-
-# Download to the DB directory on the server
-ssh root@<IP> "curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json '<CURATED_PARAMS_URL>' && \
-  curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/factor-tables.json '<FACTOR_TABLES_URL>'"
-```
-
-**Step 2b — CSV dataset (only when user asks)**: Download and extract:
+**Step 2**: Download CSV dataset and extract:
 ```bash
 ssh root@<IP> "apt-get install -y -qq zstd > /dev/null 2>&1 && \
   mkdir -p /root/ytdb/<module>/target/ldbc-dataset/sf1 && \
-  curl -sS -o /tmp/dataset.tar.zst '<PRESIGNED_URL>' && \
+  curl -sS -o /tmp/dataset.tar.zst '<CSV_PRESIGNED_URL>' && \
   cd /root/ytdb/<module>/target/ldbc-dataset/sf1 && \
   zstd -d /tmp/dataset.tar.zst -o /tmp/dataset.tar && \
   tar xf /tmp/dataset.tar && \
@@ -165,6 +124,12 @@ ssh root@<IP> "apt-get install -y -qq zstd > /dev/null 2>&1 && \
 ```
 
 The CSV dataset uses LDBC datagen v1.0.0 CsvCompositeMergeForeign format. The DB will be created from CSVs during the pre-load step (Step 4b), which takes ~21 minutes for SF 1.
+
+**Step 3**: Download canonical curated parameters (install after DB is created in Step 4b):
+```bash
+ssh root@<IP> "curl -sS -o /tmp/curated-params-v3.json '<CURATED_PARAMS_URL>' && \
+  curl -sS -o /tmp/factor-tables.json '<FACTOR_TABLES_URL>'"
+```
 
 Replace `<module>` with the benchmark module (e.g. `jmh-ldbc`) and `<PRESIGNED_URL>` with the URL from Step 1.
 
@@ -195,15 +160,22 @@ ssh root@<IP> 'cd /root/ytdb && ./mvnw -pl <module> -am verify -P bench -DskipTe
 ```
 
 This runs a single fork (`-f 1`) that triggers:
-1. DB creation from CSV files (if no pre-built DB exists) — ~21 min for SF 1
+1. DB creation from CSV files — ~21 min for SF 1
 2. Factor table computation and caching to `factor-tables.json`
 3. Parameter curation (including IC4 oldPost-count difficulty sampling) and caching to `curated-params-v<N>.json` (versioned filename — bumped when curation logic changes)
+
+After the pre-load completes, install canonical curated parameters to override any locally-generated ones:
+```bash
+ssh root@<IP> "cp /tmp/curated-params-v3.json /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json && \
+  cp /tmp/factor-tables.json /root/ytdb/<module>/target/ldbc-bench-db/factor-tables.json && \
+  echo 'Canonical curated params installed'"
+```
 
 Subsequent forked runs will find the existing DB and load curated parameters from the JSON cache — zero SQL queries needed.
 
 **Important**: Use `-f 1` (not `-f 0`). With `-f 0` the benchmark runs in-process and the database may not persist to disk.
 
-**When comparing two code versions (A/B testing)**: Deploy both versions to separate directories (e.g., `/root/ytdb` and `/root/ytdb-base`). Copy the pre-built DB (including canonical curated params) to both. **Both versions must use identical curated parameters** — never let either version regenerate params independently, as internal data structure changes can alter iteration order and produce incomparable parameter sets (see IC4 desync incident in jmh-ldbc README).
+**When comparing two code versions (A/B testing)**: Deploy both versions to separate directories (e.g., `/root/ytdb` and `/root/ytdb-base`). Load CSV and install canonical curated params for both. **Both versions must use identical curated parameters** — never let either version regenerate params independently, as internal data structure changes can alter iteration order and produce incomparable parameter sets (see IC4 desync incident in jmh-ldbc README).
 
 ### Step 5: Run benchmarks
 
@@ -304,10 +276,10 @@ Changes within ~5-7% are typically measurement noise for multi-threaded benchmar
 
 - **Server type**: CCX33 provides 8 dedicated AMD EPYC vCPUs — dedicated (not shared) cores ensure consistent benchmark results. For heavier benchmarks, consider CCX43 (16 vCPUs) or CCX53 (32 vCPUs).
 - **jmh-ldbc Threads.MAX**: The multi-threaded LDBC benchmark uses `@Threads(Threads.MAX)` — one thread per available processor. On CCX33 this means 8 threads.
-- **jmh-ldbc dataset loading**: By default, use the pre-built SF 1 database from S3 (see Step 3b). Fall back to CSV dataset only when the user explicitly asks (e.g. for storage format testing). Always pre-load with `-f 1` before real benchmarks (see Step 4b). The DB path is `./target/ldbc-bench-db`.
-- **jmh-ldbc curated params**: Canonical curated parameters are stored in S3 (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`) and included in the pre-built DB tar. **Never delete or regenerate them** — different code versions produce different iteration orders, which cause the stride-based parameter sampling to select different query parameter sets, making results incomparable. See `jmh-ldbc/README.md` for the regeneration procedure (only needed when curation algorithm changes).
+- **jmh-ldbc dataset loading**: Always load from the CSV dataset (see Step 3b). Pre-load with `-f 1` before real benchmarks (see Step 4b), then install canonical curated params. The DB path is `./target/ldbc-bench-db`.
+- **jmh-ldbc curated params**: Canonical curated parameters are stored in S3 as separate objects (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`). **Always download and install them after DB creation** — never let the benchmark regenerate params independently, as different code versions produce different iteration orders, which cause the stride-based parameter sampling to select different query parameter sets, making results incomparable. See `jmh-ldbc/README.md` for the regeneration procedure (only needed when curation algorithm changes).
 - **Never run benchmarks concurrently**: Multiple JMH processes on the same server will contend for CPU and produce unreliable numbers. Always run one at a time.
 - **Ubuntu apt lock on fresh servers**: Newly provisioned Ubuntu 24.04 servers run `unattended-upgrades` on first boot. If `apt-get install` fails with "Could not get lock", wait 30 seconds and retry.
 - **Memory file**: For LDBC benchmarks, update `ldbc-jmh-benchmarks.md` in the auto-memory directory with new results after each run.
-- **S3 artifacts**: S3 bucket `bench-cache` contains pre-built DB (`ldbc-sf1-bench-db.tar.zst`, ~930 MB, includes canonical curated params), canonical curated params (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`), SF 1 CSV (`ldbc-sf1-composite-merged-fk.tar.zst`, ~195 MB), and SF 0.1 CSV (`ldbc-sf0.1-composite-merged-fk.tar.zst`, ~19 MB). Credentials are in env vars `HETZNER_S3_ACCESS_KEY` / `HETZNER_S3_SECRET_KEY` / `HETZNER_S3_ENDPOINT` — never hardcode them.
+- **S3 artifacts**: S3 bucket `bench-cache` contains canonical curated params (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`), SF 1 CSV (`ldbc/ldbc-sf1-composite-merged-fk.tar.zst`, ~195 MB), and SF 0.1 CSV (`ldbc/ldbc-sf0.1-composite-merged-fk.tar.zst`, ~19 MB). Credentials are in env vars `HETZNER_S3_ACCESS_KEY` / `HETZNER_S3_SECRET_KEY` / `HETZNER_S3_ENDPOINT` — never hardcode them.
 - **Do not use SURF**: The SURF Data Repository (`repository.surfsara.nl`) provides the CsvComposite format (v0.3.5), which is **incompatible** with the benchmark loaders that expect CsvCompositeMergeForeign column layouts.

--- a/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
+++ b/.claude/skills/run-jmh-benchmarks-hetzner/SKILL.md
@@ -128,10 +128,28 @@ ssh root@<IP> "apt-get install -y -qq zstd > /dev/null 2>&1 && \
   echo 'DB ready' && du -sh ldbc-bench-db/"
 ```
 
-After extracting, clear any stale curation caches so the current code's curation logic runs fresh:
+The pre-built DB tar includes canonical curated parameters (`curated-params-v3.json` and `factor-tables.json`). **Do NOT delete them.** All runs must use the same canonical parameters to ensure comparable results — see the [jmh-ldbc README](jmh-ldbc/README.md#canonical-curated-parameters) for details.
+
+If the pre-built DB is missing curated params (e.g., old tar), download them separately:
 ```bash
-ssh root@<IP> 'rm -f /root/ytdb/<module>/target/ldbc-bench-db/curated-params*.json \
-  /root/ytdb/<module>/target/ldbc-bench-db/factor-tables.json'
+# Generate presigned URLs for canonical params (locally)
+for KEY in curated-params-v3.json factor-tables.json; do
+  python3 -c "
+import boto3, os
+s3 = boto3.client('s3',
+    endpoint_url='https://nbg1.your-objectstorage.com',
+    aws_access_key_id=os.environ['HETZNER_S3_ACCESS_KEY'],
+    aws_secret_access_key=os.environ['HETZNER_S3_SECRET_KEY'])
+url = s3.generate_presigned_url('get_object',
+    Params={'Bucket': 'bench-cache', 'Key': 'ldbc/$KEY'},
+    ExpiresIn=7200)
+print(url)
+"
+done
+
+# Download to the DB directory on the server
+ssh root@<IP> "curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/curated-params-v3.json '<CURATED_PARAMS_URL>' && \
+  curl -sS -o /root/ytdb/<module>/target/ldbc-bench-db/factor-tables.json '<FACTOR_TABLES_URL>'"
 ```
 
 **Step 2b — CSV dataset (only when user asks)**: Download and extract:
@@ -185,13 +203,7 @@ Subsequent forked runs will find the existing DB and load curated parameters fro
 
 **Important**: Use `-f 1` (not `-f 0`). With `-f 0` the benchmark runs in-process and the database may not persist to disk.
 
-**When comparing two code versions (A/B testing)**: After running version A, delete the benchmark database and curation caches before running version B:
-
-```bash
-ssh root@<IP> 'rm -rf /root/ytdb/jmh-ldbc/target/ldbc-bench-db'
-```
-
-The CSV dataset files (`target/ldbc-dataset/`) can be kept — only the DB needs to be recreated.
+**When comparing two code versions (A/B testing)**: Deploy both versions to separate directories (e.g., `/root/ytdb` and `/root/ytdb-base`). Copy the pre-built DB (including canonical curated params) to both. **Both versions must use identical curated parameters** — never let either version regenerate params independently, as internal data structure changes can alter iteration order and produce incomparable parameter sets (see IC4 desync incident in jmh-ldbc README).
 
 ### Step 5: Run benchmarks
 
@@ -293,9 +305,9 @@ Changes within ~5-7% are typically measurement noise for multi-threaded benchmar
 - **Server type**: CCX33 provides 8 dedicated AMD EPYC vCPUs — dedicated (not shared) cores ensure consistent benchmark results. For heavier benchmarks, consider CCX43 (16 vCPUs) or CCX53 (32 vCPUs).
 - **jmh-ldbc Threads.MAX**: The multi-threaded LDBC benchmark uses `@Threads(Threads.MAX)` — one thread per available processor. On CCX33 this means 8 threads.
 - **jmh-ldbc dataset loading**: By default, use the pre-built SF 1 database from S3 (see Step 3b). Fall back to CSV dataset only when the user explicitly asks (e.g. for storage format testing). Always pre-load with `-f 1` before real benchmarks (see Step 4b). The DB path is `./target/ldbc-bench-db`.
-- **jmh-ldbc curated params caching**: Parameter curation results are cached to a versioned file (`curated-params-v<N>.json`) alongside the DB. The version suffix is bumped in `ParameterCurator.CURATED_PARAMS_CACHE_FILE` when curation logic changes, automatically invalidating old caches. The first fork computes factor tables and curated parameters (~2 min on SF 1), subsequent forks load from cache instantly. To force recomputation: `rm -f target/ldbc-bench-db/curated-params*.json target/ldbc-bench-db/factor-tables.json`
+- **jmh-ldbc curated params**: Canonical curated parameters are stored in S3 (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`) and included in the pre-built DB tar. **Never delete or regenerate them** — different code versions produce different iteration orders, which cause the stride-based parameter sampling to select different query parameter sets, making results incomparable. See `jmh-ldbc/README.md` for the regeneration procedure (only needed when curation algorithm changes).
 - **Never run benchmarks concurrently**: Multiple JMH processes on the same server will contend for CPU and produce unreliable numbers. Always run one at a time.
 - **Ubuntu apt lock on fresh servers**: Newly provisioned Ubuntu 24.04 servers run `unattended-upgrades` on first boot. If `apt-get install` fails with "Could not get lock", wait 30 seconds and retry.
 - **Memory file**: For LDBC benchmarks, update `ldbc-jmh-benchmarks.md` in the auto-memory directory with new results after each run.
-- **S3 artifacts**: S3 bucket `bench-cache` contains pre-built DB (`ldbc-sf1-bench-db.tar.zst`, ~1.3 GB), SF 1 CSV (`ldbc-sf1-composite-merged-fk.tar.zst`, ~195 MB), and SF 0.1 CSV (`ldbc-sf0.1-composite-merged-fk.tar.zst`, ~19 MB). Credentials are in env vars `HETZNER_S3_ACCESS_KEY` / `HETZNER_S3_SECRET_KEY` / `HETZNER_S3_ENDPOINT` — never hardcode them.
+- **S3 artifacts**: S3 bucket `bench-cache` contains pre-built DB (`ldbc-sf1-bench-db.tar.zst`, ~930 MB, includes canonical curated params), canonical curated params (`ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`), SF 1 CSV (`ldbc-sf1-composite-merged-fk.tar.zst`, ~195 MB), and SF 0.1 CSV (`ldbc-sf0.1-composite-merged-fk.tar.zst`, ~19 MB). Credentials are in env vars `HETZNER_S3_ACCESS_KEY` / `HETZNER_S3_SECRET_KEY` / `HETZNER_S3_ENDPOINT` — never hardcode them.
 - **Do not use SURF**: The SURF Data Repository (`repository.surfsara.nl`) provides the CsvComposite format (v0.3.5), which is **incompatible** with the benchmark loaders that expect CsvCompositeMergeForeign column layouts.

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -7,13 +7,6 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      use_prebuilt_db:
-        description: >
-          Use pre-built DB from S3 (fast, ~2 min setup).
-          When false, loads from CSV (~21 min per run).
-        required: false
-        type: boolean
-        default: true
       queries:
         description: >
           Comma-separated query IDs to benchmark (e.g. IS1,IC2,IC13).
@@ -121,33 +114,6 @@ jobs:
             -Dspotless.check.skip=true -q
 
       # ── Download data (once) ─────────────────────────────────────────────
-      # Always download the CSV dataset as a fallback.
-      # Download the pre-built DB too when requested (faster setup).
-      - name: Download pre-built database from S3
-        id: download_prebuilt
-        if: inputs.use_prebuilt_db == true
-        continue-on-error: true
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
-          S3_ENDPOINT: ${{ secrets.HETZNER_S3_ENDPOINT }}
-        run: |
-          set -euo pipefail
-          python3 - << 'PYEOF'
-          import boto3, os
-          s3 = boto3.client('s3',
-              endpoint_url=os.environ['S3_ENDPOINT'],
-              aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
-              aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
-          print('Downloading pre-built SF 1 database from S3...')
-          s3.download_file('bench-cache', 'ldbc/ldbc-sf1-bench-db.tar.zst',
-              '/tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst')
-          print('Downloaded.')
-          PYEOF
-          zstd -d "/tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst" \
-               -o "/tmp/ldbc-bench-db-${{ github.run_id }}.tar"
-          rm -f "/tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst"
-
       - name: Download canonical curated parameters from S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
@@ -206,70 +172,35 @@ jobs:
           set -euo pipefail
           DB_DIR="jmh-ldbc/target/ldbc-bench-db"
           CSV_DIR="jmh-ldbc/target/ldbc-dataset/sf1"
-          PREBUILT_TAR="/tmp/ldbc-bench-db-${{ github.run_id }}.tar"
           CSV_TAR="/tmp/ldbc-csv-${{ github.run_id }}.tar"
-          DB_READY=false
 
-          # ── Try pre-built database first ──
-          if [ -f "$PREBUILT_TAR" ]; then
-            echo "Extracting pre-built database..."
-            mkdir -p "$DB_DIR"
-            tar xf "$PREBUILT_TAR" -C "$DB_DIR"
+          echo "Extracting CSV dataset..."
+          mkdir -p "$CSV_DIR"
+          tar xf "$CSV_TAR" --strip-components=1 -C "$CSV_DIR"
 
-            echo "=== Extracted DB contents (top-level) ==="
-            ls -la "$DB_DIR/"
+          echo "=== Extracted CSV contents ==="
+          ls -la "$CSV_DIR/" | head -20
 
-            if [ -d "$DB_DIR/ldbc_benchmark" ]; then
-              echo "Pre-built database found at expected path"
-              ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
-              DB_READY=true
-            elif [ -d "$DB_DIR/ldbc-bench-db/ldbc_benchmark" ]; then
-              echo "::warning::Tar has nested ldbc-bench-db/ directory — relocating"
-              tmp_dir="${DB_DIR}_tmp_$$"
-              mv "$DB_DIR/ldbc-bench-db" "$tmp_dir"
-              rm -rf "$DB_DIR"
-              mv "$tmp_dir" "$DB_DIR"
-              ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
-              DB_READY=true
-            else
-              echo "::warning::Pre-built database missing 'ldbc_benchmark' directory, falling back to CSV."
-              find "$DB_DIR" -maxdepth 3 -type d
-              rm -rf "$DB_DIR"
-            fi
-          else
-            echo "Pre-built database tar not available, using CSV dataset."
+          if [ ! -d "$CSV_DIR/static" ] || [ ! -d "$CSV_DIR/dynamic" ]; then
+            echo "::error::CSV dataset missing 'static' or 'dynamic' directories."
+            echo "Contents of $CSV_DIR:"
+            find "$CSV_DIR" -maxdepth 2 -type d
+            exit 1
           fi
+          echo "CSV dataset verified: static/ and dynamic/ present"
 
-          # ── Fall back to CSV dataset if pre-built DB is not ready ──
-          if [ "$DB_READY" = "false" ]; then
-            echo "Extracting CSV dataset..."
-            mkdir -p "$CSV_DIR"
-            tar xf "$CSV_TAR" --strip-components=1 -C "$CSV_DIR"
+          echo "Loading database from CSV..."
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1" \
+            2>&1 | tee /tmp/jmh-load-base-${{ github.run_id }}.txt
 
-            echo "=== Extracted CSV contents ==="
-            ls -la "$CSV_DIR/" | head -20
-
-            if [ ! -d "$CSV_DIR/static" ] || [ ! -d "$CSV_DIR/dynamic" ]; then
-              echo "::error::CSV dataset missing 'static' or 'dynamic' directories."
-              echo "Contents of $CSV_DIR:"
-              find "$CSV_DIR" -maxdepth 2 -type d
-              exit 1
-            fi
-            echo "CSV dataset verified: static/ and dynamic/ present"
-
-            echo "Loading database from CSV..."
-            ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
-              -Dspotless.check.skip=true -Dcentral.skip=true \
-              -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1" \
-              2>&1 | tee /tmp/jmh-load-base-${{ github.run_id }}.txt
-
-            # Verify the database was actually created
-            if [ ! -d "$DB_DIR/ldbc_benchmark" ]; then
-              echo "::error::Database was not created after CSV load. Check load output above."
-              exit 1
-            fi
-            echo "Database loaded successfully from CSV"
+          # Verify the database was actually created
+          if [ ! -d "$DB_DIR/ldbc_benchmark" ]; then
+            echo "::error::Database was not created after CSV load. Check load output above."
+            exit 1
           fi
+          echo "Database loaded successfully from CSV"
 
       - name: 'Base: install canonical curated parameters'
         run: |
@@ -349,70 +280,35 @@ jobs:
           set -euo pipefail
           DB_DIR="jmh-ldbc/target/ldbc-bench-db"
           CSV_DIR="jmh-ldbc/target/ldbc-dataset/sf1"
-          PREBUILT_TAR="/tmp/ldbc-bench-db-${{ github.run_id }}.tar"
           CSV_TAR="/tmp/ldbc-csv-${{ github.run_id }}.tar"
-          DB_READY=false
 
-          # ── Try pre-built database first ──
-          if [ -f "$PREBUILT_TAR" ]; then
-            echo "Extracting pre-built database..."
-            mkdir -p "$DB_DIR"
-            tar xf "$PREBUILT_TAR" -C "$DB_DIR"
+          echo "Extracting CSV dataset..."
+          mkdir -p "$CSV_DIR"
+          tar xf "$CSV_TAR" --strip-components=1 -C "$CSV_DIR"
 
-            echo "=== Extracted DB contents (top-level) ==="
-            ls -la "$DB_DIR/"
+          echo "=== Extracted CSV contents ==="
+          ls -la "$CSV_DIR/" | head -20
 
-            if [ -d "$DB_DIR/ldbc_benchmark" ]; then
-              echo "Pre-built database found at expected path"
-              ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
-              DB_READY=true
-            elif [ -d "$DB_DIR/ldbc-bench-db/ldbc_benchmark" ]; then
-              echo "::warning::Tar has nested ldbc-bench-db/ directory — relocating"
-              tmp_dir="${DB_DIR}_tmp_$$"
-              mv "$DB_DIR/ldbc-bench-db" "$tmp_dir"
-              rm -rf "$DB_DIR"
-              mv "$tmp_dir" "$DB_DIR"
-              ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
-              DB_READY=true
-            else
-              echo "::warning::Pre-built database missing 'ldbc_benchmark' directory, falling back to CSV."
-              find "$DB_DIR" -maxdepth 3 -type d
-              rm -rf "$DB_DIR"
-            fi
-          else
-            echo "Pre-built database tar not available, using CSV dataset."
+          if [ ! -d "$CSV_DIR/static" ] || [ ! -d "$CSV_DIR/dynamic" ]; then
+            echo "::error::CSV dataset missing 'static' or 'dynamic' directories."
+            echo "Contents of $CSV_DIR:"
+            find "$CSV_DIR" -maxdepth 2 -type d
+            exit 1
           fi
+          echo "CSV dataset verified: static/ and dynamic/ present"
 
-          # ── Fall back to CSV dataset if pre-built DB is not ready ──
-          if [ "$DB_READY" = "false" ]; then
-            echo "Extracting CSV dataset..."
-            mkdir -p "$CSV_DIR"
-            tar xf "$CSV_TAR" --strip-components=1 -C "$CSV_DIR"
+          echo "Loading database from CSV..."
+          ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
+            -Dspotless.check.skip=true -Dcentral.skip=true \
+            -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1" \
+            2>&1 | tee /tmp/jmh-load-head-${{ github.run_id }}.txt
 
-            echo "=== Extracted CSV contents ==="
-            ls -la "$CSV_DIR/" | head -20
-
-            if [ ! -d "$CSV_DIR/static" ] || [ ! -d "$CSV_DIR/dynamic" ]; then
-              echo "::error::CSV dataset missing 'static' or 'dynamic' directories."
-              echo "Contents of $CSV_DIR:"
-              find "$CSV_DIR" -maxdepth 2 -type d
-              exit 1
-            fi
-            echo "CSV dataset verified: static/ and dynamic/ present"
-
-            echo "Loading database from CSV..."
-            ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
-              -Dspotless.check.skip=true -Dcentral.skip=true \
-              -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1" \
-              2>&1 | tee /tmp/jmh-load-head-${{ github.run_id }}.txt
-
-            # Verify the database was actually created
-            if [ ! -d "$DB_DIR/ldbc_benchmark" ]; then
-              echo "::error::Database was not created after CSV load. Check load output above."
-              exit 1
-            fi
-            echo "Database loaded successfully from CSV"
+          # Verify the database was actually created
+          if [ ! -d "$DB_DIR/ldbc_benchmark" ]; then
+            echo "::error::Database was not created after CSV load. Check load output above."
+            exit 1
           fi
+          echo "Database loaded successfully from CSV"
 
       - name: 'Head: install canonical curated parameters'
         run: |
@@ -563,7 +459,6 @@ jobs:
         run: |
           rm -f /tmp/curated-params-${{ github.run_id }}.json \
                 /tmp/factor-tables-${{ github.run_id }}.json \
-                /tmp/ldbc-bench-db-${{ github.run_id }}.tar \
                 /tmp/ldbc-csv-${{ github.run_id }}.tar \
                 /tmp/jmh-compare-${{ github.run_id }}.py \
                 /tmp/jmh-base-${{ github.run_id }}.json \

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -174,11 +174,10 @@ jobs:
           # This ensures BASE and HEAD use identical params.
           DB_DIR="jmh-ldbc/target/ldbc-bench-db"
           mkdir -p "$DB_DIR"
-          cp /tmp/curated-params-${{ github.run_id }}.json \
-             "$DB_DIR/curated-params-v3.json"
           cp /tmp/factor-tables-${{ github.run_id }}.json \
              "$DB_DIR/factor-tables.json"
-          touch "$DB_DIR/curated-params-v3.json"
+          cp /tmp/curated-params-${{ github.run_id }}.json \
+             "$DB_DIR/curated-params-v3.json"
           echo "Canonical curated params installed for base run"
 
       - name: 'Base: setup database'
@@ -285,11 +284,10 @@ jobs:
           # base, ensuring both runs use identical benchmark parameters.
           DB_DIR="jmh-ldbc/target/ldbc-bench-db"
           mkdir -p "$DB_DIR"
-          cp /tmp/curated-params-${{ github.run_id }}.json \
-             "$DB_DIR/curated-params-v3.json"
           cp /tmp/factor-tables-${{ github.run_id }}.json \
              "$DB_DIR/factor-tables.json"
-          touch "$DB_DIR/curated-params-v3.json"
+          cp /tmp/curated-params-${{ github.run_id }}.json \
+             "$DB_DIR/curated-params-v3.json"
           echo "Canonical curated params installed for head run"
 
       - name: 'Head: setup database'

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -148,6 +148,27 @@ jobs:
                -o "/tmp/ldbc-bench-db-${{ github.run_id }}.tar"
           rm -f "/tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst"
 
+      - name: Download canonical curated parameters from S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.HETZNER_S3_SECRET_KEY }}
+          S3_ENDPOINT: ${{ secrets.HETZNER_S3_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          python3 - << 'PYEOF'
+          import boto3, os
+          s3 = boto3.client('s3',
+              endpoint_url=os.environ['S3_ENDPOINT'],
+              aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+              aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
+          print('Downloading canonical curated parameters from S3...')
+          s3.download_file('bench-cache', 'ldbc/curated-params-v3.json',
+              '/tmp/curated-params-${{ github.run_id }}.json')
+          s3.download_file('bench-cache', 'ldbc/factor-tables.json',
+              '/tmp/factor-tables-${{ github.run_id }}.json')
+          print('Downloaded curated params and factor tables.')
+          PYEOF
+
       - name: Download LDBC CSV dataset from S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.HETZNER_S3_ACCESS_KEY }}
@@ -249,6 +270,16 @@ jobs:
             fi
             echo "Database loaded successfully from CSV"
           fi
+
+      - name: 'Base: install canonical curated parameters'
+        run: |
+          # Install canonical curated params so ParameterCurator skips
+          # regeneration. This ensures BASE and HEAD use identical params.
+          cp /tmp/curated-params-${{ github.run_id }}.json \
+             jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json
+          cp /tmp/factor-tables-${{ github.run_id }}.json \
+             jmh-ldbc/target/ldbc-bench-db/factor-tables.json
+          echo "Canonical curated params installed for base run"
 
       - name: 'Base: warm OS page cache'
         env:
@@ -382,6 +413,16 @@ jobs:
             fi
             echo "Database loaded successfully from CSV"
           fi
+
+      - name: 'Head: install canonical curated parameters'
+        run: |
+          # Install canonical curated params — same as base, ensuring
+          # both runs use identical benchmark parameters.
+          cp /tmp/curated-params-${{ github.run_id }}.json \
+             jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json
+          cp /tmp/factor-tables-${{ github.run_id }}.json \
+             jmh-ldbc/target/ldbc-bench-db/factor-tables.json
+          echo "Canonical curated params installed for head run"
 
       - name: 'Head: warm OS page cache'
         env:
@@ -520,7 +561,9 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -f /tmp/ldbc-bench-db-${{ github.run_id }}.tar \
+          rm -f /tmp/curated-params-${{ github.run_id }}.json \
+                /tmp/factor-tables-${{ github.run_id }}.json \
+                /tmp/ldbc-bench-db-${{ github.run_id }}.tar \
                 /tmp/ldbc-csv-${{ github.run_id }}.tar \
                 /tmp/jmh-compare-${{ github.run_id }}.py \
                 /tmp/jmh-base-${{ github.run_id }}.json \

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -167,6 +167,20 @@ jobs:
           ./mvnw -pl jmh-ldbc -am clean compile -DskipTests \
             -Dspotless.check.skip=true -q
 
+      - name: 'Base: install canonical curated parameters'
+        run: |
+          # Install canonical curated params before DB load so
+          # ParameterCurator finds them and skips regeneration.
+          # This ensures BASE and HEAD use identical params.
+          DB_DIR="jmh-ldbc/target/ldbc-bench-db"
+          mkdir -p "$DB_DIR"
+          cp /tmp/curated-params-${{ github.run_id }}.json \
+             "$DB_DIR/curated-params-v3.json"
+          cp /tmp/factor-tables-${{ github.run_id }}.json \
+             "$DB_DIR/factor-tables.json"
+          touch "$DB_DIR/curated-params-v3.json"
+          echo "Canonical curated params installed for base run"
+
       - name: 'Base: setup database'
         run: |
           set -euo pipefail
@@ -201,16 +215,6 @@ jobs:
             exit 1
           fi
           echo "Database loaded successfully from CSV"
-
-      - name: 'Base: install canonical curated parameters'
-        run: |
-          # Install canonical curated params so ParameterCurator skips
-          # regeneration. This ensures BASE and HEAD use identical params.
-          cp /tmp/curated-params-${{ github.run_id }}.json \
-             jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json
-          cp /tmp/factor-tables-${{ github.run_id }}.json \
-             jmh-ldbc/target/ldbc-bench-db/factor-tables.json
-          echo "Canonical curated params installed for base run"
 
       - name: 'Base: warm OS page cache'
         env:
@@ -275,6 +279,19 @@ jobs:
           ./mvnw -pl jmh-ldbc -am clean compile -DskipTests \
             -Dspotless.check.skip=true -q
 
+      - name: 'Head: install canonical curated parameters'
+        run: |
+          # Install canonical curated params before DB load — same as
+          # base, ensuring both runs use identical benchmark parameters.
+          DB_DIR="jmh-ldbc/target/ldbc-bench-db"
+          mkdir -p "$DB_DIR"
+          cp /tmp/curated-params-${{ github.run_id }}.json \
+             "$DB_DIR/curated-params-v3.json"
+          cp /tmp/factor-tables-${{ github.run_id }}.json \
+             "$DB_DIR/factor-tables.json"
+          touch "$DB_DIR/curated-params-v3.json"
+          echo "Canonical curated params installed for head run"
+
       - name: 'Head: setup database'
         run: |
           set -euo pipefail
@@ -309,16 +326,6 @@ jobs:
             exit 1
           fi
           echo "Database loaded successfully from CSV"
-
-      - name: 'Head: install canonical curated parameters'
-        run: |
-          # Install canonical curated params — same as base, ensuring
-          # both runs use identical benchmark parameters.
-          cp /tmp/curated-params-${{ github.run_id }}.json \
-             jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json
-          cp /tmp/factor-tables-${{ github.run_id }}.json \
-             jmh-ldbc/target/ldbc-bench-db/factor-tables.json
-          echo "Canonical curated params installed for head run"
 
       - name: 'Head: warm OS page cache'
         env:

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -117,6 +117,21 @@ jobs:
           chmod +x mvnw
           ./mvnw -pl jmh-ldbc -am compile -DskipTests -Dspotless.check.skip=true -q
 
+      - name: Install canonical curated parameters
+        run: |
+          # Install canonical curated params before the pre-load so
+          # ParameterCurator finds them and skips regeneration.
+          # Ensures all nightly runs use identical params regardless
+          # of database iteration order.
+          DB_DIR="jmh-ldbc/target/ldbc-bench-db"
+          mkdir -p "$DB_DIR"
+          cp "/tmp/curated-params-${{ github.run_id }}.json" \
+             "$DB_DIR/curated-params-v3.json"
+          cp "/tmp/factor-tables-${{ github.run_id }}.json" \
+             "$DB_DIR/factor-tables.json"
+          touch "$DB_DIR/curated-params-v3.json"
+          echo "Canonical curated params installed"
+
       - name: Pre-load LDBC database
         run: |
           set -euo pipefail
@@ -131,18 +146,6 @@ jobs:
             exit 1
           fi
           echo "Database loaded successfully from CSV"
-
-      - name: Install canonical curated parameters
-        run: |
-          # Install canonical curated params so ParameterCurator skips
-          # regeneration. Ensures all nightly runs use identical params
-          # regardless of database iteration order.
-          DB_DIR="jmh-ldbc/target/ldbc-bench-db"
-          cp "/tmp/curated-params-${{ github.run_id }}.json" \
-             "$DB_DIR/curated-params-v3.json"
-          cp "/tmp/factor-tables-${{ github.run_id }}.json" \
-             "$DB_DIR/factor-tables.json"
-          echo "Canonical curated params installed"
 
       - name: Warm OS page cache
         run: |

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -94,6 +94,16 @@ jobs:
             "${{ secrets.HETZNER_S3_ACCESS_KEY }}" "${{ secrets.HETZNER_S3_SECRET_KEY }}"
           mc ls hetzner/bench-cache/ldbc/ || echo "Warning: could not list S3 bucket"
 
+      - name: Download canonical curated parameters from S3
+        run: |
+          set -euo pipefail
+          echo 'Downloading canonical curated parameters from S3...'
+          mc cp hetzner/bench-cache/ldbc/curated-params-v3.json \
+            "/tmp/curated-params-${{ github.run_id }}.json"
+          mc cp hetzner/bench-cache/ldbc/factor-tables.json \
+            "/tmp/factor-tables-${{ github.run_id }}.json"
+          echo 'Downloaded curated params and factor tables.'
+
       - name: Download LDBC CSV dataset from S3
         if: steps.mode.outputs.load == 'csv'
         run: |
@@ -181,6 +191,18 @@ jobs:
             exit 1
           fi
           echo "Database loaded successfully from CSV"
+
+      - name: Install canonical curated parameters
+        run: |
+          # Install canonical curated params so ParameterCurator skips
+          # regeneration. Ensures all nightly runs use identical params
+          # regardless of database iteration order.
+          DB_DIR="jmh-ldbc/target/ldbc-bench-db"
+          cp "/tmp/curated-params-${{ github.run_id }}.json" \
+             "$DB_DIR/curated-params-v3.json"
+          cp "/tmp/factor-tables-${{ github.run_id }}.json" \
+             "$DB_DIR/factor-tables.json"
+          echo "Canonical curated params installed"
 
       - name: Warm OS page cache
         run: |
@@ -276,7 +298,9 @@ jobs:
       - name: Clean up temp files
         if: always()
         run: |
-          rm -f /tmp/ldbc-csv-${{ github.run_id }}.tar \
+          rm -f /tmp/curated-params-${{ github.run_id }}.json \
+                /tmp/factor-tables-${{ github.run_id }}.json \
+                /tmp/ldbc-csv-${{ github.run_id }}.tar \
                 /tmp/ldbc-csv-${{ github.run_id }}.tar.zst \
                 /tmp/ldbc-bench-db-${{ github.run_id }}.tar \
                 /tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst \

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -125,11 +125,10 @@ jobs:
           # of database iteration order.
           DB_DIR="jmh-ldbc/target/ldbc-bench-db"
           mkdir -p "$DB_DIR"
-          cp "/tmp/curated-params-${{ github.run_id }}.json" \
-             "$DB_DIR/curated-params-v3.json"
           cp "/tmp/factor-tables-${{ github.run_id }}.json" \
              "$DB_DIR/factor-tables.json"
-          touch "$DB_DIR/curated-params-v3.json"
+          cp "/tmp/curated-params-${{ github.run_id }}.json" \
+             "$DB_DIR/curated-params-v3.json"
           echo "Canonical curated params installed"
 
       - name: Pre-load LDBC database

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -14,11 +14,6 @@ on:
         description: 'Branch to benchmark'
         required: false
         default: 'develop'
-      use_prebuilt_db:
-        description: 'Use pre-built DB from S3 (skip CSV loading). Nightly always loads fresh.'
-        required: false
-        type: boolean
-        default: true
 
 concurrency:
   group: ldbc-jmh-nightly
@@ -36,8 +31,6 @@ jobs:
       - name: Clean workspace
         run: |
           rm -rf "$GITHUB_WORKSPACE"/* "$GITHUB_WORKSPACE"/.??* || true
-          rm -f /tmp/dataset.tar.zst /tmp/dataset.tar \
-                /tmp/bench-db.tar.zst /tmp/bench-db.tar
 
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,19 +45,6 @@ jobs:
           echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "branch=$(git rev-parse --abbrev-ref HEAD)" >> "$GITHUB_OUTPUT"
           echo "timestamp=$(date -u +%s)" >> "$GITHUB_OUTPUT"
-
-      - name: Determine load mode
-        id: mode
-        run: |
-          # Nightly (schedule) always loads fresh from CSV.
-          # Manual (workflow_dispatch) uses pre-built DB by default.
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "load=csv" >> "$GITHUB_OUTPUT"
-          elif [ "${{ inputs.use_prebuilt_db }}" = "true" ]; then
-            echo "load=prebuilt" >> "$GITHUB_OUTPUT"
-          else
-            echo "load=csv" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Install CLI tools (mc, jq)
         run: |
@@ -105,7 +85,6 @@ jobs:
           echo 'Downloaded curated params and factor tables.'
 
       - name: Download LDBC CSV dataset from S3
-        if: steps.mode.outputs.load == 'csv'
         run: |
           set -euo pipefail
           CSV_DIR="jmh-ldbc/target/ldbc-dataset/sf1"
@@ -133,51 +112,12 @@ jobs:
           fi
           echo "CSV dataset verified: static/ and dynamic/ present"
 
-      - name: Download pre-built LDBC database from S3
-        if: steps.mode.outputs.load == 'prebuilt'
-        run: |
-          set -euo pipefail
-          DB_DIR="jmh-ldbc/target/ldbc-bench-db"
-          DB_TAR="/tmp/ldbc-bench-db-${{ github.run_id }}.tar"
-
-          echo 'Downloading pre-built SF 1 database from S3...'
-          mc cp hetzner/bench-cache/ldbc/ldbc-sf1-bench-db.tar.zst "${DB_TAR}.zst"
-          echo 'Downloaded from S3'
-
-          zstd -d "${DB_TAR}.zst" -o "$DB_TAR"
-          rm -f "${DB_TAR}.zst"
-
-          mkdir -p "$DB_DIR"
-          tar xf "$DB_TAR" -C "$DB_DIR"
-          rm -f "$DB_TAR"
-
-          echo "=== Extracted DB contents (top-level) ==="
-          ls -la "$DB_DIR/"
-
-          if [ -d "$DB_DIR/ldbc_benchmark" ]; then
-            echo "Pre-built database found at expected path"
-            ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
-          elif [ -d "$DB_DIR/ldbc-bench-db/ldbc_benchmark" ]; then
-            echo "::warning::Tar has nested ldbc-bench-db/ directory — relocating"
-            tmp_dir="${DB_DIR}_tmp_$$"
-            mv "$DB_DIR/ldbc-bench-db" "$tmp_dir"
-            rm -rf "$DB_DIR"
-            mv "$tmp_dir" "$DB_DIR"
-            ls -la "$DB_DIR/ldbc_benchmark/" | head -20 || true
-          else
-            echo "::error::Pre-built database missing 'ldbc_benchmark' directory."
-            find "$DB_DIR" -maxdepth 3 -type d
-            exit 1
-          fi
-          echo "Pre-built database extracted"
-
       - name: Compile
         run: |
           chmod +x mvnw
           ./mvnw -pl jmh-ldbc -am compile -DskipTests -Dspotless.check.skip=true -q
 
       - name: Pre-load LDBC database
-        if: steps.mode.outputs.load == 'csv'
         run: |
           set -euo pipefail
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
@@ -251,22 +191,6 @@ jobs:
           # Copy to workspace for artifact upload
           cp "$RESULTS" "${{ github.workspace }}/results.json"
 
-      - name: Upload built database to S3
-        if: success() && steps.mode.outputs.load == 'csv'
-        run: |
-          set -euo pipefail
-          DB_TAR="/tmp/ldbc-bench-db-upload-${{ github.run_id }}.tar"
-          cd jmh-ldbc/target/ldbc-bench-db
-          tar cf "$DB_TAR" .
-          zstd -9 "$DB_TAR" -o "${DB_TAR}.zst"
-          rm -f "$DB_TAR"
-          echo "Database archived: $(du -sh "${DB_TAR}.zst" | cut -f1)"
-
-          echo 'Uploading built database to S3...'
-          mc cp "${DB_TAR}.zst" hetzner/bench-cache/ldbc/ldbc-sf1-bench-db.tar.zst
-          rm -f "${DB_TAR}.zst"
-          echo 'Uploaded to S3: ldbc/ldbc-sf1-bench-db.tar.zst'
-
       - name: Push results to InfluxDB
         if: success()
         env:
@@ -302,10 +226,6 @@ jobs:
                 /tmp/factor-tables-${{ github.run_id }}.json \
                 /tmp/ldbc-csv-${{ github.run_id }}.tar \
                 /tmp/ldbc-csv-${{ github.run_id }}.tar.zst \
-                /tmp/ldbc-bench-db-${{ github.run_id }}.tar \
-                /tmp/ldbc-bench-db-${{ github.run_id }}.tar.zst \
-                /tmp/ldbc-bench-db-upload-${{ github.run_id }}.tar \
-                /tmp/ldbc-bench-db-upload-${{ github.run_id }}.tar.zst \
                 /tmp/jmh-results-${{ github.run_id }}.json \
                 /tmp/jmh-bench-log-${{ github.run_id }}.txt \
                 /tmp/jmh-warm-${{ github.run_id }}.txt \

--- a/jmh-ldbc/README.md
+++ b/jmh-ldbc/README.md
@@ -124,7 +124,7 @@ Both approaches fork a new JVM with all required `--add-opens` flags and 4 GB he
 ### First Run
 
 On the first run, the benchmark setup phase will:
-1. Check for an existing database at `./target/ldbc-bench-db` (or the path specified by `-Dldbc.db.path`). If a pre-built database exists, it is reused directly (skips steps 2-3).
+1. Check for an existing database at `./target/ldbc-bench-db` (or the path specified by `-Dldbc.db.path`). If a database exists, it is reused directly (skips steps 2-3).
 2. Otherwise, look for the LDBC CSV dataset at `./target/ldbc-dataset/sf1` (or the path specified by `-Dldbc.dataset.path`). The dataset must be obtained beforehand — see [Dataset](#dataset).
 3. Create a YouTrackDB database, create the LDBC schema from `ldbc-schema.sql` (vertex/edge classes + indexes), and load all CSV data (~3.6M records for SF 1, ~21 min on CCX33).
 4. Run **parameter curation** — compute factor tables from the loaded data (friend counts, FoF/FoFoF counts, name frequencies, etc.), apply gap-based grouping to select entities with similar query difficulty, and generate 500 per-query parameter tuples. Factor tables are cached to `factor-tables.json` alongside the DB so they are computed only once.
@@ -224,20 +224,23 @@ The `ParameterCurator` class implements a 3-step pipeline:
 
 ### Canonical curated parameters
 
-**Critical**: All benchmark runs — CI comparisons, nightly baselines, and local profiling — **must use the same curated parameters**. The curated parameter files are stored in Hetzner S3 alongside the pre-built database and must never be regenerated independently.
+**Critical**: All benchmark runs — CI comparisons, nightly baselines, and local profiling — **must use the same curated parameters**. The canonical parameter files are the sole source of truth, stored in Hetzner S3 as separate objects and downloaded before each run. They must never be regenerated independently.
 
 - **S3 keys**: `ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`
+- **S3 bucket**: `bench-cache`
 - **Install location**: `jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json` and `factor-tables.json`
+- **Credentials**: stored as GitHub repository secrets `HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`, `HETZNER_S3_ENDPOINT`
 
 **Why this matters**: The `ParameterCurator` samples 200 (person, date) pairs from a `friendsSelected × dates` cross-product using stride-based sampling. The stride depends on iteration order of `friendsSelected`, which comes from database query results. Any code change that affects internal data structure ordering (hash maps, indexes, etc.) changes the iteration order, causing different pairs to be sampled. For IC4 in particular, different pairs can have vastly different "old post counts" (the NOT-pattern cost factor), leading to **up to 7x throughput differences** between runs that should be identical. This was discovered when a cache layer change produced a spurious +586% IC4 "improvement" in CI that did not reproduce with shared parameters.
 
+**Regeneration is blocked by default.** If canonical curated params are missing from the DB directory, the benchmark fails with an `IllegalStateException` directing you to download them from S3. This prevents accidental parameter desync between runs.
+
 **To regenerate canonical parameters** (only when the curation algorithm itself changes):
 1. Build from develop: `./mvnw -pl jmh-ldbc -am package -DskipTests`
-2. Ensure the pre-built DB is extracted at `jmh-ldbc/target/ldbc-bench-db`
+2. Ensure a database exists at `jmh-ldbc/target/ldbc-bench-db` (load from CSV if needed)
 3. Delete existing params: `rm -f jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json jmh-ldbc/target/ldbc-bench-db/factor-tables.json`
-4. Run any benchmark to trigger regeneration: `java -jar jmh-ldbc/target/youtrackdb-jmh-ldbc-*.jar "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1`
+4. Run with the generation flag enabled: `java -Dldbc.allow.param.generation=true -jar jmh-ldbc/target/youtrackdb-jmh-ldbc-*.jar "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1`
 5. Upload the new files to S3: `ldbc/curated-params-v3.json` and `ldbc/factor-tables.json`
-6. Rebuild the pre-built DB tar to include them and upload to `ldbc/ldbc-sf1-bench-db.tar.zst`
 
 ### Per-query parameter access
 
@@ -259,10 +262,11 @@ All settings are passed as JVM system properties. When using Maven, add `-D` fla
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `ldbc.dataset.path` | `./target/ldbc-dataset/sf1` | Path to the LDBC dataset root (must contain `static/` and `dynamic/` subdirectories). Only needed if no pre-built DB exists. |
-| `ldbc.db.path` | `./target/ldbc-bench-db` | Directory where the YouTrackDB database is stored. If a pre-built DB exists here, CSV loading is skipped. |
+| `ldbc.dataset.path` | `./target/ldbc-dataset/sf1` | Path to the LDBC dataset root (must contain `static/` and `dynamic/` subdirectories). Only needed on first run when no database exists yet. |
+| `ldbc.db.path` | `./target/ldbc-bench-db` | Directory where the YouTrackDB database is stored. If a database already exists here, CSV loading is skipped. |
 | `ldbc.scale.factor` | `1` | Scale factor (used in default dataset path). |
 | `ldbc.batch.size` | `1000` | Batch size for CSV data loading. |
+| `ldbc.allow.param.generation` | `false` | When `true`, allows regeneration of curated parameters if cached files are missing. Without this flag, missing params cause a hard failure. Only set when intentionally regenerating canonical parameters. |
 
 Example with a custom dataset path or smaller scale factor:
 
@@ -271,7 +275,7 @@ Example with a custom dataset path or smaller scale factor:
 ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
     -Dldbc.scale.factor=0.1
 
-# Use a pre-built database from a custom path
+# Use an existing database from a custom path
 ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
     -Dldbc.db.path=/data/ldbc-bench-db
 
@@ -305,32 +309,11 @@ The dataset is loaded into YouTrackDB with the full LDBC schema: 15 vertex class
 
 ### Obtaining the dataset
 
-There are three ways to set up the benchmark database:
+There are two ways to set up the benchmark database:
 
-#### Option 1: Download pre-built database from S3 (fastest, recommended for manual runs)
+#### Option 1: Download CSV dataset from S3 and load fresh (recommended)
 
-A pre-built YouTrackDB database for SF 1 is maintained in Hetzner Object Storage. This is the fastest option — it skips the ~21-minute CSV loading step entirely. The nightly CI workflow automatically uploads a fresh DB snapshot after each successful run. The pre-built DB includes [canonical curated parameters](#canonical-curated-parameters) — do not delete or regenerate them.
-
-- **Bucket**: `bench-cache`
-- **Key**: `ldbc/ldbc-sf1-bench-db.tar.zst` (~1.3 GB)
-- **Credentials**: stored as GitHub repository secrets `HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`, `HETZNER_S3_ENDPOINT`
-
-```bash
-# Download and extract using the AWS CLI (or any S3-compatible client)
-aws s3 cp s3://bench-cache/ldbc/ldbc-sf1-bench-db.tar.zst /tmp/bench-db.tar.zst \
-    --endpoint-url "$HETZNER_S3_ENDPOINT"
-
-# Extract to the expected DB path
-mkdir -p jmh-ldbc/target/ldbc-bench-db
-cd jmh-ldbc/target/ldbc-bench-db
-zstd -d /tmp/bench-db.tar.zst -o /tmp/bench-db.tar
-tar xf /tmp/bench-db.tar
-rm -f /tmp/bench-db.tar.zst /tmp/bench-db.tar
-```
-
-#### Option 2: Download CSV dataset from S3 and load fresh
-
-Download the raw CSV dataset and let the benchmark load it into a new database. This is what the nightly CI workflow does.
+Download the raw CSV dataset and let the benchmark load it into a new database. This is the standard setup path used by all CI workflows.
 
 - **SF 1 CSV**: `ldbc/ldbc-sf1-composite-merged-fk.tar.zst` (~196 MB, loads in ~21 min on CCX33)
 - **SF 0.1 CSV**: `ldbc/ldbc-sf0.1-composite-merged-fk.tar.zst` (~19 MB, loads in ~30s)
@@ -360,7 +343,7 @@ s3.download_file("bench-cache",
     "/tmp/dataset.tar.zst")
 ```
 
-#### Option 3: Generate using LDBC datagen Docker image
+#### Option 2: Generate using LDBC datagen Docker image
 
 If you don't have access to the Hetzner S3 credentials, generate the dataset locally using the official [LDBC datagen](https://github.com/ldbc/ldbc_snb_datagen_spark) Docker image:
 

--- a/jmh-ldbc/README.md
+++ b/jmh-ldbc/README.md
@@ -266,7 +266,7 @@ All settings are passed as JVM system properties. When using Maven, add `-D` fla
 | `ldbc.db.path` | `./target/ldbc-bench-db` | Directory where the YouTrackDB database is stored. If a database already exists here, CSV loading is skipped. |
 | `ldbc.scale.factor` | `1` | Scale factor (used in default dataset path). |
 | `ldbc.batch.size` | `1000` | Batch size for CSV data loading. |
-| `ldbc.allow.param.generation` | `false` | When `true`, allows regeneration of curated parameters if cached files are missing. Without this flag, missing params cause a hard failure. Only set when intentionally regenerating canonical parameters. |
+| `ldbc.allow.param.generation` | `false` | When `true`, allows regeneration of curated parameters if cached files are missing or stale (factor tables newer than curated params). Without this flag, missing/stale params cause a hard failure. Only set when intentionally regenerating canonical parameters. |
 
 Example with a custom dataset path or smaller scale factor:
 

--- a/jmh-ldbc/README.md
+++ b/jmh-ldbc/README.md
@@ -239,7 +239,7 @@ The `ParameterCurator` class implements a 3-step pipeline:
 1. Build from develop: `./mvnw -pl jmh-ldbc -am package -DskipTests`
 2. Ensure a database exists at `jmh-ldbc/target/ldbc-bench-db` (load from CSV if needed)
 3. Delete existing params: `rm -f jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json jmh-ldbc/target/ldbc-bench-db/factor-tables.json`
-4. Run with the generation flag enabled: `java -jar jmh-ldbc/target/youtrackdb-jmh-ldbc-*.jar "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1 -jvmArgsAppend "-Dldbc.allow.param.generation=true"`
+4. Run with the generation flag enabled: `java -jar jmh-ldbc/target/youtrackdb-jmh-ldbc-*.jar "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1 -jvmArgsAppend "-Dldbc.allow.param.generation=true"` (note: `-f 1` is required — with `-f 0` JMH runs in-process and `-jvmArgsAppend` is ignored, so the flag never reaches `ParameterCurator`)
 5. Upload the new files to S3: `ldbc/curated-params-v3.json` and `ldbc/factor-tables.json`
 
 ### Per-query parameter access

--- a/jmh-ldbc/README.md
+++ b/jmh-ldbc/README.md
@@ -239,7 +239,7 @@ The `ParameterCurator` class implements a 3-step pipeline:
 1. Build from develop: `./mvnw -pl jmh-ldbc -am package -DskipTests`
 2. Ensure a database exists at `jmh-ldbc/target/ldbc-bench-db` (load from CSV if needed)
 3. Delete existing params: `rm -f jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json jmh-ldbc/target/ldbc-bench-db/factor-tables.json`
-4. Run with the generation flag enabled: `java -Dldbc.allow.param.generation=true -jar jmh-ldbc/target/youtrackdb-jmh-ldbc-*.jar "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1`
+4. Run with the generation flag enabled: `java -jar jmh-ldbc/target/youtrackdb-jmh-ldbc-*.jar "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1 -jvmArgsAppend "-Dldbc.allow.param.generation=true"`
 5. Upload the new files to S3: `ldbc/curated-params-v3.json` and `ldbc/factor-tables.json`
 
 ### Per-query parameter access

--- a/jmh-ldbc/README.md
+++ b/jmh-ldbc/README.md
@@ -222,6 +222,23 @@ The `ParameterCurator` class implements a 3-step pipeline:
    | IC12 | FoF-selected | tag classes |
    | IS1-7 | friends-selected | messages |
 
+### Canonical curated parameters
+
+**Critical**: All benchmark runs — CI comparisons, nightly baselines, and local profiling — **must use the same curated parameters**. The curated parameter files are stored in Hetzner S3 alongside the pre-built database and must never be regenerated independently.
+
+- **S3 keys**: `ldbc/curated-params-v3.json`, `ldbc/factor-tables.json`
+- **Install location**: `jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json` and `factor-tables.json`
+
+**Why this matters**: The `ParameterCurator` samples 200 (person, date) pairs from a `friendsSelected × dates` cross-product using stride-based sampling. The stride depends on iteration order of `friendsSelected`, which comes from database query results. Any code change that affects internal data structure ordering (hash maps, indexes, etc.) changes the iteration order, causing different pairs to be sampled. For IC4 in particular, different pairs can have vastly different "old post counts" (the NOT-pattern cost factor), leading to **up to 7x throughput differences** between runs that should be identical. This was discovered when a cache layer change produced a spurious +586% IC4 "improvement" in CI that did not reproduce with shared parameters.
+
+**To regenerate canonical parameters** (only when the curation algorithm itself changes):
+1. Build from develop: `./mvnw -pl jmh-ldbc -am package -DskipTests`
+2. Ensure the pre-built DB is extracted at `jmh-ldbc/target/ldbc-bench-db`
+3. Delete existing params: `rm -f jmh-ldbc/target/ldbc-bench-db/curated-params-v3.json jmh-ldbc/target/ldbc-bench-db/factor-tables.json`
+4. Run any benchmark to trigger regeneration: `java -jar jmh-ldbc/target/youtrackdb-jmh-ldbc-*.jar "LdbcSingleThread.*ic5_newGroups" -f 1 -wi 0 -i 1 -r 1s -t 1`
+5. Upload the new files to S3: `ldbc/curated-params-v3.json` and `ldbc/factor-tables.json`
+6. Rebuild the pre-built DB tar to include them and upload to `ldbc/ldbc-sf1-bench-db.tar.zst`
+
 ### Per-query parameter access
 
 Each `@Benchmark` method accesses its own curated parameters via typed accessors on `LdbcBenchmarkState`:
@@ -292,7 +309,7 @@ There are three ways to set up the benchmark database:
 
 #### Option 1: Download pre-built database from S3 (fastest, recommended for manual runs)
 
-A pre-built YouTrackDB database for SF 1 is maintained in Hetzner Object Storage. This is the fastest option — it skips the ~21-minute CSV loading step entirely. The nightly CI workflow automatically uploads a fresh DB snapshot after each successful run.
+A pre-built YouTrackDB database for SF 1 is maintained in Hetzner Object Storage. This is the fastest option — it skips the ~21-minute CSV loading step entirely. The nightly CI workflow automatically uploads a fresh DB snapshot after each successful run. The pre-built DB includes [canonical curated parameters](#canonical-curated-parameters) — do not delete or regenerate them.
 
 - **Bucket**: `bench-cache`
 - **Key**: `ldbc/ldbc-sf1-bench-db.tar.zst` (~1.3 GB)

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -84,14 +84,31 @@ def fmt_delta(base_val, head_val):
     return f"{sign}{delta:.1f}%"
 
 
-def delta_icon(base_val, head_val, threshold_pct=5.0):
-    """Return an icon indicating regression/improvement/neutral."""
+def errors_overlap(base_score, base_error, head_score, head_error):
+    """Return True if the confidence intervals [score ± error] overlap."""
+    base_lo = base_score - base_error
+    base_hi = base_score + base_error
+    head_lo = head_score - head_error
+    head_hi = head_score + head_error
+    return base_lo <= head_hi and head_lo <= base_hi
+
+
+def delta_icon(base_val, head_val, threshold_pct=5.0,
+               base_error=0, head_error=0):
+    """Return an icon indicating regression/improvement/neutral.
+
+    A change is only flagged when BOTH conditions hold:
+    1. The percentage change exceeds ±threshold_pct.
+    2. The error bars (score ± scoreError) do not overlap.
+    """
     if base_val == 0:
         return ""
     delta = (head_val - base_val) / base_val * 100
-    if delta <= -threshold_pct:
+    if delta <= -threshold_pct and not errors_overlap(
+            base_val, base_error, head_val, head_error):
         return " :red_circle:"
-    elif delta >= threshold_pct:
+    elif delta >= threshold_pct and not errors_overlap(
+            base_val, base_error, head_val, head_error):
         return " :green_circle:"
     return ""
 
@@ -111,7 +128,9 @@ def build_suite_table(base, head, suite):
 
         if b and h:
             delta = fmt_delta(b["score"], h["score"])
-            icon = delta_icon(b["score"], h["score"])
+            icon = delta_icon(b["score"], h["score"],
+                              base_error=b["score_error"],
+                              head_error=h["score_error"])
             rows.append(
                 f"| {query} "
                 f"| {fmt_score(b['score'])} "
@@ -139,7 +158,11 @@ def build_suite_table(base, head, suite):
 
 
 def count_changes(base, head, threshold_pct=5.0):
-    """Count regressions and improvements across all suites."""
+    """Count regressions and improvements across all suites.
+
+    A change is counted only when the percentage exceeds the threshold
+    AND the error bars do not overlap.
+    """
     regressions = 0
     improvements = 0
     for key in base.keys() | head.keys():
@@ -147,9 +170,12 @@ def count_changes(base, head, threshold_pct=5.0):
         h = head.get(key)
         if b and h and b["score"] > 0:
             delta = (h["score"] - b["score"]) / b["score"] * 100
-            if delta <= -threshold_pct:
+            overlap = errors_overlap(
+                b["score"], b["score_error"],
+                h["score"], h["score_error"])
+            if delta <= -threshold_pct and not overlap:
                 regressions += 1
-            elif delta >= threshold_pct:
+            elif delta >= threshold_pct and not overlap:
                 improvements += 1
     return regressions, improvements
 
@@ -189,7 +215,10 @@ def main():
             parts.append(f":red_circle: {regressions} regression(s)")
         if improvements > 0:
             parts.append(f":green_circle: {improvements} improvement(s)")
-        lines.append(f"**Summary:** {', '.join(parts)} (>\u00b15% threshold)")
+        lines.append(
+            f"**Summary:** {', '.join(parts)} "
+            f"(>\u00b15% threshold, non-overlapping error bars)"
+        )
     lines.append("")
 
     for suite, label in [("SingleThread", "Single-Thread"),

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -10,6 +10,18 @@ Usage:
 
 import argparse
 import json
+import math
+
+
+def _safe_score_error(value):
+    """Return a finite float for scoreError, treating NaN/missing as 0."""
+    if value is None:
+        return 0
+    try:
+        f = float(value)
+        return 0 if math.isnan(f) else f
+    except (TypeError, ValueError):
+        return 0
 
 
 def parse_jmh_results(data):
@@ -31,7 +43,7 @@ def parse_jmh_results(data):
 
         primary = entry.get("primaryMetric", {})
         score = primary.get("score", 0)
-        score_error = primary.get("scoreError", 0)
+        score_error = _safe_score_error(primary.get("scoreError"))
 
         results[(method_name, suite)] = {
             "query": method_name,

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
@@ -173,7 +173,7 @@ final class ParameterCurator {
         Boolean.getBoolean(ALLOW_PARAM_GENERATION_PROP);
     if (!allowGeneration) {
       throw new IllegalStateException(
-          "Curated parameters not found at " + cacheFile + " and regeneration"
+          "Curated parameters missing or stale at " + cacheFile + " and regeneration"
               + " is not allowed. Download canonical curated params from S3"
               + " (ldbc/curated-params-v3.json, ldbc/factor-tables.json) and"
               + " install them into the DB directory. To regenerate locally,"

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
@@ -44,6 +44,12 @@ final class ParameterCurator {
   // Bump version suffix when curation logic changes to invalidate old caches
   private static final String CURATED_PARAMS_CACHE_FILE = "curated-params-v3.json";
 
+  // System property that must be set to allow regeneration of curated parameters.
+  // Without this flag, missing canonical params cause a hard failure instead of
+  // silently regenerating — preventing accidental parameter desync between runs.
+  // Pass -Dldbc.allow.param.generation=true to enable (e.g. when updating canonical params).
+  static final String ALLOW_PARAM_GENERATION_PROP = "ldbc.allow.param.generation";
+
   // Target number of curated parameter tuples per query
   static final int PARAMS_PER_QUERY = 500;
 
@@ -148,7 +154,7 @@ final class ParameterCurator {
             && Files.getLastModifiedTime(factorCacheFile)
                 .compareTo(Files.getLastModifiedTime(cacheFile)) > 0) {
           log.info("Factor tables newer than curated params cache,"
-              + " recomputing...");
+              + " regeneration required.");
         } else {
           log.info("Loading cached curated params from: {}", cacheFile);
           CuratedParams cached = loadCuratedParamsFromJson(cacheFile);
@@ -157,11 +163,25 @@ final class ParameterCurator {
           return cached;
         }
       } catch (Exception e) {
-        log.warn("Failed to load curated params cache, recomputing: {}",
-            e.getMessage());
+        log.warn("Failed to load curated params cache: {}", e.getMessage());
       }
     }
 
+    // Canonical curated params are missing or stale — regeneration is needed.
+    // Require an explicit flag to prevent accidental parameter desync.
+    boolean allowGeneration =
+        Boolean.getBoolean(ALLOW_PARAM_GENERATION_PROP);
+    if (!allowGeneration) {
+      throw new IllegalStateException(
+          "Curated parameters not found at " + cacheFile + " and regeneration"
+              + " is not allowed. Download canonical curated params from S3"
+              + " (ldbc/curated-params-v3.json, ldbc/factor-tables.json) and"
+              + " install them into the DB directory. To regenerate locally,"
+              + " pass -D" + ALLOW_PARAM_GENERATION_PROP + "=true");
+    }
+
+    log.warn("Regenerating curated parameters ({}=true)",
+        ALLOW_PARAM_GENERATION_PROP);
     FactorTables factors = loadOrComputeFactors(state, dbPath);
     CuratedParams params = generateParams(factors, state);
 
@@ -187,10 +207,12 @@ final class ParameterCurator {
         log.info("Factor tables loaded from cache");
         return cached;
       } catch (Exception e) {
-        log.warn("Failed to load factor cache, recomputing: {}", e.getMessage());
+        log.warn("Failed to load factor cache: {}", e.getMessage());
       }
     }
 
+    // Factor tables are missing — the caller already checked the allow flag,
+    // so we can proceed with computation here.
     log.info("Computing factor tables from database...");
     long start = System.currentTimeMillis();
     FactorTables factors = computeFactorTables(state);

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
@@ -41,7 +41,11 @@ final class ParameterCurator {
   private static final Logger log = LoggerFactory.getLogger(ParameterCurator.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String FACTOR_CACHE_FILE = "factor-tables.json";
-  // Bump version suffix when curation logic changes to invalidate old caches
+  // Bump version suffix when curation logic changes to invalidate old caches.
+  // IMPORTANT: CI workflows install factor-tables BEFORE curated-params so that
+  // curated-params has a later mtime.  The staleness check below treats
+  // "factor-tables newer than curated-params" as stale.  If you change the
+  // install order, the staleness check will misfire.
   private static final String CURATED_PARAMS_CACHE_FILE = "curated-params-v3.json";
 
   // System property that must be set to allow regeneration of curated parameters.
@@ -147,39 +151,58 @@ final class ParameterCurator {
     Path cacheFile = dbPath.resolve(CURATED_PARAMS_CACHE_FILE);
     Path factorCacheFile = dbPath.resolve(FACTOR_CACHE_FILE);
 
+    // Track why we fell through to regeneration for a precise error message.
+    String failReason = "missing";
+
     if (Files.exists(cacheFile)) {
+      // Check mtime-based staleness separately so an I/O error reading
+      // timestamps does not masquerade as a JSON parse failure.
+      boolean stale = false;
       try {
-        // Invalidate if factor tables are newer than curated params
         if (Files.exists(factorCacheFile)
             && Files.getLastModifiedTime(factorCacheFile)
                 .compareTo(Files.getLastModifiedTime(cacheFile)) > 0) {
-          log.info("Factor tables newer than curated params cache,"
-              + " regeneration required.");
-        } else {
+          stale = true;
+        }
+      } catch (IOException e) {
+        log.warn("Failed to read file timestamps: {}", e.getMessage());
+        failReason = "unreadable (timestamp check failed: " + e.getMessage() + ")";
+      }
+
+      if (stale) {
+        log.info("Factor tables newer than curated params cache,"
+            + " regeneration required.");
+        failReason = "stale (factor tables newer than curated params)";
+      } else if ("missing".equals(failReason)) {
+        // Timestamps are fine — try to load the cached params.
+        try {
           log.info("Loading cached curated params from: {}", cacheFile);
           CuratedParams cached = loadCuratedParamsFromJson(cacheFile);
           log.info("Curated params loaded from cache ({} IC1, {} IC4 params)",
               cached.ic1().length, cached.ic4().length);
           return cached;
+        } catch (Exception e) {
+          log.warn("Failed to parse curated params cache: {}", e.getMessage());
+          failReason = "corrupt/unreadable (" + e.getMessage() + ")";
         }
-      } catch (Exception e) {
-        log.warn("Failed to load curated params cache: {}", e.getMessage());
       }
     }
 
-    // Canonical curated params are missing or stale — regeneration is needed.
-    // Require an explicit flag to prevent accidental parameter desync.
+    // Canonical curated params are missing, stale, or corrupt — regeneration
+    // is needed.  Require an explicit flag to prevent accidental parameter
+    // desync.
     boolean allowGeneration =
         Boolean.getBoolean(ALLOW_PARAM_GENERATION_PROP);
     if (!allowGeneration) {
       throw new IllegalStateException(
-          "Curated parameters missing or stale at " + cacheFile + " and regeneration"
-              + " is not allowed. If you downloaded canonical params from S3,"
-              + " ensure curated-params was installed after factor-tables so its"
-              + " mtime is not older. Otherwise, download canonical curated params"
-              + " (ldbc/curated-params-v3.json, ldbc/factor-tables.json) and"
-              + " install them into the DB directory. To regenerate locally,"
-              + " pass -D" + ALLOW_PARAM_GENERATION_PROP + "=true");
+          "Curated parameters " + failReason + " at " + cacheFile
+              + " and regeneration is not allowed. If you downloaded canonical"
+              + " params from S3, ensure curated-params was installed after"
+              + " factor-tables so its mtime is not older. Otherwise, download"
+              + " canonical curated params (ldbc/curated-params-v3.json,"
+              + " ldbc/factor-tables.json) and install them into the DB directory."
+              + " To regenerate locally, pass -D"
+              + ALLOW_PARAM_GENERATION_PROP + "=true");
     }
 
     log.warn("Regenerating curated parameters ({}=true)",

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/ParameterCurator.java
@@ -174,7 +174,9 @@ final class ParameterCurator {
     if (!allowGeneration) {
       throw new IllegalStateException(
           "Curated parameters missing or stale at " + cacheFile + " and regeneration"
-              + " is not allowed. Download canonical curated params from S3"
+              + " is not allowed. If you downloaded canonical params from S3,"
+              + " ensure curated-params was installed after factor-tables so its"
+              + " mtime is not older. Otherwise, download canonical curated params"
               + " (ldbc/curated-params-v3.json, ldbc/factor-tables.json) and"
               + " install them into the DB directory. To regenerate locally,"
               + " pass -D" + ALLOW_PARAM_GENERATION_PROP + "=true");


### PR DESCRIPTION
## Summary
- Fix **curated parameter desync** between BASE and HEAD in `ldbc-jmh-compare.yml` — both runs now use identical canonical parameters downloaded from S3
- Add canonical curated parameters to `ldbc-jmh-nightly.yml` — downloaded from S3 before warm-up
- Update pre-built DB tar on S3 to include canonical curated params
- Document the importance of shared params in `jmh-ldbc/README.md`
- Update `run-jmh-benchmarks-hetzner` skill to stop deleting curated params

## Motivation
The CI compare workflow's `clean compile` for HEAD deleted cached curated parameters, forcing HEAD to regenerate them independently. The IC4 parameter curation uses stride-based sampling over a `friendsSelected × dates` cross-product whose iteration order depends on internal data structures (hash maps, indexes). Any code change affecting iteration order causes different parameter sets to be selected — IC4 showed a **spurious +586% "improvement"** in the `ytdb-627-primitive-chm-cache` PR because BASE selected 47 gap-grouped pairs while HEAD selected 27 pairs with very different old-post counts (the NOT-pattern cost factor).

With shared canonical params, both BASE and HEAD measure IC4 at ~3.0 ops/s — no real difference.

## S3 Changes
- Uploaded `ldbc/curated-params-v3.json` and `ldbc/factor-tables.json` to `bench-cache` bucket
- Rebuilt `ldbc/ldbc-sf1-bench-db.tar.zst` to include canonical params

## Test plan
- [ ] Trigger `ldbc-jmh-compare.yml` on a branch with known code changes — verify both BASE and HEAD logs show "Loading cached curated params" (not "Generating")
- [ ] Verify IC4 results are comparable (no >5% delta for a no-op branch)
- [ ] Trigger `ldbc-jmh-nightly.yml` with `use_prebuilt_db: true` — verify canonical params are installed