### PR TITLE
[no-test-number-check] Harden JMH scalability comparison with CI error propagation

### DIFF
--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -126,32 +126,46 @@ def _is_high_variance(score, error):
     return error / score * 100 > MAX_RELATIVE_ERROR_PCT
 
 
-def delta_icon(base_val, head_val, threshold_pct=5.0,
-               base_error=0, head_error=0):
-    """Return an icon indicating regression/improvement/neutral/suppressed.
+def _classify_change(base_val, base_error, head_val, head_error,
+                     threshold_pct=5.0):
+    """Classify a single base→head change.
+
+    Returns one of: "regression", "improvement", "suppressed", or None.
 
     A change is only flagged when ALL three conditions hold:
     1. The percentage change exceeds ±threshold_pct.
     2. The error bars (score ± scoreError) do not overlap.
     3. Neither side has relative error > MAX_RELATIVE_ERROR_PCT.
 
-    When (1) and (2) hold but (3) fails, the change is marked :warning:
-    (suppressed due to high variance).
+    When (1) and (2) hold but (3) fails, the change is "suppressed"
+    (high variance).
     """
-    if base_val == 0:
-        return ""
+    if base_val <= 0:
+        return None
     delta = (head_val - base_val) / base_val * 100
-    exceeds_threshold = abs(delta) >= threshold_pct
-    overlap = errors_overlap(base_val, base_error, head_val, head_error)
-    high_var = (_is_high_variance(base_val, base_error)
-                or _is_high_variance(head_val, head_error))
+    if abs(delta) < threshold_pct:
+        return None
+    if errors_overlap(base_val, base_error, head_val, head_error):
+        return None
+    if (_is_high_variance(base_val, base_error)
+            or _is_high_variance(head_val, head_error)):
+        return "suppressed"
+    if delta <= -threshold_pct:
+        return "regression"
+    return "improvement"
 
-    if exceeds_threshold and not overlap:
-        if high_var:
-            return " :warning:"
-        if delta <= -threshold_pct:
-            return " :red_circle:"
+
+def delta_icon(base_val, head_val, threshold_pct=5.0,
+               base_error=0, head_error=0):
+    """Return an icon indicating regression/improvement/neutral/suppressed."""
+    kind = _classify_change(base_val, base_error, head_val, head_error,
+                            threshold_pct)
+    if kind == "regression":
+        return " :red_circle:"
+    if kind == "improvement":
         return " :green_circle:"
+    if kind == "suppressed":
+        return " :warning:"
     return ""
 
 
@@ -203,28 +217,20 @@ def _count_gated_changes(pairs, threshold_pct=5.0):
     """Count regressions, improvements, and suppressed changes.
 
     ``pairs`` is an iterable of (base_value, base_error, head_value, head_error)
