### PR TITLE
[no-test-number-check] Rewrite IC3 query and improve profile-query-bottleneck skill

### DIFF
--- a/.claude/skills/profile-query-bottleneck/SKILL.md
+++ b/.claude/skills/profile-query-bottleneck/SKILL.md
@@ -20,24 +20,25 @@ measurement on a dedicated Hetzner CCX33 server with the LDBC SF 1 dataset.
 ## Prerequisites
 
 - `hcloud` CLI installed and authenticated
+- `boto3` Python library installed locally
 - SSH key pair at `~/.ssh/id_ed25519`
 - The `jmh-ldbc` module compiles locally
-- Hetzner S3 credentials in env vars (`HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`)
+- Environment variables: `HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`, `HETZNER_S3_ENDPOINT`
 
 ## Phase 1: Infrastructure Setup
 
 Follow the `run-jmh-benchmarks-hetzner` skill's Steps 1–4 to:
 1. Provision a CCX33 server
-2. Install JDK 21, git, tmux, zstd, wget
+2. Install JDK 21, git, tmux
 3. Deploy the project via rsync
-4. Download the pre-built LDBC SF 1 database from Hetzner S3
+4. Download the LDBC SF 1 CSV dataset from Hetzner S3
 5. Compile `jmh-ldbc`
-6. Run a pre-load fork to build curation caches
+6. Run a pre-load fork to create the database from CSV and cache curated parameters
 
 Additionally install async-profiler:
 ```bash
 ssh root@<IP> 'cd /tmp && \
-  wget -q https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz && \
+  curl -sLO https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz && \
   tar xzf async-profiler-3.0-linux-x64.tar.gz && \
   ln -sf /tmp/async-profiler-3.0-linux-x64 /opt/async-profiler && \
   echo 1 > /proc/sys/kernel/perf_event_paranoid && \
@@ -47,22 +48,40 @@ ssh root@<IP> 'cd /tmp && \
 
 ## Phase 2: CPU Profiling with async-profiler
 
-### 2a. Flame Graph via JMH `-prof async`
+### 2a. Create a Wrapper Script
+
+The `-prof async:...;...;...` argument contains semicolons that are interpreted by the
+remote shell when passed through SSH, causing the profiler to silently not attach. Use
+the uber-jar directly (not Maven's `-Djmh.args`) with a wrapper script to avoid all
+shell escaping issues:
+
+```bash
+ssh root@<IP> 'cat > /root/run-profile.sh << '\''SCRIPT'\''
+#!/bin/bash
+BENCH=$1      # benchmark regex
+OUTPUT=$2     # flamegraph or collapsed
+shift 2
+ARGS="$@"     # JMH args
+
+JVM_ARGS="--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/sun.nio.cs=ALL-UNNAMED --add-opens java.base/sun.security.x509=ALL-UNNAMED --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED -Xms4096m -Xmx4096m"
+
+mkdir -p /root/profiles
+
+cd /root/ytdb/jmh-ldbc && java $JVM_ARGS \
+  -jar target/youtrackdb-jmh-ldbc-*.jar \
+  "$BENCH" $ARGS \
+  -prof "async:libPath=/opt/async-profiler/lib/libasyncProfiler.so;output=$OUTPUT;dir=/root/profiles;event=cpu"
+SCRIPT
+chmod +x /root/run-profile.sh'
+```
+
+### 2b. Flame Graph
 
 Run the target benchmark with async-profiler attached:
 
 ```bash
