### PR TITLE
[no-test-number-check] Add semi-formal reasoning protocols to review agents and workflow prompts

### DIFF
--- a/.claude/agents/review-performance.md
+++ b/.claude/agents/review-performance.md
@@ -83,15 +83,85 @@ You will receive:
 - Unnecessary use of reflection in hot paths
 - Thread-local allocation that could cause memory leaks
 
-## Process
+## Reasoning Process — Semi-formal Analysis
 
-1. Read the diff carefully, identifying:
-   - Hot paths (code called frequently — inner loops, per-record processing, per-query execution)
-   - Cold paths (initialization, shutdown, rare error handling) — be lenient here
-   - Data structure choices and their complexity implications
-2. For performance-critical code, read the full file to understand call frequency and data sizes.
-3. Consider the realistic scale: YouTrackDB may have millions of records and thousands of concurrent queries.
-4. Skip generated files and test code (unless tests themselves have performance issues that slow CI).
+Use the following structured reasoning phases internally as you analyze
+the code. Performance claims require evidence — you must trace call
+frequency, data sizes, and actual code paths rather than pattern-matching
+on keywords. An O(n^2) loop on a list of 3 elements is not a finding;
+an O(n) scan on a million-element structure with an available index is.
+You do not need to reproduce the full internal reasoning in your output,
+but your findings must be grounded in evidence gathered through these
+phases.
+
+### Phase 1: Premises — Classify Hot vs Cold Paths
+
+Before analyzing anything, document the call-frequency context:
+
+```
+PREMISE P1: [Method] at [file:line] is on a HOT/COLD path because [evidence —
+  called per-record / per-query / per-page / once at startup / on error only]
+PREMISE P2: Data scale for [collection/structure]: [evidence — unbounded /
+  bounded by page size / bounded by config / known upper limit]
+PREMISE P3: Lock [X] at [file:line] is contended by [N threads doing Y operation]
+```
+
+Read callers to establish frequency — do not assume a method is hot
+because it's in the storage engine. Some storage methods are called once
+per open/close.
+
+### Phase 2: Cost Trace — Quantify the Actual Work
+
+For each changed code path on a hot path, trace the cost:
+
+```
+COST TRACE for [method at file:line]:
+  OPERATION: [what the code does — loop, allocation, I/O, lock acquire]
+  COMPLEXITY: O([complexity]) per [invocation unit — record, query, page]
+  DATA SCALE: [collection/structure] has [estimated size from P2]
+  TOTAL COST: O([total]) per [workload unit]
+  ALLOCATIONS: [N objects per invocation — types and sizes]
+  I/O: [N reads/writes per invocation — sequential or random]
+  LOCK HOLD TIME: [duration — computation-only, includes I/O, includes other locks]
+```
+
+### Phase 3: Comparative Analysis — Is There a Better Alternative?
+
+For each cost trace with non-trivial cost, check for alternatives:
+
+```
+ALTERNATIVE CHECK for [method at file:line]:
+  CURRENT: [approach and its cost from Phase 2]
+  ALTERNATIVE: [better approach — e.g., "use index lookup instead of scan",
+    "cache result instead of recompute", "use batch API instead of one-at-a-time"]
+  EVIDENCE: [does the alternative infrastructure exist in the codebase?
+    Search result at file:line]
+  IMPROVEMENT: [estimated speedup — e.g., "O(n) → O(log n) for n up to 1M",
+    "eliminates N allocations per query"]
+  TRADEOFF: [what the alternative costs — complexity, memory, readability]
+```
+
+### Phase 4: Scale Validation — Will This Actually Matter?
+
+For each potential finding, validate it matters at realistic scale:
+
+```
+SCALE CHECK for [issue]:
+  AT SMALL SCALE (100 records): [impact — negligible / noticeable / severe]
+  AT MEDIUM SCALE (100K records): [impact]
+  AT PRODUCTION SCALE (1M+ records): [impact]
+  VERDICT: MATTERS NOW | MATTERS AT SCALE | NEGLIGIBLE
+```
+
+Only report findings with MATTERS NOW or MATTERS AT SCALE verdicts.
+
+### Phase 5: Ranked Findings
+
+Based on surviving issues from Phases 3-4, produce ranked findings.
+Each finding must cite the specific COST TRACE and SCALE CHECK.
+
+Skip generated files and test code (unless tests themselves have
+performance issues that slow CI).
 
 ## Output Format
 

--- a/.claude/agents/review-performance.md
+++ b/.claude/agents/review-performance.md
@@ -189,6 +189,7 @@ performance issues that slow CI).
 For each finding, include:
 - **File**: `path/to/file.ext` (line X-Y)
 - **Issue**: What's slow and why
+- **Evidence**: The COST TRACE and SCALE CHECK that produced this finding
 - **Impact**: Expected effect (latency, throughput, memory, GC pressure)
 - **Suggestion**: How to improve it
 

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -196,6 +196,7 @@ sensitive data.
 For each finding, include:
 - **File**: `path/to/file.ext` (line X-Y)
 - **Issue**: What's vulnerable and why
+- **Evidence**: The TAINT TRACE and EXPLOIT that produced this finding
 - **Risk Level**: Critical / High / Medium / Low
 - **Exploitability**: How an attacker could exploit it (for Critical/High)
 - **Suggestion**: How to fix it

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -159,7 +159,7 @@ severity adjustment for authenticated-only paths).
 ### Phase 5: Ranked Findings
 
 Based on surviving exploits from Phases 3-4, produce ranked findings.
-Each finding must cite the supporting TAINT TRACE and EXPLOIT.
+Each finding must cite the supporting TAINT TRACE, EXPLOIT, and REACHABILITY CHECK.
 
 Skip generated files and code that doesn't handle external input or
 sensitive data.
@@ -196,7 +196,7 @@ sensitive data.
 For each finding, include:
 - **File**: `path/to/file.ext` (line X-Y)
 - **Issue**: What's vulnerable and why
-- **Evidence**: The TAINT TRACE and EXPLOIT that produced this finding
+- **Evidence**: The TAINT TRACE, EXPLOIT, and REACHABILITY CHECK that produced this finding
 - **Risk Level**: Critical / High / Medium / Low
 - **Exploitability**: How an attacker could exploit it (for Critical/High)
 - **Suggestion**: How to fix it

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -75,18 +75,94 @@ You will receive:
 - Are file permissions set appropriately?
 - Could symlink following lead to unauthorized access?
 
-## Process
+## Reasoning Process — Semi-formal Taint Analysis
 