-    tuples.  A change is counted only when the percentage exceeds the threshold
-    AND the error bars do not overlap AND neither side has high variance.
-    Changes that meet the first two criteria but fail the variance check
-    are counted as suppressed.
+    tuples.  Each pair is classified via ``_classify_change``.
     """
     regressions = 0
     improvements = 0
     suppressed = 0
     for base_val, base_err, head_val, head_err in pairs:
-        if base_val <= 0:
-            continue
-        delta = (head_val - base_val) / base_val * 100
-        overlap = errors_overlap(base_val, base_err, head_val, head_err)
-        high_var = (_is_high_variance(base_val, base_err)
-                    or _is_high_variance(head_val, head_err))
-        if abs(delta) >= threshold_pct and not overlap:
-            if high_var:
-                suppressed += 1
-            elif delta <= -threshold_pct:
-                regressions += 1
-            else:
-                improvements += 1
+        kind = _classify_change(base_val, base_err, head_val, head_err,
+                                threshold_pct)
+        if kind == "regression":
+            regressions += 1
+        elif kind == "improvement":
+            improvements += 1
+        elif kind == "suppressed":
+            suppressed += 1
     return regressions, improvements, suppressed
 
 

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -60,15 +60,26 @@ def parse_jmh_results(data):
 
 
 def compute_scalability(results):
-    """Compute MT/ST throughput ratio per query."""
+    """Compute MT/ST throughput ratio per query with error propagation.
+
+    For R = MT/ST, the propagated error is:
+        σ_R = R * sqrt((σ_MT/MT)² + (σ_ST/ST)²)
+    """
     st = {k[0]: v for k, v in results.items() if k[1] == "SingleThread"}
     mt = {k[0]: v for k, v in results.items() if k[1] == "MultiThread"}
 
     scalability = {}
     for query in st:
         if query in mt and st[query]["score"] > 0:
+            ratio = mt[query]["score"] / st[query]["score"]
+            rel_err_mt = (mt[query]["score_error"] / mt[query]["score"]
+                          if mt[query]["score"] > 0 else 0)
+            rel_err_st = (st[query]["score_error"] / st[query]["score"]
+                          if st[query]["score"] > 0 else 0)
+            ratio_error = ratio * math.sqrt(rel_err_mt ** 2 + rel_err_st ** 2)
             scalability[query] = {
-                "ratio": mt[query]["score"] / st[query]["score"],
+                "ratio": ratio,
+                "ratio_error": ratio_error,
                 "st_score": st[query]["score"],
                 "mt_score": mt[query]["score"],
             }
@@ -243,6 +254,28 @@ def main():
 
     regressions, improvements, suppressed = count_changes(base, head)
 
+    # Count scalability ratio changes using the same gating logic
+    scal_reg = 0
+    scal_imp = 0
+    scal_sup = 0
+    for query in base_scal.keys() | head_scal.keys():
+        b = base_scal.get(query)
+        h = head_scal.get(query)
+        if b and h and b["ratio"] > 0:
+            delta = (h["ratio"] - b["ratio"]) / b["ratio"] * 100
+            overlap = errors_overlap(
+                b["ratio"], b["ratio_error"],
+                h["ratio"], h["ratio_error"])
+            high_var = (_is_high_variance(b["ratio"], b["ratio_error"])
+                        or _is_high_variance(h["ratio"], h["ratio_error"]))
+            if abs(delta) >= 5.0 and not overlap:
+                if high_var:
+                    scal_sup += 1
+                elif delta <= -5.0:
+                    scal_reg += 1
+                else:
+                    scal_imp += 1
+
     lines = []
     lines.append("## JMH LDBC Benchmark Comparison")
     lines.append("")
@@ -250,20 +283,38 @@ def main():
         f"**Base:** `{args.base_sha[:10]}` (fork-point with develop) "
         f"| **Head:** `{args.head_sha[:10]}`"
     )
-    if regressions > 0 or improvements > 0 or suppressed > 0:
-        parts = []
-        if regressions > 0:
-            parts.append(f":red_circle: {regressions} regression(s)")
-        if improvements > 0:
-            parts.append(f":green_circle: {improvements} improvement(s)")
-        if suppressed > 0:
-            parts.append(
-                f":warning: {suppressed} suppressed (high variance)")
+    has_throughput = regressions > 0 or improvements > 0 or suppressed > 0
+    has_scalability = scal_reg > 0 or scal_imp > 0 or scal_sup > 0
+    if has_throughput or has_scalability:
         conditions = (
             f">\u00b15% threshold, non-overlapping error bars, "
             f"<{MAX_RELATIVE_ERROR_PCT:.0f}% relative error"
         )
-        lines.append(f"**Summary:** {', '.join(parts)} ({conditions})")
+        if has_throughput:
+            parts = []
+            if regressions > 0:
+                parts.append(f":red_circle: {regressions} regression(s)")
+            if improvements > 0:
+                parts.append(
+                    f":green_circle: {improvements} improvement(s)")
+            if suppressed > 0:
+                parts.append(
+                    f":warning: {suppressed} suppressed (high variance)")
+            lines.append(
+                f"**Throughput:** {', '.join(parts)} ({conditions})")
+        if has_scalability:
+            parts = []
+            if scal_reg > 0:
+                parts.append(
+                    f":red_circle: {scal_reg} scaling regression(s)")
+            if scal_imp > 0:
+                parts.append(
+                    f":green_circle: {scal_imp} scaling improvement(s)")
+            if scal_sup > 0:
+                parts.append(
+                    f":warning: {scal_sup} suppressed (high variance)")
+            lines.append(
+                f"**Scalability:** {', '.join(parts)} ({conditions})")
     lines.append("")
 
     for suite, label in [("SingleThread", "Single-Thread"),
@@ -287,21 +338,47 @@ def main():
     if all_queries:
         lines.append("### Scalability (MT/ST ratio)")
         lines.append("")
-        lines.append("| Benchmark | Base ratio | Head ratio | \u0394% |")
-        lines.append("|-----------|-----------|-----------|-----|")
+        lines.append(
+            "| Benchmark | Base ratio | Base err "
+            "| Head ratio | Head err | \u0394% |"
+        )
+        lines.append(
+            "|-----------|-----------|---------|"
+            "-----------|---------|-----|"
+        )
 
         for query in all_queries:
             b = base_scal.get(query)
             h = head_scal.get(query)
             if b and h:
                 delta = fmt_delta(b["ratio"], h["ratio"])
+                icon = delta_icon(
+                    b["ratio"], h["ratio"],
+                    base_error=b["ratio_error"],
+                    head_error=h["ratio_error"])
                 lines.append(
-                    f"| {query} | {b['ratio']:.2f}x | {h['ratio']:.2f}x | {delta} |"
+                    f"| {query} "
+                    f"| {b['ratio']:.2f}x "
+                    f"| {fmt_error(b['ratio'], b['ratio_error'])} "
+                    f"| {h['ratio']:.2f}x "
+                    f"| {fmt_error(h['ratio'], h['ratio_error'])} "
+                    f"| {delta}{icon} |"
                 )
             elif b:
-                lines.append(f"| {query} | {b['ratio']:.2f}x | \u2014 | removed |")
+                lines.append(
+                    f"| {query} "
+                    f"| {b['ratio']:.2f}x "
+                    f"| {fmt_error(b['ratio'], b['ratio_error'])} "
+                    f"| \u2014 | \u2014 | removed |"
+                )
             else:
-                lines.append(f"| {query} | \u2014 | {h['ratio']:.2f}x | new |")
+                lines.append(
+                    f"| {query} "
+                    f"| \u2014 | \u2014 "
+                    f"| {h['ratio']:.2f}x "
+                    f"| {fmt_error(h['ratio'], h['ratio_error'])} "
+                    f"| new |"
+                )
         lines.append("")
 
     output = "\n".join(lines)

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -62,24 +62,29 @@ def parse_jmh_results(data):
 def compute_scalability(results):
     """Compute MT/ST throughput ratio per query with error propagation.
 