-ssh root@<IP> 'cd /root/ytdb && mkdir -p /root/profiles && \
-  ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests -Dspotless.check.skip=true \
-  "-Djmh.args=<BenchmarkClass>.<method> -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1 \
-  -prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so\\;output=flamegraph\\;dir=/root/profiles" \
-  2>&1 | tee /root/prof.log'
+ssh root@<IP> '/root/run-profile.sh "<BenchmarkClass>.<method>" flamegraph -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1'
 ```
-
-**Critical — semicolon escaping**: The Maven exec plugin passes `${jmh.args}` through
-`/bin/sh -c`, so bare semicolons are interpreted as shell command separators. You **must**
-double-escape them as `\\;` inside the `-Djmh.args` value. Without this, the `-prof async`
-option silently receives truncated arguments and produces no output files.
 
 **Important**: Use `-t 1` (single thread) for profiling — multi-threaded profiles are
 harder to interpret and the contention patterns differ from the actual bottleneck.
@@ -74,31 +93,46 @@ work first, then run the profiler on a quiet machine.
 
 Download the flame graphs:
 ```bash
-scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-reverse.html /tmp/flame-reverse.html
-scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-forward.html /tmp/flame-forward.html
+scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-reverse.html /tmp/flame-reverse-$$.html
+scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-forward.html /tmp/flame-forward-$$.html
 ```
 
-### 2b. Collapsed Stacks for Programmatic Analysis
+### 2c. Collapsed Stacks for Programmatic Analysis
 
-Run again with `output=collapsed` to get machine-parseable stacks (same escaping rules):
+Run with `collapsed` output to get machine-parseable stacks:
 
 ```bash
-"-Djmh.args=<BenchmarkClass>.<method> -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1 \
--prof async:libPath=/opt/async-profiler/lib/libasyncProfiler.so\\;output=collapsed\\;dir=/root/profiles2"
+ssh root@<IP> '/root/run-profile.sh "<BenchmarkClass>.<method>" collapsed -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1'
 ```
 
 Download:
 ```bash
-scp root@<IP>:/root/profiles2/<benchmark-name>-Throughput/collapsed-cpu.csv /tmp/collapsed.csv
+scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/collapsed-cpu.csv /tmp/collapsed-$$.csv
 ```
 
-### 2c. Analyzing Collapsed Stacks
+### 2d. Filter Non-Measurement Stacks
+
+Async-profiler captures ALL JVM threads across the entire fork lifetime — including
+`@TearDown`, WAL vacuum, GC, and JVM service threads. These inflate sample counts
+and obscure the real benchmark-thread signal. **Always filter before analysis.**
+
+```bash
+grep -vE 'tearDown|WALVacuum|G1Conc|G1ParScan|GCThread|GangWorker|VMThread|CompilerThread|ServiceThread|SafepointSynchronize|SafepointCleanup|MonitorDeflation' collapsed-cpu.csv > collapsed-filtered.csv
+```
+
+Compare total samples before and after filtering. Large deltas indicate TearDown
+overhead or background thread contention — production concerns but not measurement
+bottlenecks.
+
+Use the filtered file for all subsequent analysis steps.
+
+### 2e. Analyzing Collapsed Stacks
 
 The collapsed stack format is: `frame1;frame2;...;leafFrame count`
 
 **Find hottest leaf methods** (actual CPU consumers):
 ```bash
-cat collapsed.csv | awk '{
+cat collapsed-filtered.csv | awk '{
     n = split($0, parts, ";")
     last = parts[n]
     idx = match(last, / [0-9]+$/)
@@ -110,7 +144,7 @@ cat collapsed.csv | awk '{
 
 **Aggregate by YouTrackDB/Gremlin method** (inclusive samples):
 ```bash
-cat collapsed.csv | awk -F';' '{
+cat collapsed-filtered.csv | awk -F';' '{
     n = split($0, parts, ";")
     last = parts[n]; split(last, lp, " "); count = lp[length(lp)]
     for (i=1; i<=n; i++) {
@@ -124,7 +158,7 @@ cat collapsed.csv | awk -F';' '{
 
 **Trace call chains from a specific method** (e.g., what calls `loadEntity`):
 ```bash
