### PR TITLE
[no-test-number-check] Fix AIOOBE in ConcurrentLongIntHashMap optimistic read on ARM

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -354,8 +354,8 @@ public class ConcurrentLongIntHashMap<V> {
    * {@link StampedLock}. Uses open addressing with linear probing.
    *
    * <p>An empty slot has {@code entries[i] == null}. All mutations happen under the write lock;
-   * optimistic readers snapshot the array reference and capacity, then validate the stamp after
-   * probing.
+   * optimistic readers snapshot the array reference and derive the bucket mask from its length,
+   * then validate the stamp after probing.
    */
   private static final class Section<V> {
     private static final float FILL_FACTOR = 0.66f;
@@ -371,7 +371,10 @@ public class ConcurrentLongIntHashMap<V> {
     /** Number of occupied buckets. Drives resize threshold. */
     private int usedBuckets;
 
-    /** Current array length (always a power of two). */
+    /**
+     * Current array length (always a power of two). Only accessed under lock; the optimistic
+     * read path derives capacity from {@code entries.length} instead to avoid ARM reorder races.
+     */
     private int capacity;
 
     /** Resize when usedBuckets exceeds this. */
@@ -392,9 +395,15 @@ public class ConcurrentLongIntHashMap<V> {
       // validation will fail and we fall back to the read lock.
       long stamp = lock.tryOptimisticRead();
 
-      // Snapshot mutable fields to locals under the optimistic stamp
-      int cap = capacity;
+      // Snapshot the array reference, then derive capacity from it — NOT from the
+      // `capacity` field. On weakly-ordered architectures (ARM/aarch64), plain-field
+      // stores in rehashTo() can be reordered: a reader may observe the new `capacity`
+      // (larger) while still seeing the old `entries` array (smaller), causing
+      // ArrayIndexOutOfBoundsException when the mask exceeds the array length.
+      // Deriving the mask from tbl.length guarantees consistency: the length is an
+      // immutable property of the array object we already hold a reference to.
       Entry<V>[] tbl = entries;
+      int cap = tbl.length;
 
       int bucketMask = cap - 1;
       int bucket = hashMix & bucketMask;
@@ -756,11 +765,12 @@ public class ConcurrentLongIntHashMap<V> {
         }
       }
 
-      // Swap array BEFORE capacity — an optimistic reader that snapshots the new capacity
-      // but old array would use a mask larger than the array length, causing AIOOBE.
-      // By writing the array first, a reader that sees the old capacity uses a smaller mask
-      // against a larger array (safe), while a reader that sees the new capacity uses the
-      // correct mask against the new array (also safe).
+      // Write order between entries and capacity does not matter for correctness:
+      // optimistic readers derive their bucket mask from tbl.length (not from the
+      // `capacity` field), and validate() catches any concurrent modifications.
+      // On weakly-ordered architectures (ARM/aarch64), plain stores can be reordered
+      // by the CPU regardless of program order, so write ordering alone would be
+      // insufficient — the tbl.length approach is the actual safety mechanism.
       entries = newEntries;
       capacity = newCapacity;
       resizeThreshold = (int) (newCapacity * FILL_FACTOR);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -281,6 +281,200 @@ public class ConcurrentLongIntHashMapConcurrentTest {
         .isEqualTo(entryCount.get());
   }
 
+  /**
+   * Rehash from minimum capacity (2) under concurrent access. The capacity-2 section has resize
+   * threshold {@code (int)(2 * 0.66) = 1}, so the very first insert triggers a rehash. The mask
+   * change from 1 (0b01) to 3 (0b11) is the most extreme relative shift, maximizing the window
+   * for the ARM store-reorder race where a reader could observe the new (larger) capacity before
+   * the new (larger) array.
+   *
+   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException}, correct values returned by concurrent
+   * readers, and that the map grew well beyond the initial capacity.
+   */
+  @Test
+  public void rehashFromMinimumCapacityUnderConcurrentAccessIsCorrect() throws Exception {
+    // Single section, capacity 2 — every insert triggers rehash initially
+    var map = new ConcurrentLongIntHashMap<String>(2, 1);
+    assertThat(map.capacity()).as("initial capacity should be minimum 2").isEqualTo(2);
+
+    int totalThreads = 6; // 3 writers + 3 readers
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+    int keyBound = 5_000;
+    int opsPerThread = 50_000;
+
+    try {
+      // 3 writer threads — insert entries, causing frequent rehash from minimum capacity
+      for (int t = 0; t < 3; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int key = rng.nextInt(keyBound);
+                    long fileId = key / 100;
+                    int pageIndex = key % 100;
+                    map.put(fileId, pageIndex, fileId + ":" + pageIndex);
+                  }
+                  return null;
+                }));
+      }
+
+      // 3 reader threads — continuous reads; verify non-null results are valid
+      for (int t = 0; t < 3; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int key = rng.nextInt(keyBound);
+                    long fileId = key / 100;
+                    int pageIndex = key % 100;
+                    String result = map.get(fileId, pageIndex);
+                    if (result != null) {
+                      assertThat(result)
+                          .as("get(%d, %d) returned a valid value", fileId, pageIndex)
+                          .isEqualTo(fileId + ":" + pageIndex);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Verify consistency and that capacity grew well beyond initial 2
+    var entryCount = new AtomicLong();
+    map.forEach(
+        (fileId, pageIndex, value) -> {
+          assertThat(value).isNotNull();
+          assertThat(map.get(fileId, pageIndex))
+              .as("get(%d, %d) matches forEach entry", fileId, pageIndex)
+              .isSameAs(value);
+          entryCount.incrementAndGet();
+        });
+    assertThat(map.size())
+        .as("size() matches forEach entry count")
+        .isEqualTo(entryCount.get());
+    assertThat(map.capacity())
+        .as("capacity should have grown well beyond initial 2")
+        .isGreaterThan(2);
+  }
+
+  /**
+   * Shrink under concurrent access. Uses a single-section map that is initially grown to large
+   * capacity, then one thread repeatedly calls {@code shrink()} while reader threads continuously
+   * perform {@code get()}. Exercises the same {@code rehashTo()} code path as grow-rehash but with
+   * {@code newCapacity < capacity}, which creates the symmetric ARM store-reorder risk (reader sees
+   * new smaller array but old larger capacity). A grower thread re-inserts entries to oscillate
+   * capacity up and down, maximizing rehash frequency.
+   *
+   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException}, correct values returned by concurrent
+   * readers, and final map consistency.
+   */
+  @Test
+  public void shrinkUnderConcurrentAccessIsCorrect() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    int keyCount = 500;
+    int totalThreads = 6; // 1 shrinker + 1 grower + 4 readers
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+    int rounds = 200;
+
+    // Pre-populate so there are entries to read during shrink cycles
+    for (int i = 0; i < keyCount; i++) {
+      map.put((long) i, i, i + ":" + i);
+    }
+
+    try {
+      // 1 thread repeatedly removes entries then calls shrink()
+      futures.add(
+          executor.submit(
+              () -> {
+                startBarrier.await();
+                for (int r = 0; r < rounds; r++) {
+                  // Remove most entries to make shrink meaningful
+                  for (int i = 100; i < keyCount; i++) {
+                    map.remove((long) i, i);
+                  }
+                  map.shrink();
+                  // Re-insert to grow capacity back up for next shrink
+                  for (int i = 100; i < keyCount; i++) {
+                    map.put((long) i, i, i + ":" + i);
+                  }
+                }
+                return null;
+              }));
+
+      // 1 thread that triggers grow-rehash by inserting beyond current capacity
+      futures.add(
+          executor.submit(
+              () -> {
+                startBarrier.await();
+                var rng = ThreadLocalRandom.current();
+                for (int r = 0; r < rounds * 100; r++) {
+                  int key = rng.nextInt(keyCount);
+                  map.put((long) key, key, key + ":" + key);
+                }
+                return null;
+              }));
+
+      // 4 reader threads — continuous reads during shrink/grow cycles
+      for (int t = 0; t < 4; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int r = 0; r < rounds * 500; r++) {
+                    int key = rng.nextInt(keyCount);
+                    String result = map.get((long) key, key);
+                    if (result != null) {
+                      assertThat(result)
+                          .as("get(%d, %d) returned a valid value", (long) key, key)
+                          .isEqualTo(key + ":" + key);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Final consistency check
+    var entryCount = new AtomicLong();
+    map.forEach(
+        (fileId, pageIndex, value) -> {
+          assertThat(value).isNotNull();
+          assertThat(value)
+              .as("value at (%d, %d) matches canonical form", fileId, pageIndex)
+              .isEqualTo(fileId + ":" + pageIndex);
+          assertThat(map.get(fileId, pageIndex))
+              .as("get(%d, %d) matches forEach entry", fileId, pageIndex)
+              .isSameAs(value);
+          entryCount.incrementAndGet();
+        });
+    assertThat(map.size())
+        .as("size() matches forEach entry count after shrink stress")
+        .isEqualTo(entryCount.get());
+  }
+
   // ---- removeByFileId concurrent tests ----
 
   /**


### PR DESCRIPTION
## Summary
- Fix `ArrayIndexOutOfBoundsException` race condition in `ConcurrentLongIntHashMap.get()` optimistic read path on ARM/aarch64
- Add two concurrent stress tests covering shrink-during-reads and grow-from-minimum-capacity scenarios

## Root Cause
The `get()` method's optimistic read path read `capacity` and `entries` as separate plain (non-volatile) fields. On weakly-ordered architectures (ARM/aarch64), a concurrent `rehashTo()` writes `entries = newEntries` then `capacity = newCapacity`, but the ARM memory model allows these stores to be reordered — so a reader could observe the new (larger) `capacity` while still seeing the old (smaller) `entries` array. The bucket mask derived from the new capacity (`cap - 1`) then exceeds the old array's bounds, causing `ArrayIndexOutOfBoundsException: Index 7 out of bounds for length 4`.

The previous code comment claimed that writing `entries` before `capacity` prevented this, which is only true on x86 (TSO) but not on ARM's weak memory model.

## Changes
- **`ConcurrentLongIntHashMap.java`**: In the `get()` optimistic read path, derive `cap` from `tbl.length` instead of the `capacity` field. Since `tbl.length` is an immutable property of the array object, it is always consistent with the array being probed — regardless of store/load reordering. Updated Javadoc on the `Section` class, `capacity` field, and `rehashTo()` write-order comment to reflect the new safety mechanism.
- **`ConcurrentLongIntHashMapConcurrentTest.java`**: Added `rehashFromMinimumCapacityUnderConcurrentAccessIsCorrect` (capacity-2 section where every insert triggers rehash) and `shrinkUnderConcurrentAccessIsCorrect` (shrink under concurrent reads — the symmetric case to grow-rehash).

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/24332835986
Failed on "Linux arm - JDK 25 - temurin" job: `ConcurrentLongIntHashMapConcurrentTest.rehashUnderConcurrentAccessIsCorrect` with `ArrayIndexOutOfBoundsException: Index 7 out of bounds for length 4`.

## Test plan
- [x] Failing test passes locally
- [x] Full unit test suite passes with coverage
- [x] Dimensional code review completed (code quality, bugs/concurrency, test behavior, test completeness)
- [x] Coverage verified: Section class 98.6% line / 84.9% branch (above 85%/70% thresholds)