### PR TITLE
[no-test-number-check] Harden CI fix agent workflow and prompt

### DIFF
--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -194,28 +194,34 @@ jobs:
 
           - **Test failure**: A test assertion or error — go to Step 2.
           - **CI gate failure** (coverage gate, test count gate): A policy
-            check failed, not a test. Read PR comments for gate details.
-            Understand the gate's threshold and why it triggered — go to
-            Step 1a.
+            check failed, not a test. Understand the gate's threshold and
+            why it triggered — go to Step 1a.
           - **Build failure**: Compilation error, dependency issue — read
-            build logs, trace the error to its source file, fix the code
-            or build configuration, then go to Step 5 to verify. If the
-            error is in production code, go through Steps 3-4 first to
-            ensure you understand the root cause.
+            build logs, trace the error to its source file. Then go
+            through Steps 3-4 to understand the root cause before
+            applying a fix, and Step 5 to verify.
           - **Infrastructure failure**: Timeout, runner issue, flaky network
-            — write a summary noting this is infra-related and skip fix.
-            Close the draft PR with a comment explaining the infra issue.
+            — close the draft PR with a comment explaining the infra
+            issue, then go to Step 8 to write a summary.
 
           ### Step 1a: Diagnose CI gate failures
 
-          1. Read the gate's PR comment — it has specific data.
+          1. Check whether the failed run is associated with a PR
+             (`gh run view {run_id} --json headBranch,event`). If it is,
+             read the gate's PR comment — it has specific data (test
+             counts, coverage percentages). If it ran on `develop`
+             directly, extract gate details from the job logs instead.
           2. Check CLAUDE.md and gate scripts for exact rules.
           3. **Test Count Gate**: Compare baseline vs current per module. A
              big drop usually means tests were excluded by build config
-             changes. Trace WHY — don't just bypass.
+             changes. Trace the Maven profile chain — which profile was
+             removed, what did it activate, which `pom.xml` depended on
+             it. Don't just bypass.
           4. **Coverage Gate**: Check which lines are uncovered and whether
              existing tests should cover them.
           5. The fix is often in build configuration, not test code.
+          6. Once you understand the root cause, proceed to Step 4 to
+             apply the fix.
 
           ## Step 2: Locate and understand the failing test
 
@@ -247,9 +253,9 @@ jobs:
              - Test has overly strict assertion on genuinely non-deterministic
                behavior (e.g., iteration order of a hash set) → fix test,
                but ONLY if you can prove the non-determinism is legitimate
-          6. For build config issues: trace the Maven profile chain — which
-             profile was removed, what did it activate, which `pom.xml`
-             depended on it.
+          6. For build failures: trace the compilation or dependency error
+             back to the source — which file, which change introduced it,
+             and why it breaks the build.
           7. **Document your root cause analysis before making changes.**
              Write it out explicitly — this forces clear thinking and
              prevents jumping to superficial fixes.

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -174,19 +174,75 @@ jobs:
 
           ## Step 4: Trace the root cause
 
+          **Do NOT skip this step. Do NOT proceed to Step 5 until you can
+          clearly explain WHY the failure happens — not just WHAT fails.**
+
           1. Read the production code exercised by the failing test.
           2. Understand the full data flow from code under test to assertion.
-          3. Determine if the fix goes in the test or production code:
+          3. For concurrency failures: identify the exact race condition —
+             which threads, which shared state, which missing
+             happens-before edge.
+          4. For assertion failures: trace the actual value back to its
+             origin. Where in the production code is the wrong value
+             computed or the wrong state produced? Don't stop at "the
+             assertion got the wrong value" — find WHERE and WHY the
+             wrong value was produced.
+          5. Determine if the fix goes in the test or production code:
              - Test asserts a contract production code violates → fix prod
-             - Test has overly strict assertion → fix test
-          4. For build config issues: trace the Maven profile chain — which
+             - Test has overly strict assertion on genuinely non-deterministic
+               behavior (e.g., iteration order of a hash set) → fix test,
+               but ONLY if you can prove the non-determinism is legitimate
+          6. For build config issues: trace the Maven profile chain — which
              profile was removed, what did it activate, which `pom.xml`
              depended on it.
-          5. Document your root cause analysis before making changes.
+          7. **Document your root cause analysis before making changes.**
+             Write it out explicitly — this forces clear thinking and
+             prevents jumping to superficial fixes.
 
           ## Step 5: Apply the fix
 