-    For R = MT/ST, the propagated error is:
-        σ_R = R * sqrt((σ_MT/MT)² + (σ_ST/ST)²)
+    For R = MT/ST, the propagated absolute error is:
+        σ_R = sqrt((σ_MT/ST)² + (R·σ_ST/ST)²)
+
+    This formula is safe when MT=0 (unlike relative error propagation).
     """
     st = {k[0]: v for k, v in results.items() if k[1] == "SingleThread"}
     mt = {k[0]: v for k, v in results.items() if k[1] == "MultiThread"}
 
     scalability = {}
     for query in st:
-        if query in mt and st[query]["score"] > 0 and mt[query]["score"] > 0:
-            ratio = mt[query]["score"] / st[query]["score"]
-            rel_err_mt = mt[query]["score_error"] / mt[query]["score"]
-            rel_err_st = st[query]["score_error"] / st[query]["score"]
-            ratio_error = ratio * math.sqrt(rel_err_mt ** 2 + rel_err_st ** 2)
+        if query in mt and st[query]["score"] > 0:
+            st_score = st[query]["score"]
+            mt_score = mt[query]["score"]
+            ratio = mt_score / st_score
+            ratio_error = math.sqrt(
+                (mt[query]["score_error"] / st_score) ** 2
+                + (ratio * st[query]["score_error"] / st_score) ** 2
+            )
             scalability[query] = {
                 "ratio": ratio,
                 "ratio_error": ratio_error,
-                "st_score": st[query]["score"],
-                "mt_score": mt[query]["score"],
+                "st_score": st_score,
+                "mt_score": mt_score,
             }
     return scalability
 

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -70,12 +70,10 @@ def compute_scalability(results):
 
     scalability = {}
     for query in st:
-        if query in mt and st[query]["score"] > 0:
+        if query in mt and st[query]["score"] > 0 and mt[query]["score"] > 0:
             ratio = mt[query]["score"] / st[query]["score"]
-            rel_err_mt = (mt[query]["score_error"] / mt[query]["score"]
-                          if mt[query]["score"] > 0 else 0)
-            rel_err_st = (st[query]["score_error"] / st[query]["score"]
-                          if st[query]["score"] > 0 else 0)
+            rel_err_mt = mt[query]["score_error"] / mt[query]["score"]
+            rel_err_st = st[query]["score_error"] / st[query]["score"]
             ratio_error = ratio * math.sqrt(rel_err_mt ** 2 + rel_err_st ** 2)
             scalability[query] = {
                 "ratio": ratio,
@@ -201,10 +199,11 @@ def build_suite_table(base, head, suite):
     return rows
 
 
-def count_changes(base, head, threshold_pct=5.0):
+def _count_gated_changes(pairs, threshold_pct=5.0):
     """Count regressions, improvements, and suppressed changes.
 
-    A change is counted only when the percentage exceeds the threshold
+    ``pairs`` is an iterable of (base_value, base_error, head_value, head_error)
+    tuples.  A change is counted only when the percentage exceeds the threshold
     AND the error bars do not overlap AND neither side has high variance.
     Changes that meet the first two criteria but fail the variance check
     are counted as suppressed.
@@ -212,24 +211,45 @@ def count_changes(base, head, threshold_pct=5.0):
     regressions = 0
     improvements = 0
     suppressed = 0
