### PR TITLE
[no-test-number-check] Fix 3-way deadlock in periodic records GC during storage deletion

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -3879,14 +3879,17 @@ public abstract class AbstractStorage
             new ThreadInterruptedException("Fuzzy check point was interrupted"), e, name);
       }
 
-      if (status != STATUS.OPEN || status != STATUS.MIGRATION) {
+      // Bail out if the storage is no longer in an operational state.
+      // The original condition used || which is always true (tautology) —
+      // it should be && to express "status is neither OPEN nor MIGRATION".
+      if (status != STATUS.OPEN && status != STATUS.MIGRATION) {
         return;
       }
     }
 
     try {
 
-      if (status != STATUS.OPEN || status != STATUS.MIGRATION) {
+      if (status != STATUS.OPEN && status != STATUS.MIGRATION) {
         return;
       }
 
@@ -5941,40 +5944,70 @@ public abstract class AbstractStorage
    * {@code fuzzyCheckpointExecutor}. The method is safe to call concurrently — snapshot
    * cleanup uses {@code tryLock()}, and the per-collection GC is serialized by the
    * collection's component lock inside {@code collectDeadRecords()}.
+   *
+   * <p><b>Deadlock prevention:</b> This method acquires {@code stateLock.readLock()} for
+   * its entire duration. Without it, the delete path ({@code doShutdownOnDelete}) can
+   * acquire {@code stateLock.writeLock()} and proceed to
+   * {@code WOWCache.delete()} → {@code filesLock.writeLock()} while this GC task is
+   * still running. The GC writes pages through the read cache, which acquires a
+   * {@code PageFrame} exclusive lock and then calls {@code WOWCache.store()} →
+   * {@code filesLock.readLock()}. This creates a 3-way deadlock:
+   * <ol>
+   *   <li>main holds {@code filesLock} (write) → waits for DeleteFileTask on flush
+   *       executor</li>
+   *   <li>GC thread holds {@code PageFrame} lock → needs {@code filesLock} (read)</li>
+   *   <li>flush executor needs the same {@code PageFrame} lock</li>
+   * </ol>
+   * Holding {@code stateLock.readLock()} forces the delete path to wait until this
+   * method completes, preventing the deadlock.
    */
   public void periodicRecordsGc() {
     if (status != STATUS.OPEN) {
       return;
     }
 
-    // Step 1: Opportunistically clean snapshot/visibility indexes.
-    try {
-      cleanupSnapshotIndex();
-    } catch (Exception e) {
-      LogManager.instance().error(this, "Error during snapshot index cleanup"
-          + " in periodic records GC for storage '%s'", e, name);
+    // Acquire the state read lock to prevent concurrent storage deletion.
+    // If the write lock is already held (storage is being deleted/closed),
+    // bail out immediately — there is no point in GC'ing a dying storage.
+    if (!stateLock.readLock().tryLock()) {
+      return;
     }
-
-    // Step 2: Reclaim dead records from collections that exceed the threshold.
-    var contextConfig = configuration.getContextConfiguration();
-    int minThreshold = contextConfig
-        .getValueAsInteger(GlobalConfiguration.STORAGE_COLLECTION_GC_MIN_THRESHOLD);
-    float scaleFactor = contextConfig
-        .getValueAsFloat(GlobalConfiguration.STORAGE_COLLECTION_GC_SCALE_FACTOR);
-
-    for (var collection : collections) {
+    try {
       if (status != STATUS.OPEN) {
         return;
       }
-      if (collection instanceof PaginatedCollectionV2 pc
-          && pc.isGcTriggered(minThreshold, scaleFactor)) {
-        try {
-          pc.collectDeadRecords(sharedSnapshotIndex);
-        } catch (Exception e) {
-          LogManager.instance().error(this, "Error during records GC"
-              + " for collection '%s' in storage '%s'", e, pc.getName(), name);
+
+      // Step 1: Opportunistically clean snapshot/visibility indexes.
+      try {
+        cleanupSnapshotIndex();
+      } catch (Exception e) {
+        LogManager.instance().error(this, "Error during snapshot index cleanup"
+            + " in periodic records GC for storage '%s'", e, name);
+      }
+
+      // Step 2: Reclaim dead records from collections that exceed the threshold.
+      var contextConfig = configuration.getContextConfiguration();
+      int minThreshold = contextConfig
+          .getValueAsInteger(GlobalConfiguration.STORAGE_COLLECTION_GC_MIN_THRESHOLD);
+      float scaleFactor = contextConfig
+          .getValueAsFloat(GlobalConfiguration.STORAGE_COLLECTION_GC_SCALE_FACTOR);
+
+      for (var collection : collections) {
+        if (status != STATUS.OPEN) {
+          return;
+        }
+        if (collection instanceof PaginatedCollectionV2 pc
+            && pc.isGcTriggered(minThreshold, scaleFactor)) {
+          try {
+            pc.collectDeadRecords(sharedSnapshotIndex);
+          } catch (Exception e) {
+            LogManager.instance().error(this, "Error during records GC"
+                + " for collection '%s' in storage '%s'", e, pc.getName(), name);
+          }
         }
       }
+    } finally {
+      stateLock.readLock().unlock();
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheOptimisticTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheOptimisticTest.java
@@ -77,20 +77,39 @@ public class LockFreeReadCacheOptimisticTest {
   @Test
   public void testEvictedEntryReturnsNull() {
     // Fill cache beyond capacity to trigger eviction, then check an evicted page.
-    // Cache holds 1024 pages — load 1100 to force eviction.
-    for (int i = 0; i < 1100; i++) {
+    int capacity = 1024; // matches setUp(): maxMemory = 1024L * PAGE_SIZE
+    int totalPages = 1100;
+    int minEvicted = totalPages - capacity;
+
+    for (int i = 0; i < totalPages; i++) {
       var entry = readCache.loadForRead(0, i, writeCache, false);
       readCache.releaseFromRead(entry);
     }
 
-    // At least some early pages should have been evicted
+    // Flush all internal buffers and verify the cache's structural invariants
+    // (cacheSize counter == data map size == LRU list sizes, all <= maxCacheSize).
+    readCache.assertSize();
+
+    // The W-TinyLFU admission filter may evict either old victims or new candidates
+    // depending on the frequency sketch's hash collision pattern (which uses a random
+    // seed). Scan the full range to find evicted pages regardless of which end the
+    // policy chose to evict from.
     int nullCount = 0;
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < totalPages; i++) {
       if (readCache.getPageFrameOptimistic(0, i) == null) {
         nullCount++;
       }
     }
-    assertTrue("Some early pages should have been evicted", nullCount > 0);
+
+    int retainedCount = totalPages - nullCount;
+    assertTrue(
+        "At least " + minEvicted + " pages should have been evicted (" + totalPages
+            + " loaded, " + capacity + " capacity), but found " + nullCount + " evicted",
+        nullCount >= minEvicted);
+    assertTrue(
+        "Cache should retain up to its " + capacity + "-page capacity; retained only "
+            + retainedCount + " pages",
+        retainedCount >= capacity);
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageDeadlockFixTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorageDeadlockFixTest.java
@@ -1,0 +1,281 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.core.config.StorageConfiguration;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.storage.Storage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests for the deadlock fix in {@link AbstractStorage#periodicRecordsGc()} and the
+ * tautology fix in {@link AbstractStorage#makeFuzzyCheckpoint()}.
+ *
+ * <p>The deadlock fix wraps {@code periodicRecordsGc()} in a {@code stateLock.readLock()}
+ * to prevent a 3-way deadlock between storage deletion, periodic GC, and cache flush.
+ * The tautology fix changes {@code ||} to {@code &&} in the status check so the guard
+ * actually evaluates correctly.
+ *
+ * <p>Tests are in the same package as {@code AbstractStorage} to access {@code protected}
+ * fields ({@code status}, {@code stateLock}, {@code configuration}) for white-box testing
+ * of lock contention and error handling paths.
+ */
+@Category(SequentialTest.class)
+public class AbstractStorageDeadlockFixTest {
+
+  private YouTrackDBImpl youTrackDB;
+
+  @Before
+  public void setUp() {
+    youTrackDB = DbTestBase.createYTDBManagerAndDb(
+        "test", DatabaseType.MEMORY, getClass());
+  }
+
+  @After
+  public void tearDown() {
+    youTrackDB.close();
+  }
+
+  // ---------------------------------------------------------------------------
+  // makeFuzzyCheckpoint: tautology fix coverage
+  // ---------------------------------------------------------------------------
+
+  // When the storage is closed, makeFuzzyCheckpoint should return immediately after
+  // acquiring the read lock. The status guard after the lock evaluates to true because
+  // status is CLOSED (neither OPEN nor MIGRATION), triggering an early return.
+  @Test
+  public void makeFuzzyCheckpointReturnsOnClosedStorage() {
+    var session = openSession();
+    var storage = storage(session);
+
+    session.close();
+    youTrackDB.close();
+
+    try {
+      // Status is CLOSED. tryLock(1ms) succeeds (no write lock held after close),
+      // then the status guard after the lock triggers the early return.
+      storage.makeFuzzyCheckpoint();
+
+      // Verify the method returned without altering storage state
+      assertThat(storage.status)
+          .as("storage status should remain CLOSED after early return")
+          .isEqualTo(Storage.STATUS.CLOSED);
+    } finally {
+      // Recreate for tearDown — must always happen even if the test fails
+      youTrackDB = DbTestBase.createYTDBManagerAndDb(
+          "test", DatabaseType.MEMORY, getClass());
+    }
+  }
+
+  // When the write lock is held and status is non-OPEN, makeFuzzyCheckpoint should
+  // bail out via the status guard inside the while loop (reached when tryLock fails).
+  @Test
+  public void makeFuzzyCheckpointBailsOutDuringLockContention() throws Exception {
+    var session = openSession();
+    var storage = storage(session);
+
+    var lockAcquired = new CountDownLatch(1);
+    var canRelease = new CountDownLatch(1);
+
+    // Helper thread: holds the write lock and sets status to CLOSING.
+    // This simulates the storage deletion path holding the write lock.
+    var thread = new Thread(() -> {
+      storage.stateLock.writeLock().lock();
+      try {
+        storage.status = Storage.STATUS.CLOSING;
+        lockAcquired.countDown();
+        try {
+          canRelease.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      } finally {
+        // Restore status before releasing so session close works normally
+        storage.status = Storage.STATUS.OPEN;
+        storage.stateLock.writeLock().unlock();
+      }
+    });
+    thread.start();
+    assertThat(lockAcquired.await(10, TimeUnit.SECONDS))
+        .as("helper thread should acquire write lock in time")
+        .isTrue();
+
+    try {
+      // Main thread: makeFuzzyCheckpoint enters while loop, tryLock(1ms) fails
+      // (write lock held), reaches the in-loop status guard, status is CLOSING,
+      // condition is true, returns immediately.
+      storage.makeFuzzyCheckpoint();
+    } finally {
+      canRelease.countDown();
+      thread.join(10_000);
+      assertThat(thread.isAlive())
+          .as("helper thread should have terminated")
+          .isFalse();
+      session.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // periodicRecordsGc: readLock contention bail-out
+  // ---------------------------------------------------------------------------
+
+  // When the write lock is held, periodicRecordsGc should bail out at the
+  // tryLock() guard because it returns false. The method must not block — it
+  // uses a non-blocking tryLock to avoid holding up scheduled executor threads.
+  @Test
+  public void periodicGcBailsOutWhenWriteLockHeld() throws Exception {
+    var session = openSession();
+    var storage = storage(session);
+
+    var lockAcquired = new CountDownLatch(1);
+    var canRelease = new CountDownLatch(1);
+
+    // Helper thread: holds the write lock, simulating a concurrent storage close.
+    var thread = new Thread(() -> {
+      storage.stateLock.writeLock().lock();
+      try {
+        lockAcquired.countDown();
+        try {
+          canRelease.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      } finally {
+        storage.stateLock.writeLock().unlock();
+      }
+    });
+    thread.start();
+    assertThat(lockAcquired.await(10, TimeUnit.SECONDS))
+        .as("helper thread should acquire write lock in time")
+        .isTrue();
+
+    try {
+      // Main thread: status is OPEN (passes pre-lock check), tryLock fails
+      // (write lock held), returns immediately.
+      storage.periodicRecordsGc();
+    } finally {
+      canRelease.countDown();
+      thread.join(10_000);
+      assertThat(thread.isAlive())
+          .as("helper thread should have terminated")
+          .isFalse();
+      session.close();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // periodicRecordsGc: snapshot cleanup exception handling
+  // ---------------------------------------------------------------------------
+
+  // When cleanupSnapshotIndex throws, the exception should be caught and logged
+  // by the catch block, and the method should continue to the collection GC loop.
+  // We simulate the exception by replacing the configuration with a mock that
+  // throws on the first getContextConfiguration() call (which occurs inside
+  // cleanupSnapshotIndex) and returns the real config on subsequent calls.
+  @Test
+  public void periodicGcCatchesSnapshotCleanupException() {
+    var session = openSession();
+    var storage = storage(session);
+
+    var realConfig = storage.configuration;
+    var mockConfig = mock(StorageConfiguration.class);
+
+    // First call: from cleanupSnapshotIndex -> throws (simulates cleanup failure)
+    // Second call: from the collection GC threshold retrieval -> returns real config
+    when(mockConfig.getContextConfiguration())
+        .thenThrow(new RuntimeException("simulated snapshot cleanup failure"))
+        .thenReturn(realConfig.getContextConfiguration());
+
+    try {
+      storage.configuration = mockConfig;
+      // Should not throw — the exception is caught and logged internally
+      storage.periodicRecordsGc();
+    } finally {
+      storage.configuration = realConfig;
+      session.close();
+    }
+
+    // Verify both getContextConfiguration() calls were made — the second call
+    // proves that execution continued past the exception into the GC loop phase.
+    verify(mockConfig, times(2)).getContextConfiguration();
+  }
+
+  // ---------------------------------------------------------------------------
+  // periodicRecordsGc: loop exits when status changes
+  // ---------------------------------------------------------------------------
+
+  // When the storage status changes from OPEN during the collection iteration
+  // loop, the loop should exit immediately via the in-loop status guard.
+  // We simulate this by using a mock configuration that changes status as a
+  // side effect of the second getContextConfiguration() call (which occurs
+  // just before the loop begins).
+  @Test
+  public void periodicGcExitsLoopWhenStatusChanges() {
+    var session = openSession();
+    var storage = storage(session);
+
+    // Create data so there is at least one collection to iterate
+    session.command("CREATE CLASS GcStatusChangeTest");
+    session.begin();
+    session.command("INSERT INTO GcStatusChangeTest SET x = 1");
+    session.commit();
+
+    var realConfig = storage.configuration;
+    var mockConfig = mock(StorageConfiguration.class);
+
+    // First call: from cleanupSnapshotIndex -> returns real config (cleanup runs normally)
+    // Second call: from GC threshold retrieval -> side effect: sets status to CLOSING
+    when(mockConfig.getContextConfiguration())
+        .thenReturn(realConfig.getContextConfiguration())
+        .thenAnswer(inv -> {
+          storage.status = Storage.STATUS.CLOSING;
+          return realConfig.getContextConfiguration();
+        });
+
+    // Set GC thresholds to 0 so all collections are eligible for GC,
+    // ensuring the loop body is reached (where the status check triggers).
+    storage.getContextConfiguration()
+        .setValue(GlobalConfiguration.STORAGE_COLLECTION_GC_MIN_THRESHOLD, 0);
+    storage.getContextConfiguration()
+        .setValue(GlobalConfiguration.STORAGE_COLLECTION_GC_SCALE_FACTOR, 0.0f);
+
+    try {
+      storage.configuration = mockConfig;
+      storage.periodicRecordsGc();
+    } finally {
+      storage.status = Storage.STATUS.OPEN;
+      storage.configuration = realConfig;
+      session.close();
+    }
+
+    // Verify the method reached the collection GC phase (second getContextConfiguration
+    // call) — the status side effect was triggered, confirming the loop-exit path.
+    verify(mockConfig, times(2)).getContextConfiguration();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private DatabaseSessionEmbedded openSession() {
+    return youTrackDB.open("test", "admin", DbTestBase.ADMIN_PASSWORD);
+  }
+
+  private static AbstractStorage storage(DatabaseSessionEmbedded session) {
+    return (AbstractStorage) session.getStorage();
+  }
+}


### PR DESCRIPTION
## Motivation

CI integration test `BTreeLinkBagConcurrencySingleBasedLinkBagTestIT` was timing out after ~3600 seconds due to a 3-way deadlock between:

1. **Main thread** (storage delete): held `filesLock.writeLock()` in `WOWCache.delete()`, waiting for `DeleteFileTask` submitted to the flush executor via `future.get()`
2. **Fuzzy Checkpoint thread** (running `periodicRecordsGc`): held a `PageFrame` exclusive lock (via `LockFreeReadCache.releaseFromWrite()`), waiting for `filesLock.readLock()` in `WOWCache.store()`
3. **Flush executor** (`DeleteFileTask`): needed the same `PageFrame` exclusive lock in `WOWCache.doRemoveCachePages()`

**Root cause**: `periodicRecordsGc()` did not acquire `stateLock.readLock()`, unlike `makeFuzzyCheckpoint()`. This allowed the delete path to proceed (acquiring `stateLock.writeLock()`) concurrently while GC was still running and holding page locks, creating the circular dependency.

## Changes

### Fix 1: Deadlock prevention in `periodicRecordsGc()` (`AbstractStorage.java`)
- Wrap the entire GC body in `stateLock.readLock().tryLock()` / `unlock()`
- Uses `tryLock()` (non-blocking) so GC bails out immediately if a delete/close is in progress
- This forces the delete path's `stateLock.writeLock()` acquisition to wait for GC to finish, preventing the 3-way deadlock

### Fix 2: Tautological condition in `makeFuzzyCheckpoint()` (`AbstractStorage.java`)
- Changed `status != STATUS.OPEN || status != STATUS.MIGRATION` to `status != STATUS.OPEN && status != STATUS.MIGRATION`
- The original `||` condition is a tautology (always true for any value of `status`), causing `makeFuzzyCheckpoint()` to always return early without performing checkpoint work
- The correct `&&` condition only returns early when status is neither OPEN nor MIGRATION

### Fix 3: Flaky `testEvictedEntryReturnsNull` in `LockFreeReadCacheOptimisticTest`
- The test assumed W-TinyLFU would always evict early pages (0-99), but the admission filter's behavior depends on the `FrequencySketch`'s random seed — hash collisions can inflate older pages' apparent frequencies, causing the policy to reject new candidates instead
- Failed on Linux arm / JDK 25 / Oracle where the collision pattern consistently kept early pages alive
- Fix: scan the full loaded range (0-1099) instead of just pages 0-99, add both lower-bound (eviction happened) and upper-bound (cache retains pages) assertions, derive thresholds from named constants, and call `assertSize()` for internal consistency

## Test plan

- [x] Core unit tests pass (BUILD SUCCESS)
- [x] `LockFreeReadCacheOptimisticTest` passes consistently (8/8 runs)
- [x] Dimensional code review (bugs/concurrency, crash safety, performance, test quality) — no blockers
- [ ] CI integration tests (verified by CI pipeline)