### PR TITLE
Fix Small Cache IT dependency resolution failure

### DIFF
--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -341,7 +341,7 @@ jobs:
           architecture: x64
           overwrite-settings: false
       - name: Run Small Cache Integration Tests
-        run: ./mvnw -s .github/workflows/settings.xml -pl core clean verify -P small-cache-it -Dmaven.test.failure.ignore=true -B
+        run: ./mvnw -s .github/workflows/settings.xml -pl core -am clean verify -P small-cache-it -Dmaven.test.failure.ignore=true -B
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -146,7 +146,7 @@
 
     <!-- Run StorageComponent integration tests with a small disk cache (4 MB)
          to exercise optimistic read fallback under heavy eviction pressure.
-         Command: ./mvnw -pl core clean verify -P small-cache-it -->
+         Command: ./mvnw -pl core -am clean verify -P small-cache-it -->
     <profile>
       <id>small-cache-it</id>
       <build>


### PR DESCRIPTION
## Summary
- Add `-am` (also-make) flag to the Small Cache IT Maven command so reactor dependencies (notably `test-commons`) are built locally instead of resolved from the remote snapshot repository
- Update the command documentation comment in `core/pom.xml` to match

## Motivation
The "Small Cache IT (Linux x86)" job [fails](https://github.com/JetBrains/youtrackdb/actions/runs/24126011987/job/70390711624) because `youtrackdb-test-commons:0.5.0-SNAPSHOT` cannot be found in the Central Portal snapshot repository. The job uses `-pl core` which only builds the `core` module — Maven falls back to the remote repo for `test-commons`, but the SNAPSHOT may have expired or never been published for the PR branch. Adding `-am` makes the job self-sufficient by building all required reactor modules first.

## Test plan
- [ ] Verify the "Small Cache IT (Linux x86)" job passes on this PR's CI run
- [ ] Confirm no other CI jobs are affected