+    for base_val, base_err, head_val, head_err in pairs:
+        if base_val <= 0:
+            continue
+        delta = (head_val - base_val) / base_val * 100
+        overlap = errors_overlap(base_val, base_err, head_val, head_err)
+        high_var = (_is_high_variance(base_val, base_err)
+                    or _is_high_variance(head_val, head_err))
+        if abs(delta) >= threshold_pct and not overlap:
+            if high_var:
+                suppressed += 1
+            elif delta <= -threshold_pct:
+                regressions += 1
+            else:
+                improvements += 1
+    return regressions, improvements, suppressed
+
+
+def count_changes(base, head, threshold_pct=5.0):
+    """Count throughput regressions, improvements, and suppressed changes."""
+    pairs = []
     for key in base.keys() | head.keys():
         b = base.get(key)
         h = head.get(key)
-        if b and h and b["score"] > 0:
-            delta = (h["score"] - b["score"]) / b["score"] * 100
-            overlap = errors_overlap(
-                b["score"], b["score_error"],
-                h["score"], h["score_error"])
-            high_var = (_is_high_variance(b["score"], b["score_error"])
-                        or _is_high_variance(h["score"], h["score_error"]))
-            if abs(delta) >= threshold_pct and not overlap:
-                if high_var:
-                    suppressed += 1
-                elif delta <= -threshold_pct:
-                    regressions += 1
-                else:
-                    improvements += 1
-    return regressions, improvements, suppressed
+        if b and h:
+            pairs.append((b["score"], b["score_error"],
+                          h["score"], h["score_error"]))
+    return _count_gated_changes(pairs, threshold_pct)
+
+
+def count_scalability_changes(base_scal, head_scal, threshold_pct=5.0):
+    """Count scalability ratio regressions, improvements, and suppressed."""
+    pairs = []
+    for query in base_scal.keys() | head_scal.keys():
+        b = base_scal.get(query)
+        h = head_scal.get(query)
+        if b and h:
+            pairs.append((b["ratio"], b["ratio_error"],
+                          h["ratio"], h["ratio_error"]))
+    return _count_gated_changes(pairs, threshold_pct)
 
 
 def main():
@@ -253,28 +273,8 @@ def main():
     head_scal = compute_scalability(head)
 
     regressions, improvements, suppressed = count_changes(base, head)
-
-    # Count scalability ratio changes using the same gating logic
-    scal_reg = 0
-    scal_imp = 0
-    scal_sup = 0
-    for query in base_scal.keys() | head_scal.keys():
-        b = base_scal.get(query)
-        h = head_scal.get(query)
-        if b and h and b["ratio"] > 0:
-            delta = (h["ratio"] - b["ratio"]) / b["ratio"] * 100
-            overlap = errors_overlap(
-                b["ratio"], b["ratio_error"],
-                h["ratio"], h["ratio_error"])
-            high_var = (_is_high_variance(b["ratio"], b["ratio_error"])
-                        or _is_high_variance(h["ratio"], h["ratio_error"]))
-            if abs(delta) >= 5.0 and not overlap:
-                if high_var:
-                    scal_sup += 1
-                elif delta <= -5.0:
-                    scal_reg += 1
-                else:
-                    scal_imp += 1
+    scal_reg, scal_imp, scal_sup = count_scalability_changes(
+        base_scal, head_scal)
 
     lines = []
     lines.append("## JMH LDBC Benchmark Comparison")
@@ -315,6 +315,8 @@ def main():
                     f":warning: {scal_sup} suppressed (high variance)")
             lines.append(
                 f"**Scalability:** {', '.join(parts)} ({conditions})")
+    else:
+        lines.append("**Summary:** No significant changes detected.")
     lines.append("")
 
     for suite, label in [("SingleThread", "Single-Thread"),


### PR DESCRIPTION
#### Motivation:

The JMH comparison script (`jmh-compare.py`) reported scalability ratio changes (MT/ST) without confidence intervals, making it impossible to distinguish real scaling regressions from noise. Meanwhile, the throughput and scalability gating logic were duplicated inline in multiple places, risking drift.

This PR:

1. **Propagates confidence intervals to the scalability ratio** using standard error propagation (σ_R = R·√((σ_MT/MT)² + (σ_ST/ST)²)), so the same three-condition gating (±5% threshold, non-overlapping error bars, <15% relative error) applies to scaling changes.

2. **Extracts `_classify_change()`** as the single source of truth for the three-condition gating logic, used by both `delta_icon()` and `_count_gated_changes()`.

3. **Deduplicates counting logic** into `_count_gated_changes()` shared by throughput and scalability comparisons.

4. **Separates throughput and scalability summaries** in the PR comment header for clarity.

5. **Adds error columns** to the scalability table and applies regression/improvement icons.