-          1. Make the minimal change that fixes the root cause.
+          **CRITICAL: Fix the root cause, not the symptom.** Your job is to
+          find and fix the actual bug or design flaw that caused the failure.
+          A correct fix addresses WHY the failure happened, not just WHAT
+          failed.
+
+          **Anti-patterns to avoid (these hide real bugs):**
+          - Adding `try/catch` to swallow exceptions instead of fixing the
+            code that throws them
+          - Adding `Thread.sleep()` or retry loops to mask race conditions
+            instead of fixing synchronization
+          - Relaxing assertions (e.g., changing `assertEquals` to
+            `assertTrue(x > 0)`) instead of fixing the code that produces
+            wrong values
+          - Adding `@Ignore` / `@Disabled` to failing tests
+          - Wrapping flaky operations in "tolerance" logic that accepts
+            both correct and incorrect results
+          - Catching `ConcurrentModificationException` instead of fixing
+            the unsafe concurrent access
+          - Adding null checks at the symptom site instead of fixing the
+            code that produces null upstream
+
+          **How to determine the correct fix:**
+          1. You MUST understand the root cause from Step 4 before writing
+             any code. If you cannot articulate WHY the failure happens,
+             go back to Step 4.
+          2. The fix should make the failing scenario **impossible**, not
+             just unlikely or harder to trigger.
+          3. For concurrency bugs: fix the synchronization, data structure
+             choice, or happens-before relationship — not the timing.
+          4. For logic bugs: fix the computation or state management, not
+             the assertion that catches the wrong result.
+          5. For flaky tests caused by genuine non-determinism (e.g., hash
+             map iteration order, GC timing): it is acceptable to make
+             the test tolerant of valid variation, but you must prove the
+             variation is legitimate (not a bug) and document this in a
+             comment.
+
+          **Implementation guidelines:**
+          1. Fix the root cause in the right layer (production code vs test
+             code, per your Step 4 analysis). Keep the change focused —
+             don't refactor unrelated code — but don't artificially minimize
+             the fix if a proper solution needs more lines.
           2. Add comments explaining **why** the fix is correct.
           3. Update Javadoc for affected methods/classes.
           4. Add Java `assert` statements in production code touched by the
@@ -405,8 +461,13 @@ jobs:
 
           - Always use `gh` CLI for GitHub API, not WebFetch.
           - Read before editing — always read full test and production code.
-          - Minimal changes — fix root cause, don't refactor surroundings.
+          - **Fix root cause, not symptoms** — never apply a patch that
+            makes the failure less visible without fixing the underlying
+            bug. A correct fix makes the failure scenario impossible, not
+            just unlikely.
           - Don't blindly relax assertions — understand why they fail first.
+            If the production code returns a wrong value, fix the code, not
+            the assertion.
           - Don't bypass CI gates without understanding why tests disappeared.
           - Build config changes have test side effects — check Maven profiles.
           - NEVER run multiple test processes simultaneously.

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -114,7 +114,10 @@ jobs:
              gh run view {run_id} --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .databaseId'
              gh run view --job {job_id} --log-failed
              ```
-          3. Get check run annotations for exact test names and error messages:
+             The `databaseId` returned here doubles as the check run ID
+             for the GitHub Checks API.
+          3. Get check run annotations for exact test names and error messages
+             (use the `databaseId` from step 2 as `{check_run_id}`):
              ```bash
              gh api "repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"
              ```
@@ -195,7 +198,10 @@ jobs:
             Understand the gate's threshold and why it triggered — go to
             Step 1a.
           - **Build failure**: Compilation error, dependency issue — read
-            build logs.
+            build logs, trace the error to its source file, fix the code
+            or build configuration, then go to Step 5 to verify. If the
+            error is in production code, go through Steps 3-4 first to
+            ensure you understand the root cause.
           - **Infrastructure failure**: Timeout, runner issue, flaky network
             — write a summary noting this is infra-related and skip fix.
             Close the draft PR with a comment explaining the infra issue.
@@ -448,10 +454,17 @@ jobs:
 
           ## Step 7: Commit, push, and update the draft PR
 
-          The draft PR was already created in Step 0c. Now commit the
-          actual fix, push, and convert it to ready-for-review.
+          The draft PR was already created in Step 0c. Now either
+          commit the fix or close the draft PR.
 
-          1. Stage and commit with a descriptive message:
+          1. **If no code changes are needed** (infra issue, already
+             fixed, or unfixable), close the draft PR and skip to
+             Step 8:
+             ```bash
+             gh pr close "$PR_NUMBER" \
+               --comment "No code fix needed: <reason>"
+             ```
+          2. Stage and commit with a descriptive message:
              ```bash
              git add <changed-files>
              git commit -m "$(cat <<'EOF'
