### PR TITLE
[no-test-number-check] Fix livelock in BTreeLinkBagConcurrencySingleBasedLinkBagTestIT

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/sbtree/BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/sbtree/BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.java
@@ -71,6 +71,13 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
 
   @After
   public void afterMethod() {
+    threadExecutor.shutdownNow();
+    try {
+      threadExecutor.awaitTermination(30, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
     youTrackDB.drop(BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.class.getSimpleName());
 
     GlobalConfiguration.LINK_COLLECTION_EMBEDDED_TO_BTREE_THRESHOLD.setValue(topThreshold);
@@ -121,12 +128,14 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
         TimeUnit.SECONDS.sleep(60);
         cont = false;
 
+        // Use bounded get() so that any unexpected hang produces a clear
+        // TimeoutException instead of an uninformative CI runner timeout.
         for (var future : addFutures) {
-          future.get();
+          future.get(120, TimeUnit.SECONDS);
         }
 
         for (var future : remoteFutures) {
-          var ridsToDelete = future.get();
+          var ridsToDelete = future.get(120, TimeUnit.SECONDS);
 
           for (var rid : ridsToDelete) {
             Assert.assertTrue(ridSet.remove(rid));
@@ -183,7 +192,10 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
               }
             });
 
-            while (true) {
+            // Check cont in the retry loop to avoid livelocking when the test
+            // is shutting down and multiple threads compete for the same entity.
+            var addedToLinkBag = false;
+            while (cont) {
               try {
                 db.executeInTx(transaction -> {
                   var entity = transaction.loadEntity(entityContainerRid);
@@ -193,10 +205,19 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
                     linkBag.add(rid);
                   }
                 });
+                addedToLinkBag = true;
               } catch (ConcurrentModificationException e) {
                 continue;
               }
 
+              break;
+            }
+
+            // Only track RIDs in ridSet if they were actually committed to
+            // the LinkBag. When the loop exits because cont became false,
+            // the entities exist in the DB but are not in the LinkBag —
+            // adding them to ridSet would break the final consistency check.
+            if (!addedToLinkBag) {
               break;
             }
 
@@ -242,7 +263,12 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
               continue;
             }
 
-            while (true) {
+            // Check cont in the retry loop to avoid livelocking when the test
+            // is shutting down. Without this check, 5 RidDeleter threads competing
+            // for the same entity can livelock indefinitely — each gets
+            // ConcurrentModificationException from the others and retries forever,
+            // never reaching the outer while(cont) check.
+            while (cont) {
               try {
                 var triple = db.computeInTx(transaction -> {
                   var entity = transaction.loadEntity(entityContainerRid);
@@ -301,6 +327,8 @@ public class BTreeLinkBagConcurrencySingleBasedLinkBagTestIT {
                 //retry
               }
             }
+            // If the inner loop exited because cont became false (not via break),
+            // the outer while(cont) will also exit — no bookkeeping needed.
           }
         }
 


### PR DESCRIPTION
## Summary
- Fix livelock in `BTreeLinkBagConcurrencySingleBasedLinkBagTestIT` that caused the integration test JVM to hang for 60 minutes and then get killed by the watchdog on Linux ARM / JDK 25

## Root Cause
The inner `while(true)` retry loops in both `RidAdder` and `RidDeleter` never checked the `volatile boolean cont` shutdown flag. After the 60-second concurrent phase ended and `cont` was set to `false`, the 5 `RidDeleter` threads competing for the same entity would livelock indefinitely — each getting `ConcurrentModificationException` from the others and retrying forever, never reaching the outer `while(cont)` check.

The `JUnitTestListener` watchdog detected the stuck test after 60 minutes and called `Runtime.halt(1)`, which Maven Failsafe reported as "The forked VM terminated without properly saying goodbye."

This failure was non-deterministic — it depended on how quickly the retry loops converged after adders stopped. On faster platforms (x86, JDK 21), the deleters would occasionally succeed between retries. On slower platforms (ARM, JDK 25), the contention was worse and the livelock was effectively permanent.

## Changes
- `BTreeLinkBagConcurrencySingleBasedLinkBagTestIT.java`:
  - Replace `while(true)` with `while(cont)` in both `RidAdder` and `RidDeleter` inner retry loops
  - Add `addedToLinkBag` guard in `RidAdder` to skip `ridSet` tracking when the add was not committed to the LinkBag (prevents false assertion failures during shutdown)
  - Add 120-second timeouts to `future.get()` calls so any future hang produces a clear `TimeoutException` instead of an uninformative CI runner kill
  - Shut down `ExecutorService` in `@After` to prevent thread leaks between tests
  - Add clarifying comments for shutdown behavior in both loops

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/24186936578

## Test plan
- [x] Failing test passes locally (72s, all threads terminate cleanly)
- [x] Full test suite passes (unit + integration, BUILD SUCCESS, 3h23m)
- [x] Dimensional code review completed (6 agents: code quality, bugs/concurrency, test behavior, test completeness, test concurrency, test structure — no blockers)
- [x] Coverage gate passes (test-only change, no production code affected)