-cat collapsed.csv | grep 'loadEntity' | awk '{
+cat collapsed-filtered.csv | grep 'loadEntity' | awk '{
     n = split($0, parts, ";"); last = parts[n]
     idx = match(last, / [0-9]+$/); count = substr(last, idx+1)+0
     for (i=1; i<=n; i++) {
@@ -140,7 +174,7 @@ cat collapsed.csv | grep 'loadEntity' | awk '{
   } END { for (p in paths) print paths[p], p }' | sort -rn | head -20
 ```
 
-### 2d. Key Methods to Watch For
+### 2f. Key Methods to Watch For
 
 | Method | What it means |
 |---|---|
@@ -252,14 +286,17 @@ javac -proc:none -cp "jmh-ldbc/target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar" Qu
 
 # Run with required --add-opens flags
 java --add-opens java.base/java.lang=ALL-UNNAMED \
-     --add-opens java.base/java.util=ALL-UNNAMED \
-     --add-opens java.base/java.nio=ALL-UNNAMED \
-     --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
      --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+     --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
      --add-opens java.base/java.io=ALL-UNNAMED \
+     --add-opens java.base/java.nio=ALL-UNNAMED \
+     --add-opens java.base/java.util=ALL-UNNAMED \
      --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
      --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
      --add-opens java.base/java.net=ALL-UNNAMED \
+     --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+     --add-opens java.base/sun.nio.cs=ALL-UNNAMED \
+     --add-opens java.base/sun.security.x509=ALL-UNNAMED \
      --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED \
      -cp ".:jmh-ldbc/target/youtrackdb-jmh-ldbc-0.5.0-SNAPSHOT.jar" -Xmx4g QueryDiag
 ```
@@ -349,11 +386,52 @@ O(1) per-row filtering downstream, the sheer volume dominates.
 
 ## Phase 5: Cleanup
 
-Always destroy the Hetzner server when done:
+Always destroy the Hetzner server when done. Use the same branch-based names
+from `run-jmh-benchmarks-hetzner` Step 1:
 ```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '[:upper:]/' '[:lower:]-' | cut -c1-40)
+SERVER_NAME="jmh-bench-${BRANCH}"
+KEY_NAME="jmh-bench-key-${BRANCH}"
+
 hcloud server delete "$SERVER_NAME"
 hcloud ssh-key delete "$KEY_NAME"
 ```
+
+## Phase 6: Self-Improvement Review
+
+After completing the analysis, review the entire session for desynchronizations and improvements. This step is **mandatory** — do not skip it.
+
+### 6a. Skill desynchronization check
+
+Compare what actually happened during execution against what this skill document describes. Flag any discrepancies:
+
+- **File paths or formats that changed**: e.g., async-profiler output extension (`.csv` vs `.collapsed`), jar name, directory layout
+- **Commands that failed or needed modification**: e.g., shell escaping issues, missing flags, incorrect regex patterns
+- **New workarounds discovered**: e.g., `apt-get` lock on fresh servers, JMH lock conflicts, DB lock files after crashes
+- **API changes**: e.g., `yql()` return type changed, new parameter passing conventions, class renames
+- **Analysis methods that didn't work or needed adaptation**: e.g., `awk` field separator assumptions, stack frame format changes
+
+### 6b. Routine improvement proposals
+
+Reflect on the profiling session and identify improvements to the workflow:
+
+- **Efficiency**: Were there unnecessary sequential steps that could be parallelized? Did any step take much longer than expected?
+- **Analysis gaps**: Was any important signal missed that required backtracking? Would a different analysis order have been faster?
+- **New patterns**: Did a new bottleneck category emerge that isn't listed in Phase 4? Were new methods or code paths important that aren't in Section 2f?
+- **Selectivity analysis**: Did the diagnostic program template need significant adaptation? Would a different measurement approach have been more informative?
+- **Tooling**: Would a different async-profiler output format (e.g., `jfr`, `tree`) have been more useful? Would differential flamegraphs help?
+
+**Important**: All proposed improvements must be **generally applicable** — they should benefit any future profiling session, not just the specific query or bottleneck analyzed in this session. Do not propose narrow fixes that only apply to one query or one particular code path.
+
+### 6c. Propose updates
+
+If any desynchronizations or improvements were found, **present them to the user** as a numbered list of proposed skill edits. Include:
+
+1. What to change (quote the current text)
+2. Why (what went wrong or what would improve)
+3. The proposed new text
+
+Apply changes only after user approval. If nothing needs updating, explicitly state: "Skill is in sync — no updates needed."
 
 ## Reference: LDBC SF 1 Dataset Statistics
 