@@ -461,11 +474,11 @@ jobs:
              EOF
              )"
              ```
-          2. Push the fix:
+          3. Push the fix:
              ```bash
              git push
              ```
-          3. Update the PR title, body, and convert to ready-for-review:
+          4. Update the PR title, body, and convert to ready-for-review:
              ```bash
              gh pr edit "$PR_NUMBER" \
                --title "[no-test-number-check] Fix <description>" \
@@ -490,12 +503,6 @@ jobs:
              )"
 
              gh pr ready "$PR_NUMBER"
-             ```
-          4. If no code changes are needed (infra issue, already fixed),
-             close the draft PR with a comment explaining why:
-             ```bash
-             gh pr close "$PR_NUMBER" \
-               --comment "No code fix needed: <reason>"
              ```
 
           ## Step 8: Write summary report

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Install jq
+        run: |
+          if ! command -v jq &>/dev/null; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq jq
+          fi
+
       - name: Configure Git
         run: |
           git config user.name "ci-fix-agent[bot]"
@@ -493,7 +499,7 @@ jobs:
           echo "Agent finished. JSON log: $(wc -c < "$JSON_LOG" 2>/dev/null || echo 0) bytes"
 
       - name: Upload agent JSON log
-        if: always()
+        if: always() && steps.run-agent.outputs.json_log != ''
         uses: actions/upload-artifact@v4
         with:
           name: fix-agent-json-log

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -286,9 +286,10 @@ jobs:
             code that produces null upstream
 
           **How to determine the correct fix:**
-          1. You MUST understand the root cause from Step 3 before writing
-             any code. If you cannot articulate WHY the failure happens,
-             go back to Step 3.
+          1. You MUST understand the root cause from Step 3 (or Step 1a
+             for gate failures) before writing any code. If you cannot
+             articulate WHY the failure happens, go back to the
+             appropriate root-cause step.
           2. The fix should make the failing scenario **impossible**, not
              just unlikely or harder to trigger.
           3. For concurrency bugs: fix the synchronization, data structure

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -198,11 +198,12 @@ jobs:
             why it triggered — go to Step 1a.
           - **Build failure**: Compilation error, dependency issue — read
             build logs, trace the error to its source file. Then go
-            through Steps 3-4 to understand the root cause before
-            applying a fix, and Step 5 to verify.
+            through Steps 3-4 to understand the root cause and apply
+            the fix, Step 5 to verify, Step 6 for dimensional review,
+            and Step 7 to commit and update the PR.
           - **Infrastructure failure**: Timeout, runner issue, flaky network
-            — close the draft PR with a comment explaining the infra
-            issue, then go to Step 8 to write a summary.
+            — go to Step 7 to close the draft PR with a comment
+            explaining the infra issue, then Step 8 to write a summary.
 
           ### Step 1a: Diagnose CI gate failures
 
@@ -221,7 +222,7 @@ jobs:
              existing tests should cover them.
           5. The fix is often in build configuration, not test code.
           6. Once you understand the root cause, proceed to Step 4 to
-             apply the fix.
+             apply the fix, then continue through Steps 5-7.
 
           ## Step 2: Locate and understand the failing test
 
@@ -442,9 +443,10 @@ jobs:
           6. **Re-run only the agent(s) with open findings** on the updated
              changes.
 
-          7. **Repeat steps 4-6** until no blocker/should-fix findings remain.
-             Maximum 3 iterations. If after 3 rounds there are still critical
-             issues, document them in the summary and proceed.
+          7. **Repeat sub-steps 4-6 above** until no blocker/should-fix
+             findings remain. Maximum 3 iterations. If after 3 rounds
+             there are still critical issues, document them in the
+             summary and proceed.
 
           8. **Final full test run after review loop completes.**
              After the review loop exits (all findings addressed or max
@@ -455,7 +457,7 @@ jobs:
                -Dyoutrackdb.test.env=ci
              ```
              If any test fails, fix the failure, re-run `spotless:apply`,
