### PR TITLE
Fix CI fix agent: scope-aware testing, coverage gate, and prompt cleanup

### DIFF
--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -76,6 +76,19 @@ jobs:
       - name: Build agent prompt
         id: prompt
         run: |
+          # Determine test scope from the triggering workflow
+          if echo "$FAILED_WORKFLOW_NAME" | grep -qi "integration"; then
+            FULL_TEST_CMD="./mvnw clean verify -P ci-integration-tests -Dyoutrackdb.test.env=ci"
+            FINAL_TEST_CMD="./mvnw clean verify -P ci-integration-tests -Dyoutrackdb.test.env=ci"
+            COVERAGE_TEST_CMD="./mvnw clean package -P coverage -Dyoutrackdb.test.env=ci"
+            TEST_SCOPE="unit + integration"
+          else
+            FULL_TEST_CMD="./mvnw clean package -Dyoutrackdb.test.env=ci"
+            FINAL_TEST_CMD="./mvnw clean package -P coverage -Dyoutrackdb.test.env=ci"
+            COVERAGE_TEST_CMD=""
+            TEST_SCOPE="unit only"
+          fi
+
           cat > /tmp/fix-agent-prompt-$$.md << 'AGENT_PROMPT_EOF'
           You are an autonomous CI failure fix agent running in GitHub Actions.
           There is NO human operator — you must make all decisions independently.
@@ -348,9 +361,10 @@ jobs:
           2. If the test requires a suite runner (GremlinProcessRunner, graph
              provider), note it cannot run standalone — verify by inspection.
           3. Run `./mvnw -pl {module} spotless:check` for formatting.
-          4. **Run all project unit tests** to ensure no regressions:
+          4. **Run the full test suite** (__TEST_SCOPE__) to ensure no
+             regressions:
              ```bash
-             ./mvnw clean package -Dyoutrackdb.test.env=ci
+             __FULL_TEST_CMD__
              ```
           5. **Run only the specific integration tests you changed**
              (if any). Use failsafe's `-Dit.test=` to target them:
@@ -360,7 +374,8 @@ jobs:
                -Dit.test={ChangedITClass} \
                -Dyoutrackdb.test.env=ci
              ```
-             Skip this step if no integration test files were modified.
+             Skip this step entirely when test scope is "unit only",
+             or if no integration test files were modified.
           6. **Do NOT proceed to Step 6 if any test fails.** Fix the
              failures first and re-run.
 
@@ -469,22 +484,20 @@ jobs:
 
           8. **Final full test run after review loop completes.**
              After the review loop exits (all findings addressed or max
-             iterations reached), run the full build with all tests
-             (unit + integration) one final time:
+             iterations reached), run the full test suite (__TEST_SCOPE__)
+             one final time:
              ```bash
-             ./mvnw clean verify -P ci-integration-tests \
-               -Dyoutrackdb.test.env=ci
+             __FINAL_TEST_CMD__
              ```
              If any test fails, fix the failure, re-run `spotless:apply`,
              and re-run the suite. Do NOT proceed to step 9 with
              failing tests.
 
           9. **Check code coverage of changed lines.**
-             After all tests pass, run the coverage collection build and
-             verify that changed lines meet the project coverage thresholds
+             Verify that changed lines meet the project coverage thresholds
              (85% line, 70% branch):
              ```bash
-             ./mvnw clean package -P coverage -Dyoutrackdb.test.env=ci
+             __COVERAGE_TEST_CMD__
              python3 .github/scripts/coverage-gate.py \
                --line-threshold 85 \
                --branch-threshold 70 \
