### PR TITLE
[no-test-number-check] Restrict small cache IT and harden CI pipeline dispatch

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -1,6 +1,8 @@
 name: Java CI/CD Integration Tests Pipeline
 on:
   workflow_dispatch:
+  push:
+    branches: [ "develop" ]
   schedule:
     # Run at 2 AM CET (1 AM UTC)
     - cron: '0 1 * * *'

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -320,7 +320,10 @@ jobs:
   test-small-cache-linux:
     name: Small Cache IT (Linux x86)
     needs: [ detect-changes ]
-    if: needs.detect-changes.outputs.should_build == 'true'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/develop' &&
+      needs.detect-changes.outputs.should_build == 'true'
     runs-on:
       - self-hosted
       - in-nbg1
@@ -365,6 +368,16 @@ jobs:
             **/target/failsafe-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
+      - name: Dispatch CI Fix Agent
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.CI_FIX_AGENT_TOKEN }}
+        run: |
+          gh workflow run ci-failure-fix-agent.yml \
+            --repo "${{ github.repository }}" \
+            -f failed_run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f failed_workflow_name="${{ github.workflow }}" \
+            -f trigger_sha="${{ github.sha }}"
       - name: Send Zulip notification on failure
         if: failure()
         uses: zulip/github-actions-zulip/send-message@v1

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -368,16 +368,20 @@ jobs:
             **/target/failsafe-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
+      # Inline dispatch (single non-matrix job, no dedicated notify-failure job needed)
       - name: Dispatch CI Fix Agent
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.CI_FIX_AGENT_TOKEN }}
+          FAILED_RUN_URL: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          FAILED_WORKFLOW_NAME: ${{ github.workflow }}
+          TRIGGER_SHA: ${{ github.sha }}
         run: |
           gh workflow run ci-failure-fix-agent.yml \
             --repo "${{ github.repository }}" \
-            -f failed_run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f failed_workflow_name="${{ github.workflow }}" \
-            -f trigger_sha="${{ github.sha }}"
+            -f failed_run_url="$FAILED_RUN_URL" \
+            -f failed_workflow_name="$FAILED_WORKFLOW_NAME" \
+            -f trigger_sha="$TRIGGER_SHA"
       - name: Send Zulip notification on failure
         if: failure()
         uses: zulip/github-actions-zulip/send-message@v1


### PR DESCRIPTION
#### Motivation:

Small cache IT and integration tests were running on every PR and merge queue event, adding unnecessary CI load. These heavyweight tests only need to run on develop pushes. Additionally, the CI fix agent dispatch used direct `${{ }}` interpolation in shell blocks, which is vulnerable to script injection.

## Summary

- **Restrict small cache IT to develop pushes**: Only runs on `push` to `develop`, not on PRs or merge queue. Dispatches CI fix agent on failure.
- **Add push trigger for integration tests pipeline**: Integration tests now run immediately on develop pushes, not just on the nightly schedule.
- **Harden CI fix agent dispatch**: Move interpolated GitHub context values into `env` variables instead of direct `${{ }}` interpolation in the shell block, preventing potential script injection.

## Test plan

- [x] Workflow syntax validated (YAML is well-formed)
- [ ] Verify small cache IT only triggers on develop push (not on PR events)
- [ ] Verify integration tests pipeline triggers on develop push