-             and re-run the suite. Do NOT proceed to Step 7 with
+             and re-run the suite. Do NOT proceed to main Step 7 with
              failing tests.
 
           ## Step 7: Commit, push, and update the draft PR

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -200,7 +200,8 @@ jobs:
             build logs, trace the error to its source file. Then go
             through Steps 3-4 to understand the root cause and apply
             the fix, Step 5 to verify, Step 6 for dimensional review,
-            and Step 7 to commit and update the PR.
+            Step 7 to commit and update the PR, and Step 8 to write
+            the summary.
           - **Infrastructure failure**: Timeout, runner issue, flaky network
             — go to Step 7 to close the draft PR with a comment
             explaining the infra issue, then Step 8 to write a summary.
@@ -222,7 +223,7 @@ jobs:
              existing tests should cover them.
           5. The fix is often in build configuration, not test code.
           6. Once you understand the root cause, proceed to Step 4 to
-             apply the fix, then continue through Steps 5-7.
+             apply the fix, then continue through Steps 5-8.
 
           ## Step 2: Locate and understand the failing test
 

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -222,7 +222,11 @@ jobs:
           4. **Coverage Gate**: Check which lines are uncovered and whether
              existing tests should cover them.
           5. The fix is often in build configuration, not test code.
-          6. Once you understand the root cause, proceed to Step 4 to
+          6. **Document your root cause analysis before making changes.**
+             Write it out explicitly — this forces clear thinking and
+             prevents jumping to superficial fixes (same requirement as
+             Step 3 item 7, which gate failures skip).
+          7. Once you understand the root cause, proceed to Step 4 to
              apply the fix, then continue through Steps 5-8.
 
           ## Step 2: Locate and understand the failing test
@@ -240,6 +244,7 @@ jobs:
           **Do NOT skip this step. Do NOT proceed to Step 4 until you can
           clearly explain WHY the failure happens — not just WHAT fails.**
 
+          **For test failures (coming from Step 2):**
           1. Read the production code exercised by the failing test.
           2. Understand the full data flow from code under test to assertion.
           3. For concurrency failures: identify the exact race condition —
@@ -255,9 +260,13 @@ jobs:
              - Test has overly strict assertion on genuinely non-deterministic
                behavior (e.g., iteration order of a hash set) → fix test,
                but ONLY if you can prove the non-determinism is legitimate
-          6. For build failures: trace the compilation or dependency error
-             back to the source — which file, which change introduced it,
-             and why it breaks the build.
+
+          **For build failures (coming from Step 1):**
+          6. Trace the compilation or dependency error back to the source —
+             which file, which change introduced it, and why it breaks the
+             build. Check recent commits (`git log --oneline -20`) to
+             identify the change that introduced the breakage.
+
           7. **Document your root cause analysis before making changes.**
              Write it out explicitly — this forces clear thinking and
              prevents jumping to superficial fixes.
@@ -323,11 +332,19 @@ jobs:
 
           ## Step 5: Verify locally
 
-          1. Run the failing test first to confirm the fix:
+          1. **For test failures**: Run the failing test first to confirm
+             the fix:
              ```bash
              ./mvnw -pl {module} clean test -Dtest={TestClass} \
                -Dyoutrackdb.test.env=ci
              ```
+             **For build failures**: Verify the build compiles:
+             ```bash
+             ./mvnw -pl {module} clean compile
+             ```
+             **For gate failures**: Run the gate's check to confirm the
+             fix (e.g., test count comparison, coverage report). The
+             full test run in item 4 will also exercise the gate logic.
           2. If the test requires a suite runner (GremlinProcessRunner, graph
              provider), note it cannot run standalone — verify by inspection.
           3. Run `./mvnw -pl {module} spotless:check` for formatting.

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -493,10 +493,15 @@ jobs:
               ) catch empty
             '
 
+          CLAUDE_EXIT=${PIPESTATUS[0]}
           set -o pipefail
 
           echo "json_log=$JSON_LOG" >> "$GITHUB_OUTPUT"
-          echo "Agent finished. JSON log: $(wc -c < "$JSON_LOG" 2>/dev/null || echo 0) bytes"
+          echo "Agent finished (exit code $CLAUDE_EXIT). JSON log: $(wc -c < "$JSON_LOG" 2>/dev/null || echo 0) bytes"
+          if [ "$CLAUDE_EXIT" -ne 0 ]; then
+            echo "::warning::Claude Code exited with code $CLAUDE_EXIT"
+          fi
+          exit "$CLAUDE_EXIT"
 
       - name: Upload agent JSON log
         if: always() && steps.run-agent.outputs.json_log != ''