@@ -492,8 +505,8 @@ jobs:
                --coverage-dir .coverage/reports
              ```
              If coverage is below the threshold, add or improve tests for
-             uncovered lines, re-run `spotless:apply`, and re-run the
-             coverage check. Do NOT proceed to main Step 7 with coverage
+             uncovered lines, re-run `spotless:apply`, and re-run from
+             step 8. Do NOT proceed to main Step 7 with coverage
              failures.
 
           ## Step 7: Commit, push, and update the draft PR
@@ -616,7 +629,19 @@ jobs:
           - **Failed run URL**: ${FAILED_RUN_URL}
           - **Failed workflow name**: ${FAILED_WORKFLOW_NAME}
           - **Commit SHA**: ${TRIGGER_SHA}
+          - **Test scope**: ${TEST_SCOPE}
           EOF
+
+          # Replace test-scope placeholders with computed values
+          sed -i "s|__FULL_TEST_CMD__|${FULL_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
+          sed -i "s|__FINAL_TEST_CMD__|${FINAL_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
+          sed -i "s|__TEST_SCOPE__|${TEST_SCOPE}|g" /tmp/fix-agent-prompt-$$.md
+          if [ -n "$COVERAGE_TEST_CMD" ]; then
+            sed -i "s|__COVERAGE_TEST_CMD__|${COVERAGE_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
+          else
+            # Coverage already collected in step 8 — remove the Maven line
+            sed -i "/__COVERAGE_TEST_CMD__/d" /tmp/fix-agent-prompt-$$.md
+          fi
 
           echo "prompt_file=/tmp/fix-agent-prompt-$$.md" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -33,7 +33,7 @@ jobs:
       - type-cpx42
       - image-x86-system-ubuntu-24.04
       - in-nbg1-fsn1-hel1
-    timeout-minutes: 720
+    timeout-minutes: ${{ contains(inputs.failed_workflow_name, 'integration') && 720 || 360 }}
     env:
       FAILED_RUN_URL: ${{ inputs.failed_run_url }}
       FAILED_WORKFLOW_NAME: ${{ inputs.failed_workflow_name }}
@@ -81,10 +81,12 @@ jobs:
             FULL_TEST_CMD="./mvnw clean verify -P ci-integration-tests -Dyoutrackdb.test.env=ci"
             FINAL_TEST_CMD="./mvnw clean verify -P ci-integration-tests,coverage -Dyoutrackdb.test.env=ci"
             TEST_SCOPE="unit + integration"
+            TIME_BUDGET="12 hours"
           else
             FULL_TEST_CMD="./mvnw clean package -Dyoutrackdb.test.env=ci"
             FINAL_TEST_CMD="./mvnw clean package -P coverage -Dyoutrackdb.test.env=ci"
             TEST_SCOPE="unit only"
+            TIME_BUDGET="6 hours"
           fi
 
           cat > /tmp/fix-agent-prompt-$$.md << 'AGENT_PROMPT_EOF'
@@ -101,7 +103,7 @@ jobs:
             push, and create PRs.
           - There is no user to ask questions — make reasonable decisions
             autonomously.
-          - **Time budget: 12 hours total.** Plan accordingly — a full module
+          - **Time budget: __TIME_BUDGET__ total.** Plan accordingly — a full module
             test suite (`./mvnw -pl core clean test`) takes ~20-40 min,
             integration tests take ~60-90 min. Prefer running only the
             specific failing test first, then the full module suite only if
@@ -364,18 +366,7 @@ jobs:
              ```bash
              __FULL_TEST_CMD__
              ```
-          5. **Run only the specific integration tests you changed**
-             (if any). Use failsafe's `-Dit.test=` to target them:
-             ```bash
-             ./mvnw -pl {module} clean verify \
-               -P ci-integration-tests \
-               -Dit.test={ChangedITClass} \
-               -Dyoutrackdb.test.env=ci
-             ```
-             Skip this step when test scope is "unit + integration"
-             (step 4 already runs all integration tests), when test scope
-             is "unit only", or if no integration test files were modified.
-          6. **Do NOT proceed to Step 6 if any test fails.** Fix the
+          5. **Do NOT proceed to Step 6 if any test fails.** Fix the
              failures first and re-run.
 
           ## Step 6: Dimensional review (MANDATORY GATE)
@@ -481,7 +472,7 @@ jobs:
              there are still critical issues, document them in the
              summary and proceed.
 
-          8. **Final full test run after review loop completes.**
+          6.8. **Final full test run after review loop completes.**
              After the review loop exits (all findings addressed or max
              iterations reached), run the full test suite (__TEST_SCOPE__)
              one final time:
@@ -489,10 +480,10 @@ jobs:
              __FINAL_TEST_CMD__
              ```
              If any test fails, fix the failure, re-run `spotless:apply`,
-             and re-run the suite. Do NOT proceed to step 9 with
+             and re-run the suite. Do NOT proceed to step 6.9 with
              failing tests.
 
-          9. **Check code coverage of changed lines.**
+          6.9. **Check code coverage of changed lines.**
              Verify that changed lines meet the project coverage thresholds
              (85% line, 70% branch):
              ```bash
@@ -505,7 +496,7 @@ jobs:
              ```
              If coverage is below the threshold, add or improve tests for
              uncovered lines, re-run `spotless:apply`, and re-run from