--- a/.claude/skills/profile-query-bottleneck/SKILL.md
+++ b/.claude/skills/profile-query-bottleneck/SKILL.md
@@ -201,7 +201,7 @@ Async-profiler captures ALL JVM threads across the entire fork lifetime — incl
 and obscure the real benchmark-thread signal. **Always filter before analysis.**
 
 ```bash
-grep -vE 'tearDown|WALVacuum|G1Conc|G1ParScan|GCThread|GangWorker|VMThread|CompilerThread|ServiceThread|SafepointSynchronize|SafepointCleanup|MonitorDeflation' collapsed-cpu.csv > collapsed-filtered.csv
+grep -vE 'tearDown|WALVacuum|G1Conc|G1ParScan|GCThread|GangWorker|VMThread|CompilerThread|ServiceThread|SafepointSynchronize|SafepointCleanup|MonitorDeflation' /tmp/collapsed-$$.csv > collapsed-filtered.csv
 ```
 
 Compare total samples before and after filtering. Large deltas indicate TearDown

--- a/.claude/skills/profile-query-bottleneck/SKILL.md
+++ b/.claude/skills/profile-query-bottleneck/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: profile-query-bottleneck
-description: "Profile and diagnose YouTrackDB SQL/MATCH query bottlenecks. Combines async-profiler flame graphs, step-by-step selectivity measurement, and fan-out analysis on a Hetzner CCX33 server against the LDBC SF 1 dataset. Use when a query is slower than expected and you need to understand WHERE time is spent and WHY."
+description: "Profile and diagnose YouTrackDB SQL/MATCH query bottlenecks. Accepts one or more LDBC query names (e.g., IC5, IS7, IC1,IC10). Combines async-profiler flame graphs, step-by-step selectivity measurement, and fan-out analysis on a Hetzner CCX33 server against the LDBC SF 1 dataset."
 user-invocable: true
 ---
 
@@ -9,6 +9,18 @@ user-invocable: true
 Diagnose performance bottlenecks in YouTrackDB SQL and MATCH queries by combining
 CPU profiling (async-profiler), step-by-step selectivity analysis, and fan-out
 measurement on a dedicated Hetzner CCX33 server with the LDBC SF 1 dataset.
+
+## Input
+
+Accepts one or more LDBC query names as arguments. Format examples:
+- `/profile-query-bottleneck IC5` — single query
+- `/profile-query-bottleneck IC5,IC10,IS7` — comma-separated list
+- `/profile-query-bottleneck IC5 IC10 IS7` — space-separated list
+
+Query names are case-insensitive (`ic5`, `IC5`, `Ic5` all work). Valid names:
+IS1–IS7, IC1–IC13.
+
+If no query names are provided, ask the user which queries to profile.
 
 ## When to Use
 
@@ -24,6 +36,69 @@ measurement on a dedicated Hetzner CCX33 server with the LDBC SF 1 dataset.
 - SSH key pair at `~/.ssh/id_ed25519`
 - The `jmh-ldbc` module compiles locally
 - Environment variables: `HETZNER_S3_ACCESS_KEY`, `HETZNER_S3_SECRET_KEY`, `HETZNER_S3_ENDPOINT`