@@ -519,12 +524,12 @@ jobs:
 
           # Write to file for the Zulip step (avoids escaping issues)
           cat > /tmp/zulip-message-$$.md <<EOF
-          **CI Fix Agent Report** :robot:
-          Investigated failure in **${FAILED_WORKFLOW_NAME}** for commit \`${TRIGGER_SHA}\`.
-          [Failed Run](${FAILED_RUN_URL}) | [Agent Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+**CI Fix Agent Report** :robot:
+Investigated failure in **${FAILED_WORKFLOW_NAME}** for commit \`${TRIGGER_SHA}\`.
+[Failed Run](${FAILED_RUN_URL}) | [Agent Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-          ${SUMMARY}
-          EOF
+${SUMMARY}
+EOF
 
           echo "zulip_message_file=/tmp/zulip-message-$$.md" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -101,27 +101,9 @@ jobs:
           - NEVER run multiple test processes simultaneously in the same
             directory.
 
-          ## Step 0: Check for existing fix PRs
+          ## Step 0: Identify the failure and check for existing fix PRs
 
-          Before any investigation, check whether someone (human or previous
-          agent run) has already opened a PR that addresses this failure.
-
-          1. List open PRs targeting `develop`:
-             ```bash
-             gh pr list --base develop --state open \
-               --json number,title,headRefName,body,labels --limit 50
-             ```
-          2. Look for PRs whose title or body mentions:
-             - The failing test class name (extract from the failed run logs)
-             - "ci-fix" or "fix ci" or "flaky" keywords
-             - A branch name starting with `ci-fix/`
-          3. If a matching PR exists:
-             - Write a summary to `/tmp/fix-agent-summary.md` noting
-               that a fix PR already exists (include PR number and URL).
-             - Exit without making changes.
-          4. If no matching PR exists, proceed to Step 1.
-
-          ## Step 1: Identify the failure
+          ### 0a: Identify the failure first
 
           1. Use `gh` CLI to fetch the failed workflow run details:
              ```bash
@@ -136,22 +118,89 @@ jobs:
              ```bash
              gh api "repos/{owner}/{repo}/check-runs/{check_run_id}/annotations"
              ```
+          4. Note the failing test class name(s), error message(s), and module.
 
-          ## Step 2: Classify the failure type
+          ### 0b: Check for existing fix PRs
+
+          Before starting work, check whether someone (human or previous
+          agent run) has already opened a PR that addresses this failure.
+
+          1. List open PRs targeting `develop`:
+             ```bash
+             gh pr list --base develop --state open \
+               --json number,title,headRefName,body,labels --limit 50
+             ```
+          2. Look for PRs whose title or body mentions:
+             - The failing test class name (from Step 0a)
+             - "ci-fix" or "fix ci" or "flaky" keywords
+             - A branch name starting with `ci-fix/`
+          3. If a matching PR exists:
+             - Write a summary to `/tmp/fix-agent-summary.md` noting
+               that a fix PR already exists (include PR number and URL).
+             - Exit without making changes.
+          4. If no matching PR exists, proceed to Step 0c.
+
+          ### 0c: Create a draft PR to claim this fix
+
+          Create a draft PR immediately to prevent other agents or humans
+          from duplicating work on the same failure.
+
+          1. Create a fix branch:
+             ```bash
+             git checkout -b ci-fix/$(date +%Y%m%d-%H%M%S) develop
+             ```
+          2. Create an empty commit and push:
+             ```bash
+             git commit --allow-empty -m "$(cat <<'EOF'
+             WIP: Investigating CI failure
+
+             Placeholder commit — fix in progress.
+             EOF
+             )"
+             git push -u origin HEAD
+             ```
+          3. Create a **draft** PR:
+             ```bash
+             gh pr create --draft --base develop \
+               --title "[ci-fix] Investigating: <short failure description>" \
+               --body "$(cat <<'EOF'
+             ## Status
+             :construction: **Investigation in progress** — automated CI fix agent is working on this.
+
+             ## Failure
+             - **Failed run**: <failed_run_url>
+             - **Workflow**: <failed_workflow_name>
+             - **Commit**: <trigger_sha>
+             - **Failing test(s)**: <test class and error from Step 0a>
+
+             ## Notes
+             This draft PR was created automatically to signal that a fix is
+             in progress. It will be updated with the actual fix and converted
+             to ready-for-review when complete.
+             EOF
+             )"
+             ```
+          4. Save the PR number for later:
+             ```bash
+             PR_NUMBER=$(gh pr view --json number -q .number)
+             ```
+
+          ## Step 1: Classify the failure
 
           Identify the category before diving into code:
 