-             step 8. Maximum 3 coverage-fix iterations. If coverage still
+             step 6.8. Maximum 3 coverage-fix iterations. If coverage still
              fails after 3 attempts, document the remaining gaps in the
              summary and proceed to Step 7.
 
@@ -632,10 +623,11 @@ jobs:
           - **Test scope**: ${TEST_SCOPE}
           EOF
 
-          # Replace test-scope placeholders with computed values
+          # Replace placeholders with computed values
           sed -i "s|__FULL_TEST_CMD__|${FULL_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
           sed -i "s|__FINAL_TEST_CMD__|${FINAL_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
           sed -i "s|__TEST_SCOPE__|${TEST_SCOPE}|g" /tmp/fix-agent-prompt-$$.md
+          sed -i "s|__TIME_BUDGET__|${TIME_BUDGET}|g" /tmp/fix-agent-prompt-$$.md
           # Coverage already collected by FINAL_TEST_CMD — remove the placeholder line
           sed -i "/__COVERAGE_TEST_CMD__/d" /tmp/fix-agent-prompt-$$.md
 

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -33,7 +33,7 @@ jobs:
       - type-cpx42
       - image-x86-system-ubuntu-24.04
       - in-nbg1-fsn1-hel1
-    timeout-minutes: 360
+    timeout-minutes: 720
     env:
       FAILED_RUN_URL: ${{ inputs.failed_run_url }}
       FAILED_WORKFLOW_NAME: ${{ inputs.failed_workflow_name }}
@@ -79,13 +79,11 @@ jobs:
           # Determine test scope from the triggering workflow
           if echo "$FAILED_WORKFLOW_NAME" | grep -qi "integration"; then
             FULL_TEST_CMD="./mvnw clean verify -P ci-integration-tests -Dyoutrackdb.test.env=ci"
-            FINAL_TEST_CMD="./mvnw clean verify -P ci-integration-tests -Dyoutrackdb.test.env=ci"
-            COVERAGE_TEST_CMD="./mvnw clean package -P coverage -Dyoutrackdb.test.env=ci"
+            FINAL_TEST_CMD="./mvnw clean verify -P ci-integration-tests,coverage -Dyoutrackdb.test.env=ci"
             TEST_SCOPE="unit + integration"
           else
             FULL_TEST_CMD="./mvnw clean package -Dyoutrackdb.test.env=ci"
             FINAL_TEST_CMD="./mvnw clean package -P coverage -Dyoutrackdb.test.env=ci"
-            COVERAGE_TEST_CMD=""
             TEST_SCOPE="unit only"
           fi
 
@@ -103,7 +101,7 @@ jobs:
             push, and create PRs.
           - There is no user to ask questions — make reasonable decisions
             autonomously.
-          - **Time budget: 6 hours total.** Plan accordingly — a full module
+          - **Time budget: 12 hours total.** Plan accordingly — a full module
             test suite (`./mvnw -pl core clean test`) takes ~20-40 min,
             integration tests take ~60-90 min. Prefer running only the
             specific failing test first, then the full module suite only if
@@ -374,8 +372,9 @@ jobs:
                -Dit.test={ChangedITClass} \
                -Dyoutrackdb.test.env=ci
              ```
-             Skip this step entirely when test scope is "unit only",
-             or if no integration test files were modified.
+             Skip this step when test scope is "unit + integration"
+             (step 4 already runs all integration tests), when test scope
+             is "unit only", or if no integration test files were modified.
           6. **Do NOT proceed to Step 6 if any test fails.** Fix the
              failures first and re-run.
 
@@ -506,8 +505,9 @@ jobs:
              ```
              If coverage is below the threshold, add or improve tests for
              uncovered lines, re-run `spotless:apply`, and re-run from
-             step 8. Do NOT proceed to main Step 7 with coverage
-             failures.
+             step 8. Maximum 3 coverage-fix iterations. If coverage still
+             fails after 3 attempts, document the remaining gaps in the
+             summary and proceed to Step 7.
 
           ## Step 7: Commit, push, and update the draft PR
 
@@ -554,7 +554,7 @@ jobs:
 
              ## Test plan
              - [x] Failing test passes locally
