### PR TITLE
[no-test-number-check] Fix WOWCacheDeleteTimeoutIT flaky failure by cancelling flush future

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -1602,6 +1602,20 @@ public final class WOWCache extends AbstractWriteCache
   private void stopFlush() {
     stopFlush = true;
 
+    // Cancel the scheduled periodic flush task early, before waiting for
+    // triggeredTasks, to free up the single-threaded shared commitExecutor.
+    // This reduces congestion so the triggeredTasks await loop below completes
+    // without timing out.
+    final var future = flushFuture;
+    if (future != null) {
+      // If the task hasn't started yet, cancel prevents it from running. If the
+      // task is already running, cancel(false) won't interrupt it — the running
+      // task will check the stopFlush flag and exit promptly. In both cases,
+      // get() below throws CancellationException (because cancel(false) transitions
+      // the FutureTask state to CANCELLED even while the task's code is executing).
+      future.cancel(false);
+    }
+
     for (final var completionLatch : triggeredTasks.values()) {
       try {
         if (!completionLatch.await(shutdownTimeout, TimeUnit.MILLISECONDS)) {
@@ -1616,21 +1630,13 @@ public final class WOWCache extends AbstractWriteCache
       }
     }
 
-    // Snapshot the volatile field so we cancel and await the same future.
-    final var future = flushFuture;
     if (future != null) {
-      // Cancel the scheduled periodic flush task. If it hasn't started yet, this
-      // prevents it from running (avoiding delays when the single-threaded shared
-      // commitExecutor has a backlog from other WOWCache instances). If the task is
-      // already running, cancel(false) won't interrupt it — the running task will
-      // check the stopFlush flag and exit promptly. In either case, get() below
-      // returns immediately: CancellationException for a not-yet-started task
-      // (caught and ignored), or the task's result for an already-running task.
-      future.cancel(false);
       try {
         future.get(shutdownTimeout, TimeUnit.MILLISECONDS);
-      } catch (final java.lang.InterruptedException | CancellationException e) {
-        // ignore — task was cancelled or we were interrupted during shutdown
+      } catch (final java.lang.InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (final CancellationException e) {
+        // Expected — task was cancelled above.
       } catch (final ExecutionException e) {
         throw BaseException.wrapException(
             new WriteCacheException(storageName,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -1616,11 +1616,21 @@ public final class WOWCache extends AbstractWriteCache
       }
     }
 
-    if (flushFuture != null) {
+    // Snapshot the volatile field so we cancel and await the same future.
+    final var future = flushFuture;
+    if (future != null) {
+      // Cancel the scheduled periodic flush task. If it hasn't started yet, this
+      // prevents it from running (avoiding delays when the single-threaded shared
+      // commitExecutor has a backlog from other WOWCache instances). If the task is
+      // already running, cancel(false) won't interrupt it — the running task will
+      // check the stopFlush flag and exit promptly. In either case, get() below
+      // returns immediately: CancellationException for a not-yet-started task
+      // (caught and ignored), or the task's result for an already-running task.
+      future.cancel(false);
       try {
-        flushFuture.get(shutdownTimeout, TimeUnit.MILLISECONDS);
+        future.get(shutdownTimeout, TimeUnit.MILLISECONDS);
       } catch (final java.lang.InterruptedException | CancellationException e) {
-        // ignore
+        // ignore — task was cancelled or we were interrupted during shutdown
       } catch (final ExecutionException e) {
         throw BaseException.wrapException(
             new WriteCacheException(storageName,

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheFlushErrorTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheFlushErrorTest.java
@@ -4,12 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.jetbrains.youtrackdb.internal.common.collection.closabledictionary.ClosableLinkedContainer;
 import com.jetbrains.youtrackdb.internal.common.concur.lock.ReadersWriterSpinLock;
+import com.jetbrains.youtrackdb.internal.core.exception.WriteCacheException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
 import com.jetbrains.youtrackdb.internal.core.storage.fs.File;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.PageIsBrokenListener;
@@ -23,7 +25,10 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -415,6 +420,183 @@ public class WOWCacheFlushErrorTest {
     // segStart=1, segEnd=3 — must advance past segment 1 and terminate.
     // The @Test(timeout) guards against infinite-loop regression.
     invokeFlushWriteCacheFromMinLSN(cache, 1L, 3L, 10);
+  }
+
+  // ---------------------------------------------------------------------------
+  // stopFlush() tests
+  //
+  // These tests exercise the stopFlush() method's flushFuture handling: both
+  // branches of the null check, the normal-completion path of future.get(),
+  // the CancellationException catch arm, and the error-propagation contracts
+  // (ExecutionException → WriteCacheException, TimeoutException → WriteCacheException).
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Verifies that {@code stopFlush()} handles the case where {@code flushFuture} is null
+   * (i.e., no periodic flush was scheduled because {@code pagesFlushInterval <= 0}).
+   * Exercises the false branch of {@code if (future != null)}.
+   */
+  @Test
+  public void testStopFlushWithNullFlushFuture() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+
+    // flushFuture defaults to null in the mock (no periodic flush scheduled).
+    // shutdownTimeout and storageName are not needed: triggeredTasks is empty
+    // (latch loop body never runs) and flushFuture is null (future block skipped).
+    setField(cache, "triggeredTasks",
+        new ConcurrentHashMap<ExclusiveFlushTask, CountDownLatch>());
+
+    invokeStopFlush(cache);
+
+    // stopFlush() must set the stopFlush flag so background tasks stop running
+    assertTrue("stopFlush flag must be true after stopFlush()",
+        getStopFlushFlag(cache));
+  }
+
+  /**
+   * Verifies that {@code stopFlush()} correctly waits for an already-completed flush future.
+   * When {@code cancel(false)} is called on a completed future it returns false, and
+   * {@code future.get()} returns immediately without throwing CancellationException.
+   * This covers the normal-completion path of {@code future.get()}.
+   */
+  @Test
+  public void testStopFlushWithCompletedFlushFuture() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+
+    setField(cache, "triggeredTasks",
+        new ConcurrentHashMap<ExclusiveFlushTask, CountDownLatch>());
+    var future = Mockito.spy(CompletableFuture.completedFuture(null));
+    setField(cache, "flushFuture", future);
+    setField(cache, "shutdownTimeout", 10_000);
+    setField(cache, "storageName", "test");
+
+    invokeStopFlush(cache);
+
+    assertTrue("stopFlush flag must be true after stopFlush()",
+        getStopFlushFlag(cache));
+    // cancel(false) and get() must have been called on the future
+    Mockito.verify(future).cancel(false);
+    Mockito.verify(future).get(10_000L, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Verifies that {@code stopFlush()} silently swallows {@link CancellationException}
+   * when the flush future was successfully cancelled (task not yet started). This is the
+   * primary path introduced by the cancel(false) addition: the periodic flush task was
+   * pending on the single-threaded executor and gets cancelled before running.
+   */
+  @Test
+  public void testStopFlushWithCancelledFlushFuture() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+
+    setField(cache, "triggeredTasks",
+        new ConcurrentHashMap<ExclusiveFlushTask, CountDownLatch>());
+    // A future that is already cancelled: get() will throw CancellationException
+    var cancelledFuture = new CompletableFuture<Void>();
+    cancelledFuture.cancel(false);
+    setField(cache, "flushFuture", cancelledFuture);
+    setField(cache, "shutdownTimeout", 10_000);
+    setField(cache, "storageName", "test");
+
+    // Must not throw — CancellationException is caught and ignored
+    invokeStopFlush(cache);
+
+    assertTrue("stopFlush flag must be true after stopFlush()",
+        getStopFlushFlag(cache));
+  }
+
+  /**
+   * Verifies that {@code stopFlush()} propagates a {@link WriteCacheException} when
+   * {@code future.get()} throws {@link java.util.concurrent.ExecutionException}
+   * (i.e., the periodic flush task itself threw an unhandled exception).
+   */
+  @Test
+  public void testStopFlushWithFailedFlushFutureThrowsWriteCacheException()
+      throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+
+    setField(cache, "triggeredTasks",
+        new ConcurrentHashMap<ExclusiveFlushTask, CountDownLatch>());
+    setField(cache, "shutdownTimeout", 10_000);
+    setField(cache, "storageName", "test");
+
+    // A CompletableFuture completed exceptionally simulates a flush task crash
+    var failedFuture = new CompletableFuture<Void>();
+    failedFuture.completeExceptionally(
+        new RuntimeException("simulated flush crash"));
+    setField(cache, "flushFuture", failedFuture);
+
+    Method method = WOWCache.class.getDeclaredMethod("stopFlush");
+    method.setAccessible(true);
+    try {
+      method.invoke(cache);
+      fail("Expected WriteCacheException to be thrown");
+    } catch (InvocationTargetException e) {
+      assertTrue(
+          "Expected WriteCacheException, got: " + e.getCause().getClass().getName(),
+          e.getCause() instanceof WriteCacheException);
+    }
+  }
+
+  /**
+   * Verifies that {@code stopFlush()} propagates a {@link WriteCacheException} when
+   * {@code future.get()} throws {@link java.util.concurrent.TimeoutException}
+   * (i.e., the periodic flush task does not finish within shutdownTimeout).
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testStopFlushWithHungFlushFutureThrowsWriteCacheException()
+      throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+
+    setField(cache, "triggeredTasks",
+        new ConcurrentHashMap<ExclusiveFlushTask, CountDownLatch>());
+    setField(cache, "shutdownTimeout", 1);
+    setField(cache, "storageName", "test");
+
+    // Use a mock Future that resists cancellation and times out on get().
+    // CompletableFuture.cancel(false) always succeeds (transitions to cancelled),
+    // so we need a mock to simulate a running task that cannot be cancelled.
+    var hungFuture = Mockito.mock(java.util.concurrent.Future.class);
+    Mockito.when(hungFuture.cancel(false)).thenReturn(false);
+    Mockito.when(hungFuture.isCancelled()).thenReturn(false);
+    Mockito.when(hungFuture.get(1L, TimeUnit.MILLISECONDS))
+        .thenThrow(new java.util.concurrent.TimeoutException("simulated timeout"));
+    setField(cache, "flushFuture", hungFuture);
+
+    Method method = WOWCache.class.getDeclaredMethod("stopFlush");
+    method.setAccessible(true);
+    try {
+      method.invoke(cache);
+      fail("Expected WriteCacheException to be thrown");
+    } catch (InvocationTargetException e) {
+      assertTrue(
+          "Expected WriteCacheException, got: " + e.getCause().getClass().getName(),
+          e.getCause() instanceof WriteCacheException);
+    }
+  }
+
+  /**
+   * Invokes the private {@code stopFlush()} method via reflection, expecting it
+   * to complete without exception.
+   */
+  private static void invokeStopFlush(WOWCache cache) throws Exception {
+    Method method = WOWCache.class.getDeclaredMethod("stopFlush");
+    method.setAccessible(true);
+    try {
+      method.invoke(cache);
+    } catch (InvocationTargetException e) {
+      throw new AssertionError("stopFlush() threw unexpectedly", e.getCause());
+    }
+  }
+
+  /**
+   * Reads the private {@code stopFlush} boolean flag via reflection.
+   */
+  private static boolean getStopFlushFlag(WOWCache cache) throws Exception {
+    Field field = findField(cache.getClass(), "stopFlush");
+    field.setAccessible(true);
+    return (boolean) field.get(cache);
   }
 
   // ---------------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheFlushErrorTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheFlushErrorTest.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -503,6 +504,49 @@ public class WOWCacheFlushErrorTest {
 
     assertTrue("stopFlush flag must be true after stopFlush()",
         getStopFlushFlag(cache));
+  }
+
+  /**
+   * Verifies that {@code stopFlush()} restores the interrupt flag when
+   * {@code future.get()} throws {@link InterruptedException} (i.e., the thread
+   * waiting for the flush future is interrupted). The method must not propagate
+   * the exception but must re-set the interrupt flag so that the caller can
+   * detect the interruption.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testStopFlushWithInterruptedFlushFutureRestoresInterruptFlag()
+      throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+
+    setField(cache, "triggeredTasks",
+        new ConcurrentHashMap<ExclusiveFlushTask, CountDownLatch>());
+    setField(cache, "shutdownTimeout", 10_000);
+    setField(cache, "storageName", "test");
+
+    // Use a mock Future whose get() throws InterruptedException.
+    // We cannot use a real CompletableFuture because there is no way to make
+    // its get() throw InterruptedException without actually interrupting the
+    // calling thread before the call (which is racy).
+    var interruptedFuture = Mockito.mock(Future.class);
+    Mockito.when(interruptedFuture.cancel(false)).thenReturn(false);
+    Mockito.when(interruptedFuture.get(10_000L, TimeUnit.MILLISECONDS))
+        .thenThrow(new InterruptedException("simulated interrupt"));
+    setField(cache, "flushFuture", interruptedFuture);
+
+    // Setup: clear any stale interrupt flag from a previous test
+    Thread.interrupted();
+
+    invokeStopFlush(cache);
+
+    assertTrue("stopFlush flag must be true after stopFlush()",
+        getStopFlushFlag(cache));
+    // cancel(false) must be called before get() per the stopFlush() contract
+    Mockito.verify(interruptedFuture).cancel(false);
+    // The interrupt flag must be restored by the catch block
+    assertTrue(
+        "Thread interrupt flag must be restored after InterruptedException",
+        Thread.interrupted());
   }
 
   /**


### PR DESCRIPTION
## Summary
- Cancel the scheduled periodic flush task in `WOWCache.stopFlush()` before waiting for it, so queued tasks on the congested single-threaded shared executor don't cause a timeout
- Snapshot the volatile `flushFuture` field into a local variable to ensure `cancel()` and `get()` operate on the same `Future` instance

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/23991728258

Two jobs failed:
- **Linux arm JDK 21 temurin**: `WOWCacheDeleteTimeoutIT.testDeleteCompletesAfterManyCreateDestroyCycles` — `WriteCacheException: Can not shutdown data flush for storage storage_0` at `WOWCache.stopFlush()`. The 10s shutdown timeout expired because the periodic flush task was queued behind other tasks on the shared single-threaded `commitExecutor`.
- **Linux x86 JDK 21 temurin**: `LocalPaginatedCollectionV2TestIT` — JVM killed by OOM (exit code 137) after ~2.5 hours of integration tests. This is an infrastructure/memory pressure issue, not a code bug.

### Root cause (ARM failure)
The `WOWCache.stopFlush()` method sets `stopFlush = true` and then calls `flushFuture.get(shutdownTimeout)`. The `flushFuture` is a `ScheduledFuture` for the periodic flush task on the static single-threaded `wowCacheFlushExecutor`. When the executor has a backlog of tasks from other `WOWCache` instances (common in CI integration tests that share a JVM), the queued periodic flush task may not start within the timeout.

### Fix
Add `future.cancel(false)` before `future.get()`:
- If the task hasn't started yet: cancelled immediately, `get()` throws `CancellationException` (already caught and ignored)
- If the task is already running: `cancel(false)` won't interrupt it; the running task checks `stopFlush` and exits promptly, then `get()` returns normally

## Test plan
- [x] `WOWCacheDeleteTimeoutIT` passes locally (3.96s)
- [x] All 67 `WOWCache*` tests pass (1m26s)
- [x] Spotless formatting check passes