-          - **Test failure**: A test assertion or error — go to Step 3.
+          - **Test failure**: A test assertion or error — go to Step 2.
           - **CI gate failure** (coverage gate, test count gate): A policy
             check failed, not a test. Read PR comments for gate details.
             Understand the gate's threshold and why it triggered — go to
-            Step 2a.
+            Step 1a.
           - **Build failure**: Compilation error, dependency issue — read
             build logs.
           - **Infrastructure failure**: Timeout, runner issue, flaky network
             — write a summary noting this is infra-related and skip fix.
+            Close the draft PR with a comment explaining the infra issue.
 
-          ### Step 2a: Diagnose CI gate failures
+          ### Step 1a: Diagnose CI gate failures
 
           1. Read the gate's PR comment — it has specific data.
           2. Check CLAUDE.md and gate scripts for exact rules.
@@ -162,7 +211,7 @@ jobs:
              existing tests should cover them.
           5. The fix is often in build configuration, not test code.
 
-          ## Step 3: Locate and understand the failing test
+          ## Step 2: Locate and understand the failing test
 
           1. Find the test file: `Glob **/{TestClassName}.java`
           2. Read the full test file — understand the failing assertion.
@@ -172,9 +221,9 @@ jobs:
              - Environment issue: path separators, locale, OS-specific
              - Actual regression: code change broke the test
 
-          ## Step 4: Trace the root cause
+          ## Step 3: Trace the root cause
 
-          **Do NOT skip this step. Do NOT proceed to Step 5 until you can
+          **Do NOT skip this step. Do NOT proceed to Step 4 until you can
           clearly explain WHY the failure happens — not just WHAT fails.**
 
           1. Read the production code exercised by the failing test.
@@ -199,7 +248,7 @@ jobs:
              Write it out explicitly — this forces clear thinking and
              prevents jumping to superficial fixes.
 
-          ## Step 5: Apply the fix
+          ## Step 4: Apply the fix
 
           **CRITICAL: Fix the root cause, not the symptom.** Your job is to
           find and fix the actual bug or design flaw that caused the failure.
@@ -223,9 +272,9 @@ jobs:
             code that produces null upstream
 
           **How to determine the correct fix:**
-          1. You MUST understand the root cause from Step 4 before writing
+          1. You MUST understand the root cause from Step 3 before writing
              any code. If you cannot articulate WHY the failure happens,
-             go back to Step 4.
+             go back to Step 3.
           2. The fix should make the failing scenario **impossible**, not
              just unlikely or harder to trigger.
           3. For concurrency bugs: fix the synchronization, data structure
@@ -240,7 +289,7 @@ jobs:
 
           **Implementation guidelines:**
           1. Fix the root cause in the right layer (production code vs test
-             code, per your Step 4 analysis). Keep the change focused —
+             code, per your Step 3 analysis). Keep the change focused —
              don't refactor unrelated code — but don't artificially minimize
              the fix if a proper solution needs more lines.
           2. Add comments explaining **why** the fix is correct.
@@ -257,7 +306,7 @@ jobs:
              API** under `com.jetbrains.youtrackdb.api`.
           6. Run `./mvnw -pl {module} spotless:apply` to fix formatting.
 
-          ## Step 6: Verify locally
+          ## Step 5: Verify locally
 
           1. Run the failing test first to confirm the fix:
              ```bash
@@ -280,12 +329,12 @@ jobs:
                -Dyoutrackdb.test.env=ci
              ```
              Skip this step if no integration test files were modified.
-          6. **Do NOT proceed to Step 7 if any test fails.** Fix the
+          6. **Do NOT proceed to Step 6 if any test fails.** Fix the
              failures first and re-run.
 
-          ## Step 7: Dimensional review (MANDATORY GATE)
+          ## Step 6: Dimensional review (MANDATORY GATE)
 