-             - [x] Full test suite passes (unit + integration)
+             - [x] Full test suite passes (__TEST_SCOPE__)
              - [x] Dimensional code review completed
              EOF
              )"
@@ -636,12 +636,8 @@ jobs:
           sed -i "s|__FULL_TEST_CMD__|${FULL_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
           sed -i "s|__FINAL_TEST_CMD__|${FINAL_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
           sed -i "s|__TEST_SCOPE__|${TEST_SCOPE}|g" /tmp/fix-agent-prompt-$$.md
-          if [ -n "$COVERAGE_TEST_CMD" ]; then
-            sed -i "s|__COVERAGE_TEST_CMD__|${COVERAGE_TEST_CMD}|g" /tmp/fix-agent-prompt-$$.md
-          else
-            # Coverage already collected in step 8 — remove the Maven line
-            sed -i "/__COVERAGE_TEST_CMD__/d" /tmp/fix-agent-prompt-$$.md
-          fi
+          # Coverage already collected by FINAL_TEST_CMD — remove the placeholder line
+          sed -i "/__COVERAGE_TEST_CMD__/d" /tmp/fix-agent-prompt-$$.md
 
           echo "prompt_file=/tmp/fix-agent-prompt-$$.md" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-failure-fix-agent.yml
+++ b/.github/workflows/ci-failure-fix-agent.yml
@@ -476,8 +476,25 @@ jobs:
                -Dyoutrackdb.test.env=ci
              ```
              If any test fails, fix the failure, re-run `spotless:apply`,
-             and re-run the suite. Do NOT proceed to main Step 7 with
+             and re-run the suite. Do NOT proceed to step 9 with
              failing tests.
+
+          9. **Check code coverage of changed lines.**
+             After all tests pass, run the coverage collection build and
+             verify that changed lines meet the project coverage thresholds
+             (85% line, 70% branch):
+             ```bash
+             ./mvnw clean package -P coverage -Dyoutrackdb.test.env=ci
+             python3 .github/scripts/coverage-gate.py \
+               --line-threshold 85 \
+               --branch-threshold 70 \
+               --compare-branch origin/develop \
+               --coverage-dir .coverage/reports
+             ```
+             If coverage is below the threshold, add or improve tests for
+             uncovered lines, re-run `spotless:apply`, and re-run the
+             coverage check. Do NOT proceed to main Step 7 with coverage
+             failures.
 
           ## Step 7: Commit, push, and update the draft PR
 


### PR DESCRIPTION
#### Motivation:

The CI failure fix agent (`ci-failure-fix-agent.yml`) had several issues that reduced its effectiveness:

1. **Wrong test scope for integration failures**: The agent always ran only unit tests (`./mvnw clean package`), even when the triggering workflow was an integration test failure. This meant integration test regressions could slip through unfixed.

2. **No coverage gate**: The agent could produce fixes with poor test coverage, violating the project's 85% line / 70% branch coverage thresholds.

3. **Unconditional 6-hour timeout**: Integration test failures need more time (full integration suite takes ~60-90 min per run), but the timeout was hardcoded at 360 minutes regardless of scope.

4. **Dead step and ambiguous numbering**: Step 5 told the agent to run individual integration tests separately (which duplicated the full suite run), and sub-step numbering inside Step 6 was inconsistent (e.g., `6.8` appeared without preceding `6.1`–`6.7`).

#### Changes:

- **Derive test scope from triggering workflow**: Detect whether the failed workflow is an integration test run and set `FULL_TEST_CMD`, `FINAL_TEST_CMD`, `TEST_SCOPE`, and `TIME_BUDGET` accordingly.
- **Add coverage gate** (step 6.9): After the final test run, run the coverage gate script with up to 3 retry iterations before proceeding.
- **Dynamic timeout**: 720 minutes for integration failures, 360 minutes for unit-only.
- **Remove dead step 5** (run individual integration tests separately) — the full suite in step 4 already covers this.
- **Fix sub-step numbering** in the dimensional review section.
- **Inject computed values via `sed`** placeholders (`__FULL_TEST_CMD__`, `__TEST_SCOPE__`, etc.) so the prompt stays readable as a heredoc.

## Test plan
- [x] Workflow YAML is syntactically valid
- [x] Placeholder substitution covers all `__*__` tokens
- [ ] Manual trigger with a unit test failure — verify 360-min timeout and unit-only commands
- [ ] Manual trigger with an integration test failure — verify 720-min timeout and integration commands