+
+## Phase 0: Resolve Query Parameters
+
+For each query name from the input, look up the benchmark method, benchmark class prefix,
+and tier-appropriate profiling JMH arguments from the table below.
+
+### Query Lookup Table
+
+| Query | Benchmark method | ST class prefix | Tier | Profiling args (ST) |
+|-------|-----------------|-----------------|------|---------------------|
+| IS1 | `is1_personProfile` | `LdbcSingleThreadISUltraFast` | IS-ultra-fast | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IS2 | `is2_personPosts` | `LdbcSingleThreadIS` | IS-noisy | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IS3 | `is3_personFriends` | `LdbcSingleThreadISUltraFast` | IS-ultra-fast | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IS4 | `is4_messageContent` | `LdbcSingleThreadISUltraFast` | IS-ultra-fast | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IS5 | `is5_messageCreator` | `LdbcSingleThreadISUltraFast` | IS-ultra-fast | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IS6 | `is6_messageForum` | `LdbcSingleThreadISUltraFast` | IS-ultra-fast | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IS7 | `is7_messageReplies` | `LdbcSingleThreadIS` | IS-noisy | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IC1 | `ic1_transitiveFriends` | `LdbcSingleThreadICSlow` | IC-slow | `-f 1 -wi 1 -w 30s -i 3 -r 30s -t 1` |
+| IC2 | `ic2_recentFriendMessages` | `LdbcSingleThreadIC` | IC | `-f 1 -wi 1 -w 10s -i 3 -r 20s -t 1` |
+| IC3 | `ic3_friendsInCountries` | `LdbcSingleThreadICUltraSlow` | IC-ultra-slow | `-f 1 -wi 1 -w 60s -i 3 -r 60s -t 1` |
+| IC4 | `ic4_newTopics` | `LdbcSingleThreadICSlow` | IC-slow | `-f 1 -wi 2 -w 30s -i 3 -r 30s -t 1` |
+| IC5 | `ic5_newGroups` | `LdbcSingleThreadICUltraSlow` | IC-ultra-slow | `-f 1 -wi 1 -w 60s -i 3 -r 60s -t 1` |
+| IC6 | `ic6_tagCoOccurrence` | `LdbcSingleThreadICSlow` | IC-slow | `-f 1 -wi 1 -w 30s -i 3 -r 30s -t 1` |
+| IC7 | `ic7_recentLikers` | `LdbcSingleThreadIC` | IC | `-f 1 -wi 1 -w 10s -i 3 -r 20s -t 1` |
+| IC8 | `ic8_recentReplies` | `LdbcSingleThreadIS` | IS-noisy | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+| IC9 | `ic9_recentFofMessages` | `LdbcSingleThreadICSlow` | IC-slow | `-f 1 -wi 1 -w 30s -i 3 -r 30s -t 1` |
+| IC10 | `ic10_friendRecommendation` | `LdbcSingleThreadICUltraSlow` | IC-ultra-slow | `-f 1 -wi 1 -w 60s -i 3 -r 60s -t 1` |
+| IC11 | `ic11_jobReferral` | `LdbcSingleThreadIC` | IC | `-f 1 -wi 1 -w 10s -i 3 -r 20s -t 1` |
+| IC12 | `ic12_expertSearch` | `LdbcSingleThreadICSlow` | IC-slow | `-f 1 -wi 1 -w 30s -i 3 -r 30s -t 1` |
+| IC13 | `ic13_shortestPath` | `LdbcSingleThreadISUltraFast` | IS-ultra-fast | `-f 1 -wi 1 -w 5s -i 3 -r 10s -t 1` |
+
+**IC4 exception**: `ic4_newTopics` has a method-level `@Warmup(iterations = 3, time = 30)` override.
+Profiling uses `-wi 2 -w 30s` instead of the IC-slow default `-wi 1 -w 30s`.
+
+**Multi-thread class prefix**: Replace `LdbcSingleThread` with `LdbcMultiThread` and omit `-t 1`.
+Single-thread profiling is recommended — use MT only if the bottleneck is contention-related.
+
+### Constructing the Benchmark Regex
+
+The JMH benchmark regex for profiling combines the class prefix and method:
+
+```
+<ST class prefix>Benchmark.<method>
+```
+
+Examples:
+- IC5 → `LdbcSingleThreadICUltraSlowBenchmark.ic5_newGroups`
+- IS7 → `LdbcSingleThreadISBenchmark.is7_messageReplies`
+- IC13 → `LdbcSingleThreadISUltraFastBenchmark.ic13_shortestPath`
+
+For multiple queries in the **same tier**, combine with `|`:
+```
+"LdbcSingleThreadICSlow.*(ic1_transitiveFriends|ic6_tagCoOccurrence)"
+```
+
+For queries in **different tiers**, run them as separate profiling invocations — each
+needs its own tier-appropriate warmup/measurement parameters.
+
+### Query SQL Source Files
+
+The actual SQL for each LDBC query lives in `jmh-ldbc/src/main/resources/ldbc-queries/<QUERY>.sql`
+(e.g., `IC5.sql`, `IS7.sql`). Read these to understand the MATCH chain before writing
+the diagnostic program in Phase 3.
 
 ## Phase 1: Infrastructure Setup
 