-          **BLOCKING: Do NOT proceed to Step 8 until this step is fully
+          **BLOCKING: Do NOT proceed to Step 7 until this step is fully
           complete. Skipping this step is never acceptable — it exists to
           catch bugs in the fix itself before creating a PR.**
 
@@ -394,16 +443,15 @@ jobs:
                -Dyoutrackdb.test.env=ci
              ```
              If any test fails, fix the failure, re-run `spotless:apply`,
-             and re-run the suite. Do NOT proceed to Step 8 with
+             and re-run the suite. Do NOT proceed to Step 7 with
              failing tests.
 
-          ## Step 8: Commit, push, and create PR
+          ## Step 7: Commit, push, and update the draft PR
 
-          1. Create a fix branch:
-             ```bash
-             git checkout -b ci-fix/$(date +%Y%m%d-%H%M%S) develop
-             ```
-          2. Stage and commit with a descriptive message:
+          The draft PR was already created in Step 0c. Now commit the
+          actual fix, push, and convert it to ready-for-review.
+
+          1. Stage and commit with a descriptive message:
              ```bash
              git add <changed-files>
              git commit -m "$(cat <<'EOF'
@@ -413,34 +461,50 @@ jobs:
              EOF
              )"
              ```
-          3. Push and create PR:
+          2. Push the fix:
              ```bash
-             git push -u origin HEAD
-             gh pr create --base develop \
-               --title "Fix <description>" \
+             git push
+             ```
+          3. Update the PR title, body, and convert to ready-for-review:
+             ```bash
+             gh pr edit "$PR_NUMBER" \
+               --title "[no-test-number-check] Fix <description>" \
                --body "$(cat <<'EOF'
              ## Summary
              - <what was fixed and why>
+
+             ## Root Cause
+             <detailed technical explanation of why the failure happened>
+
+             ## Changes
+             <list of files changed and what each change does>
 
              ## Motivation
              CI failure on develop: <failed_run_url>
 
              ## Test plan
-             - [ ] Failing test passes locally
-             - [ ] No other tests broken
+             - [x] Failing test passes locally
+             - [x] Full test suite passes (unit + integration)
+             - [x] Dimensional code review completed
              EOF
              )"
+
+             gh pr ready "$PR_NUMBER"
              ```
           4. If no code changes are needed (infra issue, already fixed),
-             skip PR creation.
+             close the draft PR with a comment explaining why:
+             ```bash
+             gh pr close "$PR_NUMBER" \
+               --comment "No code fix needed: <reason>"
+             ```
 
-          ## Step 9: Write summary report
+          ## Step 8: Write summary report
 
           Write your final summary to `/tmp/fix-agent-summary.md`:
 
           ```markdown
           ## Status
-          <!-- One of: FIX_PR_CREATED, EXISTING_PR_FOUND, NO_FIX_NEEDED,
+          <!-- One of: FIX_PR_READY, EXISTING_PR_FOUND, DRAFT_PR_CLOSED,
                INVESTIGATION_ONLY -->
           <status>
 


### PR DESCRIPTION
#### PR Title:

[no-test-number-check] Harden CI fix agent workflow and prompt

#### Motivation:

The CI fix agent workflow had several reliability issues that caused it to fail or produce low-quality fixes:

1. **Missing `jq`** — the workflow used `jq` but never installed it, causing runtime failures
2. **Lost exit codes** — Claude's exit code was swallowed, so the workflow always reported success
3. **Broken Zulip notifications** — message formatting issues in failure notifications
4. **Missing artifact guard** — upload step failed when no artifacts existed
5. **Duplicate work** — concurrent agent runs or humans could start fixing the same failure simultaneously
6. **Symptom-level fixes** — the prompt led agents to patch symptoms rather than investigate root causes

**Workflow fixes:**
- Install `jq` dependency
- Propagate Claude's exit code correctly
- Fix Zulip message formatting
- Guard artifact upload against missing files
- Create a draft PR early to claim the fix and prevent duplicates

**Prompt improvements:**
- Restructure steps: identify failure first (Step 0a), then check for existing PRs (0b), then claim via draft PR (0c)
- Enforce root-cause analysis before writing any fix
- Add failure-type context throughout steps so the agent knows what kind of failure it's dealing with
- Fix step numbering, back-references, and flow consistency across all paths (build failure, gate failure, test failure)
- Add Step 8 references in all terminal paths