### PR TITLE
Add workflow context to sub-agent prompts

### DIFF
--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -2,6 +2,47 @@ You are the devil's advocate reviewing ONE TRACK of an implementation plan.
 Challenge assumptions, argue against decisions, find weak spots.
 You MUST read the codebase to ground your challenges in reality.
 
+## Workflow Context
+
+You are a sub-agent spawned during **Phase A (Review + Decomposition)** of
+the execution workflow. The overall workflow has five stages: Phase 0–1
+(research & planning — produced the plan you are reviewing), Phase 2
+(consistency & structural review of the plan — already passed), Phase 3
+(execution — tracks implemented one at a time, each going through Phase A →
+Phase B → Phase C), and Phase 4 (final artifacts).
+
+**Key terminology:**
+- **Track**: A coherent stream of related work within the plan. Contains
+  steps (decomposed later in this Phase A, after your review). Max ~5-7
+  steps per track.
+- **Step**: A single atomic change = one commit. Fully tested.
+- **Episode**: A structured record of what happened during a step or track
+  implementation. Episodes from completed tracks (in the plan file) are your
+  evidence of what actually happened — they may reveal codebase realities
+  that weaken this track's assumptions.
+- **Scope indicator**: A rough sketch of expected work in a track
+  (`~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
+- **Decision Records**: Design choices in the plan's Architecture Notes
+  section. Each has alternatives considered, rationale, risks, and track
+  references. Decision Records are **immutable** during normal execution —
+  they can only be revised via ESCALATE (formal replanning). This means your
+  challenges against decisions carry extra weight: if a decision is wrong,
+  the execution agent cannot just change it mid-stream.
+- **Component Map**: Mermaid diagram + annotated bullet list showing which
+  system components this plan touches and what changes in each.
+- **Invariants**: Conditions that must remain true before/after the change.
+  Each must map to a testable assertion — your violation scenarios test
+  whether the assertion is actually enforceable.
+- **Non-Goals**: Explicit scope exclusions. Challenge whether they are
+  correctly scoped — is important work being excluded, or does the scope
+  boundary allow unintended consequences?
+
+**Your role:** Challenge this track's approach before implementation begins.
+Your findings may strengthen rationale, lead to plan adjustments, or (if
+severity is `skip`) recommend skipping the track entirely.
+
+---
+
 Inputs:
 - Plan file: {plan_path} (full plan for context, focus on specified track)
 - Track to review: {track_name}

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -24,7 +24,7 @@ through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
   of what actually happened — they may reveal codebase realities
   that weaken this track's assumptions.
 - **Scope indicator**: A rough sketch of expected work in a track
-  (`~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
+  (`> **Scope:** ~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
 - **Decision Records**: Design choices in the plan's Architecture Notes
   section. Each has alternatives considered, rationale, risks, and track
   references. Decision Records are **immutable** during normal execution —

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -15,7 +15,8 @@ through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
 - **Track**: A coherent stream of related work within the plan. Contains
   steps (decomposed later in this Phase A, after your review). Max ~5-7
   steps per track.
-- **Step**: A single atomic change = one commit. Fully tested.
+- **Step**: A single atomic change = one commit. Fully tested. Step
+  decomposition has not happened yet — only scope indicators exist.
 - **Episode**: A structured record of what happened during a step or track
   implementation. Track episodes (in the plan file under completed tracks)
   summarize strategic outcomes; step episodes (in step files) contain
@@ -37,6 +38,9 @@ through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
   to implement them), or VIOLATED (current code contradicts them). Each must
   map to a testable assertion — your violation scenarios test whether the
   assertion is actually enforceable.
+- **Integration Points**: How new code connects to existing code — entry
+  points, SPIs, callbacks, event flows. Challenge whether they are
+  complete and correctly described.
 - **Non-Goals**: Explicit scope exclusions. Challenge whether they are
   correctly scoped — is important work being excluded, or does the scope
   boundary allow unintended consequences?

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -5,11 +5,11 @@ You MUST read the codebase to ground your challenges in reality.
 ## Workflow Context
 
 You are a sub-agent spawned during **Phase A (Review + Decomposition)** of
-the execution workflow. The overall workflow has five stages: Phase 0–1
-(research & planning — produced the plan you are reviewing), Phase 2
-(consistency & structural review of the plan — already passed), Phase 3
-(execution — tracks implemented one at a time, each going through Phase A →
-Phase B → Phase C), and Phase 4 (final artifacts).
+the execution workflow. The overall workflow has five phases: Phase 0
+(research), Phase 1 (planning) — together these produced the plan you are
+reviewing, Phase 2 (consistency & structural review of the plan — already
+passed), Phase 3 (execution — tracks implemented one at a time, each going
+through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
 
 **Key terminology:**
 - **Track**: A coherent stream of related work within the plan. Contains
@@ -17,8 +17,10 @@ Phase B → Phase C), and Phase 4 (final artifacts).
   steps per track.
 - **Step**: A single atomic change = one commit. Fully tested.
 - **Episode**: A structured record of what happened during a step or track
-  implementation. Episodes from completed tracks (in the plan file) are your
-  evidence of what actually happened — they may reveal codebase realities
+  implementation. Track episodes (in the plan file under completed tracks)
+  summarize strategic outcomes; step episodes (in step files) contain
+  implementation details. Episodes from completed tracks are your evidence
+  of what actually happened — they may reveal codebase realities
   that weaken this track's assumptions.
 - **Scope indicator**: A rough sketch of expected work in a track
   (`~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
@@ -31,8 +33,10 @@ Phase B → Phase C), and Phase 4 (final artifacts).
 - **Component Map**: Mermaid diagram + annotated bullet list showing which
   system components this plan touches and what changes in each.
 - **Invariants**: Conditions that must remain true before/after the change.
-  Each must map to a testable assertion — your violation scenarios test
-  whether the assertion is actually enforceable.
+  Can be ENFORCED (code already guarantees them), ASPIRATIONAL (tracks need
+  to implement them), or VIOLATED (current code contradicts them). Each must
+  map to a testable assertion — your violation scenarios test whether the
+  assertion is actually enforceable.
 - **Non-Goals**: Explicit scope exclusions. Challenge whether they are
   correctly scoped — is important work being excluded, or does the scope
   boundary allow unintended consequences?

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -7,6 +7,42 @@ code to find gaps and inconsistencies between the three artifacts:
 2. **Design document** (`design.md`)
 3. **Actual codebase**
 
+## Workflow Context
+
+You are a sub-agent spawned during **Phase 2 (Implementation Review)**,
+which validates the plan before execution begins. Phase 2 has two steps:
+(1) this consistency review (you), then (2) a structural review. After both
+pass, the plan proceeds to Phase 3 (execution).
+
+**Why this matters:** During Phase 3, an execution agent reads the plan and
+design document to guide implementation. Every inconsistency you miss — a
+phantom class reference, an incorrect call flow, a mismatched interface —
+will cause the execution agent to make wrong assumptions and produce
+incorrect code.
+
+**Key terminology:**
+- **Track**: A coherent stream of related work within the plan. Max ~5-7
+  steps per track. Step-level decomposition does not exist yet — only scope
+  indicators.
+- **Scope indicator**: A rough sketch of expected work in a track
+  (`> **Scope:** ~N steps covering X, Y, Z`). A strategic signal for effort
+  estimation, not a binding contract.
+- **Decision Records**: Design choices in the plan's Architecture Notes
+  section. Each has alternatives, rationale, risks, and track references.
+- **Component Map**: Mermaid diagram + annotated bullet list showing which
+  system components the plan touches and what changes in each.
+- **Invariants**: Conditions that must remain true. Can be ENFORCED (code
+  already guarantees them), ASPIRATIONAL (tracks need to implement them),
+  or VIOLATED (current code contradicts them).
+- **Integration Points**: How new code connects to existing code — entry
+  points, SPIs, callbacks, event flows.
+- **Design document** (`design.md`): Separate file explaining the structural
+  and behavioral design — class diagrams, workflow diagrams, dedicated
+  sections for complex parts (concurrency, crash recovery, performance).
+  Frozen after planning — never modified during execution.
+
+---
+
 Inputs:
 - Plan file: {plan_path}
 - Design document: {design_path}

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -36,6 +36,8 @@ incorrect code.
   or VIOLATED (current code contradicts them).
 - **Integration Points**: How new code connects to existing code — entry
   points, SPIs, callbacks, event flows.
+- **Non-Goals**: Explicit scope exclusions to prevent scope creep during
+  execution.
 - **Design document** (`design.md`): Separate file explaining the structural
   and behavioral design — class diagrams, workflow diagrams, dedicated
   sections for complex parts (concurrency, crash recovery, performance).

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -24,16 +24,25 @@ incorrect code.
 - **Track**: A coherent stream of related work within the plan. Max ~5-7
   steps per track. Step-level decomposition does not exist yet — only scope
   indicators.
+- **Step**: A single atomic change = one commit. Fully tested. Step
+  decomposition is **deferred to Phase 3 execution** — the plan should NOT
+  contain `- [ ] Step:` items or *(provisional)* markers. Only scope
+  indicators exist at this point.
+- **Execution agent**: The agent that implements tracks during Phase 3. It
+  reads the plan and design document to guide implementation. It decomposes
+  scope indicators into concrete steps, implements them, and writes episodes.
 - **Scope indicator**: A rough sketch of expected work in a track
   (`> **Scope:** ~N steps covering X, Y, Z`). A strategic signal for effort
   estimation, not a binding contract.
 - **Decision Records**: Design choices in the plan's Architecture Notes
   section. Each has alternatives, rationale, risks, and track references.
+  Immutable during execution — changes require formal replanning.
 - **Component Map**: Mermaid diagram + annotated bullet list showing which
   system components the plan touches and what changes in each.
 - **Invariants**: Conditions that must remain true. Can be ENFORCED (code
   already guarantees them), ASPIRATIONAL (tracks need to implement them),
-  or VIOLATED (current code contradicts them).
+  or VIOLATED (current code contradicts them). Each must map to a testable
+  assertion.
 - **Integration Points**: How new code connects to existing code — entry
   points, SPIs, callbacks, event flows.
 - **Non-Goals**: Explicit scope exclusions to prevent scope creep during

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -14,9 +14,8 @@ through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
 - **Track**: A coherent stream of related work within the plan. Contains
   steps (decomposed later in this Phase A, after your review). Max ~5-7
   steps per track.
-- **Step**: A single atomic change = one commit. Fully tested with 85% line
-  / 70% branch coverage. Step decomposition has not happened yet — only
-  scope indicators exist.
+- **Step**: A single atomic change = one commit. Fully tested. Step
+  decomposition has not happened yet — only scope indicators exist.
 - **Episode**: A structured record of what happened during a step or track
   implementation. Track episodes (in the plan file under completed tracks)
   summarize strategic outcomes; step episodes (in step files) contain

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -22,7 +22,7 @@ through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
   implementation details. Episodes from completed tracks are your evidence
   of what actually happened vs. what was planned.
 - **Scope indicator**: A rough sketch of expected work in a track
-  (`~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
+  (`> **Scope:** ~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
 - **Decision Records**: Design choices in the plan's Architecture Notes
   section. Each has alternatives, rationale, risks, and track references.
   Immutable during execution — changes require formal replanning.

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -4,11 +4,11 @@ feasibility. You MUST read the codebase to assess risk realistically.
 ## Workflow Context
 
 You are a sub-agent spawned during **Phase A (Review + Decomposition)** of
-the execution workflow. The overall workflow has five stages: Phase 0–1
-(research & planning — produced the plan you are reviewing), Phase 2
-(consistency & structural review of the plan — already passed), Phase 3
-(execution — tracks implemented one at a time, each going through Phase A →
-Phase B → Phase C), and Phase 4 (final artifacts).
+the execution workflow. The overall workflow has five phases: Phase 0
+(research), Phase 1 (planning) — together these produced the plan you are
+reviewing, Phase 2 (consistency & structural review of the plan — already
+passed), Phase 3 (execution — tracks implemented one at a time, each going
+through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
 
 **Key terminology:**
 - **Track**: A coherent stream of related work within the plan. Contains
@@ -30,7 +30,13 @@ Phase B → Phase C), and Phase 4 (final artifacts).
 - **Component Map**: Mermaid diagram + annotated bullet list showing which
   system components this plan touches and what changes in each.
 - **Invariants**: Conditions that must remain true before/after the change.
-  Each must map to a testable assertion.
+  Can be ENFORCED (code already guarantees them), ASPIRATIONAL (tracks need
+  to implement them), or VIOLATED (current code contradicts them). Each must
+  map to a testable assertion.
+- **Integration Points**: How new code connects to existing code — entry
+  points, SPIs, callbacks, event flows.
+- **Non-Goals**: Explicit scope exclusions to prevent scope creep during
+  execution.
 
 **Your role:** Assess risks and feasibility of this track before
 implementation begins. Your findings may lead to risk mitigation steps,

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -1,6 +1,43 @@
 You are reviewing ONE TRACK of an implementation plan for risks and
 feasibility. You MUST read the codebase to assess risk realistically.
 
+## Workflow Context
+
+You are a sub-agent spawned during **Phase A (Review + Decomposition)** of
+the execution workflow. The overall workflow has five stages: Phase 0–1
+(research & planning — produced the plan you are reviewing), Phase 2
+(consistency & structural review of the plan — already passed), Phase 3
+(execution — tracks implemented one at a time, each going through Phase A →
+Phase B → Phase C), and Phase 4 (final artifacts).
+
+**Key terminology:**
+- **Track**: A coherent stream of related work within the plan. Contains
+  steps (decomposed later in this Phase A, after your review). Max ~5-7
+  steps per track.
+- **Step**: A single atomic change = one commit. Fully tested with 85% line
+  / 70% branch coverage. Step decomposition has not happened yet — only
+  scope indicators exist.
+- **Episode**: A structured record of what happened during a step or track
+  implementation. Track episodes (in the plan file under completed tracks)
+  summarize strategic outcomes; step episodes (in step files) contain
+  implementation details. Episodes from completed tracks are your evidence
+  of what actually happened vs. what was planned.
+- **Scope indicator**: A rough sketch of expected work in a track
+  (`~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
+- **Decision Records**: Design choices in the plan's Architecture Notes
+  section. Each has alternatives, rationale, risks, and track references.
+  Immutable during execution — changes require formal replanning.
+- **Component Map**: Mermaid diagram + annotated bullet list showing which
+  system components this plan touches and what changes in each.
+- **Invariants**: Conditions that must remain true before/after the change.
+  Each must map to a testable assertion.
+
+**Your role:** Assess risks and feasibility of this track before
+implementation begins. Your findings may lead to risk mitigation steps,
+reordering, or (if severity is `skip`) a recommendation to skip the track.
+
+---
+
 Inputs:
 - Plan file: {plan_path} (full plan for context, focus on specified track)
 - Track to review: {track_name}

--- a/.claude/workflow/prompts/structural-review.md
+++ b/.claude/workflow/prompts/structural-review.md
@@ -34,13 +34,15 @@ descriptions, oversized tracks, contradictions — directly impair execution.
 - **Decision Records**: Design choices in the plan's Architecture Notes
   section. Each must include: alternatives considered, rationale, risks/
   caveats, and track references (which track(s) implement this decision).
+  Immutable during execution — changes require formal replanning.
 - **Component Map**: Mermaid diagram + annotated bullet list showing which
   system components the plan touches and what changes in each.
 - **Invariants**: Conditions that must remain true. Can be ENFORCED (code
   already guarantees them), ASPIRATIONAL (tracks need to implement them),
   or VIOLATED (current code contradicts them). Each must map to a testable
   assertion in the relevant step.
-- **Integration Points**: How new code connects to existing code.
+- **Integration Points**: How new code connects to existing code — entry
+  points, SPIs, callbacks, event flows.
 - **Non-Goals**: Explicit scope exclusions to prevent scope creep during
   execution.
 - **Design document** (`design.md`): Separate file with class diagrams,

--- a/.claude/workflow/prompts/structural-review.md
+++ b/.claude/workflow/prompts/structural-review.md
@@ -2,6 +2,50 @@ You are reviewing an implementation plan for structural correctness.
 You do NOT need to read the codebase — this review is about plan quality,
 not technical accuracy.
 
+## Workflow Context
+
+You are a sub-agent spawned during **Phase 2 (Implementation Review)**,
+which validates the plan before execution begins. Phase 2 has two steps:
+(1) a consistency review (already passed — checked plan/design vs. actual
+code), then (2) this structural review (you). After both pass, the plan
+proceeds to Phase 3 (execution).
+
+**Why this matters:** During Phase 3, an execution agent reads this plan to
+guide implementation. It processes tracks sequentially, decomposes each
+track into steps just-in-time, and relies on the plan's structure for
+correct ordering and scope. Structural defects — dependency cycles, missing
+descriptions, oversized tracks, contradictions — directly impair execution.
+
+**Key terminology:**
+- **Track**: A coherent stream of related work within the plan. Tracks are
+  implemented sequentially during Phase 3. Max ~5-7 steps per track — if
+  larger, the track should be split into dependent tracks.
+- **Step**: A single atomic change = one commit. Fully tested. Step
+  decomposition is **deferred to Phase 3 execution** — the plan should NOT
+  contain `- [ ] Step:` items or *(provisional)* markers. Only scope
+  indicators exist at this point.
+- **Scope indicator**: A rough sketch of expected work in a track
+  (`> **Scope:** ~N steps covering X, Y, Z`). A strategic signal for effort
+  estimation, not a binding contract. Phase A (first sub-phase of execution)
+  decomposes scope indicators into concrete steps just-in-time.
+- **Execution agent**: The agent that implements tracks during Phase 3. It
+  reads the plan and design document to guide implementation. It decomposes
+  scope indicators into concrete steps, implements them, and writes episodes.
+- **Decision Records**: Design choices in the plan's Architecture Notes
+  section. Each must include: alternatives considered, rationale, risks/
+  caveats, and track references (which track(s) implement this decision).
+- **Component Map**: Mermaid diagram + annotated bullet list showing which
+  system components the plan touches and what changes in each.
+- **Invariants**: Conditions that must remain true. Each must map to a
+  testable assertion in the relevant step.
+- **Integration Points**: How new code connects to existing code.
+- **Non-Goals**: Explicit scope exclusions to prevent scope creep during
+  execution.
+- **Design document** (`design.md`): Separate file with class diagrams,
+  workflow diagrams, and dedicated sections for complex/opaque parts.
+
+---
+
 Inputs:
 - Plan file: {plan_path}
 - Design document: {design_path}

--- a/.claude/workflow/prompts/structural-review.md
+++ b/.claude/workflow/prompts/structural-review.md
@@ -36,8 +36,10 @@ descriptions, oversized tracks, contradictions — directly impair execution.
   caveats, and track references (which track(s) implement this decision).
 - **Component Map**: Mermaid diagram + annotated bullet list showing which
   system components the plan touches and what changes in each.
-- **Invariants**: Conditions that must remain true. Each must map to a
-  testable assertion in the relevant step.
+- **Invariants**: Conditions that must remain true. Can be ENFORCED (code
+  already guarantees them), ASPIRATIONAL (tracks need to implement them),
+  or VIOLATED (current code contradicts them). Each must map to a testable
+  assertion in the relevant step.
 - **Integration Points**: How new code connects to existing code.
 - **Non-Goals**: Explicit scope exclusions to prevent scope creep during
   execution.

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -4,11 +4,11 @@ You MUST read the codebase to validate this track's assumptions.
 ## Workflow Context
 
 You are a sub-agent spawned during **Phase A (Review + Decomposition)** of
-the execution workflow. The overall workflow has five stages: Phase 0–1
-(research & planning — produced the plan you are reviewing), Phase 2
-(consistency & structural review of the plan — already passed), Phase 3
-(execution — tracks implemented one at a time, each going through Phase A →
-Phase B → Phase C), and Phase 4 (final artifacts).
+the execution workflow. The overall workflow has five phases: Phase 0
+(research), Phase 1 (planning) — together these produced the plan you are
+reviewing, Phase 2 (consistency & structural review of the plan — already
+passed), Phase 3 (execution — tracks implemented one at a time, each going
+through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
 
 **Key terminology:**
 - **Track**: A coherent stream of related work within the plan. Contains
@@ -29,10 +29,16 @@ Phase B → Phase C), and Phase 4 (final artifacts).
 - **Component Map**: Mermaid diagram + annotated bullet list showing which
   system components this plan touches and what changes in each.
 - **Invariants**: Conditions that must remain true before/after the change.
-  Each must map to a testable assertion in the relevant step.
+  Can be ENFORCED (code already guarantees them), ASPIRATIONAL (tracks need
+  to implement them), or VIOLATED (current code contradicts them). Each must
+  map to a testable assertion in the relevant step.
+- **Integration Points**: How new code connects to existing code — entry
+  points, SPIs, callbacks, event flows.
+- **Non-Goals**: Explicit scope exclusions to prevent scope creep during
+  execution.
 
 **Your role:** Validate this track's approach before implementation begins.
-Your findings may lead to plan adjustments, step decomposition changes, or
+Your findings may lead to plan adjustments, decomposition guidance, or
 (if severity is `skip`) a recommendation to skip the entire track. After
 your review, the main agent decomposes the track into concrete steps.
 

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -1,6 +1,43 @@
 You are reviewing ONE TRACK of an implementation plan for technical soundness.
 You MUST read the codebase to validate this track's assumptions.
 
+## Workflow Context
+
+You are a sub-agent spawned during **Phase A (Review + Decomposition)** of
+the execution workflow. The overall workflow has five stages: Phase 0–1
+(research & planning — produced the plan you are reviewing), Phase 2
+(consistency & structural review of the plan — already passed), Phase 3
+(execution — tracks implemented one at a time, each going through Phase A →
+Phase B → Phase C), and Phase 4 (final artifacts).
+
+**Key terminology:**
+- **Track**: A coherent stream of related work within the plan. Contains
+  steps (decomposed later in this Phase A, after your review). Max ~5-7
+  steps per track.
+- **Step**: A single atomic change = one commit. Fully tested. Step
+  decomposition has not happened yet — only scope indicators exist.
+- **Episode**: A structured record of what happened during a step or track
+  implementation. Track episodes (in the plan file under completed tracks)
+  summarize strategic outcomes; step episodes (in step files) contain
+  implementation details. Episodes from completed tracks are your evidence
+  of what actually happened vs. what was planned.
+- **Scope indicator**: A rough sketch of expected work in a track
+  (`~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
+- **Decision Records**: Design choices in the plan's Architecture Notes
+  section. Each has alternatives, rationale, risks, and track references.
+  They are immutable during execution — changes require formal replanning.
+- **Component Map**: Mermaid diagram + annotated bullet list showing which
+  system components this plan touches and what changes in each.
+- **Invariants**: Conditions that must remain true before/after the change.
+  Each must map to a testable assertion in the relevant step.
+
+**Your role:** Validate this track's approach before implementation begins.
+Your findings may lead to plan adjustments, step decomposition changes, or
+(if severity is `skip`) a recommendation to skip the entire track. After
+your review, the main agent decomposes the track into concrete steps.
+
+---
+
 Inputs:
 - Plan file: {plan_path} (read the full plan for context, but focus on
   the specified track)

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -22,7 +22,7 @@ through Phase A → Phase B → Phase C), and Phase 4 (final artifacts).
   implementation details. Episodes from completed tracks are your evidence
   of what actually happened vs. what was planned.
 - **Scope indicator**: A rough sketch of expected work in a track
-  (`~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
+  (`> **Scope:** ~N steps covering X, Y, Z`). Strategic signal, not a binding contract.
 - **Decision Records**: Design choices in the plan's Architecture Notes
   section. Each has alternatives, rationale, risks, and track references.
   They are immutable during execution — changes require formal replanning.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -102,6 +102,21 @@ completion**, before moving to the next step:
 
       Each agent receives the same context:
       ```
+      ## Workflow Context
+      This is a **step-level code review** within a structured development
+      workflow. A **track** is a coherent stream of related work within an
+      implementation plan; a **step** is a single atomic change (one commit,
+      fully tested). You are reviewing one step's diff. The implementation
+      plan below provides strategic context: goals, architecture decisions
+      (Decision Records), constraints, and component topology (Component Map).
+      The track steps file provides tactical context: what each step does and
+      what was discovered. **Episodes** are the blockquoted sections under
+      completed steps (starting with `**What was done:**`) — they are
+      structured records of implementation outcomes. Use episodes to
+      understand intent behind prior steps and check for cross-step
+      consistency issues. Severities: **blocker** (must fix), **should-fix**
+      (should fix before merge), **suggestion** (optional improvement).
+
       ## Review Target
       Track {N}, Step {M}: {step description}
       Reviewing: uncommitted changes or last commit (as appropriate)

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -66,6 +66,24 @@ Every sub-agent receives the same context block. Assemble it once and
 include it in each agent's prompt:
 
 ```
+## Workflow Context
+This is a **track-level code review** within a structured development
+workflow. A **track** is a coherent stream of related work containing
+multiple steps (each step = one commit, fully tested). You are reviewing
+the **full track diff** — all steps combined — to catch cross-step
+interaction issues that step-level reviews could not see (e.g.,
+inconsistent error handling across steps, missing integration between
+components introduced in different steps, architectural drift from the
+plan). The implementation plan below provides strategic context: goals,
+architecture decisions (Decision Records), constraints, and component
+topology (Component Map). The track steps file provides tactical context:
+what each step does and what was discovered. **Episodes** are the
+blockquoted sections under completed steps (starting with
+`**What was done:**`) — structured records of implementation outcomes.
+Use episodes to understand intent and check whether the combined result
+matches the plan's goals. Severities: **blocker** (must fix),
+**should-fix** (should fix before merge), **suggestion** (optional).
+
 ## Review Target
 Track {N}: {track title}
 Reviewing commit range: {base_commit}..HEAD

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -82,7 +82,7 @@ blockquoted sections under completed steps (starting with
 `**What was done:**`) — structured records of implementation outcomes.
 Use episodes to understand intent and check whether the combined result
 matches the plan's goals. Severities: **blocker** (must fix),
-**should-fix** (should fix before merge), **suggestion** (optional).
+**should-fix** (should fix before merge), **suggestion** (optional improvement).
 
 ## Review Target
 Track {N}: {track title}


### PR DESCRIPTION
## Motivation

Sub-agents spawned during the workflow (review agents, code review agents) operate without knowledge of the overall workflow structure — they don't know what phase they're in, what terminology means (track, step, episode, scope indicator, decision record), or how their output feeds into subsequent phases. This leads to shallow reviews that miss cross-cutting concerns and misinterpret plan artifacts.

## Summary

- Add **Workflow Context** sections to all 5 review sub-agent prompts (`adversarial-review.md`, `consistency-review.md`, `risk-review.md`, `structural-review.md`, `technical-review.md`) explaining the overall workflow phases, key terminology, and each agent's specific role
- Add workflow context to step-level code review prompts in `step-implementation.md` (explains track/step/episode semantics and severity levels)
- Add workflow context to track-level code review prompts in `track-code-review.md` (explains cross-step interaction review purpose and episode semantics)

## Test plan

- [x] Verify all prompt files render correctly with no broken formatting
- [ ] Run a workflow execution to confirm sub-agents receive and utilize the context correctly