### PR TITLE
[no-test-number-check] Fix integration test OOM: reduce disk cache buffer from 4096 MB to 2048 MB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -884,6 +884,20 @@
                   <youtrackdb.test.env>ci</youtrackdb.test.env>
                   <youtrackdb.test.deadlock.timeout.minutes>60
                   </youtrackdb.test.deadlock.timeout.minutes>
+                  <!-- Reduce disk cache from the default 4096 MB to 2048 MB for
+                       integration tests. The fork JVM uses -Xms4096m -Xmx4096m
+                       (4 GB committed heap) plus up to diskCache.bufferSize MB of
+                       native memory for page cache. With 4096 MB, the fork alone
+                       needs ~8 GB RSS; combined with Maven's JVM (~2-3 GB RSS),
+                       total memory exceeds the 16 GB available on CPX42 runners,
+                       triggering the OOM killer (exit code 137) late in the
+                       integration test run. 2048 MB is sufficient for all current
+                       integration tests (heaviest: BTreeTestIT with 1M keys uses
+                       ~400 MB of pages). This override takes precedence over the
+                       argLine -D flag because systemPropertyVariables are applied
+                       via System.setProperty() after JVM start. -->
+                  <youtrackdb.storage.diskCache.bufferSize>2048
+                  </youtrackdb.storage.diskCache.bufferSize>
                 </systemPropertyVariables>
               </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
- Reduce disk cache buffer size from 4096 MB to 2048 MB for failsafe integration tests in the `ci-integration-tests` Maven profile
- Prevents OOM killer (exit code 137) from crashing the JVM late in the integration test run

## Root Cause
The integration test fork JVM uses `-Xms4096m -Xmx4096m` (4 GB committed heap) plus up to `diskCache.bufferSize` MB of native memory for page cache. With the default 4096 MB disk cache, the fork alone can reach ~8 GB RSS. Combined with Maven's JVM (~2-3 GB actual RSS), total memory approaches the 16 GB available on Hetzner CPX42 runners.

As the integration test suite has grown since March 27 (new IT tests added: `CompositeIndexGrowShrinkIT`, `IndexHistogramConcurrentStressIT`, `LockFreeReadCacheConcurrentTestIT`; some tests regressed in memory/time: `AsyncReadCacheTestIT` from 768s to 1135s), the accumulated memory pressure across ~3 hours of test execution in a single reused fork JVM pushes the combined processes past the OOM threshold.

The Linux OOM killer consistently sends SIGKILL (exit code 137) to the fork JVM late in the run, crashing whichever test happens to be running at that point — consistently `LocalPaginatedCollectionV2TestIT` due to deterministic test ordering.

This has caused the integration test pipeline to fail continuously since March 28, 2026 (12 consecutive failures).

## Changes
- `pom.xml`: Added `youtrackdb.storage.diskCache.bufferSize=2048` to `systemPropertyVariables` in the `ci-integration-tests` profile's failsafe plugin configuration. This override takes precedence over the argLine `-D` flag because `systemPropertyVariables` are applied via `System.setProperty()` after JVM start.

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/24147978697

## Test plan
- [x] `LocalPaginatedCollectionV2TestIT` passes with 2048 MB disk cache (103 tests, 0 failures)
- [x] Full unit test suite passes (`./mvnw clean package -Dyoutrackdb.test.env=ci` — BUILD SUCCESS, 29 min)
- [x] Effective POM verification shows `diskCache.bufferSize=2048` in failsafe config