### PR TITLE
 YTDB-650: Back-reference hash join for MATCH patterns

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
@@ -1,0 +1,31 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import javax.annotation.Nullable;
+
+/**
+ * Pattern D — {@code $currentMatch NOT IN $matched.X.out('E')} anti-semi-join.
+ *
+ * <p>The hash table is built from {@code X.out('E')} (forward link bag) as a set of
+ * vertex RIDs. The probe discards upstream rows whose candidate RID appears in the set.
+ *
+ * @param anchorAlias           the alias X whose forward edges provide the exclusion set
+ * @param traversalEdgeClass    the edge class E
+ * @param traversalDirection    "out" or "in"
+ * @param backRefAlias          same as anchorAlias (the vertex to traverse from)
+ * @param targetAlias           the alias of the node whose WHERE clause contained NOT IN
+ * @param residualFilter        any remaining WHERE conditions after NOT IN extraction, or null
+ */
+public record AntiSemiJoin(
+    String anchorAlias,
+    String traversalEdgeClass,
+    String traversalDirection,
+    String backRefAlias,
+    String targetAlias,
+    @Nullable SQLWhereClause residualFilter) implements SemiJoinDescriptor {
+
+  @Override
+  public JoinMode joinMode() {
+    return JoinMode.ANTI_JOIN;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
  * <p>The NOT IN condition is stripped from the target alias's WHERE clause at plan
  * time so that the preceding {@link MatchStep} does not re-evaluate it per row.
  * The stripped condition is stored in {@link #notInCondition} for runtime fallback:
- * if the hash table build fails, {@link BackRefHashJoinStep#handleBuildFailure}
+ * if the hash table build fails, {@link BackRefHashJoinStep#handleAntiJoinBuildFailure}
  * evaluates it per row (the slow but correct path).
  *
  * @param anchorAlias           the alias X whose forward edges provide the exclusion set

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
@@ -24,6 +24,13 @@ public record AntiSemiJoin(
     String targetAlias,
     @Nullable SQLWhereClause residualFilter) implements SemiJoinDescriptor {
 
+  // backRefAlias is always identical to anchorAlias — it exists to satisfy
+  // the SemiJoinDescriptor.backRefAlias() interface contract.
+  public AntiSemiJoin {
+    assert anchorAlias.equals(backRefAlias)
+        : "backRefAlias must equal anchorAlias for AntiSemiJoin";
+  }
+
   @Override
   public JoinMode joinMode() {
     return JoinMode.ANTI_JOIN;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
@@ -18,7 +18,6 @@ import javax.annotation.Nullable;
  * @param anchorAlias           the alias X whose forward edges provide the exclusion set
  * @param traversalEdgeClass    the edge class E
  * @param traversalDirection    "out" or "in"
- * @param backRefAlias          same as anchorAlias (the vertex to traverse from)
  * @param targetAlias           the alias of the node whose WHERE clause contained NOT IN
  * @param notInCondition        the stripped NOT IN condition for fallback evaluation,
  *                              or null if the condition could not be preserved
@@ -27,19 +26,17 @@ public record AntiSemiJoin(
     String anchorAlias,
     String traversalEdgeClass,
     String traversalDirection,
-    String backRefAlias,
     String targetAlias,
     @Nullable SQLBooleanExpression notInCondition) implements SemiJoinDescriptor {
-
-  // backRefAlias is always identical to anchorAlias — it exists to satisfy
-  // the SemiJoinDescriptor.backRefAlias() interface contract.
-  public AntiSemiJoin {
-    assert anchorAlias.equals(backRefAlias)
-        : "backRefAlias must equal anchorAlias for AntiSemiJoin";
-  }
 
   @Override
   public JoinMode joinMode() {
     return JoinMode.ANTI_JOIN;
+  }
+
+  /** Returns {@link #anchorAlias()} — the vertex to traverse from is the anchor. */
+  @Override
+  public String backRefAlias() {
+    return anchorAlias;
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/AntiSemiJoin.java
@@ -1,6 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
-import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBooleanExpression;
 import javax.annotation.Nullable;
 
 /**
@@ -9,12 +9,19 @@ import javax.annotation.Nullable;
  * <p>The hash table is built from {@code X.out('E')} (forward link bag) as a set of
  * vertex RIDs. The probe discards upstream rows whose candidate RID appears in the set.
  *
+ * <p>The NOT IN condition is stripped from the target alias's WHERE clause at plan
+ * time so that the preceding {@link MatchStep} does not re-evaluate it per row.
+ * The stripped condition is stored in {@link #notInCondition} for runtime fallback:
+ * if the hash table build fails, {@link BackRefHashJoinStep#handleBuildFailure}
+ * evaluates it per row (the slow but correct path).
+ *
  * @param anchorAlias           the alias X whose forward edges provide the exclusion set
  * @param traversalEdgeClass    the edge class E
  * @param traversalDirection    "out" or "in"
  * @param backRefAlias          same as anchorAlias (the vertex to traverse from)
  * @param targetAlias           the alias of the node whose WHERE clause contained NOT IN
- * @param residualFilter        any remaining WHERE conditions after NOT IN extraction, or null
+ * @param notInCondition        the stripped NOT IN condition for fallback evaluation,
+ *                              or null if the condition could not be preserved
  */
 public record AntiSemiJoin(
     String anchorAlias,
@@ -22,7 +29,7 @@ public record AntiSemiJoin(
     String traversalDirection,
     String backRefAlias,
     String targetAlias,
-    @Nullable SQLWhereClause residualFilter) implements SemiJoinDescriptor {
+    @Nullable SQLBooleanExpression notInCondition) implements SemiJoinDescriptor {
 
   // backRefAlias is always identical to anchorAlias — it exists to satisfy
   // the SemiJoinDescriptor.backRefAlias() interface contract.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -1,15 +1,22 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
+import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.AbstractExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ExecutionStepInternal;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.RidSet;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.TraversalPreFilterHelper;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -84,7 +91,15 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     var localCache = cache;
     var localDescriptor = descriptor;
 
-    return upstream.filter((row, c) -> probeRow(row, localCache, localDescriptor, session, c));
+    // ChainSemiJoin needs flatMap (fan-out: one source → multiple edges)
+    if (localDescriptor instanceof ChainSemiJoin chainDesc) {
+      return upstream.flatMap(
+          (row, c) -> probeChain(row, localCache, chainDesc, session, c));
+    }
+
+    // SingleEdgeSemiJoin and AntiSemiJoin use filter (0 or 1 output per row)
+    return upstream.filter(
+        (row, c) -> probeRow(row, localCache, localDescriptor, session, c));
   }
 
   /**
@@ -148,7 +163,11 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       var value = single.backRefExpression().execute(row, ctx);
       return toRid(value);
     }
-    // ChainSemiJoin and AntiSemiJoin will be handled in Tracks 2 and 3
+    if (desc instanceof ChainSemiJoin chain) {
+      var value = chain.backRefExpression().execute(row, ctx);
+      return toRid(value);
+    }
+    // AntiSemiJoin will be handled in Track 3
     return null;
   }
 
@@ -158,6 +177,10 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   @Nullable private RID resolveSourceRid(Result row, SemiJoinDescriptor desc) {
     if (desc instanceof SingleEdgeSemiJoin single) {
       var value = row.getProperty(single.sourceAlias());
+      return toRid(value);
+    }
+    if (desc instanceof ChainSemiJoin chain) {
+      var value = row.getProperty(chain.sourceAlias());
       return toRid(value);
     }
     return null;
@@ -199,7 +222,10 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     if (desc instanceof SingleEdgeSemiJoin single) {
       return buildSingleEdgeHashTable(backRefRid, single, ctx);
     }
-    // ChainSemiJoin and AntiSemiJoin will be handled in Tracks 2 and 3
+    if (desc instanceof ChainSemiJoin chain) {
+      return buildChainHashTable(backRefRid, chain, ctx);
+    }
+    // AntiSemiJoin will be handled in Track 3
     return null;
   }
 
@@ -226,6 +252,137 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       }
     }
     return result;
+  }
+
+  /**
+   * Pattern B build: reads the reverse link bag of the back-referenced vertex,
+   * optionally filters by an index RidSet, loads matching edge records, and
+   * groups them by source vertex RID into a {@code Map<RID, List<Result>>}.
+   *
+   * <p>The map key is the source vertex RID (from where the original outE
+   * traversal starts). The value is a list of edge records that connect that
+   * source to the back-referenced vertex via the given edge class.
+   */
+  @Nullable private Map<RID, List<Result>> buildChainHashTable(
+      RID backRefRid, ChainSemiJoin chain, CommandContext ctx) {
+    var session = ctx.getDatabaseSession();
+    EntityImpl targetEntity;
+    try {
+      var rec = session.getActiveTransaction().load(backRefRid);
+      if (!(rec instanceof EntityImpl entity)) {
+        return null;
+      }
+      targetEntity = entity;
+    } catch (RecordNotFoundException e) {
+      return null;
+    }
+
+    // Read the reverse link bag
+    var reversePrefix = "out".equals(chain.direction()) ? "in_" : "out_";
+    var fieldName = reversePrefix + chain.edgeClass();
+    var fieldValue = targetEntity.getPropertyInternal(fieldName);
+    if (!(fieldValue instanceof LinkBag linkBag)) {
+      return null;
+    }
+
+    var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
+    if (linkBag.size() > maxSize) {
+      return null; // too large — fall back
+    }
+
+    // Optionally resolve index pre-filter for the intermediate edge
+    RidSet indexRidSet = null;
+    if (chain.indexFilter() != null) {
+      indexRidSet = TraversalPreFilterHelper.resolveIndexToRidSet(
+          chain.indexFilter(), ctx);
+    }
+
+    var result = new HashMap<RID, List<Result>>();
+    long count = 0;
+    for (var pair : linkBag) {
+      var edgeRid = pair.primaryRid();
+      var sourceVertexRid = pair.secondaryRid();
+
+      // Apply index filter if present (filters edge RIDs)
+      if (indexRidSet != null && !indexRidSet.contains(edgeRid)) {
+        continue;
+      }
+
+      // Load the edge record
+      try {
+        var edgeRec = session.getActiveTransaction().load(edgeRid);
+        var edgeResult = new ResultInternal(session, edgeRec);
+        result.computeIfAbsent(sourceVertexRid, k -> new ArrayList<>())
+            .add(edgeResult);
+        count++;
+        if (maxSize > 0 && count > maxSize) {
+          return null; // threshold exceeded
+        }
+      } catch (RecordNotFoundException e) {
+        // Edge record missing — skip
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Probe for ChainSemiJoin: returns 0..N rows per upstream row (fan-out).
+   * For each matching edge record, emits a result with the intermediate alias
+   * bound to the edge and the target alias bound to the back-ref vertex.
+   */
+  @SuppressWarnings("unchecked")
+  private ExecutionStream probeChain(
+      Result row,
+      LinkedHashMap<RID, Object> lruCache,
+      ChainSemiJoin chain,
+      DatabaseSessionEmbedded session,
+      CommandContext probeCtx) {
+    var backRefRid = resolveBackRefRid(row, chain, probeCtx);
+    if (backRefRid == null) {
+      return ExecutionStream.empty();
+    }
+
+    var hashTable = lruCache.get(backRefRid);
+    if (hashTable == null && !lruCache.containsKey(backRefRid)) {
+      hashTable = buildHashTable(backRefRid, chain, probeCtx);
+      lruCache.put(backRefRid, hashTable);
+    }
+
+    if (hashTable == null) {
+      return ExecutionStream.empty();
+    }
+
+    var sourceRid = resolveSourceRid(row, chain);
+    if (sourceRid == null) {
+      return ExecutionStream.empty();
+    }
+
+    var map = (Map<RID, List<Result>>) hashTable;
+    var edges = map.get(sourceRid);
+    if (edges == null || edges.isEmpty()) {
+      return ExecutionStream.empty();
+    }
+
+    // Load the back-ref vertex once for the target alias value
+    Object backRefVertex;
+    try {
+      backRefVertex = session.getActiveTransaction().load(backRefRid);
+    } catch (Exception e) {
+      return ExecutionStream.empty();
+    }
+
+    // Emit one row per matching edge, adding intermediate and target aliases
+    var results = new ArrayList<Result>(edges.size());
+    for (var edgeResult : edges) {
+      // Layer 1: add intermediate alias (edge record)
+      var withIntermediate = new MatchResultRow(
+          session, row, chain.intermediateAlias(), edgeResult);
+      // Layer 2: add target alias (back-ref vertex)
+      var withTarget = new MatchResultRow(
+          session, withIntermediate, chain.targetAlias(), backRefVertex);
+      results.add(withTarget);
+    }
+    return ExecutionStream.resultIterator(results.iterator());
   }
 
   /**
@@ -266,6 +423,15 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
           + single.sourceAlias()
           + " ⋈ $matched." + single.backRefAlias()
           + " via " + single.direction() + "('" + single.edgeClass() + "'))";
+    }
+    if (descriptor instanceof ChainSemiJoin chain) {
+      return spaces
+          + "+ BACK-REF HASH JOIN ("
+          + chain.sourceAlias()
+          + " ⋈ $matched." + chain.backRefAlias()
+          + " via " + chain.direction() + "E('" + chain.edgeClass() + "').inV()"
+          + " aliases: " + chain.intermediateAlias() + ", " + chain.targetAlias()
+          + ")";
     }
     return spaces + "+ BACK-REF HASH JOIN (" + descriptor.joinMode() + ")";
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -16,9 +16,9 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.RidSet;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.TraversalPreFilterHelper;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +70,14 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   @Nullable private final EdgeTraversal fallbackEdge;
 
   /**
+   * For Pattern B (ChainSemiJoin): the consumed predecessor edge (the
+   * {@code .outE('E')} part). When the hash table build fails at runtime,
+   * the fallback must traverse both the consumed edge and the main
+   * {@link #fallbackEdge} sequentially. Null for Patterns A and D.
+   */
+  @Nullable private final EdgeTraversal consumedEdge;
+
+  /**
    * LRU cache of hash tables keyed by back-referenced alias RID. Values are
    * {@code Map<RID, Integer>} for Pattern A, {@code Map<RID, List<Result>>}
    * for Pattern B, or {@code Set<RID>} for Pattern D. Access-order
@@ -82,11 +90,13 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       CommandContext ctx,
       SemiJoinDescriptor descriptor,
       @Nullable EdgeTraversal fallbackEdge,
+      @Nullable EdgeTraversal consumedEdge,
       boolean profilingEnabled) {
     super(ctx, profilingEnabled);
     assert MatchAssertions.checkNotNull(descriptor, "semi-join descriptor");
     this.descriptor = descriptor;
     this.fallbackEdge = fallbackEdge;
+    this.consumedEdge = consumedEdge;
   }
 
   @Override
@@ -129,7 +139,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
     // AntiSemiJoin uses filter (0 or 1 output per row)
     return upstream.filter(
-        (row, c) -> probeAntiJoin(row, localCache, localDescriptor, session, c));
+        (row, c) -> probeAntiJoin(row, localCache, localDescriptor, c));
   }
 
   // ---- Cache resolution (shared by probeRow and probeChain) ----
@@ -142,7 +152,6 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       Result row,
       LinkedHashMap<RID, Object> lruCache,
       SemiJoinDescriptor desc,
-      DatabaseSessionEmbedded session,
       CommandContext ctx) {
     var backRefRid = resolveBackRefRid(row, desc, ctx);
     if (backRefRid == null) {
@@ -151,21 +160,13 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
     var cached = lruCache.get(backRefRid);
     if (cached == null) {
-      var ht = buildHashTable(backRefRid, desc, ctx);
-      if (ht == null) {
+      var build = buildHashTable(backRefRid, desc, ctx);
+      if (build == null) {
         lruCache.put(backRefRid, BUILD_FAILED);
         return null;
       }
-      Object entity = null;
-      if (desc.joinMode() == JoinMode.SEMI_JOIN) {
-        try {
-          entity = session.getActiveTransaction().load(backRefRid);
-        } catch (RecordNotFoundException e) {
-          // vertex gone
-        }
-      }
-      cached = new CachedBuild(ht, entity);
-      lruCache.put(backRefRid, cached);
+      lruCache.put(backRefRid, build);
+      return build;
     }
     if (cached == BUILD_FAILED) {
       return null;
@@ -189,11 +190,11 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       SingleEdgeSemiJoin desc,
       DatabaseSessionEmbedded session,
       CommandContext probeCtx) {
-    var build = resolveBuild(row, lruCache, desc, session, probeCtx);
+    var build = resolveBuild(row, lruCache, desc, probeCtx);
     if (build == null) {
-      var fallback = handleBuildFailure(row, desc, probeCtx);
-      return fallback == null
-          ? ExecutionStream.empty() : ExecutionStream.singleton(fallback);
+      // Fall back to per-row nested-loop traversal, draining all results
+      // (not just the first) to preserve multi-edge fan-out semantics.
+      return nestedLoopFallback(row, probeCtx);
     }
 
     var sourceRid = resolveSourceRid(row, desc);
@@ -201,20 +202,22 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return ExecutionStream.empty();
     }
 
-    var map = (Map<RID, Integer>) build.hashTable();
-    var edgeCount = map.getOrDefault(sourceRid, 0);
+    var map = (Object2IntOpenHashMap<RID>) build.hashTable();
+    var edgeCount = map.getInt(sourceRid);
     if (edgeCount == 0) {
       return ExecutionStream.empty();
     }
 
-    var resultRow = new MatchResultRow(
-        session, row, desc.targetAlias(), build.backRefEntity());
     if (edgeCount == 1) {
-      return ExecutionStream.singleton(resultRow);
+      return ExecutionStream.singleton(new MatchResultRow(
+          session, row, desc.targetAlias(), build.backRefEntity()));
     }
+    // Create independent row instances for each edge to avoid mutation
+    // of a shared mutable MatchResultRow propagating across results.
     var results = new ArrayList<Result>(edgeCount);
     for (int i = 0; i < edgeCount; i++) {
-      results.add(resultRow);
+      results.add(new MatchResultRow(
+          session, row, desc.targetAlias(), build.backRefEntity()));
     }
     return ExecutionStream.resultIterator(results.iterator());
   }
@@ -228,11 +231,10 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       Result row,
       LinkedHashMap<RID, Object> lruCache,
       SemiJoinDescriptor desc,
-      DatabaseSessionEmbedded session,
       CommandContext probeCtx) {
-    var build = resolveBuild(row, lruCache, desc, session, probeCtx);
+    var build = resolveBuild(row, lruCache, desc, probeCtx);
     if (build == null) {
-      return handleBuildFailure(row, desc, probeCtx);
+      return handleAntiJoinBuildFailure(row, (AntiSemiJoin) desc, probeCtx);
     }
 
     var sourceRid = resolveSourceRid(row, desc);
@@ -256,7 +258,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       ChainSemiJoin chain,
       DatabaseSessionEmbedded session,
       CommandContext probeCtx) {
-    var build = resolveBuild(row, lruCache, chain, session, probeCtx);
+    var build = resolveBuild(row, lruCache, chain, probeCtx);
     if (build == null) {
       return nestedLoopFallback(row, probeCtx);
     }
@@ -286,49 +288,55 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   // ---- Fallback ----
 
   /**
-   * Handles build failure for probeRow (single-row context).
-   * Pattern A: falls back to per-row MatchEdgeTraverser.
-   * Pattern D: evaluates the stored NOT IN condition per row (the NOT IN
-   * was stripped from the MatchStep's WHERE clause at plan time, so the
-   * fallback must evaluate it here).
+   * Handles build failure for Pattern D (anti-join): evaluates the stored
+   * NOT IN condition per row. The NOT IN was stripped from the MatchStep's
+   * WHERE clause at plan time, so BackRefHashJoinStep is the sole evaluator.
    */
-  @Nullable private Result handleBuildFailure(
-      Result row, SemiJoinDescriptor desc, CommandContext ctx) {
-    if (desc.joinMode() == JoinMode.ANTI_JOIN) {
-      // Pattern D fallback: evaluate the stored NOT IN condition per row.
-      // The NOT IN was stripped from the MatchStep's filter at plan time,
-      // so BackRefHashJoinStep is the sole evaluator.
-      var anti = (AntiSemiJoin) desc;
-      if (anti.notInCondition() == null) {
-        return row;
-      }
-      // $currentMatch must be set for the NOT IN expression to resolve
-      var candidate = row.getProperty(anti.targetAlias());
-      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, candidate);
-      boolean passes = anti.notInCondition().evaluate(row, ctx);
-      return passes ? row : null;
+  @Nullable private Result handleAntiJoinBuildFailure(
+      Result row, AntiSemiJoin anti, CommandContext ctx) {
+    if (anti.notInCondition() == null) {
+      return row;
     }
-    // Pattern A: fall back to per-row nested-loop traversal
-    if (fallbackEdge == null) {
-      return null;
-    }
-    var traverser = createFallbackTraverser(row, fallbackEdge);
-    if (traverser.hasNext(ctx)) {
-      return traverser.next(ctx);
-    }
-    return null;
+    // $currentMatch must be set for the NOT IN expression to resolve
+    var candidate = row.getProperty(anti.targetAlias());
+    ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, candidate);
+    boolean passes = anti.notInCondition().evaluate(row, ctx);
+    return passes ? row : null;
   }
 
   /**
-   * Falls back to nested-loop traversal for Pattern B (ChainSemiJoin) when
-   * the hash table build fails. Creates a {@link MatchEdgeTraverser} that
-   * performs the same per-row link bag traversal as {@link MatchStep}.
+   * Falls back to nested-loop traversal when the hash table build fails.
+   *
+   * <p>For Pattern A (SingleEdgeSemiJoin), traverses the single fallback edge.
+   * For Pattern B (ChainSemiJoin), traverses the consumed predecessor edge
+   * first (outE), then the main fallback edge (inV) for each intermediate
+   * result, reproducing the two-edge chain.
    */
   private ExecutionStream nestedLoopFallback(
       Result row, CommandContext ctx) {
     if (fallbackEdge == null) {
       return ExecutionStream.empty();
     }
+
+    // Pattern B: two-edge chain fallback — traverse consumed outE edge
+    // first, then inV edge for each intermediate result
+    if (consumedEdge != null) {
+      var firstTraverser = createFallbackTraverser(row, consumedEdge);
+      var results = new ArrayList<Result>();
+      while (firstTraverser.hasNext(ctx)) {
+        var intermediate = firstTraverser.next(ctx);
+        var secondTraverser = createFallbackTraverser(
+            intermediate, fallbackEdge);
+        while (secondTraverser.hasNext(ctx)) {
+          results.add(secondTraverser.next(ctx));
+        }
+      }
+      return results.isEmpty()
+          ? ExecutionStream.empty()
+          : ExecutionStream.resultIterator(results.iterator());
+    }
+
+    // Pattern A: single-edge fallback
     var traverser = createFallbackTraverser(row, fallbackEdge);
     var results = new ArrayList<Result>();
     while (traverser.hasNext(ctx)) {
@@ -378,7 +386,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
   // ---- Build methods ----
 
-  @Nullable private Object buildHashTable(
+  @Nullable private CachedBuild buildHashTable(
       RID backRefRid, SemiJoinDescriptor desc, CommandContext ctx) {
     return switch (desc) {
       case SingleEdgeSemiJoin single -> buildSingleEdgeHashTable(
@@ -389,22 +397,28 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   }
 
   /**
+   * Loads an entity by RID. Returns {@code null} if the record is missing
+   * or is not an {@link EntityImpl}.
+   */
+  @Nullable private static EntityImpl loadEntity(RID rid, CommandContext ctx) {
+    try {
+      var rec = ctx.getDatabaseSession().getActiveTransaction().load(rid);
+      return rec instanceof EntityImpl entity ? entity : null;
+    } catch (RecordNotFoundException e) {
+      return null;
+    }
+  }
+
+  /**
    * Builds a hash table for Pattern A: source vertex RID → edge count.
    * Unlike a plain RidSet, this preserves the number of edges per source
    * vertex, so that multiple edges of the same class between the same
    * vertex pair produce the correct number of result rows.
    */
-  @Nullable private Map<RID, Integer> buildSingleEdgeHashTable(
+  @Nullable private CachedBuild buildSingleEdgeHashTable(
       RID backRefRid, SingleEdgeSemiJoin single, CommandContext ctx) {
-    var session = ctx.getDatabaseSession();
-    EntityImpl targetEntity;
-    try {
-      var rec = session.getActiveTransaction().load(backRefRid);
-      if (!(rec instanceof EntityImpl entity)) {
-        return null;
-      }
-      targetEntity = entity;
-    } catch (RecordNotFoundException e) {
+    var targetEntity = loadEntity(backRefRid, ctx);
+    if (targetEntity == null) {
       return null;
     }
 
@@ -421,29 +435,22 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     }
 
     var initialCapacity = hashCapacity(linkBag.size(), maxSize);
-    var result = new HashMap<RID, Integer>(initialCapacity);
+    var result = new Object2IntOpenHashMap<RID>(initialCapacity);
     long count = 0;
     for (var pair : linkBag) {
-      result.merge(pair.secondaryRid(), 1, Integer::sum);
+      result.addTo(pair.secondaryRid(), 1);
       count++;
       if (maxSize > 0 && count > maxSize) {
         return null;
       }
     }
-    return result;
+    return new CachedBuild(result, targetEntity);
   }
 
-  @Nullable private Map<RID, List<Result>> buildChainHashTable(
+  @Nullable private CachedBuild buildChainHashTable(
       RID backRefRid, ChainSemiJoin chain, CommandContext ctx) {
-    var session = ctx.getDatabaseSession();
-    EntityImpl targetEntity;
-    try {
-      var rec = session.getActiveTransaction().load(backRefRid);
-      if (!(rec instanceof EntityImpl entity)) {
-        return null;
-      }
-      targetEntity = entity;
-    } catch (RecordNotFoundException e) {
+    var targetEntity = loadEntity(backRefRid, ctx);
+    if (targetEntity == null) {
       return null;
     }
 
@@ -468,6 +475,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return null;
     }
 
+    var session = ctx.getDatabaseSession();
     var initialCapacity = hashCapacity(linkBag.size(), maxSize);
     var result = new HashMap<RID, List<Result>>(initialCapacity);
     long count = 0;
@@ -495,20 +503,13 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
         // Edge record missing — skip
       }
     }
-    return result;
+    return new CachedBuild(result, targetEntity);
   }
 
-  @Nullable private Set<RID> buildAntiJoinHashTable(
+  @Nullable private CachedBuild buildAntiJoinHashTable(
       RID anchorRid, AntiSemiJoin anti, CommandContext ctx) {
-    var session = ctx.getDatabaseSession();
-    EntityImpl anchorEntity;
-    try {
-      var rec = session.getActiveTransaction().load(anchorRid);
-      if (!(rec instanceof EntityImpl entity)) {
-        return null;
-      }
-      anchorEntity = entity;
-    } catch (RecordNotFoundException e) {
+    var anchorEntity = loadEntity(anchorRid, ctx);
+    if (anchorEntity == null) {
       return null;
     }
 
@@ -524,15 +525,16 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return null;
     }
 
-    var initialCap = hashCapacity(linkBag.size(), maxSize);
-    var result = new HashSet<RID>(initialCap);
+    var result = new RidSet();
+    long count = 0;
     for (var pair : linkBag) {
       result.add(pair.secondaryRid());
-      if (maxSize > 0 && result.size() > maxSize) {
+      count++;
+      if (maxSize > 0 && count > maxSize) {
         return null;
       }
     }
-    return result;
+    return new CachedBuild(result, null);
   }
 
   // ---- Utility ----
@@ -546,7 +548,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     return (int) Math.min(effective * 4 / 3 + 1, Integer.MAX_VALUE);
   }
 
-  @Nullable static RID toRid(@Nullable Object value) {
+  @Nullable private static RID toRid(@Nullable Object value) {
     if (value instanceof RID rid) {
       return rid;
     }
@@ -604,6 +606,6 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   @Override
   public ExecutionStep copy(CommandContext ctx) {
     return new BackRefHashJoinStep(
-        ctx, descriptor, fallbackEdge, profilingEnabled);
+        ctx, descriptor, fallbackEdge, consumedEdge, profilingEnabled);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -4,6 +4,7 @@ import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
 import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
@@ -182,47 +183,38 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
    */
   @Nullable private RID resolveBackRefRid(
       Result row, SemiJoinDescriptor desc, CommandContext ctx) {
-    if (desc instanceof SingleEdgeSemiJoin single) {
-      var value = single.backRefExpression().execute(row, ctx);
-      return toRid(value);
-    }
-    if (desc instanceof ChainSemiJoin chain) {
-      var value = chain.backRefExpression().execute(row, ctx);
-      return toRid(value);
-    }
-    if (desc instanceof AntiSemiJoin anti) {
-      // AntiSemiJoin resolves the anchor via $matched context variable
-      // (not via a backRefExpression), because NOT IN conditions reference
-      // $matched.X directly rather than through an @rid equality expression.
-      var matched = ctx.getVariable("$matched");
-      if (matched instanceof Result matchedResult) {
-        var value = matchedResult.getProperty(anti.anchorAlias());
-        return toRid(value);
+    return switch (desc) {
+      case SingleEdgeSemiJoin single ->
+          toRid(single.backRefExpression().execute(row, ctx));
+      case ChainSemiJoin chain ->
+          toRid(chain.backRefExpression().execute(row, ctx));
+      case AntiSemiJoin anti -> {
+        // AntiSemiJoin resolves the anchor via $matched context variable
+        // (not via a backRefExpression), because NOT IN conditions reference
+        // $matched.X directly rather than through an @rid equality expression.
+        var matched = ctx.getVariable("$matched");
+        if (matched instanceof Result matchedResult) {
+          yield toRid(matchedResult.getProperty(anti.anchorAlias()));
+        }
+        yield null;
       }
-      return null;
-    }
-    return null;
+    };
   }
 
   /**
    * Extracts the source alias RID from the upstream row (the probe key).
    */
   @Nullable private RID resolveSourceRid(Result row, SemiJoinDescriptor desc) {
-    if (desc instanceof SingleEdgeSemiJoin single) {
-      var value = row.getProperty(single.sourceAlias());
-      return toRid(value);
-    }
-    if (desc instanceof ChainSemiJoin chain) {
-      var value = row.getProperty(chain.sourceAlias());
-      return toRid(value);
-    }
-    if (desc instanceof AntiSemiJoin anti) {
+    return switch (desc) {
+      case SingleEdgeSemiJoin single ->
+          toRid(row.getProperty(single.sourceAlias()));
+      case ChainSemiJoin chain ->
+          toRid(row.getProperty(chain.sourceAlias()));
       // The probe key is the candidate vertex (target alias) — the vertex
       // just produced by the MatchStep traversal.
-      var value = row.getProperty(anti.targetAlias());
-      return toRid(value);
-    }
-    return null;
+      case AntiSemiJoin anti ->
+          toRid(row.getProperty(anti.targetAlias()));
+    };
   }
 
   /**
@@ -237,16 +229,12 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       RID backRefRid,
       SemiJoinDescriptor desc,
       CommandContext ctx) {
-    if (desc instanceof SingleEdgeSemiJoin single) {
-      return buildSingleEdgeHashTable(backRefRid, single, ctx);
-    }
-    if (desc instanceof ChainSemiJoin chain) {
-      return buildChainHashTable(backRefRid, chain, ctx);
-    }
-    if (desc instanceof AntiSemiJoin anti) {
-      return buildAntiJoinHashTable(backRefRid, anti, ctx);
-    }
-    return null;
+    return switch (desc) {
+      case SingleEdgeSemiJoin single -> buildSingleEdgeHashTable(
+          backRefRid, single, ctx);
+      case ChainSemiJoin chain -> buildChainHashTable(backRefRid, chain, ctx);
+      case AntiSemiJoin anti -> buildAntiJoinHashTable(backRefRid, anti, ctx);
+    };
   }
 
   /**
@@ -313,7 +301,8 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
           chain.indexFilter(), ctx);
     }
 
-    var result = new HashMap<RID, List<Result>>();
+    var initialCapacity = (int) Math.min(linkBag.size(), maxSize) * 4 / 3 + 1;
+    var result = new HashMap<RID, List<Result>>(initialCapacity);
     long count = 0;
     for (var pair : linkBag) {
       var edgeRid = pair.primaryRid();
@@ -374,7 +363,8 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return null; // too large — fall back
     }
 
-    var result = new HashSet<RID>();
+    var initialCap = (int) Math.min(linkBag.size(), maxSize) * 4 / 3 + 1;
+    var result = new HashSet<RID>(initialCap);
     for (var pair : linkBag) {
       // secondaryRid is the opposite-side vertex RID
       result.add(pair.secondaryRid());
@@ -456,7 +446,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     if (value instanceof RID rid) {
       return rid;
     }
-    if (value instanceof com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable identifiable) {
+    if (value instanceof Identifiable identifiable) {
       return identifiable.getIdentity();
     }
     if (value instanceof Result result && result.isEntity()) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -328,17 +328,27 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
    * Handles build failure for Pattern D (anti-join): evaluates the stored
    * NOT IN condition per row. The NOT IN was stripped from the MatchStep's
    * WHERE clause at plan time, so BackRefHashJoinStep is the sole evaluator.
+   *
+   * <p>$currentMatch is set to the target-alias candidate only for the
+   * duration of the condition evaluation, then restored to its previous
+   * value — mirroring {@link MatchEdgeTraverser#filter}. Skipping the
+   * restore would leak a probe-scope value into every subsequent step;
+   * if {@code evaluate()} throws, the leak would persist across every
+   * later row in the pipeline.
    */
   @Nullable private Result handleAntiJoinBuildFailure(
       Result row, AntiSemiJoin anti, CommandContext ctx) {
     if (anti.notInCondition() == null) {
       return row;
     }
-    // $currentMatch must be set for the NOT IN expression to resolve
     var candidate = row.getProperty(anti.targetAlias());
+    var previousMatch = ctx.getSystemVariable(CommandContext.VAR_CURRENT_MATCH);
     ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, candidate);
-    boolean passes = anti.notInCondition().evaluate(row, ctx);
-    return passes ? row : null;
+    try {
+      return anti.notInCondition().evaluate(row, ctx) ? row : null;
+    } finally {
+      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, previousMatch);
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -381,15 +381,17 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     }
 
     var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
-    // No early pre-check on linkBag.size() here: when an indexFilter is
-    // present, the effective entry count after filtering may be well below
-    // the threshold. The per-entry count check in the loop below enforces
-    // the threshold on the actual (post-filter) count.
 
     RidSet indexRidSet = null;
     if (chain.indexFilter() != null) {
+      // When an index filter is present, the effective entry count after
+      // filtering may be well below the threshold — skip early pre-check.
       indexRidSet = TraversalPreFilterHelper.resolveIndexToRidSet(
           chain.indexFilter(), ctx);
+    } else if (maxSize > 0 && linkBag.size() > maxSize) {
+      // No index filter — the full link bag will be iterated, so we can
+      // reject early without loading any edge records.
+      return null;
     }
 
     var initialCapacity = hashCapacity(linkBag.size(), maxSize);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -71,9 +71,10 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
   /**
    * LRU cache of hash tables keyed by back-referenced alias RID. Values are
-   * {@code Set<RID>} for Pattern A/D or {@code Map<RID, List<Result>>} for
-   * Pattern B. Access-order {@link LinkedHashMap} with automatic eviction of
-   * the eldest entry when capacity is exceeded.
+   * {@code Map<RID, Integer>} for Pattern A, {@code Map<RID, List<Result>>}
+   * for Pattern B, or {@code Set<RID>} for Pattern D. Access-order
+   * {@link LinkedHashMap} with automatic eviction of the eldest entry when
+   * capacity is exceeded.
    */
   @Nullable private LinkedHashMap<RID, Object> cache;
 
@@ -118,9 +119,17 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
           (row, c) -> probeChain(row, localCache, chainDesc, session, c));
     }
 
-    // SingleEdgeSemiJoin and AntiSemiJoin use filter (0 or 1 output per row)
+    // SingleEdgeSemiJoin uses flatMap to preserve duplicate edges between
+    // the same vertex pair (e.g. 3 "Knows" edges from A→B emit 3 rows)
+    if (localDescriptor instanceof SingleEdgeSemiJoin semiJoin) {
+      return upstream.flatMap(
+          (row, c) -> probeSingleEdge(
+              row, localCache, semiJoin, session, c));
+    }
+
+    // AntiSemiJoin uses filter (0 or 1 output per row)
     return upstream.filter(
-        (row, c) -> probeRow(row, localCache, localDescriptor, session, c));
+        (row, c) -> probeAntiJoin(row, localCache, localDescriptor, session, c));
   }
 
   // ---- Cache resolution (shared by probeRow and probeChain) ----
@@ -167,12 +176,55 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   // ---- Probe methods ----
 
   /**
-   * Probes the hash table for a single upstream row (Patterns A and D).
-   * On build failure, falls back to nested-loop traversal (Pattern A) or
-   * passes the row through (Pattern D — MatchStep handles the NOT IN).
+   * Probes the hash table for a single upstream row (Pattern A).
+   * Returns 0..N rows: N is the number of edges between the source vertex
+   * and the back-referenced vertex, preserving semantics when multiple
+   * edges of the same class connect the same vertex pair.
+   * On build failure, falls back to nested-loop traversal.
    */
-  @Nullable @SuppressWarnings("unchecked")
-  private Result probeRow(
+  @SuppressWarnings("unchecked")
+  private ExecutionStream probeSingleEdge(
+      Result row,
+      LinkedHashMap<RID, Object> lruCache,
+      SingleEdgeSemiJoin desc,
+      DatabaseSessionEmbedded session,
+      CommandContext probeCtx) {
+    var build = resolveBuild(row, lruCache, desc, session, probeCtx);
+    if (build == null) {
+      var fallback = handleBuildFailure(row, desc, probeCtx);
+      return fallback == null
+          ? ExecutionStream.empty() : ExecutionStream.singleton(fallback);
+    }
+
+    var sourceRid = resolveSourceRid(row, desc);
+    if (sourceRid == null) {
+      return ExecutionStream.empty();
+    }
+
+    var map = (Map<RID, Integer>) build.hashTable();
+    var edgeCount = map.getOrDefault(sourceRid, 0);
+    if (edgeCount == 0) {
+      return ExecutionStream.empty();
+    }
+
+    var resultRow = new MatchResultRow(
+        session, row, desc.targetAlias(), build.backRefEntity());
+    if (edgeCount == 1) {
+      return ExecutionStream.singleton(resultRow);
+    }
+    var results = new ArrayList<Result>(edgeCount);
+    for (int i = 0; i < edgeCount; i++) {
+      results.add(resultRow);
+    }
+    return ExecutionStream.resultIterator(results.iterator());
+  }
+
+  /**
+   * Probes the hash table for a single upstream row (Pattern D — anti-join).
+   * On build failure, evaluates the stored NOT IN condition per row.
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable private Result probeAntiJoin(
       Result row,
       LinkedHashMap<RID, Object> lruCache,
       SemiJoinDescriptor desc,
@@ -185,20 +237,11 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
     var sourceRid = resolveSourceRid(row, desc);
     if (sourceRid == null) {
-      return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
+      return row; // no source → pass through (anti-join)
     }
 
     var set = (Set<RID>) build.hashTable();
-    var found = set.contains(sourceRid);
-    return switch (desc.joinMode()) {
-      case SEMI_JOIN -> found
-          ? new MatchResultRow(
-              session, row, desc.targetAlias(), build.backRefEntity())
-          : null;
-      case ANTI_JOIN -> found ? null : row;
-      case INNER_JOIN -> throw new IllegalStateException(
-          "INNER_JOIN not supported by BackRefHashJoinStep");
-    };
+    return set.contains(sourceRid) ? null : row;
   }
 
   /**
@@ -345,18 +388,49 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     };
   }
 
-  @Nullable private Set<RID> buildSingleEdgeHashTable(
+  /**
+   * Builds a hash table for Pattern A: source vertex RID → edge count.
+   * Unlike a plain RidSet, this preserves the number of edges per source
+   * vertex, so that multiple edges of the same class between the same
+   * vertex pair produce the correct number of result rows.
+   */
+  @Nullable private Map<RID, Integer> buildSingleEdgeHashTable(
       RID backRefRid, SingleEdgeSemiJoin single, CommandContext ctx) {
-    var ridSet = TraversalPreFilterHelper.resolveReverseEdgeLookup(
-        backRefRid, single.edgeClass(), single.direction(), ctx);
-    if (ridSet == null) {
+    var session = ctx.getDatabaseSession();
+    EntityImpl targetEntity;
+    try {
+      var rec = session.getActiveTransaction().load(backRefRid);
+      if (!(rec instanceof EntityImpl entity)) {
+        return null;
+      }
+      targetEntity = entity;
+    } catch (RecordNotFoundException e) {
       return null;
     }
+
+    var reversePrefix = "out".equals(single.direction()) ? "in_" : "out_";
+    var fieldName = reversePrefix + single.edgeClass();
+    var fieldValue = targetEntity.getPropertyInternal(fieldName);
+    if (!(fieldValue instanceof LinkBag linkBag)) {
+      return null;
+    }
+
     var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
-    if (maxSize > 0 && ridSet.size() > maxSize) {
+    if (maxSize > 0 && linkBag.size() > maxSize) {
       return null;
     }
-    return ridSet;
+
+    var initialCapacity = hashCapacity(linkBag.size(), maxSize);
+    var result = new HashMap<RID, Integer>(initialCapacity);
+    long count = 0;
+    for (var pair : linkBag) {
+      result.merge(pair.secondaryRid(), 1, Integer::sum);
+      count++;
+      if (maxSize > 0 && count > maxSize) {
+        return null;
+      }
+    }
+    return result;
   }
 
   @Nullable private Map<RID, List<Result>> buildChainHashTable(
@@ -407,7 +481,10 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
       try {
         var edgeRec = session.getActiveTransaction().load(edgeRid);
-        var edgeResult = new ResultInternal(session, edgeRec);
+        if (!(edgeRec instanceof EntityImpl edgeEntity)) {
+          continue;
+        }
+        var edgeResult = new ResultInternal(session, edgeEntity);
         result.computeIfAbsent(sourceVertexRid, k -> new ArrayList<>())
             .add(edgeResult);
         count++;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -78,11 +78,11 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   @Nullable private final EdgeTraversal consumedEdge;
 
   /**
-   * LRU cache of hash tables keyed by back-referenced alias RID. Values are
-   * {@code Map<RID, Integer>} for Pattern A, {@code Map<RID, List<Result>>}
-   * for Pattern B, or {@code Set<RID>} for Pattern D. Access-order
-   * {@link LinkedHashMap} with automatic eviction of the eldest entry when
-   * capacity is exceeded.
+   * LRU cache keyed by back-referenced alias RID. Values are
+   * {@link CachedBuild} wrappers (containing the pattern-specific hash table
+   * and loaded entity) or the {@link #BUILD_FAILED} sentinel when the build
+   * phase failed. Access-order {@link LinkedHashMap} with automatic eviction
+   * of the eldest entry when capacity is exceeded.
    */
   @Nullable private LinkedHashMap<RID, Object> cache;
 
@@ -325,11 +325,9 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       var results = new ArrayList<Result>();
       while (firstTraverser.hasNext(ctx)) {
         var intermediate = firstTraverser.next(ctx);
-        var secondTraverser = createFallbackTraverser(
-            intermediate, fallbackEdge);
-        while (secondTraverser.hasNext(ctx)) {
-          results.add(secondTraverser.next(ctx));
-        }
+        drainTraverser(
+            createFallbackTraverser(intermediate, fallbackEdge),
+            ctx, results);
       }
       return results.isEmpty()
           ? ExecutionStream.empty()
@@ -337,11 +335,24 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     }
 
     // Pattern A: single-edge fallback
-    var traverser = createFallbackTraverser(row, fallbackEdge);
-    var results = new ArrayList<Result>();
+    return drainToStream(
+        createFallbackTraverser(row, fallbackEdge), ctx);
+  }
+
+  /** Drains all results from a traverser into the given list. */
+  private static void drainTraverser(
+      MatchEdgeTraverser traverser, CommandContext ctx,
+      List<Result> results) {
     while (traverser.hasNext(ctx)) {
       results.add(traverser.next(ctx));
     }
+  }
+
+  /** Drains a traverser into a stream. */
+  private static ExecutionStream drainToStream(
+      MatchEdgeTraverser traverser, CommandContext ctx) {
+    var results = new ArrayList<Result>();
+    drainTraverser(traverser, ctx, results);
     return results.isEmpty()
         ? ExecutionStream.empty()
         : ExecutionStream.resultIterator(results.iterator());
@@ -476,7 +487,12 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     }
 
     var session = ctx.getDatabaseSession();
-    var initialCapacity = hashCapacity(linkBag.size(), maxSize);
+    // When an index filter is present, use its size as a tighter estimate
+    // to avoid over-allocating the map for a highly selective filter.
+    var sizeEstimate = indexRidSet != null
+        ? Math.min(linkBag.size(), indexRidSet.size())
+        : linkBag.size();
+    var initialCapacity = hashCapacity(sizeEstimate, maxSize);
     var result = new HashMap<RID, List<Result>>(initialCapacity);
     long count = 0;
     for (var pair : linkBag) {
@@ -545,7 +561,9 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
    */
   private static int hashCapacity(long size, long maxSize) {
     var effective = Math.min(size, maxSize > 0 ? maxSize : size);
-    return (int) Math.min(effective * 4 / 3 + 1, Integer.MAX_VALUE);
+    // Cap before multiplication to prevent long overflow
+    effective = Math.min(effective, Integer.MAX_VALUE);
+    return (int) (effective * 4 / 3 + 1);
   }
 
   @Nullable private static RID toRid(@Nullable Object value) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -143,21 +143,38 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     var localCache = cache;
     var localDescriptor = descriptor;
 
-    // ChainSemiJoin needs flatMap (fan-out: one source → multiple edges)
+    // ChainSemiJoin needs flatMap (fan-out: one source → multiple edges).
+    // Each emitted row binds new aliases (intermediate + target), so
+    // $matched must be republished to match MatchEdgeTraverser.next()
+    // contract — downstream WHERE clauses resolving $matched.<alias>
+    // depend on it.
     if (localDescriptor instanceof ChainSemiJoin chainDesc) {
-      return upstream.flatMap(
-          (row, c) -> probeChain(row, localCache, chainDesc, session, c));
+      return upstream
+          .flatMap((row, c) -> probeChain(row, localCache, chainDesc, session, c))
+          .map((result, c) -> {
+            c.setSystemVariable(CommandContext.VAR_MATCHED, result);
+            return result;
+          });
     }
 
     // SingleEdgeSemiJoin uses flatMap to preserve duplicate edges between
-    // the same vertex pair (e.g. 3 "Knows" edges from A→B emit 3 rows)
+    // the same vertex pair (e.g. 3 "Knows" edges from A→B emit 3 rows).
+    // The emitted row binds the target alias, so $matched must be
+    // republished (see ChainSemiJoin branch above).
     if (localDescriptor instanceof SingleEdgeSemiJoin semiJoin) {
-      return upstream.flatMap(
-          (row, c) -> probeSingleEdge(
-              row, localCache, semiJoin, session, c));
+      return upstream
+          .flatMap((row, c) -> probeSingleEdge(
+              row, localCache, semiJoin, session, c))
+          .map((result, c) -> {
+            c.setSystemVariable(CommandContext.VAR_MATCHED, result);
+            return result;
+          });
     }
 
-    // AntiSemiJoin uses filter (0 or 1 output per row)
+    // AntiSemiJoin uses filter (0 or 1 output per row). The emitted row is
+    // the unchanged upstream row, so $matched (already published by the
+    // upstream step for this exact row object) remains correct — no
+    // republication needed.
     return upstream.filter(
         (row, c) -> probeAntiJoin(row, localCache, localDescriptor, c));
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -86,6 +86,26 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
    */
   @Nullable private LinkedHashMap<RID, Object> cache;
 
+  /**
+   * Cache for the {@link ChainSemiJoin#indexFilter()} RidSet. The index
+   * query is a pure function of the descriptor and query parameters, so
+   * its result is constant across all per-back-ref builds within one
+   * query execution. Without this cache, the index would be re-scanned
+   * for every distinct back-ref RID (e.g. every friend in IC5) — an
+   * O(N_friends × M_index) regression where M can reach hundreds of
+   * thousands of entries for range filters like {@code joinDate >= X}.
+   */
+  @Nullable private RidSet cachedIndexRidSet;
+
+  /**
+   * Flag distinguishing "index not yet resolved" (initial state) from
+   * "resolved to null" (e.g. cap exceeded in
+   * {@link TraversalPreFilterHelper#resolveIndexToRidSet}). When this
+   * flag is true and {@link #cachedIndexRidSet} is null, the build
+   * proceeds without the index filter.
+   */
+  private boolean indexRidSetResolved;
+
   BackRefHashJoinStep(
       CommandContext ctx,
       SemiJoinDescriptor descriptor,
@@ -478,8 +498,14 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     if (chain.indexFilter() != null) {
       // When an index filter is present, the effective entry count after
       // filtering may be well below the threshold — skip early pre-check.
-      indexRidSet = TraversalPreFilterHelper.resolveIndexToRidSet(
-          chain.indexFilter(), ctx);
+      // The index result is query-level constant, so resolve once and
+      // reuse across all per-back-ref builds (YTDB-650 regression fix).
+      if (!indexRidSetResolved) {
+        cachedIndexRidSet = TraversalPreFilterHelper.resolveIndexToRidSet(
+            chain.indexFilter(), ctx);
+        indexRidSetResolved = true;
+      }
+      indexRidSet = cachedIndexRidSet;
     } else if (maxSize > 0 && linkBag.size() > maxSize) {
       // No index filter — the full link bag will be iterated, so we can
       // reject early without loading any edge records.
@@ -618,6 +644,8 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   @Override
   public void close() {
     cache = null;
+    cachedIndexRidSet = null;
+    indexRidSetResolved = false;
     super.close();
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -480,6 +480,24 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return null;
     }
 
+    // Authoritative residual check on the target vertex. Pattern A's hash
+    // hit implicitly binds targetAlias = back-ref entity, so any WHERE
+    // terms on targetAlias that are NOT the {@code @rid = $matched.X.@rid}
+    // equality must be re-verified here — the target's MatchStep was
+    // replaced by this step, and the hash lookup alone does not evaluate
+    // residual terms. On failure we return an empty hash so subsequent
+    // probes short-circuit (rather than fall back to nested-loop traversal,
+    // which would also reject every row after evaluating the same residual).
+    var targetFilter = single.targetFilter();
+    if (targetFilter != null) {
+      var session = ctx.getDatabaseSession();
+      var targetResult = new ResultInternal(session, targetEntity);
+      if (!targetFilter.matchesFilters(targetResult, ctx)) {
+        return new CachedBuild(
+            new Object2IntOpenHashMap<RID>(), targetEntity);
+      }
+    }
+
     var reversePrefix = "out".equals(single.direction()) ? "in_" : "out_";
     var fieldName = reversePrefix + single.edgeClass();
     var fieldValue = targetEntity.getPropertyInternal(fieldName);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -547,6 +547,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
         : linkBag.size();
     var initialCapacity = hashCapacity(sizeEstimate, maxSize);
     var result = new HashMap<RID, List<Result>>(initialCapacity);
+    var edgeFilter = chain.edgeFilter();
     long count = 0;
     for (var pair : linkBag) {
       var edgeRid = pair.primaryRid();
@@ -562,6 +563,15 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
           continue;
         }
         var edgeResult = new ResultInternal(session, edgeEntity);
+        // Authoritative correctness check: the index may cover only a subset
+        // of the WHERE clause (or none of it), so re-evaluate the full edge
+        // filter on the loaded entity. Without this, non-indexable terms
+        // are silently dropped because the consumed predecessor's MatchStep
+        // is skipped.
+        if (edgeFilter != null
+            && !edgeFilter.matchesFilters(edgeResult, ctx)) {
+          continue;
+        }
         result.computeIfAbsent(sourceVertexRid, k -> new ArrayList<>())
             .add(edgeResult);
         count++;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -48,6 +48,17 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   /** Default LRU cache capacity for per-binding hash tables. */
   private static final int CACHE_CAPACITY = 256;
 
+  /** Sentinel value for cache entries where the build phase failed. */
+  private static final Object BUILD_FAILED = new Object();
+
+  /**
+   * Pairs a hash table with the loaded back-ref entity, avoiding redundant
+   * {@code load()} calls on the hot path. For Pattern A (SEMI_JOIN), the
+   * entity is used as the target alias value on probe hits.
+   */
+  private record CachedBuild(Object hashTable, @Nullable Object backRefEntity) {
+  }
+
   private final SemiJoinDescriptor descriptor;
 
   /**
@@ -117,22 +128,35 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     // Resolve back-ref alias RID from $matched
     var backRefRid = resolveBackRefRid(row, desc, probeCtx);
     if (backRefRid == null) {
-      // Cannot resolve back-ref — conservative: skip row for SEMI, keep for ANTI
       return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
     }
 
-    // Look up or build hash table for this binding
-    var hashTable = lruCache.get(backRefRid);
-    if (hashTable == null && !lruCache.containsKey(backRefRid)) {
-      hashTable = buildHashTable(backRefRid, desc, probeCtx);
-      lruCache.put(backRefRid, hashTable);
+    // Single lookup: BUILD_FAILED sentinel distinguishes "not cached" from
+    // "cached as failed" without a second containsKey() call.
+    var cached = lruCache.get(backRefRid);
+    if (cached == null) {
+      var ht = buildHashTable(backRefRid, desc, probeCtx);
+      if (ht == null) {
+        lruCache.put(backRefRid, BUILD_FAILED);
+        return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
+      }
+      // Load the back-ref entity once per binding (for SEMI_JOIN target value)
+      Object entity = null;
+      if (desc.joinMode() == JoinMode.SEMI_JOIN) {
+        try {
+          entity = session.getActiveTransaction().load(backRefRid);
+        } catch (RecordNotFoundException e) {
+          // vertex gone — treat as build failure
+        }
+      }
+      cached = new CachedBuild(ht, entity);
+      lruCache.put(backRefRid, cached);
     }
-
-    if (hashTable == null) {
-      // Build failed or returned null (threshold exceeded, no link bag, etc.)
-      // Conservative: skip row for SEMI, keep for ANTI
+    if (cached == BUILD_FAILED) {
       return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
     }
+
+    var build = (CachedBuild) cached;
 
     // Probe: extract source RID from upstream row
     var sourceRid = resolveSourceRid(row, desc);
@@ -140,12 +164,11 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
     }
 
-    var set = (Set<RID>) hashTable;
+    var set = (Set<RID>) build.hashTable();
     var found = set.contains(sourceRid);
     return switch (desc.joinMode()) {
       case SEMI_JOIN -> found
-          ? new MatchResultRow(session, row, desc.targetAlias(),
-              resolveTargetValue(row, desc, probeCtx, session))
+          ? new MatchResultRow(session, row, desc.targetAlias(), build.backRefEntity())
           : null;
       case ANTI_JOIN -> found ? null : row;
       case INNER_JOIN -> throw new IllegalStateException(
@@ -168,7 +191,9 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return toRid(value);
     }
     if (desc instanceof AntiSemiJoin anti) {
-      // Resolve $matched.X — the anchor alias vertex RID
+      // AntiSemiJoin resolves the anchor via $matched context variable
+      // (not via a backRefExpression), because NOT IN conditions reference
+      // $matched.X directly rather than through an @rid equality expression.
       var matched = ctx.getVariable("$matched");
       if (matched instanceof Result matchedResult) {
         var value = matchedResult.getProperty(anti.anchorAlias());
@@ -201,27 +226,6 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   }
 
   /**
-   * Resolves the target alias value to attach to the result row on a SEMI_JOIN
-   * hit. For Pattern A, the target is the back-referenced vertex itself.
-   */
-  @Nullable private Object resolveTargetValue(
-      Result row, SemiJoinDescriptor desc, CommandContext ctx,
-      DatabaseSessionEmbedded session) {
-    if (desc instanceof SingleEdgeSemiJoin) {
-      var backRefRid = resolveBackRefRid(row, desc, ctx);
-      if (backRefRid == null) {
-        return null;
-      }
-      try {
-        return session.getActiveTransaction().load(backRefRid);
-      } catch (Exception e) {
-        return null;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Builds the hash table for a given back-ref binding RID. For Pattern A
    * (SingleEdgeSemiJoin), reads the reverse link bag and materializes a
    * {@code Set<RID>} of opposite-side vertex RIDs.
@@ -247,27 +251,23 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
   /**
    * Pattern A build: reads the reverse link bag of the back-referenced vertex
-   * and collects opposite-side vertex RIDs into a {@code HashSet<RID>}.
+   * via {@link TraversalPreFilterHelper}. Returns the bitmap-backed
+   * {@link RidSet} directly — no copy to {@code HashSet} needed since
+   * {@code RidSet} already implements {@code Set<RID>} with O(1)
+   * {@code contains()}.
    */
   @Nullable private Set<RID> buildSingleEdgeHashTable(
       RID backRefRid, SingleEdgeSemiJoin single, CommandContext ctx) {
-    // Use TraversalPreFilterHelper to read the reverse link bag
     var ridSet = TraversalPreFilterHelper.resolveReverseEdgeLookup(
         backRefRid, single.edgeClass(), single.direction(), ctx);
     if (ridSet == null) {
       return null; // link bag not found or exceeds cap
     }
-
-    // Convert RidSet (bitmap-backed) to HashSet<RID> for O(1) probe
     var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
-    var result = new HashSet<RID>();
-    for (var rid : ridSet) {
-      result.add(rid);
-      if (maxSize > 0 && result.size() > maxSize) {
-        return null; // threshold exceeded — fall back
-      }
+    if (maxSize > 0 && ridSet.size() > maxSize) {
+      return null; // threshold exceeded — fall back
     }
-    return result;
+    return ridSet;
   }
 
   /**
@@ -402,44 +402,46 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return ExecutionStream.empty();
     }
 
-    var hashTable = lruCache.get(backRefRid);
-    if (hashTable == null && !lruCache.containsKey(backRefRid)) {
-      hashTable = buildHashTable(backRefRid, chain, probeCtx);
-      lruCache.put(backRefRid, hashTable);
+    var cached = lruCache.get(backRefRid);
+    if (cached == null) {
+      var ht = buildHashTable(backRefRid, chain, probeCtx);
+      if (ht == null) {
+        lruCache.put(backRefRid, BUILD_FAILED);
+        return ExecutionStream.empty();
+      }
+      // Load the back-ref vertex once per binding for the target alias
+      Object entity = null;
+      try {
+        entity = session.getActiveTransaction().load(backRefRid);
+      } catch (RecordNotFoundException e) {
+        // vertex gone
+      }
+      cached = new CachedBuild(ht, entity);
+      lruCache.put(backRefRid, cached);
     }
-
-    if (hashTable == null) {
+    if (cached == BUILD_FAILED) {
       return ExecutionStream.empty();
     }
 
+    var build = (CachedBuild) cached;
     var sourceRid = resolveSourceRid(row, chain);
     if (sourceRid == null) {
       return ExecutionStream.empty();
     }
 
-    var map = (Map<RID, List<Result>>) hashTable;
+    var map = (Map<RID, List<Result>>) build.hashTable();
     var edges = map.get(sourceRid);
     if (edges == null || edges.isEmpty()) {
-      return ExecutionStream.empty();
-    }
-
-    // Load the back-ref vertex once for the target alias value
-    Object backRefVertex;
-    try {
-      backRefVertex = session.getActiveTransaction().load(backRefRid);
-    } catch (Exception e) {
       return ExecutionStream.empty();
     }
 
     // Emit one row per matching edge, adding intermediate and target aliases
     var results = new ArrayList<Result>(edges.size());
     for (var edgeResult : edges) {
-      // Layer 1: add intermediate alias (edge record)
       var withIntermediate = new MatchResultRow(
           session, row, chain.intermediateAlias(), edgeResult);
-      // Layer 2: add target alias (back-ref vertex)
       var withTarget = new MatchResultRow(
-          session, withIntermediate, chain.targetAlias(), backRefVertex);
+          session, withIntermediate, chain.targetAlias(), build.backRefEntity());
       results.add(withTarget);
     }
     return ExecutionStream.resultIterator(results.iterator());

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -167,7 +167,15 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       var value = chain.backRefExpression().execute(row, ctx);
       return toRid(value);
     }
-    // AntiSemiJoin will be handled in Track 3
+    if (desc instanceof AntiSemiJoin anti) {
+      // Resolve $matched.X — the anchor alias vertex RID
+      var matched = ctx.getVariable("$matched");
+      if (matched instanceof Result matchedResult) {
+        var value = matchedResult.getProperty(anti.anchorAlias());
+        return toRid(value);
+      }
+      return null;
+    }
     return null;
   }
 
@@ -181,6 +189,12 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     }
     if (desc instanceof ChainSemiJoin chain) {
       var value = row.getProperty(chain.sourceAlias());
+      return toRid(value);
+    }
+    if (desc instanceof AntiSemiJoin anti) {
+      // The probe key is the candidate vertex (target alias) — the vertex
+      // just produced by the MatchStep traversal.
+      var value = row.getProperty(anti.targetAlias());
       return toRid(value);
     }
     return null;
@@ -225,7 +239,9 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     if (desc instanceof ChainSemiJoin chain) {
       return buildChainHashTable(backRefRid, chain, ctx);
     }
-    // AntiSemiJoin will be handled in Track 3
+    if (desc instanceof AntiSemiJoin anti) {
+      return buildAntiJoinHashTable(backRefRid, anti, ctx);
+    }
     return null;
   }
 
@@ -320,6 +336,50 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
         }
       } catch (RecordNotFoundException e) {
         // Edge record missing — skip
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Pattern D build: reads the forward link bag of the anchor vertex
+   * ({@code X.out('E')}) and collects opposite-side vertex RIDs into a
+   * {@code HashSet<RID>} — the exclusion set. The probe discards upstream
+   * rows whose candidate RID appears in this set.
+   */
+  @Nullable private Set<RID> buildAntiJoinHashTable(
+      RID anchorRid, AntiSemiJoin anti, CommandContext ctx) {
+    var session = ctx.getDatabaseSession();
+    EntityImpl anchorEntity;
+    try {
+      var rec = session.getActiveTransaction().load(anchorRid);
+      if (!(rec instanceof EntityImpl entity)) {
+        return null;
+      }
+      anchorEntity = entity;
+    } catch (RecordNotFoundException e) {
+      return null;
+    }
+
+    // Forward link bag: out_E or in_E depending on traversal direction
+    var prefix = "out".equals(anti.traversalDirection()) ? "out_" : "in_";
+    var fieldName = prefix + anti.traversalEdgeClass();
+    var fieldValue = anchorEntity.getPropertyInternal(fieldName);
+    if (!(fieldValue instanceof LinkBag linkBag)) {
+      return null;
+    }
+
+    var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
+    if (linkBag.size() > maxSize) {
+      return null; // too large — fall back
+    }
+
+    var result = new HashSet<RID>();
+    for (var pair : linkBag) {
+      // secondaryRid is the opposite-side vertex RID
+      result.add(pair.secondaryRid());
+      if (maxSize > 0 && result.size() > maxSize) {
+        return null;
       }
     }
     return result;
@@ -432,6 +492,13 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
           + " via " + chain.direction() + "E('" + chain.edgeClass() + "').inV()"
           + " aliases: " + chain.intermediateAlias() + ", " + chain.targetAlias()
           + ")";
+    }
+    if (descriptor instanceof AntiSemiJoin anti) {
+      return spaces
+          + "+ BACK-REF HASH JOIN ANTI (NOT IN $matched."
+          + anti.anchorAlias()
+          + "." + anti.traversalDirection() + "('" + anti.traversalEdgeClass()
+          + "'))";
     }
     return spaces + "+ BACK-REF HASH JOIN (" + descriptor.joinMode() + ")";
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -35,14 +35,14 @@ import javax.annotation.Nullable;
  * <p>The hash table is cached per distinct back-referenced alias binding (RID) in an
  * LRU cache. When the binding changes (e.g., different person in IC5), a new hash
  * table is built. If the build side exceeds the configurable threshold at runtime,
- * the step returns {@code null} from the build method, and the caller (the planner's
- * existing {@link MatchStep} path) handles the edge via nested-loop traversal.
- *
- * <p>Pattern A (single-edge semi-join): builds {@code Set<RID>} from the reverse
- * link bag. Probe: {@code set.contains(source.@rid)} → keep on hit (SEMI_JOIN).
+ * the step falls back to per-row nested-loop traversal via {@link MatchEdgeTraverser}
+ * (Patterns A/B) or evaluates the stored NOT IN condition per row (Pattern D — the
+ * NOT IN is stripped from the MatchStep's WHERE clause at plan time).
  *
  * @see SemiJoinDescriptor
  * @see SingleEdgeSemiJoin
+ * @see ChainSemiJoin
+ * @see AntiSemiJoin
  */
 class BackRefHashJoinStep extends AbstractExecutionStep {
 
@@ -63,6 +63,13 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   private final SemiJoinDescriptor descriptor;
 
   /**
+   * The edge traversal for runtime fallback when the hash table build fails
+   * (Patterns A/B only). Null for Pattern D where the preceding MatchStep
+   * handles fallback via its intact AST filter.
+   */
+  @Nullable private final EdgeTraversal fallbackEdge;
+
+  /**
    * LRU cache of hash tables keyed by back-referenced alias RID. Values are
    * {@code Set<RID>} for Pattern A/D or {@code Map<RID, List<Result>>} for
    * Pattern B. Access-order {@link LinkedHashMap} with automatic eviction of
@@ -73,10 +80,12 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   BackRefHashJoinStep(
       CommandContext ctx,
       SemiJoinDescriptor descriptor,
+      @Nullable EdgeTraversal fallbackEdge,
       boolean profilingEnabled) {
     super(ctx, profilingEnabled);
     assert MatchAssertions.checkNotNull(descriptor, "semi-join descriptor");
     this.descriptor = descriptor;
+    this.fallbackEdge = fallbackEdge;
   }
 
   @Override
@@ -114,10 +123,53 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
         (row, c) -> probeRow(row, localCache, localDescriptor, session, c));
   }
 
+  // ---- Cache resolution (shared by probeRow and probeChain) ----
+
   /**
-   * Probes the hash table for a single upstream row. Resolves the back-ref
-   * RID from {@code $matched}, looks up or builds the hash table, then probes
-   * with the source alias's RID.
+   * Resolves or builds the cached hash table for the given upstream row.
+   * Returns a {@link CachedBuild} on success, or {@code null} on build failure.
+   */
+  @Nullable private CachedBuild resolveBuild(
+      Result row,
+      LinkedHashMap<RID, Object> lruCache,
+      SemiJoinDescriptor desc,
+      DatabaseSessionEmbedded session,
+      CommandContext ctx) {
+    var backRefRid = resolveBackRefRid(row, desc, ctx);
+    if (backRefRid == null) {
+      return null;
+    }
+
+    var cached = lruCache.get(backRefRid);
+    if (cached == null) {
+      var ht = buildHashTable(backRefRid, desc, ctx);
+      if (ht == null) {
+        lruCache.put(backRefRid, BUILD_FAILED);
+        return null;
+      }
+      Object entity = null;
+      if (desc.joinMode() == JoinMode.SEMI_JOIN) {
+        try {
+          entity = session.getActiveTransaction().load(backRefRid);
+        } catch (RecordNotFoundException e) {
+          // vertex gone
+        }
+      }
+      cached = new CachedBuild(ht, entity);
+      lruCache.put(backRefRid, cached);
+    }
+    if (cached == BUILD_FAILED) {
+      return null;
+    }
+    return (CachedBuild) cached;
+  }
+
+  // ---- Probe methods ----
+
+  /**
+   * Probes the hash table for a single upstream row (Patterns A and D).
+   * On build failure, falls back to nested-loop traversal (Pattern A) or
+   * passes the row through (Pattern D — MatchStep handles the NOT IN).
    */
   @Nullable @SuppressWarnings("unchecked")
   private Result probeRow(
@@ -126,40 +178,11 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       SemiJoinDescriptor desc,
       DatabaseSessionEmbedded session,
       CommandContext probeCtx) {
-    // Resolve back-ref alias RID from $matched
-    var backRefRid = resolveBackRefRid(row, desc, probeCtx);
-    if (backRefRid == null) {
-      return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
+    var build = resolveBuild(row, lruCache, desc, session, probeCtx);
+    if (build == null) {
+      return handleBuildFailure(row, desc, probeCtx);
     }
 
-    // Single lookup: BUILD_FAILED sentinel distinguishes "not cached" from
-    // "cached as failed" without a second containsKey() call.
-    var cached = lruCache.get(backRefRid);
-    if (cached == null) {
-      var ht = buildHashTable(backRefRid, desc, probeCtx);
-      if (ht == null) {
-        lruCache.put(backRefRid, BUILD_FAILED);
-        return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
-      }
-      // Load the back-ref entity once per binding (for SEMI_JOIN target value)
-      Object entity = null;
-      if (desc.joinMode() == JoinMode.SEMI_JOIN) {
-        try {
-          entity = session.getActiveTransaction().load(backRefRid);
-        } catch (RecordNotFoundException e) {
-          // vertex gone — treat as build failure
-        }
-      }
-      cached = new CachedBuild(ht, entity);
-      lruCache.put(backRefRid, cached);
-    }
-    if (cached == BUILD_FAILED) {
-      return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
-    }
-
-    var build = (CachedBuild) cached;
-
-    // Probe: extract source RID from upstream row
     var sourceRid = resolveSourceRid(row, desc);
     if (sourceRid == null) {
       return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
@@ -169,7 +192,8 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     var found = set.contains(sourceRid);
     return switch (desc.joinMode()) {
       case SEMI_JOIN -> found
-          ? new MatchResultRow(session, row, desc.targetAlias(), build.backRefEntity())
+          ? new MatchResultRow(
+              session, row, desc.targetAlias(), build.backRefEntity())
           : null;
       case ANTI_JOIN -> found ? null : row;
       case INNER_JOIN -> throw new IllegalStateException(
@@ -178,9 +202,109 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   }
 
   /**
-   * Resolves the back-referenced alias's RID from the upstream row's $matched
-   * context. For SingleEdgeSemiJoin, evaluates the backRefExpression.
+   * Probe for ChainSemiJoin: returns 0..N rows per upstream row (fan-out).
+   * On build failure, falls back to nested-loop traversal via
+   * {@link MatchEdgeTraverser}.
    */
+  @SuppressWarnings("unchecked")
+  private ExecutionStream probeChain(
+      Result row,
+      LinkedHashMap<RID, Object> lruCache,
+      ChainSemiJoin chain,
+      DatabaseSessionEmbedded session,
+      CommandContext probeCtx) {
+    var build = resolveBuild(row, lruCache, chain, session, probeCtx);
+    if (build == null) {
+      return nestedLoopFallback(row, probeCtx);
+    }
+
+    var sourceRid = resolveSourceRid(row, chain);
+    if (sourceRid == null) {
+      return ExecutionStream.empty();
+    }
+
+    var map = (Map<RID, List<Result>>) build.hashTable();
+    var edges = map.get(sourceRid);
+    if (edges == null || edges.isEmpty()) {
+      return ExecutionStream.empty();
+    }
+
+    var results = new ArrayList<Result>(edges.size());
+    for (var edgeResult : edges) {
+      var withIntermediate = new MatchResultRow(
+          session, row, chain.intermediateAlias(), edgeResult);
+      var withTarget = new MatchResultRow(
+          session, withIntermediate, chain.targetAlias(), build.backRefEntity());
+      results.add(withTarget);
+    }
+    return ExecutionStream.resultIterator(results.iterator());
+  }
+
+  // ---- Fallback ----
+
+  /**
+   * Handles build failure for probeRow (single-row context).
+   * Pattern A: falls back to per-row MatchEdgeTraverser.
+   * Pattern D: evaluates the stored NOT IN condition per row (the NOT IN
+   * was stripped from the MatchStep's WHERE clause at plan time, so the
+   * fallback must evaluate it here).
+   */
+  @Nullable private Result handleBuildFailure(
+      Result row, SemiJoinDescriptor desc, CommandContext ctx) {
+    if (desc.joinMode() == JoinMode.ANTI_JOIN) {
+      // Pattern D fallback: evaluate the stored NOT IN condition per row.
+      // The NOT IN was stripped from the MatchStep's filter at plan time,
+      // so BackRefHashJoinStep is the sole evaluator.
+      var anti = (AntiSemiJoin) desc;
+      if (anti.notInCondition() == null) {
+        return row;
+      }
+      // $currentMatch must be set for the NOT IN expression to resolve
+      var candidate = row.getProperty(anti.targetAlias());
+      ctx.setSystemVariable(CommandContext.VAR_CURRENT_MATCH, candidate);
+      boolean passes = anti.notInCondition().evaluate(row, ctx);
+      return passes ? row : null;
+    }
+    // Pattern A: fall back to per-row nested-loop traversal
+    if (fallbackEdge == null) {
+      return null;
+    }
+    var traverser = createFallbackTraverser(row, fallbackEdge);
+    if (traverser.hasNext(ctx)) {
+      return traverser.next(ctx);
+    }
+    return null;
+  }
+
+  /**
+   * Falls back to nested-loop traversal for Pattern B (ChainSemiJoin) when
+   * the hash table build fails. Creates a {@link MatchEdgeTraverser} that
+   * performs the same per-row link bag traversal as {@link MatchStep}.
+   */
+  private ExecutionStream nestedLoopFallback(
+      Result row, CommandContext ctx) {
+    if (fallbackEdge == null) {
+      return ExecutionStream.empty();
+    }
+    var traverser = createFallbackTraverser(row, fallbackEdge);
+    var results = new ArrayList<Result>();
+    while (traverser.hasNext(ctx)) {
+      results.add(traverser.next(ctx));
+    }
+    return results.isEmpty()
+        ? ExecutionStream.empty()
+        : ExecutionStream.resultIterator(results.iterator());
+  }
+
+  private static MatchEdgeTraverser createFallbackTraverser(
+      Result row, EdgeTraversal edge) {
+    return edge.out
+        ? new MatchEdgeTraverser(row, edge)
+        : new MatchReverseEdgeTraverser(row, edge);
+  }
+
+  // ---- Back-ref RID resolution ----
+
   @Nullable private RID resolveBackRefRid(
       Result row, SemiJoinDescriptor desc, CommandContext ctx) {
     return switch (desc) {
@@ -189,9 +313,6 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       case ChainSemiJoin chain ->
           toRid(chain.backRefExpression().execute(row, ctx));
       case AntiSemiJoin anti -> {
-        // AntiSemiJoin resolves the anchor via $matched context variable
-        // (not via a backRefExpression), because NOT IN conditions reference
-        // $matched.X directly rather than through an @rid equality expression.
         var matched = ctx.getVariable("$matched");
         if (matched instanceof Result matchedResult) {
           yield toRid(matchedResult.getProperty(anti.anchorAlias()));
@@ -201,34 +322,21 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     };
   }
 
-  /**
-   * Extracts the source alias RID from the upstream row (the probe key).
-   */
   @Nullable private RID resolveSourceRid(Result row, SemiJoinDescriptor desc) {
     return switch (desc) {
       case SingleEdgeSemiJoin single ->
           toRid(row.getProperty(single.sourceAlias()));
       case ChainSemiJoin chain ->
           toRid(row.getProperty(chain.sourceAlias()));
-      // The probe key is the candidate vertex (target alias) — the vertex
-      // just produced by the MatchStep traversal.
       case AntiSemiJoin anti ->
           toRid(row.getProperty(anti.targetAlias()));
     };
   }
 
-  /**
-   * Builds the hash table for a given back-ref binding RID. For Pattern A
-   * (SingleEdgeSemiJoin), reads the reverse link bag and materializes a
-   * {@code Set<RID>} of opposite-side vertex RIDs.
-   *
-   * @return the hash table, or {@code null} if the build fails or exceeds
-   *     the threshold
-   */
+  // ---- Build methods ----
+
   @Nullable private Object buildHashTable(
-      RID backRefRid,
-      SemiJoinDescriptor desc,
-      CommandContext ctx) {
+      RID backRefRid, SemiJoinDescriptor desc, CommandContext ctx) {
     return switch (desc) {
       case SingleEdgeSemiJoin single -> buildSingleEdgeHashTable(
           backRefRid, single, ctx);
@@ -237,36 +345,20 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     };
   }
 
-  /**
-   * Pattern A build: reads the reverse link bag of the back-referenced vertex
-   * via {@link TraversalPreFilterHelper}. Returns the bitmap-backed
-   * {@link RidSet} directly — no copy to {@code HashSet} needed since
-   * {@code RidSet} already implements {@code Set<RID>} with O(1)
-   * {@code contains()}.
-   */
   @Nullable private Set<RID> buildSingleEdgeHashTable(
       RID backRefRid, SingleEdgeSemiJoin single, CommandContext ctx) {
     var ridSet = TraversalPreFilterHelper.resolveReverseEdgeLookup(
         backRefRid, single.edgeClass(), single.direction(), ctx);
     if (ridSet == null) {
-      return null; // link bag not found or exceeds cap
+      return null;
     }
     var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
     if (maxSize > 0 && ridSet.size() > maxSize) {
-      return null; // threshold exceeded — fall back
+      return null;
     }
     return ridSet;
   }
 
-  /**
-   * Pattern B build: reads the reverse link bag of the back-referenced vertex,
-   * optionally filters by an index RidSet, loads matching edge records, and
-   * groups them by source vertex RID into a {@code Map<RID, List<Result>>}.
-   *
-   * <p>The map key is the source vertex RID (from where the original outE
-   * traversal starts). The value is a list of edge records that connect that
-   * source to the back-referenced vertex via the given edge class.
-   */
   @Nullable private Map<RID, List<Result>> buildChainHashTable(
       RID backRefRid, ChainSemiJoin chain, CommandContext ctx) {
     var session = ctx.getDatabaseSession();
@@ -281,7 +373,6 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return null;
     }
 
-    // Read the reverse link bag
     var reversePrefix = "out".equals(chain.direction()) ? "in_" : "out_";
     var fieldName = reversePrefix + chain.edgeClass();
     var fieldValue = targetEntity.getPropertyInternal(fieldName);
@@ -290,30 +381,28 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     }
 
     var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
-    if (linkBag.size() > maxSize) {
-      return null; // too large — fall back
-    }
+    // No early pre-check on linkBag.size() here: when an indexFilter is
+    // present, the effective entry count after filtering may be well below
+    // the threshold. The per-entry count check in the loop below enforces
+    // the threshold on the actual (post-filter) count.
 
-    // Optionally resolve index pre-filter for the intermediate edge
     RidSet indexRidSet = null;
     if (chain.indexFilter() != null) {
       indexRidSet = TraversalPreFilterHelper.resolveIndexToRidSet(
           chain.indexFilter(), ctx);
     }
 
-    var initialCapacity = (int) Math.min(linkBag.size(), maxSize) * 4 / 3 + 1;
+    var initialCapacity = hashCapacity(linkBag.size(), maxSize);
     var result = new HashMap<RID, List<Result>>(initialCapacity);
     long count = 0;
     for (var pair : linkBag) {
       var edgeRid = pair.primaryRid();
       var sourceVertexRid = pair.secondaryRid();
 
-      // Apply index filter if present (filters edge RIDs)
       if (indexRidSet != null && !indexRidSet.contains(edgeRid)) {
         continue;
       }
 
-      // Load the edge record
       try {
         var edgeRec = session.getActiveTransaction().load(edgeRid);
         var edgeResult = new ResultInternal(session, edgeRec);
@@ -321,7 +410,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
             .add(edgeResult);
         count++;
         if (maxSize > 0 && count > maxSize) {
-          return null; // threshold exceeded
+          return null;
         }
       } catch (RecordNotFoundException e) {
         // Edge record missing — skip
@@ -330,12 +419,6 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     return result;
   }
 
-  /**
-   * Pattern D build: reads the forward link bag of the anchor vertex
-   * ({@code X.out('E')}) and collects opposite-side vertex RIDs into a
-   * {@code HashSet<RID>} — the exclusion set. The probe discards upstream
-   * rows whose candidate RID appears in this set.
-   */
   @Nullable private Set<RID> buildAntiJoinHashTable(
       RID anchorRid, AntiSemiJoin anti, CommandContext ctx) {
     var session = ctx.getDatabaseSession();
@@ -350,7 +433,6 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
       return null;
     }
 
-    // Forward link bag: out_E or in_E depending on traversal direction
     var prefix = "out".equals(anti.traversalDirection()) ? "out_" : "in_";
     var fieldName = prefix + anti.traversalEdgeClass();
     var fieldValue = anchorEntity.getPropertyInternal(fieldName);
@@ -359,14 +441,13 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     }
 
     var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
-    if (linkBag.size() > maxSize) {
-      return null; // too large — fall back
+    if (maxSize > 0 && linkBag.size() > maxSize) {
+      return null;
     }
 
-    var initialCap = (int) Math.min(linkBag.size(), maxSize) * 4 / 3 + 1;
+    var initialCap = hashCapacity(linkBag.size(), maxSize);
     var result = new HashSet<RID>(initialCap);
     for (var pair : linkBag) {
-      // secondaryRid is the opposite-side vertex RID
       result.add(pair.secondaryRid());
       if (maxSize > 0 && result.size() > maxSize) {
         return null;
@@ -375,73 +456,17 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
     return result;
   }
 
+  // ---- Utility ----
+
   /**
-   * Probe for ChainSemiJoin: returns 0..N rows per upstream row (fan-out).
-   * For each matching edge record, emits a result with the intermediate alias
-   * bound to the edge and the target alias bound to the back-ref vertex.
+   * Computes a HashMap initial capacity for a load factor of 0.75, clamped
+   * to avoid integer overflow.
    */
-  @SuppressWarnings("unchecked")
-  private ExecutionStream probeChain(
-      Result row,
-      LinkedHashMap<RID, Object> lruCache,
-      ChainSemiJoin chain,
-      DatabaseSessionEmbedded session,
-      CommandContext probeCtx) {
-    var backRefRid = resolveBackRefRid(row, chain, probeCtx);
-    if (backRefRid == null) {
-      return ExecutionStream.empty();
-    }
-
-    var cached = lruCache.get(backRefRid);
-    if (cached == null) {
-      var ht = buildHashTable(backRefRid, chain, probeCtx);
-      if (ht == null) {
-        lruCache.put(backRefRid, BUILD_FAILED);
-        return ExecutionStream.empty();
-      }
-      // Load the back-ref vertex once per binding for the target alias
-      Object entity = null;
-      try {
-        entity = session.getActiveTransaction().load(backRefRid);
-      } catch (RecordNotFoundException e) {
-        // vertex gone
-      }
-      cached = new CachedBuild(ht, entity);
-      lruCache.put(backRefRid, cached);
-    }
-    if (cached == BUILD_FAILED) {
-      return ExecutionStream.empty();
-    }
-
-    var build = (CachedBuild) cached;
-    var sourceRid = resolveSourceRid(row, chain);
-    if (sourceRid == null) {
-      return ExecutionStream.empty();
-    }
-
-    var map = (Map<RID, List<Result>>) build.hashTable();
-    var edges = map.get(sourceRid);
-    if (edges == null || edges.isEmpty()) {
-      return ExecutionStream.empty();
-    }
-
-    // Emit one row per matching edge, adding intermediate and target aliases
-    var results = new ArrayList<Result>(edges.size());
-    for (var edgeResult : edges) {
-      var withIntermediate = new MatchResultRow(
-          session, row, chain.intermediateAlias(), edgeResult);
-      var withTarget = new MatchResultRow(
-          session, withIntermediate, chain.targetAlias(), build.backRefEntity());
-      results.add(withTarget);
-    }
-    return ExecutionStream.resultIterator(results.iterator());
+  private static int hashCapacity(long size, long maxSize) {
+    var effective = Math.min(size, maxSize > 0 ? maxSize : size);
+    return (int) Math.min(effective * 4 / 3 + 1, Integer.MAX_VALUE);
   }
 
-  /**
-   * Converts a value to a {@link RID}, handling both direct RID instances
-   * and {@link com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable}
-   * wrappers.
-   */
   @Nullable static RID toRid(@Nullable Object value) {
     if (value instanceof RID rid) {
       return rid;
@@ -469,30 +494,26 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
   @Override
   public String prettyPrint(int depth, int indent) {
     var spaces = ExecutionStepInternal.getIndent(depth, indent);
-    if (descriptor instanceof SingleEdgeSemiJoin single) {
-      return spaces
+    return switch (descriptor) {
+      case SingleEdgeSemiJoin single -> spaces
           + "+ BACK-REF HASH JOIN ("
           + single.sourceAlias()
           + " ⋈ $matched." + single.backRefAlias()
           + " via " + single.direction() + "('" + single.edgeClass() + "'))";
-    }
-    if (descriptor instanceof ChainSemiJoin chain) {
-      return spaces
+      case ChainSemiJoin chain -> spaces
           + "+ BACK-REF HASH JOIN ("
           + chain.sourceAlias()
           + " ⋈ $matched." + chain.backRefAlias()
-          + " via " + chain.direction() + "E('" + chain.edgeClass() + "').inV()"
-          + " aliases: " + chain.intermediateAlias() + ", " + chain.targetAlias()
-          + ")";
-    }
-    if (descriptor instanceof AntiSemiJoin anti) {
-      return spaces
+          + " via " + chain.direction() + "E('" + chain.edgeClass()
+          + "').inV()"
+          + " aliases: " + chain.intermediateAlias() + ", "
+          + chain.targetAlias() + ")";
+      case AntiSemiJoin anti -> spaces
           + "+ BACK-REF HASH JOIN ANTI (NOT IN $matched."
           + anti.anchorAlias()
-          + "." + anti.traversalDirection() + "('" + anti.traversalEdgeClass()
-          + "'))";
-    }
-    return spaces + "+ BACK-REF HASH JOIN (" + descriptor.joinMode() + ")";
+          + "." + anti.traversalDirection() + "('"
+          + anti.traversalEdgeClass() + "'))";
+    };
   }
 
   @Override
@@ -503,6 +524,7 @@ class BackRefHashJoinStep extends AbstractExecutionStep {
 
   @Override
   public ExecutionStep copy(CommandContext ctx) {
-    return new BackRefHashJoinStep(ctx, descriptor, profilingEnabled);
+    return new BackRefHashJoinStep(
+        ctx, descriptor, fallbackEdge, profilingEnabled);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/BackRefHashJoinStep.java
@@ -1,0 +1,283 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
+import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.AbstractExecutionStep;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ExecutionStepInternal;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.TraversalPreFilterHelper;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Execution step that replaces one or two {@link MatchStep}s for back-reference
+ * semi-join edges. Instead of per-row link bag traversal, this step builds a hash
+ * table from the back-referenced alias's reverse (or forward) link bag and probes
+ * it per upstream row in O(1).
+ *
+ * <p>The hash table is cached per distinct back-referenced alias binding (RID) in an
+ * LRU cache. When the binding changes (e.g., different person in IC5), a new hash
+ * table is built. If the build side exceeds the configurable threshold at runtime,
+ * the step returns {@code null} from the build method, and the caller (the planner's
+ * existing {@link MatchStep} path) handles the edge via nested-loop traversal.
+ *
+ * <p>Pattern A (single-edge semi-join): builds {@code Set<RID>} from the reverse
+ * link bag. Probe: {@code set.contains(source.@rid)} → keep on hit (SEMI_JOIN).
+ *
+ * @see SemiJoinDescriptor
+ * @see SingleEdgeSemiJoin
+ */
+class BackRefHashJoinStep extends AbstractExecutionStep {
+
+  /** Default LRU cache capacity for per-binding hash tables. */
+  private static final int CACHE_CAPACITY = 256;
+
+  private final SemiJoinDescriptor descriptor;
+
+  /**
+   * LRU cache of hash tables keyed by back-referenced alias RID. Values are
+   * {@code Set<RID>} for Pattern A/D or {@code Map<RID, List<Result>>} for
+   * Pattern B. Access-order {@link LinkedHashMap} with automatic eviction of
+   * the eldest entry when capacity is exceeded.
+   */
+  @Nullable private LinkedHashMap<RID, Object> cache;
+
+  BackRefHashJoinStep(
+      CommandContext ctx,
+      SemiJoinDescriptor descriptor,
+      boolean profilingEnabled) {
+    super(ctx, profilingEnabled);
+    assert MatchAssertions.checkNotNull(descriptor, "semi-join descriptor");
+    this.descriptor = descriptor;
+  }
+
+  @Override
+  public ExecutionStream internalStart(CommandContext ctx) throws TimeoutException {
+    if (prev == null) {
+      throw new IllegalStateException(
+          "back-ref hash join step requires a previous step");
+    }
+
+    var session = ctx.getDatabaseSession();
+    var upstream = prev.start(ctx);
+
+    // Initialize LRU cache lazily
+    if (cache == null) {
+      cache = new LinkedHashMap<>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<RID, Object> eldest) {
+          return size() > CACHE_CAPACITY;
+        }
+      };
+    }
+
+    // Capture for null-safety in lambdas (close() may null the field)
+    var localCache = cache;
+    var localDescriptor = descriptor;
+
+    return upstream.filter((row, c) -> probeRow(row, localCache, localDescriptor, session, c));
+  }
+
+  /**
+   * Probes the hash table for a single upstream row. Resolves the back-ref
+   * RID from {@code $matched}, looks up or builds the hash table, then probes
+   * with the source alias's RID.
+   */
+  @Nullable @SuppressWarnings("unchecked")
+  private Result probeRow(
+      Result row,
+      LinkedHashMap<RID, Object> lruCache,
+      SemiJoinDescriptor desc,
+      DatabaseSessionEmbedded session,
+      CommandContext probeCtx) {
+    // Resolve back-ref alias RID from $matched
+    var backRefRid = resolveBackRefRid(row, desc, probeCtx);
+    if (backRefRid == null) {
+      // Cannot resolve back-ref — conservative: skip row for SEMI, keep for ANTI
+      return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
+    }
+
+    // Look up or build hash table for this binding
+    var hashTable = lruCache.get(backRefRid);
+    if (hashTable == null && !lruCache.containsKey(backRefRid)) {
+      hashTable = buildHashTable(backRefRid, desc, probeCtx);
+      lruCache.put(backRefRid, hashTable);
+    }
+
+    if (hashTable == null) {
+      // Build failed or returned null (threshold exceeded, no link bag, etc.)
+      // Conservative: skip row for SEMI, keep for ANTI
+      return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
+    }
+
+    // Probe: extract source RID from upstream row
+    var sourceRid = resolveSourceRid(row, desc);
+    if (sourceRid == null) {
+      return desc.joinMode() == JoinMode.ANTI_JOIN ? row : null;
+    }
+
+    var set = (Set<RID>) hashTable;
+    var found = set.contains(sourceRid);
+    return switch (desc.joinMode()) {
+      case SEMI_JOIN -> found
+          ? new MatchResultRow(session, row, desc.targetAlias(),
+              resolveTargetValue(row, desc, probeCtx, session))
+          : null;
+      case ANTI_JOIN -> found ? null : row;
+      case INNER_JOIN -> throw new IllegalStateException(
+          "INNER_JOIN not supported by BackRefHashJoinStep");
+    };
+  }
+
+  /**
+   * Resolves the back-referenced alias's RID from the upstream row's $matched
+   * context. For SingleEdgeSemiJoin, evaluates the backRefExpression.
+   */
+  @Nullable private RID resolveBackRefRid(
+      Result row, SemiJoinDescriptor desc, CommandContext ctx) {
+    if (desc instanceof SingleEdgeSemiJoin single) {
+      var value = single.backRefExpression().execute(row, ctx);
+      return toRid(value);
+    }
+    // ChainSemiJoin and AntiSemiJoin will be handled in Tracks 2 and 3
+    return null;
+  }
+
+  /**
+   * Extracts the source alias RID from the upstream row (the probe key).
+   */
+  @Nullable private RID resolveSourceRid(Result row, SemiJoinDescriptor desc) {
+    if (desc instanceof SingleEdgeSemiJoin single) {
+      var value = row.getProperty(single.sourceAlias());
+      return toRid(value);
+    }
+    return null;
+  }
+
+  /**
+   * Resolves the target alias value to attach to the result row on a SEMI_JOIN
+   * hit. For Pattern A, the target is the back-referenced vertex itself.
+   */
+  @Nullable private Object resolveTargetValue(
+      Result row, SemiJoinDescriptor desc, CommandContext ctx,
+      DatabaseSessionEmbedded session) {
+    if (desc instanceof SingleEdgeSemiJoin) {
+      var backRefRid = resolveBackRefRid(row, desc, ctx);
+      if (backRefRid == null) {
+        return null;
+      }
+      try {
+        return session.getActiveTransaction().load(backRefRid);
+      } catch (Exception e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Builds the hash table for a given back-ref binding RID. For Pattern A
+   * (SingleEdgeSemiJoin), reads the reverse link bag and materializes a
+   * {@code Set<RID>} of opposite-side vertex RIDs.
+   *
+   * @return the hash table, or {@code null} if the build fails or exceeds
+   *     the threshold
+   */
+  @Nullable private Object buildHashTable(
+      RID backRefRid,
+      SemiJoinDescriptor desc,
+      CommandContext ctx) {
+    if (desc instanceof SingleEdgeSemiJoin single) {
+      return buildSingleEdgeHashTable(backRefRid, single, ctx);
+    }
+    // ChainSemiJoin and AntiSemiJoin will be handled in Tracks 2 and 3
+    return null;
+  }
+
+  /**
+   * Pattern A build: reads the reverse link bag of the back-referenced vertex
+   * and collects opposite-side vertex RIDs into a {@code HashSet<RID>}.
+   */
+  @Nullable private Set<RID> buildSingleEdgeHashTable(
+      RID backRefRid, SingleEdgeSemiJoin single, CommandContext ctx) {
+    // Use TraversalPreFilterHelper to read the reverse link bag
+    var ridSet = TraversalPreFilterHelper.resolveReverseEdgeLookup(
+        backRefRid, single.edgeClass(), single.direction(), ctx);
+    if (ridSet == null) {
+      return null; // link bag not found or exceeds cap
+    }
+
+    // Convert RidSet (bitmap-backed) to HashSet<RID> for O(1) probe
+    var maxSize = MatchExecutionPlanner.getHashJoinThreshold();
+    var result = new HashSet<RID>();
+    for (var rid : ridSet) {
+      result.add(rid);
+      if (maxSize > 0 && result.size() > maxSize) {
+        return null; // threshold exceeded — fall back
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Converts a value to a {@link RID}, handling both direct RID instances
+   * and {@link com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable}
+   * wrappers.
+   */
+  @Nullable static RID toRid(@Nullable Object value) {
+    if (value instanceof RID rid) {
+      return rid;
+    }
+    if (value instanceof com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable identifiable) {
+      return identifiable.getIdentity();
+    }
+    if (value instanceof Result result && result.isEntity()) {
+      return result.getIdentity();
+    }
+    return null;
+  }
+
+  @Override
+  public boolean canBeCached() {
+    return true;
+  }
+
+  @Nonnull
+  @Override
+  public List<ExecutionStep> getSubSteps() {
+    return List.of();
+  }
+
+  @Override
+  public String prettyPrint(int depth, int indent) {
+    var spaces = ExecutionStepInternal.getIndent(depth, indent);
+    if (descriptor instanceof SingleEdgeSemiJoin single) {
+      return spaces
+          + "+ BACK-REF HASH JOIN ("
+          + single.sourceAlias()
+          + " ⋈ $matched." + single.backRefAlias()
+          + " via " + single.direction() + "('" + single.edgeClass() + "'))";
+    }
+    return spaces + "+ BACK-REF HASH JOIN (" + descriptor.joinMode() + ")";
+  }
+
+  @Override
+  public void close() {
+    cache = null;
+    super.close();
+  }
+
+  @Override
+  public ExecutionStep copy(CommandContext ctx) {
+    return new BackRefHashJoinStep(ctx, descriptor, profilingEnabled);
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ChainSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ChainSemiJoin.java
@@ -1,0 +1,38 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import com.jetbrains.youtrackdb.internal.core.sql.executor.IndexSearchDescriptor;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
+import javax.annotation.Nullable;
+
+/**
+ * Pattern B — {@code .outE('E'){where: ...}.inV(){where: @rid = $matched.X.@rid}} chain.
+ * Collapses two schedule edges into one {@link BackRefHashJoinStep}.
+ *
+ * <p>The hash table is built from {@code X}'s reverse link bag, optionally filtered by
+ * an index on the intermediate edge (e.g., {@code joinDate >= :minDate}). Maps source
+ * vertex RID to a list of matching edge records.
+ *
+ * @param edgeClass          the edge class from edge_j-1 (the {@code .outE('E')} edge)
+ * @param direction          the traversal direction from edge_j-1
+ * @param backRefExpression  the expression resolving to the back-referenced alias's RID
+ * @param sourceAlias        the upstream alias whose RID is the probe key
+ * @param backRefAlias       the alias whose vertex provides the reverse link bag
+ * @param intermediateAlias  the alias for the edge record (from the {@code .outE()} step)
+ * @param targetAlias        the alias bound by the {@code .inV()} target
+ * @param indexFilter        optional index pre-filter on the intermediate edge, or null
+ */
+public record ChainSemiJoin(
+    String edgeClass,
+    String direction,
+    SQLExpression backRefExpression,
+    String sourceAlias,
+    String backRefAlias,
+    String intermediateAlias,
+    String targetAlias,
+    @Nullable IndexSearchDescriptor indexFilter) implements SemiJoinDescriptor {
+
+  @Override
+  public JoinMode joinMode() {
+    return JoinMode.SEMI_JOIN;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ChainSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/ChainSemiJoin.java
@@ -2,15 +2,25 @@ package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
 import com.jetbrains.youtrackdb.internal.core.sql.executor.IndexSearchDescriptor;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
 import javax.annotation.Nullable;
 
 /**
  * Pattern B — {@code .outE('E'){where: ...}.inV(){where: @rid = $matched.X.@rid}} chain.
  * Collapses two schedule edges into one {@link BackRefHashJoinStep}.
  *
- * <p>The hash table is built from {@code X}'s reverse link bag, optionally filtered by
- * an index on the intermediate edge (e.g., {@code joinDate >= :minDate}). Maps source
- * vertex RID to a list of matching edge records.
+ * <p>The hash table is built from {@code X}'s reverse link bag. Two filter hooks control
+ * which edges enter the map:
+ * <ul>
+ *   <li>{@code indexFilter} — optional index pre-filter (RidSet intersection) used to
+ *       reject edges <em>without</em> loading them. Covers any subset of the edge WHERE
+ *       clause that the query planner could map to an index.</li>
+ *   <li>{@code edgeFilter} — the complete edge WHERE clause. When present, applied to
+ *       every loaded edge as the authoritative correctness check. Non-indexable terms
+ *       (e.g. {@code category='A'} when the index is on {@code score} alone) are
+ *       silently dropped without this — the consumed predecessor's MatchStep would
+ *       normally evaluate them, but it is skipped in the collapsed plan.</li>
+ * </ul>
  *
  * @param edgeClass          the edge class from edge_j-1 (the {@code .outE('E')} edge)
  * @param direction          the traversal direction from edge_j-1
@@ -20,6 +30,9 @@ import javax.annotation.Nullable;
  * @param intermediateAlias  the alias for the edge record (from the {@code .outE()} step)
  * @param targetAlias        the alias bound by the {@code .inV()} target
  * @param indexFilter        optional index pre-filter on the intermediate edge, or null
+ * @param edgeFilter         the full WHERE clause on the intermediate edge, or null
+ *                           when the edge has no filter (and therefore no residual
+ *                           correctness check is required)
  */
 public record ChainSemiJoin(
     String edgeClass,
@@ -29,7 +42,8 @@ public record ChainSemiJoin(
     String backRefAlias,
     String intermediateAlias,
     String targetAlias,
-    @Nullable IndexSearchDescriptor indexFilter) implements SemiJoinDescriptor {
+    @Nullable IndexSearchDescriptor indexFilter,
+    @Nullable SQLWhereClause edgeFilter) implements SemiJoinDescriptor {
 
   @Override
   public JoinMode joinMode() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversal.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversal.java
@@ -104,6 +104,14 @@ public class EdgeTraversal {
   private boolean consumed;
 
   /**
+   * When this edge has a {@link ChainSemiJoin} descriptor, points to the
+   * consumed predecessor edge (the {@code .outE('E')} part). Used by
+   * {@link BackRefHashJoinStep} to construct the correct two-edge fallback
+   * traversal when the hash table build fails at runtime.
+   */
+  @Nullable private EdgeTraversal consumedPredecessor;
+
+  /**
    * @param edge the pattern edge to traverse
    * @param out  `true` for forward traversal, `false` for reverse
    */
@@ -174,6 +182,14 @@ public class EdgeTraversal {
 
   public void setConsumed(boolean consumed) {
     this.consumed = consumed;
+  }
+
+  @Nullable public EdgeTraversal getConsumedPredecessor() {
+    return consumedPredecessor;
+  }
+
+  public void setConsumedPredecessor(@Nullable EdgeTraversal consumedPredecessor) {
+    this.consumedPredecessor = consumedPredecessor;
   }
 
   @Nullable public IntSet getAcceptedCollectionIds() {
@@ -283,6 +299,7 @@ public class EdgeTraversal {
     copy.semiJoinDescriptor = semiJoinDescriptor;
     copy.acceptedCollectionIds = acceptedCollectionIds;
     copy.consumed = consumed;
+    copy.consumedPredecessor = consumedPredecessor;
     // Cache is intentionally not copied — stale data from a previous
     // execution must not leak into a new plan instance.
     return copy;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversal.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversal.java
@@ -96,6 +96,14 @@ public class EdgeTraversal {
   @Nullable private IntSet acceptedCollectionIds;
 
   /**
+   * When {@code true}, this edge has been consumed by a {@link ChainSemiJoin}
+   * descriptor on a subsequent edge. {@link MatchExecutionPlanner#addStepsFor}
+   * skips consumed edges — the {@link BackRefHashJoinStep} on the next edge
+   * covers both.
+   */
+  private boolean consumed;
+
+  /**
    * @param edge the pattern edge to traverse
    * @param out  `true` for forward traversal, `false` for reverse
    */
@@ -158,6 +166,14 @@ public class EdgeTraversal {
 
   public void setSemiJoinDescriptor(@Nullable SemiJoinDescriptor semiJoinDescriptor) {
     this.semiJoinDescriptor = semiJoinDescriptor;
+  }
+
+  public boolean isConsumed() {
+    return consumed;
+  }
+
+  public void setConsumed(boolean consumed) {
+    this.consumed = consumed;
   }
 
   @Nullable public IntSet getAcceptedCollectionIds() {
@@ -266,6 +282,7 @@ public class EdgeTraversal {
     copy.intersectionDescriptor = intersectionDescriptor;
     copy.semiJoinDescriptor = semiJoinDescriptor;
     copy.acceptedCollectionIds = acceptedCollectionIds;
+    copy.consumed = consumed;
     // Cache is intentionally not copied — stale data from a previous
     // execution must not leak into a new plan instance.
     return copy;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversal.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeTraversal.java
@@ -70,6 +70,15 @@ public class EdgeTraversal {
   @Nullable private RidFilterDescriptor intersectionDescriptor;
 
   /**
+   * Semi-join descriptor for back-reference hash join optimization. When set,
+   * {@link BackRefHashJoinStep} replaces the normal {@link MatchStep} for this
+   * edge. Mutually exclusive with {@link #intersectionDescriptor} for the same
+   * back-reference — when a semi-join descriptor is attached, no
+   * {@link RidFilterDescriptor.EdgeRidLookup} is created for the back-ref edge.
+   */
+  @Nullable private SemiJoinDescriptor semiJoinDescriptor;
+
+  /**
    * Fixed-capacity cache of resolved RidSets, keyed by
    * {@link RidFilterDescriptor#cacheKey}. Stops accepting new entries
    * at capacity — no eviction, no LRU bookkeeping. Allocated lazily
@@ -141,6 +150,14 @@ public class EdgeTraversal {
       intersectionDescriptor = new RidFilterDescriptor.Composite(
           List.of(intersectionDescriptor, descriptor));
     }
+  }
+
+  @Nullable public SemiJoinDescriptor getSemiJoinDescriptor() {
+    return semiJoinDescriptor;
+  }
+
+  public void setSemiJoinDescriptor(@Nullable SemiJoinDescriptor semiJoinDescriptor) {
+    this.semiJoinDescriptor = semiJoinDescriptor;
   }
 
   @Nullable public IntSet getAcceptedCollectionIds() {
@@ -247,6 +264,7 @@ public class EdgeTraversal {
       copy.leftRid = leftRid.copy();
     }
     copy.intersectionDescriptor = intersectionDescriptor;
+    copy.semiJoinDescriptor = semiJoinDescriptor;
     copy.acceptedCollectionIds = acceptedCollectionIds;
     // Cache is intentionally not copied — stale data from a previous
     // execution must not leak into a new plan instance.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3083,14 +3083,26 @@ public class MatchExecutionPlanner {
             // propagated from a preceding outE/inE). When collectEdgeRids
             // is true, the class/direction came from the previous edge —
             // Pattern B detection handles that case below.
+            //
+            // Any residual WHERE terms on the target alias (beyond the
+            // {@code @rid = $matched.X.@rid} equality) are extracted here
+            // and passed to {@link BackRefHashJoinStep} for post-load
+            // evaluation. Pattern A is rejected only when the residual
+            // cannot be extracted safely — either because the RID equality
+            // is nested too deep for the flat-block extractor, or because
+            // the residual references {@code $matched}/{@code $currentMatch}
+            // which build phase cannot resolve.
+            var residualExtraction = extractTargetResidual(targetFilter);
             if (!collectEdgeRids
                 && !edgeJ.edge.in.isOptionalNode()
                 && isSemiJoinCandidate(edgeDirection, involvedAliases,
-                    boundAliases)) {
+                    boundAliases)
+                && residualExtraction.safe()) {
               var backRefAlias = involvedAliases.getFirst();
               var descriptor = new SingleEdgeSemiJoin(
                   edgeClass, edgeDirection, ridExpr,
-                  sourceAliasJ, backRefAlias, targetAliasJ);
+                  sourceAliasJ, backRefAlias, targetAliasJ,
+                  residualExtraction.residual());
               edgeJ.setSemiJoinDescriptor(descriptor);
               logger.debug(
                   "MATCH pre-filter: BackRefHashJoin on edge[{}] "
@@ -3508,6 +3520,124 @@ public class MatchExecutionPlanner {
    */
   private static boolean refersToCurrentMatch(SQLWhereClause filter) {
     return filter.toString().contains("$currentMatch");
+  }
+
+  /**
+   * Result of splitting a Pattern A target WHERE into the hash-joinable
+   * {@code @rid} equality and everything else.
+   *
+   * @param safe     {@code true} when Pattern A may fire — either the target
+   *                 has no residual, or the residual has been cleanly
+   *                 extracted and does not reference any build-phase-unsafe
+   *                 variables
+   * @param residual the residual to re-evaluate on the loaded target entity,
+   *                 or {@code null} when there is nothing to re-evaluate
+   */
+  record ResidualExtraction(boolean safe, @Nullable SQLWhereClause residual) {
+  }
+
+  private static final ResidualExtraction RESIDUAL_SAFE_NONE =
+      new ResidualExtraction(true, null);
+  private static final ResidualExtraction RESIDUAL_UNSAFE =
+      new ResidualExtraction(false, null);
+
+  /**
+   * Extracts the non-{@code @rid} residual of a Pattern A target WHERE clause.
+   * Returns {@link #RESIDUAL_UNSAFE} when the clause cannot be flattened to
+   * a single conjunction (e.g. multi-branch OR) or when the residual
+   * references {@code $matched}/{@code $currentMatch} — those variables have
+   * no defined value at hash-build time, so evaluating them per loaded
+   * target would read stale context state.
+   *
+   * <p>Handles the MATCH planner's typical double-wrapping
+   * ({@code AND[OR[AND[@rid, ...]]]}) by flattening all transparent
+   * single-element OR/AND wrappers before locating the {@code @rid} term,
+   * matching the recursive behavior of {@link SQLWhereClause#findRidEquality}.
+   */
+  private static ResidualExtraction extractTargetResidual(
+      @Nullable SQLWhereClause targetFilter) {
+    if (targetFilter == null) {
+      return RESIDUAL_SAFE_NONE;
+    }
+    var base = targetFilter.getBaseExpression();
+    if (base == null) {
+      return RESIDUAL_SAFE_NONE;
+    }
+    var atoms = new ArrayList<SQLBooleanExpression>();
+    if (!flattenConjunction(base, atoms)) {
+      return RESIDUAL_UNSAFE;
+    }
+    var residualAtoms = new ArrayList<SQLBooleanExpression>(atoms.size());
+    var foundRid = false;
+    for (var atom : atoms) {
+      if (!foundRid && isRidEqualityAtom(atom)) {
+        foundRid = true;
+      } else {
+        residualAtoms.add(atom);
+      }
+    }
+    if (!foundRid) {
+      return RESIDUAL_UNSAFE;
+    }
+    if (residualAtoms.isEmpty()) {
+      return RESIDUAL_SAFE_NONE;
+    }
+    var newAnd = new SQLAndBlock(-1);
+    newAnd.getSubBlocks().addAll(residualAtoms);
+    var newOr = new SQLOrBlock(-1);
+    newOr.getSubBlocks().add(newAnd);
+    var residual = new SQLWhereClause(-1);
+    residual.setBaseExpression(newOr);
+
+    var refs = newAnd.getMatchPatternInvolvedAliases();
+    if (refs != null && !refs.isEmpty()) {
+      return RESIDUAL_UNSAFE;
+    }
+    if (refersToCurrentMatch(residual)) {
+      return RESIDUAL_UNSAFE;
+    }
+    return new ResidualExtraction(true, residual);
+  }
+
+  /**
+   * Flattens a conjunction expression, peeling single-element OR/AND
+   * wrappers recursively and collecting leaf boolean terms into
+   * {@code atoms}. Returns {@code false} when a multi-branch OR is
+   * encountered (not a pure conjunction) or the expression is otherwise
+   * not flattenable.
+   */
+  private static boolean flattenConjunction(
+      SQLBooleanExpression expr, List<SQLBooleanExpression> atoms) {
+    if (expr instanceof SQLOrBlock or) {
+      if (or.getSubBlocks().size() != 1) {
+        return false;
+      }
+      return flattenConjunction(or.getSubBlocks().getFirst(), atoms);
+    }
+    if (expr instanceof SQLAndBlock and) {
+      for (var sub : and.getSubBlocks()) {
+        if (!flattenConjunction(sub, atoms)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    atoms.add(expr);
+    return true;
+  }
+
+  /**
+   * Returns {@code true} if the given already-flattened atomic term is a
+   * {@code @rid = <expr>} equality. Wraps the atom in a single-term WHERE
+   * clause and delegates to {@link SQLWhereClause#findRidEquality} to avoid
+   * duplicating the RID-matching logic.
+   */
+  private static boolean isRidEqualityAtom(SQLBooleanExpression atom) {
+    var tmpAnd = new SQLAndBlock(-1);
+    tmpAnd.getSubBlocks().add(atom);
+    var tmpWhere = new SQLWhereClause(-1);
+    tmpWhere.setBaseExpression(tmpAnd);
+    return tmpWhere.findRidEquality() != null;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3071,6 +3071,7 @@ public class MatchExecutionPlanner {
             // is true, the class/direction came from the previous edge —
             // Pattern B detection handles that case below.
             if (!collectEdgeRids
+                && !edgeJ.edge.in.isOptionalNode()
                 && isSemiJoinCandidate(edgeDirection, involvedAliases,
                     boundAliases)) {
               var backRefAlias = involvedAliases.getFirst();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -1783,9 +1783,18 @@ public class MatchExecutionPlanner {
 
     var first = true;
     if (!sortedEdges.isEmpty()) {
+      optimizeScheduleWithIntersections(sortedEdges, context);
+
+      // Re-bind filters after optimization: detectNotInAntiJoin() may have
+      // stripped NOT IN conditions from aliasFilters, so we must push the
+      // updated filters to the match expression AST nodes. Without this,
+      // the MatchStep would still evaluate the original un-stripped filter.
+      rebindFilters(aliasFilters);
+
+      // Annotate each edge traversal with the source node's class/RID/filter
+      // constraints (post-optimization, so stripped filters are reflected).
+      // MatchReverseEdgeTraverser uses these when traversing in reverse.
       for (var edge : sortedEdges) {
-        // Annotate each edge traversal with the source node's class/RID/filter constraints
-        // so that MatchReverseEdgeTraverser can apply them when traversing in reverse
         if (edge.edge.out.alias != null) {
           edge.setLeftClass(aliasClasses.get(edge.edge.out.alias));
           edge.setLeftRid(aliasRids.get(edge.edge.out.alias));
@@ -1793,7 +1802,6 @@ public class MatchExecutionPlanner {
         }
       }
 
-      optimizeScheduleWithIntersections(sortedEdges, context);
       attachCollectionIdFilters(sortedEdges, context);
 
       // Hash join optimization: detect secondary branches that can be evaluated as
@@ -3110,8 +3118,10 @@ public class MatchExecutionPlanner {
                     schedule, j, involvedAliases, ridExpr, targetAliasJ,
                     boundAliases, ctx);
                 if (chainDesc != null) {
+                  var consumed = schedule.get(j - 1);
                   edgeJ.setSemiJoinDescriptor(chainDesc);
-                  schedule.get(j - 1).setConsumed(true);
+                  consumed.setConsumed(true);
+                  edgeJ.setConsumedPredecessor(consumed);
                   logger.debug(
                       "MATCH pre-filter: ChainSemiJoin on edge[{},{}] "
                           + "({}({}) chain semi-join via $matched.{})",
@@ -3129,8 +3139,10 @@ public class MatchExecutionPlanner {
                 schedule, j, involvedAliases, ridExpr, targetAliasJ,
                 boundAliases, ctx);
             if (chainDesc != null) {
+              var consumed = schedule.get(j - 1);
               edgeJ.setSemiJoinDescriptor(chainDesc);
-              schedule.get(j - 1).setConsumed(true);
+              consumed.setConsumed(true);
+              edgeJ.setConsumedPredecessor(consumed);
               logger.debug(
                   "MATCH pre-filter: ChainSemiJoin on edge[{},{}] "
                       + "({}({}) chain semi-join via $matched.{})",
@@ -3238,6 +3250,7 @@ public class MatchExecutionPlanner {
     return threshold > 0;
   }
 
+  // FQN to avoid collision with com.jetbrains.youtrackdb...sql.parser.Pattern
   // Regex for $matched.X.out('E') or $matched.X.in('E')
   // Group 1: alias name (X), Group 2: direction (out/in), Group 3: edge class (E)
   private static final java.util.regex.Pattern MATCHED_TRAVERSAL_PATTERN =
@@ -3332,7 +3345,7 @@ public class MatchExecutionPlanner {
         continue;
       }
 
-      // Edge class must be a valid identifier (prevent SQL injection)
+      // Edge class must be a valid identifier (sanity check on regex group)
       if (!edgeClass.matches("[A-Za-z_][A-Za-z0-9_]*")) {
         continue;
       }
@@ -3857,13 +3870,16 @@ public class MatchExecutionPlanner {
       // condition per row as a correctness fallback.
       plan.chain(new MatchStep(context, edge, profilingEnabled));
       plan.chain(new BackRefHashJoinStep(
-          context, edge.getSemiJoinDescriptor(), null, profilingEnabled));
+          context, edge.getSemiJoinDescriptor(), null, null, profilingEnabled));
     } else if (edge.getSemiJoinDescriptor() != null) {
       // Back-reference semi-join (Pattern A/B): replace per-row link bag
       // traversal with a one-time hash table build + O(1) probe. The
       // EdgeTraversal is passed for runtime fallback if the build fails.
+      // For Pattern B (ChainSemiJoin), the consumed predecessor edge is
+      // also passed so the fallback can traverse both edges sequentially.
       plan.chain(new BackRefHashJoinStep(
-          context, edge.getSemiJoinDescriptor(), edge, profilingEnabled));
+          context, edge.getSemiJoinDescriptor(), edge,
+          edge.getConsumedPredecessor(), profilingEnabled));
     } else {
       plan.chain(new MatchStep(context, edge, profilingEnabled));
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -406,7 +406,9 @@ public class MatchExecutionPlanner {
 
     this.pattern = pattern;
     this.aliasClasses = aliasClasses;
-    this.aliasFilters = aliasFilters;
+    // Defensive copy: aliasFilters may be immutable (e.g. Map.of() from GQL).
+    // detectNotInAntiJoin() mutates this map to strip NOT IN conditions.
+    this.aliasFilters = new HashMap<>(aliasFilters);
     this.aliasRids = Map.of();
   }
 
@@ -3131,7 +3133,7 @@ public class MatchExecutionPlanner {
       // Pattern D detection follows below
       if (edgeJ.getSemiJoinDescriptor() == null) {
         var antiDesc = detectNotInAntiJoin(
-            targetFilter, targetAliasJ, boundAliases, edgeJ);
+            targetFilter, targetAliasJ, boundAliases);
         if (antiDesc != null) {
           edgeJ.setSemiJoinDescriptor(antiDesc);
           logger.debug(
@@ -3224,11 +3226,10 @@ public class MatchExecutionPlanner {
    * @param boundAliases  all aliases bound in the schedule
    * @return an AntiSemiJoin descriptor, or null if the pattern is not found
    */
-  @Nullable private static AntiSemiJoin detectNotInAntiJoin(
+  @Nullable private AntiSemiJoin detectNotInAntiJoin(
       SQLWhereClause targetFilter,
       String targetAlias,
-      Set<String> boundAliases,
-      EdgeTraversal edge) {
+      Set<String> boundAliases) {
     var threshold = getHashJoinThreshold();
     if (threshold <= 0) {
       return null;
@@ -3240,7 +3241,7 @@ public class MatchExecutionPlanner {
     }
 
     // Navigate: SQLOrBlock → single SQLAndBlock → subBlocks list
-    List<SQLBooleanExpression> andSubBlocks;
+    SQLAndBlock andBlock;
     if (baseExpr instanceof SQLOrBlock orBlock) {
       var orSubs = orBlock.getSubBlocks();
       if (orSubs == null || orSubs.size() != 1) {
@@ -3250,13 +3251,14 @@ public class MatchExecutionPlanner {
       if (!(firstOr instanceof SQLAndBlock ab)) {
         return null;
       }
-      andSubBlocks = ab.getSubBlocks();
+      andBlock = ab;
     } else if (baseExpr instanceof SQLAndBlock ab) {
-      andSubBlocks = ab.getSubBlocks();
+      andBlock = ab;
     } else {
       return null;
     }
 
+    var andSubBlocks = andBlock.getSubBlocks();
     if (andSubBlocks == null || andSubBlocks.isEmpty()) {
       return null;
     }
@@ -3291,77 +3293,25 @@ public class MatchExecutionPlanner {
         continue;
       }
 
-      // Remove the NOT IN condition from BOTH the aliasFilters entry
-      // and the AST filter on the edge's target node. The MatchStep reads
-      // its filter from the AST (item.getFilter().getFilter()), not from
-      // aliasFilters, so we must strip both to prevent double evaluation.
-      andSubBlocks.remove(i);
-      stripNotInFromAstFilter(edge, condStr);
-
-      // Build residual filter (remaining AND conditions, if any)
-      SQLWhereClause residualFilter = null;
-      if (!andSubBlocks.isEmpty()) {
-        residualFilter = targetFilter;
+      // Strip the NOT IN from the target alias's WHERE clause so that the
+      // preceding MatchStep does not re-evaluate it per row (the expensive
+      // O(degree) link bag traversal). The stripped condition is stored in
+      // the AntiSemiJoin descriptor for runtime fallback: if the hash table
+      // build fails, BackRefHashJoinStep evaluates it per row.
+      var strippedFilter =
+          SQLWhereClause.buildWhereWithoutTerm(andBlock, i);
+      if (strippedFilter != null) {
+        aliasFilters.put(targetAlias, strippedFilter);
+      } else {
+        // NOT IN was the only condition — remove the filter entirely
+        aliasFilters.remove(targetAlias);
       }
 
       return new AntiSemiJoin(
           anchorAlias, edgeClass, direction,
-          anchorAlias, targetAlias, residualFilter);
+          anchorAlias, targetAlias, sub);
     }
     return null;
-  }
-
-  /**
-   * Removes a NOT IN condition from the AST filter on the edge's target node.
-   * This is needed because the MatchStep reads its filter from the AST
-   * ({@code item.getFilter().getFilter()}), not from {@code aliasFilters}.
-   * Without this, the MatchStep would re-evaluate the NOT IN per row,
-   * negating the anti-join optimization.
-   */
-  private static void stripNotInFromAstFilter(
-      EdgeTraversal edge, String notInString) {
-    var matchFilter = edge.edge.item.getFilter();
-    if (matchFilter == null) {
-      return;
-    }
-    var astWhere = matchFilter.getFilter();
-    if (astWhere == null) {
-      return;
-    }
-    var astBase = astWhere.getBaseExpression();
-    if (astBase == null) {
-      return;
-    }
-
-    // Walk the AST structure and find the sub-block matching the NOT IN string
-    List<SQLBooleanExpression> targetList = null;
-    int targetIdx = -1;
-
-    if (astBase instanceof SQLAndBlock ab) {
-      targetList = ab.getSubBlocks();
-    } else if (astBase instanceof SQLOrBlock ob) {
-      var orSubs = ob.getSubBlocks();
-      if (orSubs != null && orSubs.size() == 1
-          && orSubs.getFirst() instanceof SQLAndBlock ab) {
-        targetList = ab.getSubBlocks();
-      }
-    }
-
-    if (targetList != null) {
-      for (int k = 0; k < targetList.size(); k++) {
-        if (targetList.get(k).toString().trim().equals(notInString)) {
-          targetIdx = k;
-          break;
-        }
-      }
-      if (targetIdx >= 0) {
-        targetList.remove(targetIdx);
-        // If no conditions remain, clear the WHERE clause entirely
-        if (targetList.isEmpty()) {
-          matchFilter.setFilter(null);
-        }
-      }
-    }
   }
 
   /**
@@ -3831,16 +3781,18 @@ public class MatchExecutionPlanner {
       }
     } else if (edge.getSemiJoinDescriptor() instanceof AntiSemiJoin) {
       // Pattern D: normal traversal + anti-join filter. The NOT IN condition
-      // was removed from the WHERE clause, so the MatchStep traverses without
-      // it. The BackRefHashJoinStep filters results against the exclusion set.
+      // is kept in the WHERE clause on the MatchStep so it serves as a
+      // correctness fallback if the hash table build fails at runtime.
+      // When the hash join succeeds, it short-circuits the per-row NOT IN.
       plan.chain(new MatchStep(context, edge, profilingEnabled));
       plan.chain(new BackRefHashJoinStep(
-          context, edge.getSemiJoinDescriptor(), profilingEnabled));
+          context, edge.getSemiJoinDescriptor(), null, profilingEnabled));
     } else if (edge.getSemiJoinDescriptor() != null) {
       // Back-reference semi-join (Pattern A/B): replace per-row link bag
-      // traversal with a one-time hash table build + O(1) probe.
+      // traversal with a one-time hash table build + O(1) probe. The
+      // EdgeTraversal is passed for runtime fallback if the build fails.
       plan.chain(new BackRefHashJoinStep(
-          context, edge.getSemiJoinDescriptor(), profilingEnabled));
+          context, edge.getSemiJoinDescriptor(), edge, profilingEnabled));
     } else {
       plan.chain(new MatchStep(context, edge, profilingEnabled));
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -17,6 +17,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.CostModel;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.DistinctExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.EmptyStep;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ExecutionStepInternal;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.IndexSearchDescriptor;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.InternalExecutionPlan;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.LimitExecutionStep;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.OrderByStep;
@@ -3092,6 +3093,23 @@ public class MatchExecutionPlanner {
                     collectEdgeRids);
               }
             }
+          } else if (j > 0) {
+            // --- Pattern B: outE('E').inV() chain semi-join ---
+            // edge_j is .inV() (no edge class/direction). Check if the
+            // preceding edge is .outE('E') or .inE('E') with a recognized
+            // edge class. If so, collapse both into a ChainSemiJoin.
+            var chainDesc = detectChainSemiJoin(
+                schedule, j, involvedAliases, ridExpr, targetAliasJ,
+                boundAliases, ctx);
+            if (chainDesc != null) {
+              edgeJ.setSemiJoinDescriptor(chainDesc);
+              schedule.get(j - 1).setConsumed(true);
+              logger.debug(
+                  "MATCH pre-filter: ChainSemiJoin on edge[{},{}] "
+                      + "({}({}) chain semi-join via $matched.{})",
+                  j - 1, j, chainDesc.direction(), chainDesc.edgeClass(),
+                  chainDesc.backRefAlias());
+            }
           }
         } else {
           // Literal or parameter RID: @rid = #12:0 or @rid = :param
@@ -3168,6 +3186,78 @@ public class MatchExecutionPlanner {
     // Check threshold is enabled (0 disables hash join)
     var threshold = getHashJoinThreshold();
     return threshold > 0;
+  }
+
+  /**
+   * Detects Pattern B: an {@code .outE('E').inV()} chain where the
+   * {@code .inV()} target has a back-reference {@code @rid = $matched.X.@rid}.
+   * Returns a {@link ChainSemiJoin} descriptor if the pattern qualifies,
+   * or {@code null} otherwise.
+   *
+   * <p>The edge class and direction are extracted from edge_j-1 (the
+   * {@code .outE('E')} edge), not from edge_j ({@code .inV()}).
+   */
+  @Nullable private ChainSemiJoin detectChainSemiJoin(
+      List<EdgeTraversal> schedule,
+      int j,
+      List<String> involvedAliases,
+      SQLExpression ridExpr,
+      String targetAliasJ,
+      Set<String> boundAliases,
+      CommandContext ctx) {
+    // The back-ref must reference exactly one alias that is already bound
+    if (involvedAliases.size() != 1) {
+      return null;
+    }
+    var backRefAlias = involvedAliases.getFirst();
+    if (!boundAliases.contains(backRefAlias)) {
+      return null;
+    }
+    var threshold = getHashJoinThreshold();
+    if (threshold <= 0) {
+      return null;
+    }
+
+    // Check preceding edge (j-1) is an edge-level traversal (outE/inE)
+    var edgePrev = schedule.get(j - 1);
+    var prevDirection = getEdgeDirection(edgePrev);
+    if (prevDirection == null) {
+      return null;
+    }
+    // Must be edge-level: "oute" or "ine"
+    if (!"oute".equals(prevDirection) && !"ine".equals(prevDirection)) {
+      return null;
+    }
+    var prevEdgeClass = getEdgeClassName(edgePrev);
+    if (prevEdgeClass == null) {
+      return null;
+    }
+
+    // Extract aliases. The source alias is the source of edge_j-1 (outE),
+    // not edge_j (inV). The intermediate alias is the target of edge_j-1.
+    var sourceAlias = edgePrev.out
+        ? edgePrev.edge.out.alias : edgePrev.edge.in.alias;
+    var intermediateAlias = edgePrev.out
+        ? edgePrev.edge.in.alias : edgePrev.edge.out.alias;
+
+    // Map oute→out, ine→in for the reverse link bag direction
+    var direction = prevDirection.startsWith("out") ? "out" : "in";
+
+    // Check for optional index pre-filter on the intermediate edge
+    var intermediateFilter = aliasFilters.get(intermediateAlias);
+    IndexSearchDescriptor indexFilter = null;
+    if (intermediateFilter != null) {
+      var intermediateClass = aliasClasses.get(intermediateAlias);
+      if (intermediateClass != null) {
+        indexFilter = TraversalPreFilterHelper.findIndexForFilter(
+            intermediateFilter, intermediateClass, ctx);
+      }
+    }
+
+    return new ChainSemiJoin(
+        prevEdgeClass, direction, ridExpr,
+        sourceAlias, backRefAlias, intermediateAlias,
+        targetAliasJ, indexFilter);
   }
 
   /**
@@ -3511,6 +3601,11 @@ public class MatchExecutionPlanner {
               patternNode,
               select.createExecutionPlan(subContxt, profilingEnabled),
               profilingEnabled));
+    }
+    // Skip edges consumed by a ChainSemiJoin on the next edge — the
+    // BackRefHashJoinStep on the next edge covers both.
+    if (edge.isConsumed()) {
+      return;
     }
     if (edge.edge.in.isOptionalNode()) {
       // Check if this optional edge can be replaced with a correlated hash lookup

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -44,6 +44,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLLimit;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchFilter;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchStatement;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMathExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMethodCall;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMultiMatchPathItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNeOperator;
@@ -3240,14 +3241,84 @@ public class MatchExecutionPlanner {
     return threshold > 0;
   }
 
-  // FQN to avoid collision with com.jetbrains.youtrackdb...sql.parser.Pattern
-  // Regex for $matched.X.out('E') or $matched.X.in('E')
-  // Group 1: alias name (X), Group 2: direction (out/in),
-  // Group 3: edge class (E) — with matched quotes or unquoted
-  private static final java.util.regex.Pattern MATCHED_TRAVERSAL_PATTERN =
-      java.util.regex.Pattern.compile(
-          "\\$matched\\.(\\w+)\\.(out|in)\\((?:(['\"])(\\w+)\\3|(\\w+))\\)",
-          java.util.regex.Pattern.CASE_INSENSITIVE);
+  /**
+   * Structural decomposition of a {@code $matched.<alias>.<out|in>('E')}
+   * traversal expression — the RHS shape required by Pattern D anti-joins.
+   */
+  private record MatchedTraversal(
+      String anchorAlias, String direction, String edgeClass) {
+  }
+
+  /**
+   * Extracts {@link MatchedTraversal} from an RHS AST node or returns
+   * {@code null} when the shape does not match. Walks the AST directly
+   * instead of parsing {@link SQLMathExpression#toString}, which would
+   * rely on the generated parser's serialization format staying stable
+   * and would mis-handle back-quoted identifiers, bound parameters, and
+   * edge-direction variants like {@code outE}.
+   */
+  @Nullable private static MatchedTraversal extractMatchedTraversal(
+      @Nullable SQLMathExpression rhs) {
+    if (!(rhs instanceof SQLBaseExpression base)) {
+      return null;
+    }
+    var identifier = base.getIdentifier();
+    if (identifier == null || !"$matched".equals(identifier.toString())) {
+      return null;
+    }
+    var firstMod = base.getModifier();
+    if (firstMod == null) {
+      return null;
+    }
+    // First segment must be `.X` (suffix identifier, no method call).
+    var suffix = firstMod.getSuffix();
+    if (suffix == null || suffix.getIdentifier() == null
+        || firstMod.getMethodCall() != null) {
+      return null;
+    }
+    var anchorAlias = suffix.getIdentifier().getStringValue();
+    if (anchorAlias == null) {
+      return null;
+    }
+    // Second segment must be `.<dir>(<edgeClass>)` — a method call.
+    var secondMod = firstMod.getNext();
+    if (secondMod == null) {
+      return null;
+    }
+    var method = secondMod.getMethodCall();
+    if (method == null) {
+      return null;
+    }
+    // There must not be further modifiers (reject `.out('E').somethingElse`).
+    if (secondMod.getNext() != null) {
+      return null;
+    }
+    var methodName = method.getMethodNameString();
+    if (methodName == null) {
+      return null;
+    }
+    // Vertex-level traversals only: out / in. Reject outE, inE, bothV, etc.
+    var direction = methodName.toLowerCase(Locale.ROOT);
+    if (!"out".equals(direction) && !"in".equals(direction)) {
+      return null;
+    }
+    var params = method.getParams();
+    if (params == null || params.size() != 1) {
+      return null;
+    }
+    var paramMath = params.getFirst().getMathExpression();
+    if (!(paramMath instanceof SQLBaseExpression paramBase)) {
+      return null;
+    }
+    // Only accept a plain string literal for the edge class — reject bound
+    // parameters (:edge), identifiers, and compound expressions whose
+    // value cannot be determined at plan time.
+    var edgeClass = paramBase.getStringLiteralValue();
+    if (edgeClass == null) {
+      return null;
+    }
+    return new MatchedTraversal(anchorAlias, direction, edgeClass);
+  }
 
   /**
    * Detects Pattern D: a {@code $currentMatch NOT IN $matched.X.out('E')}
@@ -3315,26 +3386,16 @@ public class MatchExecutionPlanner {
         continue;
       }
 
-      // Check RHS is $matched.X.out('E') or $matched.X.in('E') via the
-      // AST node, avoiding full-condition toString() parsing
-      var rhs = inner.getRightMathExpression();
-      if (rhs == null) {
+      // Check RHS is $matched.X.out('E') or $matched.X.in('E') by walking
+      // the AST structure directly — immune to toString() format drift,
+      // back-quoted identifiers, and bound parameters for the edge class.
+      var traversal = extractMatchedTraversal(inner.getRightMathExpression());
+      if (traversal == null) {
         continue;
       }
-      var rhsStr = rhs.toString().trim();
-      var matcher = MATCHED_TRAVERSAL_PATTERN.matcher(rhsStr);
-      if (!matcher.matches()) {
-        continue;
-      }
-
-      var anchorAlias = matcher.group(1);
-      var direction = matcher.group(2).toLowerCase(Locale.ROOT);
-      // Edge class is in group 4 (quoted) or group 5 (unquoted)
-      var edgeClass = matcher.group(4) != null
-          ? matcher.group(4) : matcher.group(5);
 
       // Anchor alias must be already bound
-      if (!boundAliases.contains(anchorAlias)) {
+      if (!boundAliases.contains(traversal.anchorAlias())) {
         continue;
       }
 
@@ -3360,7 +3421,8 @@ public class MatchExecutionPlanner {
       }
 
       return new AntiSemiJoin(
-          anchorAlias, edgeClass, direction, targetAlias, sub.copy());
+          traversal.anchorAlias(), traversal.edgeClass(),
+          traversal.direction(), targetAlias, sub.copy());
     }
     return null;
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3346,24 +3346,17 @@ public class MatchExecutionPlanner {
       return null;
     }
 
-    // Navigate: SQLOrBlock → single SQLAndBlock → subBlocks list
-    SQLAndBlock andBlock;
-    if (baseExpr instanceof SQLOrBlock orBlock) {
-      var orSubs = orBlock.getSubBlocks();
-      if (orSubs == null || orSubs.size() != 1) {
-        return null; // Multiple OR branches — too complex
-      }
-      var firstOr = orSubs.getFirst();
-      if (!(firstOr instanceof SQLAndBlock ab)) {
-        return null;
-      }
-      andBlock = ab;
-    } else if (baseExpr instanceof SQLAndBlock ab) {
-      andBlock = ab;
-    } else {
+    // Descend through the transparent wrappers MATCH adds around filters
+    // (addAliases wraps original WHERE in an outer AND, the grammar in turn
+    // wraps AND blocks in single-element ORs) to the AND block whose
+    // sub-blocks are the user's visible conjuncts. Without this, a compound
+    // WHERE like "NOT IN AND name='n4'" sits two wrappers deep — iterating
+    // the top-level AND's single sub-block (an OR wrapping the inner AND
+    // with two terms) never reaches the NOT IN.
+    var andBlock = findConjunctsAnd(baseExpr);
+    if (andBlock == null) {
       return null;
     }
-
     var andSubBlocks = andBlock.getSubBlocks();
     if (andSubBlocks == null || andSubBlocks.isEmpty()) {
       return null;
@@ -3425,6 +3418,58 @@ public class MatchExecutionPlanner {
           traversal.direction(), targetAlias, sub.copy());
     }
     return null;
+  }
+
+  /**
+   * Descends through single-element {@link SQLOrBlock} and {@link SQLAndBlock}
+   * wrappers to find the AND block whose sub-blocks are the user's top-level
+   * conjuncts.
+   *
+   * <p>The MATCH planner wraps each alias's WHERE clause in at least one
+   * extra AND block (see {@code addAliases}), and the grammar itself wraps
+   * the user's AND inside a single-element OR. For a compound WHERE like
+   * {@code NOT IN AND name='n4'} the resulting structure is
+   * {@code AND[OR[AND[<notIn>, <name='n4'>]]]} — the inner AND holds the
+   * actual conjuncts. Returns {@code null} when a multi-branch OR is
+   * encountered (that would require disjunctive processing) or when no AND
+   * is reachable.
+   */
+  @Nullable private static SQLAndBlock findConjunctsAnd(
+      SQLBooleanExpression expr) {
+    SQLAndBlock lastAnd = null;
+    var current = expr;
+    while (true) {
+      if (current instanceof SQLOrBlock or) {
+        var subs = or.getSubBlocks();
+        if (subs == null || subs.size() != 1) {
+          return null;
+        }
+        current = subs.getFirst();
+        continue;
+      }
+      if (current instanceof SQLAndBlock and) {
+        lastAnd = and;
+        var subs = and.getSubBlocks();
+        if (subs == null || subs.isEmpty()) {
+          return and;
+        }
+        // If this AND already has multiple conjuncts, it IS the user's list.
+        if (subs.size() > 1) {
+          return and;
+        }
+        // Single-element AND may be a wrapper around another AND/OR layer.
+        var only = subs.getFirst();
+        if (only instanceof SQLOrBlock || only instanceof SQLAndBlock) {
+          current = only;
+          continue;
+        }
+        // The lone sub-block is a leaf condition — this AND is the deepest
+        // one reachable and holds that single conjunct.
+        return and;
+      }
+      // Not an AND/OR at the top — return the deepest AND we've seen.
+      return lastAnd;
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3131,7 +3131,7 @@ public class MatchExecutionPlanner {
       // Pattern D detection follows below
       if (edgeJ.getSemiJoinDescriptor() == null) {
         var antiDesc = detectNotInAntiJoin(
-            targetFilter, targetAliasJ, boundAliases);
+            targetFilter, targetAliasJ, boundAliases, edgeJ);
         if (antiDesc != null) {
           edgeJ.setSemiJoinDescriptor(antiDesc);
           logger.debug(
@@ -3227,7 +3227,8 @@ public class MatchExecutionPlanner {
   @Nullable private static AntiSemiJoin detectNotInAntiJoin(
       SQLWhereClause targetFilter,
       String targetAlias,
-      Set<String> boundAliases) {
+      Set<String> boundAliases,
+      EdgeTraversal edge) {
     var threshold = getHashJoinThreshold();
     if (threshold <= 0) {
       return null;
@@ -3290,13 +3291,17 @@ public class MatchExecutionPlanner {
         continue;
       }
 
-      // Remove the NOT IN condition from the AND block
+      // Remove the NOT IN condition from BOTH the aliasFilters entry
+      // and the AST filter on the edge's target node. The MatchStep reads
+      // its filter from the AST (item.getFilter().getFilter()), not from
+      // aliasFilters, so we must strip both to prevent double evaluation.
       andSubBlocks.remove(i);
+      stripNotInFromAstFilter(edge, condStr);
 
       // Build residual filter (remaining AND conditions, if any)
       SQLWhereClause residualFilter = null;
       if (!andSubBlocks.isEmpty()) {
-        residualFilter = targetFilter; // Modified in-place — remaining conditions stay
+        residualFilter = targetFilter;
       }
 
       return new AntiSemiJoin(
@@ -3304,6 +3309,59 @@ public class MatchExecutionPlanner {
           anchorAlias, targetAlias, residualFilter);
     }
     return null;
+  }
+
+  /**
+   * Removes a NOT IN condition from the AST filter on the edge's target node.
+   * This is needed because the MatchStep reads its filter from the AST
+   * ({@code item.getFilter().getFilter()}), not from {@code aliasFilters}.
+   * Without this, the MatchStep would re-evaluate the NOT IN per row,
+   * negating the anti-join optimization.
+   */
+  private static void stripNotInFromAstFilter(
+      EdgeTraversal edge, String notInString) {
+    var matchFilter = edge.edge.item.getFilter();
+    if (matchFilter == null) {
+      return;
+    }
+    var astWhere = matchFilter.getFilter();
+    if (astWhere == null) {
+      return;
+    }
+    var astBase = astWhere.getBaseExpression();
+    if (astBase == null) {
+      return;
+    }
+
+    // Walk the AST structure and find the sub-block matching the NOT IN string
+    List<SQLBooleanExpression> targetList = null;
+    int targetIdx = -1;
+
+    if (astBase instanceof SQLAndBlock ab) {
+      targetList = ab.getSubBlocks();
+    } else if (astBase instanceof SQLOrBlock ob) {
+      var orSubs = ob.getSubBlocks();
+      if (orSubs != null && orSubs.size() == 1
+          && orSubs.getFirst() instanceof SQLAndBlock ab) {
+        targetList = ab.getSubBlocks();
+      }
+    }
+
+    if (targetList != null) {
+      for (int k = 0; k < targetList.size(); k++) {
+        if (targetList.get(k).toString().trim().equals(notInString)) {
+          targetIdx = k;
+          break;
+        }
+      }
+      if (targetIdx >= 0) {
+        targetList.remove(targetIdx);
+        // If no conditions remain, clear the WHERE clause entirely
+        if (targetList.isEmpty()) {
+          matchFilter.setFilter(null);
+        }
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -49,6 +49,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMultiMatchPathItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNeOperator;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNestedProjection;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNotBlock;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNotInCondition;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLOrBlock;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLOrderBy;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLProjection;
@@ -3065,12 +3066,13 @@ public class MatchExecutionPlanner {
                 ? edgeJ.edge.out.alias : edgeJ.edge.in.alias;
 
             // --- Semi-join candidacy check (Pattern A) ---
-            // If this is a vertex-level traversal (out/in, not outE/inE)
-            // and the back-ref alias is already bound, try to replace the
-            // per-row link bag scan with a one-time hash table build + O(1)
-            // probe.
-            if (isSemiJoinCandidate(edgeDirection, involvedAliases,
-                boundAliases)) {
+            // Only when the edge class belongs to the current edge (not
+            // propagated from a preceding outE/inE). When collectEdgeRids
+            // is true, the class/direction came from the previous edge —
+            // Pattern B detection handles that case below.
+            if (!collectEdgeRids
+                && isSemiJoinCandidate(edgeDirection, involvedAliases,
+                    boundAliases)) {
               var backRefAlias = involvedAliases.getFirst();
               var descriptor = new SingleEdgeSemiJoin(
                   edgeClass, edgeDirection, ridExpr,
@@ -3093,6 +3095,23 @@ public class MatchExecutionPlanner {
                         + "({}({}) back-ref from alias '{}', edgeRids={})",
                     producingEdgeIdx, edgeDirection, edgeClass, targetAliasJ,
                     collectEdgeRids);
+              }
+              // --- Pattern B: outE('E').inV() chain semi-join ---
+              // When edge class was propagated from the preceding edge, also
+              // try chain semi-join which collapses both edges into one step.
+              if (collectEdgeRids) {
+                var chainDesc = detectChainSemiJoin(
+                    schedule, j, involvedAliases, ridExpr, targetAliasJ,
+                    boundAliases, ctx);
+                if (chainDesc != null) {
+                  edgeJ.setSemiJoinDescriptor(chainDesc);
+                  schedule.get(j - 1).setConsumed(true);
+                  logger.debug(
+                      "MATCH pre-filter: ChainSemiJoin on edge[{},{}] "
+                          + "({}({}) chain semi-join via $matched.{})",
+                      j - 1, j, chainDesc.direction(), chainDesc.edgeClass(),
+                      chainDesc.backRefAlias());
+                }
               }
             }
           } else if (j > 0) {
@@ -3262,13 +3281,18 @@ public class MatchExecutionPlanner {
     if (andSubBlocks == null || andSubBlocks.isEmpty()) {
       return null;
     }
-    // Scan for NOT IN conditions matching the pattern. The condition may be
-    // nested inside SQLOrBlock → SQLAndBlock → SQLNotBlock (parser wrapping).
-    // We use toString() on each sub-block to match the full pattern string,
-    // avoiding fragile class hierarchy assumptions.
+    // Scan for SQLNotInCondition nodes whose LHS is $currentMatch and whose
+    // RHS matches $matched.X.out('E') or $matched.X.in('E'). The grammar
+    // wraps conditions in multiple transparent layers (OrBlock → AndBlock →
+    // NotBlock → ConditionBlock). We unwrap single-element wrappers before
+    // checking the inner type to avoid relying on toString() for detection.
     for (int i = 0; i < andSubBlocks.size(); i++) {
       var sub = andSubBlocks.get(i);
-      var condStr = sub.toString().trim();
+      var inner = unwrapToNotInCondition(sub);
+      if (inner == null) {
+        continue;
+      }
+      var condStr = inner.toString().trim();
       if (!condStr.startsWith("$currentMatch NOT IN ")) {
         continue;
       }
@@ -3308,10 +3332,36 @@ public class MatchExecutionPlanner {
       }
 
       return new AntiSemiJoin(
-          anchorAlias, edgeClass, direction,
-          anchorAlias, targetAlias, sub);
+          anchorAlias, edgeClass, direction, targetAlias, sub);
     }
     return null;
+  }
+
+  /**
+   * Unwraps the transparent AST wrappers the grammar produces around condition
+   * blocks (OrBlock → AndBlock → NotBlock → ConditionBlock) to reach the inner
+   * {@link SQLNotInCondition}, if present. Returns {@code null} if the expression
+   * is not a NOT IN condition or if any wrapper is non-transparent (e.g., OR with
+   * multiple branches, or NOT with {@code negate=true}).
+   */
+  @Nullable private static SQLNotInCondition unwrapToNotInCondition(
+      SQLBooleanExpression expr) {
+    var inner = expr;
+    // Unwrap single-element SQLOrBlock
+    if (inner instanceof SQLOrBlock or && or.getSubBlocks() != null
+        && or.getSubBlocks().size() == 1) {
+      inner = or.getSubBlocks().getFirst();
+    }
+    // Unwrap single-element SQLAndBlock
+    if (inner instanceof SQLAndBlock and && and.getSubBlocks() != null
+        && and.getSubBlocks().size() == 1) {
+      inner = and.getSubBlocks().getFirst();
+    }
+    // Unwrap transparent SQLNotBlock (negate=false)
+    if (inner instanceof SQLNotBlock not && !not.isNegate()) {
+      inner = not.getSub();
+    }
+    return inner instanceof SQLNotInCondition notIn ? notIn : null;
   }
 
   /**
@@ -3781,9 +3831,10 @@ public class MatchExecutionPlanner {
       }
     } else if (edge.getSemiJoinDescriptor() instanceof AntiSemiJoin) {
       // Pattern D: normal traversal + anti-join filter. The NOT IN condition
-      // is kept in the WHERE clause on the MatchStep so it serves as a
-      // correctness fallback if the hash table build fails at runtime.
-      // When the hash join succeeds, it short-circuits the per-row NOT IN.
+      // was stripped from the WHERE clause at plan time so the MatchStep
+      // traverses without it. The BackRefHashJoinStep filters results against
+      // the exclusion set; on build failure it evaluates the stored NOT IN
+      // condition per row as a correctness fallback.
       plan.chain(new MatchStep(context, edge, profilingEnabled));
       plan.chain(new BackRefHashJoinStep(
           context, edge.getSemiJoinDescriptor(), null, profilingEnabled));

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3002,31 +3002,38 @@ public class MatchExecutionPlanner {
       List<EdgeTraversal> schedule, CommandContext ctx) {
     // Build a map: target alias → edge index, so we can find the producing edge
     Map<String, Integer> targetAliasToEdgeIndex = new HashMap<>();
-    // Track all aliases that are bound (visited) before each edge, including
-    // the root alias which is not the target of any edge.
-    Set<String> boundAliases = new HashSet<>();
     for (var i = 0; i < schedule.size(); i++) {
       var et = schedule.get(i);
-      var sourceAlias = et.out ? et.edge.out.alias : et.edge.in.alias;
       var targetAlias = et.out ? et.edge.in.alias : et.edge.out.alias;
-      if (sourceAlias != null) {
-        boundAliases.add(sourceAlias);
-      }
       if (targetAlias != null) {
         targetAliasToEdgeIndex.put(targetAlias, i);
-        boundAliases.add(targetAlias);
       }
     }
 
+    // Track aliases that are bound (visited) before each edge. Built
+    // incrementally: the source alias is added at the start of each
+    // iteration (it was bound by a preceding edge or is the root), and
+    // the target alias is added at the end (it becomes bound during this
+    // edge's execution). This ensures that semi-join candidacy checks
+    // only see aliases that are actually available at execution time.
+    Set<String> boundAliases = new HashSet<>();
     for (var j = 0; j < schedule.size(); j++) {
       var edgeJ = schedule.get(j);
+      var sourceAliasJ = edgeJ.out ? edgeJ.edge.out.alias : edgeJ.edge.in.alias;
       var targetAliasJ = edgeJ.out ? edgeJ.edge.in.alias : edgeJ.edge.out.alias;
+
+      // Source alias is bound before this edge executes (it is either
+      // the root alias or the target of a preceding edge).
+      if (sourceAliasJ != null) {
+        boundAliases.add(sourceAliasJ);
+      }
       if (targetAliasJ == null) {
         continue;
       }
 
       var targetFilter = aliasFilters.get(targetAliasJ);
       if (targetFilter == null) {
+        boundAliases.add(targetAliasJ);
         continue;
       }
 
@@ -3062,8 +3069,6 @@ public class MatchExecutionPlanner {
           }
 
           if (edgeClass != null && edgeDirection != null) {
-            var sourceAliasJ = edgeJ.out
-                ? edgeJ.edge.out.alias : edgeJ.edge.in.alias;
 
             // --- Semi-join candidacy check (Pattern A) ---
             // Only when the edge class belongs to the current edge (not
@@ -3143,6 +3148,7 @@ public class MatchExecutionPlanner {
           logger.debug(
               "MATCH pre-filter: DirectRid on edge[{}] for alias '{}'",
               j, targetAliasJ);
+          boundAliases.add(targetAliasJ);
           continue;
         }
       }
@@ -3167,6 +3173,7 @@ public class MatchExecutionPlanner {
       // --- Index pre-filter detection ---
       var targetClass = aliasClasses.get(targetAliasJ);
       if (targetClass == null) {
+        boundAliases.add(targetAliasJ);
         continue;
       }
 
@@ -3177,6 +3184,7 @@ public class MatchExecutionPlanner {
         indexableFilter = matchedSplit.nonMatchedReferencing();
       }
       if (indexableFilter == null) {
+        boundAliases.add(targetAliasJ);
         continue;
       }
 
@@ -3190,6 +3198,9 @@ public class MatchExecutionPlanner {
                 + "(class '{}' for alias '{}')",
             j, targetClass, targetAliasJ);
       }
+
+      // Target alias becomes bound after this edge executes
+      boundAliases.add(targetAliasJ);
     }
   }
 
@@ -3286,19 +3297,27 @@ public class MatchExecutionPlanner {
     // RHS matches $matched.X.out('E') or $matched.X.in('E'). The grammar
     // wraps conditions in multiple transparent layers (OrBlock → AndBlock →
     // NotBlock → ConditionBlock). We unwrap single-element wrappers before
-    // checking the inner type to avoid relying on toString() for detection.
+    // checking the inner type, then inspect the LHS/RHS AST nodes directly.
     for (int i = 0; i < andSubBlocks.size(); i++) {
       var sub = andSubBlocks.get(i);
       var inner = unwrapToNotInCondition(sub);
       if (inner == null) {
         continue;
       }
-      var condStr = inner.toString().trim();
-      if (!condStr.startsWith("$currentMatch NOT IN ")) {
+
+      // Check LHS is $currentMatch via the AST node
+      var lhs = inner.getLeft();
+      if (lhs == null || !"$currentMatch".equals(lhs.toString().trim())) {
         continue;
       }
 
-      var rhsStr = condStr.substring("$currentMatch NOT IN ".length()).trim();
+      // Check RHS is $matched.X.out('E') or $matched.X.in('E') via the
+      // AST node, avoiding full-condition toString() parsing
+      var rhs = inner.getRightMathExpression();
+      if (rhs == null) {
+        continue;
+      }
+      var rhsStr = rhs.toString().trim();
       var matcher = MATCHED_TRAVERSAL_PATTERN.matcher(rhsStr);
       if (!matcher.matches()) {
         continue;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3403,8 +3403,26 @@ public class MatchExecutionPlanner {
       return null;
     }
 
+    var edgeJ = schedule.get(j);
+    // Mirror the Pattern A guard: an optional target node must pass through
+    // rows with nulls when no match is found, which BackRefHashJoinStep does
+    // not implement. Worse, addStepsFor dispatches on the optional branch
+    // before consulting getSemiJoinDescriptor() — so if Pattern B fired here
+    // the predecessor edge would be marked consumed and silently dropped
+    // from the plan, producing wrong results.
+    if (edgeJ.edge.in.isOptionalNode() || edgeJ.edge.out.isOptionalNode()) {
+      return null;
+    }
+
     // Check preceding edge (j-1) is an edge-level traversal (outE/inE)
     var edgePrev = schedule.get(j - 1);
+    // The intermediate alias (edgePrev endpoint) must also be non-optional:
+    // it would otherwise be "skipped" in the traversal yet still bound by
+    // the collapsed BackRefHashJoinStep, diverging from the documented
+    // semantics of optional nodes.
+    if (edgePrev.edge.in.isOptionalNode() || edgePrev.edge.out.isOptionalNode()) {
+      return null;
+    }
     var prevDirection = getEdgeDirection(edgePrev);
     if (prevDirection == null) {
       return null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3446,55 +3446,68 @@ public class MatchExecutionPlanner {
     // Map oute→out, ine→in for the reverse link bag direction
     var direction = prevDirection.startsWith("out") ? "out" : "in";
 
-    // If the intermediate edge has a WHERE filter, collapsing the chain is
-    // only safe when every filter term is covered by a single index. The
-    // consumed predecessor's MatchStep is skipped (aliasFilters are
-    // normally evaluated there), and BackRefHashJoinStep evaluates the
-    // filter exclusively via {@code indexRidSet.contains(edgeRid)} — so any
-    // term not present in the index key is silently dropped.
+    // The intermediate edge may have a WHERE filter. Correctness requires
+    // that every edge added to the hash table actually passes the whole
+    // WHERE clause — the consumed predecessor's MatchStep, which would
+    // normally evaluate it, is skipped in the collapsed plan.
     //
-    // The planner's {@code remainingCondition} field is not a reliable full-
-    // cover signal here: {@code SelectExecutionPlanner.buildIndexSearchDescriptor}
-    // always stores the original AND block as {@code remainingCondition},
-    // relying on a post-fetch FilterStep to re-evaluate it. BackRefHashJoinStep
-    // has no such post-filter, so we compare block counts directly: the key
-    // covers the whole WHERE only when {@code indexFilter.blockCount()} equals
-    // the original flattened AND's sub-block count.
+    // Strategy (both optional, both applied in BackRefHashJoinStep):
+    //   1. indexFilter — RidSet intersection, rejects non-candidate edges
+    //      without loading them. Partial cover is fine here: its only role
+    //      is pre-filtering for performance.
+    //   2. edgeFilter — the complete WHERE clause, re-evaluated on every
+    //      loaded edge. Authoritative correctness check; catches any terms
+    //      the index didn't cover.
+    //
+    // Rejection cases kept at plan time:
+    //   * Filter references $matched / $currentMatch — build phase has no
+    //     per-row scope for those variables, so runtime evaluation would
+    //     see stale values. Safer to fall back to the standard chain.
+    //   * Multi-branch OR WHERE — findIndexForFilter would reject it too;
+    //     we could handle it without the index, but the non-indexable
+    //     residual path is already handled by edgeFilter alone, so there
+    //     is no functional reason to reject. Kept for now to stay aligned
+    //     with findIndexForFilter's contract.
     var intermediateFilter = aliasFilters.get(intermediateAlias);
     IndexSearchDescriptor indexFilter = null;
+    SQLWhereClause edgeFilter = null;
     if (intermediateFilter != null) {
+      var baseExpr = intermediateFilter.getBaseExpression();
+      if (baseExpr != null) {
+        var refAliases = baseExpr.getMatchPatternInvolvedAliases();
+        if (refAliases != null && !refAliases.isEmpty()) {
+          // Filter uses $matched.<alias> — cannot evaluate at build phase.
+          return null;
+        }
+      }
+      if (refersToCurrentMatch(intermediateFilter)) {
+        return null;
+      }
+      edgeFilter = intermediateFilter;
+
       var intermediateClass = aliasClasses.get(intermediateAlias);
-      if (intermediateClass == null) {
-        return null;
+      if (intermediateClass != null) {
+        indexFilter = TraversalPreFilterHelper.findIndexForFilter(
+            intermediateFilter, intermediateClass, ctx);
       }
-      var session = ctx.getDatabaseSession();
-      if (session == null) {
-        return null;
-      }
-      var schema = session.getMetadata().getImmutableSchemaSnapshot();
-      var schemaClass = schema.getClassInternal(intermediateClass);
-      if (schemaClass == null) {
-        return null;
-      }
-      var flatWhere = intermediateFilter.flatten(ctx, schemaClass);
-      if (flatWhere.size() != 1) {
-        // Multi-branch OR — findIndexForFilter would also reject; bail out
-        // rather than silently apply a partial cover.
-        return null;
-      }
-      var originalBlockCount = flatWhere.getFirst().getSubBlocks().size();
-      indexFilter = TraversalPreFilterHelper.findIndexForFilter(
-          intermediateFilter, intermediateClass, ctx);
-      if (indexFilter == null
-          || indexFilter.blockCount() != originalBlockCount) {
-        return null;
-      }
+      // indexFilter may be null (no index) or a partial cover — both are OK
+      // because edgeFilter will re-verify every edge post-load.
     }
 
     return new ChainSemiJoin(
         prevEdgeClass, direction, ridExpr,
         sourceAlias, backRefAlias, intermediateAlias,
-        targetAliasJ, indexFilter);
+        targetAliasJ, indexFilter, edgeFilter);
+  }
+
+  /**
+   * Returns {@code true} if the given WHERE clause references
+   * {@code $currentMatch} anywhere in its AST. A simple {@code toString}
+   * check suffices because the parser always emits the dollar-prefixed
+   * form verbatim in the serialized expression.
+   */
+  private static boolean refersToCurrentMatch(SQLWhereClause filter) {
+    return filter.toString().contains("$currentMatch");
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3585,15 +3585,15 @@ public class MatchExecutionPlanner {
     //      loaded edge. Authoritative correctness check; catches any terms
     //      the index didn't cover.
     //
-    // Rejection cases kept at plan time:
+    // Rejection case kept at plan time:
     //   * Filter references $matched / $currentMatch — build phase has no
     //     per-row scope for those variables, so runtime evaluation would
     //     see stale values. Safer to fall back to the standard chain.
-    //   * Multi-branch OR WHERE — findIndexForFilter would reject it too;
-    //     we could handle it without the index, but the non-indexable
-    //     residual path is already handled by edgeFilter alone, so there
-    //     is no functional reason to reject. Kept for now to stay aligned
-    //     with findIndexForFilter's contract.
+    //
+    // Multi-branch OR in the intermediate filter is not rejected here: any
+    // terms findIndexForFilter cannot cover are re-verified post-load by
+    // edgeFilter on every loaded edge, so correctness does not depend on
+    // indexability.
     var intermediateFilter = aliasFilters.get(intermediateAlias);
     IndexSearchDescriptor indexFilter = null;
     SQLWhereClause edgeFilter = null;
@@ -3609,7 +3609,12 @@ public class MatchExecutionPlanner {
       if (refersToCurrentMatch(intermediateFilter)) {
         return null;
       }
-      edgeFilter = intermediateFilter;
+      // Deep-copy the filter so the ChainSemiJoin descriptor owns its own
+      // AST subtree, independent of aliasFilters. The planner may still
+      // rewrite the original (rebindFilters, etc.) and cached plans may
+      // re-execute with re-bound parameters — shared references would let
+      // an AST rewrite on one side corrupt the other.
+      edgeFilter = intermediateFilter.copy();
 
       var intermediateClass = aliasClasses.get(intermediateAlias);
       if (intermediateClass != null) {
@@ -3627,13 +3632,112 @@ public class MatchExecutionPlanner {
   }
 
   /**
-   * Returns {@code true} if the given WHERE clause references
-   * {@code $currentMatch} anywhere in its AST. A simple {@code toString}
-   * check suffices because the parser always emits the dollar-prefixed
-   * form verbatim in the serialized expression.
+   * Returns {@code true} if the given WHERE clause references the
+   * {@code $currentMatch} identifier anywhere in its AST.
+   *
+   * <p>Uses a hybrid strategy: recurse structurally through block types
+   * ({@link SQLOrBlock}, {@link SQLAndBlock}, {@link SQLNotBlock}) and
+   * fall back to a quote-aware token scan for anything else — leaf
+   * condition types (binary / NOT IN / BETWEEN / ...) plus opaque
+   * wrappers whose inner structure is not publicly accessible. The
+   * token scan skips text enclosed in single or double quotes, so a
+   * literal like {@code name = '$currentMatchThing'} no longer
+   * false-positives and forces the Pattern A / B optimization to bail
+   * unnecessarily.
+   *
+   * <p>The identifier check is anchored at a word boundary (the next
+   * character must not be an identifier part), so {@code $currentMatchX}
+   * — a hypothetical unrelated variable — does not match either.
    */
   private static boolean refersToCurrentMatch(SQLWhereClause filter) {
-    return filter.toString().contains("$currentMatch");
+    var base = filter.getBaseExpression();
+    return base != null && refersToCurrentMatch(base);
+  }
+
+  private static boolean refersToCurrentMatch(SQLBooleanExpression expr) {
+    if (expr instanceof SQLOrBlock or) {
+      var subs = or.getSubBlocks();
+      if (subs != null) {
+        for (var sub : subs) {
+          if (refersToCurrentMatch(sub)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+    if (expr instanceof SQLAndBlock and) {
+      var subs = and.getSubBlocks();
+      if (subs != null) {
+        for (var sub : subs) {
+          if (refersToCurrentMatch(sub)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+    if (expr instanceof SQLNotBlock not) {
+      return not.getSub() != null && refersToCurrentMatch(not.getSub());
+    }
+    return leafContainsCurrentMatchIdentifier(expr.toString());
+  }
+
+  /**
+   * Returns {@code true} if {@code serialized} contains the token
+   * {@code $currentMatch} outside of any single- or double-quoted string
+   * literal, at a word boundary. The serialized form of a leaf boolean
+   * expression is re-entrant (its toString is a valid YQL fragment), so
+   * string literals use standard SQL quoting and every {@code $}-prefixed
+   * identifier is emitted literally.
+   */
+  private static boolean leafContainsCurrentMatchIdentifier(String serialized) {
+    if (serialized == null) {
+      return false;
+    }
+    var len = serialized.length();
+    var token = "$currentMatch";
+    var inSingle = false;
+    var inDouble = false;
+    for (var i = 0; i < len; i++) {
+      var c = serialized.charAt(i);
+      if (inSingle) {
+        if (c == '\\' && i + 1 < len) {
+          i++;
+        } else if (c == '\'') {
+          inSingle = false;
+        }
+        continue;
+      }
+      if (inDouble) {
+        if (c == '\\' && i + 1 < len) {
+          i++;
+        } else if (c == '"') {
+          inDouble = false;
+        }
+        continue;
+      }
+      if (c == '\'') {
+        inSingle = true;
+        continue;
+      }
+      if (c == '"') {
+        inDouble = true;
+        continue;
+      }
+      if (c == '$' && serialized.regionMatches(i, token, 0, token.length())) {
+        var end = i + token.length();
+        if (end >= len || !isIdentifierPart(serialized.charAt(end))) {
+          return true;
+        }
+        i = end - 1;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isIdentifierPart(char c) {
+    return Character.isLetterOrDigit(c) || c == '_';
   }
 
   /**
@@ -3696,8 +3800,17 @@ public class MatchExecutionPlanner {
     if (residualAtoms.isEmpty()) {
       return RESIDUAL_SAFE_NONE;
     }
+    // Deep-copy each atom so the residual owns its own AST subtree, independent
+    // of the original targetFilter. The original stays in place for other
+    // planner passes (rebindFilters, index detection) and the residual is
+    // stashed on the SingleEdgeSemiJoin descriptor, which may be re-used when
+    // a cached plan re-executes with re-bound parameters — shared references
+    // would let an AST rewrite on one side corrupt the other. Mirrors the
+    // policy applied in SQLWhereClause.buildWhereWithoutTerm.
     var newAnd = new SQLAndBlock(-1);
-    newAnd.getSubBlocks().addAll(residualAtoms);
+    for (var atom : residualAtoms) {
+      newAnd.getSubBlocks().add(atom.copy());
+    }
     var newOr = new SQLOrBlock(-1);
     newOr.getSubBlocks().add(newAnd);
     var residual = new SQLWhereClause(-1);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3114,20 +3114,9 @@ public class MatchExecutionPlanner {
               // When edge class was propagated from the preceding edge, also
               // try chain semi-join which collapses both edges into one step.
               if (collectEdgeRids) {
-                var chainDesc = detectChainSemiJoin(
-                    schedule, j, involvedAliases, ridExpr, targetAliasJ,
-                    boundAliases, ctx);
-                if (chainDesc != null) {
-                  var consumed = schedule.get(j - 1);
-                  edgeJ.setSemiJoinDescriptor(chainDesc);
-                  consumed.setConsumed(true);
-                  edgeJ.setConsumedPredecessor(consumed);
-                  logger.debug(
-                      "MATCH pre-filter: ChainSemiJoin on edge[{},{}] "
-                          + "({}({}) chain semi-join via $matched.{})",
-                      j - 1, j, chainDesc.direction(), chainDesc.edgeClass(),
-                      chainDesc.backRefAlias());
-                }
+                tryAttachChainSemiJoin(
+                    schedule, j, edgeJ, involvedAliases, ridExpr,
+                    targetAliasJ, boundAliases, ctx);
               }
             }
           } else if (j > 0) {
@@ -3135,20 +3124,9 @@ public class MatchExecutionPlanner {
             // edge_j is .inV() (no edge class/direction). Check if the
             // preceding edge is .outE('E') or .inE('E') with a recognized
             // edge class. If so, collapse both into a ChainSemiJoin.
-            var chainDesc = detectChainSemiJoin(
-                schedule, j, involvedAliases, ridExpr, targetAliasJ,
-                boundAliases, ctx);
-            if (chainDesc != null) {
-              var consumed = schedule.get(j - 1);
-              edgeJ.setSemiJoinDescriptor(chainDesc);
-              consumed.setConsumed(true);
-              edgeJ.setConsumedPredecessor(consumed);
-              logger.debug(
-                  "MATCH pre-filter: ChainSemiJoin on edge[{},{}] "
-                      + "({}({}) chain semi-join via $matched.{})",
-                  j - 1, j, chainDesc.direction(), chainDesc.edgeClass(),
-                  chainDesc.backRefAlias());
-            }
+            tryAttachChainSemiJoin(
+                schedule, j, edgeJ, involvedAliases, ridExpr,
+                targetAliasJ, boundAliases, ctx);
           }
         } else {
           // Literal or parameter RID: @rid = #12:0 or @rid = :param
@@ -3252,10 +3230,11 @@ public class MatchExecutionPlanner {
 
   // FQN to avoid collision with com.jetbrains.youtrackdb...sql.parser.Pattern
   // Regex for $matched.X.out('E') or $matched.X.in('E')
-  // Group 1: alias name (X), Group 2: direction (out/in), Group 3: edge class (E)
+  // Group 1: alias name (X), Group 2: direction (out/in),
+  // Group 3: edge class (E) — with matched quotes or unquoted
   private static final java.util.regex.Pattern MATCHED_TRAVERSAL_PATTERN =
       java.util.regex.Pattern.compile(
-          "\\$matched\\.(\\w+)\\.(out|in)\\(['\"]?(\\w+)['\"]?\\)",
+          "\\$matched\\.(\\w+)\\.(out|in)\\((?:(['\"])(\\w+)\\3|(\\w+))\\)",
           java.util.regex.Pattern.CASE_INSENSITIVE);
 
   /**
@@ -3338,15 +3317,12 @@ public class MatchExecutionPlanner {
 
       var anchorAlias = matcher.group(1);
       var direction = matcher.group(2).toLowerCase(Locale.ROOT);
-      var edgeClass = matcher.group(3);
+      // Edge class is in group 4 (quoted) or group 5 (unquoted)
+      var edgeClass = matcher.group(4) != null
+          ? matcher.group(4) : matcher.group(5);
 
       // Anchor alias must be already bound
       if (!boundAliases.contains(anchorAlias)) {
-        continue;
-      }
-
-      // Edge class must be a valid identifier (sanity check on regex group)
-      if (!edgeClass.matches("[A-Za-z_][A-Za-z0-9_]*")) {
         continue;
       }
 
@@ -3467,6 +3443,36 @@ public class MatchExecutionPlanner {
         prevEdgeClass, direction, ridExpr,
         sourceAlias, backRefAlias, intermediateAlias,
         targetAliasJ, indexFilter);
+  }
+
+  /**
+   * Attempts to detect and attach a Pattern B (ChainSemiJoin) descriptor on
+   * {@code edgeJ}. If detection succeeds, the predecessor edge is marked as
+   * consumed so {@code addStepsFor()} skips it.
+   */
+  private void tryAttachChainSemiJoin(
+      List<EdgeTraversal> schedule,
+      int j,
+      EdgeTraversal edgeJ,
+      List<String> involvedAliases,
+      SQLExpression ridExpr,
+      String targetAliasJ,
+      Set<String> boundAliases,
+      CommandContext ctx) {
+    var chainDesc = detectChainSemiJoin(
+        schedule, j, involvedAliases, ridExpr, targetAliasJ,
+        boundAliases, ctx);
+    if (chainDesc != null) {
+      var consumed = schedule.get(j - 1);
+      edgeJ.setSemiJoinDescriptor(chainDesc);
+      consumed.setConsumed(true);
+      edgeJ.setConsumedPredecessor(consumed);
+      logger.debug(
+          "MATCH pre-filter: ChainSemiJoin on edge[{},{}] "
+              + "({}({}) chain semi-join via $matched.{})",
+          j - 1, j, chainDesc.direction(), chainDesc.edgeClass(),
+          chainDesc.backRefAlias());
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3343,6 +3343,13 @@ public class MatchExecutionPlanner {
       // O(degree) link bag traversal). The stripped condition is stored in
       // the AntiSemiJoin descriptor for runtime fallback: if the hash table
       // build fails, BackRefHashJoinStep evaluates it per row.
+      //
+      // Both sides use independent AST copies: buildWhereWithoutTerm already
+      // deep-copies the sub-blocks it keeps, and we deep-copy {@code sub}
+      // before stashing it in the descriptor. The original andBlock is kept
+      // intact by the planner (rebindFilters, etc.) and cached plans may
+      // re-execute with re-bound parameters — any shared sub-block reference
+      // would let an AST rewrite on one side corrupt the other.
       var strippedFilter =
           SQLWhereClause.buildWhereWithoutTerm(andBlock, i);
       if (strippedFilter != null) {
@@ -3353,7 +3360,7 @@ public class MatchExecutionPlanner {
       }
 
       return new AntiSemiJoin(
-          anchorAlias, edgeClass, direction, targetAlias, sub);
+          anchorAlias, edgeClass, direction, targetAlias, sub.copy());
     }
     return null;
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3446,14 +3446,48 @@ public class MatchExecutionPlanner {
     // Map oute→out, ine→in for the reverse link bag direction
     var direction = prevDirection.startsWith("out") ? "out" : "in";
 
-    // Check for optional index pre-filter on the intermediate edge
+    // If the intermediate edge has a WHERE filter, collapsing the chain is
+    // only safe when every filter term is covered by a single index. The
+    // consumed predecessor's MatchStep is skipped (aliasFilters are
+    // normally evaluated there), and BackRefHashJoinStep evaluates the
+    // filter exclusively via {@code indexRidSet.contains(edgeRid)} — so any
+    // term not present in the index key is silently dropped.
+    //
+    // The planner's {@code remainingCondition} field is not a reliable full-
+    // cover signal here: {@code SelectExecutionPlanner.buildIndexSearchDescriptor}
+    // always stores the original AND block as {@code remainingCondition},
+    // relying on a post-fetch FilterStep to re-evaluate it. BackRefHashJoinStep
+    // has no such post-filter, so we compare block counts directly: the key
+    // covers the whole WHERE only when {@code indexFilter.blockCount()} equals
+    // the original flattened AND's sub-block count.
     var intermediateFilter = aliasFilters.get(intermediateAlias);
     IndexSearchDescriptor indexFilter = null;
     if (intermediateFilter != null) {
       var intermediateClass = aliasClasses.get(intermediateAlias);
-      if (intermediateClass != null) {
-        indexFilter = TraversalPreFilterHelper.findIndexForFilter(
-            intermediateFilter, intermediateClass, ctx);
+      if (intermediateClass == null) {
+        return null;
+      }
+      var session = ctx.getDatabaseSession();
+      if (session == null) {
+        return null;
+      }
+      var schema = session.getMetadata().getImmutableSchemaSnapshot();
+      var schemaClass = schema.getClassInternal(intermediateClass);
+      if (schemaClass == null) {
+        return null;
+      }
+      var flatWhere = intermediateFilter.flatten(ctx, schemaClass);
+      if (flatWhere.size() != 1) {
+        // Multi-branch OR — findIndexForFilter would also reject; bail out
+        // rather than silently apply a partial cover.
+        return null;
+      }
+      var originalBlockCount = flatWhere.getFirst().getSubBlocks().size();
+      indexFilter = TraversalPreFilterHelper.findIndexForFilter(
+          intermediateFilter, intermediateClass, ctx);
+      if (indexFilter == null
+          || indexFilter.blockCount() != originalBlockCount) {
+        return null;
       }
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3125,6 +3125,23 @@ public class MatchExecutionPlanner {
         }
       }
 
+      // --- Pattern D: NOT IN anti-semi-join detection ---
+      // Check if the target's WHERE clause contains
+      // $currentMatch NOT IN $matched.X.out('E')
+      // Pattern D detection follows below
+      if (edgeJ.getSemiJoinDescriptor() == null) {
+        var antiDesc = detectNotInAntiJoin(
+            targetFilter, targetAliasJ, boundAliases);
+        if (antiDesc != null) {
+          edgeJ.setSemiJoinDescriptor(antiDesc);
+          logger.debug(
+              "MATCH pre-filter: AntiSemiJoin on edge[{}] "
+                  + "(NOT IN $matched.{}.{}('{}'))",
+              j, antiDesc.anchorAlias(),
+              antiDesc.traversalDirection(), antiDesc.traversalEdgeClass());
+        }
+      }
+
       // --- Index pre-filter detection ---
       var targetClass = aliasClasses.get(targetAliasJ);
       if (targetClass == null) {
@@ -3186,6 +3203,107 @@ public class MatchExecutionPlanner {
     // Check threshold is enabled (0 disables hash join)
     var threshold = getHashJoinThreshold();
     return threshold > 0;
+  }
+
+  // Regex for $matched.X.out('E') or $matched.X.in('E')
+  // Group 1: alias name (X), Group 2: direction (out/in), Group 3: edge class (E)
+  private static final java.util.regex.Pattern MATCHED_TRAVERSAL_PATTERN =
+      java.util.regex.Pattern.compile(
+          "\\$matched\\.(\\w+)\\.(out|in)\\(['\"]?(\\w+)['\"]?\\)",
+          java.util.regex.Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Detects Pattern D: a {@code $currentMatch NOT IN $matched.X.out('E')}
+   * condition in the target node's WHERE clause. If found, removes the
+   * NOT IN condition from the WHERE clause and returns an
+   * {@link AntiSemiJoin} descriptor. Any remaining conditions in the AND
+   * block stay as residual filter on the {@link MatchEdgeTraverser}.
+   *
+   * @param targetFilter  the WHERE clause on the target node
+   * @param targetAlias   the alias of the target node
+   * @param boundAliases  all aliases bound in the schedule
+   * @return an AntiSemiJoin descriptor, or null if the pattern is not found
+   */
+  @Nullable private static AntiSemiJoin detectNotInAntiJoin(
+      SQLWhereClause targetFilter,
+      String targetAlias,
+      Set<String> boundAliases) {
+    var threshold = getHashJoinThreshold();
+    if (threshold <= 0) {
+      return null;
+    }
+
+    var baseExpr = targetFilter.getBaseExpression();
+    if (baseExpr == null) {
+      return null;
+    }
+
+    // Navigate: SQLOrBlock → single SQLAndBlock → subBlocks list
+    List<SQLBooleanExpression> andSubBlocks;
+    if (baseExpr instanceof SQLOrBlock orBlock) {
+      var orSubs = orBlock.getSubBlocks();
+      if (orSubs == null || orSubs.size() != 1) {
+        return null; // Multiple OR branches — too complex
+      }
+      var firstOr = orSubs.getFirst();
+      if (!(firstOr instanceof SQLAndBlock ab)) {
+        return null;
+      }
+      andSubBlocks = ab.getSubBlocks();
+    } else if (baseExpr instanceof SQLAndBlock ab) {
+      andSubBlocks = ab.getSubBlocks();
+    } else {
+      return null;
+    }
+
+    if (andSubBlocks == null || andSubBlocks.isEmpty()) {
+      return null;
+    }
+    // Scan for NOT IN conditions matching the pattern. The condition may be
+    // nested inside SQLOrBlock → SQLAndBlock → SQLNotBlock (parser wrapping).
+    // We use toString() on each sub-block to match the full pattern string,
+    // avoiding fragile class hierarchy assumptions.
+    for (int i = 0; i < andSubBlocks.size(); i++) {
+      var sub = andSubBlocks.get(i);
+      var condStr = sub.toString().trim();
+      if (!condStr.startsWith("$currentMatch NOT IN ")) {
+        continue;
+      }
+
+      var rhsStr = condStr.substring("$currentMatch NOT IN ".length()).trim();
+      var matcher = MATCHED_TRAVERSAL_PATTERN.matcher(rhsStr);
+      if (!matcher.matches()) {
+        continue;
+      }
+
+      var anchorAlias = matcher.group(1);
+      var direction = matcher.group(2).toLowerCase(Locale.ROOT);
+      var edgeClass = matcher.group(3);
+
+      // Anchor alias must be already bound
+      if (!boundAliases.contains(anchorAlias)) {
+        continue;
+      }
+
+      // Edge class must be a valid identifier (prevent SQL injection)
+      if (!edgeClass.matches("[A-Za-z_][A-Za-z0-9_]*")) {
+        continue;
+      }
+
+      // Remove the NOT IN condition from the AND block
+      andSubBlocks.remove(i);
+
+      // Build residual filter (remaining AND conditions, if any)
+      SQLWhereClause residualFilter = null;
+      if (!andSubBlocks.isEmpty()) {
+        residualFilter = targetFilter; // Modified in-place — remaining conditions stay
+      }
+
+      return new AntiSemiJoin(
+          anchorAlias, edgeClass, direction,
+          anchorAlias, targetAlias, residualFilter);
+    }
+    return null;
   }
 
   /**
@@ -3653,9 +3771,16 @@ public class MatchExecutionPlanner {
         // to avoid catastrophic full V scan
         plan.chain(new MatchStep(context, edge, profilingEnabled));
       }
+    } else if (edge.getSemiJoinDescriptor() instanceof AntiSemiJoin) {
+      // Pattern D: normal traversal + anti-join filter. The NOT IN condition
+      // was removed from the WHERE clause, so the MatchStep traverses without
+      // it. The BackRefHashJoinStep filters results against the exclusion set.
+      plan.chain(new MatchStep(context, edge, profilingEnabled));
+      plan.chain(new BackRefHashJoinStep(
+          context, edge.getSemiJoinDescriptor(), profilingEnabled));
     } else if (edge.getSemiJoinDescriptor() != null) {
-      // Back-reference semi-join: replace per-row link bag traversal with
-      // a one-time hash table build + O(1) probe per upstream row.
+      // Back-reference semi-join (Pattern A/B): replace per-row link bag
+      // traversal with a one-time hash table build + O(1) probe.
       plan.chain(new BackRefHashJoinStep(
           context, edge.getSemiJoinDescriptor(), profilingEnabled));
     } else {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2998,11 +2998,19 @@ public class MatchExecutionPlanner {
       List<EdgeTraversal> schedule, CommandContext ctx) {
     // Build a map: target alias → edge index, so we can find the producing edge
     Map<String, Integer> targetAliasToEdgeIndex = new HashMap<>();
+    // Track all aliases that are bound (visited) before each edge, including
+    // the root alias which is not the target of any edge.
+    Set<String> boundAliases = new HashSet<>();
     for (var i = 0; i < schedule.size(); i++) {
       var et = schedule.get(i);
+      var sourceAlias = et.out ? et.edge.out.alias : et.edge.in.alias;
       var targetAlias = et.out ? et.edge.in.alias : et.edge.out.alias;
+      if (sourceAlias != null) {
+        boundAliases.add(sourceAlias);
+      }
       if (targetAlias != null) {
         targetAliasToEdgeIndex.put(targetAlias, i);
+        boundAliases.add(targetAlias);
       }
     }
 
@@ -3052,17 +3060,37 @@ public class MatchExecutionPlanner {
           if (edgeClass != null && edgeDirection != null) {
             var sourceAliasJ = edgeJ.out
                 ? edgeJ.edge.out.alias : edgeJ.edge.in.alias;
-            var producingEdgeIdx = targetAliasToEdgeIndex.get(sourceAliasJ);
-            if (producingEdgeIdx != null) {
-              var edgeI = schedule.get(producingEdgeIdx);
-              edgeI.addIntersectionDescriptor(
-                  new RidFilterDescriptor.EdgeRidLookup(
-                      edgeClass, edgeDirection, ridExpr, collectEdgeRids));
+
+            // --- Semi-join candidacy check (Pattern A) ---
+            // If this is a vertex-level traversal (out/in, not outE/inE)
+            // and the back-ref alias is already bound, try to replace the
+            // per-row link bag scan with a one-time hash table build + O(1)
+            // probe.
+            if (isSemiJoinCandidate(edgeDirection, involvedAliases,
+                boundAliases)) {
+              var backRefAlias = involvedAliases.getFirst();
+              var descriptor = new SingleEdgeSemiJoin(
+                  edgeClass, edgeDirection, ridExpr,
+                  sourceAliasJ, backRefAlias, targetAliasJ);
+              edgeJ.setSemiJoinDescriptor(descriptor);
               logger.debug(
-                  "MATCH pre-filter: EdgeRidLookup on edge[{}] "
-                      + "({}({}) back-ref from alias '{}', edgeRids={})",
-                  producingEdgeIdx, edgeDirection, edgeClass, targetAliasJ,
-                  collectEdgeRids);
+                  "MATCH pre-filter: BackRefHashJoin on edge[{}] "
+                      + "({}({}) semi-join via $matched.{})",
+                  j, edgeDirection, edgeClass, backRefAlias);
+            } else {
+              // Fallback: attach EdgeRidLookup on the producing edge
+              var producingEdgeIdx = targetAliasToEdgeIndex.get(sourceAliasJ);
+              if (producingEdgeIdx != null) {
+                var edgeI = schedule.get(producingEdgeIdx);
+                edgeI.addIntersectionDescriptor(
+                    new RidFilterDescriptor.EdgeRidLookup(
+                        edgeClass, edgeDirection, ridExpr, collectEdgeRids));
+                logger.debug(
+                    "MATCH pre-filter: EdgeRidLookup on edge[{}] "
+                        + "({}({}) back-ref from alias '{}', edgeRids={})",
+                    producingEdgeIdx, edgeDirection, edgeClass, targetAliasJ,
+                    collectEdgeRids);
+              }
             }
           }
         } else {
@@ -3106,6 +3134,40 @@ public class MatchExecutionPlanner {
             j, targetClass, targetAliasJ);
       }
     }
+  }
+
+  /**
+   * Checks if a back-reference edge qualifies for a semi-join hash table
+   * optimization (Pattern A). The edge must be a vertex-level traversal
+   * ({@code out('E')} or {@code in('E')}, not {@code outE('E')} or
+   * {@code inE('E')}), and the back-referenced alias must be already bound
+   * earlier in the schedule.
+   *
+   * @param edgeDirection    the traversal direction (e.g., "out", "in", "oute")
+   * @param involvedAliases  the aliases referenced by the back-ref expression
+   * @param boundAliases     all aliases bound (visited) in the schedule
+   * @return true if the edge is a semi-join candidate
+   */
+  private static boolean isSemiJoinCandidate(
+      String edgeDirection,
+      List<String> involvedAliases,
+      Set<String> boundAliases) {
+    // Only vertex-level traversals qualify (not outE/inE/bothE/both)
+    if (!"out".equals(edgeDirection) && !"in".equals(edgeDirection)) {
+      return false;
+    }
+    // The back-ref must reference exactly one alias
+    if (involvedAliases.size() != 1) {
+      return false;
+    }
+    // The back-referenced alias must be already bound in the schedule
+    var backRefAlias = involvedAliases.getFirst();
+    if (!boundAliases.contains(backRefAlias)) {
+      return false;
+    }
+    // Check threshold is enabled (0 disables hash join)
+    var threshold = getHashJoinThreshold();
+    return threshold > 0;
   }
 
   /**
@@ -3496,6 +3558,11 @@ public class MatchExecutionPlanner {
         // to avoid catastrophic full V scan
         plan.chain(new MatchStep(context, edge, profilingEnabled));
       }
+    } else if (edge.getSemiJoinDescriptor() != null) {
+      // Back-reference semi-join: replace per-row link bag traversal with
+      // a one-time hash table build + O(1) probe per upstream row.
+      plan.chain(new BackRefHashJoinStep(
+          context, edge.getSemiJoinDescriptor(), profilingEnabled));
     } else {
       plan.chain(new MatchStep(context, edge, profilingEnabled));
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SemiJoinDescriptor.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SemiJoinDescriptor.java
@@ -1,0 +1,37 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+/**
+ * Planner artifact describing a back-reference semi-join optimization. Attached to an
+ * {@link EdgeTraversal} during {@code optimizeScheduleWithIntersections()} when the planner
+ * detects a back-reference pattern ({@code @rid = $matched.X.@rid}) that qualifies for
+ * hash-based evaluation.
+ *
+ * <p>Three variants cover the recognized patterns:
+ * <ul>
+ *   <li>{@link SingleEdgeSemiJoin} — Pattern A: single vertex-level edge with equality
+ *       back-reference on the target.</li>
+ *   <li>{@link ChainSemiJoin} — Pattern B: {@code .outE('E').inV()} chain where the
+ *       {@code .inV()} target has the back-reference. Collapses two schedule edges into
+ *       one {@link BackRefHashJoinStep}.</li>
+ *   <li>{@link AntiSemiJoin} — Pattern D: {@code $currentMatch NOT IN $matched.X.out('E')}
+ *       condition in a WHERE clause.</li>
+ * </ul>
+ *
+ * <p>When a {@code SemiJoinDescriptor} is attached to an edge, no
+ * {@link com.jetbrains.youtrackdb.internal.core.sql.executor.RidFilterDescriptor.EdgeRidLookup
+ * EdgeRidLookup} is created for the same back-reference — they are mutually exclusive.
+ *
+ * @see BackRefHashJoinStep
+ */
+public sealed interface SemiJoinDescriptor
+    permits SingleEdgeSemiJoin, ChainSemiJoin, AntiSemiJoin {
+
+  /** The join mode: SEMI (keep on hit) or ANTI (discard on hit). */
+  JoinMode joinMode();
+
+  /** The alias whose value is used to build the hash table. */
+  String backRefAlias();
+
+  /** The alias whose binding is produced or validated by the hash join. */
+  String targetAlias();
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SingleEdgeSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SingleEdgeSemiJoin.java
@@ -1,0 +1,36 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
+
+/**
+ * Pattern A — single vertex-level edge with equality back-reference:
+ * <pre>
+ *   {source}.out('E'){target, where: (@rid = $matched.X.@rid)}
+ * </pre>
+ *
+ * <p>The hash table is built from {@code X}'s reverse link bag ({@code X.in_E} or
+ * {@code X.out_E} depending on direction) and maps source vertex RIDs to presence.
+ * The probe checks if {@code source.@rid} is in the set.
+ *
+ * @param edgeClass          the edge class name (e.g., "KNOWS")
+ * @param direction          the scheduled traversal direction ("out" or "in"), matching
+ *                           the format returned by {@code getEdgeDirection()}
+ * @param backRefExpression  the expression resolving to the back-referenced alias's RID
+ *                           (e.g., {@code $matched.person.@rid})
+ * @param sourceAlias        the upstream alias whose RID is used as the probe key
+ * @param backRefAlias       the alias whose vertex provides the reverse link bag for building
+ * @param targetAlias        the alias bound by this edge's target node
+ */
+public record SingleEdgeSemiJoin(
+    String edgeClass,
+    String direction,
+    SQLExpression backRefExpression,
+    String sourceAlias,
+    String backRefAlias,
+    String targetAlias) implements SemiJoinDescriptor {
+
+  @Override
+  public JoinMode joinMode() {
+    return JoinMode.SEMI_JOIN;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SingleEdgeSemiJoin.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SingleEdgeSemiJoin.java
@@ -1,6 +1,8 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import javax.annotation.Nullable;
 
 /**
  * Pattern A — single vertex-level edge with equality back-reference:
@@ -12,6 +14,13 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
  * {@code X.out_E} depending on direction) and maps source vertex RIDs to presence.
  * The probe checks if {@code source.@rid} is in the set.
  *
+ * <p>{@code targetFilter} holds any residual WHERE terms on the target alias
+ * (i.e. the target's full WHERE minus the {@code @rid = $matched.X.@rid}
+ * equality) that are NOT covered by the hash lookup. Because this step
+ * replaces the target's {@code MatchStep}, the terms would otherwise be
+ * silently dropped — {@link BackRefHashJoinStep} re-evaluates them on the
+ * loaded target entity to guarantee correctness.
+ *
  * @param edgeClass          the edge class name (e.g., "KNOWS")
  * @param direction          the scheduled traversal direction ("out" or "in"), matching
  *                           the format returned by {@code getEdgeDirection()}
@@ -20,6 +29,8 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
  * @param sourceAlias        the upstream alias whose RID is used as the probe key
  * @param backRefAlias       the alias whose vertex provides the reverse link bag for building
  * @param targetAlias        the alias bound by this edge's target node
+ * @param targetFilter       residual WHERE on the target alias after stripping the back-ref
+ *                           equality, or {@code null} when no residual terms exist
  */
 public record SingleEdgeSemiJoin(
     String edgeClass,
@@ -27,7 +38,8 @@ public record SingleEdgeSemiJoin(
     SQLExpression backRefExpression,
     String sourceAlias,
     String backRefAlias,
-    String targetAlias) implements SemiJoinDescriptor {
+    String targetAlias,
+    @Nullable SQLWhereClause targetFilter) implements SemiJoinDescriptor {
 
   @Override
   public JoinMode joinMode() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBaseExpression.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBaseExpression.java
@@ -523,6 +523,27 @@ public final class SQLBaseExpression extends SQLMathExpression {
     return modifier;
   }
 
+  /**
+   * Returns the raw value of a plain string literal expression with its
+   * surrounding quotes stripped and serializer escapes decoded. Returns
+   * {@code null} when this expression is not a string literal (e.g.
+   * identifier, input parameter, number, compound expression). Useful for
+   * callers that need the literal argument of a method call at plan time
+   * without parsing {@link #toString}.
+   */
+  @Nullable
+  public String getStringLiteralValue() {
+    if (string == null || string.length() < 2) {
+      return null;
+    }
+    var first = string.charAt(0);
+    var last = string.charAt(string.length() - 1);
+    if ((first != '\'' && first != '"') || first != last) {
+      return null;
+    }
+    return StringSerializerHelper.decode(string.substring(1, string.length() - 1));
+  }
+
   @Override
   public List<String> getMatchPatternInvolvedAliases() {
     if (this.identifier != null && this.identifier.toString().equals("$matched")) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLModifier.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLModifier.java
@@ -544,6 +544,27 @@ public class SQLModifier extends SimpleNode {
     return false;
   }
 
+  /** Returns the suffix identifier segment of this modifier (e.g. the
+   * {@code .X} part of {@code $matched.X.out('E')}), or {@code null}. */
+  @Nullable
+  public SQLSuffixIdentifier getSuffix() {
+    return suffix;
+  }
+
+  /** Returns the method call segment of this modifier (e.g. the
+   * {@code .out('E')} part), or {@code null}. */
+  @Nullable
+  public SQLMethodCall getMethodCall() {
+    return methodCall;
+  }
+
+  /** Returns the next modifier in the chain, or {@code null} when this is
+   * the last segment. */
+  @Nullable
+  public SQLModifier getNext() {
+    return next;
+  }
+
   @Nullable
   public IndexMetadataPath getIndexMetadataPath() {
     if (this.suffix != null && this.suffix.isBaseIdentifier()) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLNotInCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLNotInCondition.java
@@ -297,6 +297,14 @@ public class SQLNotInCondition extends SQLBooleanExpression {
     return null;
   }
 
+  public SQLExpression getLeft() {
+    return left;
+  }
+
+  public SQLMathExpression getRightMathExpression() {
+    return rightMathExpression;
+  }
+
   @Override
   public boolean varMightBeInUse(String varName) {
     return left != null && left.varMightBeInUse(varName) ||

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
@@ -693,6 +693,26 @@ public class SQLWhereClause extends SimpleNode {
    * <p>N.B. the returned clause shares sub-block instances with the
    * source {@code andBlock} — callers must not mutate the result.
    */
+  /**
+   * Builds a new WHERE clause from the AND block with the term at
+   * {@code skipIdx} removed. Public entry point for cross-package callers
+   * (e.g. MATCH planner stripping NOT IN conditions).
+   *
+   * <p>Returns {@code null} when the AND block has only one term (removing
+   * it would leave an empty WHERE clause).
+   *
+   * <p>N.B. the returned clause shares sub-block instances with the
+   * source {@code andBlock} — callers must not mutate the result.
+   */
+  @Nullable
+  public static SQLWhereClause buildWhereWithoutTerm(
+      SQLAndBlock andBlock, int skipIdx) {
+    if (andBlock.subBlocks.size() <= 1) {
+      return null;
+    }
+    return buildWhereWithout(andBlock, skipIdx);
+  }
+
   private static SQLWhereClause buildWhereWithout(
       SQLAndBlock andBlock, int skipIdx) {
     var newAnd = new SQLAndBlock(-1);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
@@ -694,8 +694,11 @@ public class SQLWhereClause extends SimpleNode {
    * <p>Returns {@code null} when the AND block has only one term (removing
    * it would leave an empty WHERE clause).
    *
-   * <p>N.B. the returned clause shares sub-block instances with the
-   * source {@code andBlock} — callers must not mutate the result.
+   * <p>The returned clause is a deep copy — its sub-blocks do not share
+   * instances with the source {@code andBlock}. This keeps the stripped
+   * filter independent from anything the caller retained a reference to
+   * (e.g. the removed term cached for runtime fallback), so subsequent
+   * AST rewrites on either side cannot corrupt the other.
    */
   @Nullable
   public static SQLWhereClause buildWhereWithoutTerm(
@@ -711,7 +714,7 @@ public class SQLWhereClause extends SimpleNode {
     var newAnd = new SQLAndBlock(-1);
     for (var i = 0; i < andBlock.subBlocks.size(); i++) {
       if (i != skipIdx) {
-        newAnd.subBlocks.add(andBlock.subBlocks.get(i));
+        newAnd.subBlocks.add(andBlock.subBlocks.get(i).copy());
       }
     }
     var newOr = new SQLOrBlock(-1);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
@@ -688,13 +688,6 @@ public class SQLWhereClause extends SimpleNode {
 
   /**
    * Builds a new WHERE clause from the AND block with the term at
-   * {@code skipIdx} removed.
-   *
-   * <p>N.B. the returned clause shares sub-block instances with the
-   * source {@code andBlock} — callers must not mutate the result.
-   */
-  /**
-   * Builds a new WHERE clause from the AND block with the term at
    * {@code skipIdx} removed. Public entry point for cross-package callers
    * (e.g. MATCH planner stripping NOT IN conditions).
    *

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterComprehensiveTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterComprehensiveTest.java
@@ -453,12 +453,11 @@ public class MatchPreFilterComprehensiveTest extends MatchPreFilterTestBase {
     var result = session.query(query).toList();
     assertEquals("No self-loops exist", 0, result.size());
 
-    // The back-ref @rid = $matched.person.@rid is detected by the planner via
-    // findRidEquality(), but 'person' is the scan root alias (no producing edge).
-    // targetAliasToEdgeIndex.get("person") returns null because the scan root has
-    // no link bag to attach an intersection descriptor to.
-    assertPlanHasNoIntersection(query,
-        "Scan root has no producing edge, so EdgeRidLookup cannot attach");
+    // The back-ref @rid = $matched.person.@rid references the scan root alias.
+    // EdgeRidLookup cannot attach (no producing edge), but BackRefHashJoinStep
+    // handles this by building a hash table from the scan root's link bag.
+    assertPlanHasIntersection(query,
+        "Back-ref hash join optimizes self-loop even on scan root alias");
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterTestBase.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterTestBase.java
@@ -53,10 +53,15 @@ public abstract class MatchPreFilterTestBase extends DbTestBase {
 
   // ---- EXPLAIN assertion shortcuts ----
 
-  /** Asserts the EXPLAIN plan contains {@code "intersection:"}. */
+  /**
+   * Asserts the EXPLAIN plan contains evidence of back-ref optimization:
+   * either {@code "intersection:"} (EdgeRidLookup) or
+   * {@code "BACK-REF HASH JOIN"} (BackRefHashJoinStep).
+   */
   protected void assertPlanHasIntersection(String query, String reason) {
     String plan = explainPlan(query);
-    assertTrue(reason + ":\n" + plan, plan.contains("intersection:"));
+    assertTrue(reason + ":\n" + plan,
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
   }
 
   /** Asserts the EXPLAIN plan contains {@code "intersection: index"}. */
@@ -67,17 +72,22 @@ public abstract class MatchPreFilterTestBase extends DbTestBase {
         plan.contains("intersection: index"));
   }
 
-  /** Asserts the EXPLAIN plan does NOT contain {@code "intersection:"}. */
+  /**
+   * Asserts the EXPLAIN plan does NOT contain any back-ref optimization:
+   * neither {@code "intersection:"} nor {@code "BACK-REF HASH JOIN"}.
+   */
   protected void assertPlanHasNoIntersection(String query, String reason) {
     String plan = explainPlan(query);
-    assertFalse(reason + ":\n" + plan, plan.contains("intersection:"));
+    assertFalse(reason + ":\n" + plan,
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
   }
 
   /** Named-parameter variant of {@link #assertPlanHasIntersection}. */
   protected void assertPlanHasIntersection(
       String query, Map<String, Object> params, String reason) {
     String plan = explainPlan(query, params);
-    assertTrue(reason + ":\n" + plan, plan.contains("intersection:"));
+    assertTrue(reason + ":\n" + plan,
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
   }
 
   /** Named-parameter variant of {@link #assertPlanHasIndexIntersection}. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterTestBase.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterTestBase.java
@@ -57,11 +57,48 @@ public abstract class MatchPreFilterTestBase extends DbTestBase {
    * Asserts the EXPLAIN plan contains evidence of back-ref optimization:
    * either {@code "intersection:"} (EdgeRidLookup) or
    * {@code "BACK-REF HASH JOIN"} (BackRefHashJoinStep).
+   *
+   * <p>This is an intentionally-permissive legacy helper — the caller
+   * accepts whichever optimization family the planner currently selects.
+   * Prefer the narrower {@link #assertPlanUsesBackRefHashJoin} or
+   * {@link #assertPlanUsesEdgeRidLookup} when the test is meant to guard
+   * a specific optimization path; those fail if the plan silently switches
+   * family on a regression.
    */
   protected void assertPlanHasIntersection(String query, String reason) {
     String plan = explainPlan(query);
     assertTrue(reason + ":\n" + plan,
         plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+  }
+
+  /** Named-parameter variant of {@link #assertPlanHasIntersection}. */
+  protected void assertPlanHasIntersection(
+      String query, Map<String, Object> params, String reason) {
+    String plan = explainPlan(query, params);
+    assertTrue(reason + ":\n" + plan,
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+  }
+
+  /**
+   * Asserts the EXPLAIN plan uses the BackRefHashJoin optimization
+   * ({@code "BACK-REF HASH JOIN"} marker). Use this for queries where the
+   * planner is expected to select Pattern A/B/D and the assertion must fail
+   * if the plan silently falls back to the EdgeRidLookup family.
+   */
+  protected void assertPlanUsesBackRefHashJoin(String query, String reason) {
+    String plan = explainPlan(query);
+    assertTrue(reason + ":\n" + plan, plan.contains("BACK-REF HASH JOIN"));
+  }
+
+  /**
+   * Asserts the EXPLAIN plan uses the legacy EdgeRidLookup intersection
+   * ({@code "intersection:"} marker) — for queries whose shape is known
+   * to fall outside the Pattern A/B/D semi-join criteria and must still
+   * benefit from the index-intersection pre-filter.
+   */
+  protected void assertPlanUsesEdgeRidLookup(String query, String reason) {
+    String plan = explainPlan(query);
+    assertTrue(reason + ":\n" + plan, plan.contains("intersection:"));
   }
 
   /** Asserts the EXPLAIN plan contains {@code "intersection: index"}. */
@@ -82,12 +119,18 @@ public abstract class MatchPreFilterTestBase extends DbTestBase {
         plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
   }
 
-  /** Named-parameter variant of {@link #assertPlanHasIntersection}. */
-  protected void assertPlanHasIntersection(
+  /** Named-parameter variant of {@link #assertPlanUsesBackRefHashJoin}. */
+  protected void assertPlanUsesBackRefHashJoin(
       String query, Map<String, Object> params, String reason) {
     String plan = explainPlan(query, params);
-    assertTrue(reason + ":\n" + plan,
-        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+    assertTrue(reason + ":\n" + plan, plan.contains("BACK-REF HASH JOIN"));
+  }
+
+  /** Named-parameter variant of {@link #assertPlanUsesEdgeRidLookup}. */
+  protected void assertPlanUsesEdgeRidLookup(
+      String query, Map<String, Object> params, String reason) {
+    String plan = explainPlan(query, params);
+    assertTrue(reason + ":\n" + plan, plan.contains("intersection:"));
   }
 
   /** Named-parameter variant of {@link #assertPlanHasIndexIntersection}. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionTest.java
@@ -3771,8 +3771,11 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
-        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+    assertTrue(
+        "Plan should use BACK-REF HASH JOIN (Pattern A — vertex-level "
+            + "back-ref equality on small build-side qualifies for hash "
+            + "join below threshold):\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -3861,8 +3864,11 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
-        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+    assertTrue(
+        "Plan should use BACK-REF HASH JOIN (Pattern A — vertex-level "
+            + "back-ref equality on small build-side qualifies for hash "
+            + "join below threshold):\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -3973,8 +3979,11 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
-        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+    assertTrue(
+        "Plan should use BACK-REF HASH JOIN (Pattern A — vertex-level "
+            + "back-ref equality on small build-side qualifies for hash "
+            + "join below threshold):\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -4051,8 +4060,11 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
-        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+    assertTrue(
+        "Plan should use BACK-REF HASH JOIN (Pattern A — vertex-level "
+            + "back-ref equality on small build-side qualifies for hash "
+            + "join below threshold):\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -4171,8 +4183,11 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
-        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
+    assertTrue(
+        "Plan should use BACK-REF HASH JOIN (Pattern A — vertex-level "
+            + "back-ref equality on small build-side qualifies for hash "
+            + "join below threshold):\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchStatementExecutionTest.java
@@ -3771,8 +3771,8 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show intersection optimization for back-reference",
-        plan.contains("intersection:"));
+    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -3861,8 +3861,8 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show intersection optimization for back-reference",
-        plan.contains("intersection:"));
+    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -3973,8 +3973,8 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show intersection optimization for back-reference",
-        plan.contains("intersection:"));
+    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -4051,8 +4051,8 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show intersection optimization for back-reference",
-        plan.contains("intersection:"));
+    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -4171,8 +4171,8 @@ public class MatchStatementExecutionTest extends DbTestBase {
     assertEquals(1, explain.size());
     String plan = explain.get(0).getProperty("executionPlanAsString");
     assertNotNull("EXPLAIN should produce executionPlanAsString", plan);
-    assertTrue("Plan should show intersection optimization for back-reference",
-        plan.contains("intersection:"));
+    assertTrue("Plan should show back-ref optimization (intersection or hash join)",
+        plan.contains("intersection:") || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -4404,9 +4404,10 @@ public class MatchStatementExecutionTest extends DbTestBase {
     var explain = session.query("EXPLAIN " + matchQuery).toList();
     var plan = (String) explain.getFirst().getProperty("executionPlanAsString");
     assertTrue(
-        "Plan should show EdgeRidLookup intersection with in('EHasCreator'),"
-            + " plan was:\n" + plan,
-        plan.contains("intersection:") && plan.contains("EHasCreator"));
+        "Plan should show back-ref optimization (intersection or hash join)"
+            + " for EHasCreator, plan was:\n" + plan,
+        (plan.contains("intersection:") && plan.contains("EHasCreator"))
+            || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -4518,9 +4519,10 @@ public class MatchStatementExecutionTest extends DbTestBase {
     // Plan should show "intersection: in('CxHasCreator')" — confirming
     // EdgeRidLookup descriptor was used with the correct edge class.
     assertTrue(
-        "Plan should show CxHasCreator in intersection annotation,"
+        "Plan should show back-ref optimization for CxHasCreator,"
             + " plan was:\n" + plan,
-        plan.contains("CxHasCreator") && plan.contains("intersection"));
+        (plan.contains("CxHasCreator") && plan.contains("intersection"))
+            || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 
@@ -4595,9 +4597,9 @@ public class MatchStatementExecutionTest extends DbTestBase {
     var explain = session.query("EXPLAIN " + matchQuery).toList();
     var plan = (String) explain.getFirst().getProperty("executionPlanAsString");
     assertTrue(
-        "Plan should show intersection pre-filter for large link bag,"
+        "Plan should show back-ref optimization for large link bag,"
             + " plan was:\n" + plan,
-        plan.contains("intersection"));
+        plan.contains("intersection") || plan.contains("BACK-REF HASH JOIN"));
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertTrue;
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
@@ -2066,6 +2068,51 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
 
     assertEquals(1, result.size());
     assertEquals("n1", result.get(0).getProperty("cName"));
+  }
+
+  /**
+   * Regression: Pattern D detection must walk the AST instead of parsing
+   * the RHS {@code toString()}. The previous regex-based detector accepted
+   * {@code $matched.X.out(:edge)} by capturing the bare parameter name
+   * (without the {@code :} prefix) as the edge-class string, which then
+   * failed at runtime because the anti-join build scanned a non-existent
+   * {@code out_:edge} link bag and passed every candidate through —
+   * inverting the intended NOT IN semantics.
+   *
+   * <p>The AST walker rejects the expression as a Pattern D candidate
+   * when the edge-class argument is anything other than a plain string
+   * literal (parameters, identifiers, compound expressions). The NOT IN
+   * then stays on the target's WHERE clause and is evaluated by the
+   * standard MatchStep — producing the correct exclusion.
+   */
+  @Test
+  public void backRef_notIn_boundParameterEdgeClass_correctResults() {
+    // n1→n2→n4 and n1→n3→n5 from the shared graph (Friend edges).
+    // Starting from n2, fof ∈ n2.in('Friend') = {n1}.
+    // n1 is in n2.start's out('Friend') = {n2,n3}? Wait, start=n2 itself:
+    //   start=n2 → n2.out('Friend') = {n4}.
+    // n1 ∉ {n4}, so fof=n1 passes the NOT IN (not excluded).
+    session.begin();
+    Map<String, Object> params = new HashMap<>();
+    params.put("edgeClass", "Friend");
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n2')}"
+            + ".in('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out(:edgeClass))}"
+            + " RETURN fof.name as fofName",
+        params)
+        .toList();
+    session.commit();
+
+    // n2.in('Friend') = {n1}; n2.out('Friend') = {n4}. n1 ∉ {n4} → pass.
+    // With the buggy regex, the descriptor would be built for edge class
+    // "edgeClass" (non-existent). The build side would be empty, so the
+    // anti-join emits every fof — same result here (1 row), but for the
+    // wrong reason. The correctness invariant exercised by this test is
+    // consistent with either code path; it primarily guards against
+    // future regressions in the AST rejection.
+    assertEquals(1, result.size());
+    assertEquals("n1", result.get(0).getProperty("fofName"));
   }
 
   // ── $matched publication regression ────────────────────────────────────

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1872,18 +1872,23 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
   }
 
   /**
-   * Regression: Pattern B (outE+inV chain) must reject an intermediate edge
-   * filter that is not fully covered by a single index. Before the fix,
-   * {@code detectChainSemiJoin} produced a ChainSemiJoin whose only filter
-   * evaluator was {@code indexRidSet.contains(edgeRid)} — that covers the
-   * indexable part only. Non-indexable residual terms (e.g.
-   * {@code category='A'} when the index is on {@code score}) were silently
-   * dropped because the consumed predecessor's MatchStep (which would
-   * normally evaluate them) was skipped.
+   * Regression: Pattern B (outE+inV chain) must apply the full edge WHERE
+   * clause even when the index only covers it partially. Before the fix,
+   * {@code BackRefHashJoinStep} filtered edges exclusively via
+   * {@code indexRidSet.contains(edgeRid)} — which only checks indexable
+   * terms. Non-indexable residual terms (e.g. {@code category='A'} when
+   * the index is on {@code score}) were silently dropped because the
+   * consumed predecessor's MatchStep (which would normally evaluate them)
+   * was skipped.
+   *
+   * <p>The fix stores the full edge filter in {@link ChainSemiJoin} and
+   * re-evaluates it on every loaded edge, keeping the index as a
+   * zero-load pre-filter. Pattern B still applies — this is a correctness
+   * fix, not a fallback — so the plan must show BACK-REF HASH JOIN.
    *
    * <p>Graph setup: two Rated5 edges both pass the indexable
-   * {@code score > 5} but differ on {@code category}. A correct plan returns
-   * only the edge matching both terms.
+   * {@code score > 5} but differ on {@code category}. The correct plan
+   * returns only the edge matching both terms.
    */
   @Test
   public void backRef_outEInV_partialIndexCover_correctResults() {
@@ -1908,6 +1913,20 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     session.commit();
 
     session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".outE('Rated5'){as:e, where:(score > 5 AND category = 'A')}"
+            + ".inV(){as:check, where:(@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName, e.category as cat")
+        .toList();
+    assertEquals(1, explain.size());
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "partial index cover should still collapse the chain, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
     var result = session.query(
         "MATCH {class:Person, as:a, where:(name='n1')}"
             + ".out('Friend'){as:b}"
@@ -1924,6 +1943,50 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     assertEquals(1, result.size());
     assertEquals("n2", result.get(0).getProperty("bName"));
     assertEquals("A", result.get(0).getProperty("cat"));
+  }
+
+  /**
+   * Regression: Pattern B (outE+inV chain) must apply the edge WHERE clause
+   * even when there is no index at all on the edge property. Before the
+   * fix, the filter was stored only as an {@code IndexSearchDescriptor}
+   * pre-filter; when no index existed, the descriptor was null and the
+   * filter was silently dropped entirely.
+   *
+   * <p>Same setup as the partial-cover test but on an unindexed edge class.
+   */
+  @Test
+  public void backRef_outEInV_noIndexCover_correctResults() {
+    session.execute("CREATE class Rated6 extends E").close();
+    session.execute("CREATE PROPERTY Rated6.score INTEGER").close();
+    // Deliberately no index at all on Rated6.
+
+    session.begin();
+    session.execute(
+        "CREATE EDGE Rated6 from (select from Person where name='n2')"
+            + " to (select from Person where name='n1') set score = 10")
+        .close();
+    session.execute(
+        "CREATE EDGE Rated6 from (select from Person where name='n3')"
+            + " to (select from Person where name='n1') set score = 2")
+        .close();
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".outE('Rated6'){as:e, where:(score > 5)}"
+            + ".inV(){as:check, where:(@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName, e.score as score")
+        .toList();
+    session.commit();
+
+    // Only the n2→n1 edge (score=10) passes score > 5; the n3→n1 edge
+    // (score=2) must be filtered out. Without the fix, both would enter
+    // the hash table (no filter evaluator whatsoever).
+    assertEquals(1, result.size());
+    assertEquals("n2", result.get(0).getProperty("bName"));
+    assertEquals(10, (int) result.get(0).getProperty("score"));
   }
 
   // ── $matched publication regression ────────────────────────────────────

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1254,28 +1254,33 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
   // ── Pattern D — in-direction NOT IN ──
 
   /**
-   * Pattern D with "in" direction — NOT IN $matched.X.in('Friend').
-   * Verifies anti-semi-join works for incoming edge traversals.
+   * Pattern D with "in" direction — NOT IN {@code $matched.X.in('Friend')}.
+   * Verifies anti-semi-join works when the NOT IN RHS traverses incoming
+   * edges instead of outgoing ones.
    *
-   * Query: find FoF of n1, excluding vertices that have an incoming
-   * Friend edge from n1 (i.e., direct friends of n1 are excluded).
+   * <p>Graph (reversed): {@code n4 <--Friend-- n2 <--Friend-- n1}. Starting
+   * at {@code n4}, walk back twice via {@code .in('Friend')}:
+   * {@code friend = n2}, then {@code fof = n1}. The NOT IN RHS
+   * {@code $matched.start.in('Friend')} resolves to {@code n4}'s incoming
+   * Friend neighbors = {n2}. Candidate {@code n1 NOT IN {n2}} → accepted.
+   * Expected result: {@code {n1}}.
    */
   @Test
   public void backRef_notIn_inDirection_correctResults() {
     session.begin();
     var result = session.query(
-        "MATCH {class:Person, as:start, where:(name='n1')}"
-            + ".out('Friend'){as:friend}"
-            + ".out('Friend'){as:fof,"
-            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+        "MATCH {class:Person, as:start, where:(name='n4')}"
+            + ".in('Friend'){as:friend}"
+            + ".in('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.in('Friend'))}"
             + " RETURN fof.name as fofName")
         .toList();
 
     var names = result.stream()
         .map(r -> (String) r.getProperty("fofName"))
         .collect(Collectors.toSet());
-    // n4, n5 are FoF; neither is a direct friend of n1
-    assertEquals(Set.of("n4", "n5"), names);
+    // n1 is the only FoF via reverse Friend; n2 (direct in-neighbor) excluded
+    assertEquals(Set.of("n1"), names);
     session.commit();
   }
 
@@ -2124,6 +2129,53 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     // future regressions in the AST rejection.
     assertEquals(1, result.size());
     assertEquals("n1", result.get(0).getProperty("fofName"));
+  }
+
+  /**
+   * Pattern A residual handling when the target WHERE contains a second
+   * {@code @rid = <literal>} equality alongside the back-ref
+   * {@code @rid = $matched.a.@rid}.
+   *
+   * <p>{@code findRidEquality} walks the atoms and returns the first match —
+   * here the {@code $matched.a.@rid} one (atom order in the parser). The
+   * planner enters the Pattern A path; {@code extractTargetResidual} strips
+   * that atom and leaves {@code @rid = <literal>} as residual. The residual
+   * has no {@code $matched}/{@code $currentMatch} reference, so Pattern A
+   * is safe. At probe time, {@code BackRefHashJoinStep} re-evaluates the
+   * residual per loaded target: only entities whose RID also equals the
+   * literal pass.
+   *
+   * <p>Graph: {@code n1 --Friend--> n1} (self-loop), added to the shared
+   * graph. The back-ref {@code @rid = $matched.a.@rid} selects {@code c=n1}.
+   * The literal half {@code @rid = #<impossible>} can never hold, so the
+   * residual filters everything out and the result is empty. Without the
+   * residual, the probe would emit {@code c=n1}.
+   */
+  @Test
+  public void backRef_patternA_compoundRidEquality_residualRejects() {
+    session.begin();
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n1')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    // #9999:9999 is a RID that cannot exist in the test database (cluster
+    // 9999 is never created). Using an impossible RID keeps the test
+    // independent of cluster-id assignment across runs.
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid AND @rid = #9999:9999)}"
+            + " RETURN c.name as cName")
+        .toList();
+    session.commit();
+
+    // Pattern A picks c=n1 via $matched.a.@rid; literal residual
+    // @rid=#9999:9999 rejects it. Correct result: zero rows.
+    assertEquals(0, result.size());
   }
 
   // ── $matched publication regression ────────────────────────────────────

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -663,12 +663,15 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     }
   }
 
+  // ── Back-reference hash join tests (Pattern B — outE+inV chain) ─────
+
   /**
-   * Pattern A — edge-level traversals (outE/inE) should NOT use back-ref
-   * hash join (only vertex-level out/in are eligible).
+   * Pattern B — outE('E').inV() chain with back-reference on the .inV()
+   * target should use ChainSemiJoin, collapsing two edges into one step.
+   * EXPLAIN should show BACK-REF HASH JOIN with both aliases.
    */
   @Test
-  public void backRef_edgeLevelTraversal_notEligible() {
+  public void explainBackRef_outEInV_usesChainSemiJoin() {
     session.begin();
     var result = session.query(
         "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
@@ -680,11 +683,105 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     assertEquals(1, result.size());
     String plan = result.get(0).getProperty("executionPlanAsString");
     assertNotNull(plan);
-    // outE/inE are not vertex-level traversals → no back-ref hash join
-    assertFalse(
-        "edge-level traversal should not use back-ref hash join, got:\n" + plan,
+    assertTrue(
+        "outE+inV chain should use back-ref hash join, got:\n" + plan,
         plan.contains("BACK-REF HASH JOIN"));
     session.commit();
+  }
+
+  /**
+   * Pattern B — correctness test. Uses the same Person/Friend graph with
+   * outE().inV() traversal. Creates a cycle n2→n1 to have a matching result.
+   */
+  @Test
+  public void backRef_outEInV_withCycle_correctResults() {
+    session.begin();
+    // Add a cycle: n2→n1
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e1}.inV(){as:b}"
+            + ".outE('Friend'){as:e2}.inV(){as:check,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+
+    // n1→(e1)→n2→(e2)→n1 matches (check.@rid == a.@rid == n1)
+    // n1→(e1)→n3→(e2)→n5 doesn't match (n5 != n1)
+    assertEquals(1, result.size());
+    assertEquals("n2", result.get(0).getProperty("bName"));
+    session.commit();
+  }
+
+  /**
+   * Pattern B — correctness test with fan-out. When multiple edges from
+   * the source vertex match, the chain semi-join should emit one row per
+   * matching edge (intermediate alias gets each edge record).
+   */
+  @Test
+  public void backRef_outEInV_fanOut_multipleEdges() {
+    session.begin();
+    // Add two edges from n2 back to n1 to test fan-out
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e1}.inV(){as:b}"
+            + ".outE('Friend'){as:e2}.inV(){as:check,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName, e2 as edge2")
+        .toList();
+
+    // n2 has 2 outgoing Friend edges to n1. Each should produce a result row.
+    // b=n2 with 2 different e2 edge records.
+    assertTrue("fan-out should produce multiple rows, got " + result.size(),
+        result.size() >= 2);
+    for (var row : result) {
+      assertEquals("n2", row.getProperty("bName"));
+      assertNotNull("edge2 should be populated", row.getProperty("edge2"));
+    }
+    session.commit();
+  }
+
+  /**
+   * Pattern B — threshold=0 disables chain semi-join. Falls back to regular
+   * MatchStep for both the outE and inV edges.
+   */
+  @Test
+  public void backRef_outEInV_thresholdZero_fallsBack() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(0L);
+
+      session.begin();
+      var result = session.query(
+          "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+              + ".outE('Friend'){as:e}.inV(){as:b}"
+              + ".outE('Friend'){as:e2}.inV(){as:check,"
+              + " where: (@rid = $matched.a.@rid)}"
+              + " RETURN b.name")
+          .toList();
+      assertEquals(1, result.size());
+      String plan = result.get(0).getProperty("executionPlanAsString");
+      assertNotNull(plan);
+      assertFalse(
+          "threshold=0 should disable chain semi-join, got:\n" + plan,
+          plan.contains("BACK-REF HASH JOIN"));
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
   }
 
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
@@ -1312,6 +1313,49 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
         "optional edge should not use back-ref hash join, got:\n" + plan,
         plan.contains("BACK-REF HASH JOIN"));
     session.commit();
+  }
+
+  /**
+   * Regression: Pattern B (outE+inV chain) must reject an optional
+   * {@code .inV()} target. Before the fix, {@code detectChainSemiJoin}
+   * had no optional guard (only Pattern A did), so the predecessor
+   * {@code .outE('E')} got marked {@code consumed=true}; then
+   * {@code addStepsFor} dispatched on the {@code isOptionalNode()} branch
+   * before consulting {@code getSemiJoinDescriptor()}, producing a plan
+   * where the predecessor's {@link MatchStep} was silently dropped and no
+   * {@link BackRefHashJoinStep} was inserted — leaving the intermediate
+   * alias unbound at runtime and collapsing all outE edges into a single
+   * null-filled row.
+   *
+   * <p>Correct semantics: traverse every outE('Friend') from {@code a=n1}
+   * (the graph has n1→n2 and n1→n3), emit one row per edge. The back-ref
+   * filter rejects both targets so {@code check} is null under the
+   * optional pass-through.
+   */
+  @Test
+  public void backRef_optionalInV_patternB_correctResults() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e}"
+            + ".inV(){as:check, optional:true,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN a.name as aName, e.@rid as eRid,"
+            + " check.name as checkName")
+        .toList();
+    session.commit();
+
+    // Without the fix: outE dropped, only OptionalMatchStep runs, intermediate
+    // alias e is unbound → the plan yields a single degenerate row (or none).
+    // With the fix: two outE edges are each traversed, both have null check.
+    assertEquals(2, result.size());
+    for (var row : result) {
+      assertEquals("n1", row.getProperty("aName"));
+      assertNotNull("edge RID must be bound", row.getProperty("eRid"));
+      assertNull(
+          "check must be null under optional back-ref rejection",
+          row.getProperty("checkName"));
+    }
   }
 
   // ── Pattern B — threshold=1 fallback correctness ──

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -10,6 +10,7 @@ import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -315,8 +316,10 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
 
   /**
    * Diamond pattern with intermediate alias in RETURN — correctness test.
-   * All four aliases (a, b, c, t) must appear in the result rows with correct
-   * values, including the intermediate 'c' merged from the build side.
+   * Enumerates the full row set so a regression that duplicates, drops, or
+   * swaps rows (e.g. stale {@code c} binding from the build side) surfaces
+   * directly. Graph: n1→{n2,n3}, n2→Likes→{t1,t2}, n3→Likes→{t1}. For each
+   * (b,c)∈n1.Friends² row exists for every t in b.Likes∩c.Likes.
    */
   @Test
   public void diamondPattern_innerJoin_correctResults() {
@@ -329,13 +332,23 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
             + " t.name as tName")
         .toList();
 
-    assertFalse("inner join query should return results", result.isEmpty());
-    for (var row : result) {
-      assertNotNull("a.name missing", row.getProperty("aName"));
-      assertNotNull("b.name missing", row.getProperty("bName"));
-      assertNotNull("c.name missing", row.getProperty("cName"));
-      assertNotNull("t.name missing", row.getProperty("tName"));
-    }
+    // (b,c,t) combinations where t ∈ b.Likes ∩ c.Likes, with a pinned to n1:
+    //   (n2,n2): t1, t2            (n2,n3): t1
+    //   (n3,n2): t1                (n3,n3): t1
+    // Total 5 rows, each with a=n1.
+    var rows = result.stream()
+        .map(r -> r.getProperty("aName") + "|" + r.getProperty("bName")
+            + "|" + r.getProperty("cName") + "|" + r.getProperty("tName"))
+        .collect(Collectors.toSet());
+    assertEquals(
+        Set.of(
+            "n1|n2|n2|t1",
+            "n1|n2|n2|t2",
+            "n1|n2|n3|t1",
+            "n1|n3|n2|t1",
+            "n1|n3|n3|t1"),
+        rows);
+    assertEquals("no duplicate rows expected", 5, result.size());
     session.commit();
   }
 
@@ -510,15 +523,24 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
               + " c.name as cName, t.name as tName")
           .toList();
 
-      assertFalse("inner-join fallback should still return results",
-          result.isEmpty());
-      // Every row must have all four aliases populated
-      for (var row : result) {
-        assertNotNull("a.name missing", row.getProperty("aName"));
-        assertNotNull("b.name missing", row.getProperty("bName"));
-        assertNotNull("c.name missing", row.getProperty("cName"));
-        assertNotNull("t.name missing", row.getProperty("tName"));
-      }
+      // Runtime fallback must produce the same logical rows as the
+      // hash-join path — see diamondPattern_innerJoin_correctResults for
+      // the derivation. If the nested-loop fallback duplicates, drops,
+      // or swaps rows, the exact-set assertion flags it.
+      var rows = result.stream()
+          .map(r -> r.getProperty("aName") + "|" + r.getProperty("bName")
+              + "|" + r.getProperty("cName") + "|" + r.getProperty("tName"))
+          .collect(Collectors.toSet());
+      assertEquals(
+          Set.of(
+              "n1|n2|n2|t1",
+              "n1|n2|n2|t2",
+              "n1|n2|n3|t1",
+              "n1|n3|n2|t1",
+              "n1|n3|n3|t1"),
+          rows);
+      assertEquals("no duplicate rows in fallback path",
+          5, result.size());
       session.commit();
     } finally {
       GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
@@ -746,14 +768,23 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
             + " RETURN b.name as bName, e2 as edge2")
         .toList();
 
-    // n2 has 2 outgoing Friend edges to n1. Each should produce a result row.
-    // b=n2 with 2 different e2 edge records.
-    assertTrue("fan-out should produce multiple rows, got " + result.size(),
-        result.size() >= 2);
-    for (var row : result) {
-      assertEquals("n2", row.getProperty("bName"));
-      assertNotNull("edge2 should be populated", row.getProperty("edge2"));
-    }
+    // Only b=n2 back-refs to n1 (via the two added n2→n1 edges). b=n3's
+    // out('Friend') is {n5}, no back-ref. Fan-out must emit exactly 2 rows
+    // — one per edge — both with b=n2 and distinct e2 edge identities.
+    assertEquals("fan-out should emit one row per matching edge",
+        2, result.size());
+    var bNames = result.stream()
+        .map(r -> (String) r.getProperty("bName"))
+        .collect(Collectors.toList());
+    assertEquals(List.of("n2", "n2"), bNames);
+    var edgeIds = result.stream()
+        .map(r -> {
+          var e = r.getProperty("edge2");
+          return e == null ? null : e.toString();
+        })
+        .collect(Collectors.toSet());
+    assertEquals("both emitted edges must be distinct",
+        2, edgeIds.size());
     session.commit();
   }
 
@@ -2095,40 +2126,36 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
    * {@code out_:edge} link bag and passed every candidate through —
    * inverting the intended NOT IN semantics.
    *
-   * <p>The AST walker rejects the expression as a Pattern D candidate
-   * when the edge-class argument is anything other than a plain string
-   * literal (parameters, identifiers, compound expressions). The NOT IN
-   * then stays on the target's WHERE clause and is evaluated by the
-   * standard MatchStep — producing the correct exclusion.
+   * <p>The query is crafted so the buggy path and the correct path yield
+   * <strong>different</strong> row sets: each fof <em>is</em> one of
+   * {@code n1.out('Friend')}. A correct per-row NOT IN excludes them
+   * (zero rows); the old regex bug would build an empty hash on the
+   * non-existent {@code :edgeClass} class, so every fof would survive
+   * (two rows) — inverting the intended exclusion.
    */
   @Test
   public void backRef_notIn_boundParameterEdgeClass_correctResults() {
-    // n1→n2→n4 and n1→n3→n5 from the shared graph (Friend edges).
-    // Starting from n2, fof ∈ n2.in('Friend') = {n1}.
-    // n1 is in n2.start's out('Friend') = {n2,n3}? Wait, start=n2 itself:
-    //   start=n2 → n2.out('Friend') = {n4}.
-    // n1 ∉ {n4}, so fof=n1 passes the NOT IN (not excluded).
     session.begin();
     Map<String, Object> params = new HashMap<>();
     params.put("edgeClass", "Friend");
+    // Fof traversal: n1.out('Friend') = {n2, n3}. The NOT IN RHS resolves
+    // (at runtime, per-row) to n1.out('Friend') = {n2, n3} as well — so
+    // both fof candidates are excluded. Correct result: zero rows.
     var result = session.query(
-        "MATCH {class:Person, as:start, where:(name='n2')}"
-            + ".in('Friend'){as:fof,"
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:fof,"
             + " where: ($currentMatch NOT IN $matched.start.out(:edgeClass))}"
             + " RETURN fof.name as fofName",
         params)
         .toList();
     session.commit();
 
-    // n2.in('Friend') = {n1}; n2.out('Friend') = {n4}. n1 ∉ {n4} → pass.
-    // With the buggy regex, the descriptor would be built for edge class
-    // "edgeClass" (non-existent). The build side would be empty, so the
-    // anti-join emits every fof — same result here (1 row), but for the
-    // wrong reason. The correctness invariant exercised by this test is
-    // consistent with either code path; it primarily guards against
-    // future regressions in the AST rejection.
-    assertEquals(1, result.size());
-    assertEquals("n1", result.get(0).getProperty("fofName"));
+    // If Pattern D wrongly fired with edge class literally "edgeClass",
+    // the hash build would be empty and NOT IN ∅ would pass every fof —
+    // the result would be {n2, n3}. The correct result (per-row NOT IN
+    // with the resolved Friend class) is the empty set.
+    assertEquals("all fof candidates are in the exclusion set — must be "
+        + "filtered out by correct per-row NOT IN", 0, result.size());
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1034,14 +1034,22 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
   }
 
   /**
-   * EXPLAIN of compound WHERE — when NOT IN is combined with additional AND
-   * conditions, the anti-join optimization does not fire (pre-existing
-   * limitation of toString-based pattern detection). The query falls back
-   * to standard MatchStep WHERE evaluation. Verify the plan uses a regular
-   * MATCH step (no BACK-REF HASH JOIN ANTI) and results are still correct.
+   * EXPLAIN of compound WHERE — a NOT IN combined with additional AND
+   * conditions must now (post-fix) strip only the NOT IN and still fire
+   * the anti-join optimization. The residual conjunct ({@code name='n4'})
+   * stays on the preceding {@link MatchStep}, so the plan has both the
+   * MATCH step (evaluating the residual) and the BACK-REF HASH JOIN ANTI
+   * step (evaluating the NOT IN exclusion).
+   *
+   * <p>Regression: {@code detectNotInAntiJoin} previously iterated only
+   * the top-level AND sub-blocks. With MATCH's double-nesting
+   * ({@code AND[OR[AND[notIn, residual]]]}) the NOT IN sat two wrappers
+   * deep, so compound WHERE fell back to standard MatchStep evaluation.
+   * The fix descends through transparent single-element OR/AND wrappers
+   * to reach the actual conjuncts list.
    */
   @Test
-  public void explainBackRef_notIn_compoundWhere_fallsBackToMatchStep() {
+  public void explainBackRef_notIn_compoundWhere_usesAntiJoinWithResidual() {
     session.begin();
     var result = session.query(
         "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
@@ -1054,11 +1062,14 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     assertEquals(1, result.size());
     String plan = result.get(0).getProperty("executionPlanAsString");
     assertNotNull(plan);
-    // Compound NOT IN + AND does not trigger anti-join optimization —
-    // falls back to standard MATCH step with full WHERE evaluation
-    assertFalse(
-        "compound WHERE should not use anti-join, got:\n" + plan,
+    assertTrue(
+        "compound WHERE should use anti-join, got:\n" + plan,
         plan.contains("BACK-REF HASH JOIN ANTI"));
+    // Residual evaluation is verified end-to-end by
+    // backRef_notIn_compoundWhere_correctResults — it filters to n4 only,
+    // which only works if the stripped WHERE (name='n4') still runs in
+    // the preceding MatchStep. EXPLAIN does not print per-MatchStep
+    // WHERE clauses, so we can't assert the residual text in the plan.
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1059,4 +1059,330 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     session.commit();
   }
 
+  // ── Pattern A — in-direction back-reference ──
+
+  /**
+   * Pattern A with "in" direction — the back-reference uses .in('Friend')
+   * instead of .out('Friend'). The hash table is built from the back-ref
+   * vertex's out_ link bag (reverse of "in" direction).
+   *
+   * Graph: n1→n2 via Friend. Query: find vertices whose incoming Friend
+   * edges include a vertex reachable from n1's friends.
+   * n2.in('Friend') includes n1. Check: @rid = $matched.a.@rid = n1 → match.
+   */
+  @Test
+  public void backRef_singleEdge_inDirection_correctResults() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".in('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+
+    // n1→n2: n2.in('Friend') = {n1}. check.@rid must equal n1.@rid → n1 matches
+    // n1→n3: n3.in('Friend') = {n1}. check.@rid must equal n1.@rid → n1 matches
+    // Both b=n2 and b=n3 should produce results
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("bName"))
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("n2", "n3"), names);
+    session.commit();
+  }
+
+  /**
+   * EXPLAIN for Pattern A with "in" direction — verifies the planner
+   * selects BACK-REF HASH JOIN for in-direction traversals.
+   */
+  @Test
+  public void explainBackRef_singleEdge_inDirection_usesBackRefHashJoin() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".in('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "in-direction back-ref should use hash join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+    session.commit();
+  }
+
+  // ── Pattern A — multi-edge fan-out ──
+
+  /**
+   * Pattern A with multiple edges of the same class between the same
+   * vertex pair. Verifies that the hash join correctly emits N rows
+   * when N edges exist between source and target (no deduplication).
+   *
+   * Creates 3 Friend edges from n2→n1, then checks back-ref from n2.
+   */
+  @Test
+  public void backRef_singleEdge_multipleEdges_emitsCorrectCount() {
+    session.begin();
+    // Add 3 Friend edges from n2→n1 (on top of the existing n1→n2)
+    for (int i = 0; i < 3; i++) {
+      session.execute(
+          "CREATE EDGE Friend from (select from Person where name='n2')"
+              + " to (select from Person where name='n1')")
+          .close();
+    }
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b, where:(name='n2')}"
+            + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+
+    // n2 has 3 outgoing Friend edges to n1. Each should produce a result row.
+    assertEquals("multi-edge should produce 3 rows", 3, result.size());
+    for (var row : result) {
+      assertEquals("n2", row.getProperty("bName"));
+    }
+    session.commit();
+  }
+
+  // ── Pattern A — threshold=1 fallback ──
+
+  /**
+   * Pattern A threshold=1 fallback correctness. The build side for the
+   * back-ref hash table will have 2 entries (n2 and n3 are friends of n1),
+   * exceeding threshold=1. The step falls back to per-row nested-loop
+   * traversal via MatchEdgeTraverser. Results must still be correct.
+   */
+  @Test
+  public void backRef_singleEdge_thresholdOne_fallbackCorrectResults() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(1L);
+
+      session.begin();
+      // Add cycle: n2→n1 so there's a matching result
+      session.execute(
+          "CREATE EDGE Friend from (select from Person where name='n2')"
+              + " to (select from Person where name='n1')")
+          .close();
+
+      var result = session.query(
+          "MATCH {class:Person, as:a, where:(name='n1')}"
+              + ".out('Friend'){as:b}"
+              + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+              + " RETURN b.name as bName")
+          .toList();
+
+      // n1→n2→{n1,n4}: n1 matches (check.@rid==a.@rid)
+      // n1→n3→{n5}: no match
+      assertEquals(1, result.size());
+      assertEquals("n2", result.get(0).getProperty("bName"));
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
+  }
+
+  // ── Pattern B — in-direction chain (inE+outV) ──
+
+  /**
+   * Pattern B with inE().outV() chain — the reverse direction of the
+   * standard outE().inV() chain. Verifies that ChainSemiJoin handles
+   * inE-based chains correctly.
+   */
+  @Test
+  public void backRef_inEOutV_withCycle_correctResults() {
+    session.begin();
+    // Add cycle: n2→n1
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n2')}"
+            + ".inE('Friend'){as:e1}.outV(){as:b}"
+            + ".inE('Friend'){as:e2}.outV(){as:check,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+
+    // n2.inE('Friend') = {e from n1→n2}. outV() = n1.
+    // n1.inE('Friend') = {e from n2→n1}. outV() = n2.
+    // check.@rid must equal a.@rid = n2 → n2 matches.
+    assertEquals(1, result.size());
+    assertEquals("n1", result.get(0).getProperty("bName"));
+    session.commit();
+  }
+
+  /**
+   * Pattern B — no matching result. The inV/outV traversal doesn't lead
+   * back to the starting vertex, so the query returns empty.
+   */
+  @Test
+  public void backRef_outEInV_noMatch_emptyResult() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e1}.inV(){as:b}"
+            + ".outE('Friend'){as:e2}.inV(){as:check,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+
+    // No cycle back to n1, so no results
+    assertEquals(0, result.size());
+    session.commit();
+  }
+
+  // ── Pattern D — in-direction NOT IN ──
+
+  /**
+   * Pattern D with "in" direction — NOT IN $matched.X.in('Friend').
+   * Verifies anti-semi-join works for incoming edge traversals.
+   *
+   * Query: find FoF of n1, excluding vertices that have an incoming
+   * Friend edge from n1 (i.e., direct friends of n1 are excluded).
+   */
+  @Test
+  public void backRef_notIn_inDirection_correctResults() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("fofName"))
+        .collect(Collectors.toSet());
+    // n4, n5 are FoF; neither is a direct friend of n1
+    assertEquals(Set.of("n4", "n5"), names);
+    session.commit();
+  }
+
+  /**
+   * Pattern D — EXPLAIN verifies plan uses ANTI for in-direction traversal.
+   */
+  @Test
+  public void explainBackRef_notIn_inDirection_usesAntiSemiJoin() {
+    session.begin();
+    // Use in() direction in NOT IN: exclude vertices that have incoming Friend
+    // from start's friends
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:start, where:(name='n2')}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.in('Friend'))}"
+            + " RETURN fof.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "in-direction NOT IN should use anti-join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN ANTI"));
+    session.commit();
+  }
+
+  // ── Pattern A — optional edge should NOT trigger back-ref hash join ──
+
+  /**
+   * Optional edges should not use Pattern A back-ref hash join, because
+   * optional traversals must pass through rows even when no match is found.
+   */
+  @Test
+  public void backRef_optionalEdge_notUsedForHashJoin() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:check, optional:true,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    // Optional edges should not use back-ref hash join
+    assertFalse(
+        "optional edge should not use back-ref hash join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+    session.commit();
+  }
+
+  // ── Pattern B — threshold=1 fallback correctness ──
+
+  /**
+   * Pattern B threshold=1 fallback correctness. Forces the chain hash
+   * build to fail because the reverse link bag exceeds threshold=1.
+   * Falls back to nested-loop traversal via MatchEdgeTraverser.
+   */
+  @Test
+  public void backRef_outEInV_thresholdOne_fallbackCorrectResults() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(1L);
+
+      session.begin();
+      // Add cycle: n2→n1
+      session.execute(
+          "CREATE EDGE Friend from (select from Person where name='n2')"
+              + " to (select from Person where name='n1')")
+          .close();
+
+      var result = session.query(
+          "MATCH {class:Person, as:a, where:(name='n1')}"
+              + ".outE('Friend'){as:e1}.inV(){as:b}"
+              + ".outE('Friend'){as:e2}.inV(){as:check,"
+              + " where: (@rid = $matched.a.@rid)}"
+              + " RETURN b.name as bName")
+          .toList();
+
+      // With fallback, should still produce correct results
+      assertEquals(1, result.size());
+      assertEquals("n2", result.get(0).getProperty("bName"));
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
+  }
+
+  // ── Pattern D — NOT IN is the sole WHERE condition ──
+
+  /**
+   * Pattern D where NOT IN is the only condition in the WHERE clause.
+   * After stripping, the filter is completely removed from the MatchStep.
+   * Verify the plan shape (BACK-REF HASH JOIN ANTI with no residual WHERE).
+   */
+  @Test
+  public void backRef_notIn_soleCondition_correctResults() {
+    session.begin();
+    // Add n2→n1 to create a direct cycle
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    // Query: all friends-of-n1, excluding n1.out('Friend')
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("fofName"))
+        .collect(Collectors.toSet());
+    // n2→{n1,n4}, n3→{n5}. n1 IS a direct friend of n1 (via n2→n1), so
+    // n1 is excluded. n4 and n5 are not direct friends → included.
+    assertEquals(Set.of("n1", "n4", "n5"), names);
+    session.commit();
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -2234,4 +2234,293 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     assertEquals("t1", result.get(0).getProperty("tName"));
   }
 
+  // ── Rejection-path branch coverage for MatchExecutionPlanner ───────────
+  //
+  // These tests each run EXPLAIN and assert the plan does NOT include
+  // BACK-REF HASH JOIN. This is the load-bearing assertion: a result-only
+  // check would pass even if the planner took the hash-join path and still
+  // happened to return the right rows. Data-correctness assertions (where
+  // they differentiate the paths) follow as a secondary safeguard.
+
+  /**
+   * Pattern A rejected — target WHERE is a multi-branch OR.
+   * {@code extractTargetResidual.flattenConjunction} bails out on multi-branch
+   * OR so the residual cannot be isolated, and the planner must fall back to
+   * the standard {@code MatchStep} + {@code EdgeRidLookup} path. The plan
+   * assertion is load-bearing: the row-set below would look identical if
+   * Pattern A fired and dropped or preserved the OR branch differently, so
+   * result correctness alone could mask a regression.
+   */
+  @Test
+  public void backRef_patternA_rejectedOnMultiBranchOrTargetFilter() {
+    session.begin();
+    // Add cycle n2→n1 so that a real match for $matched.a.@rid exists.
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid OR name = 'n4')}"
+            + " RETURN b.name, c.name")
+        .toList();
+    assertEquals(1, explain.size());
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "multi-branch OR in target filter must not take BACK-REF HASH JOIN, "
+            + "got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid OR name = 'n4')}"
+            + " RETURN b.name as bName, c.name as cName")
+        .toList();
+    session.commit();
+
+    // Under standard MatchStep: b=n2 → c=n1 (back-ref) or c=n4 (name='n4').
+    // b=n3 → no match. Resulting set: { (n2,n1), (n2,n4) }.
+    var rows = result.stream()
+        .map(r -> r.getProperty("bName") + "->" + r.getProperty("cName"))
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("n2->n1", "n2->n4"), rows);
+  }
+
+  /**
+   * Pattern A rejected — residual term references {@code $matched.<alias>}.
+   * The residual would be evaluated at hash-table build time (no per-row
+   * {@code $matched} scope) so {@code extractTargetResidual} must return
+   * UNSAFE and the planner falls back. The plan assertion is the primary
+   * verification: if Pattern A applied the residual was semantically invalid
+   * but might still have produced the correct rows by accident.
+   */
+  @Test
+  public void backRef_patternA_rejectedWhenResidualReferencesMatched() {
+    session.begin();
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid AND name = $matched.a.name)}"
+            + " RETURN b.name, c.name")
+        .toList();
+    assertEquals(1, explain.size());
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "residual referencing $matched must not take BACK-REF HASH JOIN, "
+            + "got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid AND name = $matched.a.name)}"
+            + " RETURN b.name as bName, c.name as cName")
+        .toList();
+    session.commit();
+
+    // $matched.a.name = 'n1'. Correct rows: c.name='n1' AND c≡a.
+    // b=n2 back-refs to n1 → (n2, n1). b=n3 → no back-ref.
+    var rows = result.stream()
+        .map(r -> r.getProperty("bName") + "->" + r.getProperty("cName"))
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("n2->n1"), rows);
+  }
+
+  /**
+   * Pattern A rejected — residual contains {@code $currentMatch}.
+   * {@link com.jetbrains.youtrackdb.internal.core.sql.executor.match
+   * .MatchExecutionPlanner#refersToCurrentMatch} detects the reference
+   * inside the residual and {@code extractTargetResidual} returns UNSAFE.
+   *
+   * <p>Uses a tautology ({@code $currentMatch.@rid IS NOT NULL}) rather
+   * than a NOT-IN clause so Pattern D cannot fire as a fall-through —
+   * the assertion must fail cleanly on Pattern A alone. A NOT-IN residual
+   * would be picked up by {@code detectNotInAntiJoin} after Pattern A
+   * rejection and emit an ANTI step, masking the branch under test.
+   */
+  @Test
+  public void backRef_patternA_rejectedWhenResidualReferencesCurrentMatch() {
+    session.begin();
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid"
+            + " AND $currentMatch.@rid IS NOT NULL)}"
+            + " RETURN b.name, c.name")
+        .toList();
+    assertEquals(1, explain.size());
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "residual referencing $currentMatch must not take BACK-REF HASH JOIN, "
+            + "got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid"
+            + " AND $currentMatch.@rid IS NOT NULL)}"
+            + " RETURN b.name as bName, c.name as cName")
+        .toList();
+    session.commit();
+
+    // $currentMatch.@rid IS NOT NULL is tautologically true, so only the
+    // back-ref filters. b=n2 back-refs to n1 → (n2, n1); b=n3 → no match.
+    var rows = result.stream()
+        .map(r -> r.getProperty("bName") + "->" + r.getProperty("cName"))
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("n2->n1"), rows);
+  }
+
+  /**
+   * Pattern B rejected — intermediate edge WHERE references
+   * {@code $matched.<alias>}. {@code detectChainSemiJoin} inspects the
+   * intermediate filter's involved-aliases set and bails when it is
+   * non-empty. The EXPLAIN assertion is the load-bearing check: both the
+   * rejection path and a hypothetical (wrong) Pattern-B firing would yield
+   * the same result count, so data correctness alone cannot distinguish
+   * them. The query intentionally returns zero rows — the outgoing
+   * Friend targets of n1 ({n2, n3}) cannot back-ref to n1 itself through
+   * a single {@code .outE('Friend').inV()} step.
+   */
+  @Test
+  public void backRef_patternB_rejectedWhenIntermediateFilterReferencesMatched() {
+    session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e, where: ($matched.a.@rid IS NOT NULL)}"
+            + ".inV(){as:c, where: (@rid = $matched.a.@rid)}"
+            + " RETURN c.name")
+        .toList();
+    assertEquals(1, explain.size());
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "Pattern B must not fire when intermediate filter references "
+            + "$matched.<alias>, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e, where: ($matched.a.@rid IS NOT NULL)}"
+            + ".inV(){as:c, where: (@rid = $matched.a.@rid)}"
+            + " RETURN c.name as cName")
+        .toList();
+    session.commit();
+
+    // n1.outE('Friend').inV() = {n2, n3}, neither back-refs to n1. Zero rows.
+    assertEquals(0, result.size());
+  }
+
+  /**
+   * Pattern D NOT IN rejected — the RHS of NOT IN is a bare
+   * {@code $matched.<alias>} with no trailing traversal call.
+   * {@code extractMatchedTraversal} requires a second modifier ({@code .out}
+   * or {@code .in}) and returns {@code null} when it is missing.
+   *
+   * <p>The plan assertion is the primary branch-coverage check. The data
+   * assertion is a second safety net: with Pattern D rejected, per-row NOT
+   * IN treats the single-vertex RHS as a singleton set; neither friend of
+   * n1 ({@code n2}, {@code n3}) equals n1, so both rows pass. If a broken
+   * planner tried to build a hash on the malformed RHS and dropped rows,
+   * the returned set would shrink and the assertion would flag it.
+   */
+  @Test
+  public void backRef_notIn_rejectedOnMalformedMatchedTraversalRhs() {
+    session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend,"
+            + " where: ($currentMatch NOT IN $matched.start)}"
+            + " RETURN friend.name")
+        .toList();
+    assertEquals(1, explain.size());
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "Pattern D must not fire when RHS has no traversal call, got:\n"
+            + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend,"
+            + " where: ($currentMatch NOT IN $matched.start)}"
+            + " RETURN friend.name as fName")
+        .toList();
+    session.commit();
+
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("fName"))
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("n2", "n3"), names);
+  }
+
+  /**
+   * Pattern D NOT IN rejected — the RHS traversal method is
+   * {@code .both(...)}, which is not one of the accepted {@code .out/.in}
+   * shapes. {@code extractMatchedTraversal} rejects anything but out/in.
+   *
+   * <p>The plan assertion is the primary branch-coverage check. The data
+   * assertion complements it: {@code n1.both('Friend')} is {@code {n2, n3}}
+   * and the fof set {@code n1.out('Friend')} is also {@code {n2, n3}}, so
+   * every candidate is excluded by the per-row NOT IN and the query returns
+   * zero rows. A regression that returned unexpected rows would still fail
+   * the data check even if the plan check somehow missed the shift.
+   */
+  @Test
+  public void backRef_notIn_rejectedOnUnacceptedTraversalMethod() {
+    session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.both('Friend'))}"
+            + " RETURN fof.name")
+        .toList();
+    assertEquals(1, explain.size());
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "Pattern D must not fire for .both(...) traversal RHS, got:\n"
+            + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.both('Friend'))}"
+            + " RETURN fof.name as fName")
+        .toList();
+    session.commit();
+
+    assertEquals(0, result.size());
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1871,6 +1871,61 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     session.commit();
   }
 
+  /**
+   * Regression: Pattern B (outE+inV chain) must reject an intermediate edge
+   * filter that is not fully covered by a single index. Before the fix,
+   * {@code detectChainSemiJoin} produced a ChainSemiJoin whose only filter
+   * evaluator was {@code indexRidSet.contains(edgeRid)} — that covers the
+   * indexable part only. Non-indexable residual terms (e.g.
+   * {@code category='A'} when the index is on {@code score}) were silently
+   * dropped because the consumed predecessor's MatchStep (which would
+   * normally evaluate them) was skipped.
+   *
+   * <p>Graph setup: two Rated5 edges both pass the indexable
+   * {@code score > 5} but differ on {@code category}. A correct plan returns
+   * only the edge matching both terms.
+   */
+  @Test
+  public void backRef_outEInV_partialIndexCover_correctResults() {
+    session.execute("CREATE class Rated5 extends E").close();
+    session.execute("CREATE PROPERTY Rated5.score INTEGER").close();
+    session.execute("CREATE PROPERTY Rated5.category STRING").close();
+    // Deliberately index only score; category is unindexed so
+    // {@code score > 5 AND category = 'A'} produces a partial cover.
+    session.execute("CREATE INDEX Rated5_score ON Rated5 (score) NOTUNIQUE").close();
+
+    session.begin();
+    session.execute(
+        "CREATE EDGE Rated5 from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')"
+            + " set score = 10, category = 'A'")
+        .close();
+    session.execute(
+        "CREATE EDGE Rated5 from (select from Person where name='n3')"
+            + " to (select from Person where name='n1')"
+            + " set score = 20, category = 'B'")
+        .close();
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".outE('Rated5'){as:e, where:(score > 5 AND category = 'A')}"
+            + ".inV(){as:check, where:(@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName, e.category as cat")
+        .toList();
+    session.commit();
+
+    // Only the n2→n1 edge (score=10, category='A') satisfies both terms.
+    // Without the fix, the n3→n1 edge (score=20, category='B') would also
+    // slip through because the index matches score>5 but never checks
+    // category — the chain semi-join would return 2 rows.
+    assertEquals(1, result.size());
+    assertEquals("n2", result.get(0).getProperty("bName"));
+    assertEquals("A", result.get(0).getProperty("cat"));
+  }
+
   // ── $matched publication regression ────────────────────────────────────
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -898,4 +898,165 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     }
   }
 
+  // ── Pattern D stripping verification tests ──
+
+  /**
+   * Verifies that the NOT IN condition is stripped from the MatchStep's WHERE
+   * clause at plan time. The EXPLAIN output should show BACK-REF HASH JOIN ANTI
+   * but the preceding MATCH step should NOT contain the NOT IN condition —
+   * it is now handled exclusively by the BackRefHashJoinStep.
+   */
+  @Test
+  public void explainBackRef_notIn_strippedFromMatchStep() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "plan should use BACK-REF HASH JOIN ANTI, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN ANTI"));
+    // The NOT IN should have been stripped from MatchStep's filter.
+    // After stripping, $currentMatch NOT IN should not appear in any
+    // MATCH step line — only in the BACK-REF HASH JOIN ANTI step.
+    var lines = plan.split("\n");
+    for (var line : lines) {
+      if (line.contains("MATCH") && !line.contains("BACK-REF")
+          && !line.contains("$matched")) {
+        assertFalse(
+            "NOT IN should be stripped from MatchStep filter, got line:\n"
+                + line,
+            line.contains("NOT IN"));
+      }
+    }
+    session.commit();
+  }
+
+  /**
+   * Pattern D fallback correctness — threshold=1 forces hash build failure
+   * (n1.out('Friend') has 2 entries > 1). The stored NOT IN condition must
+   * be evaluated per row by BackRefHashJoinStep as fallback.
+   */
+  @Test
+  public void backRef_notIn_thresholdOne_fallbackCorrectResults() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      // threshold=1: n1.out('Friend') has 2 entries (n2,n3) > 1, build fails
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(1L);
+
+      session.begin();
+      var result = session.query(
+          "MATCH {class:Person, as:start, where:(name='n1')}"
+              + ".out('Friend'){as:friend}"
+              + ".out('Friend'){as:fof,"
+              + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+              + " RETURN fof.name as fofName")
+          .toList();
+
+      var names = result.stream()
+          .map(r -> (String) r.getProperty("fofName"))
+          .collect(Collectors.toSet());
+      // n2→n4, n3→n5. Neither n4 nor n5 is in n1.out('Friend')={n2,n3}
+      assertEquals(Set.of("n4", "n5"), names);
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
+  }
+
+  /**
+   * Pattern D fallback with exclusion — threshold=1 forces fallback. Add n4
+   * as a direct friend of n1, then n4 should be excluded from FoF results.
+   */
+  @Test
+  public void backRef_notIn_withExclusion_thresholdOne_fallbackCorrectResults() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(1L);
+
+      session.begin();
+      // Make n4 a direct friend of n1
+      session.execute(
+          "CREATE EDGE Friend from (select from Person where name='n1')"
+              + " to (select from Person where name='n4')")
+          .close();
+
+      var result = session.query(
+          "MATCH {class:Person, as:start, where:(name='n1')}"
+              + ".out('Friend'){as:friend}"
+              + ".out('Friend'){as:fof,"
+              + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+              + " RETURN fof.name as fofName")
+          .toList();
+
+      var names = result.stream()
+          .map(r -> (String) r.getProperty("fofName"))
+          .collect(Collectors.toSet());
+      // n4 is now a direct friend of n1, so it's excluded. Only n5 remains.
+      assertEquals(Set.of("n5"), names);
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
+  }
+
+  /**
+   * Pattern D with compound WHERE — NOT IN + additional condition. Verifies
+   * that stripping removes only the NOT IN, leaving the residual condition
+   * (name = 'n4') on the MatchStep.
+   */
+  @Test
+  public void backRef_notIn_compoundWhere_correctResults() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend')"
+            + " AND name = 'n4')}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    // FoF = {n4, n5}. NOT IN filters nothing (neither is direct friend of n1).
+    // AND name='n4' filters to just n4.
+    assertEquals(1, result.size());
+    assertEquals("n4", result.get(0).getProperty("fofName"));
+    session.commit();
+  }
+
+  /**
+   * EXPLAIN of compound WHERE — when NOT IN is combined with additional AND
+   * conditions, the anti-join optimization does not fire (pre-existing
+   * limitation of toString-based pattern detection). The query falls back
+   * to standard MatchStep WHERE evaluation. Verify the plan uses a regular
+   * MATCH step (no BACK-REF HASH JOIN ANTI) and results are still correct.
+   */
+  @Test
+  public void explainBackRef_notIn_compoundWhere_fallsBackToMatchStep() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend')"
+            + " AND name = 'n4')}"
+            + " RETURN fof.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    // Compound NOT IN + AND does not trigger anti-join optimization —
+    // falls back to standard MATCH step with full WHERE evaluation
+    assertFalse(
+        "compound WHERE should not use anti-join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN ANTI"));
+    session.commit();
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1989,6 +1989,85 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     assertEquals(10, (int) result.get(0).getProperty("score"));
   }
 
+  /**
+   * Regression: Pattern A (single-edge back-ref) must apply residual WHERE
+   * terms on the target alias. Before the fix, {@code probeSingleEdge}
+   * emitted rows based on the hash lookup alone — the hash encodes only
+   * the {@code @rid = $matched.X.@rid} equality — so any additional
+   * constraints on the target vertex (e.g. {@code name != 'n1'}) were
+   * silently dropped because Pattern A replaces the target's MatchStep.
+   *
+   * <p>Graph setup: a self-loop on n1 makes {@code a=n1, b=n1} a valid
+   * back-ref candidate via {@code b.out('Friend')=n1=$matched.a}. The
+   * target residual {@code name != 'n1'} must reject n1, so the correct
+   * result is zero rows. Without the fix, one spurious row leaks through.
+   */
+  @Test
+  public void backRef_patternA_residualTargetFilter_correctResults() {
+    session.begin();
+    // Self-loop so the back-ref @rid = $matched.a.@rid succeeds for b=n1.
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n1')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid AND name <> 'n1')}"
+            + " RETURN c.name as cName")
+        .toList();
+    session.commit();
+
+    // @rid = $matched.a.@rid picks c=n1, but name<>'n1' must reject it.
+    // Without the residual filter the probe emits one row (c=n1) — wrong.
+    assertEquals(0, result.size());
+  }
+
+  /**
+   * Sanity companion to {@link #backRef_patternA_residualTargetFilter_correctResults}:
+   * when the residual filter is satisfied, Pattern A still fires and the
+   * row is emitted. Confirms the fix does not over-reject.
+   */
+  @Test
+  public void backRef_patternA_residualTargetFilter_passing_correctResults() {
+    session.begin();
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n1')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var explain = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid AND name = 'n1')}"
+            + " RETURN c.name as cName")
+        .toList();
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "residual-safe Pattern A should still collapse via hash join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c,"
+            + " where: (@rid = $matched.a.@rid AND name = 'n1')}"
+            + " RETURN c.name as cName")
+        .toList();
+    session.commit();
+
+    assertEquals(1, result.size());
+    assertEquals("n1", result.get(0).getProperty("cName"));
+  }
+
   // ── $matched publication regression ────────────────────────────────────
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1732,4 +1732,99 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     session.commit();
   }
 
+  // ── ChainSemiJoin — indexFilter caching across back-ref builds ─────
+
+  /**
+   * Pattern B — query with {@link ChainSemiJoin#indexFilter()} set must
+   * resolve the index only once for the whole query, even when many
+   * distinct back-ref RIDs probe the hash.
+   *
+   * <p>Regression test for a YTDB-650 performance bug: before the fix,
+   * {@code BackRefHashJoinStep.buildChainHashTable} called
+   * {@code TraversalPreFilterHelper.resolveIndexToRidSet} every time a new
+   * back-ref RID missed the LRU cache. On LDBC SF1 IC5 (~800 distinct
+   * friends, cache capacity 256) this re-scanned the
+   * {@code HAS_MEMBER.joinDate} index ~540 times, pushing the single
+   * query past 5 minutes and tripping the 20 h CI timeout. With the fix,
+   * the index RidSet is cached on the {@link BackRefHashJoinStep} instance
+   * and reused across all per-back-ref builds.
+   *
+   * <p>This test creates a synthetic graph where the ChainSemiJoin fires
+   * with an indexed edge filter and multiple distinct back-ref RIDs, then
+   * asserts correctness. The planner path is the same as IC5's.
+   */
+  @Test
+  public void backRef_outEInV_withIndexedEdgeFilter_multipleBackRefs_correctResults() {
+    // Add an edge class with an indexed property so
+    // TraversalPreFilterHelper.findIndexForFilter returns a descriptor
+    // that becomes ChainSemiJoin#indexFilter().
+    session.execute("CREATE class Rated extends E").close();
+    session.execute("CREATE PROPERTY Rated.score INTEGER").close();
+    session.execute("CREATE INDEX Rated_score ON Rated (score) NOTUNIQUE").close();
+
+    session.begin();
+    // Each of n2, n3 is a distinct back-ref in the probe — both need
+    // their own hash build. The fix ensures the Rated.score index is
+    // scanned only once across both builds.
+    // n2 → Rated(score=10) → n1  : matches back-ref (inV=n1 == $matched.a)
+    // n3 → Rated(score=20) → n1  : matches back-ref
+    // n3 → Rated(score=1)  → n5  : filtered by score>5; also wrong target
+    session.execute(
+        "CREATE EDGE Rated from (select from Person where name='n2')"
+            + " to (select from Person where name='n1') set score = 10")
+        .close();
+    session.execute(
+        "CREATE EDGE Rated from (select from Person where name='n3')"
+            + " to (select from Person where name='n1') set score = 20")
+        .close();
+    session.execute(
+        "CREATE EDGE Rated from (select from Person where name='n3')"
+            + " to (select from Person where name='n5') set score = 1")
+        .close();
+    session.commit();
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".outE('Rated'){as:e, where:(score > 5)}"
+            + ".inV(){as:check, where:(@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName, e.score as score")
+        .toList();
+
+    // Expected: both n2→n1 (score=10) and n3→n1 (score=20) match.
+    // n3→n5 is excluded both by the score filter AND the back-ref check.
+    var rows = result.stream()
+        .map(r -> r.getProperty("bName") + ":" + r.getProperty("score"))
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("n2:10", "n3:20"), rows);
+  }
+
+  /**
+   * Pattern B EXPLAIN sanity: when an indexed edge property is present,
+   * the plan still uses BACK-REF HASH JOIN (the index feeds the build
+   * side, not a separate pre-filter step).
+   */
+  @Test
+  public void explainBackRef_outEInV_withIndexedEdgeFilter_usesChainSemiJoin() {
+    session.execute("CREATE class Rated2 extends E").close();
+    session.execute("CREATE PROPERTY Rated2.score INTEGER").close();
+    session.execute("CREATE INDEX Rated2_score ON Rated2 (score) NOTUNIQUE").close();
+
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".outE('Rated2'){as:e, where:(score > 5)}"
+            + ".inV(){as:check, where:(@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "indexed edge filter should still use ChainSemiJoin, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+    session.commit();
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1379,9 +1379,356 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     var names = result.stream()
         .map(r -> (String) r.getProperty("fofName"))
         .collect(Collectors.toSet());
-    // n2→{n1,n4}, n3→{n5}. n1 IS a direct friend of n1 (via n2→n1), so
-    // n1 is excluded. n4 and n5 are not direct friends → included.
+    // n2→{n1,n4}, n3→{n5}. start.out('Friend') = {n2,n3}.
+    // n1 not in {n2,n3} → included, n4 not in {n2,n3} → included,
+    // n5 not in {n2,n3} → included.
     assertEquals(Set.of("n1", "n4", "n5"), names);
+    session.commit();
+  }
+
+  // ── isSemiJoinCandidate — direction rejection ──
+
+  /**
+   * The both() traversal direction should NOT qualify for Pattern A
+   * back-ref hash join. isSemiJoinCandidate rejects non-out/in directions.
+   * Verify the plan falls back to standard MatchStep.
+   */
+  @Test
+  public void backRef_bothDirection_notUsedForHashJoin() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".both('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    // both() is not a directed traversal — cannot use semi-join
+    assertFalse(
+        "both() direction should not use back-ref hash join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+    session.commit();
+  }
+
+  /**
+   * The bothE() traversal should NOT qualify for Pattern B chain semi-join.
+   * detectChainSemiJoin rejects non-outE/inE preceding edge directions.
+   */
+  @Test
+  public void backRef_bothE_notUsedForChainSemiJoin() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".bothE('Friend'){as:e2}.inV(){as:check,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    // bothE() is not oute/ine — cannot use chain semi-join
+    assertFalse(
+        "bothE() should not use chain semi-join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+    session.commit();
+  }
+
+  // ── Pattern A — in-direction threshold=1 fallback ──
+
+  /**
+   * Pattern A with "in" direction and threshold=1 forces build failure.
+   * Falls back to MatchReverseEdgeTraverser (edge.out=false) for in-direction
+   * traversal. Covers createFallbackTraverser reverse branch.
+   */
+  @Test
+  public void backRef_singleEdge_inDirection_thresholdOne_fallback() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(1L);
+
+      session.begin();
+      var result = session.query(
+          "MATCH {class:Person, as:a, where:(name='n1')}"
+              + ".out('Friend'){as:b}"
+              + ".in('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+              + " RETURN b.name as bName")
+          .toList();
+
+      // Even with threshold=1 fallback, results should be correct
+      var names = result.stream()
+          .map(r -> (String) r.getProperty("bName"))
+          .collect(Collectors.toSet());
+      assertEquals(Set.of("n2", "n3"), names);
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
+  }
+
+  // ── EXPLAIN text verification — prettyPrint branches ──
+
+  /**
+   * Verify EXPLAIN output for Pattern A (SingleEdgeSemiJoin) contains
+   * the expected semi-join descriptor text with alias and direction info.
+   */
+  @Test
+  public void explainBackRef_singleEdge_prettyPrintFormat() {
+    session.begin();
+    // Add cycle so plan is generated with the back-ref
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    // prettyPrint for SingleEdgeSemiJoin should contain direction and edge class
+    assertTrue("plan should show direction and edge class, got:\n" + plan,
+        plan.contains("out('Friend')") || plan.contains("in('Friend')"));
+    assertTrue("plan should show ⋈ join symbol, got:\n" + plan,
+        plan.contains("⋈"));
+    session.commit();
+  }
+
+  /**
+   * Verify EXPLAIN output for Pattern B (ChainSemiJoin) contains the
+   * outE...inV chain notation and both alias names.
+   */
+  @Test
+  public void explainBackRef_chain_prettyPrintFormat() {
+    session.begin();
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e1}.inV(){as:b}"
+            + ".outE('Friend'){as:e2}.inV(){as:check,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    // prettyPrint for ChainSemiJoin includes .inV() and aliases keyword
+    assertTrue("plan should show outE chain, got:\n" + plan,
+        plan.contains("outE('Friend')") || plan.contains("inE('Friend')"));
+    assertTrue("plan should show 'aliases:' keyword, got:\n" + plan,
+        plan.contains("aliases:"));
+    session.commit();
+  }
+
+  /**
+   * Verify EXPLAIN output for Pattern D (AntiSemiJoin) contains the
+   * NOT IN descriptor text.
+   */
+  @Test
+  public void explainBackRef_anti_prettyPrintFormat() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name")
+        .toList();
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    // prettyPrint for AntiSemiJoin includes NOT IN and traversal direction
+    assertTrue("plan should show NOT IN, got:\n" + plan,
+        plan.contains("NOT IN $matched."));
+    assertTrue("plan should show traversal direction, got:\n" + plan,
+        plan.contains("out('Friend')") || plan.contains("in('Friend')"));
+    session.commit();
+  }
+
+  // ── Anti-join — source vertex not found → pass through ──
+
+  /**
+   * Pattern D correctness when the fof candidate has no Friend edges at all.
+   * The source RID resolves correctly, but the candidate is simply NOT IN
+   * the set — it passes through. This covers the anti-join "not found" branch.
+   */
+  @Test
+  public void backRef_notIn_candidateNotInSet_passesThrough() {
+    session.begin();
+    // n5 has no outgoing Friend edges. When we traverse n3→n5, then check
+    // $currentMatch (n5) NOT IN start.out('Friend')={n2,n3}, n5 is not in
+    // the set so it passes through.
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend, where:(name='n3')}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    assertEquals(1, result.size());
+    assertEquals("n5", result.get(0).getProperty("fofName"));
+    session.commit();
+  }
+
+  // ── Anti-join — candidate IS in set → filtered out ──
+
+  /**
+   * Pattern D correctness when the candidate IS in the exclusion set.
+   * This covers the anti-join "found → null" branch (row is dropped).
+   */
+  @Test
+  public void backRef_notIn_candidateInSet_filteredOut() {
+    session.begin();
+    // Make n4 a direct friend of n1
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n1')"
+            + " to (select from Person where name='n4')")
+        .close();
+
+    // n2→n4, and n4 IS in start.out('Friend')={n2,n3,n4}
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend, where:(name='n2')}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    // n2→n4, but n4 is now a direct friend of n1 → excluded
+    assertEquals(0, result.size());
+    session.commit();
+  }
+
+  // ── Pattern A — back-ref with non-existent edge class ──
+
+  /**
+   * Pattern A where the edge class in the back-ref hash table build
+   * doesn't exist on the target vertex (no reverse link bag). The hash
+   * table build returns null, triggering the fallback path.
+   */
+  @Test
+  public void backRef_singleEdge_missingEdgeClass_fallsBack() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Likes'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+
+    // n1 has no incoming Likes edges, so reverse link bag is empty/missing.
+    // Build returns null → fallback to nested-loop → no match
+    assertEquals(0, result.size());
+    session.commit();
+  }
+
+  // ── Pattern D — NOT IN with additional WHERE conditions ──
+
+  /**
+   * Pattern D where NOT IN is combined with a simple property filter
+   * in a single AND block with exactly 2 conditions. Verifies that
+   * the NOT IN is stripped but the residual condition is preserved.
+   */
+  @Test
+  public void backRef_notIn_withResidualFilter_correctResults() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof, where: ("
+            + " $currentMatch NOT IN $matched.start.out('Friend')"
+            + " AND name = 'n5')}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    // FoF = {n4, n5}. NOT IN {n2,n3} keeps both. AND name='n5' → only n5.
+    assertEquals(1, result.size());
+    assertEquals("n5", result.get(0).getProperty("fofName"));
+    session.commit();
+  }
+
+  // ── Multiple patterns in single query ──
+
+  /**
+   * Query with both Pattern A (back-ref semi-join) and Pattern D (NOT IN
+   * anti-semi-join) in the same MATCH. Covers multiple semi-join descriptors
+   * in a single schedule and incremental boundAliases building.
+   */
+  @Test
+  public void backRef_combinedPatterns_correctResults() {
+    session.begin();
+    // Add cycle n4→n1 so Pattern A has a match
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n4')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c}"
+            + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName, c.name as cName")
+        .toList();
+
+    // n1→n2→n4→n1 (via new edge). check.@rid = a.@rid = n1 → match.
+    // b=n2, c=n4.
+    assertEquals(1, result.size());
+    assertEquals("n2", result.get(0).getProperty("bName"));
+    assertEquals("n4", result.get(0).getProperty("cName"));
+    session.commit();
+  }
+
+  // ── Edge cases — no edges at all ──
+
+  /**
+   * Pattern A on a vertex with no outgoing edges of the specified class.
+   * Hash table build finds no link bag → returns null → fallback.
+   */
+  @Test
+  public void backRef_singleEdge_targetHasNoEdges_emptyResult() {
+    session.begin();
+    // n5 has no outgoing Friend edges
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c}"
+            + ".out('Friend'){as:d}"
+            + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+    // n1→n2→n4→(no out Friend)→nothing, n1→n3→n5→(no out Friend)→nothing
+    assertEquals(0, result.size());
+    session.commit();
+  }
+
+  /**
+   * Pattern D on a vertex where the anchor has no edges of the specified
+   * class. The anti-join hash table build finds no link bag → build failure
+   * → fallback evaluates NOT IN per row.
+   */
+  @Test
+  public void backRef_notIn_anchorHasNoEdges_passesAll() {
+    session.begin();
+    // n5 has no outgoing Friend edges
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n5')}"
+            + ".in('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    // n5.in('Friend') = {n3}. start.out('Friend') has no entries.
+    // Since there are no friends to exclude, n3 passes through.
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("fofName"))
+        .collect(Collectors.toSet());
+    assertEquals(Set.of("n3"), names);
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -1827,4 +1827,60 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     session.commit();
   }
 
+  // ── $matched publication regression ────────────────────────────────────
+
+  /**
+   * Regression test: when {@code BackRefHashJoinStep} (Pattern A) binds a
+   * target alias, a downstream MATCH branch whose WHERE references
+   * {@code $matched.<that alias>} must observe the fresh binding.
+   *
+   * <p>Before the fix, {@code probeSingleEdge} emitted rows via
+   * {@code ExecutionStream.flatMap} without republishing
+   * {@link com.jetbrains.youtrackdb.internal.core.command.CommandContext#VAR_MATCHED},
+   * leaving the context with the stale value from the upstream
+   * {@link MatchEdgeTraverser}. {@code MatchEdgeTraverser.filter} patches
+   * only the starting-point alias of the downstream edge onto the stale
+   * $matched object, so any other alias bound by the hash-join step is
+   * invisible to the filter — it resolves {@code $matched.c} to null and
+   * rejects every row, producing zero results.
+   *
+   * <p>Graph augmentation ({@code n2→Friend→n1}, {@code n1→Likes→t1})
+   * lets the query hit Pattern A (only {@code b=n2} back-refs to
+   * {@code a=n1}, so {@code c=n1}) and provides a non-empty branch from
+   * {@code a}. The branch starts from {@code a} — not {@code c} — so
+   * {@code MatchEdgeTraverser.filter}'s auto-patch restores only
+   * {@code a} on any stale $matched object, making the reference to
+   * {@code $matched.c.name} the load-bearing assertion.
+   */
+  @Test
+  public void backRef_patternA_publishesMatchedForDownstreamAliasRef() {
+    session.begin();
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+    session.execute(
+        "CREATE EDGE Likes from (select from Person where name='n1')"
+            + " to (select from Tag where name='t1')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c, where:(@rid = $matched.a.@rid)},"
+            + " {as:a}.out('Likes'){as:t, where:($matched.c.name = 'n1')}"
+            + " RETURN t.name as tName")
+        .toList();
+    session.commit();
+
+    // Main path: a=n1, b ∈ {n2,n3}, back-ref requires b→n1 — only b=n2
+    // hits (via the added n2→Friend→n1 edge), so c=n1.
+    // Branch: a=n1 has one Likes target (t1). Branch filter requires
+    // $matched.c.name='n1'; with the fix it is true and t=t1 passes.
+    assertEquals(1, result.size());
+    assertEquals("t1", result.get(0).getProperty("tName"));
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -784,4 +784,118 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     }
   }
 
+  // ── Back-reference hash join tests (Pattern D — NOT IN anti-join) ──
+
+  /**
+   * Pattern D — IC10-style NOT IN exclusion. The query finds friends-of-friends
+   * of n1, excluding direct friends of n1.
+   *
+   * Graph: n1→n2, n1→n3, n2→n4, n3→n5
+   * n1.out('Friend') = {n2, n3}
+   * n1.out('Friend').out('Friend') = {n4, n5}
+   * After NOT IN n1.out('Friend'): n4 and n5 remain (they are NOT direct friends)
+   */
+  @Test
+  public void explainBackRef_notIn_usesAntiSemiJoin() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "plan should use BACK-REF HASH JOIN ANTI, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN ANTI"));
+    session.commit();
+  }
+
+  /**
+   * Pattern D — correctness test. Friends-of-friends of n1, excluding
+   * direct friends. n1's direct friends are {n2, n3}. FoF are {n4, n5}.
+   * Neither n4 nor n5 is a direct friend of n1, so both should appear.
+   */
+  @Test
+  public void backRef_notIn_correctResults() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("fofName"))
+        .collect(Collectors.toSet());
+    // n2→n4, n3→n5. Neither n4 nor n5 is in n1.out('Friend')={n2,n3}
+    assertEquals(Set.of("n4", "n5"), names);
+    session.commit();
+  }
+
+  /**
+   * Pattern D — correctness with exclusion. Add n4 as a direct friend of n1,
+   * then n4 should be excluded from FoF results because it IS in
+   * n1.out('Friend').
+   */
+  @Test
+  public void backRef_notIn_withExclusion_correctResults() {
+    session.begin();
+    // Make n4 a direct friend of n1
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n1')"
+            + " to (select from Person where name='n4')")
+        .close();
+
+    var result = session.query(
+        "MATCH {class:Person, as:start, where:(name='n1')}"
+            + ".out('Friend'){as:friend}"
+            + ".out('Friend'){as:fof,"
+            + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+            + " RETURN fof.name as fofName")
+        .toList();
+
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("fofName"))
+        .collect(Collectors.toSet());
+    // n4 is now a direct friend of n1, so it's excluded. Only n5 remains.
+    assertEquals(Set.of("n5"), names);
+    session.commit();
+  }
+
+  /**
+   * Pattern D — threshold=0 disables anti-semi-join. Falls back to standard
+   * WHERE evaluation with NOT IN.
+   */
+  @Test
+  public void backRef_notIn_thresholdZero_fallsBack() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(0L);
+
+      session.begin();
+      var result = session.query(
+          "EXPLAIN MATCH {class:Person, as:start, where:(name='n1')}"
+              + ".out('Friend'){as:friend}"
+              + ".out('Friend'){as:fof,"
+              + " where: ($currentMatch NOT IN $matched.start.out('Friend'))}"
+              + " RETURN fof.name")
+          .toList();
+      assertEquals(1, result.size());
+      String plan = result.get(0).getProperty("executionPlanAsString");
+      assertNotNull(plan);
+      assertFalse(
+          "threshold=0 should disable anti-semi-join, got:\n" + plan,
+          plan.contains("BACK-REF HASH JOIN ANTI"));
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -553,4 +553,138 @@ public class HashJoinPlannerIntegrationTest extends DbTestBase {
     }
   }
 
+  // ── Back-reference hash join tests (Pattern A) ─────────────────────────
+
+  /**
+   * Pattern A — single-edge back-reference semi-join. The query traverses
+   * from person n1 to friends, then checks each friend via a back-reference
+   * against n1's known friends. This is the simplest back-reference pattern:
+   * {@code .out('Friend'){target, where: (@rid = $matched.a.@rid)}}.
+   *
+   * <p>Expected: EXPLAIN shows BACK-REF HASH JOIN instead of a regular MatchStep
+   * with EdgeRidLookup intersection.
+   */
+  @Test
+  public void explainBackRef_singleEdge_usesBackRefHashJoin() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c}"
+            + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "plan should use back-ref hash join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+    session.commit();
+  }
+
+  /**
+   * Pattern A — correctness test. Creates a cycle: n1→n2→n4, and checks
+   * if traversing n4.out('Friend') reaches n1 via back-reference.
+   * Since n4 has no outgoing Friend edges to n1 in our graph, the query
+   * should return no results.
+   */
+  @Test
+  public void backRef_singleEdge_noMatch_emptyResult() {
+    session.begin();
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:c}"
+            + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+    // n1→n2→n4→(no outgoing Friend to n1), n1→n3→n5→(no outgoing Friend to n1)
+    assertEquals(0, result.size());
+    session.commit();
+  }
+
+  /**
+   * Pattern A — correctness with a cycle that DOES match. Creates a
+   * Friend edge from n2 back to n1, forming a cycle n1→n2→n1.
+   * The back-ref check should find n1 via n2.out('Friend').
+   */
+  @Test
+  public void backRef_singleEdge_withCycle_findsMatch() {
+    session.begin();
+    // Add a cycle: n2→n1
+    session.execute(
+        "CREATE EDGE Friend from (select from Person where name='n2')"
+            + " to (select from Person where name='n1')")
+        .close();
+
+    var result = session.query(
+        "MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".out('Friend'){as:b}"
+            + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name as bName")
+        .toList();
+
+    // n1→n2→(check: n2.out('Friend') includes {n1,n4}), @rid=$matched.a.@rid
+    // means check.@rid must equal n1.@rid. n2.out('Friend') contains n1
+    // (the edge we just added) and n4. Only n1 matches → b=n2 is a result.
+    // n1→n3→(check: n3.out('Friend') includes {n5}), no match → filtered out.
+    assertEquals(1, result.size());
+    assertEquals("n2", result.get(0).getProperty("bName"));
+    session.commit();
+  }
+
+  /**
+   * Pattern A — threshold=0 disables back-ref hash join. The planner should
+   * fall back to standard MatchStep with EdgeRidLookup intersection.
+   */
+  @Test
+  public void backRef_thresholdZero_fallsBackToMatchStep() {
+    var saved = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
+    try {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(0L);
+
+      session.begin();
+      var result = session.query(
+          "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+              + ".out('Friend'){as:b}"
+              + ".out('Friend'){as:check, where: (@rid = $matched.a.@rid)}"
+              + " RETURN b.name")
+          .toList();
+      assertEquals(1, result.size());
+      String plan = result.get(0).getProperty("executionPlanAsString");
+      assertNotNull(plan);
+      assertFalse(
+          "threshold=0 should disable back-ref hash join, got:\n" + plan,
+          plan.contains("BACK-REF HASH JOIN"));
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(saved);
+    }
+  }
+
+  /**
+   * Pattern A — edge-level traversals (outE/inE) should NOT use back-ref
+   * hash join (only vertex-level out/in are eligible).
+   */
+  @Test
+  public void backRef_edgeLevelTraversal_notEligible() {
+    session.begin();
+    var result = session.query(
+        "EXPLAIN MATCH {class:Person, as:a, where:(name='n1')}"
+            + ".outE('Friend'){as:e}.inV(){as:b}"
+            + ".outE('Friend'){as:e2}.inV(){as:check,"
+            + " where: (@rid = $matched.a.@rid)}"
+            + " RETURN b.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    // outE/inE are not vertex-level traversals → no back-ref hash join
+    assertFalse(
+        "edge-level traversal should not use back-ref hash join, got:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
+    session.commit();
+  }
+
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SemiJoinDescriptorUnitTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/SemiJoinDescriptorUnitTest.java
@@ -1,0 +1,99 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for the three {@link SemiJoinDescriptor} record implementations.
+ *
+ * <p>The interface methods ({@code joinMode}, {@code backRefAlias}) are small
+ * dispatch points wired into {@link BackRefHashJoinStep} and
+ * {@link MatchExecutionPlanner}. Exercising them directly avoids relying on a
+ * full end-to-end MATCH test to reach every descriptor variant — integration
+ * coverage is patchy for Pattern D (NOT IN anti-join) because it requires a
+ * specific WHERE shape that other tests do not always construct.
+ *
+ * <p>Each test asserts on every record component (not just the interface
+ * methods) so that a silent mis-wiring of a constructor argument — for
+ * example, swapping {@code sourceAlias} and {@code backRefAlias} — is caught
+ * at the record boundary rather than surviving to runtime.
+ */
+public class SemiJoinDescriptorUnitTest {
+
+  /**
+   * {@link SingleEdgeSemiJoin} (Pattern A) reports SEMI_JOIN and exposes
+   * every record component exactly as passed to the constructor. The
+   * distinct-value matrix (each argument is a unique string) verifies that
+   * no two accessors return the same underlying field — a common mistake in
+   * hand-written records.
+   */
+  @Test
+  public void singleEdgeSemiJoinExposesAllComponents() {
+    var descriptor = new SingleEdgeSemiJoin(
+        "KNOWS", "out", null,
+        "sourceAlias", "anchorAlias", "targetAlias", null);
+
+    assertSame(JoinMode.SEMI_JOIN, descriptor.joinMode());
+    assertEquals("KNOWS", descriptor.edgeClass());
+    assertEquals("out", descriptor.direction());
+    assertNull(descriptor.backRefExpression());
+    assertEquals("sourceAlias", descriptor.sourceAlias());
+    assertEquals("anchorAlias", descriptor.backRefAlias());
+    assertEquals("targetAlias", descriptor.targetAlias());
+    assertNull(descriptor.targetFilter());
+  }
+
+  /**
+   * {@link ChainSemiJoin} (Pattern B) reports SEMI_JOIN and exposes every
+   * record component. Verifies the three alias fields
+   * ({@code sourceAlias}, {@code backRefAlias}, {@code intermediateAlias},
+   * {@code targetAlias}) are independently addressable — a wrong
+   * constructor-argument order would leak into the semi-join descriptor.
+   */
+  @Test
+  public void chainSemiJoinExposesAllComponents() {
+    var descriptor = new ChainSemiJoin(
+        "HAS_MEMBER", "out", null,
+        "sourceAlias", "anchorAlias",
+        "intermediateAlias", "targetAlias", null, null);
+
+    assertSame(JoinMode.SEMI_JOIN, descriptor.joinMode());
+    assertEquals("HAS_MEMBER", descriptor.edgeClass());
+    assertEquals("out", descriptor.direction());
+    assertNull(descriptor.backRefExpression());
+    assertEquals("sourceAlias", descriptor.sourceAlias());
+    assertEquals("anchorAlias", descriptor.backRefAlias());
+    assertEquals("intermediateAlias", descriptor.intermediateAlias());
+    assertEquals("targetAlias", descriptor.targetAlias());
+    assertNull(descriptor.indexFilter());
+    assertNull(descriptor.edgeFilter());
+  }
+
+  /**
+   * {@link AntiSemiJoin} (Pattern D) reports ANTI_JOIN and — unlike the other
+   * two variants — overrides {@code backRefAlias()} to return
+   * {@code anchorAlias()}. Asserting both values separately guards against
+   * a future refactor that stores a separate {@code backRefAlias} field and
+   * forgets to forward it through the override.
+   */
+  @Test
+  public void antiSemiJoinReportsAntiJoinAndAnchorAsBackRef() {
+    var descriptor = new AntiSemiJoin(
+        "anchorAlias", "HAS_MEMBER", "out", "targetAlias", null);
+
+    assertSame(JoinMode.ANTI_JOIN, descriptor.joinMode());
+    assertEquals("anchorAlias", descriptor.anchorAlias());
+    assertEquals("HAS_MEMBER", descriptor.traversalEdgeClass());
+    assertEquals("out", descriptor.traversalDirection());
+    assertEquals("targetAlias", descriptor.targetAlias());
+    assertNull(descriptor.notInCondition());
+    // backRefAlias() is an interface method override on AntiSemiJoin —
+    // unlike the other two variants it does not take the value from a
+    // dedicated constructor argument. It must mirror anchorAlias().
+    assertEquals("anchorAlias", descriptor.backRefAlias());
+    assertEquals(descriptor.anchorAlias(), descriptor.backRefAlias());
+  }
+}

--- a/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryExplainTest.java
+++ b/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryExplainTest.java
@@ -93,50 +93,51 @@ public class LdbcQueryExplainTest {
    * Person -> HAS_CREATOR -> Post -> CONTAINER_OF -> Forum ->
    * outE(HAS_MEMBER) -> inV (back-ref to person).
    *
-   * <p>The planner should detect the {@code .inV()} back-reference
-   * ({@code @rid = $matched.person.@rid}), propagate the edge class
-   * from the preceding {@code .outE('HAS_MEMBER')} step, and set an
-   * intersection descriptor on the HAS_MEMBER edge traversal step.
+   * <p>The planner should detect the {@code outE('HAS_MEMBER').inV()} chain
+   * back-reference ({@code @rid = $matched.person.@rid}) and replace the
+   * per-row link bag scan with a back-ref hash join (Pattern B — ChainSemiJoin).
    */
   @Test
-  public void testIC5_backReferenceIntersection() {
+  public void testIC5_backReferenceHashJoin() {
     String plan = explain(LdbcQuerySql.IC5,
         "personId", 1L, "minDate", new Date(epochMillis(2010, 1, 1)),
         "limit", 10);
     assertTrue(
-        "IC5 plan should show intersection optimization on the HAS_MEMBER "
-            + "edge traversal step (back-ref from .inV()). Plan was:\n" + plan,
-        plan.contains("intersection:"));
+        "IC5 plan should show BACK-REF HASH JOIN for the outE/inV chain. "
+            + "Plan was:\n" + plan,
+        plan.contains("BACK-REF HASH JOIN"));
   }
 
   /**
    * IC7: The MATCH pattern checks whether a liker KNOWS the start person
    * via an optional edge: {@code .out('KNOWS'){where: (@rid = $matched.startPerson.@rid),
-   * optional: true}}. The planner should detect the back-reference and
-   * set an intersection descriptor on the KNOWS edge traversal step.
+   * optional: true}}. The planner should detect the correlated optional
+   * back-reference and use a hash join or intersection optimization.
    */
   @Test
-  public void testIC7_backReferenceIntersectionOptional() {
+  public void testIC7_backReferenceOptionalHashJoin() {
     String plan = explain(LdbcQuerySql.IC7, "personId", 1L, "limit", 10);
     assertTrue(
-        "IC7 plan should show intersection optimization on the KNOWS "
-            + "optional back-reference edge. Plan was:\n" + plan,
-        plan.contains("intersection:"));
+        "IC7 plan should show correlated optional hash join or intersection "
+            + "on the KNOWS optional back-reference edge. Plan was:\n" + plan,
+        plan.contains("CORRELATED OPTIONAL HASH JOIN")
+            || plan.contains("intersection:"));
   }
 
   /**
    * IS7: The MATCH pattern checks whether a reply author KNOWS the original
    * message author via an optional edge: {@code .out('KNOWS'){where:
    * (@rid = $matched.author.@rid), optional: true}}. The planner should
-   * detect the back-reference and set an intersection descriptor.
+   * detect the correlated optional back-reference and use a hash join.
    */
   @Test
-  public void testIS7_backReferenceIntersectionOptional() {
+  public void testIS7_backReferenceOptionalHashJoin() {
     String plan = explain(LdbcQuerySql.IS7, "messageId", 800L, "limit", 10);
     assertTrue(
-        "IS7 plan should show intersection optimization on the KNOWS "
-            + "optional back-reference edge. Plan was:\n" + plan,
-        plan.contains("intersection:"));
+        "IS7 plan should show correlated optional hash join or intersection "
+            + "on the KNOWS optional back-reference edge. Plan was:\n" + plan,
+        plan.contains("CORRELATED OPTIONAL HASH JOIN")
+            || plan.contains("intersection:"));
   }
 
   // ==================== Index pre-filter on edge properties ====================


### PR DESCRIPTION
#### PR Title:

`YTDB-650: Back-reference hash join for MATCH patterns`

#### Motivation:

PR #918 (hash-join-match-patterns) optimized MATCH sub-patterns that are independent of `$matched` — NOT patterns, multi-branch joins, WHILE hierarchies. But a different class of bottleneck remained: **back-reference edges** like `where: (@rid = $matched.person.@rid)` and `where: ($currentMatch NOT IN $matched.start.out('KNOWS'))`. These edges depend on a previously-bound alias, so the engine re-traverses the source vertex's link bag for every upstream row — O(upstream_rows × link_bag_size). In LDBC IC5, this means ~700K link bag entry scans of which 96% are rejected; in IC10, ~39K redundant edge reads.

This PR converts those per-row scans into a one-time hash table build per distinct binding + O(1) probes, via three recognized patterns:

| Pattern | Shape | Example | Build → Probe |
|---|---|---|---|
| **A** — single edge | `.out('E'){where: @rid = $matched.X.@rid}` | IC5 final edge | reverse link bag → `Set<RID>`, probe source ∈ set |
| **B** — outE+inV chain | `.outE('E'){...}.inV(){where: @rid = $matched.X.@rid}` | IC5 with edge properties | reverse link bag + optional index → `Map<RID, List<Edge>>`, probe source → edges |
| **D** — NOT IN | `where: ($currentMatch NOT IN $matched.X.out('E'))` | IC10 exclusion | forward link bag → `Set<RID>`, probe candidate ∈ set (anti-join) |

Key design decisions:

- **Per-binding LRU cache** (capacity 256) avoids rebuilding the hash table when the same binding recurs — critical for IC5 where ~58 distinct persons produce ~5K triples each.
- **Sealed `SemiJoinDescriptor` interface** (records: `SingleEdgeSemiJoin`, `ChainSemiJoin`, `AntiSemiJoin`) carries planner metadata to runtime via `EdgeTraversal`, with exhaustive `switch` dispatch in `BackRefHashJoinStep`.
- **Edge collapsing** (Pattern B): marks the `.outE()` edge as `consumed` so `addStepsFor()` skips it — one `BackRefHashJoinStep` covers both edges.
- **NOT IN stripping** (Pattern D): removes the NOT IN from the `MatchStep`'s WHERE clause at plan time to avoid the expensive O(degree) per-row evaluation; stores the condition in `AntiSemiJoin.notInCondition` for runtime fallback.
- **Type-safe detection**: Pattern D uses `instanceof SQLNotInCondition` with AST unwrapping instead of fragile `toString()` pattern matching.
- **Runtime fallback**: if the hash table build fails (threshold exceeded, missing data), Patterns A/B fall back to `MatchEdgeTraverser` nested-loop; Pattern D evaluates the stored NOT IN condition per row. `BUILD_FAILED` sentinel is cached per binding to avoid re-attempting.

The optimization is purely additive — when any eligibility check fails, the existing nested-loop path is used unchanged.

## Test plan

- [x] 17 new tests in `HashJoinPlannerIntegrationTest`: EXPLAIN plan shape assertions + correctness for all three patterns, including fan-out, cycles, fallback on threshold, and NOT IN stripping verification
- [x] `MatchStatementExecutionTest` — 146 tests pass (0 regressions)
- [x] Run full `./mvnw clean package` to verify no cross-module regressions
- [x] LDBC JMH benchmarks on Hetzner to measure IC5/IC10 improvement