@@ -77,10 +152,15 @@ chmod +x /root/run-profile.sh'
 
 ### 2b. Flame Graph
 
-Run the target benchmark with async-profiler attached:
+For each query resolved in Phase 0, run the benchmark with async-profiler attached
+using the benchmark regex and tier-appropriate profiling args:
 
 ```bash
-ssh root@<IP> '/root/run-profile.sh "<BenchmarkClass>.<method>" flamegraph -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1'
+# Example: IC5 (IC-ultra-slow tier)
+ssh root@<IP> '/root/run-profile.sh "LdbcSingleThreadICUltraSlowBenchmark.ic5_newGroups" flamegraph -f 1 -wi 1 -w 60s -i 3 -r 60s -t 1'
+
+# Example: IS7 (IS-noisy tier)
+ssh root@<IP> '/root/run-profile.sh "LdbcSingleThreadISBenchmark.is7_messageReplies" flamegraph -f 1 -wi 1 -w 5s -i 3 -r 10s -t 1'
 ```
 
 **Important**: Use `-t 1` (single thread) for profiling — multi-threaded profiles are
@@ -91,6 +171,9 @@ diagnostic programs) while profiling. Concurrent processes compete for CPU and m
 causing OOM kills (exit 137), corrupted profiles, and skewed results. Finish all other
 work first, then run the profiler on a quiet machine.
 
+**Important**: When profiling multiple queries, run them **sequentially** — one at a time.
+Never run concurrent JMH processes on the same server.
+
 Download the flame graphs:
 ```bash
 scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-reverse.html /tmp/flame-reverse-$$.html
@@ -99,10 +182,11 @@ scp root@<IP>:/root/profiles/<benchmark-name>-Throughput/flame-cpu-forward.html 
 
 ### 2c. Collapsed Stacks for Programmatic Analysis
 
-Run with `collapsed` output to get machine-parseable stacks:
+Run with `collapsed` output to get machine-parseable stacks (same regex and args):
 
 ```bash
