### PR TITLE
Fix WOWCache.delete() deadlock on single-threaded commitExecutor

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -1935,6 +1935,14 @@ public final class WOWCache extends AbstractWriteCache
 
   @Override
   public long[] delete() throws IOException {
+    // Stop the periodic flush FIRST so the single-threaded commitExecutor is free
+    // for DeleteFileTask submissions below. Without this, delete() can deadlock:
+    // the main thread holds filesLock write lock and blocks on future.get(), while
+    // a PeriodicFlushTask occupying the same single-threaded executor cannot
+    // complete (e.g., stuck in writePageChunksToFiles retry loop or waiting on a
+    // resource held by the main thread).
+    stopFlush();
+
     final var result = new LongArrayList(1_024);
     filesLock.acquireWriteLock();
     try {
@@ -1982,7 +1990,6 @@ public final class WOWCache extends AbstractWriteCache
       filesLock.releaseWriteLock();
     }
 
-    stopFlush();
     doubleWriteLog.close();
 
     return result.toLongArray();


### PR DESCRIPTION
## Motivation

The integration test CI pipeline has been failing for 6+ consecutive days (since ~March 28) due to a deadlock in `WOWCache.delete()`. The issue was introduced by YTDB-609 (commit 3102120d9b) which changed the `commitExecutor` to a single-threaded `ScheduledExecutorService` shared across all WOWCache instances.

**Deadlock scenario**: `delete()` acquires `filesLock` write lock, then submits `DeleteFileTask` to the single-threaded `commitExecutor` and blocks on `future.get()`. If a `PeriodicFlushTask` is currently running on the executor (e.g., stuck in `writePageChunksToFiles` retry loop), the delete task is queued but can never run — the executor is single-threaded and occupied. Meanwhile, the calling thread holds `filesLock` indefinitely, blocking all other file operations.

## Changes

Moved `stopFlush()` from after `filesLock.releaseWriteLock()` to before `filesLock.acquireWriteLock()` in `WOWCache.delete()`. This ensures the periodic flush task completes (or times out) before the write lock is acquired and delete tasks are submitted to the executor.

This matches the existing pattern in `close()` (line 1641), which already calls `stopFlush()` before acquiring `filesLock`.

## Test plan

- [x] Existing regression test `WOWCacheDeleteTimeoutIT` passes (verifies delete completes within 30s after many create/destroy cycles)
- [x] `WOWCacheTestIT` passes (data operation tests with checksums)
- [x] `AsyncReadCacheTestIT` passes (read cache integration)
- [ ] Full integration test suite (`-P ci-integration-tests`)

## CI failure reference

- Failed run: https://github.com/JetBrains/youtrackdb/actions/runs/23929903728
- Failing since: ~2026-03-28 (6+ consecutive days, multiple commits)
- Root cause: YTDB-609 changed commitExecutor to single-threaded shared executor