### PR TITLE
[no-test-number-check] Add commit links and DB load time to JMH benchmark report

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -181,6 +181,7 @@ jobs:
           echo "Canonical curated params installed for base run"
 
       - name: 'Base: setup database'
+        id: base_load
         run: |
           set -euo pipefail
           DB_DIR="jmh-ldbc/target/ldbc-bench-db"
@@ -203,17 +204,20 @@ jobs:
           echo "CSV dataset verified: static/ and dynamic/ present"
 
           echo "Loading database from CSV..."
+          LOAD_START=$(date +%s)
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
             -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1" \
             2>&1 | tee /tmp/jmh-load-base-${{ github.run_id }}.txt
+          LOAD_END=$(date +%s)
+          echo "load_time=$((LOAD_END - LOAD_START))" >> "$GITHUB_OUTPUT"
 
           # Verify the database was actually created
           if [ ! -d "$DB_DIR/ldbc_benchmark" ]; then
             echo "::error::Database was not created after CSV load. Check load output above."
             exit 1
           fi
-          echo "Database loaded successfully from CSV"
+          echo "Database loaded successfully from CSV ($(( LOAD_END - LOAD_START ))s)"
 
       - name: 'Base: warm OS page cache'
         env:
@@ -291,6 +295,7 @@ jobs:
           echo "Canonical curated params installed for head run"
 
       - name: 'Head: setup database'
+        id: head_load
         run: |
           set -euo pipefail
           DB_DIR="jmh-ldbc/target/ldbc-bench-db"
@@ -313,17 +318,20 @@ jobs:
           echo "CSV dataset verified: static/ and dynamic/ present"
 
           echo "Loading database from CSV..."
+          LOAD_START=$(date +%s)
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
             -Djmh.args="LdbcSingleThreadIC.*ic5_newGroups -f 0 -wi 0 -i 1 -r 1s -t 1" \
             2>&1 | tee /tmp/jmh-load-head-${{ github.run_id }}.txt
+          LOAD_END=$(date +%s)
+          echo "load_time=$((LOAD_END - LOAD_START))" >> "$GITHUB_OUTPUT"
 
           # Verify the database was actually created
           if [ ! -d "$DB_DIR/ldbc_benchmark" ]; then
             echo "::error::Database was not created after CSV load. Check load output above."
             exit 1
           fi
-          echo "Database loaded successfully from CSV"
+          echo "Database loaded successfully from CSV ($(( LOAD_END - LOAD_START ))s)"
 
       - name: 'Head: warm OS page cache'
         env:
@@ -384,6 +392,9 @@ jobs:
             --head "/tmp/jmh-head-${{ github.run_id }}.json" \
             --base-sha "${{ steps.commits.outputs.fork_point }}" \
             --head-sha "${{ steps.commits.outputs.head_sha }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}" \
+            --base-load-time "${{ steps.base_load.outputs.load_time }}" \
+            --head-load-time "${{ steps.head_load.outputs.load_time }}" \
             --output "/tmp/jmh-comparison-${{ github.run_id }}.md"
 
       - name: Upload artifacts

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -269,6 +269,12 @@ def main():
     parser.add_argument("--head", required=True, help="Head (branch tip) results JSON")
     parser.add_argument("--base-sha", required=True, help="Base commit SHA")
     parser.add_argument("--head-sha", required=True, help="Head commit SHA")
+    parser.add_argument("--repo-url", default="",
+                        help="Repository URL for commit links (e.g. https://github.com/owner/repo)")
+    parser.add_argument("--base-load-time", type=float, default=None,
+                        help="Base database load time in seconds")
+    parser.add_argument("--head-load-time", type=float, default=None,
+                        help="Head database load time in seconds")
     parser.add_argument("--output", default="-", help="Output file (- for stdout)")
     args = parser.parse_args()
 
@@ -287,12 +293,18 @@ def main():
     scal_reg, scal_imp, scal_sup = count_scalability_changes(
         base_scal, head_scal)
 