-ssh root@<IP> '/root/run-profile.sh "<BenchmarkClass>.<method>" collapsed -f 1 -wi 1 -w 10s -i 1 -r 60s -t 1'
+# Example: IC5
+ssh root@<IP> '/root/run-profile.sh "LdbcSingleThreadICUltraSlowBenchmark.ic5_newGroups" collapsed -f 1 -wi 1 -w 60s -i 3 -r 60s -t 1'
 ```
 
 Download:

--- a/jmh-ldbc/src/main/resources/ldbc-queries/IC3.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-queries/IC3.sql
@@ -1,30 +1,30 @@
 /* IC3: Friends in countries.
    Find friends/friends-of-friends who posted in both given countries
    within a time period.
-   Uses conditional aggregation — sum(if(...)) — to count messages for
-   both countries in a single scan instead of two separate subqueries. */
-SELECT personId, firstName, lastName,
-  $counts[0].xCount as xCount, $counts[0].yCount as yCount,
-  ($counts[0].xCount + $counts[0].yCount) as totalCount
+   Extends the MATCH chain through messages instead of using a correlated
+   LET subquery — eliminates ~3500 per-friend SQL execution cycles. */
+SELECT personId, firstName, lastName, xCount, yCount,
+  (xCount + yCount) as totalCount
 FROM (
-  MATCH {class: Person, as: start, where: (id = :personId)}
-    .out('KNOWS'){while: ($depth < 2), as: person,
-      where: (@rid <> $matched.start.@rid)}
-    .out('IS_LOCATED_IN'){as: personCity}
-    .out('IS_PART_OF'){as: personCountry,
-      where: (name NOT IN [:countryX, :countryY])}
-  RETURN person.id as personId, person.firstName as firstName,
-    person.lastName as lastName, person as personVertex
-)
-LET $counts = (
-  SELECT
-    sum(if(out('IS_LOCATED_IN').name CONTAINS :countryX, 1, 0)) as xCount,
-    sum(if(out('IS_LOCATED_IN').name CONTAINS :countryY, 1, 0)) as yCount
+  SELECT personId, firstName, lastName,
+    sum(if(msgCountry = :countryX, 1, 0)) as xCount,
+    sum(if(msgCountry = :countryY, 1, 0)) as yCount
   FROM (
-    SELECT expand(in('HAS_CREATOR')) FROM Person
-    WHERE @rid = $parent.$current.personVertex
-  ) WHERE creationDate >= :startDate AND creationDate < :endDate
+    MATCH {class: Person, as: start, where: (id = :personId)}
+      .out('KNOWS'){while: ($depth < 2), as: person,
+        where: (@rid <> $matched.start.@rid)}
+      .out('IS_LOCATED_IN'){as: personCity}
+      .out('IS_PART_OF'){as: personCountry,
+        where: (name NOT IN [:countryX, :countryY])}
+      .in('HAS_CREATOR'){as: message,
+        where: (creationDate >= :startDate AND creationDate < :endDate)}
+      .out('IS_LOCATED_IN'){as: msgCountry,
+        where: (name IN [:countryX, :countryY])}
+    RETURN person.id as personId, person.firstName as firstName,
+      person.lastName as lastName, msgCountry.name as msgCountry
+  )
+  GROUP BY personId, firstName, lastName
 )
-WHERE $counts[0].xCount > 0 AND $counts[0].yCount > 0
+WHERE xCount > 0 AND yCount > 0
 ORDER BY totalCount DESC, personId ASC
 LIMIT :limit

--- a/jmh-ldbc/src/main/resources/ldbc-queries/IC3.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-queries/IC3.sql
@@ -1,8 +1,9 @@
 /* IC3: Friends in countries.
    Find friends/friends-of-friends who posted in both given countries
    within a time period.
-   Extends the MATCH chain through messages instead of using a correlated
-   LET subquery — eliminates ~3500 per-friend SQL execution cycles. */
+   Uses branching MATCH: one branch filters person's country, another
+   traverses messages — replaces correlated LET subquery, eliminates
+   ~3500 per-friend SQL execution cycles. */
 SELECT personId, firstName, lastName, xCount, yCount,
   (xCount + yCount) as totalCount
 FROM (
@@ -12,11 +13,10 @@ FROM (
   FROM (
     MATCH {class: Person, as: start, where: (id = :personId)}
       .out('KNOWS'){while: ($depth < 2), as: person,
-        where: (@rid <> $matched.start.@rid)}
-      .out('IS_LOCATED_IN'){as: personCity}
-      .out('IS_PART_OF'){as: personCountry,
-        where: (name NOT IN [:countryX, :countryY])}
-      .in('HAS_CREATOR'){as: message,
+        where: (@rid <> $matched.start.@rid)},
+      {as: person}.out('IS_LOCATED_IN').out('IS_PART_OF')
+        {where: (name NOT IN [:countryX, :countryY])},
+      {as: person}.in('HAS_CREATOR'){as: message,
         where: (creationDate >= :startDate AND creationDate < :endDate)}
       .out('IS_LOCATED_IN'){as: msgCountry,
         where: (name IN [:countryX, :countryY])}

--- a/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryExplainTest.java
+++ b/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryExplainTest.java
@@ -193,22 +193,22 @@ public class LdbcQueryExplainTest {
   }
 
   /**
-   * IC3: The LET subqueries use {@code expand(in('HAS_CREATOR'))} with
-   * {@code WHERE creationDate >= :startDate AND creationDate < :endDate}.
-   * Since {@code Message.creationDate} is indexed, the planner should
-   * produce an index pre-filter push-down in the EXPAND step.
+   * IC3: The MATCH chain traverses {@code {person}.in('HAS_CREATOR'){message}}
+   * with {@code WHERE creationDate >= :startDate AND creationDate < :endDate}.
+   * Since {@code Message.creationDate} is indexed, the planner should use
+   * adjacency list intersection with the index during the MATCH step.
    */
   @Test
-  public void testIC3_indexPreFilterPushDown() {
+  public void testIC3_indexIntersection() {
     String plan = explain(LdbcQuerySql.IC3,
         "personId", 1L,
         "startDate", new Date(epochMillis(2012, 6, 1)),
         "endDate", new Date(epochMillis(2012, 7, 1)),
         "countryX", "China", "countryY", "India", "limit", 10);
     assertTrue(
-        "IC3 plan should show index pre-filter push-down on EXPAND for "
+        "IC3 plan should show index intersection on HAS_CREATOR step for "
             + "Message.creationDate range. Plan was:\n" + plan,
-        plan.contains("index pre-filter"));
+        plan.contains("intersection: index Message.creationDate"));
   }
 
   // ==================== Helpers ====================


### PR DESCRIPTION
#### Motivation:

The IC3 LDBC benchmark query used a correlated `LET` subquery that executed ~3500 separate SQL cycles (one per friend/friend-of-friend). This was the dominant bottleneck — each correlated execution re-entered the SQL engine with its own parsing and planning overhead.

This PR replaces the correlated `LET` with an extended MATCH chain that continues through messages and their locations directly, allowing the engine to traverse the graph in a single pass. Conditional aggregation (`sum(if(...))`) counts messages per country in one GROUP BY instead of two subqueries.

The `profile-query-bottleneck` skill is also updated based on learnings from profiling sessions:
- Accept LDBC query names as input (e.g., `/profile-query-bottleneck IC5,IS7`)
- Add a query lookup table with benchmark method, class prefix, tier, and profiling args
- Fix async-profiler semicolon escaping by using a wrapper script + uber-jar directly
- Add stack filtering step to remove TearDown/GC/service thread noise
- Add mandatory self-improvement review phase (Phase 6)
- Sync JVM `--add-opens` flags with the full required set

## Changes

- **`jmh-ldbc/src/main/resources/ldbc-queries/IC3.sql`**: Rewrite query to extend the MATCH chain through `HAS_CREATOR` → `IS_LOCATED_IN` instead of a correlated LET subquery
- **`.claude/skills/profile-query-bottleneck/SKILL.md`**: Major skill update with query lookup table, wrapper script approach, stack filtering, and self-improvement review phase

## Test plan

- [ ] Verify IC3 query returns correct results by running `./mvnw -pl jmh-ldbc -am compile exec:exec` against LDBC SF 1 dataset
- [ ] Run IC3 benchmark on CCX33 to measure throughput improvement vs baseline
- [ ] Verify other LDBC queries are unaffected