### PR TITLE
Fix AIOOBE in ConcurrentLongIntHashMap optimistic read on ARM

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -275,11 +275,16 @@ public class ConcurrentLongIntHashMap<V> {
     }
   }
 
-  /** Returns the total capacity (sum of all section capacities). */
+  /**
+   * Returns the total capacity (sum of all section capacities). Reads each section's
+   * {@code entries.length} without locking — safe for diagnostics and test assertions
+   * (the array reference is always a valid object, though the value may be momentarily stale
+   * during concurrent rehash).
+   */
   public long capacity() {
     long total = 0;
     for (Section<V> s : sections) {
-      total += s.capacity;
+      total += s.entries.length;
     }
     return total;
   }
@@ -354,8 +359,8 @@ public class ConcurrentLongIntHashMap<V> {
    * {@link StampedLock}. Uses open addressing with linear probing.
    *
    * <p>An empty slot has {@code entries[i] == null}. All mutations happen under the write lock;
-   * optimistic readers snapshot the array reference and capacity, then validate the stamp after
-   * probing.
+   * optimistic readers snapshot the array reference and derive the bucket mask from its length,
+   * then validate the stamp after probing.
    */
   private static final class Section<V> {
     private static final float FILL_FACTOR = 0.66f;
@@ -371,7 +376,10 @@ public class ConcurrentLongIntHashMap<V> {
     /** Number of occupied buckets. Drives resize threshold. */
     private int usedBuckets;
 
-    /** Current array length (always a power of two). */
+    /**
+     * Current array length (always a power of two). Only accessed under lock; the optimistic
+     * read path derives capacity from {@code entries.length} instead to avoid ARM reorder races.
+     */
     private int capacity;
 
     /** Resize when usedBuckets exceeds this. */
@@ -392,9 +400,15 @@ public class ConcurrentLongIntHashMap<V> {
       // validation will fail and we fall back to the read lock.
       long stamp = lock.tryOptimisticRead();
 
-      // Snapshot mutable fields to locals under the optimistic stamp
-      int cap = capacity;
+      // Snapshot the array reference, then derive capacity from it — NOT from the
+      // `capacity` field. On weakly-ordered architectures (ARM/aarch64), plain-field
+      // stores in rehashTo() can be reordered: a reader may observe the new `capacity`
+      // (larger) while still seeing the old `entries` array (smaller), causing
+      // ArrayIndexOutOfBoundsException when the mask exceeds the array length.
+      // Deriving the mask from tbl.length guarantees consistency: the length is an
+      // immutable property of the array object we already hold a reference to.
       Entry<V>[] tbl = entries;
+      int cap = tbl.length;
 
       int bucketMask = cap - 1;
       int bucket = hashMix & bucketMask;
@@ -756,11 +770,12 @@ public class ConcurrentLongIntHashMap<V> {
         }
       }
 
-      // Swap array BEFORE capacity — an optimistic reader that snapshots the new capacity
-      // but old array would use a mask larger than the array length, causing AIOOBE.
-      // By writing the array first, a reader that sees the old capacity uses a smaller mask
-      // against a larger array (safe), while a reader that sees the new capacity uses the
-      // correct mask against the new array (also safe).
+      // Write order between entries and capacity does not matter for correctness:
+      // optimistic readers derive their bucket mask from tbl.length (not from the
+      // `capacity` field), and validate() catches any concurrent modifications.
+      // On weakly-ordered architectures (ARM/aarch64), plain stores can be reordered
+      // by the CPU regardless of program order, so write ordering alone would be
+      // insufficient — the tbl.length approach is the actual safety mechanism.
       entries = newEntries;
       capacity = newCapacity;
       resizeThreshold = (int) (newCapacity * FILL_FACTOR);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -281,6 +281,215 @@ public class ConcurrentLongIntHashMapConcurrentTest {
         .isEqualTo(entryCount.get());
   }
 
+  /**
+   * Rehash from minimum capacity (2) under concurrent access. The capacity-2 section has resize
+   * threshold {@code (int)(2 * 0.66) = 1}, so the second insert triggers a rehash. The mask
+   * change from 1 (0b01) to 3 (0b11) is the most extreme relative shift, maximizing the window
+   * for the ARM store-reorder race where a reader could observe the new (larger) capacity before
+   * the new (larger) array.
+   *
+   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException}, correct values returned by concurrent
+   * readers, and that the map grew well beyond the initial capacity.
+   */
+  @Test
+  public void rehashFromMinimumCapacityUnderConcurrentAccessIsCorrect() throws Exception {
+    // Single section, capacity 2 — rehash triggers on the second insert
+    var map = new ConcurrentLongIntHashMap<String>(2, 1);
+    assertThat(map.capacity()).as("initial capacity should be minimum 2").isEqualTo(2);
+
+    int totalThreads = 6; // 3 writers + 3 readers
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+    int keyBound = 5_000;
+    int opsPerThread = 50_000;
+
+    try {
+      // 3 writer threads — insert entries, causing frequent rehash from minimum capacity
+      for (int t = 0; t < 3; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int key = rng.nextInt(keyBound);
+                    long fileId = key / 100;
+                    int pageIndex = key % 100;
+                    map.put(fileId, pageIndex, fileId + ":" + pageIndex);
+                  }
+                  return null;
+                }));
+      }
+
+      // 3 reader threads — continuous reads; verify non-null results are valid
+      for (int t = 0; t < 3; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  for (int i = 0; i < opsPerThread; i++) {
+                    int key = rng.nextInt(keyBound);
+                    long fileId = key / 100;
+                    int pageIndex = key % 100;
+                    String result = map.get(fileId, pageIndex);
+                    if (result != null) {
+                      assertThat(result)
+                          .as("get(%d, %d) returned a valid value", fileId, pageIndex)
+                          .isEqualTo(fileId + ":" + pageIndex);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Verify consistency and that capacity grew well beyond initial 2
+    var entryCount = new AtomicLong();
+    map.forEach(
+        (fileId, pageIndex, value) -> {
+          assertThat(value).isNotNull();
+          assertThat(value)
+              .as("value at (%d, %d) matches canonical form", fileId, pageIndex)
+              .isEqualTo(fileId + ":" + pageIndex);
+          assertThat(map.get(fileId, pageIndex))
+              .as("get(%d, %d) matches forEach entry", fileId, pageIndex)
+              .isSameAs(value);
+          entryCount.incrementAndGet();
+        });
+    assertThat(map.size())
+        .as("size() matches forEach entry count")
+        .isEqualTo(entryCount.get());
+    assertThat(entryCount.get())
+        .as("map should contain entries after 150K puts with no removers into 5K key space")
+        .isGreaterThan(0);
+    assertThat(map.capacity())
+        .as("capacity should have grown well beyond initial 2")
+        .isGreaterThan(2);
+  }
+
+  /**
+   * Shrink under concurrent access. Uses a single-section map that is initially grown to large
+   * capacity, then one thread repeatedly calls {@code shrink()} while reader threads continuously
+   * perform {@code get()}. Exercises the same {@code rehashTo()} code path as grow-rehash but with
+   * {@code newCapacity < capacity}, which creates the symmetric ARM store-reorder risk (reader sees
+   * new smaller array but old larger capacity). A grower thread re-inserts entries to oscillate
+   * capacity up and down, maximizing rehash frequency.
+   *
+   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException}, correct values returned by concurrent
+   * readers, and final map consistency.
+   */
+  @Test
+  public void shrinkUnderConcurrentAccessIsCorrect() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    // 500 total keys: entries 0-99 are always kept (readers have stable data),
+    // entries 100-499 are removed/re-inserted each round to oscillate capacity.
+    int keyCount = 500;
+    int totalThreads = 6; // 1 shrinker + 1 grower + 4 readers
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+    int rounds = 200;
+
+    // Pre-populate so there are entries to read during shrink cycles
+    for (int i = 0; i < keyCount; i++) {
+      map.put((long) i, i, i + ":" + i);
+    }
+
+    try {
+      // 1 thread repeatedly removes entries then calls shrink()
+      futures.add(
+          executor.submit(
+              () -> {
+                startBarrier.await();
+                for (int r = 0; r < rounds; r++) {
+                  // Remove most entries to make shrink meaningful
+                  for (int i = 100; i < keyCount; i++) {
+                    map.remove((long) i, i);
+                  }
+                  map.shrink();
+                  // Re-insert to grow capacity back up for next shrink
+                  for (int i = 100; i < keyCount; i++) {
+                    map.put((long) i, i, i + ":" + i);
+                  }
+                }
+                return null;
+              }));
+
+      // 1 thread that triggers grow-rehash by inserting beyond current capacity
+      futures.add(
+          executor.submit(
+              () -> {
+                startBarrier.await();
+                var rng = ThreadLocalRandom.current();
+                // 100x more iterations than shrinker to ensure grow-rehash overlaps
+                // with shrink-rehash windows
+                for (int r = 0; r < rounds * 100; r++) {
+                  int key = rng.nextInt(keyCount);
+                  map.put((long) key, key, key + ":" + key);
+                }
+                return null;
+              }));
+
+      // 4 reader threads — continuous reads during shrink/grow cycles
+      for (int t = 0; t < 4; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  // 500x more iterations than shrinker to maximize read coverage
+                  // during both shrink-rehash and grow-rehash
+                  for (int r = 0; r < rounds * 500; r++) {
+                    int key = rng.nextInt(keyCount);
+                    String result = map.get((long) key, key);
+                    if (result != null) {
+                      assertThat(result)
+                          .as("get(%d, %d) returned a valid value", (long) key, key)
+                          .isEqualTo(key + ":" + key);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+    } finally {
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Final consistency check
+    var entryCount = new AtomicLong();
+    map.forEach(
+        (fileId, pageIndex, value) -> {
+          assertThat(value).isNotNull();
+          assertThat(value)
+              .as("value at (%d, %d) matches canonical form", fileId, pageIndex)
+              .isEqualTo(fileId + ":" + pageIndex);
+          assertThat(map.get(fileId, pageIndex))
+              .as("get(%d, %d) matches forEach entry", fileId, pageIndex)
+              .isSameAs(value);
+          entryCount.incrementAndGet();
+        });
+    assertThat(map.size())
+        .as("size() matches forEach entry count after shrink stress")
+        .isEqualTo(entryCount.get());
+    assertThat(entryCount.get())
+        .as("map should contain entries after shrink/grow oscillation")
+        .isGreaterThan(0);
+  }
+
   // ---- removeByFileId concurrent tests ----
 
   /**


### PR DESCRIPTION
## Summary
- Fix ARM store-reorder race in `ConcurrentLongIntHashMap.Section.get()`: derive bucket mask from `tbl.length` (immutable array property) instead of the `capacity` field, which could be reordered relative to the `entries` reference on weakly-ordered architectures (aarch64)
- Make `capacity()` diagnostic method use `entries.length` for consistency with the optimistic read path
- Add concurrent stress tests for rehash-from-minimum-capacity and shrink-under-concurrent-access scenarios

## Motivation
CI failure on `develop` after YTDB-523 merge — `ConcurrentLongIntHashMapConcurrentTest.rehashUnderConcurrentAccessIsCorrect` failed with `ArrayIndexOutOfBoundsException: Index 7 out of bounds for length 4` on Linux ARM JDK 25 temurin (run `24332835986`, job `71042530028`). The reader observed `capacity=8` (mask=7) with the old 4-element entries array due to ARM's weak memory ordering of plain stores in `rehashTo()`.

## Test plan
- [x] `ConcurrentLongIntHashMapConcurrentTest` — all 7 tests pass (5 existing + 2 new)
- [x] `ConcurrentLongIntHashMapTest` — all 106 unit tests pass
- [x] Spotless check passes
- [ ] CI: Linux ARM JDK 25 temurin (the failing platform)
- [ ] CI: all other platform/JDK matrix entries