### PR TITLE
[no-test-number-check] Fix readCache.clear() crash from negative cacheSize during engine shutdown

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/engine/local/EngineLocalPaginated.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/engine/local/EngineLocalPaginated.java
@@ -196,7 +196,10 @@ public class EngineLocalPaginated extends EngineAbstract {
   @Override
   public void shutdown() {
     try {
-      readCache.clear();
+      var cache = readCache;
+      if (cache != null) {
+        cache.clear();
+      }
     } catch (Exception e) {
       LogManager.instance().error(this, "Error clearing read cache during shutdown", e);
     } finally {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/engine/local/EngineLocalPaginated.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/engine/local/EngineLocalPaginated.java
@@ -197,9 +197,14 @@ public class EngineLocalPaginated extends EngineAbstract {
   public void shutdown() {
     try {
       readCache.clear();
-      files.clear();
+    } catch (Exception e) {
+      LogManager.instance().error(this, "Error clearing read cache during shutdown", e);
     } finally {
-      super.shutdown();
+      try {
+        files.clear();
+      } finally {
+        super.shutdown();
+      }
     }
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -337,6 +337,7 @@ public final class LockFreeReadCache implements ReadCache {
           "Page  " + fileId + ":" + pageIndex + " was allocated in other thread");
     }
 
+    cacheSize.incrementAndGet();
     afterAdd(cacheEntry);
 
     return cacheEntry;
@@ -595,9 +596,9 @@ public final class LockFreeReadCache implements ReadCache {
     try {
       emptyBuffers();
 
-      // Guard against negative cacheSize — a counter drift can occur under heavy
-      // concurrent load/evict/clearFile activity. Using the actual data map size
-      // as the capacity hint ensures we never pass a negative value to ArrayList.
+      // Guard against negative cacheSize — the counter can drift negative under heavy
+      // concurrent load/evict/clearFile activity because increments and decrements use
+      // different locks. Clamp to zero to avoid IllegalArgumentException from ArrayList.
       var currentCacheSize = cacheSize.get();
       var entries = new ArrayList<CacheEntry>(Math.max(0, currentCacheSize));
       data.forEachValue(entries::add);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -595,7 +595,11 @@ public final class LockFreeReadCache implements ReadCache {
     try {
       emptyBuffers();
 
-      var entries = new ArrayList<CacheEntry>(cacheSize.get());
+      // Guard against negative cacheSize — a counter drift can occur under heavy
+      // concurrent load/evict/clearFile activity. Using the actual data map size
+      // as the capacity hint ensures we never pass a negative value to ArrayList.
+      var currentCacheSize = cacheSize.get();
+      var entries = new ArrayList<CacheEntry>(Math.max(0, currentCacheSize));
       data.forEachValue(entries::add);
 
       for (final var entry : entries) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -596,9 +596,8 @@ public final class LockFreeReadCache implements ReadCache {
     try {
       emptyBuffers();
 
-      // Guard against negative cacheSize — the counter can drift negative under heavy
-      // concurrent load/evict/clearFile activity because increments and decrements use
-      // different locks. Clamp to zero to avoid IllegalArgumentException from ArrayList.
+      // Defense-in-depth: clamp cacheSize to zero to avoid IllegalArgumentException
+      // from ArrayList if the counter ever drifts negative due to a future bug.
       var currentCacheSize = cacheSize.get();
       var entries = new ArrayList<CacheEntry>(Math.max(0, currentCacheSize));
       data.forEachValue(entries::add);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/YouTrackDBEnginesManagerStartUpTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/YouTrackDBEnginesManagerStartUpTest.java
@@ -2,12 +2,16 @@ package com.jetbrains.youtrackdb.internal.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBInternalEmbedded;
+import com.jetbrains.youtrackdb.internal.core.engine.EngineAbstract;
 import com.jetbrains.youtrackdb.internal.core.engine.local.EngineLocalPaginated;
 import com.jetbrains.youtrackdb.internal.core.exception.DatabaseException;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
@@ -319,6 +323,65 @@ public class YouTrackDBEnginesManagerStartUpTest {
       }
       manager.shutdownPools();
     }
+  }
+
+  /**
+   * Shutting down an EngineLocalPaginated that was never started (readCache is null)
+   * must complete without NPE. The null guard in shutdown() skips cache.clear()
+   * and proceeds to files.clear() and super.shutdown().
+   */
+  @Test
+  public void shutdownWithNullReadCacheCompletesNormally() throws Exception {
+    var engine = new EngineLocalPaginated();
+    // readCache is null because startup() was never called.
+    assertThat(engine.getReadCache()).isNull();
+
+    // Force running=true so the isRunning() assertion after shutdown() is
+    // falsifiable — it will only pass if super.shutdown() actually executed.
+    Field runningField = EngineAbstract.class.getDeclaredField("running");
+    runningField.setAccessible(true);
+    runningField.set(engine, true);
+    assertThat(engine.isRunning()).isTrue();
+
+    // Must not throw — the null guard should skip cache.clear().
+    engine.shutdown();
+
+    // super.shutdown() must have set running=false.
+    assertThat(engine.isRunning()).isFalse();
+  }
+
+  /**
+   * When readCache.clear() throws during shutdown, the exception must be caught
+   * and logged (not propagated), and files.clear() + super.shutdown() must still
+   * execute. This covers the {@code catch (Exception e)} block in
+   * {@link EngineLocalPaginated#shutdown()}.
+   */
+  @Test
+  public void shutdownCatchesReadCacheClearException() throws Exception {
+    var engine = new EngineLocalPaginated();
+
+    // Inject a mock ReadCache whose clear() throws, simulating a failure
+    // during cache cleanup (e.g., concurrent modification, I/O error).
+    var mockCache = mock(ReadCache.class);
+    doThrow(new RuntimeException("simulated clear failure")).when(mockCache).clear();
+
+    Field readCacheField = EngineLocalPaginated.class.getDeclaredField("readCache");
+    readCacheField.setAccessible(true);
+    readCacheField.set(engine, mockCache);
+
+    // Force running=true so the isRunning() assertion after shutdown() is
+    // falsifiable — it will only pass if super.shutdown() actually executed.
+    Field runningField = EngineAbstract.class.getDeclaredField("running");
+    runningField.setAccessible(true);
+    runningField.set(engine, true);
+
+    // shutdown() must not propagate the exception.
+    engine.shutdown();
+
+    // Verify clear() was actually called (exception was caught, not avoided).
+    verify(mockCache).clear();
+    // super.shutdown() must have transitioned running from true to false.
+    assertThat(engine.isRunning()).isFalse();
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -421,6 +422,82 @@ public class LockFreeReadCacheBatchingTest {
 
     readCache.assertSize();
     readCache.assertConsistency();
+  }
+
+  // --- allocateNewPage cacheSize tracking tests ---
+
+  /**
+   * allocateNewPage() must increment cacheSize so that getUsedMemory() reflects the newly
+   * allocated page. This is the root-cause fix for cacheSize counter drift — without the
+   * increment in addNewPagePointerToTheCache(), eviction decrements for allocated pages
+   * would drive cacheSize negative, eventually crashing clear() with
+   * IllegalArgumentException from ArrayList(negativeCapacity).
+   */
+  @Test
+  public void testAllocateNewPageIncrementsCacheSize() throws Exception {
+    long initialMemory = readCache.getUsedMemory();
+
+    var entry = readCache.allocateNewPage(0, writeCache, new LogSequenceNumber(-1, -1));
+    readCache.releaseFromWrite(entry, writeCache, false);
+
+    // cacheSize must have been incremented: memory should increase by exactly one page.
+    Assert.assertEquals(
+        "allocateNewPage must increment cacheSize",
+        initialMemory + PAGE_SIZE, readCache.getUsedMemory());
+
+    readCache.assertSize();
+    readCache.assertConsistency();
+  }
+
+  /**
+   * Multiple allocateNewPage() calls across different file IDs must each increment
+   * cacheSize correctly, keeping memory tracking accurate. Uses different fileIds
+   * because MockedWriteCache.allocateNewPage() always returns pageIndex 0.
+   */
+  @Test
+  public void testMultipleAllocateNewPagesTrackMemoryCorrectly() throws Exception {
+    int allocCount = 5;
+    var entries = new ArrayList<CacheEntry>();
+    for (int fileId = 0; fileId < allocCount; fileId++) {
+      var entry = readCache.allocateNewPage(fileId, writeCache,
+          new LogSequenceNumber(-1, -1));
+      entries.add(entry);
+    }
+
+    Assert.assertEquals(
+        "Each allocateNewPage must increment cacheSize",
+        (long) allocCount * PAGE_SIZE, readCache.getUsedMemory());
+
+    for (var entry : entries) {
+      readCache.releaseFromWrite(entry, writeCache, false);
+    }
+
+    readCache.assertSize();
+    readCache.assertConsistency();
+  }
+
+  // --- clear() with negative cacheSize defense-in-depth test ---
+
+  /**
+   * clear() must not throw when cacheSize has drifted to a negative value.
+   * The Math.max(0, cacheSize) guard in clear() prevents IllegalArgumentException
+   * from ArrayList(negativeCapacity). After clear(), cacheSize must be reset to 0.
+   */
+  @Test
+  public void testClearWithNegativeCacheSizeDoesNotThrow() throws Exception {
+    // Force cacheSize to a negative value via reflection, simulating the
+    // counter drift that could occur from a future increment/decrement bug.
+    var cacheSizeField = LockFreeReadCache.class.getDeclaredField("cacheSize");
+    cacheSizeField.setAccessible(true);
+    var cacheSize = (AtomicInteger) cacheSizeField.get(readCache);
+    cacheSize.set(-5);
+
+    // clear() must not throw IllegalArgumentException.
+    readCache.clear();
+
+    // After clear(), cacheSize must be reset to 0 (not left at -5).
+    Assert.assertEquals("cacheSize must be 0 after clear()", 0, cacheSize.get());
+    Assert.assertEquals("Used memory must be 0 after clear()", 0, readCache.getUsedMemory());
   }
 
   // --- resolveCacheHitRatio tests ---


### PR DESCRIPTION
## Motivation

CI integration tests on `develop` (run [#24194327326](https://github.com/JetBrains/youtrackdb/actions/runs/24194327326)) failed with a Failsafe "forked VM terminated without properly saying goodbye" error. The root cause is a cascading failure:

1. `LockFreeReadCache.clear()` called `new ArrayList<>(cacheSize.get())` where `cacheSize` had drifted to a large negative value
2. This threw `IllegalArgumentException: Illegal Capacity` from the `ArrayList` constructor
3. The exception propagated through `EngineLocalPaginated.shutdown()`, skipping `files.clear()` and `super.shutdown()`
4. Direct memory buffers allocated by WAL and cache components were never released
5. The `JUnitTestListener.testRunFinished()` triggered `YouTrackDBEnginesManager.shutdown()` → `ByteBufferPool.checkMemoryLeaks()` → `assert trackedReferences.isEmpty()` → `AssertionError` → JVM crash

### Root Cause

The `cacheSize` AtomicInteger drifted negative because `addNewPagePointerToTheCache()` (called from `allocateNewPage()`) inserted entries into the data map via `putIfAbsent` without incrementing `cacheSize`. When those entries were later evicted by `WTinyLFUPolicy.purgeEden()`, the eviction decremented `cacheSize` — but since the counter was never incremented for those entries, it drifted negative over time.

## Changes

### `LockFreeReadCache.java`
- **Root cause fix**: Add missing `cacheSize.incrementAndGet()` in `addNewPagePointerToTheCache()` after successful `putIfAbsent`
- **Defensive guard**: Use `Math.max(0, cacheSize.get())` in `clear()` as an ArrayList capacity hint to prevent `IllegalArgumentException` even if drift recurs

### `EngineLocalPaginated.java`
- Restructure `shutdown()` to catch exceptions from `readCache.clear()` so that `files.clear()` and `super.shutdown()` still execute, preventing cascading resource leaks
- Add null guard for `readCache` matching the existing pattern in `createStorage()`

## Test plan

- [x] `FreeSpaceMapTestIT` passes (11 tests)
- [x] `LockFreeReadCacheConcurrentTestIT` passes (2 tests)
- [x] `LockFreeReadCacheBatchingTest` passes (14 tests)
- [x] `LockFreeReadCacheOptimisticTest` passes (9 tests)
- [x] Full unit + integration test suite passes (820 test classes, zero failures, 3h7m)
- [ ] CI pipeline validates on push