### PR TITLE
YTDB-624: Add index BTree tombstone GC during leaf bucket overflow

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
@@ -74,9 +74,11 @@ public final class BTreeMultiValueIndexEngine
       svTree =
           new BTree<>(
               name, DATA_FILE_EXTENSION, NULL_BUCKET_FILE_EXTENSION, storage);
+      svTree.setEngineId(id);
       nullTree =
           new BTree<>(
               nullTreeName, DATA_FILE_EXTENSION, NULL_BUCKET_FILE_EXTENSION, storage);
+      nullTree.setEngineId(id);
       indexesSnapshot = storage.subIndexSnapshot(id);
       nullIndexesSnapshot = storage.subNullIndexSnapshot(id);
     } else {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeMultiValueIndexEngine.java
@@ -66,7 +66,7 @@ public final class BTreeMultiValueIndexEngine
     this.id = id;
     this.name = name;
     this.storage = storage;
-    nullTreeName = name + "$null";
+    nullTreeName = name + AbstractStorage.NULL_TREE_SUFFIX;
 
     if (version == 1 || version == 2 || version == 3) {
       throw new IllegalArgumentException("Unsupported version of index : " + version);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
@@ -64,6 +64,7 @@ public final class BTreeSingleValueIndexEngine
       this.sbTree =
           new BTree<>(
               name, DATA_FILE_EXTENSION, NULL_BUCKET_FILE_EXTENSION, storage);
+      this.sbTree.setEngineId(id);
       indexesSnapshot = storage.subIndexSnapshot(id);
     } else {
       throw new IllegalStateException("Invalid tree version " + version);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -6368,7 +6368,7 @@ public abstract class AbstractStorage
 
   /**
    * Resolves the sub-{@link IndexesSnapshot} for an index engine by its name.
-   * Used by {@code BTree} during tombstone GC to check for active snapshot entries.
+   * Used by test infrastructure for snapshot cleanup and assertions.
    *
    * <p><b>Warning:</b> This method acquires {@code stateLock.readLock()}. It must
    * not be called while holding a BTree component lock, as this would create a
@@ -6433,6 +6433,7 @@ public abstract class AbstractStorage
    * @return {@code true} if at least one snapshot entry exists with version >= lwm,
    *     or {@code false} if no engine or no matching entries exist
    */
+  // Visible for testing — production code uses hasActiveIndexSnapshotEntriesById.
   public boolean hasActiveIndexSnapshotEntries(
       String engineName, CompositeKey userKeyPrefix, long lwm) {
     final String resolvedName;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -164,6 +164,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
@@ -6360,6 +6361,91 @@ public abstract class AbstractStorage
     return new IndexesSnapshot(
         sharedNullIndexesSnapshot, nullIndexSnapshotVisibilityIndex, indexesSnapshotEntriesCount,
         indexId);
+  }
+
+  /**
+   * Resolves the sub-{@link IndexesSnapshot} for an index engine by its name.
+   * Used by {@code BTree} during tombstone GC to check for active snapshot entries.
+   *
+   * @return the scoped snapshot, or {@code null} if no engine with this name exists
+   */
+  @Nullable public IndexesSnapshot getIndexSnapshotByEngineName(String engineName) {
+    var engine = indexEngineNameMap.get(engineName);
+    if (engine == null) {
+      return null;
+    }
+    return subIndexSnapshot(engine.getId());
+  }
+
+  /**
+   * Resolves the null-key sub-{@link IndexesSnapshot} for an index engine by its name.
+   * Used by {@code BTree} during tombstone GC for null-key trees in multi-value indexes.
+   *
+   * @return the scoped null snapshot, or {@code null} if no engine with this name exists
+   */
+  @Nullable public IndexesSnapshot getNullIndexSnapshotByEngineName(String engineName) {
+    var engine = indexEngineNameMap.get(engineName);
+    if (engine == null) {
+      return null;
+    }
+    return subNullIndexSnapshot(engine.getId());
+  }
+
+  private static final String NULL_TREE_SUFFIX = "$null";
+
+  /**
+   * Checks whether any snapshot entries exist for the given user-key prefix with
+   * {@code version >= lwm} in the index identified by {@code engineName}.
+   * For null-key trees (name ending with {@code "$null"}), the null snapshot is used.
+   *
+   * <p>Queries the shared {@code ConcurrentSkipListMap} directly without creating
+   * an intermediate {@link IndexesSnapshot} instance.
+   *
+   * @param engineName the index engine name (may end with "$null" for null-key trees)
+   * @param userKeyPrefix the key prefix (all CompositeKey elements except the version)
+   * @param lwm the global low-water mark
+   * @return {@code true} if at least one snapshot entry exists with version >= lwm,
+   *     or {@code false} if no engine or no matching entries exist
+   */
+  public boolean hasActiveIndexSnapshotEntries(
+      String engineName, CompositeKey userKeyPrefix, long lwm) {
+    final String resolvedName;
+    final NavigableMap<CompositeKey, RID> snapshotMap;
+    if (engineName.endsWith(NULL_TREE_SUFFIX)) {
+      resolvedName = engineName.substring(
+          0, engineName.length() - NULL_TREE_SUFFIX.length());
+      snapshotMap = sharedNullIndexesSnapshot;
+    } else {
+      resolvedName = engineName;
+      snapshotMap = sharedIndexesSnapshot;
+    }
+
+    var engine = indexEngineNameMap.get(resolvedName);
+    if (engine == null) {
+      return false;
+    }
+    long indexId = engine.getId();
+
+    // Build range keys: CompositeKey(indexId, userKeyPrefix..., lwm) to
+    // CompositeKey(indexId, userKeyPrefix..., Long.MAX_VALUE)
+    var prefixKeys = userKeyPrefix.getKeys();
+    int size = prefixKeys.size();
+
+    var lower = new CompositeKey(size + 2);
+    lower.addKey(indexId);
+    for (int i = 0; i < size; i++) {
+      lower.addKey(prefixKeys.get(i));
+    }
+    lower.addKey(lwm);
+
+    var upper = new CompositeKey(size + 2);
+    upper.addKey(indexId);
+    for (int i = 0; i < size; i++) {
+      upper.addKey(prefixKeys.get(i));
+    }
+    upper.addKey(Long.MAX_VALUE);
+
+    return !snapshotMap.subMap(lower, true, upper, true).isEmpty();
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -216,6 +216,9 @@ public abstract class AbstractStorage
       Comparator.comparing(
           o -> o.record.getIdentity());
 
+  /** Suffix appended to index engine names for null-key trees. */
+  public static final String NULL_TREE_SUFFIX = "$null";
+
   /**
    * Version comparator for index snapshot visibility-index maps: orders by the
    * last key element (the committing TX's version = newVersion), falling back
@@ -6367,6 +6370,11 @@ public abstract class AbstractStorage
    * Resolves the sub-{@link IndexesSnapshot} for an index engine by its name.
    * Used by {@code BTree} during tombstone GC to check for active snapshot entries.
    *
+   * <p><b>Warning:</b> This method acquires {@code stateLock.readLock()}. It must
+   * not be called while holding a BTree component lock, as this would create a
+   * lock ordering inversion. Use {@link #hasActiveIndexSnapshotEntriesById} from
+   * within BTree code paths instead.
+   *
    * @return the scoped snapshot, or {@code null} if no engine with this name exists
    */
   @Nullable public IndexesSnapshot getIndexSnapshotByEngineName(String engineName) {
@@ -6387,6 +6395,10 @@ public abstract class AbstractStorage
    * Currently used only by test infrastructure for snapshot cleanup; reserved for
    * future null-key tree GC support (Track 2).
    *
+   * <p><b>Warning:</b> This method acquires {@code stateLock.readLock()}. It must
+   * not be called while holding a BTree component lock, as this would create a
+   * lock ordering inversion.
+   *
    * @return the scoped null snapshot, or {@code null} if no engine with this name exists
    */
   @Nullable public IndexesSnapshot getNullIndexSnapshotByEngineName(String engineName) {
@@ -6401,8 +6413,6 @@ public abstract class AbstractStorage
       stateLock.readLock().unlock();
     }
   }
-
-  private static final String NULL_TREE_SUFFIX = "$null";
 
   /**
    * Checks whether any snapshot entries exist for the given user-key prefix with
@@ -6473,29 +6483,28 @@ public abstract class AbstractStorage
     return hasActiveSnapshotEntriesInMap(snapshotMap, indexId, userKeyPrefix, lwm);
   }
 
+  private static final Long LONG_MAX_VALUE = Long.MAX_VALUE;
+
   private static boolean hasActiveSnapshotEntriesInMap(
       NavigableMap<CompositeKey, RID> snapshotMap,
       long indexId,
       CompositeKey userKeyPrefix,
       long lwm) {
     var prefixKeys = userKeyPrefix.getKeys();
-    int size = prefixKeys.size();
-
-    var lower = new CompositeKey(size + 2);
-    lower.addKey(indexId);
-    for (int i = 0; i < size; i++) {
-      lower.addKey(prefixKeys.get(i));
-    }
-    lower.addKey(lwm);
-
-    var upper = new CompositeKey(size + 2);
-    upper.addKey(indexId);
-    for (int i = 0; i < size; i++) {
-      upper.addKey(prefixKeys.get(i));
-    }
-    upper.addKey(Long.MAX_VALUE);
-
+    var lower = buildSnapshotBoundKey(indexId, prefixKeys, lwm);
+    var upper = buildSnapshotBoundKey(indexId, prefixKeys, LONG_MAX_VALUE);
     return !snapshotMap.subMap(lower, true, upper, true).isEmpty();
+  }
+
+  private static CompositeKey buildSnapshotBoundKey(
+      long indexId, List<Object> prefixKeys, long version) {
+    var key = new CompositeKey(prefixKeys.size() + 2);
+    key.addKey(indexId);
+    for (var pk : prefixKeys) {
+      key.addKey(pk);
+    }
+    key.addKey(version);
+    return key;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -6479,6 +6479,7 @@ public abstract class AbstractStorage
    */
   public boolean hasActiveIndexSnapshotEntriesById(
       long indexId, boolean useNullSnapshot, CompositeKey userKeyPrefix, long lwm) {
+    assert indexId >= 0 : "indexId must be non-negative, got " + indexId;
     final NavigableMap<CompositeKey, RID> snapshotMap =
         useNullSnapshot ? sharedNullIndexesSnapshot : sharedIndexesSnapshot;
     return hasActiveSnapshotEntriesInMap(snapshotMap, indexId, userKeyPrefix, lwm);
@@ -6491,6 +6492,7 @@ public abstract class AbstractStorage
       long indexId,
       CompositeKey userKeyPrefix,
       long lwm) {
+    assert lwm >= 0 : "LWM must be non-negative, got " + lwm;
     var prefixKeys = userKeyPrefix.getKeys();
     var lower = buildSnapshotBoundKey(indexId, prefixKeys, lwm);
     var upper = buildSnapshotBoundKey(indexId, prefixKeys, LONG_MAX_VALUE);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -6384,7 +6384,8 @@ public abstract class AbstractStorage
 
   /**
    * Resolves the null-key sub-{@link IndexesSnapshot} for an index engine by its name.
-   * Used by {@code BTree} during tombstone GC for null-key trees in multi-value indexes.
+   * Currently used only by test infrastructure for snapshot cleanup; reserved for
+   * future null-key tree GC support (Track 2).
    *
    * @return the scoped null snapshot, or {@code null} if no engine with this name exists
    */
@@ -6410,6 +6411,11 @@ public abstract class AbstractStorage
    *
    * <p>Queries the shared {@code ConcurrentSkipListMap} directly without creating
    * an intermediate {@link IndexesSnapshot} instance.
+   *
+   * <p><b>Note:</b> This method acquires {@code stateLock.readLock()} to resolve
+   * the engine name to an ID. If the caller already knows the engine ID (e.g.,
+   * from a cached field), prefer {@link #hasActiveIndexSnapshotEntriesById} to
+   * avoid the lock acquisition.
    *
    * @param engineName the index engine name (may end with "$null" for null-key trees)
    * @param userKeyPrefix the key prefix (all CompositeKey elements except the version)
@@ -6444,8 +6450,34 @@ public abstract class AbstractStorage
       stateLock.readLock().unlock();
     }
 
-    // Build range keys: CompositeKey(indexId, userKeyPrefix..., lwm) to
-    // CompositeKey(indexId, userKeyPrefix..., Long.MAX_VALUE)
+    return hasActiveSnapshotEntriesInMap(snapshotMap, indexId, userKeyPrefix, lwm);
+  }
+
+  /**
+   * Lock-free variant of {@link #hasActiveIndexSnapshotEntries} that accepts a
+   * pre-resolved engine ID and a flag to select the snapshot map. This avoids
+   * acquiring {@code stateLock.readLock()} for the {@code indexEngineNameMap}
+   * lookup, eliminating the lock-ordering inversion when called while holding
+   * a BTree component lock.
+   *
+   * @param indexId the pre-resolved index engine ID
+   * @param useNullSnapshot {@code true} to query the null-key snapshot map
+   * @param userKeyPrefix the key prefix (all CompositeKey elements except the version)
+   * @param lwm the global low-water mark
+   * @return {@code true} if at least one snapshot entry exists with version >= lwm
+   */
+  public boolean hasActiveIndexSnapshotEntriesById(
+      long indexId, boolean useNullSnapshot, CompositeKey userKeyPrefix, long lwm) {
+    final NavigableMap<CompositeKey, RID> snapshotMap =
+        useNullSnapshot ? sharedNullIndexesSnapshot : sharedIndexesSnapshot;
+    return hasActiveSnapshotEntriesInMap(snapshotMap, indexId, userKeyPrefix, lwm);
+  }
+
+  private static boolean hasActiveSnapshotEntriesInMap(
+      NavigableMap<CompositeKey, RID> snapshotMap,
+      long indexId,
+      CompositeKey userKeyPrefix,
+      long lwm) {
     var prefixKeys = userKeyPrefix.getKeys();
     int size = prefixKeys.size();
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -6370,11 +6370,16 @@ public abstract class AbstractStorage
    * @return the scoped snapshot, or {@code null} if no engine with this name exists
    */
   @Nullable public IndexesSnapshot getIndexSnapshotByEngineName(String engineName) {
-    var engine = indexEngineNameMap.get(engineName);
-    if (engine == null) {
-      return null;
+    stateLock.readLock().lock();
+    try {
+      var engine = indexEngineNameMap.get(engineName);
+      if (engine == null) {
+        return null;
+      }
+      return subIndexSnapshot(engine.getId());
+    } finally {
+      stateLock.readLock().unlock();
     }
-    return subIndexSnapshot(engine.getId());
   }
 
   /**
@@ -6384,11 +6389,16 @@ public abstract class AbstractStorage
    * @return the scoped null snapshot, or {@code null} if no engine with this name exists
    */
   @Nullable public IndexesSnapshot getNullIndexSnapshotByEngineName(String engineName) {
-    var engine = indexEngineNameMap.get(engineName);
-    if (engine == null) {
-      return null;
+    stateLock.readLock().lock();
+    try {
+      var engine = indexEngineNameMap.get(engineName);
+      if (engine == null) {
+        return null;
+      }
+      return subNullIndexSnapshot(engine.getId());
+    } finally {
+      stateLock.readLock().unlock();
     }
-    return subNullIndexSnapshot(engine.getId());
   }
 
   private static final String NULL_TREE_SUFFIX = "$null";
@@ -6420,11 +6430,19 @@ public abstract class AbstractStorage
       snapshotMap = sharedIndexesSnapshot;
     }
 
-    var engine = indexEngineNameMap.get(resolvedName);
-    if (engine == null) {
-      return false;
+    // indexEngineNameMap is a plain HashMap — guard with stateLock.readLock()
+    // to avoid racing with concurrent index creation/deletion.
+    final long indexId;
+    stateLock.readLock().lock();
+    try {
+      var engine = indexEngineNameMap.get(resolvedName);
+      if (engine == null) {
+        return false;
+      }
+      indexId = engine.getId();
+    } finally {
+      stateLock.readLock().unlock();
     }
-    long indexId = engine.getId();
 
     // Build range keys: CompositeKey(indexId, userKeyPrefix..., lwm) to
     // CompositeKey(indexId, userKeyPrefix..., Long.MAX_VALUE)

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/CellBTreeSingleValue.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/CellBTreeSingleValue.java
@@ -119,4 +119,13 @@ public interface CellBTreeSingleValue<K> {
    */
   void addToApproximateEntriesCount(
       @Nonnull AtomicOperation atomicOperation, long delta);
+
+  /**
+   * Sets the cached engine ID for lock-free snapshot queries during
+   * tombstone GC. Called by the owning index engine after construction.
+   * Default no-op for implementations that don't support GC.
+   */
+  default void setEngineId(long engineId) {
+    // no-op by default
+  }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -29,6 +29,8 @@ import com.jetbrains.youtrackdb.internal.common.util.RawPair;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.TooBigIndexKeyException;
+import com.jetbrains.youtrackdb.internal.core.id.SnapshotMarkerRID;
+import com.jetbrains.youtrackdb.internal.core.id.TombstoneRID;
 import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
 import com.jetbrains.youtrackdb.internal.core.index.IndexesSnapshot;
 import com.jetbrains.youtrackdb.internal.core.index.comparator.AlwaysGreaterKey;
@@ -728,7 +730,31 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
                 sizeDiff = 1;
               }
 
+              // GC flag: attempt tombstone filtering at most once per insert.
+              // If GC frees enough space, the retry succeeds without splitting.
+              // If not, the normal split proceeds on the already-filtered bucket.
+              boolean gcAttempted = false;
+
               while (!keyBucket.addLeafEntry(insertionIndex, serializedKey, serializedValue)) {
+                // Attempt tombstone GC before splitting — removes tombstones
+                // below the global LWM and demotes stale SnapshotMarkerRIDs.
+                if (!gcAttempted) {
+                  gcAttempted = true;
+                  int removedCount =
+                      filterAndRebuildBucket(keyBucket);
+                  if (removedCount > 0) {
+                    updateSize(-removedCount, atomicOperation);
+                    // Re-derive insertion index — bucket contents shifted after GC.
+                    insertionIndex =
+                        -keyBucket.find(
+                            serializedKey, keySerializer, serializerFactory) - 1;
+                    assert insertionIndex >= 0
+                        : "Insertion index must be non-negative after GC, got "
+                            + insertionIndex;
+                    continue;
+                  }
+                }
+
                 bucketSearchResult =
                     splitBucket(
                         keyBucket,
@@ -2731,5 +2757,127 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
     }
 
     return false;
+  }
+
+  // ---- Tombstone GC helpers (used during leaf page split) ----
+
+  /**
+   * Filters removable tombstones from a leaf bucket and rebuilds it in-place
+   * with only the surviving entries. Stale {@link SnapshotMarkerRID} entries
+   * are demoted to plain {@code RecordId} in the raw bytes.
+   *
+   * <p>A tombstone is removable when:
+   * <ol>
+   *   <li>Its value is a {@link TombstoneRID}</li>
+   *   <li>Its version (last CompositeKey element) is strictly below LWM</li>
+   * </ol>
+   *
+   * <p>A {@link SnapshotMarkerRID} is demotable when:
+   * <ol>
+   *   <li>Its version is strictly below LWM</li>
+   *   <li>No snapshot entries with version >= LWM exist for the same
+   *       user-key prefix</li>
+   * </ol>
+   *
+   * @return the number of entries removed (tombstones deleted); demotions
+   *     do not change the count
+   */
+  private int filterAndRebuildBucket(
+      final CellBTreeSingleValueBucketV3<K> keyBucket) {
+    final long lwm = storage.computeGlobalLowWaterMark();
+    assert lwm >= 0 : "Global LWM must be non-negative, got " + lwm;
+    assert keyBucket.isLeaf() : "GC must only run on leaf buckets";
+
+    final int bucketSize = keyBucket.size();
+    final List<byte[]> survivors = new ArrayList<>(bucketSize);
+    int removedCount = 0;
+    boolean demoted = false;
+
+    for (int i = 0; i < bucketSize; i++) {
+      final var value =
+          keyBucket.getValue(i, keySerializer, serializerFactory);
+
+      // Plain RecordId — not a tombstone or marker, always a survivor.
+      // Skip key deserialization for performance (T5 optimization).
+      if (!(value instanceof TombstoneRID) && !(value instanceof SnapshotMarkerRID)) {
+        survivors.add(
+            keyBucket.getRawEntry(i, keySerializer, serializerFactory));
+        continue;
+      }
+
+      final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
+
+      // Extract version — always the last element of the CompositeKey
+      final long version;
+      if (key instanceof CompositeKey compositeKey) {
+        version = (Long) compositeKey.getKeys().getLast();
+      } else {
+        // Not a versioned key — keep as-is
+        survivors.add(
+            keyBucket.getRawEntry(i, keySerializer, serializerFactory));
+        continue;
+      }
+
+      if (value instanceof TombstoneRID && version < lwm) {
+        // Tombstone below LWM — remove (GC'd)
+        removedCount++;
+      } else if (value instanceof SnapshotMarkerRID && version < lwm) {
+        // SnapshotMarkerRID below LWM — demote to plain RecordId if no
+        // active snapshot entries exist for this user-key prefix
+        var userKeyPrefix = new CompositeKey(
+            compositeKey.getKeys().subList(
+                0, compositeKey.getKeys().size() - 1));
+        if (!storage.hasActiveIndexSnapshotEntries(getName(), userKeyPrefix, lwm)) {
+          survivors.add(
+              demoteMarkerRawBytes(
+                  keyBucket.getRawEntry(i, keySerializer, serializerFactory)));
+          demoted = true;
+        } else {
+          survivors.add(
+              keyBucket.getRawEntry(i, keySerializer, serializerFactory));
+        }
+      } else {
+        survivors.add(
+            keyBucket.getRawEntry(i, keySerializer, serializerFactory));
+      }
+    }
+
+    if (removedCount == 0 && !demoted) {
+      return 0;
+    }
+
+    assert removedCount + survivors.size() == bucketSize
+        : "Partition invariant violated: removed (" + removedCount
+            + ") + survivors (" + survivors.size()
+            + ") != original size (" + bucketSize + ")";
+
+    keyBucket.shrink(0, keySerializer, serializerFactory);
+    keyBucket.addAll(survivors, keySerializer);
+
+    return removedCount;
+  }
+
+  /**
+   * Demotes a {@link SnapshotMarkerRID} in a raw leaf entry to a plain
+   * {@code RecordId} by rewriting the encoded {@code collectionPosition}.
+   *
+   * <p>Raw leaf entry layout: {@code [key_bytes | 2-byte collectionId | 8-byte
+   * collectionPosition]}. For {@code SnapshotMarkerRID}, the
+   * {@code collectionPosition} is encoded as {@code -(realPos + 1)}. This
+   * method decodes it back to the real positive value.
+   *
+   * @param rawEntry the raw entry bytes (modified in-place and returned)
+   * @return the same byte array with the position corrected
+   */
+  private static byte[] demoteMarkerRawBytes(byte[] rawEntry) {
+    // collectionPosition is the last 8 bytes of the raw entry
+    int posOffset = rawEntry.length - LongSerializer.LONG_SIZE;
+    long encodedPosition = LongSerializer.deserializeNative(rawEntry, posOffset);
+    // SnapshotMarkerRID encodes as -(realPos + 1); decode back
+    long realPosition = -(encodedPosition + 1);
+    assert realPosition >= 0
+        : "Demoted position must be non-negative, got " + realPosition;
+    LongSerializer.serializeNative(realPosition, rawEntry, posOffset);
+    return rawEntry;
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -2807,10 +2807,19 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
 
       final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
 
-      // Extract version — always the last element of the CompositeKey
+      // Extract version — always the last element of the CompositeKey.
+      // Defensive: guard against empty keys or non-Long last element to
+      // avoid NoSuchElementException / ClassCastException if the BTree
+      // is ever used with a non-standard key structure.
       final long version;
       if (key instanceof CompositeKey compositeKey) {
-        version = (Long) compositeKey.getKeys().getLast();
+        final var keys = compositeKey.getKeys();
+        if (keys.isEmpty() || !(keys.getLast() instanceof Long v)) {
+          survivors.add(
+              keyBucket.getRawEntry(i, keySerializer, serializerFactory));
+          continue;
+        }
+        version = v;
       } else {
         // Not a versioned key — keep as-is
         survivors.add(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -2909,6 +2909,9 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
         : "Partition invariant violated: removed (" + removedCount
             + ") + survivors (" + survivors.size()
             + ") != original size (" + bucketSize + ")";
+    assert survivors.size() <= bucketSize
+        : "Survivors (" + survivors.size()
+            + ") cannot exceed original bucket size (" + bucketSize + ")";
 
     keyBucket.clear();
     assert keyBucket.size() == 0

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -120,6 +120,11 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
   private final BinarySerializerFactory serializerFactory;
   private volatile PropertyTypeInternal[] keyTypes;
 
+  // Cached engine ID for lock-free snapshot queries during GC.
+  // Set by the owning index engine after construction via setEngineId().
+  // -1 means not set (GC will skip snapshot-entry checks).
+  private volatile long engineId = -1;
+
   public BTree(
       @Nonnull final String name,
       final String dataFileExtension,
@@ -148,6 +153,17 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
     } finally {
       releaseExclusiveLock();
     }
+  }
+
+  /**
+   * Sets the cached engine ID for this BTree, used during tombstone GC to
+   * perform lock-free snapshot queries via
+   * {@link AbstractStorage#hasActiveIndexSnapshotEntriesById}.
+   * Must be called by the owning index engine after construction.
+   */
+  @Override
+  public void setEngineId(long engineId) {
+    this.engineId = engineId;
   }
 
   @Override
@@ -2762,9 +2778,45 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
   // ---- Tombstone GC helpers (used during leaf page split) ----
 
   /**
+   * Extracts the version from a CompositeKey — always the last element.
+   * Returns -1 if the key is not a versioned CompositeKey (empty keys,
+   * non-Long last element, or non-CompositeKey).
+   */
+  private static long extractVersion(Object key) {
+    if (key instanceof CompositeKey compositeKey) {
+      final var keys = compositeKey.getKeys();
+      if (!keys.isEmpty() && keys.getLast() instanceof Long v) {
+        return v;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Checks whether any active snapshot entries exist for the given
+   * user-key prefix, using the cached {@link #engineId} for a lock-free
+   * lookup. Falls back to {@code false} (safe: never demotes) if the
+   * engine ID was not set.
+   */
+  private boolean hasActiveSnapshotEntries(
+      CompositeKey compositeKey, long lwm) {
+    if (engineId < 0) {
+      // engineId not set — conservatively assume active entries exist,
+      // so markers are not demoted.
+      return true;
+    }
+    var allKeys = compositeKey.getKeys();
+    var userKeyPrefix = new CompositeKey(
+        allKeys.subList(0, allKeys.size() - 1));
+    boolean isNullTree = getName().endsWith("$null");
+    return storage.hasActiveIndexSnapshotEntriesById(
+        engineId, isNullTree, userKeyPrefix, lwm);
+  }
+
+  /**
    * Filters removable tombstones from a leaf bucket and rebuilds it in-place
    * with only the surviving entries. Stale {@link SnapshotMarkerRID} entries
-   * are demoted to plain {@code RecordId} in the raw bytes.
+   * are demoted to plain {@code RecordId} directly on the page.
    *
    * <p>A tombstone is removable when:
    * <ol>
@@ -2784,76 +2836,67 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
    */
   private int filterAndRebuildBucket(
       final CellBTreeSingleValueBucketV3<K> keyBucket) {
-    final long lwm = storage.computeGlobalLowWaterMark();
-    assert lwm > 0 : "Global LWM must be positive, got " + lwm;
     assert keyBucket.isLeaf() : "GC must only run on leaf buckets";
 
+    // Prescan: check raw value bytes for tombstones/markers without
+    // allocating RID objects or byte arrays. Early-out when the bucket
+    // contains only plain RecordId entries (common case for append-heavy
+    // workloads).
+    if (!keyBucket.hasAnyTombstoneOrMarker(keySerializer, serializerFactory)) {
+      return 0;
+    }
+
+    final long lwm = storage.computeGlobalLowWaterMark();
+    assert lwm > 0 : "Global LWM must be positive, got " + lwm;
+
+    // First pass: classify entries and apply in-place demotions.
+    // Collect indices of tombstones to remove; demote markers directly
+    // on the page without rebuilding.
     final int bucketSize = keyBucket.size();
-    final List<byte[]> survivors = new ArrayList<>(bucketSize);
-    int removedCount = 0;
-    boolean demoted = false;
+    IntList tombstoneIndices = null;
 
     for (int i = 0; i < bucketSize; i++) {
       final var value =
           keyBucket.getValue(i, keySerializer, serializerFactory);
 
-      // Plain RecordId — not a tombstone or marker, always a survivor.
-      // Skip key deserialization for performance (T5 optimization).
-      if (!(value instanceof TombstoneRID) && !(value instanceof SnapshotMarkerRID)) {
-        survivors.add(
-            keyBucket.getRawEntry(i, keySerializer, serializerFactory));
-        continue;
-      }
-
-      final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
-
-      // Extract version — always the last element of the CompositeKey.
-      // Defensive: guard against empty keys or non-Long last element to
-      // avoid NoSuchElementException / ClassCastException if the BTree
-      // is ever used with a non-standard key structure.
-      final long version;
-      if (key instanceof CompositeKey compositeKey) {
-        final var keys = compositeKey.getKeys();
-        if (keys.isEmpty() || !(keys.getLast() instanceof Long v)) {
-          survivors.add(
-              keyBucket.getRawEntry(i, keySerializer, serializerFactory));
-          continue;
+      if (value instanceof TombstoneRID) {
+        final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
+        final long version = extractVersion(key);
+        if (version >= 0 && version < lwm) {
+          if (tombstoneIndices == null) {
+            tombstoneIndices = new IntArrayList();
+          }
+          tombstoneIndices.add(i);
         }
-        version = v;
-      } else {
-        // Not a versioned key — keep as-is
-        survivors.add(
-            keyBucket.getRawEntry(i, keySerializer, serializerFactory));
-        continue;
-      }
-
-      if (value instanceof TombstoneRID && version < lwm) {
-        // Tombstone below LWM — remove (GC'd)
-        removedCount++;
-      } else if (value instanceof SnapshotMarkerRID && version < lwm) {
-        // SnapshotMarkerRID below LWM — demote to plain RecordId if no
-        // active snapshot entries exist for this user-key prefix
-        var allKeys = compositeKey.getKeys();
-        var userKeyPrefix = new CompositeKey(
-            allKeys.subList(0, allKeys.size() - 1));
-        if (!storage.hasActiveIndexSnapshotEntries(
-            getName(), userKeyPrefix, lwm)) {
-          survivors.add(
-              demoteMarkerRawBytes(
-                  keyBucket.getRawEntry(i, keySerializer, serializerFactory)));
-          demoted = true;
-        } else {
-          survivors.add(
-              keyBucket.getRawEntry(i, keySerializer, serializerFactory));
+      } else if (value instanceof SnapshotMarkerRID) {
+        final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
+        final long version = extractVersion(key);
+        if (version >= 0 && version < lwm
+            && key instanceof CompositeKey compositeKey
+            && !hasActiveSnapshotEntries(compositeKey, lwm)) {
+          // Demote in-place on the page (WAL-tracked via setLongValue)
+          keyBucket.demoteSnapshotMarkerValue(
+              i, keySerializer, serializerFactory);
         }
-      } else {
-        survivors.add(
-            keyBucket.getRawEntry(i, keySerializer, serializerFactory));
       }
+      // Plain RecordId entries and entries above LWM are left untouched.
     }
 
-    if (removedCount == 0 && !demoted) {
+    if (tombstoneIndices == null) {
+      // No tombstones to remove. Demotions (if any) were applied in-place
+      // and don't free space, so no rebuild needed.
       return 0;
+    }
+
+    // Second pass: rebuild the bucket without the removed tombstones.
+    final int removedCount = tombstoneIndices.size();
+    final var tombstoneSet = new IntOpenHashSet(tombstoneIndices);
+    final List<byte[]> survivors = new ArrayList<>(bucketSize - removedCount);
+    for (int i = 0; i < bucketSize; i++) {
+      if (!tombstoneSet.contains(i)) {
+        survivors.add(
+            keyBucket.getRawEntry(i, keySerializer, serializerFactory));
+      }
     }
 
     assert removedCount + survivors.size() == bucketSize
@@ -2861,38 +2904,14 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
             + ") + survivors (" + survivors.size()
             + ") != original size (" + bucketSize + ")";
 
-    keyBucket.shrink(0, keySerializer, serializerFactory);
+    keyBucket.clear();
     assert keyBucket.size() == 0
-        : "Bucket must be empty after shrink(0), got " + keyBucket.size();
+        : "Bucket must be empty after clear(), got " + keyBucket.size();
     keyBucket.addAll(survivors, keySerializer);
     assert keyBucket.size() == survivors.size()
         : "Bucket size after rebuild (" + keyBucket.size()
             + ") must equal survivor count (" + survivors.size() + ")";
 
     return removedCount;
-  }
-
-  /**
-   * Demotes a {@link SnapshotMarkerRID} in a raw leaf entry to a plain
-   * {@code RecordId} by rewriting the encoded {@code collectionPosition}.
-   *
-   * <p>Raw leaf entry layout: {@code [key_bytes | 2-byte collectionId | 8-byte
-   * collectionPosition]}. For {@code SnapshotMarkerRID}, the
-   * {@code collectionPosition} is encoded as {@code -(realPos + 1)}. This
-   * method decodes it back to the real positive value.
-   *
-   * @param rawEntry the raw entry bytes (modified in-place and returned)
-   * @return the same byte array with the position corrected
-   */
-  private static byte[] demoteMarkerRawBytes(byte[] rawEntry) {
-    // collectionPosition is the last 8 bytes of the raw entry
-    int posOffset = rawEntry.length - LongSerializer.LONG_SIZE;
-    long encodedPosition = LongSerializer.deserializeNative(rawEntry, posOffset);
-    // SnapshotMarkerRID encodes as -(realPos + 1); decode back
-    long realPosition = -(encodedPosition + 1);
-    assert realPosition >= 0
-        : "Demoted position must be non-negative, got " + realPosition;
-    LongSerializer.serializeNative(realPosition, rawEntry, posOffset);
-    return rawEntry;
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -2785,7 +2785,7 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
   private int filterAndRebuildBucket(
       final CellBTreeSingleValueBucketV3<K> keyBucket) {
     final long lwm = storage.computeGlobalLowWaterMark();
-    assert lwm >= 0 : "Global LWM must be non-negative, got " + lwm;
+    assert lwm > 0 : "Global LWM must be positive, got " + lwm;
     assert keyBucket.isLeaf() : "GC must only run on leaf buckets";
 
     final int bucketSize = keyBucket.size();
@@ -2852,7 +2852,12 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
             + ") != original size (" + bucketSize + ")";
 
     keyBucket.shrink(0, keySerializer, serializerFactory);
+    assert keyBucket.size() == 0
+        : "Bucket must be empty after shrink(0), got " + keyBucket.size();
     keyBucket.addAll(survivors, keySerializer);
+    assert keyBucket.size() == survivors.size()
+        : "Bucket size after rebuild (" + keyBucket.size()
+            + ") must equal survivor count (" + survivors.size() + ")";
 
     return removedCount;
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -2847,6 +2847,7 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
     // Single pass: classify entries from raw bytes, deserialize keys only
     // for tombstones/markers. LWM is computed lazily on first candidate.
     final int bucketSize = keyBucket.size();
+    assert bucketSize > 0 : "filterAndRebuildBucket called on empty bucket";
     long lwm = -1;
     boolean isNullTree = false;
     IntList tombstoneIndices = null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -2795,11 +2795,13 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
   /**
    * Checks whether any active snapshot entries exist for the given
    * user-key prefix, using the cached {@link #engineId} for a lock-free
-   * lookup. Falls back to {@code false} (safe: never demotes) if the
+   * lookup. Falls back to {@code true} (safe: never demotes) if the
    * engine ID was not set.
+   *
+   * @param isNullTree pre-computed flag for null-tree detection
    */
   private boolean hasActiveSnapshotEntries(
-      CompositeKey compositeKey, long lwm) {
+      CompositeKey compositeKey, boolean isNullTree, long lwm) {
     if (engineId < 0) {
       // engineId not set — conservatively assume active entries exist,
       // so markers are not demoted.
@@ -2808,7 +2810,6 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
     var allKeys = compositeKey.getKeys();
     var userKeyPrefix = new CompositeKey(
         allKeys.subList(0, allKeys.size() - 1));
-    boolean isNullTree = getName().endsWith("$null");
     return storage.hasActiveIndexSnapshotEntriesById(
         engineId, isNullTree, userKeyPrefix, lwm);
   }
@@ -2817,6 +2818,11 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
    * Filters removable tombstones from a leaf bucket and rebuilds it in-place
    * with only the surviving entries. Stale {@link SnapshotMarkerRID} entries
    * are demoted to plain {@code RecordId} directly on the page.
+   *
+   * <p>Uses a single scan that classifies each entry's value type from raw
+   * bytes (zero RID allocations for plain entries), then deserializes the
+   * key only for tombstones and markers that need version checking. The LWM
+   * is computed lazily on the first tombstone/marker encountered.
    *
    * <p>A tombstone is removable when:
    * <ol>
@@ -2838,48 +2844,47 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
       final CellBTreeSingleValueBucketV3<K> keyBucket) {
     assert keyBucket.isLeaf() : "GC must only run on leaf buckets";
 
-    // Prescan: check raw value bytes for tombstones/markers without
-    // allocating RID objects or byte arrays. Early-out when the bucket
-    // contains only plain RecordId entries (common case for append-heavy
-    // workloads).
-    if (!keyBucket.hasAnyTombstoneOrMarker(keySerializer, serializerFactory)) {
-      return 0;
-    }
-
-    final long lwm = storage.computeGlobalLowWaterMark();
-    assert lwm > 0 : "Global LWM must be positive, got " + lwm;
-
-    // First pass: classify entries and apply in-place demotions.
-    // Collect indices of tombstones to remove; demote markers directly
-    // on the page without rebuilding.
+    // Single pass: classify entries from raw bytes, deserialize keys only
+    // for tombstones/markers. LWM is computed lazily on first candidate.
     final int bucketSize = keyBucket.size();
+    long lwm = -1;
+    boolean isNullTree = false;
     IntList tombstoneIndices = null;
 
     for (int i = 0; i < bucketSize; i++) {
-      final var value =
-          keyBucket.getValue(i, keySerializer, serializerFactory);
+      final var type =
+          keyBucket.classifyValueType(i, keySerializer, serializerFactory);
+      if (type == CellBTreeSingleValueBucketV3.ValueType.PLAIN) {
+        continue;
+      }
 
-      if (value instanceof TombstoneRID) {
-        final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
-        final long version = extractVersion(key);
-        if (version >= 0 && version < lwm) {
-          if (tombstoneIndices == null) {
-            tombstoneIndices = new IntArrayList();
-          }
-          tombstoneIndices.add(i);
+      // Compute LWM lazily on first tombstone/marker encountered.
+      if (lwm < 0) {
+        lwm = storage.computeGlobalLowWaterMark();
+        assert lwm >= 0 : "Global LWM must be non-negative, got " + lwm;
+        isNullTree = getName().endsWith(AbstractStorage.NULL_TREE_SUFFIX);
+      }
+
+      final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
+      final long version = extractVersion(key);
+      if (version < 0 || version >= lwm) {
+        continue;
+      }
+
+      if (type == CellBTreeSingleValueBucketV3.ValueType.TOMBSTONE) {
+        if (tombstoneIndices == null) {
+          tombstoneIndices = new IntArrayList();
         }
-      } else if (value instanceof SnapshotMarkerRID) {
-        final var key = keyBucket.getKey(i, keySerializer, serializerFactory);
-        final long version = extractVersion(key);
-        if (version >= 0 && version < lwm
-            && key instanceof CompositeKey compositeKey
-            && !hasActiveSnapshotEntries(compositeKey, lwm)) {
+        tombstoneIndices.add(i);
+      } else {
+        // MARKER — demote if no active snapshot entries exist
+        if (key instanceof CompositeKey compositeKey
+            && !hasActiveSnapshotEntries(compositeKey, isNullTree, lwm)) {
           // Demote in-place on the page (WAL-tracked via setLongValue)
           keyBucket.demoteSnapshotMarkerValue(
               i, keySerializer, serializerFactory);
         }
       }
-      // Plain RecordId entries and entries above LWM are left untouched.
     }
 
     if (tombstoneIndices == null) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTree.java
@@ -2833,10 +2833,11 @@ public final class BTree<K> extends StorageComponent implements CellBTreeSingleV
       } else if (value instanceof SnapshotMarkerRID && version < lwm) {
         // SnapshotMarkerRID below LWM — demote to plain RecordId if no
         // active snapshot entries exist for this user-key prefix
+        var allKeys = compositeKey.getKeys();
         var userKeyPrefix = new CompositeKey(
-            compositeKey.getKeys().subList(
-                0, compositeKey.getKeys().size() - 1));
-        if (!storage.hasActiveIndexSnapshotEntries(getName(), userKeyPrefix, lwm)) {
+            allKeys.subList(0, allKeys.size() - 1));
+        if (!storage.hasActiveIndexSnapshotEntries(
+            getName(), userKeyPrefix, lwm)) {
           survivors.add(
               demoteMarkerRawBytes(
                   keyBucket.getRawEntry(i, keySerializer, serializerFactory)));

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
@@ -476,6 +476,7 @@ public final class CellBTreeSingleValueBucketV3<K> extends DurablePage {
    * into byte arrays only to discard them.
    */
   public void clear() {
+    assert isLeaf() : "clear() must only be called on leaf buckets";
     setFreePointer(MAX_PAGE_SIZE_BYTES);
     setSize(0);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
@@ -470,6 +470,70 @@ public final class CellBTreeSingleValueBucketV3<K> extends DurablePage {
     setSize(newSize);
   }
 
+  /**
+   * Resets the bucket to an empty state without reading any existing entries.
+   * More efficient than {@code shrink(0)} which materializes all entries
+   * into byte arrays only to discard them.
+   */
+  public void clear() {
+    setFreePointer(MAX_PAGE_SIZE_BYTES);
+    setSize(0);
+  }
+
+  /**
+   * Checks whether any entry in this leaf bucket has a tombstone or snapshot
+   * marker value, by inspecting only the raw value bytes (collectionId sign
+   * and collectionPosition sign) without allocating RID objects or byte arrays.
+   *
+   * @return {@code true} if at least one entry is a {@link TombstoneRID}
+   *     or {@link SnapshotMarkerRID}
+   */
+  public boolean hasAnyTombstoneOrMarker(
+      final BinarySerializer<K> keySerializer,
+      final BinarySerializerFactory serializerFactory) {
+    assert isLeaf();
+    final int bucketSize = size();
+    for (int i = 0; i < bucketSize; i++) {
+      var entryPosition = getPointer(i);
+      entryPosition +=
+          getObjectSizeInDirectMemory(keySerializer, serializerFactory, entryPosition);
+      final int collectionId = getShortValue(entryPosition);
+      if (collectionId < 0) {
+        return true;
+      }
+      final long collectionPosition =
+          getLongValue(entryPosition + ShortSerializer.SHORT_SIZE);
+      if (collectionPosition < 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Demotes a {@link SnapshotMarkerRID} value to a plain {@code RecordId}
+   * in-place on the page by rewriting the encoded {@code collectionPosition}.
+   *
+   * <p>{@code SnapshotMarkerRID} encodes as {@code -(realPos + 1)}. This
+   * method decodes it back to the real positive value and writes it directly
+   * to the page buffer (WAL-tracked via {@code setLongValue}).
+   */
+  public void demoteSnapshotMarkerValue(
+      final int entryIndex,
+      final BinarySerializer<K> keySerializer,
+      final BinarySerializerFactory serializerFactory) {
+    assert isLeaf();
+    var entryPosition = getPointer(entryIndex);
+    entryPosition +=
+        getObjectSizeInDirectMemory(keySerializer, serializerFactory, entryPosition);
+    final int posOffset = entryPosition + ShortSerializer.SHORT_SIZE;
+    final long encodedPosition = getLongValue(posOffset);
+    final long realPosition = -(encodedPosition + 1);
+    assert realPosition >= 0
+        : "Demoted position must be non-negative, got " + realPosition;
+    setLongValue(posOffset, realPosition);
+  }
+
   private void setSize(final int newSize) {
     setIntValue(SIZE_OFFSET, newSize);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
@@ -494,6 +494,9 @@ public final class CellBTreeSingleValueBucketV3<K> extends DurablePage {
       final BinarySerializer<K> keySerializer,
       final BinarySerializerFactory serializerFactory) {
     assert isLeaf();
+    assert entryIndex >= 0 && entryIndex < size()
+        : "classifyValueType index out of bounds: " + entryIndex
+            + ", size=" + size();
     var entryPosition = getPointer(entryIndex);
     entryPosition +=
         getObjectSizeInDirectMemory(keySerializer, serializerFactory, entryPosition);
@@ -527,11 +530,18 @@ public final class CellBTreeSingleValueBucketV3<K> extends DurablePage {
       final BinarySerializer<K> keySerializer,
       final BinarySerializerFactory serializerFactory) {
     assert isLeaf();
+    assert entryIndex >= 0 && entryIndex < size()
+        : "demoteSnapshotMarkerValue index out of bounds: " + entryIndex
+            + ", size=" + size();
     var entryPosition = getPointer(entryIndex);
     entryPosition +=
         getObjectSizeInDirectMemory(keySerializer, serializerFactory, entryPosition);
     final int posOffset = entryPosition + ShortSerializer.SHORT_SIZE;
     final long encodedPosition = getLongValue(posOffset);
+    assert encodedPosition < 0
+        : "demoteSnapshotMarkerValue called on non-marker entry:"
+            + " encodedPosition=" + encodedPosition
+            + " at index " + entryIndex;
     final long realPosition = -(encodedPosition + 1);
     assert realPosition >= 0
         : "Demoted position must be non-negative, got " + realPosition;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/CellBTreeSingleValueBucketV3.java
@@ -481,33 +481,37 @@ public final class CellBTreeSingleValueBucketV3<K> extends DurablePage {
   }
 
   /**
-   * Checks whether any entry in this leaf bucket has a tombstone or snapshot
-   * marker value, by inspecting only the raw value bytes (collectionId sign
-   * and collectionPosition sign) without allocating RID objects or byte arrays.
+   * Classifies the value type of the entry at the given index by inspecting
+   * only the raw value bytes (collectionId sign and collectionPosition sign)
+   * without allocating RID objects.
    *
-   * @return {@code true} if at least one entry is a {@link TombstoneRID}
-   *     or {@link SnapshotMarkerRID}
+   * @return {@link ValueType#TOMBSTONE} if collectionId is negative,
+   *     {@link ValueType#MARKER} if collectionPosition is negative,
+   *     {@link ValueType#PLAIN} otherwise
    */
-  public boolean hasAnyTombstoneOrMarker(
+  public ValueType classifyValueType(
+      final int entryIndex,
       final BinarySerializer<K> keySerializer,
       final BinarySerializerFactory serializerFactory) {
     assert isLeaf();
-    final int bucketSize = size();
-    for (int i = 0; i < bucketSize; i++) {
-      var entryPosition = getPointer(i);
-      entryPosition +=
-          getObjectSizeInDirectMemory(keySerializer, serializerFactory, entryPosition);
-      final int collectionId = getShortValue(entryPosition);
-      if (collectionId < 0) {
-        return true;
-      }
-      final long collectionPosition =
-          getLongValue(entryPosition + ShortSerializer.SHORT_SIZE);
-      if (collectionPosition < 0) {
-        return true;
-      }
+    var entryPosition = getPointer(entryIndex);
+    entryPosition +=
+        getObjectSizeInDirectMemory(keySerializer, serializerFactory, entryPosition);
+    final int collectionId = getShortValue(entryPosition);
+    if (collectionId < 0) {
+      return ValueType.TOMBSTONE;
     }
-    return false;
+    final long collectionPosition =
+        getLongValue(entryPosition + ShortSerializer.SHORT_SIZE);
+    if (collectionPosition < 0) {
+      return ValueType.MARKER;
+    }
+    return ValueType.PLAIN;
+  }
+
+  /** Classification of a leaf entry's value without RID allocation. */
+  enum ValueType {
+    PLAIN, TOMBSTONE, MARKER
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeGCTestSupport.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeGCTestSupport.java
@@ -13,6 +13,13 @@ import java.util.concurrent.locks.ReadWriteLock;
  * Shared test infrastructure for BTree tombstone GC tests.
  * Provides a stub {@link BaseIndexEngine} for {@code indexEngineNameMap} registration
  * and reflection helpers for LWM pinning and engine registration/unregistration.
+ *
+ * <p><b>Fragile reflection coupling:</b> This class accesses private fields of
+ * {@link AbstractStorage} ({@code tsMins}, {@code stateLock}, {@code indexEngineNameMap})
+ * and the package-private class {@code TsMinHolder} via reflection. If any of
+ * these fields are renamed or their types change, this class will fail at runtime
+ * with reflection errors rather than compile-time failures. Update field names here
+ * whenever the corresponding {@code AbstractStorage} internals change.
  */
 final class BTreeGCTestSupport {
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeGCTestSupport.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeGCTestSupport.java
@@ -1,0 +1,229 @@
+package com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+
+/**
+ * Shared test infrastructure for BTree tombstone GC tests.
+ * Provides a stub {@link BaseIndexEngine} for {@code indexEngineNameMap} registration
+ * and reflection helpers for LWM pinning and engine registration/unregistration.
+ */
+final class BTreeGCTestSupport {
+
+  private BTreeGCTestSupport() {
+  }
+
+  // ---- LWM pinning helpers (via reflection) ----
+
+  @SuppressWarnings("unchecked")
+  static Object pinLwm(AbstractStorage storage, long lwmValue) throws Exception {
+    Class<?> holderClass = Class.forName(
+        "com.jetbrains.youtrackdb.internal.core.storage.impl.local.TsMinHolder");
+    var ctor = holderClass.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    Object holder = ctor.newInstance();
+    Field tsMinField = holderClass.getDeclaredField("tsMin");
+    tsMinField.setAccessible(true);
+    tsMinField.setLong(holder, lwmValue);
+
+    Field tsMinsField = AbstractStorage.class.getDeclaredField("tsMins");
+    tsMinsField.setAccessible(true);
+    Set<Object> tsMins = (Set<Object>) tsMinsField.get(storage);
+    tsMins.add(holder);
+    return holder;
+  }
+
+  @SuppressWarnings("unchecked")
+  static void unpinLwm(AbstractStorage storage, Object holder) throws Exception {
+    Field tsMinsField = AbstractStorage.class.getDeclaredField("tsMins");
+    tsMinsField.setAccessible(true);
+    Set<Object> tsMins = (Set<Object>) tsMinsField.get(storage);
+    tsMins.remove(holder);
+  }
+
+  // ---- Stub engine registration (via reflection) ----
+
+  /**
+   * Registers a minimal stub {@link BaseIndexEngine} in AbstractStorage's
+   * {@code indexEngineNameMap} so that snapshot entry queries can resolve the
+   * index. Acquires stateLock.writeLock() because indexEngineNameMap is a plain
+   * HashMap that requires external synchronization.
+   */
+  @SuppressWarnings("unchecked")
+  static void registerStubEngine(
+      AbstractStorage storage, String name, int id) throws Exception {
+    BaseIndexEngine stub = new StubIndexEngine(name, id);
+    var lock = getStateLock(storage);
+    lock.writeLock().lock();
+    try {
+      Field mapField =
+          AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+      mapField.setAccessible(true);
+      Map<String, BaseIndexEngine> map =
+          (Map<String, BaseIndexEngine>) mapField.get(storage);
+      map.put(name, stub);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static void unregisterStubEngine(
+      AbstractStorage storage, String name) throws Exception {
+    var lock = getStateLock(storage);
+    lock.writeLock().lock();
+    try {
+      Field mapField =
+          AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+      mapField.setAccessible(true);
+      Map<String, BaseIndexEngine> map =
+          (Map<String, BaseIndexEngine>) mapField.get(storage);
+      map.remove(name);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  static ReadWriteLock getStateLock(AbstractStorage storage) throws Exception {
+    Field lockField = AbstractStorage.class.getDeclaredField("stateLock");
+    lockField.setAccessible(true);
+    return (ReadWriteLock) lockField.get(storage);
+  }
+
+  // ---- Stub engine ----
+
+  /**
+   * Minimal {@link BaseIndexEngine} stub that provides only {@code getId()}
+   * and {@code getName()} — the only methods used by
+   * {@code AbstractStorage.hasActiveSnapshotEntries()}.
+   */
+  static class StubIndexEngine implements BaseIndexEngine {
+    private final String name;
+    private final int id;
+
+    StubIndexEngine(String name, int id) {
+      this.name = name;
+      this.id = id;
+    }
+
+    @Override
+    public int getId() {
+      return id;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public void init(
+        com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded s,
+        com.jetbrains.youtrackdb.internal.core.index.IndexMetadata m) {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void create(AtomicOperation o,
+        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d) {
+    }
+
+    @Override
+    public void load(
+        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d,
+        AtomicOperation o) {
+    }
+
+    @Override
+    public void delete(AtomicOperation o) {
+    }
+
+    @Override
+    public void clear(
+        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
+        AtomicOperation o) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesBetween(Object f, boolean fi, Object t, boolean ti,
+            boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer tr,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesMajor(Object k, boolean i, boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesMinor(Object k, boolean i, boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        stream(
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        descStream(
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<Object> keyStream(AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public long size(
+        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
+        com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+        AtomicOperation o) {
+      return 0;
+    }
+
+    @Override
+    public int getEngineAPIVersion() {
+      return 0;
+    }
+
+    @Override
+    public boolean acquireAtomicExclusiveLock(AtomicOperation o) {
+      return false;
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
@@ -198,6 +198,48 @@ public class BTreeTombstoneGCDurabilityTest {
           .as("Deleted values must not reappear after recovery (ghost resurrection)")
           .doesNotContainAnyElementsOf(deletedValues);
 
+      // Verify index-directed lookups work after recovery. A full scan
+      // reads records from clusters, bypassing the index — if the B-tree
+      // is corrupt but records are intact, the scan passes. Index-targeted
+      // queries exercise the B-tree structure directly.
+      var sampleSurvivors = survivingValues.stream().limit(10).toList();
+      for (var val : sampleSurvivors) {
+        try (var lookupResult = txVerify.query(
+            "SELECT FROM TestDoc WHERE value = ?", val)) {
+          assertThat(lookupResult.hasNext())
+              .as("Index lookup must find surviving value '%s' after recovery",
+                  val)
+              .isTrue();
+          assertThat(lookupResult.next().<String>getProperty("value"))
+              .isEqualTo(val);
+        }
+      }
+
+      var sampleNew = newValues.stream().limit(10).toList();
+      for (var val : sampleNew) {
+        try (var lookupResult = txVerify.query(
+            "SELECT FROM TestDoc WHERE value = ?", val)) {
+          assertThat(lookupResult.hasNext())
+              .as("Index lookup must find new value '%s' after recovery", val)
+              .isTrue();
+          assertThat(lookupResult.next().<String>getProperty("value"))
+              .isEqualTo(val);
+        }
+      }
+
+      // Verify deleted values are not found via index lookup either
+      // (ghost resurrection through index path)
+      var sampleDeleted = deletedValues.stream().limit(10).toList();
+      for (var val : sampleDeleted) {
+        try (var lookupResult = txVerify.query(
+            "SELECT FROM TestDoc WHERE value = ?", val)) {
+          assertThat(lookupResult.hasNext())
+              .as("Index lookup must NOT find deleted value '%s' after "
+                  + "recovery", val)
+              .isFalse();
+        }
+      }
+
       txVerify.commit();
     } finally {
       recoveredSession.close();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
@@ -109,9 +109,8 @@ public class BTreeTombstoneGCDurabilityTest {
     var survivingValues = new HashSet<String>();
     var deletedValues = new HashSet<String>();
     var newValues = new HashSet<String>();
-    // Store RIDs and values from phase 1 for cross-tx deletion in phase 2
+    // Store RIDs from phase 1 for cross-tx deletion in phase 2
     List<RID> allRids = new ArrayList<>();
-    List<String> allValues = new ArrayList<>();
 
     var session = ytdb.open(dbName, ADMIN, ADMIN_PWD);
     try {
@@ -127,7 +126,6 @@ public class BTreeTombstoneGCDurabilityTest {
         var doc = tx.newVertex("TestDoc");
         var val = "val" + String.format("%06d", i);
         doc.setProperty("value", val);
-        allValues.add(val);
         survivingValues.add(val);
       }
       tx.commit();
@@ -175,45 +173,30 @@ public class BTreeTombstoneGCDurabilityTest {
     try {
       var txVerify = recoveredSession.begin();
 
+      // Collect all values found via full scan after recovery
+      var recoveredValues = new HashSet<String>();
+      try (var results = txVerify.query("SELECT FROM TestDoc")) {
+        while (results.hasNext()) {
+          var val = results.next().<String>getProperty("value");
+          recoveredValues.add(val);
+        }
+      }
+
       // Build the full expected set: original survivors + new records
       var expectedValues = new HashSet<>(survivingValues);
       expectedValues.addAll(newValues);
 
-      // Verify each expected value is findable via index lookup
-      for (var val : expectedValues) {
-        try (var results = txVerify.query(
-            "SELECT FROM TestDoc WHERE value = ?", val)) {
-          assertThat(results.hasNext())
-              .as("Expected value '%s' must be findable via index after recovery",
-                  val)
-              .isTrue();
-        }
-      }
+      // Exact-match assertion: catches ghosts, missing entries, duplicates,
+      // and count mismatches in one shot with a clear diff in failure message.
+      assertThat(recoveredValues)
+          .as("Recovered values must exactly match expected survivors + new values")
+          .containsExactlyInAnyOrderElementsOf(expectedValues);
 
-      // Verify deleted values do NOT appear (no ghost resurrection)
-      for (var val : deletedValues) {
-        try (var results = txVerify.query(
-            "SELECT FROM TestDoc WHERE value = ?", val)) {
-          assertThat(results.hasNext())
-              .as("Deleted value '%s' must not reappear after recovery "
-                  + "(ghost resurrection)", val)
-              .isFalse();
-        }
-      }
-
-      // Verify total count matches expected
-      long totalCount;
-      try (var countResults = txVerify.query(
-          "SELECT count(*) as cnt FROM TestDoc")) {
-        assertThat(countResults.hasNext()).isTrue();
-        totalCount = countResults.next().<Long>getProperty("cnt");
-      }
-
-      long expectedCount =
-          INITIAL_COUNT - DELETE_COUNT + INSERT_AFTER_DELETE_COUNT;
-      assertThat(totalCount)
-          .as("Total record count after recovery must match expected")
-          .isEqualTo(expectedCount);
+      // Separate ghost-resurrection check for diagnostic clarity —
+      // if it fails, the developer immediately knows the issue.
+      assertThat(recoveredValues)
+          .as("Deleted values must not reappear after recovery (ghost resurrection)")
+          .doesNotContainAnyElementsOf(deletedValues);
 
       txVerify.commit();
     } finally {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
@@ -212,6 +212,10 @@ public class BTreeTombstoneGCDurabilityTest {
               .isTrue();
           assertThat(lookupResult.next().<String>getProperty("value"))
               .isEqualTo(val);
+          assertThat(lookupResult.hasNext())
+              .as("Index lookup must return exactly one result for "
+                  + "surviving value '%s'", val)
+              .isFalse();
         }
       }
 
@@ -224,6 +228,10 @@ public class BTreeTombstoneGCDurabilityTest {
               .isTrue();
           assertThat(lookupResult.next().<String>getProperty("value"))
               .isEqualTo(val);
+          assertThat(lookupResult.hasNext())
+              .as("Index lookup must return exactly one result for "
+                  + "new value '%s'", val)
+              .isFalse();
         }
       }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCDurabilityTest.java
@@ -1,0 +1,223 @@
+package com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Vertex;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Durability test for tombstone GC in the index {@link BTree}.
+ *
+ * <p>Verifies that after a non-graceful shutdown (via {@code forceDatabaseClose}
+ * without prior session close), the database reopens with consistent index
+ * state: surviving entries are findable via index lookup, deleted entries do
+ * not reappear (no ghost resurrection), and no exceptions occur during
+ * traversal.
+ *
+ * <p><b>Note on crash fidelity:</b> {@code forceDatabaseClose} performs a
+ * storage-level shutdown that flushes WAL and dirty pages before closing.
+ * This means it tests durability across a non-graceful close (no explicit
+ * session close), not true mid-operation crash recovery. True WAL replay
+ * testing would require preventing the flush — e.g., by copying data files
+ * before operations and replaying WAL against the stale copy. The current
+ * test still provides value by verifying that GC-modified B-tree state
+ * survives the close/reopen cycle without corruption.
+ *
+ * <p>The test creates a class with an indexed STRING property, inserts enough
+ * records to fill multiple BTree buckets (~400+ entries), then performs
+ * cross-tx deletion + new inserts to trigger tombstone GC during bucket
+ * overflow.
+ *
+ * <p>Does NOT extend {@link DbTestBase} because we need explicit control
+ * over the database lifecycle (close, reopen, forceDatabaseClose).
+ */
+public class BTreeTombstoneGCDurabilityTest {
+
+  private static final String ADMIN = "admin";
+  private static final String ADMIN_PWD = "adminpwd";
+
+  // Enough entries to trigger multiple bucket overflows and GC in the index
+  // BTree. With ~30 bytes per entry (CompositeKey(String, Long) + RID) and
+  // ~8KB usable per bucket, ~250 entries per bucket. 500 entries ensures
+  // multiple splits.
+  private static final int INITIAL_COUNT = 500;
+
+  // Number of records to delete in the cross-tx phase. These create
+  // index tombstones that should be GC'd during subsequent inserts.
+  private static final int DELETE_COUNT = 200;
+
+  // Number of additional records to insert after deletion. These trigger
+  // bucket overflows that invoke tombstone GC.
+  private static final int INSERT_AFTER_DELETE_COUNT = 300;
+
+  private String testDir;
+  private YouTrackDBImpl ytdb;
+
+  @Before
+  public void setUp() {
+    testDir = DbTestBase.getBaseDirectoryPathStr(getClass());
+    ytdb = (YouTrackDBImpl) YourTracks.instance(testDir);
+  }
+
+  @After
+  public void tearDown() {
+    if (ytdb != null) {
+      ytdb.close();
+    }
+    FileUtils.deleteRecursively(new File(testDir));
+  }
+
+  /**
+   * Force-closes the database after tombstone GC has occurred (committed
+   * cross-tx deletions + new inserts that trigger GC), then reopens and
+   * verifies the index state is consistent.
+   *
+   * <p>The test flow:
+   * <ol>
+   *   <li>Create a class with an indexed STRING property. Insert
+   *       INITIAL_COUNT records (tx1, committed).</li>
+   *   <li>Delete DELETE_COUNT records in a new tx (creates cross-tx
+   *       index tombstones), then insert INSERT_AFTER_DELETE_COUNT new
+   *       records (triggers GC on tombstones during bucket overflow).
+   *       Commit tx2.</li>
+   *   <li>Force-close the database without session close.</li>
+   *   <li>Reopen and verify: surviving + new records are findable via
+   *       index lookup, deleted records not returned (no ghost
+   *       resurrection), total indexed count is correct.</li>
+   * </ol>
+   */
+  @Test
+  public void forceClose_afterTombstoneGC_preservesIndexEntries() {
+    var dbName = "forceCloseIndexGCRecovery";
+    ytdb.create(dbName, DatabaseType.DISK, ADMIN, ADMIN_PWD, "admin");
+
+    // Phase 1: Create schema, insert initial records, commit.
+    var survivingValues = new HashSet<String>();
+    var deletedValues = new HashSet<String>();
+    var newValues = new HashSet<String>();
+    // Store RIDs and values from phase 1 for cross-tx deletion in phase 2
+    List<RID> allRids = new ArrayList<>();
+    List<String> allValues = new ArrayList<>();
+
+    var session = ytdb.open(dbName, ADMIN, ADMIN_PWD);
+    try {
+      // Create schema with indexed property
+      var cls = session.createVertexClass("TestDoc");
+      cls.createProperty("value", PropertyType.STRING);
+      cls.createIndex("TestDoc_value_idx",
+          SchemaClass.INDEX_TYPE.NOTUNIQUE, "value");
+
+      // Insert initial records
+      var tx = session.begin();
+      for (int i = 0; i < INITIAL_COUNT; i++) {
+        var doc = tx.newVertex("TestDoc");
+        var val = "val" + String.format("%06d", i);
+        doc.setProperty("value", val);
+        allValues.add(val);
+        survivingValues.add(val);
+      }
+      tx.commit();
+
+      // Collect committed RIDs (stable after commit)
+      var txRead = session.begin();
+      try (var results = txRead.query("SELECT FROM TestDoc ORDER BY value")) {
+        while (results.hasNext()) {
+          allRids.add(results.next().getIdentity());
+        }
+      }
+      txRead.commit();
+
+      // Phase 2: In a new tx, delete some records (creating tombstones),
+      // then insert new ones (triggering GC on tombstones during overflow).
+      var tx2 = session.begin();
+
+      // Delete first DELETE_COUNT records by loading via stored RIDs.
+      // Deleting in a new tx creates cross-tx index tombstones.
+      for (int i = 0; i < DELETE_COUNT; i++) {
+        Vertex v = tx2.load(allRids.get(i));
+        var val = v.<String>getProperty("value");
+        deletedValues.add(val);
+        survivingValues.remove(val);
+        tx2.delete(v);
+      }
+
+      // Insert new records to trigger bucket overflow + GC on tombstones
+      for (int i = 0; i < INSERT_AFTER_DELETE_COUNT; i++) {
+        var doc = tx2.newVertex("TestDoc");
+        var val = "new" + String.format("%06d", i);
+        doc.setProperty("value", val);
+        newValues.add(val);
+      }
+      tx2.commit();
+
+      // Phase 3: Force-close without session close.
+      session.activateOnCurrentThread();
+    } finally {
+      ytdb.internal.forceDatabaseClose(dbName);
+    }
+
+    // Phase 4: Reopen and verify index state.
+    var recoveredSession = ytdb.open(dbName, ADMIN, ADMIN_PWD);
+    try {
+      var txVerify = recoveredSession.begin();
+
+      // Build the full expected set: original survivors + new records
+      var expectedValues = new HashSet<>(survivingValues);
+      expectedValues.addAll(newValues);
+
+      // Verify each expected value is findable via index lookup
+      for (var val : expectedValues) {
+        try (var results = txVerify.query(
+            "SELECT FROM TestDoc WHERE value = ?", val)) {
+          assertThat(results.hasNext())
+              .as("Expected value '%s' must be findable via index after recovery",
+                  val)
+              .isTrue();
+        }
+      }
+
+      // Verify deleted values do NOT appear (no ghost resurrection)
+      for (var val : deletedValues) {
+        try (var results = txVerify.query(
+            "SELECT FROM TestDoc WHERE value = ?", val)) {
+          assertThat(results.hasNext())
+              .as("Deleted value '%s' must not reappear after recovery "
+                  + "(ghost resurrection)", val)
+              .isFalse();
+        }
+      }
+
+      // Verify total count matches expected
+      long totalCount;
+      try (var countResults = txVerify.query(
+          "SELECT count(*) as cnt FROM TestDoc")) {
+        assertThat(countResults.hasNext()).isTrue();
+        totalCount = countResults.next().<Long>getProperty("cnt");
+      }
+
+      long expectedCount =
+          INITIAL_COUNT - DELETE_COUNT + INSERT_AFTER_DELETE_COUNT;
+      assertThat(totalCount)
+          .as("Total record count after recovery must match expected")
+          .isEqualTo(expectedCount);
+
+      txVerify.commit();
+    } finally {
+      recoveredSession.close();
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
@@ -10,23 +10,18 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.TombstoneRID;
 import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
-import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.impl.index.IndexMultiValuKeySerializer;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
-import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReadWriteLock;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -110,6 +105,7 @@ public class BTreeTombstoneGCStressTest {
   @Before
   public void beforeMethod() throws Exception {
     bTree = new BTree<>(ENGINE_NAME, ".cbt", ".nbt", storage);
+    bTree.setEngineId(STUB_ENGINE_ID);
     atomicOperationsManager.executeInsideAtomicOperation(
         atomicOperation -> bTree.create(
             atomicOperation,
@@ -119,7 +115,7 @@ public class BTreeTombstoneGCStressTest {
                 PropertyTypeInternal.LONG},
             2));
 
-    registerStubEngine(ENGINE_NAME, STUB_ENGINE_ID);
+    BTreeGCTestSupport.registerStubEngine(storage, ENGINE_NAME, STUB_ENGINE_ID);
   }
 
   @After
@@ -129,50 +125,9 @@ public class BTreeTombstoneGCStressTest {
       snapshot.clear();
     }
 
-    unregisterStubEngine(ENGINE_NAME);
+    BTreeGCTestSupport.unregisterStubEngine(storage, ENGINE_NAME);
     atomicOperationsManager.executeInsideAtomicOperation(
         atomicOperation -> bTree.delete(atomicOperation));
-  }
-
-  // ---- Reflection helpers (duplicated from BTreeTombstoneGCTest) ----
-
-  @SuppressWarnings("unchecked")
-  private static void registerStubEngine(String name, int id) throws Exception {
-    BaseIndexEngine stub = new StubIndexEngine(name, id);
-    var lock = getStateLock();
-    lock.writeLock().lock();
-    try {
-      Field mapField =
-          AbstractStorage.class.getDeclaredField("indexEngineNameMap");
-      mapField.setAccessible(true);
-      Map<String, BaseIndexEngine> map =
-          (Map<String, BaseIndexEngine>) mapField.get(storage);
-      map.put(name, stub);
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void unregisterStubEngine(String name) throws Exception {
-    var lock = getStateLock();
-    lock.writeLock().lock();
-    try {
-      Field mapField =
-          AbstractStorage.class.getDeclaredField("indexEngineNameMap");
-      mapField.setAccessible(true);
-      Map<String, BaseIndexEngine> map =
-          (Map<String, BaseIndexEngine>) mapField.get(storage);
-      map.remove(name);
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  private static ReadWriteLock getStateLock() throws Exception {
-    Field lockField = AbstractStorage.class.getDeclaredField("stateLock");
-    lockField.setAccessible(true);
-    return (ReadWriteLock) lockField.get(storage);
   }
 
   // ---- Stress tests ----
@@ -639,129 +594,4 @@ public class BTreeTombstoneGCStressTest {
     }
   }
 
-  // ---- Stub engine (duplicated from BTreeTombstoneGCTest) ----
-
-  private static class StubIndexEngine implements BaseIndexEngine {
-    private final String name;
-    private final int id;
-
-    StubIndexEngine(String name, int id) {
-      this.name = name;
-      this.id = id;
-    }
-
-    @Override
-    public int getId() {
-      return id;
-    }
-
-    @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public void init(
-        com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded s,
-        com.jetbrains.youtrackdb.internal.core.index.IndexMetadata m) {
-    }
-
-    @Override
-    public void flush() {
-    }
-
-    @Override
-    public void create(AtomicOperation o,
-        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d) {
-    }
-
-    @Override
-    public void load(
-        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d,
-        AtomicOperation o) {
-    }
-
-    @Override
-    public void delete(AtomicOperation o) {
-    }
-
-    @Override
-    public void clear(
-        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
-        AtomicOperation o) {
-    }
-
-    @Override
-    public void close() {
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        iterateEntriesBetween(Object f, boolean fi, Object t, boolean ti,
-            boolean a,
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer tr,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        iterateEntriesMajor(Object k, boolean i, boolean a,
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        iterateEntriesMinor(Object k, boolean i, boolean a,
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        stream(
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        descStream(
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<Object> keyStream(AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public long size(
-        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
-        com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-        AtomicOperation o) {
-      return 0;
-    }
-
-    @Override
-    public int getEngineAPIVersion() {
-      return 0;
-    }
-
-    @Override
-    public boolean acquireAtomicExclusiveLock(AtomicOperation o) {
-      return false;
-    }
-  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
@@ -577,7 +577,8 @@ public class BTreeTombstoneGCStressTest {
                     + "GC (reader thread %d, round %d)",
                     pos, threadId, round)
                 .isNotNull()
-                .isInstanceOf(RecordId.class);
+                .isInstanceOf(RecordId.class)
+                .isNotInstanceOf(TombstoneRID.class);
             assertThat(result[0].getCollectionId())
                 .as("Live entry pos=%d must have collectionId=2 "
                     + "(reader thread %d, round %d)",

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
@@ -458,6 +458,10 @@ public class BTreeTombstoneGCStressTest {
                   keyIndex, threadId)
               .isInstanceOf(RecordId.class)
               .isNotInstanceOf(TombstoneRID.class);
+          assertThat(result[0].getCollectionId())
+              .as("Live entry at keyIndex=%d must have clusterId=2 (thread %d)",
+                  keyIndex, threadId)
+              .isEqualTo(2);
           assertThat(result[0].getCollectionPosition())
               .as("Live entry at keyIndex=%d must have position=%d (thread %d)",
                   keyIndex, keyIndex, threadId)

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
@@ -509,13 +509,12 @@ public class BTreeTombstoneGCStressTest {
     }
 
     // Phase 2: concurrent writers + readers
+    int writerCount = THREAD_COUNT / 2;
+    int readerCount = THREAD_COUNT - writerCount;
     ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
     try {
       CountDownLatch startLatch = new CountDownLatch(1);
       List<Future<?>> futures = new ArrayList<>();
-
-      int writerCount = THREAD_COUNT / 2;
-      int readerCount = THREAD_COUNT - writerCount;
 
       // Writer threads: insert new entries to trigger bucket overflow + GC
       for (int t = 0; t < writerCount; t++) {
@@ -556,12 +555,15 @@ public class BTreeTombstoneGCStressTest {
             return;
           }
 
+          // Number of distinct live positions in the pre-populated range.
+          // Derived from prePopCount: every 3rd entry is a tombstone,
+          // so there are prePopCount/3 live "slots" at offset *3 + 1.
+          int livePositionCount = prePopCount / 3;
+
           for (int round = 0; round < OPS_PER_THREAD; round++) {
             // Pick a known live entry (position where i % 3 != 0).
-            // 133 * 3 + 1 = 400 = prePopCount, so all computed positions
-            // fall within the pre-populated range. The *3 + 1 offset
-            // skips tombstone positions (i % 3 == 0).
-            int pos = (round % 133) * 3 + 1;
+            // The *3 + 1 offset skips tombstone positions (i % 3 == 0).
+            int pos = (round % livePositionCount) * 3 + 1;
             final var key = new CompositeKey(
                 "key" + String.format("%06d", pos), 100L);
             final RID[] result = {null};
@@ -606,6 +608,107 @@ public class BTreeTombstoneGCStressTest {
     } finally {
       executor.shutdownNow();
     }
+
+    // Verify: writer entries must be present after the concurrent phase.
+    // Without this check, a GC bug that silently drops the pending
+    // insertion would go undetected (readers only check pre-populated data).
+    for (int t = 0; t < writerCount; t++) {
+      for (int i = 0; i < Math.min(20, OPS_PER_THREAD); i++) {
+        final int pos = 1000 + t * OPS_PER_THREAD + i;
+        final int threadId = t;
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", pos), 100L);
+        final RID[] result = {null};
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> result[0] = bTree.get(key, op));
+        assertThat(result[0])
+            .as("Writer entry at pos=%d must exist after concurrent "
+                + "phase (writer thread %d)", pos, threadId)
+            .isNotNull()
+            .isInstanceOf(RecordId.class)
+            .isNotInstanceOf(TombstoneRID.class);
+        assertThat(result[0].getCollectionId())
+            .as("Writer entry at pos=%d must have collectionId=3", pos)
+            .isEqualTo(3);
+        assertThat(result[0].getCollectionPosition())
+            .as("Writer entry at pos=%d must have collectionPosition=%d",
+                pos, pos)
+            .isEqualTo(pos);
+      }
+    }
   }
+
+  // ---- Lock ordering safety ----
+
+  /**
+   * Verifies that GC does not deadlock when {@code stateLock.writeLock()}
+   * is held by another thread. The production GC code uses
+   * {@link AbstractStorage#hasActiveIndexSnapshotEntriesById} (lock-free)
+   * instead of {@code hasActiveIndexSnapshotEntries} (acquires
+   * {@code stateLock.readLock()}). If a future refactor accidentally used
+   * the name-based variant, this test would deadlock because the write-lock
+   * holder blocks the read-lock acquisition.
+   *
+   * <p>Thread 1 holds {@code stateLock.writeLock()} while Thread 2
+   * triggers GC via {@code put()} on a bucket full of tombstones.
+   */
+  @Test
+  public void testGCDoesNotDeadlockWithStateLockWriter() throws Exception {
+    // Pre-populate with tombstones to guarantee GC triggers on next insert
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i), 1L);
+      final var value = new TombstoneRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, key, value));
+    }
+
+    var stateLock = BTreeGCTestSupport.getStateLock(storage);
+    CountDownLatch writerReady = new CountDownLatch(1);
+    CountDownLatch putDone = new CountDownLatch(1);
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      // Thread 1: hold stateLock.writeLock() while Thread 2 triggers GC.
+      // If GC tried to acquire stateLock.readLock(), it would deadlock.
+      Future<?> lockHolder = executor.submit(() -> {
+        stateLock.writeLock().lock();
+        try {
+          writerReady.countDown();
+          putDone.await(30, TimeUnit.SECONDS);
+        } finally {
+          stateLock.writeLock().unlock();
+        }
+        return null;
+      });
+
+      // Thread 2: after stateLock.writeLock() is held, insert a live entry
+      // that triggers bucket overflow + GC on the tombstones.
+      Future<?> gcTrigger = executor.submit(() -> {
+        writerReady.await();
+        final var key = new CompositeKey("key000050", 100L);
+        final var value = new RecordId(2, 50);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+        putDone.countDown();
+        return null;
+      });
+
+      executor.shutdown();
+      assertThat(executor.awaitTermination(30, TimeUnit.SECONDS))
+          .as("GC must not deadlock when stateLock.writeLock is held "
+              + "by another thread")
+          .isTrue();
+
+      // Propagate exceptions from both threads
+      lockHolder.get();
+      gcTrigger.get();
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  // Enough entries to fill multiple buckets (matches BTreeTombstoneGCTest)
+  private static final int FILL_COUNT = 400;
 
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
@@ -135,7 +135,7 @@ public class BTreeTombstoneGCStressTest {
   /**
    * Multiple threads concurrently insert live entries and tombstones into
    * the same B-tree. All threads share a common key prefix with non-overlapping
-   * version ranges, so entries from different threads co-locate in the same
+   * key-position ranges, so entries from different threads co-locate in the same
    * B-tree buckets. Bucket overflows trigger GC attempts that filter tombstones
    * from any thread's entries, testing cross-thread GC correctness.
    *
@@ -557,7 +557,10 @@ public class BTreeTombstoneGCStressTest {
           }
 
           for (int round = 0; round < OPS_PER_THREAD; round++) {
-            // Pick a known live entry (position where i % 3 != 0)
+            // Pick a known live entry (position where i % 3 != 0).
+            // 133 * 3 + 1 = 400 = prePopCount, so all computed positions
+            // fall within the pre-populated range. The *3 + 1 offset
+            // skips tombstone positions (i % 3 == 0).
             int pos = (round % 133) * 3 + 1;
             final var key = new CompositeKey(
                 "key" + String.format("%06d", pos), 100L);
@@ -575,6 +578,16 @@ public class BTreeTombstoneGCStressTest {
                     pos, threadId, round)
                 .isNotNull()
                 .isInstanceOf(RecordId.class);
+            assertThat(result[0].getCollectionId())
+                .as("Live entry pos=%d must have collectionId=2 "
+                    + "(reader thread %d, round %d)",
+                    pos, threadId, round)
+                .isEqualTo(2);
+            assertThat(result[0].getCollectionPosition())
+                .as("Live entry pos=%d must have collectionPosition=%d "
+                    + "(reader thread %d, round %d)",
+                    pos, pos, threadId, round)
+                .isEqualTo(pos);
           }
         }));
       }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
@@ -1,0 +1,644 @@
+package com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.id.TombstoneRID;
+import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
+import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.impl.index.IndexMultiValuKeySerializer;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Stress test for tombstone GC under concurrent contention in the index
+ * {@link BTree}. Multiple threads concurrently perform {@code put()}
+ * operations, each in separate atomic operations. All threads share the
+ * same key prefix so entries co-locate in the same B-tree buckets,
+ * maximizing the chance that one thread's insert triggers GC on a bucket
+ * containing another thread's tombstones.
+ *
+ * <p>Operations serialize at the B-tree level (component exclusive lock),
+ * so this tests contention safety — correctness under rapid lock
+ * acquisition/release by multiple threads — not true intra-GC
+ * concurrency. The test verifies that after all threads complete:
+ * (1) no deadlocks or exceptions occurred, (2) tree invariants hold
+ * (all expected entries are findable, no duplicates), (3) live entries
+ * are never lost by GC, (4) surviving tombstones retain their state.
+ *
+ * <p>Uses the same static storage/atomicOperationsManager setup as
+ * {@link BTreeTombstoneGCTest}.
+ */
+public class BTreeTombstoneGCStressTest {
+
+  private static final String DB_NAME = "btreeIndexTombstoneGCStressTest";
+  private static final String DIR_NAME = "/btreeIndexTombstoneGCStressTest";
+
+  // Thread count — enough contention to stress lock handoff and GC
+  // interleaving, but not so many that the test becomes slow.
+  private static final int THREAD_COUNT = 4;
+
+  // Operations per thread. Each thread inserts this many entries,
+  // alternating between live entries and tombstones. With 4 threads
+  // x 300 entries = 1200 total entries, enough to trigger many
+  // bucket overflows and GC attempts.
+  private static final int OPS_PER_THREAD = 300;
+
+  private static final int STUB_ENGINE_ID = 99;
+  private static final String ENGINE_NAME = "tombstoneGCStressIdx";
+
+  private static YouTrackDBImpl youTrackDB;
+  private static AtomicOperationsManager atomicOperationsManager;
+  private static AbstractStorage storage;
+  private static String buildDirectory;
+
+  private BTree<CompositeKey> bTree;
+
+  @BeforeClass
+  public static void beforeClass() {
+    buildDirectory = System.getProperty("buildDirectory");
+    if (buildDirectory == null) {
+      buildDirectory = "./target" + DIR_NAME;
+    } else {
+      buildDirectory += DIR_NAME;
+    }
+
+    FileUtils.deleteRecursively(new File(buildDirectory));
+
+    youTrackDB = (YouTrackDBImpl) YourTracks.instance(buildDirectory);
+    if (youTrackDB.exists(DB_NAME)) {
+      youTrackDB.drop(DB_NAME);
+    }
+    youTrackDB.create(DB_NAME, DatabaseType.DISK, "admin", "admin", "admin");
+
+    var databaseSession = youTrackDB.open(DB_NAME, "admin", "admin");
+    storage = databaseSession.getStorage();
+    atomicOperationsManager = storage.getAtomicOperationsManager();
+    databaseSession.close();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    youTrackDB.drop(DB_NAME);
+    youTrackDB.close();
+    FileUtils.deleteRecursively(new File(buildDirectory));
+  }
+
+  @Before
+  public void beforeMethod() throws Exception {
+    bTree = new BTree<>(ENGINE_NAME, ".cbt", ".nbt", storage);
+    atomicOperationsManager.executeInsideAtomicOperation(
+        atomicOperation -> bTree.create(
+            atomicOperation,
+            new IndexMultiValuKeySerializer(),
+            new PropertyTypeInternal[] {
+                PropertyTypeInternal.STRING,
+                PropertyTypeInternal.LONG},
+            2));
+
+    registerStubEngine(ENGINE_NAME, STUB_ENGINE_ID);
+  }
+
+  @After
+  public void afterMethod() throws Exception {
+    var snapshot = storage.getIndexSnapshotByEngineName(ENGINE_NAME);
+    if (snapshot != null) {
+      snapshot.clear();
+    }
+
+    unregisterStubEngine(ENGINE_NAME);
+    atomicOperationsManager.executeInsideAtomicOperation(
+        atomicOperation -> bTree.delete(atomicOperation));
+  }
+
+  // ---- Reflection helpers (duplicated from BTreeTombstoneGCTest) ----
+
+  @SuppressWarnings("unchecked")
+  private static void registerStubEngine(String name, int id) throws Exception {
+    BaseIndexEngine stub = new StubIndexEngine(name, id);
+    var lock = getStateLock();
+    lock.writeLock().lock();
+    try {
+      Field mapField =
+          AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+      mapField.setAccessible(true);
+      Map<String, BaseIndexEngine> map =
+          (Map<String, BaseIndexEngine>) mapField.get(storage);
+      map.put(name, stub);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void unregisterStubEngine(String name) throws Exception {
+    var lock = getStateLock();
+    lock.writeLock().lock();
+    try {
+      Field mapField =
+          AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+      mapField.setAccessible(true);
+      Map<String, BaseIndexEngine> map =
+          (Map<String, BaseIndexEngine>) mapField.get(storage);
+      map.remove(name);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  private static ReadWriteLock getStateLock() throws Exception {
+    Field lockField = AbstractStorage.class.getDeclaredField("stateLock");
+    lockField.setAccessible(true);
+    return (ReadWriteLock) lockField.get(storage);
+  }
+
+  // ---- Stress tests ----
+
+  /**
+   * Multiple threads concurrently insert live entries and tombstones into
+   * the same B-tree. All threads share a common key prefix with non-overlapping
+   * version ranges, so entries from different threads co-locate in the same
+   * B-tree buckets. Bucket overflows trigger GC attempts that filter tombstones
+   * from any thread's entries, testing cross-thread GC correctness.
+   *
+   * <p>Each thread uses keys {@code "key" + formatted(base+i)} where even
+   * indices are tombstones (version=1, below default LWM) and odd indices are
+   * live entries (version=100). The base offset ensures non-overlapping key
+   * spaces across threads while the shared prefix ensures bucket co-location.
+   *
+   * <p>After all threads complete, verifies:
+   * <ul>
+   *   <li>No exceptions or deadlocks during execution</li>
+   *   <li>All live entries are findable with correct RID values</li>
+   *   <li>Surviving tombstones retain their tombstone state</li>
+   *   <li>No live entry was incorrectly removed by GC</li>
+   * </ul>
+   */
+  @Test
+  public void testConcurrentPutWithTombstonesAndGC() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    try {
+      CountDownLatch startLatch = new CountDownLatch(1);
+      List<Future<?>> futures = new ArrayList<>();
+
+      for (int t = 0; t < THREAD_COUNT; t++) {
+        final int threadId = t;
+        futures.add(executor.submit(() -> {
+          try {
+            startLatch.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+
+          // All threads share key prefix "key" with non-overlapping position
+          // ranges. Even positions are tombstones (version=1), odd positions
+          // are live entries (version=100). This forces entries from all
+          // threads into the same key-space region, maximizing bucket
+          // co-location and cross-thread GC filtering.
+          int base = threadId * OPS_PER_THREAD * 2;
+          for (int i = 0; i < OPS_PER_THREAD; i++) {
+            final int pos = base + i;
+            final boolean isTombstone = (i % 2 == 0);
+            final long version = isTombstone ? 1L : 100L;
+            final String keyStr = "key" + String.format("%06d", pos);
+            try {
+              if (isTombstone) {
+                final var key = new CompositeKey(keyStr, version);
+                final var value = new TombstoneRID(new RecordId(1, pos));
+                atomicOperationsManager.executeInsideAtomicOperation(
+                    op -> bTree.put(op, key, value));
+              } else {
+                final var key = new CompositeKey(keyStr, version);
+                final var value = new RecordId(2, pos);
+                atomicOperationsManager.executeInsideAtomicOperation(
+                    op -> bTree.put(op, key, value));
+              }
+            } catch (Exception e) {
+              throw new RuntimeException(
+                  "Thread " + threadId + " failed at position " + pos, e);
+            }
+          }
+        }));
+      }
+
+      // Release all threads simultaneously
+      startLatch.countDown();
+
+      // Wait for completion with timeout to detect deadlocks
+      executor.shutdown();
+      assertThat(executor.awaitTermination(120, TimeUnit.SECONDS))
+          .as("Executor should terminate within timeout (deadlock detection)")
+          .isTrue();
+
+      // Propagate any thread exceptions
+      for (Future<?> future : futures) {
+        future.get();
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+
+    // Verify: all live entries (odd positions within each thread's range)
+    // must be present with correct RID values.
+    for (int t = 0; t < THREAD_COUNT; t++) {
+      int base = t * OPS_PER_THREAD * 2;
+      for (int i = 1; i < OPS_PER_THREAD; i += 2) {
+        final int pos = base + i;
+        final int threadId = t;
+        final String keyStr = "key" + String.format("%06d", pos);
+        final var key = new CompositeKey(keyStr, 100L);
+        final RID[] result = {null};
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> result[0] = bTree.get(key, op));
+        assertThat(result[0])
+            .as("Live entry at pos=%d must exist (thread %d)", pos, threadId)
+            .isNotNull();
+        assertThat(result[0])
+            .as("Live entry at pos=%d must be a plain RecordId (thread %d)",
+                pos, threadId)
+            .isInstanceOf(RecordId.class)
+            .isNotInstanceOf(TombstoneRID.class);
+        assertThat(result[0].getCollectionId())
+            .as("Live entry at pos=%d must have clusterId=2 (thread %d)",
+                pos, threadId)
+            .isEqualTo(2);
+        assertThat(result[0].getCollectionPosition())
+            .as("Live entry at pos=%d must have clusterPosition=%d (thread %d)",
+                pos, pos, threadId)
+            .isEqualTo(pos);
+      }
+    }
+
+    // Verify: tombstone entries (even positions), if still present after GC,
+    // must still be tombstones — GC must not flip tombstone to live or
+    // corrupt value fields.
+    for (int t = 0; t < THREAD_COUNT; t++) {
+      int base = t * OPS_PER_THREAD * 2;
+      for (int i = 0; i < OPS_PER_THREAD; i += 2) {
+        final int pos = base + i;
+        final int threadId = t;
+        final String keyStr = "key" + String.format("%06d", pos);
+        final var key = new CompositeKey(keyStr, 1L);
+        final RID[] result = {null};
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> result[0] = bTree.get(key, op));
+        if (result[0] != null) {
+          assertThat(result[0])
+              .as("Surviving entry at pos=%d must still be tombstone (thread %d)",
+                  pos, threadId)
+              .isInstanceOf(TombstoneRID.class);
+        }
+        // result == null means GC removed it, which is acceptable
+      }
+    }
+  }
+
+  /**
+   * Threads perform interleaved put and "remove" operations on the index
+   * B-tree. Half the threads insert tombstones (simulating cross-tx
+   * deletion at the engine level), while the other half insert live entries
+   * that trigger bucket overflow and GC. All threads use an interleaved
+   * key space ({@code keyIndex = i * THREAD_COUNT + threadId}) so entries
+   * from different threads co-locate in the same B-tree buckets.
+   *
+   * <p>Phase 1 pre-populates entries at "remover" thread positions.
+   * Phase 2 launches concurrent threads: removers overwrite existing live
+   * entries with TombstoneRID (simulating cross-tx delete at the engine
+   * level), inserters add new live entries that trigger GC.
+   *
+   * <p>Verifies that:
+   * <ul>
+   *   <li>All inserted live entries survive with correct values</li>
+   *   <li>All "removed" entries become tombstones (none remain live)</li>
+   *   <li>No exceptions or deadlocks during execution</li>
+   * </ul>
+   */
+  @Test
+  public void testConcurrentPutAndRemoveWithGC() throws Exception {
+    // Phase 1: Pre-populate entries at positions belonging to remover
+    // threads. All threads share an interleaved key space:
+    // keyIndex = i * THREAD_COUNT + threadId.
+    for (int t = 0; t < THREAD_COUNT; t++) {
+      if (t % 2 != 0) {
+        continue; // only pre-populate for remover threads (even threadId)
+      }
+      for (int i = 0; i < OPS_PER_THREAD; i++) {
+        final int keyIndex = i * THREAD_COUNT + t;
+        final String keyStr = "key" + String.format("%06d", keyIndex);
+        final var key = new CompositeKey(keyStr, 1L);
+        final var value = new RecordId(1, keyIndex);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+    }
+
+    // Phase 2: Concurrent threads — removers overwrite pre-populated entries
+    // with TombstoneRID (simulating cross-tx deletion), inserters add new
+    // live entries at their interleaved positions. Bucket overflows from
+    // inserters trigger GC that encounters remover tombstones.
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    try {
+      CountDownLatch startLatch = new CountDownLatch(1);
+      List<Future<?>> futures = new ArrayList<>();
+
+      for (int t = 0; t < THREAD_COUNT; t++) {
+        final int threadId = t;
+        final boolean isRemover = (threadId % 2 == 0);
+
+        futures.add(executor.submit(() -> {
+          try {
+            startLatch.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+
+          if (isRemover) {
+            // Overwrite pre-populated entries with TombstoneRID. In the
+            // real system, cross-tx deletion creates a new version entry
+            // with TombstoneRID; here we simulate by putting a new key
+            // at a higher version with TombstoneRID value.
+            for (int i = 0; i < OPS_PER_THREAD; i++) {
+              final int keyIndex = i * THREAD_COUNT + threadId;
+              final String keyStr =
+                  "key" + String.format("%06d", keyIndex);
+              try {
+                final var key = new CompositeKey(keyStr, 5L);
+                final var value =
+                    new TombstoneRID(new RecordId(1, keyIndex));
+                atomicOperationsManager.executeInsideAtomicOperation(
+                    op -> bTree.put(op, key, value));
+              } catch (Exception e) {
+                throw new RuntimeException(
+                    "Remover thread " + threadId
+                        + " failed at keyIndex " + keyIndex,
+                    e);
+              }
+            }
+          } else {
+            // Insert live entries at this thread's interleaved positions —
+            // these share buckets with remover entries and may trigger
+            // bucket overflow + GC on tombstones from remover threads.
+            for (int i = 0; i < OPS_PER_THREAD; i++) {
+              final int keyIndex = i * THREAD_COUNT + threadId;
+              final String keyStr =
+                  "key" + String.format("%06d", keyIndex);
+              try {
+                final var key = new CompositeKey(keyStr, 100L);
+                final var value = new RecordId(2, keyIndex);
+                atomicOperationsManager.executeInsideAtomicOperation(
+                    op -> bTree.put(op, key, value));
+              } catch (Exception e) {
+                throw new RuntimeException(
+                    "Inserter thread " + threadId
+                        + " failed at keyIndex " + keyIndex,
+                    e);
+              }
+            }
+          }
+        }));
+      }
+
+      startLatch.countDown();
+
+      executor.shutdown();
+      assertThat(executor.awaitTermination(120, TimeUnit.SECONDS))
+          .as("Executor should terminate within timeout")
+          .isTrue();
+
+      for (Future<?> future : futures) {
+        future.get();
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+
+    // Verify: for inserter threads (odd threadId), all live entries must
+    // be present with correct values.
+    for (int t = 0; t < THREAD_COUNT; t++) {
+      if (t % 2 != 0) { // inserter threads
+        for (int i = 0; i < OPS_PER_THREAD; i++) {
+          final int keyIndex = i * THREAD_COUNT + t;
+          final int threadId = t;
+          final String keyStr = "key" + String.format("%06d", keyIndex);
+          final var key = new CompositeKey(keyStr, 100L);
+          final RID[] result = {null};
+          atomicOperationsManager.executeInsideAtomicOperation(
+              op -> result[0] = bTree.get(key, op));
+          assertThat(result[0])
+              .as("Live entry at keyIndex=%d must exist (thread %d)",
+                  keyIndex, threadId)
+              .isNotNull();
+          assertThat(result[0])
+              .as("Live entry at keyIndex=%d must be RecordId (thread %d)",
+                  keyIndex, threadId)
+              .isInstanceOf(RecordId.class)
+              .isNotInstanceOf(TombstoneRID.class);
+          assertThat(result[0].getCollectionPosition())
+              .as("Live entry at keyIndex=%d must have position=%d (thread %d)",
+                  keyIndex, keyIndex, threadId)
+              .isEqualTo(keyIndex);
+        }
+      }
+    }
+
+    // Verify: for remover threads (even threadId), the tombstone entries
+    // at version=5 must either still exist as TombstoneRID (if not yet
+    // GC'd) or be null (if GC removed them). They must never appear as
+    // live RecordId — that would mean GC corrupted the tombstone state.
+    for (int t = 0; t < THREAD_COUNT; t++) {
+      if (t % 2 == 0) { // remover threads
+        for (int i = 0; i < OPS_PER_THREAD; i++) {
+          final int keyIndex = i * THREAD_COUNT + t;
+          final int threadId = t;
+          final String keyStr = "key" + String.format("%06d", keyIndex);
+          final var key = new CompositeKey(keyStr, 5L);
+          final RID[] result = {null};
+          atomicOperationsManager.executeInsideAtomicOperation(
+              op -> result[0] = bTree.get(key, op));
+          if (result[0] != null) {
+            assertThat(result[0])
+                .as("Removed entry at keyIndex=%d must be TombstoneRID "
+                    + "(thread %d)",
+                    keyIndex, threadId)
+                .isInstanceOf(TombstoneRID.class);
+          }
+          // result == null means GC removed it, which is acceptable
+        }
+      }
+    }
+
+    // Verify: tree size is consistent — reported size matches actual count
+    long[] reportedSize = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(
+        op -> reportedSize[0] = bTree.size(op));
+
+    long[] actualCount = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(op -> {
+      var firstKey = bTree.firstKey(op);
+      if (firstKey == null) {
+        return;
+      }
+      var lastKey = bTree.lastKey(op);
+      try (var stream = bTree.iterateEntriesBetween(
+          firstKey, true, lastKey, true, true, op)) {
+        actualCount[0] = stream.count();
+      }
+    });
+
+    assertThat(reportedSize[0])
+        .as("Reported tree size must match actual entry count after "
+            + "concurrent GC")
+        .isEqualTo(actualCount[0]);
+  }
+
+  // ---- Stub engine (duplicated from BTreeTombstoneGCTest) ----
+
+  private static class StubIndexEngine implements BaseIndexEngine {
+    private final String name;
+    private final int id;
+
+    StubIndexEngine(String name, int id) {
+      this.name = name;
+      this.id = id;
+    }
+
+    @Override
+    public int getId() {
+      return id;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public void init(
+        com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded s,
+        com.jetbrains.youtrackdb.internal.core.index.IndexMetadata m) {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void create(AtomicOperation o,
+        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d) {
+    }
+
+    @Override
+    public void load(
+        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d,
+        AtomicOperation o) {
+    }
+
+    @Override
+    public void delete(AtomicOperation o) {
+    }
+
+    @Override
+    public void clear(
+        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
+        AtomicOperation o) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesBetween(Object f, boolean fi, Object t, boolean ti,
+            boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer tr,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesMajor(Object k, boolean i, boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesMinor(Object k, boolean i, boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        stream(
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        descStream(
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<Object> keyStream(AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public long size(
+        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
+        com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+        AtomicOperation o) {
+      return 0;
+    }
+
+    @Override
+    public int getEngineAPIVersion() {
+      return 0;
+    }
+
+    @Override
+    public boolean acquireAtomicExclusiveLock(AtomicOperation o) {
+      return false;
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCStressTest.java
@@ -520,6 +520,125 @@ public class BTreeTombstoneGCStressTest {
         .isEqualTo(actualCount[0]);
   }
 
+  /**
+   * Reader threads concurrently call {@code bTree.get()} while writer threads
+   * trigger bucket overflow and GC. The B-tree's optimistic read path
+   * ({@code getOptimistic}) relies on sequence counters to detect concurrent
+   * modifications and falls back to pinned reads. GC introduces a new kind
+   * of bucket restructuring (rebuild via {@code filterAndRebuildBucket})
+   * that must be correctly detected by the optimistic validation.
+   *
+   * <p>Phase 1 pre-populates the tree with a mix of live entries and
+   * tombstones. Phase 2 launches concurrent writers (adding new live entries
+   * to trigger GC during overflow) and readers (continuously looking up
+   * pre-populated live entries). All live entries must remain readable
+   * throughout the concurrent phase.
+   */
+  @Test
+  public void testConcurrentReadDuringGCTriggeredByWrites() throws Exception {
+    // Phase 1: Pre-populate with a mix of live entries and tombstones.
+    // Every 3rd entry is a tombstone (version=1, below LWM), the rest
+    // are live (version=100).
+    int prePopCount = 400;
+    for (int i = 0; i < prePopCount; i++) {
+      final int pos = i;
+      final boolean isTombstone = (i % 3 == 0);
+      final long version = isTombstone ? 1L : 100L;
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", pos), version);
+      final RID value = isTombstone
+          ? new TombstoneRID(new RecordId(1, pos))
+          : new RecordId(2, pos);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, key, value));
+    }
+
+    // Phase 2: concurrent writers + readers
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    try {
+      CountDownLatch startLatch = new CountDownLatch(1);
+      List<Future<?>> futures = new ArrayList<>();
+
+      int writerCount = THREAD_COUNT / 2;
+      int readerCount = THREAD_COUNT - writerCount;
+
+      // Writer threads: insert new entries to trigger bucket overflow + GC
+      for (int t = 0; t < writerCount; t++) {
+        final int threadId = t;
+        futures.add(executor.submit(() -> {
+          try {
+            startLatch.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+
+          for (int i = 0; i < OPS_PER_THREAD; i++) {
+            final int pos = 1000 + threadId * OPS_PER_THREAD + i;
+            final var key = new CompositeKey(
+                "key" + String.format("%06d", pos), 100L);
+            final var value = new RecordId(3, pos);
+            try {
+              atomicOperationsManager.executeInsideAtomicOperation(
+                  op -> bTree.put(op, key, value));
+            } catch (Exception e) {
+              throw new RuntimeException(
+                  "Writer thread " + threadId + " failed at pos " + pos, e);
+            }
+          }
+        }));
+      }
+
+      // Reader threads: continuously read pre-populated live entries.
+      // Live entries are at non-tombstone positions (i % 3 != 0).
+      for (int t = 0; t < readerCount; t++) {
+        final int threadId = writerCount + t;
+        futures.add(executor.submit(() -> {
+          try {
+            startLatch.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+          }
+
+          for (int round = 0; round < OPS_PER_THREAD; round++) {
+            // Pick a known live entry (position where i % 3 != 0)
+            int pos = (round % 133) * 3 + 1;
+            final var key = new CompositeKey(
+                "key" + String.format("%06d", pos), 100L);
+            final RID[] result = {null};
+            try {
+              atomicOperationsManager.executeInsideAtomicOperation(
+                  op -> result[0] = bTree.get(key, op));
+            } catch (Exception e) {
+              throw new RuntimeException(
+                  "Reader thread " + threadId + " failed at pos " + pos, e);
+            }
+            assertThat(result[0])
+                .as("Live entry pos=%d must be readable during concurrent "
+                    + "GC (reader thread %d, round %d)",
+                    pos, threadId, round)
+                .isNotNull()
+                .isInstanceOf(RecordId.class);
+          }
+        }));
+      }
+
+      startLatch.countDown();
+
+      executor.shutdown();
+      assertThat(executor.awaitTermination(120, TimeUnit.SECONDS))
+          .as("Executor should terminate within timeout (deadlock detection)")
+          .isTrue();
+
+      for (Future<?> future : futures) {
+        future.get();
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
   // ---- Stub engine (duplicated from BTreeTombstoneGCTest) ----
 
   private static class StubIndexEngine implements BaseIndexEngine {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -1,0 +1,685 @@
+package com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.id.SnapshotMarkerRID;
+import com.jetbrains.youtrackdb.internal.core.id.TombstoneRID;
+import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
+import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.impl.index.IndexMultiValuKeySerializer;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for tombstone GC during leaf page splits in {@link BTree}. Verifies
+ * that removable {@link TombstoneRID} entries (below global LWM) are filtered
+ * out during bucket overflow, that stale {@link SnapshotMarkerRID} entries are
+ * demoted to plain {@link RecordId}, and that live entries remain untouched.
+ *
+ * <p>The GC is triggered when {@code addLeafEntry()} returns false (bucket
+ * full) in the {@code update()} method.
+ *
+ * <p>Keys use the single-value index format: {@code CompositeKey(userKey, version)}.
+ * Tombstones and live entries are interleaved in key space to ensure they share
+ * buckets, so that overflow on one triggers GC of the other.
+ */
+public class BTreeTombstoneGCTest {
+
+  private static final String DB_NAME = "btreeIndexTombstoneGCTest";
+  private static final String DIR_NAME = "/btreeIndexTombstoneGCTest";
+
+  // Enough entries to fill multiple buckets and trigger splits. With ~30 bytes
+  // per entry (CompositeKey(String, Long) + RID) and ~8KB usable per bucket,
+  // ~250 entries per bucket. We use 400 to ensure multiple splits.
+  private static final int FILL_COUNT = 400;
+
+  // Stub engine ID used for indexEngineNameMap registration so that
+  // AbstractStorage.hasActiveSnapshotEntries() resolves the correct index.
+  private static final int STUB_ENGINE_ID = 99;
+  private static final String ENGINE_NAME = "tombstoneGCIdx";
+
+  private static YouTrackDBImpl youTrackDB;
+  private static AtomicOperationsManager atomicOperationsManager;
+  private static AbstractStorage storage;
+  private static String buildDirectory;
+
+  private BTree<CompositeKey> bTree;
+
+  @BeforeClass
+  public static void beforeClass() {
+    buildDirectory = System.getProperty("buildDirectory");
+    if (buildDirectory == null) {
+      buildDirectory = "./target" + DIR_NAME;
+    } else {
+      buildDirectory += DIR_NAME;
+    }
+
+    FileUtils.deleteRecursively(new File(buildDirectory));
+
+    youTrackDB = (YouTrackDBImpl) YourTracks.instance(buildDirectory);
+    if (youTrackDB.exists(DB_NAME)) {
+      youTrackDB.drop(DB_NAME);
+    }
+    youTrackDB.create(DB_NAME, DatabaseType.DISK, "admin", "admin", "admin");
+
+    var databaseSession = youTrackDB.open(DB_NAME, "admin", "admin");
+    storage = databaseSession.getStorage();
+    atomicOperationsManager = storage.getAtomicOperationsManager();
+    databaseSession.close();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    youTrackDB.drop(DB_NAME);
+    youTrackDB.close();
+    FileUtils.deleteRecursively(new File(buildDirectory));
+  }
+
+  @Before
+  public void beforeMethod() throws Exception {
+    // Create a BTree with CompositeKey(userKey, version) layout, matching
+    // BTreeSingleValueIndexEngine's key structure.
+    bTree = new BTree<>(ENGINE_NAME, ".cbt", ".nbt", storage);
+    atomicOperationsManager.executeInsideAtomicOperation(
+        atomicOperation -> bTree.create(
+            atomicOperation,
+            new IndexMultiValuKeySerializer(),
+            new PropertyTypeInternal[] {
+                PropertyTypeInternal.STRING,
+                PropertyTypeInternal.LONG},
+            2));
+
+    // Register a stub engine so AbstractStorage.hasActiveSnapshotEntries() resolves it
+    registerStubEngine(ENGINE_NAME, STUB_ENGINE_ID);
+  }
+
+  @After
+  public void afterMethod() throws Exception {
+    // Clear any snapshot entries added during the test to prevent leakage
+    // between tests. The IndexesSnapshot is scoped to our stub engine's ID,
+    // so clear() only removes entries for this test's index.
+    var snapshot = storage.getIndexSnapshotByEngineName(ENGINE_NAME);
+    if (snapshot != null) {
+      snapshot.clear();
+    }
+
+    unregisterStubEngine(ENGINE_NAME);
+    atomicOperationsManager.executeInsideAtomicOperation(
+        atomicOperation -> bTree.delete(atomicOperation));
+  }
+
+  // ---- LWM pinning helpers (via reflection) ----
+
+  @SuppressWarnings("unchecked")
+  private static Object pinLwm(long lwmValue) throws Exception {
+    Class<?> holderClass = Class.forName(
+        "com.jetbrains.youtrackdb.internal.core.storage.impl.local.TsMinHolder");
+    var ctor = holderClass.getDeclaredConstructor();
+    ctor.setAccessible(true);
+    Object holder = ctor.newInstance();
+    Field tsMinField = holderClass.getDeclaredField("tsMin");
+    tsMinField.setAccessible(true);
+    tsMinField.setLong(holder, lwmValue);
+
+    Field tsMinsField = AbstractStorage.class.getDeclaredField("tsMins");
+    tsMinsField.setAccessible(true);
+    Set<Object> tsMins = (Set<Object>) tsMinsField.get(storage);
+    tsMins.add(holder);
+    return holder;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void unpinLwm(Object holder) throws Exception {
+    Field tsMinsField = AbstractStorage.class.getDeclaredField("tsMins");
+    tsMinsField.setAccessible(true);
+    Set<Object> tsMins = (Set<Object>) tsMinsField.get(storage);
+    tsMins.remove(holder);
+  }
+
+  // ---- Stub engine registration (via reflection) ----
+
+  /**
+   * Registers a minimal stub {@link BaseIndexEngine} in AbstractStorage's
+   * {@code indexEngineNameMap} so that
+   * {@code AbstractStorage.hasActiveSnapshotEntries()} can resolve the index.
+   */
+  @SuppressWarnings("unchecked")
+  private static void registerStubEngine(String name, int id) throws Exception {
+    // Create a minimal stub that only needs getId() and getName()
+    BaseIndexEngine stub = new StubIndexEngine(name, id);
+    Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+    mapField.setAccessible(true);
+    Map<String, BaseIndexEngine> map =
+        (Map<String, BaseIndexEngine>) mapField.get(storage);
+    map.put(name, stub);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void unregisterStubEngine(String name) throws Exception {
+    Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+    mapField.setAccessible(true);
+    Map<String, BaseIndexEngine> map =
+        (Map<String, BaseIndexEngine>) mapField.get(storage);
+    map.remove(name);
+  }
+
+  // ---- Helpers ----
+
+  /**
+   * Counts entries of a specific RID type in the tree by iterating all
+   * entries from firstKey to lastKey.
+   */
+  private long countEntriesOfType(Class<? extends RID> ridType) throws Exception {
+    long[] count = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+      var firstKey = bTree.firstKey(atomicOperation);
+      if (firstKey == null) {
+        return;
+      }
+      var lastKey = bTree.lastKey(atomicOperation);
+      try (var stream = bTree.iterateEntriesBetween(
+          firstKey, true, lastKey, true, true, atomicOperation)) {
+        count[0] = stream.filter(p -> ridType.isInstance(p.second())).count();
+      }
+    });
+    return count[0];
+  }
+
+  /**
+   * Counts all entries in the tree (regardless of type).
+   */
+  private long countAllEntries() throws Exception {
+    long[] count = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+      var firstKey = bTree.firstKey(atomicOperation);
+      if (firstKey == null) {
+        return;
+      }
+      var lastKey = bTree.lastKey(atomicOperation);
+      try (var stream = bTree.iterateEntriesBetween(
+          firstKey, true, lastKey, true, true, atomicOperation)) {
+        count[0] = stream.count();
+      }
+    });
+    return count[0];
+  }
+
+  // ---- Basic tombstone GC during put() ----
+
+  @Test
+  public void testTombstonesBelowLwmAreRemovedDuringPut() throws Exception {
+    // Fill the tree with tombstones at even-numbered keys (version=1), then
+    // insert live entries at odd-numbered keys (version=100) to trigger
+    // bucket overflows. Tombstones and live entries share buckets because
+    // they interleave in key space. GC should remove tombstones below LWM.
+
+    // Insert FILL_COUNT tombstones at even positions
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey("key" + String.format("%06d", i * 2), 1L);
+      final var value = new TombstoneRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
+
+    // Insert FILL_COUNT live entries at odd positions to trigger overflows
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2 + 1), 100L);
+      final var value = new RecordId(2, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    long tombstonesAfter = countEntriesOfType(TombstoneRID.class);
+
+    // We assert "fewer tombstones" rather than "zero tombstones" because GC
+    // only runs on buckets that actually overflow. Tombstones in buckets that
+    // had room for the new entry are never visited, so a strict isZero()
+    // assertion would be flaky depending on key distribution and bucket sizing.
+    assertThat(tombstonesAfter)
+        .as("Tombstones below LWM should be GC'd during bucket overflow")
+        .isLessThan(tombstonesBefore);
+
+    // All live entries must be present
+    assertThat(countEntriesOfType(RecordId.class))
+        .as("All live entries must survive GC")
+        .isEqualTo(FILL_COUNT);
+  }
+
+  @Test
+  public void testTombstonesAboveLwmArePreserved() throws Exception {
+    // Pin LWM so that tombstones with ts=100 are ABOVE it
+    var holder = pinLwm(5L);
+    try {
+      // Insert tombstones at version=100 (above lwm=5)
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), 100L);
+        final var value = new TombstoneRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> bTree.put(atomicOperation, key, value));
+      }
+
+      // Insert live entries to trigger overflows
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2 + 1), 200L);
+        final var value = new RecordId(2, i);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> bTree.put(atomicOperation, key, value));
+      }
+
+      // All tombstones should be preserved (version 100 > lwm 5)
+      assertThat(countEntriesOfType(TombstoneRID.class))
+          .as("Tombstones above LWM must not be removed")
+          .isEqualTo(FILL_COUNT);
+    } finally {
+      unpinLwm(holder);
+    }
+  }
+
+  @Test
+  public void testTombstonesAtExactLwmArePreserved() throws Exception {
+    // The GC condition is `version < LWM` (strictly below). Tombstones whose
+    // version equals exactly the LWM must NOT be removed — they may still be
+    // needed by a transaction reading at exactly that timestamp.
+
+    final long lwmValue = 50L;
+    var holder = pinLwm(lwmValue);
+    try {
+      // Insert tombstones at version == LWM (exactly 50)
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), lwmValue);
+        final var value = new TombstoneRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> bTree.put(atomicOperation, key, value));
+      }
+
+      long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
+
+      // Insert live entries at odd positions to trigger overflows
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2 + 1), 200L);
+        final var value = new RecordId(2, i);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> bTree.put(atomicOperation, key, value));
+      }
+
+      // Tombstones at exactly LWM must survive (condition is version < lwm, not <=)
+      assertThat(countEntriesOfType(TombstoneRID.class))
+          .as("Tombstones at exactly LWM must not be removed (strict < comparison)")
+          .isEqualTo(tombstonesBefore);
+    } finally {
+      unpinLwm(holder);
+    }
+  }
+
+  @Test
+  public void testNoGhostResurrectionAfterGC() throws Exception {
+    // After tombstone GC removes entries, looking up the deleted keys via
+    // BTree.get() must return null — the deletion must not be "undone" by
+    // the removal of the tombstone marker. This validates the "no ghost
+    // resurrection" invariant from the design document.
+
+    // Insert tombstones at even positions (version=1, below default LWM)
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2), 1L);
+      final var value = new TombstoneRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    // Insert live entries at odd positions to trigger overflows and GC
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2 + 1), 100L);
+      final var value = new RecordId(2, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    // Verify: looking up tombstoned keys must return null (no ghost resurrection)
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2), 1L);
+      final RID[] result = {null};
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> result[0] = bTree.get(key, atomicOperation));
+
+      // Whether the tombstone was GC'd or not, get() should return either a
+      // TombstoneRID (still present) or null (GC'd). It must NEVER return a
+      // plain RecordId — that would be ghost resurrection.
+      assertThat(result[0])
+          .as("Key at even position %d must not resurrect as live entry", i * 2)
+          .satisfiesAnyOf(
+              rid -> assertThat(rid).isNull(),
+              rid -> assertThat(rid).isInstanceOf(TombstoneRID.class));
+    }
+  }
+
+  @Test
+  public void testLiveEntriesAreNeverRemovedByGC() throws Exception {
+    // Insert all live entries (no tombstones) and trigger overflows.
+    // GC should not remove any entries.
+    for (int i = 0; i < FILL_COUNT * 2; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i), 50L);
+      final var value = new RecordId(1, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    assertThat(countAllEntries())
+        .as("Live entries must never be removed by GC")
+        .isEqualTo(FILL_COUNT * 2);
+  }
+
+  // ---- SnapshotMarkerRID demotion ----
+
+  @Test
+  public void testSnapshotMarkerDemotedWhenNoActiveSnapshotEntries() throws Exception {
+    // Insert SnapshotMarkerRID entries at version=1 (below default LWM).
+    // When bucket overflows, markers should be demoted to plain RecordId.
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2), 1L);
+      final var value = new SnapshotMarkerRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    long markersBefore = countEntriesOfType(SnapshotMarkerRID.class);
+    assertThat(markersBefore)
+        .as("Markers should exist before live entry inserts")
+        .isGreaterThan(0);
+
+    // Insert live entries at odd positions to trigger overflows
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2 + 1), 100L);
+      final var value = new RecordId(2, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    long markersAfter = countEntriesOfType(SnapshotMarkerRID.class);
+    long recordIdsAfter = countEntriesOfType(RecordId.class);
+
+    // Markers should have been demoted to RecordId during GC
+    assertThat(markersAfter)
+        .as("SnapshotMarkerRID entries below LWM should be demoted")
+        .isLessThan(markersBefore);
+
+    // Total entry count should remain the same (demotions don't remove)
+    assertThat(countAllEntries())
+        .as("Demotions should not change total entry count")
+        .isEqualTo(FILL_COUNT * 2);
+  }
+
+  @Test
+  public void testSnapshotMarkerPreservedWhenActiveSnapshotEntriesExist()
+      throws Exception {
+    // Add snapshot entries BEFORE inserting markers so that GC during marker
+    // insertion (caused by bucket overflow) correctly preserves markers that
+    // have active snapshot entries.
+    var snapshot = storage.getIndexSnapshotByEngineName(ENGINE_NAME);
+    assertThat(snapshot).isNotNull();
+
+    for (int i = 0; i < FILL_COUNT; i++) {
+      var userKeyPrefix = new CompositeKey(
+          "key" + String.format("%06d", i * 2));
+      snapshot.addSnapshotPair(
+          new CompositeKey(userKeyPrefix, 1L),
+          new CompositeKey(userKeyPrefix, 50L),
+          new RecordId(1, i));
+    }
+
+    // Pin LWM at 5 so markers at version=1 are below LWM (eligible for
+    // demotion check), but snapshot entries at version 50 >= LWM prevent it.
+    var holder = pinLwm(5L);
+    try {
+      // Insert markers at version=1 (below LWM=5)
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), 1L);
+        final var value = new SnapshotMarkerRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> bTree.put(atomicOperation, key, value));
+      }
+
+      // Insert live entries to trigger overflows
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2 + 1), 100L);
+        final var value = new RecordId(2, i);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            atomicOperation -> bTree.put(atomicOperation, key, value));
+      }
+
+      // Markers should be preserved (snapshot entries with version >= LWM exist)
+      assertThat(countEntriesOfType(SnapshotMarkerRID.class))
+          .as("Markers with active snapshot entries must be preserved")
+          .isEqualTo(FILL_COUNT);
+    } finally {
+      unpinLwm(holder);
+    }
+  }
+
+  // ---- Tree size consistency ----
+
+  @Test
+  public void testTreeSizeConsistentAfterGC() throws Exception {
+    // Fill with tombstones, then live entries. After GC, reported tree size
+    // must match the actual count of entries.
+
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2), 1L);
+      final var value = new TombstoneRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2 + 1), 100L);
+      final var value = new RecordId(2, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    long[] reportedSize = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+      reportedSize[0] = bTree.size(atomicOperation);
+    });
+
+    long actualCount = countAllEntries();
+
+    assertThat(reportedSize[0])
+        .as("Reported tree size must match actual entry count after GC")
+        .isEqualTo(actualCount);
+  }
+
+  // ---- GC-once guard ----
+
+  @Test
+  public void testGCRunsAtMostOncePerInsert() throws Exception {
+    // Fill the tree so buckets are nearly full, then insert entries that
+    // trigger overflow. Even if GC doesn't free enough space (e.g., no
+    // tombstones to remove), the split should still proceed without error.
+
+    // Fill with only live entries (no tombstones to GC)
+    for (int i = 0; i < FILL_COUNT * 2; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i), 50L);
+      final var value = new RecordId(1, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    // Insert more entries to trigger further splits — GC finds nothing
+    // to remove but should not loop or error
+    for (int i = FILL_COUNT * 2; i < FILL_COUNT * 3; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i), 50L);
+      final var value = new RecordId(1, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> bTree.put(atomicOperation, key, value));
+    }
+
+    assertThat(countAllEntries())
+        .as("All entries must be present after splits with no GC candidates")
+        .isEqualTo(FILL_COUNT * 3);
+  }
+
+  // ---- Stub engine for indexEngineNameMap registration ----
+
+  /**
+   * Minimal {@link BaseIndexEngine} stub that provides only {@code getId()}
+   * and {@code getName()} — the only methods used by
+   * {@code AbstractStorage.hasActiveSnapshotEntries()}.
+   */
+  private static class StubIndexEngine implements BaseIndexEngine {
+    private final String name;
+    private final int id;
+
+    StubIndexEngine(String name, int id) {
+      this.name = name;
+      this.id = id;
+    }
+
+    @Override
+    public int getId() {
+      return id;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public void init(
+        com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded s,
+        com.jetbrains.youtrackdb.internal.core.index.IndexMetadata m) {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void create(AtomicOperation o,
+        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d) {
+    }
+
+    @Override
+    public void load(
+        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d,
+        AtomicOperation o) {
+    }
+
+    @Override
+    public void delete(AtomicOperation o) {
+    }
+
+    @Override
+    public void clear(
+        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
+        AtomicOperation o) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesBetween(Object f, boolean fi, Object t, boolean ti,
+            boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer tr,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesMajor(Object k, boolean i, boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        iterateEntriesMinor(Object k, boolean i, boolean a,
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        stream(com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<
+        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
+        descStream(
+            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+            AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<Object> keyStream(AtomicOperation o) {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public long size(com.jetbrains.youtrackdb.internal.core.storage.Storage s,
+        com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
+        AtomicOperation o) {
+      return 0;
+    }
+
+    @Override
+    public int getEngineAPIVersion() {
+      return 0;
+    }
+
+    @Override
+    public boolean acquireAtomicExclusiveLock(AtomicOperation o) {
+      return false;
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -610,9 +610,21 @@ public class BTreeTombstoneGCTest {
   public void testGetIndexSnapshotByEngineNameReturnsNullForUnknownEngine() {
     // Verifies the defensive null-return path in getIndexSnapshotByEngineName
     // when the engine name is not registered in indexEngineNameMap.
-    var snapshot = storage.getIndexSnapshotByEngineName("nonExistentEngine");
-    assertThat(snapshot)
+    assertThat(storage.getIndexSnapshotByEngineName(ENGINE_NAME))
+        .as("Registered engine name must return a non-null snapshot")
+        .isNotNull();
+    assertThat(storage.getIndexSnapshotByEngineName("nonExistentEngine"))
         .as("Unknown engine name must return null snapshot")
+        .isNull();
+  }
+
+  @Test
+  public void testGetNullIndexSnapshotByEngineNameReturnsNullForUnknownEngine() {
+    // Verifies the defensive null-return path in getNullIndexSnapshotByEngineName
+    // when the engine name is not registered in indexEngineNameMap.
+    var snapshot = storage.getNullIndexSnapshotByEngineName("nonExistentEngine");
+    assertThat(snapshot)
+        .as("Unknown engine name must return null for null-index snapshot")
         .isNull();
   }
 
@@ -624,6 +636,18 @@ public class BTreeTombstoneGCTest {
         "nonExistentEngine", new CompositeKey("key"), 1L);
     assertThat(result)
         .as("Unknown engine name must return false for active snapshot check")
+        .isFalse();
+  }
+
+  @Test
+  public void testHasActiveSnapshotEntriesReturnsFalseForUnknownNullTreeEngine() {
+    // The "$null" suffix triggers a different code path that strips the suffix
+    // and queries sharedNullIndexesSnapshot. An unregistered base name must
+    // still return false.
+    var result = storage.hasActiveIndexSnapshotEntries(
+        "nonExistentEngine$null", new CompositeKey("key"), 1L);
+    assertThat(result)
+        .as("Unknown null-tree engine name must return false")
         .isFalse();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -211,6 +211,28 @@ public class BTreeTombstoneGCTest {
     assertThat(countEntriesOfType(RecordId.class))
         .as("All live entries must survive GC")
         .isEqualTo(FILL_COUNT);
+
+    // Spot-check that live entries retain their original RID identity
+    for (int i = 0; i < 10; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2 + 1), 100L);
+      final RID[] result = {null};
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> result[0] = bTree.get(key, atomicOperation));
+      assertThat(result[0])
+          .as("Live entry at odd position %d must exist", i * 2 + 1)
+          .isNotNull()
+          .isInstanceOf(RecordId.class)
+          .isNotInstanceOf(TombstoneRID.class);
+      assertThat(result[0].getCollectionId())
+          .as("Live entry at odd position %d must have collectionId=2",
+              i * 2 + 1)
+          .isEqualTo(2);
+      assertThat(result[0].getCollectionPosition())
+          .as("Live entry at odd position %d must have "
+              + "collectionPosition=%d", i * 2 + 1, i)
+          .isEqualTo(i);
+    }
   }
 
   @Test
@@ -643,6 +665,28 @@ public class BTreeTombstoneGCTest {
     assertThat(reportedSize[0])
         .as("Reported tree size must match actual count after mixed GC")
         .isEqualTo(countAllEntries());
+
+    // Spot-check that original live entries survive with correct identity
+    for (int i = 0; i < Math.min(5, count); i++) {
+      int base = i * 6;
+      final var lKey = new CompositeKey(
+          "key" + String.format("%06d", base + 4), 3L);
+      final RID[] result = {null};
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> result[0] = bTree.get(lKey, op));
+      assertThat(result[0])
+          .as("Live entry at base+4 position %d must survive", base + 4)
+          .isNotNull()
+          .isInstanceOf(RecordId.class)
+          .isNotInstanceOf(TombstoneRID.class);
+      assertThat(result[0].getCollectionId())
+          .as("Live entry at base+4 must retain collectionId=1")
+          .isEqualTo(1);
+      assertThat(result[0].getCollectionPosition())
+          .as("Live entry at base+4 must retain position=%d",
+              i + 2 * count)
+          .isEqualTo(i + 2 * count);
+    }
   }
 
   // ---- Sort order preservation ----
@@ -686,6 +730,271 @@ public class BTreeTombstoneGCTest {
         }
       }
     });
+  }
+
+  // ---- Null-tree GC path ----
+
+  @Test
+  public void testNullTreeGCQueriesNullSnapshotMap() throws Exception {
+    // BTreeMultiValueIndexEngine creates a nullTree with name ending in
+    // "$null". GC must query sharedNullIndexesSnapshot (not the regular
+    // sharedIndexesSnapshot) for demotion decisions. This test verifies
+    // that markers on a null tree are preserved when the null snapshot
+    // map has active entries — proving isNullTree routes correctly.
+    var nullEngineName =
+        ENGINE_NAME + AbstractStorage.NULL_TREE_SUFFIX;
+    var nullTree =
+        new BTree<CompositeKey>(nullEngineName, ".cbt", ".nbt", storage);
+    nullTree.setEngineId(STUB_ENGINE_ID);
+    atomicOperationsManager.executeInsideAtomicOperation(
+        op -> nullTree.create(
+            op,
+            new IndexMultiValuKeySerializer(),
+            new PropertyTypeInternal[] {
+                PropertyTypeInternal.STRING,
+                PropertyTypeInternal.LONG},
+            2));
+    try {
+      // Add snapshot entries to the NULL snapshot map. The stub engine
+      // is registered under ENGINE_NAME (without $null suffix).
+      var nullSnapshot =
+          storage.getNullIndexSnapshotByEngineName(ENGINE_NAME);
+      assertThat(nullSnapshot)
+          .as("Null snapshot for registered engine must exist")
+          .isNotNull();
+
+      var holder = BTreeGCTestSupport.pinLwm(storage, 5L);
+      try {
+        for (int i = 0; i < FILL_COUNT; i++) {
+          var userKeyPrefix = new CompositeKey(
+              "key" + String.format("%06d", i * 2));
+          nullSnapshot.addSnapshotPair(
+              new CompositeKey(userKeyPrefix, 1L),
+              new CompositeKey(userKeyPrefix, 50L),
+              new RecordId(1, i));
+        }
+
+        // Insert markers at version=1 (below LWM=5)
+        for (int i = 0; i < FILL_COUNT; i++) {
+          final var key = new CompositeKey(
+              "key" + String.format("%06d", i * 2), 1L);
+          final var value = new SnapshotMarkerRID(new RecordId(1, i));
+          atomicOperationsManager.executeInsideAtomicOperation(
+              op -> nullTree.put(op, key, value));
+        }
+
+        // Insert live entries to trigger overflow + GC
+        for (int i = 0; i < FILL_COUNT; i++) {
+          final var key = new CompositeKey(
+              "key" + String.format("%06d", i * 2 + 1), 100L);
+          final var value = new RecordId(2, i);
+          atomicOperationsManager.executeInsideAtomicOperation(
+              op -> nullTree.put(op, key, value));
+        }
+
+        // Markers should be preserved: GC queries the null snapshot map
+        // where active entries exist (version 50 >= LWM 5).
+        long[] markerCount = {0};
+        atomicOperationsManager.executeInsideAtomicOperation(op -> {
+          var firstKey = nullTree.firstKey(op);
+          var lastKey = nullTree.lastKey(op);
+          try (var stream = nullTree.iterateEntriesBetween(
+              firstKey, true, lastKey, true, true, op)) {
+            markerCount[0] = stream
+                .filter(p -> p.second() instanceof SnapshotMarkerRID)
+                .count();
+          }
+        });
+        assertThat(markerCount[0])
+            .as("Markers on null tree must be preserved when null "
+                + "snapshot map has active entries")
+            .isEqualTo(FILL_COUNT);
+      } finally {
+        nullSnapshot.clear();
+        BTreeGCTestSupport.unpinLwm(storage, holder);
+      }
+    } finally {
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> nullTree.delete(op));
+    }
+  }
+
+  // ---- engineId fallback ----
+
+  @Test
+  public void testMarkersNotDemotedWhenEngineIdNotSet() throws Exception {
+    // When engineId is not set (-1), hasActiveSnapshotEntries
+    // conservatively returns true, preventing marker demotion.
+    // Tombstones should still be removed (they bypass snapshot checks).
+    var unregisteredTree = new BTree<CompositeKey>(
+        "unregisteredTree", ".cbt", ".nbt", storage);
+    // Deliberately do NOT call setEngineId — default is -1
+    atomicOperationsManager.executeInsideAtomicOperation(
+        op -> unregisteredTree.create(
+            op,
+            new IndexMultiValuKeySerializer(),
+            new PropertyTypeInternal[] {
+                PropertyTypeInternal.STRING,
+                PropertyTypeInternal.LONG},
+            2));
+    try {
+      // Insert markers at version=1 (below default LWM)
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), 1L);
+        final var value = new SnapshotMarkerRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> unregisteredTree.put(op, key, value));
+      }
+
+      long markersBefore = countEntriesOfType(
+          unregisteredTree, SnapshotMarkerRID.class);
+      assertThat(markersBefore)
+          .as("Markers should exist before live entry inserts")
+          .isGreaterThan(0);
+
+      // Insert live entries to trigger overflow + GC
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2 + 1), 100L);
+        final var value = new RecordId(2, i);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> unregisteredTree.put(op, key, value));
+      }
+
+      // With engineId == -1, ALL markers must be preserved
+      // (conservative fallback prevents demotion)
+      assertThat(countEntriesOfType(
+          unregisteredTree, SnapshotMarkerRID.class))
+          .as("All markers must be preserved when engineId is not set")
+          .isEqualTo(markersBefore);
+    } finally {
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> unregisteredTree.delete(op));
+    }
+  }
+
+  // ---- SnapshotMarkerRID boundary ----
+
+  @Test
+  public void testSnapshotMarkersAtExactLwmArePreserved() throws Exception {
+    // The GC condition is `version < LWM` (strictly below). Markers whose
+    // version equals exactly the LWM must NOT be demoted — they may still
+    // be needed by a transaction reading at exactly that timestamp.
+    final long lwmValue = 50L;
+    var holder = BTreeGCTestSupport.pinLwm(storage, lwmValue);
+    try {
+      // Insert markers at version == LWM (exactly 50)
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), lwmValue);
+        final var value = new SnapshotMarkerRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+
+      // Insert live entries at odd positions to trigger overflows
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2 + 1), 200L);
+        final var value = new RecordId(2, i);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+
+      // Markers at exactly LWM must NOT be demoted
+      assertThat(countEntriesOfType(SnapshotMarkerRID.class))
+          .as("Markers at exactly LWM must not be demoted "
+              + "(strict < comparison)")
+          .isEqualTo(FILL_COUNT);
+    } finally {
+      BTreeGCTestSupport.unpinLwm(storage, holder);
+    }
+  }
+
+  // ---- Snapshot entry scoping ----
+
+  @Test
+  public void testSnapshotMarkerDemotedOnlyForKeysWithoutSnapshotEntries()
+      throws Exception {
+    // Snapshot entries exist for keys at indices 50+ but NOT for indices
+    // 0-49. Markers at indices 0-49 should be demoted (no matching
+    // snapshot entries); markers at indices 50+ should be preserved.
+    // This verifies that hasActiveSnapshotEntriesInMap correctly scopes
+    // the subMap query to the specific user-key prefix.
+    var snapshot = storage.getIndexSnapshotByEngineName(ENGINE_NAME);
+    assertThat(snapshot).isNotNull();
+
+    var holder = BTreeGCTestSupport.pinLwm(storage, 5L);
+    try {
+      // Only add snapshot entries for keys at indices 50+
+      for (int i = 50; i < FILL_COUNT; i++) {
+        var userKeyPrefix = new CompositeKey(
+            "key" + String.format("%06d", i * 2));
+        snapshot.addSnapshotPair(
+            new CompositeKey(userKeyPrefix, 1L),
+            new CompositeKey(userKeyPrefix, 50L),
+            new RecordId(1, i));
+      }
+
+      // Insert markers for ALL keys (version=1, below LWM=5)
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), 1L);
+        final var value = new SnapshotMarkerRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+
+      // Insert live entries to trigger overflow + GC
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2 + 1), 100L);
+        final var value = new RecordId(2, i);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+
+      // Markers at indices 50+ should be preserved (snapshot entries
+      // exist). Markers at indices 0-49 should be demoted (no snapshot
+      // entries) — at least in buckets that overflowed. Overall marker
+      // count should be less than FILL_COUNT (some demoted) but at
+      // least FILL_COUNT - 50 (those with snapshot entries survive).
+      long survivingMarkers =
+          countEntriesOfType(SnapshotMarkerRID.class);
+      assertThat(survivingMarkers)
+          .as("Some markers without snapshot entries should be demoted")
+          .isLessThan((long) FILL_COUNT);
+      assertThat(survivingMarkers)
+          .as("Markers with snapshot entries must be preserved")
+          .isGreaterThanOrEqualTo((long) FILL_COUNT - 50);
+    } finally {
+      BTreeGCTestSupport.unpinLwm(storage, holder);
+    }
+  }
+
+  // ---- Helpers (overloads for arbitrary trees) ----
+
+  /**
+   * Counts entries of a specific RID type in the given tree.
+   */
+  private long countEntriesOfType(
+      BTree<CompositeKey> tree,
+      Class<? extends RID> ridType) throws Exception {
+    long[] count = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+      var firstKey = tree.firstKey(atomicOperation);
+      if (firstKey == null) {
+        return;
+      }
+      var lastKey = tree.lastKey(atomicOperation);
+      try (var stream = tree.iterateEntriesBetween(
+          firstKey, true, lastKey, true, true, atomicOperation)) {
+        count[0] = stream.filter(p -> ridType.isInstance(p.second()))
+            .count();
+      }
+    });
+    return count[0];
   }
 
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -277,13 +277,14 @@ public class BTreeTombstoneGCTest {
 
     long tombstonesAfter = countEntriesOfType(TombstoneRID.class);
 
-    // We assert "fewer tombstones" rather than "zero tombstones" because GC
-    // only runs on buckets that actually overflow. Tombstones in buckets that
-    // had room for the new entry are never visited, so a strict isZero()
-    // assertion would be flaky depending on key distribution and bucket sizing.
+    // We assert "substantially fewer tombstones" rather than "zero tombstones"
+    // because GC only runs on buckets that actually overflow. Tombstones in
+    // buckets that had room for the new entry are never visited. However,
+    // overflow events are distributed across buckets, so at least half should
+    // be collected.
     assertThat(tombstonesAfter)
         .as("Tombstones below LWM should be GC'd during bucket overflow")
-        .isLessThan(tombstonesBefore);
+        .isLessThan(tombstonesBefore / 2);
 
     // All live entries must be present
     assertThat(countEntriesOfType(RecordId.class))
@@ -342,6 +343,11 @@ public class BTreeTombstoneGCTest {
       }
 
       long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
+      // At version == LWM, even bucket overflows during tombstone insertion
+      // should not GC any tombstones (condition is version < lwm, not <=).
+      assertThat(tombstonesBefore)
+          .as("All tombstones at version == LWM should survive insertion-phase overflows")
+          .isEqualTo(FILL_COUNT);
 
       // Insert live entries at odd positions to trigger overflows
       for (int i = 0; i < FILL_COUNT; i++) {
@@ -452,19 +458,20 @@ public class BTreeTombstoneGCTest {
 
     long markersAfter = countEntriesOfType(SnapshotMarkerRID.class);
 
-    // Markers should have been demoted to RecordId during GC. Note: some
-    // markers may already be demoted during the marker insertion phase itself
-    // (bucket overflows during insertion trigger GC on earlier markers).
+    // Markers should have been demoted to RecordId during GC. Overflow events
+    // are distributed across buckets, so at least half should be demoted.
     assertThat(markersAfter)
         .as("SnapshotMarkerRID entries below LWM should be demoted")
-        .isLessThan(markersBefore);
+        .isLessThan(markersBefore / 2);
 
     // Total entry count should remain the same (demotions don't remove)
     assertThat(countAllEntries())
         .as("Demotions should not change total entry count")
         .isEqualTo(FILL_COUNT * 2);
 
-    // Spot-check that demoted entries retain their original identity
+    // Spot-check that demoted entries retain their original identity.
+    // Track demotedCount to ensure at least one identity assertion fires.
+    int demotedCount = 0;
     for (int i = 0; i < 10; i++) {
       final var key = new CompositeKey(
           "key" + String.format("%06d", i * 2), 1L);
@@ -472,7 +479,9 @@ public class BTreeTombstoneGCTest {
       atomicOperationsManager.executeInsideAtomicOperation(
           atomicOperation -> result[0] = bTree.get(key, atomicOperation));
       // If demoted, the entry should be a plain RecordId with the original identity
-      if (result[0] instanceof RecordId && !(result[0] instanceof SnapshotMarkerRID)) {
+      if (result[0] instanceof RecordId
+          && !(result[0] instanceof SnapshotMarkerRID)) {
+        demotedCount++;
         assertThat(result[0].getCollectionId())
             .as("Demoted marker at position %d should retain original collection ID", i)
             .isEqualTo(1);
@@ -481,6 +490,9 @@ public class BTreeTombstoneGCTest {
             .isEqualTo(i);
       }
     }
+    assertThat(demotedCount)
+        .as("At least one of the first 10 markers should have been demoted")
+        .isGreaterThan(0);
   }
 
   @Test
@@ -698,10 +710,10 @@ public class BTreeTombstoneGCTest {
 
     assertThat(countEntriesOfType(TombstoneRID.class))
         .as("Tombstones should be GC'd from mixed bucket")
-        .isLessThan(tombstonesBefore);
+        .isLessThan(tombstonesBefore / 2);
     assertThat(countEntriesOfType(SnapshotMarkerRID.class))
         .as("Markers should be demoted from mixed bucket")
-        .isLessThan(markersBefore);
+        .isLessThan(markersBefore / 2);
 
     // Verify tree size consistency after mixed GC
     long[] reportedSize = {0};

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -180,12 +180,14 @@ public class BTreeTombstoneGCTest {
     }
 
     long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
-    // Some tombstones may already be GC'd during their own insertion phase
-    // (bucket overflows during tombstone insertion trigger GC on earlier
-    // tombstones). Verify at least some survive.
+    // GC during the insertion phase is aggressive: every bucket overflow
+    // removes all tombstones in that bucket. Only partially-filled
+    // buckets at the end survive. Require enough for the post-condition
+    // ratio check (isLessThan(before / 2)) to be meaningful.
     assertThat(tombstonesBefore)
-        .as("At least some tombstones should exist before live entry inserts")
-        .isGreaterThan(0);
+        .as("Enough tombstones should survive insertion-phase GC "
+            + "for the ratio check to be meaningful")
+        .isGreaterThan(5);
 
     // Insert FILL_COUNT live entries at odd positions to trigger overflows
     for (int i = 0; i < FILL_COUNT; i++) {
@@ -386,9 +388,13 @@ public class BTreeTombstoneGCTest {
     }
 
     long markersBefore = countEntriesOfType(SnapshotMarkerRID.class);
+    // GC during the insertion phase is aggressive: bucket overflows
+    // demote all markers in overflowing buckets. Require enough for
+    // the ratio check to be meaningful.
     assertThat(markersBefore)
-        .as("Markers should exist before live entry inserts")
-        .isGreaterThan(0);
+        .as("Enough markers should survive insertion-phase GC "
+            + "for the ratio check to be meaningful")
+        .isGreaterThan(5);
 
     // Insert live entries at odd positions to trigger overflows
     for (int i = 0; i < FILL_COUNT; i++) {
@@ -575,10 +581,11 @@ public class BTreeTombstoneGCTest {
 
   @Test
   public void testGetNullIndexSnapshotByEngineNameReturnsNullForUnknownEngine() {
-    // Verifies the defensive null-return path in getNullIndexSnapshotByEngineName
-    // when the engine name is not registered in indexEngineNameMap.
-    var snapshot = storage.getNullIndexSnapshotByEngineName("nonExistentEngine");
-    assertThat(snapshot)
+    // Verifies both positive and negative paths in getNullIndexSnapshotByEngineName.
+    assertThat(storage.getNullIndexSnapshotByEngineName(ENGINE_NAME))
+        .as("Registered engine name must return a non-null null-index snapshot")
+        .isNotNull();
+    assertThat(storage.getNullIndexSnapshotByEngineName("nonExistentEngine"))
         .as("Unknown engine name must return null for null-index snapshot")
         .isNull();
   }
@@ -838,25 +845,40 @@ public class BTreeTombstoneGCTest {
                 PropertyTypeInternal.LONG},
             2));
     try {
-      // Insert markers at version=1 (below default LWM)
+      // Insert interleaved markers and tombstones (same key prefix so
+      // they co-locate in the same B-tree buckets). Markers at positions
+      // i*3, tombstones at positions i*3+1. Version=1 (below default LWM).
       for (int i = 0; i < FILL_COUNT; i++) {
-        final var key = new CompositeKey(
-            "key" + String.format("%06d", i * 2), 1L);
-        final var value = new SnapshotMarkerRID(new RecordId(1, i));
+        final var mKey = new CompositeKey(
+            "key" + String.format("%06d", i * 3), 1L);
+        final var mVal = new SnapshotMarkerRID(new RecordId(1, i));
         atomicOperationsManager.executeInsideAtomicOperation(
-            op -> unregisteredTree.put(op, key, value));
+            op -> unregisteredTree.put(op, mKey, mVal));
+
+        final var tKey = new CompositeKey(
+            "key" + String.format("%06d", i * 3 + 1), 1L);
+        final var tVal = new TombstoneRID(new RecordId(3, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> unregisteredTree.put(op, tKey, tVal));
       }
 
       long markersBefore = countEntriesOfType(
           unregisteredTree, SnapshotMarkerRID.class);
       assertThat(markersBefore)
-          .as("Markers should exist before live entry inserts")
-          .isGreaterThan(0);
+          .as("Enough markers should survive insertion-phase GC")
+          .isGreaterThan(5);
 
-      // Insert live entries to trigger overflow + GC
+      long tombstonesBefore = countEntriesOfType(
+          unregisteredTree, TombstoneRID.class);
+      assertThat(tombstonesBefore)
+          .as("Enough tombstones should survive insertion-phase GC")
+          .isGreaterThan(5);
+
+      // Insert live entries at interleaved positions (i*3+2) to trigger
+      // overflow + GC. These share buckets with markers and tombstones.
       for (int i = 0; i < FILL_COUNT; i++) {
         final var key = new CompositeKey(
-            "key" + String.format("%06d", i * 2 + 1), 100L);
+            "key" + String.format("%06d", i * 3 + 2), 100L);
         final var value = new RecordId(2, i);
         atomicOperationsManager.executeInsideAtomicOperation(
             op -> unregisteredTree.put(op, key, value));
@@ -868,6 +890,13 @@ public class BTreeTombstoneGCTest {
           unregisteredTree, SnapshotMarkerRID.class))
           .as("All markers must be preserved when engineId is not set")
           .isEqualTo(markersBefore);
+
+      // Tombstones must still be GC'd even without engineId —
+      // tombstone removal bypasses the snapshot check entirely
+      assertThat(countEntriesOfType(
+          unregisteredTree, TombstoneRID.class))
+          .as("Tombstones must be removed regardless of engineId")
+          .isLessThan(tombstonesBefore / 2);
     } finally {
       atomicOperationsManager.executeInsideAtomicOperation(
           op -> unregisteredTree.delete(op));
@@ -971,6 +1000,94 @@ public class BTreeTombstoneGCTest {
     } finally {
       BTreeGCTestSupport.unpinLwm(storage, holder);
     }
+  }
+
+  // ---- All-tombstone bucket GC ----
+
+  @Test
+  public void testAllTombstoneBucketIsFullyClearedByGC() throws Exception {
+    // When a leaf bucket contains ONLY tombstones below LWM,
+    // filterAndRebuildBucket removes all entries, calls clear(), then
+    // addAll(survivors) with an empty list. The subsequent addLeafEntry
+    // must succeed on the empty bucket. This exercises the extreme case
+    // where the survivor list is empty after GC.
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i), 1L);
+      final var value = new TombstoneRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, key, value));
+    }
+
+    // Insert a single live entry into the middle of the key range
+    // to trigger GC on a bucket full of tombstones
+    final var liveKey = new CompositeKey("key000100", 100L);
+    final var liveVal = new RecordId(2, 100);
+    atomicOperationsManager.executeInsideAtomicOperation(
+        op -> bTree.put(op, liveKey, liveVal));
+
+    // Verify the live entry exists
+    final RID[] result = {null};
+    atomicOperationsManager.executeInsideAtomicOperation(
+        op -> result[0] = bTree.get(liveKey, op));
+    assertThat(result[0])
+        .as("Live entry must be findable after all-tombstone GC")
+        .isNotNull()
+        .isInstanceOf(RecordId.class)
+        .isNotInstanceOf(TombstoneRID.class);
+
+    // Tree size must be consistent
+    long[] reportedSize = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(
+        op -> reportedSize[0] = bTree.size(op));
+    assertThat(reportedSize[0])
+        .as("Reported tree size must match actual count after "
+            + "all-tombstone GC")
+        .isEqualTo(countAllEntries());
+  }
+
+  // ---- Snapshot entry boundary tests ----
+
+  @Test
+  public void testHasActiveSnapshotEntriesReturnsTrueForEntryAtExactLwm() {
+    // Register a snapshot entry at version exactly == LWM. The subMap
+    // query uses inclusive bounds, so an entry at exactly LWM must be
+    // detected.
+    var snapshot = storage.getIndexSnapshotByEngineName(ENGINE_NAME);
+    assertThat(snapshot).isNotNull();
+    final long lwm = 50L;
+    var userKeyPrefix = new CompositeKey("testKey");
+    snapshot.addSnapshotPair(
+        new CompositeKey(userKeyPrefix, 1L),
+        new CompositeKey(userKeyPrefix, lwm),
+        new RecordId(1, 1));
+
+    var result = storage.hasActiveIndexSnapshotEntries(
+        ENGINE_NAME, userKeyPrefix, lwm);
+    assertThat(result)
+        .as("Snapshot entry at exactly LWM should be detected (inclusive)")
+        .isTrue();
+  }
+
+  @Test
+  public void testHasActiveSnapshotEntriesReturnsFalseWhenAllBelowLwm() {
+    // Register a snapshot entry at version below LWM. The subMap query
+    // range starts at LWM (inclusive), so an entry at version < LWM
+    // must not be detected.
+    var snapshot = storage.getIndexSnapshotByEngineName(ENGINE_NAME);
+    assertThat(snapshot).isNotNull();
+    final long lwm = 50L;
+    var userKeyPrefix = new CompositeKey("testKey");
+    snapshot.addSnapshotPair(
+        new CompositeKey(userKeyPrefix, 1L),
+        new CompositeKey(userKeyPrefix, 49L),
+        new RecordId(1, 1));
+
+    var result = storage.hasActiveIndexSnapshotEntries(
+        ENGINE_NAME, userKeyPrefix, lwm);
+    assertThat(result)
+        .as("Snapshot entry below LWM should not be detected")
+        .isFalse();
   }
 
   // ---- Helpers (overloads for arbitrary trees) ----

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -371,6 +371,27 @@ public class BTreeTombstoneGCTest {
     assertThat(countAllEntries())
         .as("Live entries must never be removed by GC")
         .isEqualTo(FILL_COUNT * 2);
+
+    // Spot-check that entries retain correct RID identity after splits
+    // with no GC candidates — catches silent value corruption during
+    // bucket rebuild.
+    for (int i = 0; i < 10; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i), 50L);
+      final RID[] result = {null};
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> result[0] = bTree.get(key, op));
+      assertThat(result[0])
+          .as("Entry at position %d must exist with correct identity", i)
+          .isNotNull()
+          .isInstanceOf(RecordId.class);
+      assertThat(result[0].getCollectionId())
+          .as("Entry at position %d must have collectionId=1", i)
+          .isEqualTo(1);
+      assertThat(result[0].getCollectionPosition())
+          .as("Entry at position %d must have collectionPosition=%d", i, i)
+          .isEqualTo(i);
+    }
   }
 
   // ---- SnapshotMarkerRID demotion ----
@@ -563,6 +584,26 @@ public class BTreeTombstoneGCTest {
     assertThat(countAllEntries())
         .as("All entries must be present after splits with no GC candidates")
         .isEqualTo(FILL_COUNT * 3);
+
+    // Spot-check entry identity across the key range — catches silent
+    // value corruption during normal splits when GC finds nothing.
+    for (int i = 0; i < 10; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i), 50L);
+      final RID[] result = {null};
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> result[0] = bTree.get(key, op));
+      assertThat(result[0])
+          .as("Entry at position %d must exist with correct identity", i)
+          .isNotNull()
+          .isInstanceOf(RecordId.class);
+      assertThat(result[0].getCollectionId())
+          .as("Entry at position %d must have collectionId=1", i)
+          .isEqualTo(1);
+      assertThat(result[0].getCollectionPosition())
+          .as("Entry at position %d must have collectionPosition=%d", i, i)
+          .isEqualTo(i);
+    }
   }
 
   // ---- AbstractStorage helper edge cases ----
@@ -761,11 +802,11 @@ public class BTreeTombstoneGCTest {
                 PropertyTypeInternal.STRING,
                 PropertyTypeInternal.LONG},
             2));
+    // Track nullSnapshot outside the inner try block so cleanup
+    // is unconditional regardless of where an exception occurs.
+    var nullSnapshot =
+        storage.getNullIndexSnapshotByEngineName(ENGINE_NAME);
     try {
-      // Add snapshot entries to the NULL snapshot map. The stub engine
-      // is registered under ENGINE_NAME (without $null suffix).
-      var nullSnapshot =
-          storage.getNullIndexSnapshotByEngineName(ENGINE_NAME);
       assertThat(nullSnapshot)
           .as("Null snapshot for registered engine must exist")
           .isNotNull();
@@ -817,10 +858,12 @@ public class BTreeTombstoneGCTest {
                 + "snapshot map has active entries")
             .isEqualTo(FILL_COUNT);
       } finally {
-        nullSnapshot.clear();
         BTreeGCTestSupport.unpinLwm(storage, holder);
       }
     } finally {
+      if (nullSnapshot != null) {
+        nullSnapshot.clear();
+      }
       atomicOperationsManager.executeInsideAtomicOperation(
           op -> nullTree.delete(op));
     }
@@ -997,6 +1040,22 @@ public class BTreeTombstoneGCTest {
       assertThat(survivingMarkers)
           .as("Markers with snapshot entries must be preserved")
           .isGreaterThanOrEqualTo((long) FILL_COUNT - 50);
+
+      // Spot-check that markers at indices 50+ (which HAVE snapshot entries)
+      // are specifically preserved as SnapshotMarkerRID — catches a scoping
+      // bug where the wrong user-key prefix is queried.
+      for (int i = 50; i < Math.min(60, FILL_COUNT); i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), 1L);
+        final RID[] result = {null};
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> result[0] = bTree.get(key, op));
+        assertThat(result[0])
+            .as("Marker at index %d (has snapshot entries) must be "
+                + "preserved as SnapshotMarkerRID", i)
+            .isNotNull()
+            .isInstanceOf(SnapshotMarkerRID.class);
+      }
     } finally {
       BTreeGCTestSupport.unpinLwm(storage, holder);
     }
@@ -1011,22 +1070,50 @@ public class BTreeTombstoneGCTest {
     // addAll(survivors) with an empty list. The subsequent addLeafEntry
     // must succeed on the empty bucket. This exercises the extreme case
     // where the survivor list is empty after GC.
+
+    // Pin LWM at 1 (equal to tombstone version) during insertion so
+    // tombstones are NOT eligible for GC (condition is version < lwm,
+    // and version == lwm is preserved). This prevents insertion-phase
+    // GC from removing tombstones before we're ready.
+    var holder = BTreeGCTestSupport.pinLwm(storage, 1L);
+    try {
+      // Insert tombstones at even positions so they interleave with
+      // live entries (odd positions) inserted after the LWM is unpinned.
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), 1L);
+        final var value = new TombstoneRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+
+      // All tombstones must survive: version == LWM, not eligible for GC
+      assertThat(countEntriesOfType(TombstoneRID.class))
+          .as("All tombstones must survive when version == LWM")
+          .isEqualTo(FILL_COUNT);
+    } finally {
+      BTreeGCTestSupport.unpinLwm(storage, holder);
+    }
+
+    // Now LWM is back to default (very high), so tombstones at version=1
+    // are below LWM and eligible for GC. Insert live entries at odd key
+    // positions to interleave with tombstones at even positions, ensuring
+    // they co-locate in the same buckets and trigger overflow + GC.
+    long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
+    assertThat(tombstonesBefore)
+        .as("Pre-condition: all tombstones should be present before GC")
+        .isEqualTo(FILL_COUNT);
+
     for (int i = 0; i < FILL_COUNT; i++) {
       final var key = new CompositeKey(
-          "key" + String.format("%06d", i), 1L);
-      final var value = new TombstoneRID(new RecordId(1, i));
+          "key" + String.format("%06d", i * 2 + 1), 100L);
+      final var value = new RecordId(2, i);
       atomicOperationsManager.executeInsideAtomicOperation(
           op -> bTree.put(op, key, value));
     }
 
-    // Insert a single live entry into the middle of the key range
-    // to trigger GC on a bucket full of tombstones
-    final var liveKey = new CompositeKey("key000100", 100L);
-    final var liveVal = new RecordId(2, 100);
-    atomicOperationsManager.executeInsideAtomicOperation(
-        op -> bTree.put(op, liveKey, liveVal));
-
-    // Verify the live entry exists
+    // Verify a live entry exists
+    final var liveKey = new CompositeKey("key000001", 100L);
     final RID[] result = {null};
     atomicOperationsManager.executeInsideAtomicOperation(
         op -> result[0] = bTree.get(liveKey, op));
@@ -1035,6 +1122,23 @@ public class BTreeTombstoneGCTest {
         .isNotNull()
         .isInstanceOf(RecordId.class)
         .isNotInstanceOf(TombstoneRID.class);
+
+    // GC must have actually removed tombstones from overflowing buckets.
+    // Without this assertion, the test passes even if GC is a no-op.
+    // We assert "fewer than before" rather than a specific ratio because
+    // GC only runs on buckets that actually overflow during insertion
+    // (gcAttempted flag limits it to once per put() call).
+    long tombstonesAfter = countEntriesOfType(TombstoneRID.class);
+    assertThat(tombstonesAfter)
+        .as("GC must remove at least some tombstones from overflowing "
+            + "buckets (was %d before, %d after)",
+            tombstonesBefore, tombstonesAfter)
+        .isLessThan(tombstonesBefore);
+
+    // All live entries must be present
+    assertThat(countEntriesOfType(RecordId.class))
+        .as("All live entries must survive GC")
+        .isEqualTo(FILL_COUNT);
 
     // Tree size must be consistent
     long[] reportedSize = {0};
@@ -1088,6 +1192,103 @@ public class BTreeTombstoneGCTest {
     assertThat(result)
         .as("Snapshot entry below LWM should not be detected")
         .isFalse();
+  }
+
+  // ---- Version=0 boundary ----
+
+  @Test
+  public void testTombstoneAtVersionZeroIsRemovedWhenBelowLwm() throws Exception {
+    // Version 0 is the minimum valid version. The GC guard `version < 0`
+    // must NOT treat version=0 as "not a versioned key" (extractVersion
+    // returns -1 for that). With LWM pinned at 1, version=0 is strictly
+    // below LWM and eligible for removal.
+    var holder = BTreeGCTestSupport.pinLwm(storage, 1L);
+    try {
+      // Insert tombstones at version=0
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2), 0L);
+        final var value = new TombstoneRID(new RecordId(1, i));
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+
+      long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
+      assertThat(tombstonesBefore)
+          .as("Enough tombstones at version=0 should survive for ratio check")
+          .isGreaterThan(5);
+
+      // Insert live entries to trigger overflows and GC
+      for (int i = 0; i < FILL_COUNT; i++) {
+        final var key = new CompositeKey(
+            "key" + String.format("%06d", i * 2 + 1), 100L);
+        final var value = new RecordId(2, i);
+        atomicOperationsManager.executeInsideAtomicOperation(
+            op -> bTree.put(op, key, value));
+      }
+
+      assertThat(countEntriesOfType(TombstoneRID.class))
+          .as("Tombstones at version=0, below LWM=1, must be GC'd")
+          .isLessThan(tombstonesBefore / 2);
+      assertThat(countEntriesOfType(RecordId.class))
+          .as("All live entries must survive GC")
+          .isEqualTo(FILL_COUNT);
+    } finally {
+      BTreeGCTestSupport.unpinLwm(storage, holder);
+    }
+  }
+
+  // ---- hasActiveIndexSnapshotEntriesById direct tests ----
+
+  @Test
+  public void testHasActiveSnapshotEntriesByIdSelectsCorrectMap() {
+    // Directly test the lock-free variant that production GC code uses.
+    // Add entries to the regular snapshot map; query with useNullSnapshot=false
+    // should find them, useNullSnapshot=true should not.
+    var snapshot = storage.getIndexSnapshotByEngineName(ENGINE_NAME);
+    assertThat(snapshot).isNotNull();
+    var userKeyPrefix = new CompositeKey("testKey");
+    snapshot.addSnapshotPair(
+        new CompositeKey(userKeyPrefix, 1L),
+        new CompositeKey(userKeyPrefix, 50L),
+        new RecordId(1, 1));
+
+    assertThat(storage.hasActiveIndexSnapshotEntriesById(
+        STUB_ENGINE_ID, false, userKeyPrefix, 50L))
+        .as("Regular map should contain the entry")
+        .isTrue();
+    assertThat(storage.hasActiveIndexSnapshotEntriesById(
+        STUB_ENGINE_ID, true, userKeyPrefix, 50L))
+        .as("Null map should NOT contain the entry")
+        .isFalse();
+  }
+
+  @Test
+  public void testHasActiveSnapshotEntriesByIdNullMapSelectsCorrectMap()
+      throws Exception {
+    // Add entries to the null snapshot map; query with useNullSnapshot=true
+    // should find them, useNullSnapshot=false should not.
+    var nullSnapshot =
+        storage.getNullIndexSnapshotByEngineName(ENGINE_NAME);
+    assertThat(nullSnapshot).isNotNull();
+    var userKeyPrefix = new CompositeKey("testKey");
+    nullSnapshot.addSnapshotPair(
+        new CompositeKey(userKeyPrefix, 1L),
+        new CompositeKey(userKeyPrefix, 50L),
+        new RecordId(1, 1));
+
+    try {
+      assertThat(storage.hasActiveIndexSnapshotEntriesById(
+          STUB_ENGINE_ID, true, userKeyPrefix, 50L))
+          .as("Null map should contain the entry")
+          .isTrue();
+      assertThat(storage.hasActiveIndexSnapshotEntriesById(
+          STUB_ENGINE_ID, false, userKeyPrefix, 50L))
+          .as("Regular map should NOT contain the entry")
+          .isFalse();
+    } finally {
+      nullSnapshot.clear();
+    }
   }
 
   // ---- Helpers (overloads for arbitrary trees) ----

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -11,17 +11,11 @@ import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.SnapshotMarkerRID;
 import com.jetbrains.youtrackdb.internal.core.id.TombstoneRID;
 import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
-import com.jetbrains.youtrackdb.internal.core.index.engine.BaseIndexEngine;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.impl.index.IndexMultiValuKeySerializer;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
-import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.File;
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -98,6 +92,7 @@ public class BTreeTombstoneGCTest {
     // Create a BTree with CompositeKey(userKey, version) layout, matching
     // BTreeSingleValueIndexEngine's key structure.
     bTree = new BTree<>(ENGINE_NAME, ".cbt", ".nbt", storage);
+    bTree.setEngineId(STUB_ENGINE_ID);
     atomicOperationsManager.executeInsideAtomicOperation(
         atomicOperation -> bTree.create(
             atomicOperation,
@@ -107,8 +102,8 @@ public class BTreeTombstoneGCTest {
                 PropertyTypeInternal.LONG},
             2));
 
-    // Register a stub engine so AbstractStorage.hasActiveSnapshotEntries() resolves it
-    registerStubEngine(ENGINE_NAME, STUB_ENGINE_ID);
+    // Register a stub engine so AbstractStorage snapshot queries resolve it
+    BTreeGCTestSupport.registerStubEngine(storage, ENGINE_NAME, STUB_ENGINE_ID);
   }
 
   @After
@@ -121,83 +116,9 @@ public class BTreeTombstoneGCTest {
       snapshot.clear();
     }
 
-    unregisterStubEngine(ENGINE_NAME);
+    BTreeGCTestSupport.unregisterStubEngine(storage, ENGINE_NAME);
     atomicOperationsManager.executeInsideAtomicOperation(
         atomicOperation -> bTree.delete(atomicOperation));
-  }
-
-  // ---- LWM pinning helpers (via reflection) ----
-
-  @SuppressWarnings("unchecked")
-  private static Object pinLwm(long lwmValue) throws Exception {
-    Class<?> holderClass = Class.forName(
-        "com.jetbrains.youtrackdb.internal.core.storage.impl.local.TsMinHolder");
-    var ctor = holderClass.getDeclaredConstructor();
-    ctor.setAccessible(true);
-    Object holder = ctor.newInstance();
-    Field tsMinField = holderClass.getDeclaredField("tsMin");
-    tsMinField.setAccessible(true);
-    tsMinField.setLong(holder, lwmValue);
-
-    Field tsMinsField = AbstractStorage.class.getDeclaredField("tsMins");
-    tsMinsField.setAccessible(true);
-    Set<Object> tsMins = (Set<Object>) tsMinsField.get(storage);
-    tsMins.add(holder);
-    return holder;
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void unpinLwm(Object holder) throws Exception {
-    Field tsMinsField = AbstractStorage.class.getDeclaredField("tsMins");
-    tsMinsField.setAccessible(true);
-    Set<Object> tsMins = (Set<Object>) tsMinsField.get(storage);
-    tsMins.remove(holder);
-  }
-
-  // ---- Stub engine registration (via reflection) ----
-
-  /**
-   * Registers a minimal stub {@link BaseIndexEngine} in AbstractStorage's
-   * {@code indexEngineNameMap} so that
-   * {@code AbstractStorage.hasActiveSnapshotEntries()} can resolve the index.
-   * Acquires stateLock.writeLock() because indexEngineNameMap is a plain HashMap
-   * that requires external synchronization.
-   */
-  @SuppressWarnings("unchecked")
-  private static void registerStubEngine(String name, int id) throws Exception {
-    BaseIndexEngine stub = new StubIndexEngine(name, id);
-    var lock = getStateLock();
-    lock.writeLock().lock();
-    try {
-      Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
-      mapField.setAccessible(true);
-      Map<String, BaseIndexEngine> map =
-          (Map<String, BaseIndexEngine>) mapField.get(storage);
-      map.put(name, stub);
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void unregisterStubEngine(String name) throws Exception {
-    var lock = getStateLock();
-    lock.writeLock().lock();
-    try {
-      Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
-      mapField.setAccessible(true);
-      Map<String, BaseIndexEngine> map =
-          (Map<String, BaseIndexEngine>) mapField.get(storage);
-      map.remove(name);
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  private static ReadWriteLock getStateLock() throws Exception {
-    Field lockField = AbstractStorage.class.getDeclaredField("stateLock");
-    lockField.setAccessible(true);
-    return (ReadWriteLock) lockField.get(storage);
   }
 
   // ---- Helpers ----
@@ -295,7 +216,7 @@ public class BTreeTombstoneGCTest {
   @Test
   public void testTombstonesAboveLwmArePreserved() throws Exception {
     // Pin LWM so that tombstones with ts=100 are ABOVE it
-    var holder = pinLwm(5L);
+    var holder = BTreeGCTestSupport.pinLwm(storage, 5L);
     try {
       // Insert tombstones at version=100 (above lwm=5)
       for (int i = 0; i < FILL_COUNT; i++) {
@@ -320,7 +241,7 @@ public class BTreeTombstoneGCTest {
           .as("Tombstones above LWM must not be removed")
           .isEqualTo(FILL_COUNT);
     } finally {
-      unpinLwm(holder);
+      BTreeGCTestSupport.unpinLwm(storage, holder);
     }
   }
 
@@ -331,7 +252,7 @@ public class BTreeTombstoneGCTest {
     // needed by a transaction reading at exactly that timestamp.
 
     final long lwmValue = 50L;
-    var holder = pinLwm(lwmValue);
+    var holder = BTreeGCTestSupport.pinLwm(storage, lwmValue);
     try {
       // Insert tombstones at version == LWM (exactly 50)
       for (int i = 0; i < FILL_COUNT; i++) {
@@ -363,7 +284,7 @@ public class BTreeTombstoneGCTest {
           .as("Tombstones at exactly LWM must not be removed (strict < comparison)")
           .isEqualTo(tombstonesBefore);
     } finally {
-      unpinLwm(holder);
+      BTreeGCTestSupport.unpinLwm(storage, holder);
     }
   }
 
@@ -515,7 +436,7 @@ public class BTreeTombstoneGCTest {
 
     // Pin LWM at 5 so markers at version=1 are below LWM (eligible for
     // demotion check), but snapshot entries at version 50 >= LWM prevent it.
-    var holder = pinLwm(5L);
+    var holder = BTreeGCTestSupport.pinLwm(storage, 5L);
     try {
       // Insert markers at version=1 (below LWM=5)
       for (int i = 0; i < FILL_COUNT; i++) {
@@ -540,7 +461,7 @@ public class BTreeTombstoneGCTest {
           .as("Markers with active snapshot entries must be preserved")
           .isEqualTo(FILL_COUNT);
     } finally {
-      unpinLwm(holder);
+      BTreeGCTestSupport.unpinLwm(storage, holder);
     }
   }
 
@@ -767,132 +688,4 @@ public class BTreeTombstoneGCTest {
     });
   }
 
-  // ---- Stub engine for indexEngineNameMap registration ----
-
-  /**
-   * Minimal {@link BaseIndexEngine} stub that provides only {@code getId()}
-   * and {@code getName()} — the only methods used by
-   * {@code AbstractStorage.hasActiveSnapshotEntries()}.
-   */
-  private static class StubIndexEngine implements BaseIndexEngine {
-    private final String name;
-    private final int id;
-
-    StubIndexEngine(String name, int id) {
-      this.name = name;
-      this.id = id;
-    }
-
-    @Override
-    public int getId() {
-      return id;
-    }
-
-    @Override
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public void init(
-        com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded s,
-        com.jetbrains.youtrackdb.internal.core.index.IndexMetadata m) {
-    }
-
-    @Override
-    public void flush() {
-    }
-
-    @Override
-    public void create(AtomicOperation o,
-        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d) {
-    }
-
-    @Override
-    public void load(
-        com.jetbrains.youtrackdb.internal.core.config.IndexEngineData d,
-        AtomicOperation o) {
-    }
-
-    @Override
-    public void delete(AtomicOperation o) {
-    }
-
-    @Override
-    public void clear(
-        com.jetbrains.youtrackdb.internal.core.storage.Storage s,
-        AtomicOperation o) {
-    }
-
-    @Override
-    public void close() {
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        iterateEntriesBetween(Object f, boolean fi, Object t, boolean ti,
-            boolean a,
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer tr,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        iterateEntriesMajor(Object k, boolean i, boolean a,
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        iterateEntriesMinor(Object k, boolean i, boolean a,
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        stream(com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<
-        com.jetbrains.youtrackdb.internal.common.util.RawPair<Object, RID>>
-        descStream(
-            com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-            AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public java.util.stream.Stream<Object> keyStream(AtomicOperation o) {
-      return java.util.stream.Stream.empty();
-    }
-
-    @Override
-    public long size(com.jetbrains.youtrackdb.internal.core.storage.Storage s,
-        com.jetbrains.youtrackdb.internal.core.index.engine.IndexEngineValuesTransformer t,
-        AtomicOperation o) {
-      return 0;
-    }
-
-    @Override
-    public int getEngineAPIVersion() {
-      return 0;
-    }
-
-    @Override
-    public boolean acquireAtomicExclusiveLock(AtomicOperation o) {
-      return false;
-    }
-  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -159,25 +160,44 @@ public class BTreeTombstoneGCTest {
    * Registers a minimal stub {@link BaseIndexEngine} in AbstractStorage's
    * {@code indexEngineNameMap} so that
    * {@code AbstractStorage.hasActiveSnapshotEntries()} can resolve the index.
+   * Acquires stateLock.writeLock() because indexEngineNameMap is a plain HashMap
+   * that requires external synchronization.
    */
   @SuppressWarnings("unchecked")
   private static void registerStubEngine(String name, int id) throws Exception {
-    // Create a minimal stub that only needs getId() and getName()
     BaseIndexEngine stub = new StubIndexEngine(name, id);
-    Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
-    mapField.setAccessible(true);
-    Map<String, BaseIndexEngine> map =
-        (Map<String, BaseIndexEngine>) mapField.get(storage);
-    map.put(name, stub);
+    var lock = getStateLock();
+    lock.writeLock().lock();
+    try {
+      Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+      mapField.setAccessible(true);
+      Map<String, BaseIndexEngine> map =
+          (Map<String, BaseIndexEngine>) mapField.get(storage);
+      map.put(name, stub);
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   @SuppressWarnings("unchecked")
   private static void unregisterStubEngine(String name) throws Exception {
-    Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
-    mapField.setAccessible(true);
-    Map<String, BaseIndexEngine> map =
-        (Map<String, BaseIndexEngine>) mapField.get(storage);
-    map.remove(name);
+    var lock = getStateLock();
+    lock.writeLock().lock();
+    try {
+      Field mapField = AbstractStorage.class.getDeclaredField("indexEngineNameMap");
+      mapField.setAccessible(true);
+      Map<String, BaseIndexEngine> map =
+          (Map<String, BaseIndexEngine>) mapField.get(storage);
+      map.remove(name);
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  private static ReadWriteLock getStateLock() throws Exception {
+    Field lockField = AbstractStorage.class.getDeclaredField("stateLock");
+    lockField.setAccessible(true);
+    return (ReadWriteLock) lockField.get(storage);
   }
 
   // ---- Helpers ----
@@ -239,6 +259,12 @@ public class BTreeTombstoneGCTest {
     }
 
     long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
+    // Some tombstones may already be GC'd during their own insertion phase
+    // (bucket overflows during tombstone insertion trigger GC on earlier
+    // tombstones). Verify at least some survive.
+    assertThat(tombstonesBefore)
+        .as("At least some tombstones should exist before live entry inserts")
+        .isGreaterThan(0);
 
     // Insert FILL_COUNT live entries at odd positions to trigger overflows
     for (int i = 0; i < FILL_COUNT; i++) {
@@ -425,9 +451,10 @@ public class BTreeTombstoneGCTest {
     }
 
     long markersAfter = countEntriesOfType(SnapshotMarkerRID.class);
-    long recordIdsAfter = countEntriesOfType(RecordId.class);
 
-    // Markers should have been demoted to RecordId during GC
+    // Markers should have been demoted to RecordId during GC. Note: some
+    // markers may already be demoted during the marker insertion phase itself
+    // (bucket overflows during insertion trigger GC on earlier markers).
     assertThat(markersAfter)
         .as("SnapshotMarkerRID entries below LWM should be demoted")
         .isLessThan(markersBefore);
@@ -436,6 +463,24 @@ public class BTreeTombstoneGCTest {
     assertThat(countAllEntries())
         .as("Demotions should not change total entry count")
         .isEqualTo(FILL_COUNT * 2);
+
+    // Spot-check that demoted entries retain their original identity
+    for (int i = 0; i < 10; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2), 1L);
+      final RID[] result = {null};
+      atomicOperationsManager.executeInsideAtomicOperation(
+          atomicOperation -> result[0] = bTree.get(key, atomicOperation));
+      // If demoted, the entry should be a plain RecordId with the original identity
+      if (result[0] instanceof RecordId && !(result[0] instanceof SnapshotMarkerRID)) {
+        assertThat(result[0].getCollectionId())
+            .as("Demoted marker at position %d should retain original collection ID", i)
+            .isEqualTo(1);
+        assertThat(result[0].getCollectionPosition())
+            .as("Demoted marker at position %d should retain original position", i)
+            .isEqualTo(i);
+      }
+    }
   }
 
   @Test
@@ -517,15 +562,20 @@ public class BTreeTombstoneGCTest {
 
     long actualCount = countAllEntries();
 
+    // Verify GC actually removed some tombstones (actualCount < total inserted)
+    assertThat(actualCount)
+        .as("GC should have removed some tombstones, reducing count below 2*FILL_COUNT")
+        .isLessThan(FILL_COUNT * 2L);
+
     assertThat(reportedSize[0])
         .as("Reported tree size must match actual entry count after GC")
         .isEqualTo(actualCount);
   }
 
-  // ---- GC-once guard ----
+  // ---- Splits proceed when GC finds no candidates ----
 
   @Test
-  public void testGCRunsAtMostOncePerInsert() throws Exception {
+  public void testSplitsProceedNormallyWhenNoTombstonesExist() throws Exception {
     // Fill the tree so buckets are nearly full, then insert entries that
     // trigger overflow. Even if GC doesn't free enough space (e.g., no
     // tombstones to remove), the split should still proceed without error.
@@ -552,6 +602,110 @@ public class BTreeTombstoneGCTest {
     assertThat(countAllEntries())
         .as("All entries must be present after splits with no GC candidates")
         .isEqualTo(FILL_COUNT * 3);
+  }
+
+  // ---- Mixed entry types ----
+
+  @Test
+  public void testMixedTombstonesMarkersAndLiveEntriesInSameBucket() throws Exception {
+    // Insert interleaved tombstones (version=1), markers (version=2), and live
+    // entries (version=3) — all below default LWM. Then trigger overflow.
+    // Tombstones should be removed, markers demoted, live entries preserved.
+    // This exercises the case where both removedCount > 0 and demoted == true
+    // in filterAndRebuildBucket, plus the partition invariant across all three
+    // entry types.
+    int count = FILL_COUNT / 3;
+    for (int i = 0; i < count; i++) {
+      int base = i * 6;
+      // Tombstone
+      final var tKey = new CompositeKey(
+          "key" + String.format("%06d", base), 1L);
+      final var tVal = new TombstoneRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, tKey, tVal));
+      // SnapshotMarker
+      final var mKey = new CompositeKey(
+          "key" + String.format("%06d", base + 2), 2L);
+      final var mVal = new SnapshotMarkerRID(new RecordId(1, i + count));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, mKey, mVal));
+      // Live entry
+      final var lKey = new CompositeKey(
+          "key" + String.format("%06d", base + 4), 3L);
+      final var lVal = new RecordId(1, i + 2 * count);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, lKey, lVal));
+    }
+
+    long tombstonesBefore = countEntriesOfType(TombstoneRID.class);
+    long markersBefore = countEntriesOfType(SnapshotMarkerRID.class);
+
+    // Trigger overflow with more live entries at higher key values
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", count * 6 + i), 100L);
+      final var val = new RecordId(2, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, key, val));
+    }
+
+    assertThat(countEntriesOfType(TombstoneRID.class))
+        .as("Tombstones should be GC'd from mixed bucket")
+        .isLessThan(tombstonesBefore);
+    assertThat(countEntriesOfType(SnapshotMarkerRID.class))
+        .as("Markers should be demoted from mixed bucket")
+        .isLessThan(markersBefore);
+
+    // Verify tree size consistency after mixed GC
+    long[] reportedSize = {0};
+    atomicOperationsManager.executeInsideAtomicOperation(
+        op -> reportedSize[0] = bTree.size(op));
+    assertThat(reportedSize[0])
+        .as("Reported tree size must match actual count after mixed GC")
+        .isEqualTo(countAllEntries());
+  }
+
+  // ---- Sort order preservation ----
+
+  @Test
+  public void testEntriesRemainCorrectlyOrderedAfterGC() throws Exception {
+    // After GC removes tombstones and rebuilds the bucket, the insertion index
+    // is recalculated via keyBucket.find(). If the recalculated index is wrong,
+    // entries are inserted at incorrect positions, corrupting B-tree sort order.
+    // This test verifies that all entries remain in strictly ascending key order
+    // after GC + insert.
+
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2), 1L);
+      final var value = new TombstoneRID(new RecordId(1, i));
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, key, value));
+    }
+    for (int i = 0; i < FILL_COUNT; i++) {
+      final var key = new CompositeKey(
+          "key" + String.format("%06d", i * 2 + 1), 100L);
+      final var value = new RecordId(2, i);
+      atomicOperationsManager.executeInsideAtomicOperation(
+          op -> bTree.put(op, key, value));
+    }
+
+    // Verify ascending key order across the entire tree
+    atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+      var firstKey = bTree.firstKey(atomicOperation);
+      var lastKey = bTree.lastKey(atomicOperation);
+      try (var stream = bTree.iterateEntriesBetween(
+          firstKey, true, lastKey, true, true, atomicOperation)) {
+        var keys = stream.map(p -> (Comparable<?>) p.first()).toList();
+        for (int i = 1; i < keys.size(); i++) {
+          @SuppressWarnings("unchecked")
+          var prev = (Comparable<Object>) keys.get(i - 1);
+          assertThat(prev.compareTo(keys.get(i)))
+              .as("Keys must be in ascending order at position %d", i)
+              .isLessThan(0);
+        }
+      }
+    });
   }
 
   // ---- Stub engine for indexEngineNameMap registration ----

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTombstoneGCTest.java
@@ -604,6 +604,29 @@ public class BTreeTombstoneGCTest {
         .isEqualTo(FILL_COUNT * 3);
   }
 
+  // ---- AbstractStorage helper edge cases ----
+
+  @Test
+  public void testGetIndexSnapshotByEngineNameReturnsNullForUnknownEngine() {
+    // Verifies the defensive null-return path in getIndexSnapshotByEngineName
+    // when the engine name is not registered in indexEngineNameMap.
+    var snapshot = storage.getIndexSnapshotByEngineName("nonExistentEngine");
+    assertThat(snapshot)
+        .as("Unknown engine name must return null snapshot")
+        .isNull();
+  }
+
+  @Test
+  public void testHasActiveSnapshotEntriesReturnsFalseForUnknownEngine() {
+    // Verifies the defensive false-return path in hasActiveIndexSnapshotEntries
+    // when the resolved engine name is not found in indexEngineNameMap.
+    var result = storage.hasActiveIndexSnapshotEntries(
+        "nonExistentEngine", new CompositeKey("key"), 1L);
+    assertThat(result)
+        .as("Unknown engine name must return false for active snapshot check")
+        .isFalse();
+  }
+
   // ---- Mixed entry types ----
 
   @Test

--- a/docs/adr/index-gc/adr.md
+++ b/docs/adr/index-gc/adr.md
@@ -1,0 +1,174 @@
+# Index BTree Tombstone GC During Leaf Bucket Overflow — Architecture Decision Record
+
+## Summary
+
+Tombstone entries (`TombstoneRID`) and snapshot markers (`SnapshotMarkerRID`)
+accumulate indefinitely in index B-trees, leading to search slowdown and
+wasted space. This change garbage-collects them during leaf bucket overflow
+in `BTree.put()` — when entries are already being redistributed — reclaiming
+space with minimal overhead and without a separate background GC sweep.
+
+Tombstones below the global low-water mark (LWM) are removed. Snapshot
+markers below LWM are demoted to plain `RecordId` entries (preserving the
+live value) when no active snapshot entries exist for the same user-key
+prefix. Both `BTreeSingleValueIndexEngine` and `BTreeMultiValueIndexEngine`
+are covered since they share the same `BTree.java` implementation.
+
+## Goals
+
+- **Reclaim space**: Remove tombstones that are unreachable by any active
+  transaction, preventing unbounded growth.
+- **Avoid unnecessary splits**: If tombstone removal frees enough space, the
+  insert succeeds without splitting, preserving tree depth and bucket count.
+- **Minimal overhead**: Piggyback on the existing overflow entry
+  redistribution — zero extra I/O for the scan.
+- **Demote stale markers**: Convert `SnapshotMarkerRID` to plain `RecordId`
+  when safe, simplifying future reads.
+
+All goals were achieved as planned. No descoping occurred.
+
+## Constraints
+
+- **Performance**: GC runs on the write hot path. Mitigated by: (1) at most
+  once per insert via `gcAttempted` flag, (2) LWM computed once per attempt,
+  (3) plain `RecordId` entries skip key deserialization entirely.
+- **Atomicity**: Tombstone removal is atomic with the insert — both happen
+  within the same `AtomicOperation`.
+- **WAL correctness**: No new WAL record types needed. Filtered entries
+  simply don't appear in the rebuilt page.
+- **Only leaf buckets**: Internal nodes store separator keys without values.
+- **Only put() path**: `BTree.remove()` performs physical deletion only (no
+  overflow). Tombstone insertion happens via `BTree.put()`.
+- **HashMap locking** (discovered): `indexEngineNameMap` is a plain
+  `HashMap` — all access must be guarded by `stateLock`. The new
+  `hasActiveIndexSnapshotEntries()` call from `BTree` runs under the BTree
+  component lock, not `stateLock`, so explicit `stateLock.readLock()` was
+  added around the map lookup.
+
+## Architecture Notes
+
+### Component Map
+
+```mermaid
+flowchart LR
+    BT["BTree\n(put + GC filtering)"]
+    BKT["CellBTreeSingleValueBucketV3\n(page-level storage)"]
+    AS["AbstractStorage\n(LWM computation +\nsnapshot query)"]
+    ISS["IndexesSnapshot\n(ConcurrentSkipListMap)"]
+
+    BT -->|"reads/rebuilds entries"| BKT
+    BT -->|"computeGlobalLowWaterMark()"| AS
+    BT -->|"hasActiveIndexSnapshotEntries()"| AS
+    AS -->|"queries"| ISS
+```
+
+- **BTree**: Modified — added `filterAndRebuildBucket()` and
+  `demoteMarkerRawBytes()`. GC integrated into the `update()` while loop.
+- **CellBTreeSingleValueBucketV3**: Unchanged. Existing `shrink()`,
+  `addAll()`, `getRawEntry()`, `getKey()`, `getValue()`, `find()` methods
+  are used as-is.
+- **AbstractStorage**: Added `hasActiveIndexSnapshotEntries()`,
+  `getIndexSnapshotByEngineName()`, `getNullIndexSnapshotByEngineName()`.
+  Existing `computeGlobalLowWaterMark()` used as-is.
+- **IndexesSnapshot**: Read-only during GC. Not modified by GC filtering.
+
+### Decision Records
+
+#### D1: GC during bucket overflow vs. separate background sweep
+
+Implemented as planned. Overflow handling already iterates all entries;
+filtering adds minimal overhead (one LWM computation + one snapshot query
+per SnapshotMarkerRID). Tombstones in pages that never overflow again will
+never be collected — acceptable since such pages are cold.
+
+#### D2: Filter-rebuild-retry before splitting
+
+Implemented as planned. The `filterAndRebuildBucket()` method collects
+survivors, rebuilds via `shrink(0)` + `addAll()`, and returns the removed
+count. Three cases are handled: all removed (trivial insert), some removed
+(may or may not need split), none removed (normal split). When only
+demotions occur (no tombstones removed), the bucket is still rebuilt to
+persist the demoted entries.
+
+#### D3: No snapshot check for TombstoneRID removal
+
+Implemented as planned. Tombstones below LWM are removed unconditionally.
+The `IndexesSnapshot` is cleaned separately via
+`evictStaleIndexesSnapshotEntries()`, and tombstones below LWM are
+unreachable by any active transaction.
+
+#### D4: SnapshotMarkerRID demotion vs. removal
+
+Implemented as planned. `demoteMarkerRawBytes()` rewrites the last 8 bytes
+(collectionPosition) from `-(realPos + 1)` back to `realPos`. Demotion
+only occurs when `hasActiveIndexSnapshotEntries()` returns false.
+
+#### D5: LWM computation — once per GC attempt
+
+Implemented as planned. `computeGlobalLowWaterMark()` is called once at the
+start of `filterAndRebuildBucket()`. Using a stale (lower) LWM is
+conservative — may skip eligible entries but never removes prematurely.
+
+#### D6: Plain RecordId key deserialization skip (emerged during implementation)
+
+For plain `RecordId` entries (not `TombstoneRID` or `SnapshotMarkerRID`),
+key deserialization is skipped entirely — only the raw entry bytes are
+collected. This was identified during Phase A review (suggestion T5) as a
+performance optimization. Since `instanceof` on the deserialized value is
+sufficient to determine that an entry is not a GC candidate, there is no
+need to deserialize the key.
+
+### Invariants
+
+- **No ghost resurrection**: After tombstone removal, the index read path
+  never returns a live entry for a deleted key. Guaranteed by the LWM
+  threshold.
+- **Tree size consistency**: `removedCount + survivors.size() == bucketSize`
+  (partition invariant, enforced by assertion).
+  `updateSize(-removedCount)` adjusts the entry point's tree size counter.
+- **No unnecessary splits**: If tombstone removal frees enough space, no
+  split occurs.
+- **SnapshotMarkerRID demotion safety**: Demotion only when no active
+  snapshot entries exist for the user-key prefix with `version >= LWM`.
+
+### Integration Points
+
+- **`BTree.update()` while loop**: Entry point for GC logic, before
+  `splitBucket()`.
+- **`AbstractStorage.computeGlobalLowWaterMark()`**: Existing method.
+- **`AbstractStorage.hasActiveIndexSnapshotEntries()`**: New method.
+- **`BTree.updateSize()`**: Existing method for tree size adjustment.
+
+### Non-Goals
+
+- Background sweep of cold pages.
+- GC of non-tombstone stale versions.
+- Page compaction or defragmentation after removal.
+- IndexesSnapshot cleanup (handled separately).
+
+## Key Discoveries
+
+1. **`indexEngineNameMap` requires `stateLock`**: The map is a plain
+   `HashMap`. The new `hasActiveIndexSnapshotEntries()` call originates from
+   `BTree` under its component lock, not `stateLock`. Fixed by adding
+   explicit `stateLock.readLock()` around the map lookup. This pattern must
+   be followed by any future code that accesses `indexEngineNameMap` from
+   outside `AbstractStorage`'s normal lock scope.
+
+2. **GC triggers during initial insertion phase**: When filling a bucket
+   with tombstones/markers, bucket overflows during insertion can trigger GC
+   on already-inserted entries. This means the number of tombstones after a
+   fill operation may be less than the number inserted. Test assertions must
+   use relative thresholds (e.g., `isLessThan(before / 2)`) rather than
+   exact counts to accommodate this behavior.
+
+3. **Core module query API quirks**: `query()` takes SQL directly (no
+   language prefix), `command()` returns void,
+   `FrontendTransactionImpl.browseClass()` is unavailable — must use
+   `tx.load(rid)` for cross-transaction record access.
+
+4. **Uncoverable defensive paths**: The non-`CompositeKey` fallback in
+   `filterAndRebuildBucket()` (3 lines) cannot be exercised through index
+   engines because they always use versioned `CompositeKey`. This is a
+   defensive guard, not dead code — it protects against hypothetical
+   non-versioned BTree usage.

--- a/docs/adr/index-gc/adr.md
+++ b/docs/adr/index-gc/adr.md
@@ -118,6 +118,15 @@ performance optimization. Since `instanceof` on the deserialized value is
 sufficient to determine that an entry is not a GC candidate, there is no
 need to deserialize the key.
 
+#### D7: Defensive version extraction guard (emerged during code review)
+
+Version extraction from `CompositeKey` uses pattern matching
+(`instanceof Long v`) and an emptiness check instead of an unsafe cast.
+This prevents `NoSuchElementException`, `ClassCastException`, or
+`NullPointerException` if the BTree is ever used with a non-standard key
+structure. Entries with unexpected key shapes are preserved as survivors
+(the conservative choice for a GC pass).
+
 ### Invariants
 
 - **No ghost resurrection**: After tombstone removal, the index read path

--- a/docs/adr/index-gc/design-final.md
+++ b/docs/adr/index-gc/design-final.md
@@ -1,0 +1,277 @@
+# Index BTree Tombstone GC During Leaf Bucket Overflow — Final Design
+
+## Overview
+
+Tombstone garbage collection was added to `BTree` (the shared B-tree
+implementation used by both `BTreeSingleValueIndexEngine` and
+`BTreeMultiValueIndexEngine`), triggered when a leaf bucket overflows during
+`put()`. When a bucket is full, the GC filters out removable `TombstoneRID`
+entries and demotes stale `SnapshotMarkerRID` entries, rebuilds the bucket
+with survivors only, and retries the insert. A split occurs only if the
+bucket is still full after filtering.
+
+The implementation follows the filter-rebuild-retry pattern established by
+the edge tombstone GC in `SharedLinkBagBTree`, with two key differences:
+(1) tombstones are removed unconditionally below LWM (no snapshot entry
+check needed), and (2) `SnapshotMarkerRID` entries are demoted to plain
+`RecordId` rather than removed.
+
+No deviations from the original design plan were needed — the
+implementation matches the planned architecture.
+
+## Class Design
+
+```mermaid
+classDiagram
+    class BTree~K~ {
+        <<final>>
+        -long fileId
+        -BinarySerializer~K~ keySerializer
+        -BinarySerializerFactory serializerFactory
+        +put(AtomicOperation, K, RID) boolean
+        -update(AtomicOperation, K, RID, IndexEngineValidator) int
+        -splitBucket(...) UpdateBucketSearchResult
+        -filterAndRebuildBucket(CellBTreeSingleValueBucketV3~K~) int
+        -demoteMarkerRawBytes(byte[]) byte[]$
+        -updateSize(long, AtomicOperation) void
+    }
+
+    class StorageComponent {
+        <<abstract>>
+        #storage: AbstractStorage
+        +getName() String
+    }
+
+    class CellBTreeSingleValueBucketV3~K~ {
+        +addLeafEntry(int, byte[], byte[]) boolean
+        +size() int
+        +isLeaf() boolean
+        +getKey(int, BinarySerializer, BinarySerializerFactory) K
+        +getValue(int, BinarySerializer, BinarySerializerFactory) RID
+        +getRawEntry(int, BinarySerializer, BinarySerializerFactory) byte[]
+        +find(byte[], BinarySerializer, BinarySerializerFactory) int
+        +shrink(int, BinarySerializer, BinarySerializerFactory) void
+        +addAll(List~byte[]~, BinarySerializer) void
+        +decodeRID(int, long) RID$
+    }
+
+    class AbstractStorage {
+        -sharedIndexesSnapshot: ConcurrentSkipListMap
+        -sharedNullIndexesSnapshot: ConcurrentSkipListMap
+        -indexEngineNameMap: Map~String, BaseIndexEngine~
+        -stateLock: ReentrantReadWriteLock
+        +computeGlobalLowWaterMark() long
+        +hasActiveIndexSnapshotEntries(String, CompositeKey, long) boolean
+        +getIndexSnapshotByEngineName(String) IndexesSnapshot
+        +getNullIndexSnapshotByEngineName(String) IndexesSnapshot
+    }
+
+    class RID {
+        <<interface>>
+        +getCollectionId() int
+        +getCollectionPosition() long
+        +getIdentity() RID
+    }
+
+    class TombstoneRID {
+        <<final>>
+        -collectionId: int
+        -collectionPosition: long
+        -identity: RecordId
+    }
+
+    class SnapshotMarkerRID {
+        <<final>>
+        -collectionId: int
+        -collectionPosition: long
+        -identity: RecordId
+    }
+
+    StorageComponent <|-- BTree
+    RID <|.. TombstoneRID
+    RID <|.. SnapshotMarkerRID
+    BTree --> CellBTreeSingleValueBucketV3 : reads/rebuilds leaf pages
+    BTree --> AbstractStorage : computes LWM, queries snapshot
+    CellBTreeSingleValueBucketV3 ..> TombstoneRID : decodes from raw bytes
+    CellBTreeSingleValueBucketV3 ..> SnapshotMarkerRID : decodes from raw bytes
+```
+
+`BTree<K>` extends `StorageComponent` (which provides the `storage`
+reference to `AbstractStorage`) and implements `CellBTreeSingleValue<K>`.
+Two private methods were added: `filterAndRebuildBucket()` performs the
+GC scan and rebuild, `demoteMarkerRawBytes()` rewrites SnapshotMarkerRID
+encoding in raw bytes. Both are contained entirely within `BTree`.
+
+`AbstractStorage` gained three new public methods:
+`hasActiveIndexSnapshotEntries()` queries the `ConcurrentSkipListMap` for
+active snapshot entries by engine name and user-key prefix;
+`getIndexSnapshotByEngineName()` and `getNullIndexSnapshotByEngineName()`
+resolve scoped snapshots for test infrastructure. All three guard
+`indexEngineNameMap` access with `stateLock.readLock()`.
+
+`TombstoneRID` and `SnapshotMarkerRID` are final classes implementing
+`RID`, storing primitive fields directly (avoiding intermediate `RecordId`
+allocation on the hot decode path). `TombstoneRID` encodes collectionId
+as `-(id + 1)`; `SnapshotMarkerRID` encodes collectionPosition as
+`-(pos + 1)`. `CellBTreeSingleValueBucketV3.decodeRID()` distinguishes
+the three types by sign.
+
+## Workflow
+
+### Filter-Rebuild-Retry in put()
+
+```mermaid
+sequenceDiagram
+    participant Put as BTree.update()<br/>insert loop
+    participant Bucket as CellBTreeSingleValue<br/>BucketV3 (leaf)
+    participant Filter as filterAndRebuild<br/>Bucket()
+    participant Storage as AbstractStorage
+    participant Split as splitBucket()
+
+    Put->>Bucket: addLeafEntry() → false (overflow)
+
+    alt gcAttempted == false
+        Put->>Filter: filterAndRebuildBucket(bucket)
+        Filter->>Storage: computeGlobalLowWaterMark()
+        Storage-->>Filter: lwm
+
+        loop each entry i in bucket
+            Filter->>Bucket: getValue(i) — check type
+            alt TombstoneRID or SnapshotMarkerRID
+                Filter->>Bucket: getKey(i) — extract version
+                alt TombstoneRID && version < lwm
+                    Note over Filter: discard (GC'd)
+                else SnapshotMarkerRID && version < lwm
+                    Filter->>Storage: hasActiveIndexSnapshotEntries()
+                    alt no active entries
+                        Note over Filter: demote via demoteMarkerRawBytes()
+                    else has active entries
+                        Note over Filter: keep as-is
+                    end
+                else version >= lwm
+                    Note over Filter: keep as-is
+                end
+            else plain RecordId
+                Note over Filter: keep (skip key deserialization)
+            end
+        end
+
+        alt removedCount > 0
+            Filter->>Bucket: shrink(0) + addAll(survivors)
+            Filter-->>Put: removedCount
+            Put->>Put: updateSize(-removedCount)
+            Put->>Put: re-derive insertionIndex via find()
+            Put->>Bucket: addLeafEntry() — retry
+            alt succeeds
+                Note over Put: done, no split needed
+            else still overflows
+                Put->>Split: splitBucket()
+            end
+        else removedCount == 0 but demoted
+            Filter->>Bucket: shrink(0) + addAll(survivors)
+            Filter-->>Put: 0
+            Put->>Split: splitBucket()
+        else no changes
+            Filter-->>Put: 0 (no rebuild)
+            Put->>Split: splitBucket()
+        end
+    else gcAttempted == true
+        Put->>Split: splitBucket()
+    end
+```
+
+The `update()` method's `while (!addLeafEntry(...))` loop handles bucket
+overflow. GC is inserted as a first-attempt optimization before splitting.
+The `gcAttempted` boolean ensures filtering runs at most once per `put()`
+call. An important optimization (T5): plain `RecordId` entries skip key
+deserialization entirely — only `TombstoneRID` and `SnapshotMarkerRID`
+entries need the key to extract the version.
+
+### Tombstone Eligibility Flowchart
+
+```mermaid
+flowchart TD
+    A[Entry from bucket] --> B{value instanceof<br/>TombstoneRID or<br/>SnapshotMarkerRID?}
+    B -->|no| KEEP[Keep as-is<br/>skip key deser]
+    B -->|yes| C{key instanceof<br/>CompositeKey?}
+    C -->|no| KEEP2[Keep as-is]
+    C -->|yes| D{version < lwm?}
+    D -->|no| KEEP3[Keep as-is]
+    D -->|yes| E{TombstoneRID?}
+    E -->|yes| REMOVE[Remove — GC'd]
+    E -->|no| F["hasActiveIndexSnapshotEntries()<br/>for user-key prefix?"]
+    F -->|yes| KEEP4[Keep as-is]
+    F -->|no| DEMOTE[Demote to RecordId<br/>via demoteMarkerRawBytes]
+```
+
+Three outcomes for each entry:
+1. **Remove** — TombstoneRID below LWM is discarded. Tree size decremented.
+2. **Demote** — SnapshotMarkerRID below LWM with no active snapshot entries
+   has its raw bytes rewritten to a plain RecordId. Tree size unchanged.
+3. **Keep** — all other entries preserved as-is.
+
+## SnapshotMarkerRID Demotion Encoding
+
+`SnapshotMarkerRID` encodes `collectionPosition` as `-(realPos + 1)`.
+Demotion rewrites the last 8 bytes of the raw leaf entry (the
+`collectionPosition` field) back to the real positive value using
+`LongSerializer` read-modify-write. The `collectionId` is unchanged
+(always positive for `SnapshotMarkerRID`).
+
+Raw leaf entry layout: `[serialized_key | 2-byte collectionId | 8-byte
+collectionPosition]`.
+
+The `demoteMarkerRawBytes()` method modifies the byte array in-place and
+returns it. The caller passes the same array to `addAll()` during bucket
+rebuild.
+
+**Gotcha**: The demotion check requires a `subMap()` range query on the
+`ConcurrentSkipListMap` for each `SnapshotMarkerRID` candidate. This is
+O(log S) per marker, acceptable during overflow handling since markers
+are typically a small fraction of bucket entries.
+
+## Snapshot Query for Demotion Safety
+
+Before demoting a `SnapshotMarkerRID`,
+`AbstractStorage.hasActiveIndexSnapshotEntries()` checks whether any
+snapshot entries with `version >= LWM` exist for the same user-key prefix.
+
+The method:
+1. Resolves the `$null` suffix — if the engine name ends with `$null`,
+   strips it and uses `sharedNullIndexesSnapshot`; otherwise uses
+   `sharedIndexesSnapshot`.
+2. Looks up the engine by resolved name in `indexEngineNameMap` under
+   `stateLock.readLock()` to avoid racing with concurrent index
+   creation/deletion.
+3. Constructs range keys: `CompositeKey(indexId, userKeyPrefix..., lwm)` to
+   `CompositeKey(indexId, userKeyPrefix..., Long.MAX_VALUE)`.
+4. Queries via `subMap(lower, true, upper, true).isEmpty()`.
+
+**Gotcha**: `indexEngineNameMap` is a plain `HashMap`, not a concurrent
+map. All access must be guarded by `stateLock`. The existing codebase
+already follows this pattern; the new methods were aligned to match.
+
+## Tree Size Accounting
+
+Tree size is tracked in the B-tree entry point page. `updateSize()` is
+called with `-removedCount` immediately after GC succeeds. The subsequent
+insert's size change is handled by the existing `updateSize(sizeDiff)` at
+the end of `update()`.
+
+Partition invariant: `removedCount + survivors.size() == bucketSize` —
+enforced by an assertion after the scan loop.
+
+## Performance Characteristics
+
+| Operation | Cost | Notes |
+|---|---|---|
+| LWM computation | O(T), T = active threads | Once per GC attempt |
+| Entry iteration | O(N), N = bucket entries | Value deserialization for all; key deserialization only for tombstones/markers |
+| Snapshot query | O(log S) per marker | S = snapshot index size. Only for SnapshotMarkerRID below LWM |
+| Bucket rebuild | O(N), N = survivors | shrink(0) + addAll(). Only when changes found |
+| Overall | O(N + M log S) | M = markers below LWM, typically small |
+
+When no tombstones or markers exist in the bucket, the only overhead is
+the `instanceof` check on each entry's value — key deserialization is
+skipped entirely. When tombstones exist but no markers do, there are zero
+snapshot queries.

--- a/docs/adr/index-gc/design.md
+++ b/docs/adr/index-gc/design.md
@@ -1,0 +1,323 @@
+# Index BTree Tombstone GC During Leaf Bucket Overflow — Design
+
+## Overview
+
+The design adds tombstone garbage collection to `BTree` (the shared B-tree
+implementation used by both `BTreeSingleValueIndexEngine` and
+`BTreeMultiValueIndexEngine`), triggered when a leaf bucket overflows during
+`put()`. When a bucket is full, the GC filters out removable `TombstoneRID`
+entries and demotes stale `SnapshotMarkerRID` entries, rebuilds the bucket
+with survivors only, and retries the insert. A split occurs only if the
+bucket is still full after filtering.
+
+The approach mirrors the edge tombstone GC in `SharedLinkBagBTree` but with
+two key differences: (1) tombstones are removed unconditionally below LWM
+(no snapshot entry check needed), and (2) `SnapshotMarkerRID` entries are
+demoted to plain `RecordId` rather than removed.
+
+## Class Design
+
+```mermaid
+classDiagram
+    class BTree~K~ {
+        -long fileId
+        -BinarySerializer~K~ keySerializer
+        -BinarySerializerFactory serializerFactory
+        -AbstractStorage storage
+        +put(AtomicOperation, K, RID) boolean
+        -update(AtomicOperation, K, RID, IndexEngineValidator) int
+        -splitBucket(...) UpdateBucketSearchResult
+        -filterAndRebuildBucket(CellBTreeSingleValueBucketV3) int
+        -demoteMarkerRawBytes(byte[]) byte[]$
+        -updateSize(long, AtomicOperation) void
+    }
+
+    class CellBTreeSingleValueBucketV3~K~ {
+        +addLeafEntry(int, byte[], byte[]) boolean
+        +size() int
+        +isLeaf() boolean
+        +getKey(int, BinarySerializer, BinarySerializerFactory) K
+        +getValue(int, BinarySerializer, BinarySerializerFactory) RID
+        +getRawEntry(int, BinarySerializer, BinarySerializerFactory) byte[]
+        +find(byte[], BinarySerializer, BinarySerializerFactory) int
+        +shrink(int, BinarySerializer, BinarySerializerFactory) void
+        +addAll(List~byte[]~, BinarySerializer) void
+        +decodeRID(int, long) RID$
+    }
+
+    class AbstractStorage {
+        -sharedIndexesSnapshot: ConcurrentSkipListMap
+        -sharedNullIndexesSnapshot: ConcurrentSkipListMap
+        -indexEngineNameMap: Map~String, BaseIndexEngine~
+        +computeGlobalLowWaterMark() long
+        +hasActiveIndexSnapshotEntries(String, CompositeKey, long) boolean
+    }
+
+    class TombstoneRID {
+        -collectionId: int
+        -collectionPosition: long
+        -identity: RecordId
+        +getCollectionId() int
+        +getCollectionPosition() long
+        +getIdentity() RID
+    }
+
+    class SnapshotMarkerRID {
+        -collectionId: int
+        -collectionPosition: long
+        -identity: RecordId
+        +getCollectionId() int
+        +getCollectionPosition() long
+        +getIdentity() RID
+    }
+
+    class CompositeKey {
+        -keys: List~Object~
+        +getKeys() List~Object~
+        +addKey(Object) void
+        +addKeyDirect(Object) void
+    }
+
+    BTree --> CellBTreeSingleValueBucketV3 : reads/rebuilds leaf pages
+    BTree --> AbstractStorage : computes LWM, queries snapshot
+    CellBTreeSingleValueBucketV3 ..> TombstoneRID : decodes from raw bytes
+    CellBTreeSingleValueBucketV3 ..> SnapshotMarkerRID : decodes from raw bytes
+    BTree ..> CompositeKey : extracts version from key
+```
+
+**`BTree`** is the only class with new methods. Two private methods are added:
+`filterAndRebuildBucket()` (iterates bucket entries, filters tombstones,
+demotes markers, rebuilds) and `demoteMarkerRawBytes()` (rewrites the
+`SnapshotMarkerRID` encoding in raw bytes). One call site is modified: the
+`while (!addLeafEntry(...))` loop in `update()` (called by `put()`).
+
+**`AbstractStorage`** gains one new public method:
+`hasActiveIndexSnapshotEntries()` — resolves an engine by name (handling
+the `$null` suffix for null-key trees), constructs range keys from the
+user-key prefix and LWM, and queries the shared `ConcurrentSkipListMap` via
+`subMap()`. Returns `true` if any snapshot entries exist with
+`version >= LWM` for the user-key prefix.
+
+**`CellBTreeSingleValueBucketV3`** is unchanged. **`TombstoneRID`** and
+**`SnapshotMarkerRID`** were refactored from records to final classes with
+primitive fields (avoiding intermediate `RecordId` allocation on the hot
+decode path), but their on-disk encoding is unchanged — `instanceof` checks
+and `demoteMarkerRawBytes()` byte-level rewriting remain valid.
+**`CompositeKey`** gained `addKeyDirect()` (bypasses unmodifiable-view cache
+invalidation) but `addKey()` is still the public API used by the GC.
+
+## Workflow
+
+### Filter-Rebuild-Retry in put()
+
+```mermaid
+sequenceDiagram
+    participant Put as BTree.update()<br/>insert loop
+    participant Bucket as CellBTreeSingleValue<br/>BucketV3 (leaf)
+    participant Filter as filterAndRebuild<br/>Bucket()
+    participant Storage as AbstractStorage
+    participant Split as splitBucket()
+
+    Put->>Bucket: addLeafEntry() -> false (overflow)
+
+    alt gcAttempted == false
+        Put->>Filter: filterAndRebuildBucket(bucket)
+        Filter->>Storage: computeGlobalLowWaterMark()
+        Storage-->>Filter: lwm
+
+        loop each entry i in bucket
+            Filter->>Bucket: getKey(i), getValue(i)
+            alt TombstoneRID && version < lwm
+                Note over Filter: discard (GC'd)
+            else SnapshotMarkerRID && version < lwm
+                Filter->>Storage: hasActiveIndexSnapshotEntries(name, prefix, lwm)
+                alt no active entries
+                    Note over Filter: demote to RecordId
+                else has active entries
+                    Note over Filter: keep as-is
+                end
+            else live or version >= lwm
+                Note over Filter: keep as-is
+            end
+        end
+
+        alt removedCount > 0
+            Filter->>Bucket: shrink(0) + addAll(survivors)
+            Filter-->>Put: removedCount
+            Put->>Put: updateSize(-removedCount)
+            Put->>Put: re-derive insertionIndex via find()
+            Put->>Bucket: addLeafEntry() - retry
+            alt succeeds
+                Note over Put: done, no split needed
+            else still overflows
+                Put->>Split: splitBucket()
+            end
+        else removedCount == 0 but demoted
+            Note over Filter: bucket rebuilt with demoted<br/>markers but no space freed
+            Filter->>Bucket: shrink(0) + addAll(survivors)
+            Filter-->>Put: 0
+            Put->>Split: splitBucket()
+        else removedCount == 0 and no demotion
+            Filter-->>Put: 0 (no rebuild)
+            Put->>Split: splitBucket()
+        end
+    else gcAttempted == true
+        Put->>Split: splitBucket()
+    end
+```
+
+The `update()` method (called by `put()`) already contains a
+`while (!addLeafEntry(...))` loop that handles bucket overflow by splitting.
+The GC is inserted as a first-attempt optimization before splitting. The
+`gcAttempted` boolean ensures filtering runs at most once per `put()` call,
+preventing repeated scans.
+
+### Tombstone Eligibility Flowchart
+
+```mermaid
+flowchart TD
+    A[Entry from bucket] --> B{key instanceof CompositeKey?}
+    B -->|no| KEEP[Keep entry as-is]
+    B -->|yes| C{value instanceof TombstoneRID?}
+    C -->|yes| D{version < lwm?}
+    D -->|no| KEEP
+    D -->|yes| REMOVE[Remove - GC'd]
+    C -->|no| E{value instanceof SnapshotMarkerRID?}
+    E -->|no| KEEP
+    E -->|yes| F{version < lwm?}
+    F -->|no| KEEP
+    F -->|yes| G["hasActiveIndexSnapshotEntries()\nfor user-key prefix?"]
+    G -->|yes| KEEP
+    G -->|no| DEMOTE[Demote to RecordId]
+```
+
+Three outcomes for each entry:
+1. **Remove** — TombstoneRID below LWM is discarded entirely. The tree
+   size is decremented.
+2. **Demote** — SnapshotMarkerRID below LWM with no active snapshot
+   entries is rewritten to a plain RecordId in the raw bytes. The tree
+   size is unchanged (entry is preserved, just re-typed).
+3. **Keep** — all other entries are preserved as-is.
+
+### Engine-Level Call Chain
+
+```mermaid
+sequenceDiagram
+    participant Engine as BTreeSingleValue<br/>IndexEngine
+    participant BTree as BTree
+    participant GC as filterAndRebuild<br/>Bucket()
+
+    Note over Engine: put(key, value)
+    Engine->>BTree: put(atomicOp, compositeKey, value)
+    BTree->>BTree: addLeafEntry() -> overflow
+    BTree->>GC: filterAndRebuildBucket()
+    GC-->>BTree: removedCount
+    BTree->>BTree: retry addLeafEntry()
+
+    Note over Engine: remove(key)
+    Engine->>BTree: remove(atomicOp, oldKey)
+    Note over BTree: physical deletion (no overflow)
+    Engine->>BTree: put(atomicOp, newKey, TombstoneRID)
+    BTree->>BTree: addLeafEntry() -> may overflow
+    BTree->>GC: filterAndRebuildBucket()
+    GC-->>BTree: removedCount
+```
+
+Both the engine-level `put()` and `remove()` paths flow through
+`BTree.put()`. The engine's `remove()` first does a physical deletion
+(`BTree.remove()`), then inserts a tombstone entry (`BTree.put()`) — the
+tombstone insertion can trigger overflow and thus GC. This means GC in
+`BTree.put()` covers all scenarios.
+
+## SnapshotMarkerRID Demotion Encoding
+
+`SnapshotMarkerRID` uses a negative `collectionPosition` encoding:
+`-(realPosition + 1)`. A plain `RecordId` uses the real positive value.
+Demotion rewrites the last 8 bytes of the raw entry (the `collectionPosition`
+field) from the negative encoding back to the real value.
+
+Raw leaf entry layout: `[serialized_key | 2-byte collectionId | 8-byte
+collectionPosition]`.
+
+For `SnapshotMarkerRID`:
+```
+collectionPosition = -(realPosition + 1)
+```
+
+After demotion:
+```
+collectionPosition = realPosition
+```
+
+The `collectionId` remains unchanged (it is always positive for
+`SnapshotMarkerRID`). This is a single `LongSerializer` read-modify-write
+on the raw byte array — no deserialization/reserialization of the full entry
+is needed.
+
+**Gotcha**: The demotion modifies the byte array in-place and returns it.
+The caller must ensure the byte array is the one that will be passed to
+`addAll()` during bucket rebuild.
+
+## Snapshot Query for SnapshotMarkerRID Safety
+
+Before demoting a `SnapshotMarkerRID`, the GC must verify that no active
+snapshot entries exist for the same user-key prefix with `version >= LWM`.
+This prevents a scenario where:
+
+1. A `SnapshotMarkerRID` M is demoted to `RecordId`.
+2. A concurrent reader using the snapshot index sees an older version of
+   the same key (stored in `IndexesSnapshot`).
+3. The reader's visibility logic misinterprets the demoted entry because
+   the marker flag is gone.
+
+The check queries `AbstractStorage.hasActiveIndexSnapshotEntries()`, which:
+1. Resolves the engine by name from `indexEngineNameMap` (handles `$null`
+   suffix for null-key trees in multi-value indexes).
+2. Constructs range keys: `CompositeKey(indexId, userKeyPrefix..., lwm)` to
+   `CompositeKey(indexId, userKeyPrefix..., Long.MAX_VALUE)`.
+3. Queries the shared `ConcurrentSkipListMap` via
+   `subMap(lower, true, upper, true)` (inclusive on both bounds).
+4. Returns `true` if any entries exist in the range.
+
+The `indexId` used in range key construction is resolved internally from
+the `engineName` parameter via `indexEngineNameMap`.
+
+**Gotcha**: The user-key prefix is extracted by stripping the last element
+(version) from the `CompositeKey`. For single-value indexes, this is the
+original user key. For multi-value indexes, this includes both the user key
+and the RID (e.g., `CompositeKey(userKey, rid)` without the version).
+
+## Tree Size Accounting
+
+Tree size is tracked in the B-tree entry point page and must equal the
+actual number of leaf entries. Size changes during GC-enabled insert:
+
+| Scenario | Size change |
+|---|---|
+| New entry, no GC | +1 |
+| New entry, GC removed N tombstones | -N (GC) then +1 (insert) |
+| Replacement (SnapshotMarkerRID), no GC | 0 (remove old -1, insert new +1) |
+| Replacement with GC | -N (GC) then 0 (replacement) |
+| Demotion only (no removal) | 0 (entry preserved, just re-typed) |
+
+`updateSize(-removedCount)` is called immediately after GC succeeds.
+The final `updateSize(sizeDiff)` at the end of `update()` handles the
+insert itself.
+
+Note: Rows without "GC" in the scenario name document existing behavior
+for context — no changes are needed for those paths.
+
+## Performance Characteristics
+
+| Operation | Cost | Notes |
+|---|---|---|
+| LWM computation | O(T), T = active threads | Once per GC attempt. Iterates `TsMinHolder` instances, typically < 100. |
+| Entry iteration | O(N), N = bucket entries | Key + value deserialization per entry. N bounded by bucket capacity (~hundreds for 8 KB pages). |
+| Snapshot query | O(log S) per marker | S = snapshot index size. Only for `SnapshotMarkerRID` entries passing the LWM check. Tombstones require no snapshot query. |
+| Bucket rebuild | O(N), N = survivors | `shrink(0)` + `addAll()`. Only when removedCount > 0 or demotion occurred. |
+| Overall per GC attempt | O(N + M log S), M = markers | M is typically a small fraction of N. Tombstones are filtered cheaply by `instanceof` check. |
+
+The GC adds no cost when there are no tombstones or markers in the bucket
+(the `instanceof` check on each entry is the only overhead). When tombstones
+exist but no markers do, there are zero snapshot queries — removal is
+unconditional.

--- a/docs/adr/index-gc/implementation-plan.md
+++ b/docs/adr/index-gc/implementation-plan.md
@@ -1,0 +1,335 @@
+# Index BTree Tombstone GC During Leaf Bucket Overflow
+
+## Design Document
+[design.md](design.md)
+
+## High-level plan
+
+### Goals
+
+Garbage-collect tombstone entries (`TombstoneRID`) and demote stale snapshot
+markers (`SnapshotMarkerRID`) from index B-trees during leaf bucket overflow.
+Tombstones are created by cross-transaction index updates and deletions and
+accumulate indefinitely in the B-tree today, leading to index search slowdown
+and wasted space. By filtering them out when a leaf bucket overflows — when
+entries are already being redistributed — we reclaim space with minimal
+overhead and without a separate background GC sweep.
+
+A tombstone is safe to remove when:
+1. Its version (last element of the `CompositeKey`) is strictly below the
+   global low-water mark (LWM), meaning all active transactions can already
+   see past the deletion.
+
+No snapshot entry check is needed for tombstone removal — the in-memory
+`IndexesSnapshot` is cleaned separately via
+`AbstractStorage.evictStaleIndexesSnapshotEntries()`.
+
+A `SnapshotMarkerRID` is safe to demote to a plain `RecordId` when:
+1. Its version is strictly below LWM.
+2. No snapshot entries with `version >= LWM` exist for the same user-key
+   prefix in the shared `IndexesSnapshot` map.
+
+Both `BTreeSingleValueIndexEngine` and `BTreeMultiValueIndexEngine` are
+covered — they both delegate to the same `BTree.java` implementation.
+
+### Constraints
+
+- **Performance**: Bucket overflow is on the write hot path. The GC check
+  must be cheap. Deserializing key+value for each entry adds cost, but
+  the overflow already iterates all entries during split — the additional
+  deserialization is bounded by bucket size (~hundreds of entries per 8 KB
+  page).
+- **Snapshot query cost**: Checking the index snapshot for SnapshotMarkerRID
+  demotion requires a range query per marker. This is a
+  `ConcurrentSkipListMap.subMap()` call — O(log n) per marker, acceptable
+  during overflow handling.
+- **LWM computation**: Computing the global LWM iterates all `TsMinHolder`
+  instances (one per thread with active transactions). Computed once per GC
+  attempt, not per entry.
+- **Atomicity**: Tombstone removal during overflow must be atomic with the
+  insert — both happen within the same `AtomicOperation`. The tree size
+  counter must be adjusted for removed tombstones.
+- **Non-leaf nodes**: Only leaf buckets contain tombstones. Internal
+  (non-leaf) nodes store separator keys without values. Filtering applies
+  only to leaf buckets.
+- **WAL correctness**: No new WAL record types needed. Filtered entries
+  simply don't appear in the rebuilt page. Crash recovery replays as-is.
+- **Null-key trees**: For multi-value indexes, the null-key tree is a
+  separate `BTree` instance with `$null` suffix — GC applies automatically
+  since it's the same `BTree.java`. For single-value indexes, null keys use
+  a single-page `CellBTreeSingleValueV3NullBucket` (not a BTree) — no GC
+  applicable.
+- **Only put() path**: `BTree.remove()` performs physical deletion only
+  (no `addLeafEntry()`, no overflow possible). Tombstone insertion happens
+  at the engine level via `BTree.put()`, so the `put()` GC path covers both
+  insert and delete scenarios at the engine level.
+
+### Architecture Notes
+
+#### Component Map
+
+```mermaid
+flowchart LR
+    BT["BTree\n(put + GC filtering)"]
+    BKT["CellBTreeSingleValueBucketV3\n(page-level storage)"]
+    AS["AbstractStorage\n(LWM computation +\nsnapshot query)"]
+    ISS["IndexesSnapshot\n(ConcurrentSkipListMap)"]
+
+    BT -->|"reads/rebuilds entries"| BKT
+    BT -->|"computeGlobalLowWaterMark()"| AS
+    BT -->|"hasActiveIndexSnapshotEntries()"| AS
+    AS -->|"queries"| ISS
+```
+
+- **BTree**: Modified to filter removable tombstones and demote stale
+  markers during leaf bucket overflow in `put()`. Computes LWM once per GC
+  attempt via the `storage` reference inherited from `StorageComponent`.
+  Queries snapshot index via `AbstractStorage.hasActiveIndexSnapshotEntries()`
+  for each `SnapshotMarkerRID` candidate.
+- **CellBTreeSingleValueBucketV3**: Unchanged. Entries are filtered before
+  being passed to `addAll()` on the rebuilt bucket. Existing `shrink()`,
+  `addAll()`, `getRawEntry()`, `getKey()`, `getValue()`, `find()` methods
+  are used as-is.
+- **AbstractStorage**: New helper method `hasActiveIndexSnapshotEntries()`
+  added — queries the shared `ConcurrentSkipListMap` for active snapshot
+  entries by engine name and user-key prefix. Existing
+  `computeGlobalLowWaterMark()` is used as-is.
+- **IndexesSnapshot**: Read-only during GC check. Not modified by the
+  GC filtering. Cleaned separately by `evictStaleIndexesSnapshotEntries()`.
+
+#### D1: GC during bucket overflow vs. separate background sweep
+
+- **Alternatives considered**:
+  1. Background sweep: periodic scan of all leaf pages to remove stale
+     tombstones. Requires full tree traversal, extra I/O, and a separate
+     locking protocol.
+  2. GC during bucket overflow (chosen): piggyback on the overflow's entry
+     redistribution. Zero extra I/O — entries are already being copied.
+  3. GC during reads: check and remove on read. Violates read-only
+     semantics and adds write contention to reads.
+- **Rationale**: Overflow handling already iterates and copies all entries.
+  Filtering during this redistribution adds minimal overhead (one LWM
+  computation + one snapshot query per SnapshotMarkerRID) while avoiding a
+  separate sweep infrastructure. Tombstones accumulate in hot pages (pages
+  that receive writes and thus overflow), so overflow-time GC naturally
+  targets the right pages.
+- **Risks/Caveats**: Tombstones in pages that never overflow again will
+  never be collected. This is acceptable — such pages are cold and the
+  space waste is bounded. A future background sweep can address this if
+  needed.
+- **Implemented in**: Track 1
+
+#### D2: Filter-rebuild-retry before splitting
+
+- **Alternatives considered**:
+  1. Filter during entry collection for split: skip tombstones when
+     building left/right entry lists, always proceed with the split.
+  2. Filter-rebuild-retry (chosen): collect surviving entries, rebuild
+     the bucket without tombstones, then retry the insert. Only proceed
+     with the split if the insert still fails (bucket still full).
+- **Rationale**: If tombstone removal frees enough space, the insert
+  succeeds without splitting at all — avoiding an unnecessary split that
+  would create two under-filled buckets. The rebuild uses the existing
+  `shrink(0)` + `addAll()` pattern. This naturally handles every case:
+  all entries removed (empty bucket, insert trivially succeeds), some
+  removed (may or may not need split), none removed (normal split).
+- **Risks/Caveats**: The rebuild adds one extra page write when
+  tombstones are found but the insert still fails. When only demotions
+  occur (no tombstones removed), the bucket is still rebuilt to persist
+  the demoted entries, adding one page write before the inevitable split.
+  Both costs are negligible compared to the split's own page writes.
+- **Implemented in**: Track 1
+
+#### D3: No snapshot check for TombstoneRID removal
+
+- **Alternatives considered**:
+  1. Check snapshot index before removing tombstones (as edge GC does).
+  2. Remove tombstones unconditionally below LWM (chosen).
+- **Rationale**: The edge GC must check the snapshot index because edge
+  snapshot entries can linger due to lazy/threshold-based cleanup — removing
+  a tombstone without checking could cause ghost resurrection via stale
+  snapshot entries. For index B-trees, the `IndexesSnapshot` is cleaned
+  separately via `evictStaleIndexesSnapshotEntries()`, and tombstones below
+  LWM are unreachable by any active transaction. The B-tree tombstone's
+  purpose is to signal "deleted" to concurrent readers; once below LWM,
+  no reader needs it.
+- **Risks/Caveats**: Correctness depends on the assumption that
+  `IndexesSnapshot` cleanup runs independently and that stale snapshot
+  entries cannot cause ghost resurrection after tombstone removal. This
+  is validated by the existing `evictStaleIndexesSnapshotEntries()`
+  mechanism.
+- **Implemented in**: Track 1
+- **Validated in**: Track 2, Track 3
+
+#### D4: SnapshotMarkerRID demotion vs. removal
+
+- **Alternatives considered**:
+  1. Remove SnapshotMarkerRID entries (same as tombstones).
+  2. Demote to plain RecordId by rewriting raw bytes (chosen).
+- **Rationale**: A `SnapshotMarkerRID` marks that a key was re-inserted
+  or updated — the underlying `RecordId` is still a valid live value.
+  Removing it would lose the live entry. Demotion rewrites the negative
+  `collectionPosition` encoding back to positive, converting the marker
+  to a plain `RecordId` while preserving the entry.
+- **Risks/Caveats**: Demotion must only happen when no active snapshot
+  entries exist for the user-key prefix with `version >= LWM`. Otherwise,
+  a concurrent reader using the snapshot index could see inconsistent
+  state.
+- **Implemented in**: Track 1
+- **Validated in**: Track 2, Track 3
+
+#### D5: LWM computation — once per GC attempt
+
+- **Alternatives considered**:
+  1. Cache LWM globally with periodic refresh.
+  2. Compute per entry.
+  3. Compute once per GC attempt (chosen).
+- **Rationale**: LWM computation iterates `TsMinHolder` instances
+  (typically <100). Computing once per GC attempt amortizes the cost
+  across all entry checks.
+- **Risks/Caveats**: LWM may advance between computation and use. This
+  is safe — using a stale (lower) LWM is conservative: we may skip some
+  eligible entries but never remove one prematurely.
+- **Implemented in**: Track 1
+- **Validated in**: Track 2, Track 3
+
+#### Invariants
+
+- **No ghost resurrection**: After tombstone removal, the index read
+  path (via `iterateEntriesBetween()` and snapshot lookups) must never
+  return a live entry for an index key that was deleted. Guaranteed by
+  the LWM threshold — all active transactions see past the tombstone.
+- **Tree size consistency**: The entry point's `treeSize` must equal the
+  actual number of leaf entries. Tombstone removal must decrement the
+  counter via `updateSize(-removedCount, atomicOperation)`.
+- **No unnecessary splits**: If tombstone removal frees enough space for
+  the insert, no split occurs — the tree depth and bucket count remain
+  unchanged.
+- **Partition invariant**: `removedCount + survivors.size() == bucketSize`
+  — every original entry is either removed or kept.
+- **SnapshotMarkerRID demotion safety**: A marker is demoted only when no
+  active snapshot entries exist for the same user-key prefix with
+  `version >= LWM`.
+
+#### Integration Points
+
+- **`BTree.update()` while loop (called by `put()`)**: Entry point for
+  the GC logic. The filtering happens before `splitBucket()` when
+  `addLeafEntry()` fails.
+- **`AbstractStorage.computeGlobalLowWaterMark()`**: Existing method,
+  already used by snapshot cleanup.
+- **`AbstractStorage.hasActiveIndexSnapshotEntries()`**: New method —
+  queries the shared `ConcurrentSkipListMap` for active snapshot entries
+  by engine name and user-key prefix.
+- **`BTree.updateSize()`**: Existing method to adjust tree size counter.
+
+#### Non-Goals
+
+- Background sweep of cold pages (tombstones in pages that never overflow).
+- GC of non-tombstone stale versions (these go to the snapshot index and
+  are already cleaned by `evictStaleIndexesSnapshotEntries()`).
+- Compaction or defragmentation of pages after tombstone removal.
+- IndexesSnapshot cleanup — handled separately, out of scope.
+
+## Checklist
+
+- [x] Track 1: Core GC implementation in BTree and AbstractStorage
+  > Implement tombstone GC and SnapshotMarkerRID demotion during leaf
+  > bucket overflow in `BTree.put()`. This is the core implementation
+  > track, following the filter-rebuild-retry pattern established by the
+  > edge GC in `SharedLinkBagBTree`.
+  >
+  > **Track episode:**
+  > Implemented tombstone GC and SnapshotMarkerRID demotion during leaf
+  > bucket overflow in `BTree.put()`, following the filter-rebuild-retry
+  > pattern from `SharedLinkBagBTree`. Added `filterAndRebuildBucket()`
+  > — removes TombstoneRID below LWM, demotes SnapshotMarkerRID below
+  > LWM when no active snapshot entries exist, rebuilds bucket via
+  > `shrink(0)` + `addAll()`. GC runs at most once per insert via
+  > `gcAttempted` flag. Added `hasActiveIndexSnapshotEntries()` to
+  > `AbstractStorage` with `stateLock.readLock()` protection. Also added
+  > `getIndexSnapshotByEngineName()` / `getNullIndexSnapshotByEngineName()`
+  > helpers for Track 2. Key discovery: `indexEngineNameMap` is a plain
+  > `HashMap` requiring `stateLock` — fixed by adding `stateLock.readLock()`
+  > around the map lookup. Post-validation against edge GC found two
+  > missing defensive assertions (post-rebuild size checks, strict LWM
+  > positivity) — aligned.
+  >
+  > **Step file:** `tracks/track-1.md` (1 steps, 0 failed)
+  >
+  > **Strategy refresh:** CONTINUE — no downstream impact detected. Track 2/3 assumptions remain valid; helpers for Track 2 confirmed available.
+  >
+  > **What**:
+  > - Add `filterAndRebuildBucket()` to `BTree` — iterates all entries
+  >   in a leaf bucket, collects survivors (removing TombstoneRID below
+  >   LWM, demoting SnapshotMarkerRID below LWM when safe), rebuilds the
+  >   bucket via `shrink(0)` + `addAll()`.
+  > - Add `demoteMarkerRawBytes()` static helper — rewrites the negative
+  >   `collectionPosition` encoding of `SnapshotMarkerRID` back to positive.
+  > - Integrate GC into `BTree.put()` `while (!addLeafEntry(...))` loop:
+  >   before calling `splitBucket()`, attempt tombstone filtering at most
+  >   once per insert (`gcAttempted` flag). If tombstones removed, update
+  >   tree size and re-derive insertion index, then retry.
+  > - Add `hasActiveIndexSnapshotEntries()` to `AbstractStorage` — queries
+  >   the shared `ConcurrentSkipListMap` for active snapshot entries by
+  >   engine name and user-key prefix. Handles `$null` suffix resolution.
+  >
+  > **Constraints**:
+  > - LWM computed once per GC attempt.
+  > - GC runs at most once per insert — `gcAttempted` flag prevents
+  >   repeated filtering.
+  > - Only leaf buckets are filtered.
+  > - WAL: no new record types; filtered entries don't appear in rebuilt
+  >   page.
+  > - Applies to both single-value and multi-value index engines
+  >   (both use `BTree.java`).
+  >
+  > **Scope:** ~3-4 steps covering BTree GC filtering methods, put() loop
+  > integration, and AbstractStorage snapshot query helper
+
+- [x] Track 2: Tests for index tombstone GC
+  > Comprehensive tests verifying tombstone GC correctness during bucket
+  > overflow. Tests must cover: basic tombstone removal, LWM boundary
+  > conditions, SnapshotMarkerRID demotion, snapshot entry preservation,
+  > live entry safety, tree size consistency, and mixed scenarios.
+  >
+  > **Track episode:**
+  > Comprehensive test suite for BTree tombstone GC (15 tests, 95.6% line /
+  > 90.0% branch coverage). Covers tombstone removal below LWM, preservation
+  > above and at-exact LWM, no ghost resurrection, live entry safety,
+  > SnapshotMarkerRID demotion with/without active snapshot entries, tree size
+  > consistency, splits with no GC candidates, mixed entry types, sort order
+  > preservation, and AbstractStorage helper edge cases. Key discovery: GC
+  > triggers during initial insertion phase — bucket overflows during
+  > tombstone/marker insertion cause GC on already-inserted entries.
+  > Assertions use `isLessThan(before / 2)` thresholds to catch regressions
+  > while accommodating this behavior. No cross-track impact — Track 3
+  > assumptions remain valid.
+  >
+  > **Step file:** `tracks/track-2.md` (2 steps, 0 failed)
+  > **Depends on:** Track 1
+  >
+  > **Strategy refresh:** CONTINUE — no downstream impact detected. Track 3 assumptions remain valid.
+
+- [x] Track 3: Concurrent and durability tests
+  > Robustness tests verifying tombstone GC correctness under concurrent
+  > access and after non-graceful shutdown.
+  >
+  > **Track episode:**
+  > Comprehensive concurrent and durability test suite for BTree tombstone
+  > GC (3 stress tests + 1 durability test). Stress tests cover: concurrent
+  > put with interleaved tombstones/live entries (cross-thread GC
+  > correctness), concurrent put-and-remove with pre-populated entries
+  > (remover/inserter interleaving), and concurrent read-during-write
+  > (optimistic read path under GC-triggered bucket restructuring). Durability
+  > test verifies index state after non-graceful close — both full-scan and
+  > index-directed lookups confirm no ghost resurrection and no data loss. No
+  > cross-track impact — all findings resolved in-track.
+  >
+  > **Step file:** `tracks/track-3.md` (2 steps, 0 failed)
+  > **Depends on:** Track 1
+  >
+  > **Strategy refresh:** CONTINUE — all implementation tracks complete, no downstream impact.
+
+## Final Artifacts
+- [x] Phase 4: Final artifacts (`design-final.md`, `adr.md`)

--- a/docs/adr/index-gc/reviews/consistency.md
+++ b/docs/adr/index-gc/reviews/consistency.md
@@ -1,0 +1,37 @@
+# Consistency Review — Index BTree Tombstone GC
+
+## Iteration 1
+
+### Finding CR1 [should-fix] — RESOLVED
+**Location**: Implementation plan, Invariants section
+**Issue**: `findVisibleEntry()` is a method on `SharedLinkBagBTree` (edge B-tree), not on `BTree` (index B-tree). Phantom reference.
+**Evidence**: `findVisibleEntry` found only in `SharedLinkBagBTree.java`, not in any index B-tree code.
+**Fix applied**: Reworded invariant to reference `iterateEntriesBetween()` and snapshot lookups.
+
+### Finding CR2 [should-fix] — RESOLVED
+**Location**: Design document, workflow sequence diagram
+**Issue**: Diagram implied rebuild only happens when `removedCount > 0`. Code also rebuilds when `demoted == true` (demotion-only case).
+**Evidence**: `BTree.java` line 2536: `if (removedCount == 0 && !demoted) { return 0; }`
+**Fix applied**: Added third `alt` branch for demotion-only case showing rebuild but returning 0.
+
+### Finding CR3 [suggestion] — RESOLVED
+**Location**: Design document, Snapshot Query section
+**Issue**: Design said `subMap(lower, upper)` but code uses `subMap(lower, true, upper, true)`.
+**Fix applied**: Updated to `subMap(lower, true, upper, true)` with "inclusive on both bounds" note.
+
+### Finding CR4 [suggestion] — RESOLVED
+**Location**: Implementation plan, Integration Points
+**Issue**: Said "BTree.put() while loop" but loop is in `update()`.
+**Fix applied**: Changed to "BTree.update() while loop (called by put())".
+
+### Finding CR5 [suggestion] — RESOLVED
+**Location**: Design document, class diagram
+**Issue**: `indexEngineNameMap: Map` missing value type.
+**Fix applied**: Updated to `indexEngineNameMap: Map~String, BaseIndexEngine~`.
+
+### Finding CR6 [suggestion] — SKIPPED
+**Location**: Design document, demotion encoding section
+**Issue**: Already covered by existing layout diagram. No change needed.
+
+## Result: PASS
+All findings resolved. No blockers.

--- a/docs/adr/index-gc/reviews/structural.md
+++ b/docs/adr/index-gc/reviews/structural.md
@@ -1,0 +1,41 @@
+# Structural Review — Index BTree Tombstone GC
+
+## Iteration 1
+
+### Finding S1 [should-fix] — RESOLVED
+**Location**: Track 1, Scope line
+**Issue**: "formatting" is not a meaningful scope work item.
+**Fix applied**: Changed to `~3-4 steps covering BTree GC filtering methods, put() loop integration, and AbstractStorage snapshot query helper`.
+
+### Finding S2 [should-fix] — RESOLVED
+**Location**: Track 2, Scope line
+**Issue**: 7 test scenarios in 3-4 steps needed clearer bundling signal.
+**Fix applied**: Changed to `~3-4 steps covering test infrastructure setup, tombstone removal/preservation tests, marker demotion/snapshot preservation tests, and tree size/edge case tests`.
+
+### Finding S3 [suggestion] — RESOLVED
+**Location**: Architecture Notes, D2
+**Issue**: Missing demotion-only rebuild cost note in Risks/Caveats.
+**Fix applied**: Added sentence about demotion-only page write before inevitable split.
+
+### Finding S4 [suggestion] — RESOLVED
+**Location**: Design document, Snapshot Query section
+**Issue**: indexId resolved from engineName not explicitly stated.
+**Fix applied**: Added note that indexId is resolved internally via indexEngineNameMap.
+
+### Finding S5 [suggestion] — RESOLVED
+**Location**: Track 3 description
+**Issue**: Missing clarification on storage type for durability test.
+**Fix applied**: Added constraint note about in-memory vs disk storage.
+
+### Finding S6 [should-fix] — RESOLVED
+**Location**: Decision Records D3, D4, D5
+**Issue**: Missing references to validation tracks (Track 2, Track 3).
+**Fix applied**: Added `**Validated in**: Track 2, Track 3` to D3, D4, D5.
+
+### Finding S7 [suggestion] — RESOLVED
+**Location**: Design document, Tree Size Accounting
+**Issue**: Replacement rows document existing behavior but not labeled as such.
+**Fix applied**: Added footnote clarifying unchanged behavior rows.
+
+## Result: PASS
+No blockers. All findings resolved.

--- a/docs/adr/index-gc/reviews/track-1-risk.md
+++ b/docs/adr/index-gc/reviews/track-1-risk.md
@@ -1,0 +1,36 @@
+# Track 1 Risk Review — Index BTree Tombstone GC
+
+## Result: PASS (0 blockers, 0 should-fix, 4 suggestions)
+
+### Finding R1 [suggestion]
+**Certificate**: EC-1 (HashMap thread-safety)
+**Location**: `AbstractStorage.hasActiveIndexSnapshotEntries()` line 6423
+**Issue**: `indexEngineNameMap` (plain `HashMap`) accessed without `stateLock`. Pre-existing pattern shared by other methods.
+**Proposed fix**: No action for Track 1. Pre-existing pattern.
+
+### Finding R2 [suggestion]
+**Certificate**: EC-5 (insertion index after GC)
+**Location**: `BTree.update()` lines 748-750
+**Issue**: After GC rebuild, `find()` re-derives insertion index. If uniqueness invariant violated, produces negative index. Extremely low likelihood.
+**Proposed fix**: Add defensive assertion `assert insertionIndex >= 0`.
+
+### Finding R3 [suggestion]
+**Certificate**: EC-3 (LWM assertion in tests)
+**Location**: `BTree.filterAndRebuildBucket()` line 2785
+**Issue**: `assert lwm > 0` may fail in unit tests with improperly initialized storage.
+**Proposed fix**: Ensure Track 2 test setup initializes atomic operation lifecycle properly.
+
+### Finding R4 [suggestion]
+**Certificate**: EC-4 (per-entry deserialization cost)
+**Location**: `BTree.filterAndRebuildBucket()` lines 2793-2830
+**Issue**: 2-3 page reads per entry. Bounded by bucket size, consistent with edge GC pattern.
+**Proposed fix**: No action. Optimize only if profiling identifies bottleneck.
+
+## Evidence Summary
+- All modifications within single AtomicOperation — rollback safe
+- WAL correctness maintained without new record types
+- Concurrency safe: exclusive lock held, concurrent reads to ConcurrentSkipListMap safe
+- indexEngineNameMap access is pre-existing pattern (not introduced by this track)
+- Bucket rebuild after demotion-only verified safe (entry count/order unchanged)
+- Snapshot query range key construction verified consistent
+- Blast radius: limited to the single overflowing leaf page within an atomic operation

--- a/docs/adr/index-gc/reviews/track-1-technical.md
+++ b/docs/adr/index-gc/reviews/track-1-technical.md
@@ -1,0 +1,44 @@
+# Track 1 Technical Review — Index BTree Tombstone GC
+
+## Result: PASS (0 blockers, 0 should-fix, 5 suggestions)
+
+### Finding T1 [suggestion]
+**Certificate**: EC12 (LWM assert on fresh database)
+**Location**: `BTree.filterAndRebuildBucket()` — `assert lwm > 0`
+**Issue**: Could theoretically fail on fresh DB where `idGen.getLastId()` returns 0. In practice safe since `put()` runs within an atomic operation.
+**Proposed fix**: Change to `assert lwm >= 0` or add comment explaining guarantee.
+
+### Finding T2 [suggestion]
+**Certificate**: EC4, EC3 (demotion encoding)
+**Location**: `BTree.demoteMarkerRawBytes()`
+**Issue**: No defensive assertion that decoded `realPosition` is non-negative.
+**Proposed fix**: Add `assert realPosition >= 0` after computing it.
+
+### Finding T3 [suggestion]
+**Certificate**: EC6 (insertion index re-derivation)
+**Location**: `BTree.update()` line 748-750
+**Issue**: Re-derivation assumes key not in bucket; defensive assert would catch bugs.
+**Proposed fix**: Add `assert insertionIndex >= 0` after re-derivation.
+
+### Finding T5 [suggestion]
+**Certificate**: EC11 (performance)
+**Location**: `BTree.filterAndRebuildBucket()` lines 2793-2830
+**Issue**: Key deserialization is unconditional for all entries. For plain RecordId entries (common case), key is not needed — only value type check matters.
+**Proposed fix**: Check `value instanceof TombstoneRID || value instanceof SnapshotMarkerRID` before deserializing key. Skip key deserialization for plain RecordId.
+
+### Finding T7 [suggestion]
+**Certificate**: EC8 (double page read)
+**Location**: `BTree.filterAndRebuildBucket()`
+**Issue**: Each survivor entry causes two page reads (value/key deserialization + getRawEntry). Could read raw entry once and decode RID from it.
+**Proposed fix**: Read `getRawEntry` first, decode RID type from last 10 bytes, only deserialize key when needed.
+
+## Evidence Summary
+- All component references verified (StorageComponent, AbstractStorage, CellBTreeSingleValueBucketV3)
+- TombstoneRID/SnapshotMarkerRID encoding confirmed correct
+- Filter-rebuild-retry pattern verified with correct atomicity
+- WAL correctness confirmed (no new record types needed)
+- Concurrency verified (exclusive lock held, concurrent reads safe)
+- Tree size accounting verified
+- Partition invariant enforced by assertion
+- gcAttempted flag prevents infinite loops
+- Null-key tree resolution ($null suffix) verified

--- a/docs/adr/index-gc/reviews/track-2-technical.md
+++ b/docs/adr/index-gc/reviews/track-2-technical.md
@@ -1,0 +1,37 @@
+# Track 2 Technical Review
+
+## Summary
+
+Track 2 has an existing untracked test file (`BTreeTombstoneGCTest.java`)
+that covers most planned scenarios. The test infrastructure (LWM pinning,
+stub engine registration, entry counting) is sound.
+
+## Findings
+
+### Finding T1 [should-fix]
+**Location**: `BTreeTombstoneGCTest.java:afterMethod`
+**Issue**: `afterMethod` does not clean `sharedIndexesSnapshot` /
+`indexesSnapshotVisibilityIndex` after tests that call `addSnapshotPair`.
+Leftover entries could cause test pollution. The edge GC test correctly
+clears its equivalent maps.
+**Proposed fix**: Add reflection-based cleanup of `sharedIndexesSnapshot`
+and `indexesSnapshotVisibilityIndex` in `afterMethod`.
+
+### Finding T2 [suggestion]
+**Location**: Missing test
+**Issue**: No test for LWM boundary (`version == lwm`). The implementation
+uses strict `<`, so boundary entries should be preserved.
+**Proposed fix**: Add `testTombstonesAtExactLwmArePreserved`.
+
+### Finding T3 [suggestion]
+**Location**: Missing test
+**Issue**: No explicit "no ghost resurrection" test. The invariant is
+enforced by `assert` in production code but not tested at API level.
+**Proposed fix**: Add test that inserts key, deletes (tombstone), triggers
+GC, then verifies `get()` returns null.
+
+### Finding T4 [suggestion]
+**Location**: `testTombstonesBelowLwmAreRemovedDuringPut` assertion
+**Issue**: `isLessThan(tombstonesBefore)` is intentionally weak (GC only
+runs on overflowing buckets). A comment explaining this would help.
+**Proposed fix**: Add explanatory comment.

--- a/docs/adr/index-gc/reviews/track-3-technical.md
+++ b/docs/adr/index-gc/reviews/track-3-technical.md
@@ -1,0 +1,33 @@
+# Track 3 Technical Review
+
+## Findings
+
+### Finding T1 [should-fix]
+**Certificate**: EC-3 (storage.close API verification)
+**Location**: Track 3 plan, durability test constraint
+**Issue**: `storage.close(true)` is not the correct API. The established pattern uses `ytdb.internal.forceDatabaseClose(dbName)`. Both still flush WAL + dirty pages — neither simulates true mid-operation crash.
+**Proposed fix**: Use `forceDatabaseClose` pattern from `SharedLinkBagBTreeTombstoneGCDurabilityTest`. Document crash fidelity limitation in Javadoc.
+
+### Finding T2 [suggestion]
+**Certificate**: EC-4, EC-8 (storage type consistency)
+**Location**: Track 3 plan, concurrent test constraint: "can use in-memory storage"
+**Issue**: Both `SharedLinkBagBTreeTombstoneGCStressTest` and `BTreeTombstoneGCTest` use DISK storage. In-memory diverges without clear benefit.
+**Proposed fix**: Use DISK storage for consistency.
+
+### Finding T3 [suggestion]
+**Certificate**: EC-10 (reflection helpers)
+**Location**: Track 3 concurrent stress test approach
+**Issue**: Raw BTree level test requires duplicating reflection helpers from `BTreeTombstoneGCTest` (pinLwm, registerStubEngine). Graph API level avoids this but offers less control.
+**Proposed fix**: Use raw BTree level for stress test (more precise GC triggering control), duplicate helpers. Use graph API level for durability test (more realistic).
+
+### Finding T4 [should-fix]
+**Certificate**: EC-9 (test suite placement)
+**Location**: Track 3 plan: "placed in integration test suite if I/O-bound"
+**Issue**: Edge GC equivalent tests run in regular unit test suite. Lightweight entry counts don't warrant integration test placement.
+**Proposed fix**: Place both tests in regular unit test suite.
+
+### Finding T5 [suggestion]
+**Certificate**: EC-2, EC-7 (BTree exclusive lock serialization)
+**Location**: Track 3 plan: "cross-thread GC interaction"
+**Issue**: `BTree.put()` acquires exclusive lock — operations serialize. Tests verify contention safety, not true concurrent GC.
+**Proposed fix**: Document this in test Javadoc, matching edge GC stress test pattern.

--- a/docs/adr/index-gc/tracks/track-1.md
+++ b/docs/adr/index-gc/tracks/track-1.md
@@ -1,0 +1,43 @@
+# Track 1: Core GC implementation in BTree and AbstractStorage
+
+## Progress
+- [x] Review + decomposition
+- [x] Step implementation (1/1 complete)
+- [x] Track-level code review (skipped — single-step track, fully reviewed in Phase B)
+
+## Base commit
+`412c2d9b62`
+
+## Reviews completed
+- [x] Technical (0 blockers, 5 suggestions — defensive asserts and perf optimizations)
+- [x] Risk (0 blockers, 4 suggestions — defensive asserts, pre-existing patterns)
+
+## Steps
+
+- [x] Step: Add filterAndRebuildBucket(), demoteMarkerRawBytes(), put() loop GC integration, and hasActiveIndexSnapshotEntries()
+  - [x] Context: unavailable
+  > **What was done:** Implemented tombstone GC during leaf bucket overflow
+  > in `BTree.put()`. Added `filterAndRebuildBucket()` — iterates bucket
+  > entries, removes TombstoneRID below LWM, demotes SnapshotMarkerRID
+  > below LWM when no active snapshot entries exist, and rebuilds the
+  > bucket via `shrink(0)` + `addAll(survivors)`. Added
+  > `demoteMarkerRawBytes()` static helper for position encoding
+  > reversal. Integrated into the `update()` while loop with
+  > `gcAttempted` flag (at most once per insert). Added
+  > `hasActiveIndexSnapshotEntries()` to `AbstractStorage` — queries
+  > `ConcurrentSkipListMap` via `subMap()` range query with
+  > `stateLock.readLock()` protection. Also added
+  > `getIndexSnapshotByEngineName()` and
+  > `getNullIndexSnapshotByEngineName()` helpers for Track 2 tests.
+  > Applied all Phase A review suggestions: T1 (LWM >= 0), T2
+  > (demote position assert), T3/R2 (insertion index assert), T5
+  > (skip key deserialization for plain RecordId).
+  >
+  > **What was discovered:** `indexEngineNameMap` is a plain `HashMap`
+  > with all existing accesses guarded by `stateLock`. The new
+  > `hasActiveIndexSnapshotEntries()` call from BTree runs under the
+  > BTree component lock, not `stateLock`. Fixed by adding
+  > `stateLock.readLock()` around the map lookup (review fix BC1).
+  >
+  > **Key files:** `BTree.java` (modified), `AbstractStorage.java`
+  > (modified)

--- a/docs/adr/index-gc/tracks/track-2.md
+++ b/docs/adr/index-gc/tracks/track-2.md
@@ -1,0 +1,52 @@
+# Track 2: Tests for index tombstone GC
+
+## Progress
+- [x] Review + decomposition
+- [x] Step implementation (2/2 complete)
+- [x] Track-level code review (1/3 iterations)
+
+## Base commit
+`08fe533746`
+
+## Reviews completed
+- [x] Technical
+
+## Steps
+- [x] Step: Fix test infrastructure and add missing tests
+  - [x] Context: unavailable
+  > **What was done:** Added snapshot cleanup in `afterMethod` (T1). Added
+  > `testTombstonesAtExactLwmArePreserved` (T2) and
+  > `testNoGhostResurrectionAfterGC` (T3). Added explanatory comment on weak
+  > `isLessThan` assertion (T4). Review fixes: guarded `indexEngineNameMap`
+  > access with `stateLock.writeLock()` (BC1), strengthened assertions with
+  > pre-condition checks and lower-bound thresholds (TB2/TB3/TB6), added
+  > demoted marker identity spot-check (TB4), renamed
+  > `testGCRunsAtMostOncePerInsert` to match actual behavior (TB1), added
+  > mixed entry types test (TC1) and sort order verification test (TC5).
+  >
+  > **What was discovered:** GC triggers during the initial insertion phase
+  > itself — bucket overflows during tombstone/marker insertion cause GC on
+  > already-inserted entries. This means `tombstonesBefore < FILL_COUNT` and
+  > markers may already be demoted before the live entry insertion phase.
+  > Assertions were adjusted to accommodate this behavior.
+  >
+  > **Key files:** `BTreeTombstoneGCTest.java` (modified)
+
+- [x] Step: Commit test file and verify coverage
+  - [x] Context: unavailable
+  > **What was done:** Ran coverage with `BTreeTombstoneGCTest` only. Initial
+  > result: 84.4% line / 80.0% branch — line coverage 0.6% below threshold.
+  > Added 2 edge-case tests for `getIndexSnapshotByEngineName` null-return and
+  > `hasActiveIndexSnapshotEntries` false-return paths for unknown engines.
+  > After review, added 2 more tests: `getNullIndexSnapshotByEngineName`
+  > unknown engine and `$null` suffix path in `hasActiveIndexSnapshotEntries`.
+  > Also added positive assertion for known engine name. Final coverage: 95.6%
+  > line / 90.0% branch — well above thresholds.
+  >
+  > **What was discovered:** The remaining uncovered lines (4/90) are defensive
+  > paths: BTree non-CompositeKey fallback (3 lines) and one null-return in
+  > AbstractStorage. These are extremely unlikely paths in production — the
+  > non-CompositeKey path requires a BTree used with non-versioned keys,
+  > which doesn't happen for index engines.
+  >
+  > **Key files:** `BTreeTombstoneGCTest.java` (modified)

--- a/docs/adr/index-gc/tracks/track-3.md
+++ b/docs/adr/index-gc/tracks/track-3.md
@@ -1,0 +1,45 @@
+# Track 3: Concurrent and durability tests
+
+## Progress
+- [x] Review + decomposition
+- [x] Step implementation (2/2 complete)
+- [x] Track-level code review (passed after 1 iteration)
+
+## Base commit
+`205f5bd0`
+
+## Reviews completed
+- [x] Technical
+
+## Steps
+
+- [x] Step: Concurrent stress test for index BTree tombstone GC
+  - [x] Context: unavailable
+  > **What was done:** Created `BTreeTombstoneGCStressTest` with two test
+  > methods following the `SharedLinkBagBTreeTombstoneGCStressTest` pattern.
+  > `testConcurrentPutWithTombstonesAndGC()` — 4 threads, 300 ops/thread,
+  > interleaved tombstones and live entries with non-overlapping key ranges.
+  > `testConcurrentPutAndRemoveWithGC()` — pre-populate then concurrent
+  > removers (TombstoneRID put) and inserters with interleaved key space.
+  > Both verify: no exceptions/deadlocks, all live entries survive with
+  > correct RID values, surviving tombstones retain state, tree size
+  > consistency. Review fix: added missing `collectionId` assertion in
+  > second test's inserter verification.
+  > **Key files:** `BTreeTombstoneGCStressTest.java` (new)
+
+- [x] Step: Durability test for index BTree tombstone GC after non-graceful close
+  - [x] Context: unavailable
+  > **What was done:** Created `BTreeTombstoneGCDurabilityTest` following the
+  > `SharedLinkBagBTreeTombstoneGCDurabilityTest` pattern. Uses graph-level
+  > API with indexed STRING property. Inserts 500 records, cross-tx deletes
+  > 200 (creating index tombstones), inserts 300 more (triggering GC during
+  > overflow), commits, force-closes without session close, reopens. Verifies
+  > exact-match set equality between recovered and expected values, plus
+  > separate ghost-resurrection check. Review fix: replaced per-value loop
+  > verification with collect-and-compare pattern matching reference test,
+  > removed dead `allValues` variable.
+  > **What was discovered:** Core module `query()` API takes SQL directly
+  > (no language prefix), `command()` returns void, `FrontendTransactionImpl`
+  > doesn't have `browseClass()` — must use `tx.load(rid)` for cross-tx
+  > record access. These are API quirks, no cross-track impact.
+  > **Key files:** `BTreeTombstoneGCDurabilityTest.java` (new)


### PR DESCRIPTION
#### Motivation:

Index B-trees accumulate `TombstoneRID` and `SnapshotMarkerRID` entries indefinitely from cross-transaction updates and deletions. These stale entries slow down index searches and waste space because there is no mechanism to reclaim them. This PR adds garbage collection of these entries during leaf bucket overflow in `BTree.put()` — piggybacking on the existing entry redistribution so there is zero extra I/O.

The approach mirrors the edge tombstone GC in `SharedLinkBagBTree` but with two key differences: (1) tombstones below the global low-water mark (LWM) are removed unconditionally (no snapshot entry check needed), and (2) `SnapshotMarkerRID` entries are demoted to plain `RecordId` rather than removed, preserving the live value.

## Summary

- **`BTree.filterAndRebuildBucket()`** — iterates all entries in a leaf bucket, removes `TombstoneRID` below LWM, demotes `SnapshotMarkerRID` below LWM when no active snapshot entries exist, and rebuilds the bucket via `shrink(0)` + `addAll(survivors)`. If tombstone removal frees enough space, the insert succeeds without splitting.
- **`BTree.demoteMarkerRawBytes()`** — rewrites `SnapshotMarkerRID` raw byte encoding (negative `collectionPosition`) back to the real positive value.
- **GC integration in `BTree.update()` while loop** — attempts tombstone filtering at most once per insert (`gcAttempted` flag) before falling back to `splitBucket()`.
- **`AbstractStorage.hasActiveIndexSnapshotEntries()`** — queries the shared `ConcurrentSkipListMap` for active snapshot entries by engine name and user-key prefix, with `stateLock.readLock()` protection for `indexEngineNameMap` access.
- **`AbstractStorage.getIndexSnapshotByEngineName()` / `getNullIndexSnapshotByEngineName()`** — resolve scoped snapshots by engine name (used by test infrastructure).

## Test plan

- [x] `BTreeTombstoneGCTest` — 15 unit tests covering tombstone removal below LWM, preservation above/at-exact LWM, no ghost resurrection, live entry safety, SnapshotMarkerRID demotion with/without active snapshot entries, tree size consistency, splits with no GC candidates, mixed entry types, sort order preservation, and AbstractStorage helper edge cases (95.6% line / 90.0% branch coverage)
- [x] `BTreeTombstoneGCStressTest` — 3 concurrent stress tests: put with interleaved tombstones/live entries, put-and-remove with pre-populated entries, read-during-write under GC-triggered bucket restructuring
- [x] `BTreeTombstoneGCDurabilityTest` — verifies index state after non-graceful close with both full-scan and index-directed lookups (no ghost resurrection, no data loss)
- [x] All existing core unit tests pass