### PR TITLE
[no-test-number-check] Fix WOWCacheDeleteTimeoutIT and IndexHistogramConcurrentStressIT flaky failures

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
@@ -359,9 +359,19 @@ public class IndexHistogramConcurrentStressIT extends DbTestBase {
         statsIncremental.nullCount(), statsAnalyzed.nullCount());
 
     if (histogramIncremental != null && histogramAnalyzed != null) {
-      assertEquals("nonNullCount: incremental vs ANALYZE",
-          histogramIncremental.nonNullCount(),
-          histogramAnalyzed.nonNullCount());
+      // nonNullCount can drift slightly because in-flight frequency deltas
+      // sized for an old bucket layout are discarded during rebalancing.
+      // The same root cause produces the per-bucket frequency deviations
+      // tolerated below. Allow up to 1% relative drift (observed ~0.18%
+      // on CI with 4 writers over 2 minutes).
+      long incrNnc = histogramIncremental.nonNullCount();
+      long analyzeNnc = histogramAnalyzed.nonNullCount();
+      double nncRelDev = Math.abs(incrNnc - analyzeNnc)
+          / (double) Math.max(analyzeNnc, 1);
+      assertTrue("nonNullCount drift too large: incremental="
+          + incrNnc + " ANALYZE=" + analyzeNnc
+          + " relDev=" + String.format("%.4f", nncRelDev),
+          nncRelDev <= 0.01);
 
       // Sum of bucket frequencies should equal nonNullCount
       long freqSum = 0;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
@@ -369,10 +369,10 @@ public class IndexHistogramConcurrentStressIT extends DbTestBase {
       long incrNnc = histogramIncremental.nonNullCount();
       long analyzeNnc = histogramAnalyzed.nonNullCount();
       double nncRelDev = Math.abs((double) incrNnc - analyzeNnc)
+          / Math.max(analyzeNnc, 1);
       assertTrue("nonNullCount drift too large: incremental="
           + incrNnc + " ANALYZE=" + analyzeNnc
-          + " relDev=" + nncRelDev,
-          nncRelDev <= 0.01);
+          + " relDev=" + String.format(Locale.US, "%.4f", nncRelDev),
           nncRelDev <= 0.01);
 
       // Sum of bucket frequencies should equal nonNullCount

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
@@ -369,10 +369,10 @@ public class IndexHistogramConcurrentStressIT extends DbTestBase {
       long incrNnc = histogramIncremental.nonNullCount();
       long analyzeNnc = histogramAnalyzed.nonNullCount();
       double nncRelDev = Math.abs((double) incrNnc - analyzeNnc)
-          / Math.max(analyzeNnc, 1);
       assertTrue("nonNullCount drift too large: incremental="
           + incrNnc + " ANALYZE=" + analyzeNnc
-          + " relDev=" + String.format(Locale.US, "%.4f", nncRelDev),
+          + " relDev=" + nncRelDev,
+          nncRelDev <= 0.01);
           nncRelDev <= 0.01);
 
       // Sum of bucket frequencies should equal nonNullCount

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
@@ -363,8 +363,9 @@ public class IndexHistogramConcurrentStressIT extends DbTestBase {
       // nonNullCount can drift slightly because in-flight frequency deltas
       // sized for an old bucket layout are discarded during rebalancing.
       // The same root cause produces the per-bucket frequency deviations
-      // tolerated below. Allow up to 1% relative drift (observed ~0.18%
-      // on CI with 4 writers over 2 minutes).
+      // tolerated below. Allow up to 1% relative drift — ~5x headroom
+      // over the worst observed drift (0.18% on CI with 4 writers over
+      // 2 minutes) to accommodate variance across CI hardware configs.
       long incrNnc = histogramIncremental.nonNullCount();
       long analyzeNnc = histogramAnalyzed.nonNullCount();
       double nncRelDev = Math.abs((double) incrNnc - analyzeNnc)

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
@@ -367,8 +367,8 @@ public class IndexHistogramConcurrentStressIT extends DbTestBase {
       // on CI with 4 writers over 2 minutes).
       long incrNnc = histogramIncremental.nonNullCount();
       long analyzeNnc = histogramAnalyzed.nonNullCount();
-      double nncRelDev = Math.abs(incrNnc - analyzeNnc)
-          / (double) Math.max(analyzeNnc, 1);
+      double nncRelDev = Math.abs((double) incrNnc - analyzeNnc)
+          / Math.max(analyzeNnc, 1);
       assertTrue("nonNullCount drift too large: incremental="
           + incrNnc + " ANALYZE=" + analyzeNnc
           + " relDev=" + String.format(Locale.US, "%.4f", nncRelDev),

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/IndexHistogramConcurrentStressIT.java
@@ -31,6 +31,7 @@ import com.jetbrains.youtrackdb.internal.core.index.IndexAbstract;
 import com.jetbrains.youtrackdb.internal.core.index.engine.v1.BTreeIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -370,7 +371,7 @@ public class IndexHistogramConcurrentStressIT extends DbTestBase {
           / (double) Math.max(analyzeNnc, 1);
       assertTrue("nonNullCount drift too large: incremental="
           + incrNnc + " ANALYZE=" + analyzeNnc
-          + " relDev=" + String.format("%.4f", nncRelDev),
+          + " relDev=" + String.format(Locale.US, "%.4f", nncRelDev),
           nncRelDev <= 0.01);
 
       // Sum of bucket frequencies should equal nonNullCount

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheDeleteTimeoutIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheDeleteTimeoutIT.java
@@ -179,7 +179,7 @@ public class WOWCacheDeleteTimeoutIT {
         wal,
         new DoubleWriteLogNoOP(),
         1, // pagesFlushInterval: 1ms — short interval to trigger frequent periodic flushes
-        10, // shutdownTimeout: 10ms — intentionally short for this test
+        10_000, // shutdownTimeout: 10s — long enough for flush to finish on slow hardware
         100,
         path,
         name,

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheDeleteTimeoutIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheDeleteTimeoutIT.java
@@ -78,7 +78,8 @@ public class WOWCacheDeleteTimeoutIT {
    *
    * <p>Before the fix, the timeout in stopFlush() was 10000 MINUTES (~7 days), so any
    * transient delay would hang indefinitely. With the fix (10000 MILLISECONDS = 10s),
-   * the system recovers promptly.
+   * the system recovers promptly. The test uses the same 10s shutdown timeout as
+   * production to avoid false failures on slow CI hardware (e.g., ARM runners).
    */
   @Test
   public void testDeleteCompletesAfterManyCreateDestroyCycles() throws Exception {


### PR DESCRIPTION
## Summary
- Increase `WOWCacheDeleteTimeoutIT` shutdown timeout from 10ms to 10s — the 10ms value was too aggressive for ARM hardware, causing `stopFlush()` to time out before the periodic flush task could complete
- Relax `IndexHistogramConcurrentStressIT` nonNullCount comparison from exact equality to 1% tolerance — under concurrent stress with histogram rebalancing, in-flight deltas get discarded, causing ~0.18% drift

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/23968533273

Four jobs failed:
- **Linux arm JDK 21 oracle**: `WOWCacheDeleteTimeoutIT.testDeleteCompletesAfterManyCreateDestroyCycles` — `WriteCacheException: Can not shutdown data flush` at `WOWCache.stopFlush()` (10ms timeout too short)
- **Linux x86 JDK 25 temurin**: `IndexHistogramConcurrentStressIT.singleValueIntegerIndex_concurrentInsertsAndDeletes` — `nonNullCount: incremental vs ANALYZE expected:<1429667> but was:<1427118>` (0.18% drift)
- **Linux arm JDK 21 temurin** and **Linux x86 JDK 25 oracle**: Timed out (likely same WOWCache issue causing Maven to hang)

### Root causes

**WOWCacheDeleteTimeoutIT**: After commit d2cef43308 moved `stopFlush()` before `filesLock.acquireWriteLock()` in `WOWCache.delete()`, the test's 10ms shutdown timeout became insufficient. The periodic flush task scheduled on the single-threaded `commitExecutor` may not complete in 10ms on slower ARM hardware, causing `flushFuture.get(10, MILLISECONDS)` to throw `TimeoutException`. The test's actual contract is that `delete()` doesn't deadlock (30s guard in Phase 2), not that it completes in 10ms.

**IndexHistogramConcurrentStressIT**: During the 2-minute concurrent stress phase, histogram rebalancing discards in-flight frequency deltas sized for the old bucket layout (version mismatch). This causes the incremental histogram's `nonNullCount` to drift from the ANALYZE-rebuilt value. The test already tolerates this same effect for per-bucket frequency deviations (up to 200% for last bucket, 50% for others), but used exact equality for `nonNullCount`. A 1% tolerance is consistent and sufficient (observed drift is 0.18%).

## Test plan
- [x] `WOWCacheDeleteTimeoutIT` passes locally (3.6s)
- [x] Code compiles and passes Spotless formatting check
- [x] No production code changes — test-only fixes
- [ ] Full CI integration test suite