-1. Read the diff carefully, focusing on:
-   - Any code that processes external input (network, query, file)
-   - Authentication/authorization logic
-   - Serialization/deserialization code
-   - Cryptographic operations
-   - File I/O with user-influenced paths
-   - Logging statements that might include sensitive data
-   - New dependencies in `pom.xml`
-2. For input-handling code, trace the data flow from entry to use — identify where validation occurs (or doesn't).
-3. Skip generated files and code that doesn't handle external input or sensitive data.
+Use the following structured reasoning phases internally as you analyze
+the code. Security vulnerabilities are data-flow problems — untrusted
+input reaching a sensitive sink without proper sanitization. Structured
+tracing prevents both false negatives (missing a real vulnerability
+because you assumed a function sanitizes) and false positives (flagging
+code that is actually unreachable from external input). You do not need
+to reproduce the full internal reasoning in your output, but your
+findings must be grounded in evidence gathered through these phases.
+
+### Phase 1: Premises — Identify Sources and Sinks
+
+Before analyzing anything, document the attack surface in the diff:
+
+```
+PREMISE P1: [File:line] introduces/modifies a SOURCE — [type: network input / query parameter / file path / deserialized data]
+PREMISE P2: [File:line] introduces/modifies a SINK — [type: SQL execution / process exec / file I/O / log output / response body / memory allocation]
+PREMISE P3: [File:line] introduces/modifies VALIDATION — [type: bounds check / sanitization / encoding / authentication]
+PREMISE P4: The trust boundary is at [description — e.g., "Gremlin Server request handler", "SQL parser entry point"]
+```
+
+If the diff does not touch any source or sink, state this explicitly
+and keep the review brief.
+
+### Phase 2: Taint Propagation Trace — Follow Data from Source to Sink
+
+For each source identified in Phase 1, trace the data flow through the
+code to every reachable sink:
+
+```
+TAINT TRACE T[N]:
+  SOURCE: [untrusted input] @ [file:line]
+  1. Input enters via [method(params)] @ [file:line]
+  2. Passed to [method(params)] @ [file:line] — transformed? [yes: how / no]
+  3. Validation at [file:line]: [what is checked — type, length, chars, bounds]
+     OR: NO VALIDATION before reaching sink
+  4. Reaches SINK: [method(params)] @ [file:line] — [what happens with the data]
+  VERDICT: SANITIZED | UNSANITIZED | PARTIALLY SANITIZED
+  DETAIL: [if not fully sanitized — what can slip through]
+```
+
+Follow calls interprocedurally — if a method delegates to another, read
+the callee. A method named `validate()` may not actually validate, or may
+validate the wrong property. Do not assume based on names.
+
+### Phase 3: Exploit Construction — Build a Concrete Attack
+
+For each UNSANITIZED or PARTIALLY SANITIZED trace, construct a specific
+exploit:
+
+```
+EXPLOIT for T[N]:
+  ATTACKER INPUT: [specific malicious value — e.g., "'; DROP TABLE--", "../../../etc/passwd"]
+  TRACE WITH MALICIOUS INPUT:
+    1. Input [value] enters @ [file:line]
+    2. Passes through [method] @ [file:line] — [not caught because ...]
+    3. Reaches sink @ [file:line] — produces [specific harmful effect]
+  IMPACT: [what the attacker achieves — data exfiltration, auth bypass, RCE, DoS]
+  PREREQUISITES: [authentication required? specific permissions? network access?]
+```
+
+If you cannot construct a concrete exploit (the attack requires
+unrealistic preconditions), downgrade the severity accordingly.
+
+### Phase 4: Reachability Check — Can External Input Actually Get Here?
+
+For each exploit, verify that the source is actually reachable from
+external input:
+
+```
+REACHABILITY CHECK for T[N]:
+  - Is the source method callable from a network endpoint? Checked [callers] → [evidence]
+  - Is authentication required to reach this path? Checked [auth filter chain] → [evidence]
+  - Could this code path be reached with the default configuration? [YES/NO — evidence]
+  VERDICT: REACHABLE | REQUIRES AUTH | UNREACHABLE
+```
+
+Only report exploits for REACHABLE or REQUIRES AUTH paths (with appropriate
+severity adjustment for authenticated-only paths).
+
+### Phase 5: Ranked Findings
+
+Based on surviving exploits from Phases 3-4, produce ranked findings.
+Each finding must cite the supporting TAINT TRACE and EXPLOIT.
+
+Skip generated files and code that doesn't handle external input or
+sensitive data.
 
 ## Output Format
 

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -99,7 +99,7 @@ For each test, trace the execution through the production code:
 
 ```
 TEST: [testMethodName]
-TRACE:
+BEHAVIOR TRACE:
   1. Test calls [method(args)] @ [production file:line]
   2. Method does [action] — returns [value] / modifies [state]
   3. Test asserts [what] on [which part of the result/state]

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -144,7 +144,7 @@ ASSERTION at test line X: [actual assertion code]
 ### Phase 5: Ranked Findings
 
 Based on surviving issues from Phases 3-4, produce ranked findings. Each
-finding must cite the specific BEHAVIOR TRACE and FALSIFIABILITY CHECK that
+finding must cite the specific BEHAVIOR TRACE, FALSIFIABILITY CHECK, or ASSERTION PRECISION CHECK that
 produced it.
 
 ## Output Format
@@ -170,7 +170,7 @@ produced it.
 For each finding, include:
 - **File**: `path/to/TestFile.java`, method `testName` (line X)
 - **Issue**: What's wrong (coverage-driven pattern, shallow assertion, imprecise exception test)
-- **Evidence**: The BEHAVIOR TRACE and FALSIFIABILITY CHECK that produced this finding
+- **Evidence**: The BEHAVIOR TRACE, FALSIFIABILITY CHECK, or ASSERTION PRECISION CHECK that produced this finding
 - **Missing behavior**: What should actually be verified
 - **Suggested fix**:
   ```java

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -170,6 +170,7 @@ produced it.
 For each finding, include:
 - **File**: `path/to/TestFile.java`, method `testName` (line X)
 - **Issue**: What's wrong (coverage-driven pattern, shallow assertion, imprecise exception test)
+- **Evidence**: The BEHAVIOR TRACE and FALSIFIABILITY CHECK that produced this finding
 - **Missing behavior**: What should actually be verified
 - **Suggested fix**:
   ```java

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -71,14 +71,81 @@ Tests that verify error behavior must do so precisely.
 - Not testing that the system state is consistent after an error (e.g., resource is still usable, or properly closed)
 - Missing tests for error propagation in async/concurrent code
 
-## Process
+## Reasoning Process — Semi-formal Analysis
 
-1. Identify test files in the diff (files under `src/test/`).
-2. For each test file, read the production code being tested to understand the expected behavior.
-3. Analyze each test method: Does it verify behavior, or just execute code?
-4. Check assertion quality: Are assertions precise enough to catch real bugs?
-5. Check exception tests: Are error paths tested with precision?
-6. Skip generated files and non-test files.
+Use the following structured reasoning phases internally as you analyze
+the tests. This forces you to trace what tests actually exercise in the
+production code, rather than judging test quality from test code alone.
+You do not need to reproduce the full internal reasoning in your output,
+but your findings must be grounded in evidence gathered through these
+phases.
+
+### Phase 1: Premises — Map Tests to Production Behavior
+
+For each test file in the diff, document what it tests:
+
+```
+PREMISE P1: Test [testMethodName] in [TestFile.java] calls [productionMethod(args)]
+PREMISE P2: Production method at [file:line] is supposed to [expected behavior / contract]
+PREMISE P3: The test asserts [what the test actually checks — list each assertion]
+```
+
+Read the production code being tested — do not guess what it does from
+the method name. This is mandatory.
+
+### Phase 2: Behavior Trace — What Does the Test Actually Exercise?
+
+For each test, trace the execution through the production code:
+
+```
+TEST: [testMethodName]
+TRACE:
+  1. Test calls [method(args)] @ [production file:line]
+  2. Method does [action] — returns [value] / modifies [state]
+  3. Test asserts [what] on [which part of the result/state]
+
+BEHAVIOR COVERAGE:
+  - Contract point A (e.g., "returns sorted results"): VERIFIED by assertion at test line X
+  - Contract point B (e.g., "updates internal counter"): NOT CHECKED — no assertion
+  - Contract point C (e.g., "throws on invalid input"): NOT TESTED — no test for this path
+```
+
+This trace reveals the gap between what the production code does and what
+the test actually verifies.
+
+### Phase 3: Falsifiability Analysis — Would This Test Catch a Real Bug?
+
+For each test, construct a specific mutation scenario:
+
+```
+FALSIFIABILITY CHECK for [testMethodName]:
+  MUTATION: If the production code at [file:line] were changed to [specific wrong behavior],
+            would this test fail?
+  ANALYSIS: The test asserts [X], and the mutation would produce [Y],
+            so the test would [FAIL — catches the bug | PASS — false confidence].
+```
+
+If the test would still pass with the mutation, it's coverage-driven,
+not behavior-driven. This is a finding.
+
+### Phase 4: Assertion Precision Check
+
+For each assertion in the test, check if a more precise assertion exists:
+
+```
+ASSERTION at test line X: [actual assertion code]
+  PRODUCTION VALUE: The production code returns/produces [full value]
+  PRECISION: [PRECISE — asserts the meaningful part |
+              SHALLOW — asserts only existence/non-null/size |
+              WEAK — would pass for multiple different incorrect values]
+  STRONGER ALTERNATIVE: [specific assertion code, or "already optimal"]
+```
+
+### Phase 5: Ranked Findings
+
+Based on surviving issues from Phases 3-4, produce ranked findings. Each
+finding must cite the specific TRACE and FALSIFIABILITY CHECK that
+produced it.
 
 ## Output Format
 

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -144,7 +144,7 @@ ASSERTION at test line X: [actual assertion code]
 ### Phase 5: Ranked Findings
 
 Based on surviving issues from Phases 3-4, produce ranked findings. Each
-finding must cite the specific TRACE and FALSIFIABILITY CHECK that
+finding must cite the specific BEHAVIOR TRACE and FALSIFIABILITY CHECK that
 produced it.
 
 ## Output Format

--- a/.claude/agents/review-test-concurrency.md
+++ b/.claude/agents/review-test-concurrency.md
@@ -152,7 +152,7 @@ INTERLEAVING for [contract]:
 ### Phase 5: Ranked Findings
 
 Based on Phases 2-4, produce ranked findings. Each finding must cite the
-specific CONTRACT, TEST TRACE, or INTERLEAVING that produced it.
+specific CONTRACT, TEST TRACE, TEST RACE CHECK, or INTERLEAVING that produced it.
 
 Skip generated files.
 
@@ -180,7 +180,7 @@ For each finding, include:
 - **File**: `path/to/TestFile.java`, method `testName` (line X)
 - **Production code**: `path/to/Production.java` (line X-Y) — the concurrent code being tested
 - **Issue**: What concurrent scenario is untested or poorly tested
-- **Evidence**: The CONTRACT, TEST TRACE, or INTERLEAVING that produced this finding
+- **Evidence**: The CONTRACT, TEST TRACE, TEST RACE CHECK, or INTERLEAVING that produced this finding
 - **Why it matters**: What race condition or deadlock this could hide
 - **Suggested test**:
   ```java

--- a/.claude/agents/review-test-concurrency.md
+++ b/.claude/agents/review-test-concurrency.md
@@ -74,13 +74,87 @@ You will receive:
 - Missing concurrent WAL write tests (multiple threads logging simultaneously)
 - Missing tests for storage engine concurrent open/close/reopen
 
-## Process
+## Reasoning Process — Semi-formal Analysis
 
-1. Identify production code in the diff that involves concurrency (shared state, locks, volatile, concurrent collections).
-2. Read the production code to understand the thread-safety guarantees it claims.
-3. Check if the test code exercises those guarantees under actual concurrent access.
-4. Evaluate test synchronization: are primitives used correctly, or are there races in the test itself?
-5. Skip generated files.
+Use the following structured reasoning phases internally as you analyze
+the tests. Concurrency test quality cannot be assessed from test code
+alone — you must trace what the production code's thread-safety contract
+is and verify that the test actually exercises it. You do not need to
+reproduce the full internal reasoning in your output, but your findings
+must be grounded in evidence gathered through these phases.
+
+### Phase 1: Premises — Map Concurrency Contracts
+
+For each production file in the diff that involves concurrency, document:
+
+```
+PREMISE P1: [Class.field] at [file:line] is shared mutable state, protected by [lock/volatile/CAS/none]
+PREMISE P2: [Class.method()] at [file:line] claims thread-safety via [mechanism — e.g., synchronized block, StampedLock, atomic CAS]
+PREMISE P3: Expected concurrent access pattern: [readers/writers/mixed] from [which threads/contexts]
+```
+
+Read the production code fully — do not guess concurrency semantics from
+field types alone. A `ConcurrentHashMap` field may still have compound
+check-then-act races in the methods that use it.
+
+### Phase 2: Test Coverage Trace — What Do Tests Actually Exercise?
+
+For each concurrency contract identified, trace whether the tests
+exercise it:
+
+```
+CONTRACT: [Class.method() is thread-safe under concurrent read/write]
+TEST TRACE:
+  - Test [testMethodName] @ [test file:line]
+  - Thread count: [N threads]
+  - Synchronization used: [CountDownLatch/CyclicBarrier/Thread.sleep/none]
+  - Contention point: [what shared resource threads compete for]
+  - Interleaving exercised: [what concurrent operation mix runs — e.g.,
+    "3 writers + 3 readers on same index" or "only sequential access"]
+  - Verification: [what the test asserts after concurrent execution]
+VERDICT: EXERCISED | WEAK (low contention/thread count) | NOT TESTED
+```
+
+If no test exercises the contract, that's a finding.
+
+### Phase 3: Test Race Analysis — Could the Test Itself Have Races?
+
+For each concurrency test, check for races in the test code itself:
+
+```
+TEST RACE CHECK for [testMethodName]:
+  - Thread coordination: [mechanism used — latch, barrier, sleep, none]
+  - Shared test state: [what variables are shared between test threads]
+  - Assertion timing: [are assertions run after all threads complete,
+    or could they race with thread execution?]
+  - Result collection: [is the result container thread-safe?]
+  VERDICT: SOUND | RACY (the test itself has a race — explain)
+```
+
+A racy test gives false confidence — it may pass even if the production
+code has a concurrency bug, because the test itself doesn't reliably
+produce contention.
+
+### Phase 4: Interleaving Construction — What Races Could Hide?
+
+For each NOT TESTED or WEAK contract from Phase 2, construct a specific
+harmful interleaving:
+
+```
+INTERLEAVING for [contract]:
+  Thread T1: [operation sequence with file:line references]
+  Thread T2: [operation sequence with file:line references]
+  Critical point: Between T1's [step X] and [step Y], T2 does [step Z]
+  Consequence: [data corruption / lost update / stale read / deadlock]
+  Test needed: [specific test that would expose this]
+```
+
+### Phase 5: Ranked Findings
+
+Based on Phases 2-4, produce ranked findings. Each finding must cite the
+specific CONTRACT, TEST TRACE, or INTERLEAVING that produced it.
+
+Skip generated files.
 
 ## Output Format
 

--- a/.claude/agents/review-test-concurrency.md
+++ b/.claude/agents/review-test-concurrency.md
@@ -180,6 +180,7 @@ For each finding, include:
 - **File**: `path/to/TestFile.java`, method `testName` (line X)
 - **Production code**: `path/to/Production.java` (line X-Y) — the concurrent code being tested
 - **Issue**: What concurrent scenario is untested or poorly tested
+- **Evidence**: The CONTRACT, TEST TRACE, or INTERLEAVING that produced this finding
 - **Why it matters**: What race condition or deadlock this could hide
 - **Suggested test**:
   ```java

--- a/.claude/agents/review-test-crash-safety.md
+++ b/.claude/agents/review-test-crash-safety.md
@@ -179,6 +179,7 @@ Skip generated files and code that doesn't touch persistent state.
 For each crash safety finding, include:
 - **File**: `path/to/TestFile.java`
 - **Production code**: `path/to/Production.java` (line X-Y)
+- **Evidence**: The CRASH POINT and TEST TRACE that produced this finding
 - **Missing scenario**: What crash/recovery scenario is untested
 - **Why it matters**: What data loss or corruption this could hide
 - **Suggested test**:
@@ -191,6 +192,7 @@ For each crash safety finding, include:
 
 For each assert statement finding, include:
 - **File**: `path/to/Production.java` (line X)
+- **Evidence**: The INVARIANT analysis that produced this finding
 - **Invariant**: What should always be true
 - **Suggested assertion**:
   ```java

--- a/.claude/agents/review-test-crash-safety.md
+++ b/.claude/agents/review-test-crash-safety.md
@@ -79,13 +79,82 @@ Recommend adding Java `assert` statements in production code **only where they a
 3. Explain what invariant it protects and what bug it would catch during testing
 4. If the assertion condition involves complex logic, recommend extracting it to a helper method (per CLAUDE.md tip #10)
 
-## Process
+## Reasoning Process — Semi-formal Analysis
 
-1. Identify production code in the diff that involves persistent state, WAL, storage, or durable components.
-2. Read the production code to understand the durability guarantees.
-3. Check if test code exercises crash/recovery scenarios for these guarantees.
-4. Identify production methods where assert statements would protect important invariants.
-5. Skip generated files and code that doesn't touch persistent state.
+Use the following structured reasoning phases internally as you analyze
+the tests. Crash safety testing quality cannot be assessed from test code
+alone — you must trace the production code's write and recovery paths,
+then verify that tests exercise crash points along those paths. You do
+not need to reproduce the full internal reasoning in your output, but
+your findings must be grounded in evidence gathered through these phases.
+
+### Phase 1: Premises — Map Durability Contracts
+
+For each production file in the diff that touches persistent state:
+
+```
+PREMISE P1: [Class.method()] at [file:line] modifies persistent state [page/WAL/index]
+PREMISE P2: Write path: [mutation → WAL record → page modification → commit → checkpoint]
+PREMISE P3: Recovery path: redo() at [file:line] replays via [mechanism]
+PREMISE P4: Crash-critical window: between [step X] and [step Y], a crash would leave [state]
+```
+
+Read the production code to trace the full write path — do not guess
+from class names or WAL record types.
+
+### Phase 2: Test Coverage Trace — What Crash Points Do Tests Exercise?
+
+For each crash-critical window identified, check test coverage:
+
+```
+CRASH POINT: Between [step X at file:line] and [step Y at file:line]
+TEST TRACE:
+  - Test [testMethodName] @ [test file:line]
+  - Crash simulation method: [how the test simulates crash — e.g.,
+    kill process, close without flush, inject error]
+  - Recovery verification: [what the test asserts after recovery —
+    data consistent, partial ops rolled back, WAL replayed correctly]
+  - Crash timing: [does the test crash at THIS specific point, or
+    only at a different point in the write path?]
+VERDICT: COVERED | WRONG TIMING (covers different crash point) | NOT TESTED
+```
+
+### Phase 3: Recovery Path Verification — Do Tests Check the Right Thing?
+
+For each test that exercises crash recovery, verify it checks the
+correct postcondition:
+
+```
+RECOVERY CHECK for [testMethodName]:
+  - Test crashes at: [which point in the write path]
+  - Test asserts after recovery: [what is checked]
+  - Correct postcondition: [what SHOULD be true after recovery from
+    this crash point — trace the redo() path]
+  - Match: [does the test assert the correct postcondition? YES/NO]
+  - Missing checks: [what the test should also verify but doesn't —
+    e.g., atomicity of multi-page update, LSN consistency, index integrity]
+```
+
+### Phase 4: Assert Statement Analysis — Invariant Identification
+
+For production code in the diff, identify invariants that should hold
+but aren't enforced:
+
+```
+INVARIANT at [file:line]:
+  - What must be true: [condition — e.g., "offset >= 0 && offset < pageSize"]
+  - When it could break: [scenario — e.g., "arithmetic error in page offset calculation"]
+  - Current enforcement: [existing check at file:line, or "NONE"]
+  - Assert candidate: [YES — zero cost, catches bugs during testing |
+    NO — already enforced / would have side effects / in tight loop]
+```
+
+### Phase 5: Ranked Findings
+
+Based on Phases 2-4, produce ranked findings. Each finding must cite
+the specific CRASH POINT, TEST TRACE, or INVARIANT that produced it.
+
+Skip generated files and code that doesn't touch persistent state.
 
 ## Output Format
 

--- a/.claude/agents/review-test-crash-safety.md
+++ b/.claude/agents/review-test-crash-safety.md
@@ -152,7 +152,7 @@ INVARIANT at [file:line]:
 ### Phase 5: Ranked Findings
 
 Based on Phases 2-4, produce ranked findings. Each finding must cite
-the specific CRASH POINT, TEST TRACE, or INVARIANT that produced it.
+the specific CRASH POINT, TEST TRACE, RECOVERY CHECK, or INVARIANT that produced it.
 
 Skip generated files and code that doesn't touch persistent state.
 
@@ -179,7 +179,7 @@ Skip generated files and code that doesn't touch persistent state.
 For each crash safety finding, include:
 - **File**: `path/to/TestFile.java`
 - **Production code**: `path/to/Production.java` (line X-Y)
-- **Evidence**: The CRASH POINT and TEST TRACE that produced this finding
+- **Evidence**: The CRASH POINT, TEST TRACE, or RECOVERY CHECK that produced this finding
 - **Missing scenario**: What crash/recovery scenario is untested
 - **Why it matters**: What data loss or corruption this could hide
 - **Suggested test**:

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -29,12 +29,100 @@ SIMPLIFICATION CHALLENGES
 - Could the same goals be achieved with fewer steps?
 - Is there an existing mechanism that replaces a proposed new component?
 
+## Semi-Formal Reasoning Protocol
+
+As a devil's advocate, you must construct **concrete counterexamples and
+violation scenarios** grounded in codebase evidence. Every challenge must
+include a specific scenario trace — not just "this might fail" but a
+step-by-step path showing how it would fail. This prevents handwaving
+challenges that waste the team's time and catches real vulnerabilities
+that survive scrutiny.
+
+### Certificate requirements
+
+**For every decision challenged**, produce:
+
+```markdown
+#### Challenge: Decision D<N> — <decision title>
+- **Chosen approach**: <what the plan decided>
+- **Best rejected alternative**: <the strongest alternative not chosen>
+- **Counterargument trace**:
+  1. In scenario [specific situation], the chosen approach does [X]
+     because [code evidence at file:line]
+  2. The rejected alternative would instead do [Y]
+     because [code evidence or domain reasoning]
+  3. This produces outcome [concrete difference]
+- **Codebase evidence**: <file:line showing why the alternative might
+  work better, or showing a weakness in the chosen approach>
+- **Survival test**: Does the chosen approach survive this challenge?
+  YES (rationale holds) | NO (should reconsider) | WEAK (rationale
+  needs strengthening)
+```
+
+**For every invariant challenged**, produce:
+
+```markdown
+#### Violation scenario: <invariant statement>
+- **Invariant claim**: <what must remain true>
+- **Violation construction**:
+  1. Start state: <concrete initial conditions>
+  2. Action sequence: <specific operations, with file:line for each>
+  3. Intermediate state: <what the system looks like mid-sequence>
+  4. Violation point: <where the invariant breaks — file:line, condition>
+  5. Observable consequence: <what goes wrong — data corruption, wrong
+     result, crash>
+- **Feasibility**: CONSTRUCTIBLE (real scenario) | THEORETICAL (requires
+  unlikely conditions) | INFEASIBLE (cannot actually happen because [reason])
+```
+
+**For every assumption challenged**, produce:
+
+```markdown
+#### Assumption test: <what the track takes for granted>
+- **Claim**: <the assumption>
+- **Stress scenario**: <specific conditions that would break the assumption>
+- **Code evidence**: <file:line showing the assumption holds or doesn't
+  under the stress scenario>
+- **Verdict**: HOLDS | FRAGILE (holds but barely) | BREAKS
+```
+
+### Rules for certificates
+
+- **Counterexamples must be concrete.** "This might not scale" is not a
+  challenge. "With N=10000 entries and the current O(n^2) loop at
+  file:line, this takes X seconds" is a challenge.
+- **Violation scenarios must be constructible.** Trace the actual code
+  path that would produce the violation. If you cannot construct a path,
+  the invariant may be stronger than you think — mark as INFEASIBLE.
+- **Always search for the rejected alternative in the codebase.** The
+  strongest adversarial challenge is showing that the codebase already
+  has infrastructure for the rejected approach.
+- **Survival tests are mandatory.** After constructing the challenge,
+  honestly assess whether the chosen approach survives. A challenge
+  that the decision survives still has value (it strengthens rationale)
+  but gets a lower severity.
+
+---
+
+## Output Format
+
+### Part 1: Challenge Certificates
+
+Include all certificate entries (Challenge, Violation scenario,
+Assumption test) grouped by review criterion. This is the evidence base.
+
+### Part 2: Findings
+
+Derived from certificates. Each finding must reference the certificate
+entry that produced it.
+
 For each challenge, produce a finding:
 
 ### Finding A<N> [blocker|should-fix|suggestion]
+**Certificate**: <Challenge/Violation/Assumption entry that produced this>
 **Target**: <Decision D<N> | Non-Goal | Invariant | Assumption>
 **Challenge**: <the strongest counter-argument>
-**Evidence**: <codebase or domain evidence>
+**Evidence**: <codebase or domain evidence — summarized from certificate>
 **Proposed fix**: <strengthen rationale, change decision, add step, etc.>
 
 Severity guide:

--- a/.claude/workflow/prompts/consistency-gate-verification.md
+++ b/.claude/workflow/prompts/consistency-gate-verification.md
@@ -19,9 +19,40 @@ Then briefly re-scan the areas that were modified — fixes sometimes shift
 inconsistencies rather than resolving them (e.g., fixing a class name in
 the design document but not updating the corresponding sequence diagram).
 
+## Semi-Formal Verification Protocol
+
+For each ACCEPTED finding being verified, you must produce a
+**verification certificate** — not just assert "looks fixed." The
+certificate traces the same code reference or flow that was originally
+flagged and confirms the fix resolves it.
+
+```markdown
+#### Verify CR<N>: <finding title>
+- **Original issue**: <what was wrong — from the finding>
+- **Fix applied**: <what changed in the plan/design text>
+- **Re-check**:
+  - Search/trace performed: <Grep/Glob query or flow trace>
+  - Code location: <file:line — same reference as original, or updated>
+  - Current state: <what the document now says vs. what the code shows>
+- **Regression check**: <did the fix introduce new inconsistencies
+  in related sections? Checked [which sections] — [clean / new issue]>
+- **Verdict**: VERIFIED | STILL OPEN (explain) | REGRESSION (new issue)
+```
+
+For REJECTED findings, verify the rejection reason with a lighter check:
+
+```markdown
+#### Verify CR<N> (REJECTED): <finding title>
+- **Rejection reason**: <from the previous iteration>
+- **Downstream check**: <does leaving this unfixed cause any inconsistency
+  elsewhere? Checked [which sections] — [clean / downstream issue]>
+- **Verdict**: REJECTED (no action needed) | RECONSIDER (downstream issue found)
+```
+
+---
+
 Output:
-- For each previous finding: VERIFIED, STILL OPEN (with explanation),
-  or REJECTED (no action needed)
+- For each previous finding: the verification certificate above
 - New findings (if any) in the same format with cumulative numbering
   (continue from the highest CR number)
 - Summary: PASS (all verified/rejected, no new blockers) or FAIL (with

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -88,14 +88,100 @@ Inputs:
 
 ---
 
+## Semi-Formal Reasoning Protocol
+
+This review requires **structured evidence certificates** for every claim
+about code behavior. You must not assert that a code reference is correct
+or incorrect without documented evidence. This prevents logical jumps
+("this class probably exists") and catches subtle mismatches (shadowed
+methods, renamed classes, changed signatures).
+
+### Certificate requirements
+
+**For every code reference verified** (class, interface, method, SPI,
+file path, configuration parameter), produce a verification entry:
+
+```markdown
+#### Ref: <name from document>
+- **Document claim**: <what the plan or design document says — quote or
+  paraphrase the specific claim>
+- **Search performed**: <Grep/Glob query used to locate the construct>
+- **Code location**: <file:line where found, or "NOT FOUND">
+- **Actual signature/role**: <what the code actually shows — copy the
+  relevant declaration or excerpt>
+- **Verdict**: MATCHES | MISMATCHES | PARTIAL | NOT FOUND
+- **Detail**: <if MISMATCHES/PARTIAL/NOT FOUND — what specifically differs>
+```
+
+**For every workflow/sequence diagram traced**, produce a flow trace:
+
+```markdown
+#### Flow: <diagram name or operation>
+- **Document claim**: <the sequence of interactions the diagram shows>
+- **Trace**:
+  1. <Caller> → <method(args)> @ <file:line> — <what actually happens>
+  2. <Next call> → <method(args)> @ <file:line> — <what actually happens>
+  3. ... (continue until the flow completes or diverges)
+- **Divergence point**: <step N where reality differs from diagram, or "none">
+- **Verdict**: MATCHES | MISMATCHES | PARTIAL
+- **Detail**: <if divergent — what the diagram claims vs. what the code does>
+```
+
+**For every invariant checked**, produce an invariant trace:
+
+```markdown
+#### Invariant: <invariant statement>
+- **Document claim**: <what the plan says must be true>
+- **Code evidence**: <file:line(s) that enforce or violate this invariant>
+- **Mechanism**: <how the code enforces it — e.g., "inside WAL atomic
+  operation at X.java:142", or "no enforcement found">
+- **Verdict**: ENFORCED | ASPIRATIONAL | VIOLATED
+- **Detail**: <if ASPIRATIONAL — the tracks that need to implement it;
+  if VIOLATED — what contradicts it>
+```
+
+### Rules for certificates
+
+- **Every claim requires a search.** Do not assume a class exists because
+  its name is plausible. Search for it explicitly.
+- **Follow calls interprocedurally.** When tracing a flow, if a method
+  delegates to another, follow the delegation. The paper's motivating
+  example: a function named `format()` was assumed to be Python's built-in,
+  but was actually a module-level shadow with different semantics. The same
+  class of error applies here — always verify what a method actually does,
+  not what its name suggests.
+- **Document negative results.** If a search finds nothing, that is a
+  finding (phantom reference). Record the search query and "NOT FOUND."
+- **Trace until divergence or completion.** Do not stop a flow trace at
+  the first matching step. Continue until the flow completes or you find
+  a divergence.
+- **Certificates feed findings.** Each MISMATCHES, PARTIAL, NOT FOUND, or
+  ASPIRATIONAL verdict becomes a finding (below). MATCHES verdicts are
+  recorded but do not generate findings.
+
+---
+
 ## Output Format
+
+### Part 1: Verification Certificates
+
+Include all certificate entries (Ref, Flow, Invariant) grouped by review
+criterion (Design ↔ Code, Plan ↔ Code, Design ↔ Plan, Gaps). This is
+the evidence base.
+
+### Part 2: Findings
+
+Derived from certificates with non-MATCHES verdicts. Each finding must
+reference the certificate entry that produced it.
 
 For each issue found, produce a finding:
 
 ### Finding CR<N> [blocker|should-fix|suggestion]
+**Certificate**: <Ref/Flow/Invariant entry ID that produced this finding>
 **Location**: <which document and section, plus code location if applicable>
 **Issue**: <what's inconsistent or missing>
-**Evidence**: <what you found in the code vs. what the document says>
+**Evidence**: <what you found in the code vs. what the document says —
+  summarize from the certificate>
 **Proposed fix**: <concrete change to the plan/design text>
 
 Severity guide:

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -145,11 +145,9 @@ file path, configuration parameter), produce a verification entry:
 - **Every claim requires a search.** Do not assume a class exists because
   its name is plausible. Search for it explicitly.
 - **Follow calls interprocedurally.** When tracing a flow, if a method
-  delegates to another, follow the delegation. The paper's motivating
-  example: a function named `format()` was assumed to be Python's built-in,
-  but was actually a module-level shadow with different semantics. The same
-  class of error applies here — always verify what a method actually does,
-  not what its name suggests.
+  delegates to another, follow the delegation. A method named `validate()`
+  may not actually validate, or may validate the wrong property — always
+  verify what a method actually does, not what its name suggests.
 - **Document negative results.** If a search finds nothing, that is a
   finding (phantom reference). Record the search query and "NOT FOUND."
 - **Trace until divergence or completion.** Do not stop a flow trace at

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -54,6 +54,31 @@ Rules:
 - Complex parts (concurrency, crash recovery, performance paths) are mandatory.
 - Do NOT modify `design.md`.
 
+**Verification protocol:** Before writing each diagram, build a
+verification table to ensure the diagram reflects actual code:
+
+For class diagrams:
+```
+| Diagram Element        | Code Location        | Verified? | Notes           |
+|------------------------|----------------------|-----------|-----------------|
+| Class X                | file:line            | YES/NO    | actual name/role |
+| X extends Y            | file:line            | YES/NO    |                 |
+| X.method(args): return | file:line            | YES/NO    | actual signature |
+```
+
+For workflow/sequence diagrams:
+```
+| Step | Diagram Claim                 | Code Location | Actual Behavior | Match? |
+|------|-------------------------------|---------------|-----------------|--------|
+| 1    | Caller → method(args)         | file:line     | [what happens]  | YES/NO |
+| 2    | Method → delegate(args)       | file:line     | [what happens]  | YES/NO |
+```
+
+Every element in the diagram must have a corresponding row. Do not
+include classes, methods, or flows that you have not verified exist in
+the current code. The tables do not appear in the final artifact — they
+are working notes that ensure accuracy.
+
 ### Artifact 2: ADR (`adr.md`)
 
 Write `docs/adr/<dir-name>/adr.md` — a post-implementation Architecture

--- a/.claude/workflow/prompts/review-gate-verification.md
+++ b/.claude/workflow/prompts/review-gate-verification.md
@@ -12,8 +12,36 @@ For each previous finding:
 2. If the finding was REJECTED: verify the rejection reason is sound
    and no downstream issue was introduced. Mark as REJECTED.
 
+## Semi-Formal Verification Protocol
+
+For each ACCEPTED finding being verified, produce a **verification
+certificate** that re-checks the specific location:
+
+```markdown
+#### Verify <PREFIX><N>: <finding title>
+- **Original issue**: <what was wrong>
+- **Fix applied**: <what changed in the plan/track description>
+- **Re-check**:
+  - Code/plan location: <where the fix was applied>
+  - Current state: <what it now says vs. original issue>
+  - Criteria met: <which review criteria are now satisfied>
+- **Regression check**: <did the fix introduce new issues?
+  Checked [which areas] — [clean / new issue]>
+- **Verdict**: VERIFIED | STILL OPEN (explain) | REGRESSION (new issue)
+```
+
+For REJECTED findings:
+
+```markdown
+#### Verify <PREFIX><N> (REJECTED): <finding title>
+- **Rejection reason**: <from the previous iteration>
+- **Downstream check**: <any downstream issues from leaving unfixed?>
+- **Verdict**: REJECTED (no action needed) | RECONSIDER (downstream issue)
+```
+
+---
+
 Output:
-- For each finding: VERIFIED, STILL OPEN (with explanation), or
-  REJECTED (no action needed)
+- For each finding: the verification certificate above
 - New findings (if any) with cumulative numbering
 - Summary: PASS or FAIL

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -32,9 +32,87 @@ ROLLBACK & RECOVERY
 - If a step's approach fails, what's the rollback story?
 - Are there irreversible state changes?
 
+## Semi-Formal Reasoning Protocol
+
+This review requires **structured evidence certificates** for every risk
+claim. You must not assert that something is risky without tracing the
+actual code path and documenting concrete evidence. This prevents
+pattern-matching on keywords ("WAL" → "must be risky") and catches cases
+where existing safeguards already mitigate the perceived risk.
+
+### Certificate requirements
+
+**For every critical path exposure assessed**, produce:
+
+```markdown
+#### Exposure: <what the track touches on a critical path>
+- **Track claim**: <what the track plans to do to this path>
+- **Critical path trace**:
+  1. Entry: <method(args)> @ <file:line>
+  2. <next call> @ <file:line> — <what happens here>
+  3. ... (trace until the operation completes or reaches disk/network)
+- **Blast radius**: <what breaks if this step has a bug — list affected
+  callers, data structures, recovery paths>
+- **Existing safeguards**: <locks, WAL coverage, validation, tests that
+  already protect this path — with file:line references>
+- **Residual risk**: HIGH | MEDIUM | LOW — <what can still go wrong
+  despite safeguards>
+```
+
+**For every assumption verified**, produce:
+
+```markdown
+#### Assumption: <what the track takes for granted>
+- **Track claim**: <quote or paraphrase the assumption>
+- **Evidence search**: <Grep/Glob query performed>
+- **Code evidence**: <file:line showing the assumption holds or doesn't>
+- **Verdict**: VALIDATED | UNVALIDATED | CONTRADICTED
+- **Detail**: <if not VALIDATED — what the code actually shows>
+```
+
+**For every testability concern**, produce:
+
+```markdown
+#### Testability: <step description>
+- **Coverage target**: 85% line / 70% branch
+- **Difficulty assessment**: <what makes this step hard to test>
+- **Existing test infrastructure**: <relevant test base classes, fixtures,
+  helpers at file:line>
+- **Feasibility**: ACHIEVABLE | DIFFICULT | INFEASIBLE
+- **Detail**: <if not ACHIEVABLE — what specific coverage gaps are expected>
+```
+
+### Rules for certificates
+
+- **Trace critical paths fully.** Do not claim blast radius without tracing
+  the callers. A method that looks critical may be called from only one
+  isolated test helper.
+- **Document existing safeguards.** A risk that already has WAL coverage,
+  lock protection, or comprehensive tests is lower severity than the same
+  risk without safeguards. Check before flagging.
+- **Assumptions require code evidence.** "It should work" is not validation.
+  Search for the specific API, interface, or behavior the track assumes.
+- **Prior track episodes are evidence.** If a prior track discovered
+  something, cite the episode and verify it still holds.
+
+---
+
+## Output Format
+
+### Part 1: Evidence Certificates
+
+Include all certificate entries (Exposure, Assumption, Testability)
+grouped by review criterion. This is the evidence base.
+
+### Part 2: Findings
+
+Derived from certificates. Each finding must reference the certificate
+entry that produced it.
+
 For each issue found, produce a finding:
 
 ### Finding R<N> [blocker|should-fix|suggestion]
+**Certificate**: <Exposure/Assumption/Testability entry that produced this>
 **Location**: <where in the track + relevant source/test file(s)>
 **Issue**: <the risk, with likelihood and impact assessment>
 **Proposed fix**: <mitigation — reorder steps, add verification steps,

--- a/.claude/workflow/prompts/structural-gate-verification.md
+++ b/.claude/workflow/prompts/structural-gate-verification.md
@@ -16,9 +16,40 @@ For each previous finding:
 Then briefly scan for any new issues in the areas that were modified —
 fixes sometimes shift problems rather than solving them.
 
+## Semi-Formal Verification Protocol
+
+For each ACCEPTED finding being verified, produce a **verification
+certificate** that re-checks the specific plan location:
+
+```markdown
+#### Verify S<N>: <finding title>
+- **Original issue**: <what was wrong — from the finding>
+- **Fix applied**: <what changed in the plan text>
+- **Re-check**:
+  - Plan location: <section and line where the fix was applied>
+  - Current state: <what the plan now says>
+  - Criteria met: <which structural criteria from the review checklist
+    are now satisfied>
+- **Regression check**: <did the fix shift the problem elsewhere?
+  E.g., reordering tracks may fix one dependency but create another.
+  Checked [which sections] — [clean / new issue]>
+- **Verdict**: VERIFIED | STILL OPEN (explain) | REGRESSION (new issue)
+```
+
+For REJECTED findings:
+
+```markdown
+#### Verify S<N> (REJECTED): <finding title>
+- **Rejection reason**: <from the previous iteration>
+- **Downstream check**: <does leaving this unfixed cause inconsistency
+  elsewhere? Checked [which sections] — [clean / downstream issue]>
+- **Verdict**: REJECTED (no action needed) | RECONSIDER (downstream issue found)
+```
+
+---
+
 Output:
-- For each previous finding: VERIFIED, STILL OPEN (with explanation),
-  or REJECTED (no action needed)
+- For each previous finding: the verification certificate above
 - New findings (if any) in the same format, with cumulative numbering
   (continue from the highest finding number)
 - Summary: PASS (all verified/rejected, no new blockers) or FAIL (with

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -47,9 +47,89 @@ BACKWARD COMPATIBILITY
 - Will existing data/formats still work?
 - Are migrations needed that the plan doesn't mention?
 
+## Semi-Formal Reasoning Protocol
+
+This review requires **structured evidence certificates** for every claim
+about the codebase. You must not assert that an API exists, a component
+works as described, or an approach is feasible without documented evidence
+from reading the actual code. This prevents assumptions like "this
+interface probably has that method" and catches subtle mismatches.
+
+### Certificate requirements
+
+**For every component/API assumption verified**, produce:
+
+```markdown
+#### Premise: <what the track assumes>
+- **Track claim**: <quote or paraphrase from the track description>
+- **Search performed**: <Grep/Glob query used>
+- **Code location**: <file:line, or "NOT FOUND">
+- **Actual behavior**: <what the code actually shows — copy relevant
+  declaration, method signature, or excerpt>
+- **Verdict**: CONFIRMED | WRONG | PARTIAL | NOT FOUND
+- **Detail**: <if not CONFIRMED — what specifically differs>
+```
+
+**For every edge case / error path analyzed**, produce:
+
+```markdown
+#### Edge case: <scenario description>
+- **Trigger**: <specific condition — e.g., "null index name", "concurrent
+  WAL flush during histogram read">
+- **Code path trace**:
+  1. Entry: <method(args)> @ <file:line>
+  2. <next call> @ <file:line> — <behavior with this input>
+  3. ... (trace until outcome)
+- **Outcome**: <what happens — exception type, partial state, silent
+  corruption, correct handling>
+- **Track coverage**: <does the track description address this? yes/no>
+```
+
+**For every integration point verified**, produce:
+
+```markdown
+#### Integration: <integration point name>
+- **Plan claim**: <what the plan says about how new code connects>
+- **Actual entry point**: <file:line of the real integration surface>
+- **Caller analysis**: <who calls this today — list callers found via Grep>
+- **Breaking change risk**: <will the track's changes break existing callers?>
+- **Verdict**: MATCHES | MISMATCHES | CALLERS AT RISK
+```
+
+### Rules for certificates
+
+- **Every premise requires a search.** Do not confirm an API exists
+  because its name is plausible. Search and read the actual code.
+- **Follow calls interprocedurally.** When checking feasibility of an
+  approach, trace the actual call chain. A method may delegate, throw,
+  or behave differently than its name suggests.
+- **Trace edge cases to completion.** Do not stop at "an exception is
+  thrown." Trace what catches it, whether state is left inconsistent,
+  and whether the track accounts for this.
+- **Document negative results.** If a component is NOT FOUND or an API
+  works differently than assumed, that is a finding.
+- **Prior track episodes are evidence.** When a prior track's episode
+  reveals a codebase reality (renamed class, changed API), use it as
+  a premise and verify it still holds.
+
+---
+
+## Output Format
+
+### Part 1: Evidence Certificates
+
+Include all certificate entries (Premise, Edge case, Integration) in
+order of review criteria. This is the evidence base.
+
+### Part 2: Findings
+
+Derived from certificates. Each finding must reference the certificate
+entry that produced it.
+
 For each issue found, produce a finding:
 
 ### Finding T<N> [blocker|should-fix|suggestion]
+**Certificate**: <Premise/Edge case/Integration entry that produced this>
 **Location**: <where in the track + relevant source file(s)>
 **Issue**: <what's wrong, with evidence from the codebase>
 **Proposed fix**: <concrete change — may include modifying steps,


### PR DESCRIPTION
#### Motivation:

Review agents and workflow prompts could make logical jumps — claiming "this class probably exists" or "this path is safe" — without tracing actual code paths or citing evidence. Based on "Agentic Code Reasoning" (arxiv 2603.01896), this adds structured evidence certificate templates that force agents to trace code paths, cite evidence, and chain conclusions to premises before making claims.

## Summary

- Add semi-formal reasoning protocols to 13 agents/prompts across workflow and code review
- Workflow prompts: consistency-review, technical-review, risk-review, adversarial-review, create-final-design, and 3 gate verifications
- Code review agents: security, performance, test-behavior, test-concurrency, test-crash-safety
- Add **Evidence** field to finding output templates so agents have a place to cite their reasoning
- Fix label mismatches in review-test-behavior agent (TRACE vs BEHAVIOR TRACE)

Three agents already had semi-formal protocols (review-bugs-concurrency, review-crash-safety, review-test-completeness) and were not modified. Two agents (review-code-quality, review-test-structure) were intentionally excluded since they review surface-level form rather than behavioral claims about code paths.

## Test plan

- [x] No source code changes — only `.claude/` workflow/agent prompts modified
- [ ] Verify agents produce findings with Evidence fields in next code review run