+    def fmt_sha(sha):
+        short = sha[:10]
+        if args.repo_url:
+            return f"[`{short}`]({args.repo_url}/commit/{sha})"
+        return f"`{short}`"
+
     lines = []
     lines.append("## JMH LDBC Benchmark Comparison")
     lines.append("")
     lines.append(
-        f"**Base:** `{args.base_sha[:10]}` (fork-point with develop) "
-        f"| **Head:** `{args.head_sha[:10]}`"
+        f"**Base:** {fmt_sha(args.base_sha)} (fork-point with develop) "
+        f"| **Head:** {fmt_sha(args.head_sha)}"
     )
     has_throughput = regressions > 0 or improvements > 0 or suppressed > 0
     has_scalability = scal_reg > 0 or scal_imp > 0 or scal_sup > 0
@@ -329,6 +341,36 @@ def main():
     else:
         lines.append("**Summary:** No significant changes detected.")
     lines.append("")
+
+    # Database load time comparison
+    if args.base_load_time is not None and args.head_load_time is not None:
+        def fmt_time(seconds):
+            m, s = divmod(int(seconds), 60)
+            return f"{m}m {s}s" if m > 0 else f"{s}s"
+
+        base_t = args.base_load_time
+        head_t = args.head_load_time
+        delta_t = head_t - base_t
+        delta_pct = (delta_t / base_t * 100) if base_t > 0 else 0
+        sign = "+" if delta_t >= 0 else ""
+        # For load time, faster (negative delta) is improvement
+        if abs(delta_pct) < 5.0:
+            icon = ""
+        elif delta_t < 0:
+            icon = " :green_circle:"
+        else:
+            icon = " :red_circle:"
+        lines.append("### Database Load Time")
+        lines.append("")
+        lines.append("| | Time | \u0394 |")
+        lines.append("|---|---|---|")
+        lines.append(f"| Base | {fmt_time(base_t)} | |")
+        lines.append(
+            f"| Head | {fmt_time(head_t)} "
+            f"| {sign}{delta_pct:.1f}% ({sign}{fmt_time(abs(delta_t))})"
+            f"{icon} |"
+        )
+        lines.append("")
 
     for suite, label in [("SingleThread", "Single-Thread"),
                          ("MultiThread", "Multi-Thread")]:

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -344,15 +344,18 @@ def main():
 
     # Database load time comparison
     if args.base_load_time is not None and args.head_load_time is not None:
-        def fmt_time(seconds):
-            m, s = divmod(int(seconds), 60)
-            return f"{m}m {s}s" if m > 0 else f"{s}s"
+        def fmt_time(seconds, signed=False):
+            abs_s = abs(seconds)
+            m, s = divmod(abs_s, 60)
+            res = f"{int(m)}m {s:.1f}s" if m > 0 else f"{s:.1f}s"
+            if signed:
+                return f"{'+' if seconds >= 0 else '-'}{res}"
+            return res
 
         base_t = args.base_load_time
         head_t = args.head_load_time
         delta_t = head_t - base_t
         delta_pct = (delta_t / base_t * 100) if base_t > 0 else 0
-        sign = "+" if delta_t >= 0 else ""
         # For load time, faster (negative delta) is improvement
         if abs(delta_pct) < 5.0:
             icon = ""
@@ -367,7 +370,7 @@ def main():
         lines.append(f"| Base | {fmt_time(base_t)} | |")
         lines.append(
             f"| Head | {fmt_time(head_t)} "
-            f"| {sign}{delta_pct:.1f}% ({sign}{fmt_time(abs(delta_t))})"
+            f"| {delta_pct:+.1f}% ({fmt_time(delta_t, signed=True)})"
             f"{icon} |"
         )
         lines.append("")


### PR DESCRIPTION
#### Motivation:

The JMH benchmark comparison report posted on PRs showed commit SHAs as plain text, making it hard to quickly navigate to the actual commits being compared. Additionally, database load time — which can be a significant indicator of storage/indexing regressions — was not captured or compared at all.

This change:
- Renders commit SHAs as clickable GitHub links in the markdown report
- Captures wall-clock database load time for both base and head runs via `GITHUB_OUTPUT`
- Adds a load time comparison table to the report with percentage change and regression/improvement indicators (using the same ±5% threshold as throughput)

No test changes — this only affects CI workflow and the report generator script.