### PR TITLE
[no-test-number-check] Fix YAML syntax error in CI fix agent workflow

### DIFF
--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -682,13 +682,13 @@ jobs:
           fi
 
           # Write to file for the Zulip step (avoids escaping issues)
-          cat > /tmp/zulip-message-$$.md <<EOF
-**CI Fix Agent Report** :robot:
-Investigated failure in **${FAILED_WORKFLOW_NAME}** for commit \`${TRIGGER_SHA}\`.
-[Failed Run](${FAILED_RUN_URL}) | [Agent Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-${SUMMARY}
-EOF
+          {
+            echo "**CI Fix Agent Report** :robot:"
+            echo "Investigated failure in **${FAILED_WORKFLOW_NAME}** for commit \`${TRIGGER_SHA}\`."
+            echo "[Failed Run](${FAILED_RUN_URL}) | [Agent Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo ""
+            echo "${SUMMARY}"
+          } > /tmp/zulip-message-$$.md
 
           echo "zulip_message_file=/tmp/zulip-message-$$.md" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Fix YAML parse error in `ci-failure-fix-agent.yml` that caused every push-triggered run to fail with 0 jobs since April 7

## Root Cause
The heredoc body in the "Prepare Zulip summary" step (line 686) had zero indentation inside a `run: |` YAML literal block scalar. The YAML parser treated the unindented `**CI Fix Agent Report**` content as the end of the block scalar and failed to parse it as valid YAML, preventing any jobs from being created.

## Changes
- `.github/workflows/ci-failure-fix-agent.yml`: Replace `cat <<EOF` heredoc with a `{ echo ...; } > file` block that stays properly indented within the YAML block scalar

## Motivation
CI failure: https://github.com/JetBrains/youtrackdb/actions/runs/24128571072
All 30 runs of this workflow since April 7 have failed with 0 jobs due to this YAML syntax error.

## Test plan
- [x] YAML validated with `yaml` npm parser
- [x] Verified no column-0 content remains inside `run: |` blocks