### PR TITLE
YTDB-662: Add withSuspendedTransaction to YTDBGraph API

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraph.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraph.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableFunction;
+import org.apache.commons.lang3.function.FailableSupplier;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.service.ServiceRegistry;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactoryClass;
@@ -122,6 +123,21 @@ public interface YTDBGraph extends Graph {
   /// It is used during generation of backups and also to identify the same replicas of the database
   /// on different hosts.
   UUID uuid();
+
+  /// Suspends the current thread's transaction and session, runs the block, and restores them.
+  /// The block can open its own independent transaction on a fresh session from the pool.
+  ///
+  /// If there is no active transaction on the current thread, the block still runs in its own
+  /// isolated context; nothing needs to be suspended or restored.
+  ///
+  /// If the block leaves a transaction open (does not commit or rollback), it will be rolled back
+  /// and the session will be closed automatically. A warning is logged in this case.
+  ///
+  /// Nesting is supported: calling {@code withSuspendedTransaction} inside the block suspends the
+  /// inner transaction and creates another independent one. Each level saves and restores its own
+  /// state via the call stack.
+  <T, X extends Exception> T withSuspendedTransaction(
+      @Nonnull FailableSupplier<T, X> block) throws X;
 
   /// Closes current graph instance and release acquired resources.
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraphImplAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraphImplAbstract.java
@@ -43,9 +43,11 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.function.FailableSupplier;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.Edge;
@@ -416,8 +418,10 @@ public abstract class YTDBGraphImplAbstract implements YTDBGraphInternal, Consum
       throw new IllegalStateException("Transaction is still active");
     }
 
-    currentSession.close();
+    // Null the field before closing so that cleanup code (e.g., withSuspendedTransaction)
+    // never attempts a second close on the same session if close() throws.
     threadLocalState.sessionEmbedded = null;
+    currentSession.close();
   }
 
   @Override
@@ -449,6 +453,53 @@ public abstract class YTDBGraphImplAbstract implements YTDBGraphInternal, Consum
   public UUID uuid() {
     try (var session = acquireSession()) {
       return session.uuid();
+    }
+  }
+
+  @Override
+  public <T, X extends Exception> T withSuspendedTransaction(
+      @Nonnull FailableSupplier<T, X> block) throws X {
+    // Save the entire thread-local state and replace it with a fresh one.
+    // The outer state is fully isolated — the lambda gets its own transaction,
+    // session, and listener set.
+    var savedState = threadLocalState.get();
+    var innerState = new ThreadLocalState(new YTDBTransaction(this));
+    threadLocalState.set(innerState);
+    try {
+      return block.get();
+    } finally {
+      try {
+        // Clean up any transaction/session left open by the lambda.
+        // Using tx().rollback() goes through the normal TinkerPop path:
+        // doRollback() nulls activeSession, fireOnRollback() calls accept(Status)
+        // which closes sessionEmbedded. This handles both in a single call.
+        // The isOpen() + rollback() is wrapped in a single try-catch because isOpen()
+        // itself can throw if the lambda left the session in a bad state (e.g., manually
+        // closed the session without going through tx().rollback()).
+        try {
+          if (innerState.transaction.isOpen()) {
+            logger.warn(
+                "withSuspendedTransaction: lambda left an open transaction; rolling back");
+            innerState.transaction.rollback();
+          }
+        } catch (Exception e) {
+          logger.warn("withSuspendedTransaction: error during leftover tx rollback", e);
+        }
+
+        // If the lambda acquired a session without opening a transaction (e.g., via
+        // getUnderlyingDatabaseSession()), sessionEmbedded is non-null but the rollback
+        // above didn't touch it. Close it directly.
+        if (innerState.sessionEmbedded != null) {
+          try {
+            innerState.sessionEmbedded.close();
+          } catch (Exception e) {
+            logger.warn("withSuspendedTransaction: error closing leftover session", e);
+          }
+        }
+      } finally {
+        // Restore the suspended state regardless of cleanup outcome.
+        threadLocalState.set(savedState);
+      }
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/GraphSuspendedTransactionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/GraphSuspendedTransactionTest.java
@@ -1,0 +1,449 @@
+package com.jetbrains.youtrackdb.internal.core.gremlin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.jetbrains.youtrackdb.api.exception.ConcurrentModificationException;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.junit.Test;
+
+public class GraphSuspendedTransactionTest extends DbTestBase {
+
+  @Test
+  public void withSuspendedTransaction_innerTransactionIsIndependent() {
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").property("counter", 0).next();
+    graph.tx().commit();
+
+    graph.tx().open();
+    var v = graph.traversal().V().hasLabel("TestEntity").next();
+    v.property("counter", 1);
+
+    graph.withSuspendedTransaction(() -> {
+      graph.tx().open();
+      var inner = graph.traversal().V().hasLabel("TestEntity").next();
+      assertEquals(0, (int) inner.property("counter").value());
+      inner.property("counter", 99);
+      graph.tx().commit();
+      return null;
+    });
+
+    // outer transaction still has its modification
+    assertEquals(1, (int) v.property("counter").value());
+    // outer commit conflicts with inner — that's expected
+    try {
+      graph.tx().commit();
+      fail("Expected ConcurrentModificationException");
+    } catch (ConcurrentModificationException expected) {
+      // ok
+    }
+  }
+
+  @Test
+  public void withSuspendedTransaction_exceptionInLambda_outerTransactionRestored() {
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").property("counter", 0).next();
+    graph.tx().commit();
+
+    graph.tx().open();
+    var v = graph.traversal().V().hasLabel("TestEntity").next();
+    v.property("counter", 1);
+
+    try {
+      graph.withSuspendedTransaction(() -> {
+        graph.tx().open();
+        graph.traversal().V().hasLabel("TestEntity").next().property("counter", 99);
+        // don't commit — throw instead
+        throw new RuntimeException("intentional");
+      });
+      fail("Should have thrown");
+    } catch (RuntimeException e) {
+      assertEquals("intentional", e.getMessage());
+    }
+
+    // outer transaction should still be usable
+    assertEquals(1, (int) v.property("counter").value());
+    graph.tx().rollback();
+  }
+
+  @Test
+  public void withSuspendedTransaction_lambdaDoesNotOpenTx() {
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").property("counter", 0).next();
+    graph.tx().commit();
+
+    graph.tx().open();
+    var v = graph.traversal().V().hasLabel("TestEntity").next();
+    v.property("counter", 1);
+
+    graph.withSuspendedTransaction(() -> {
+      // no tx operations at all
+      return 42;
+    });
+
+    assertEquals(1, (int) v.property("counter").value());
+    graph.tx().commit();
+  }
+
+  @Test
+  public void withSuspendedTransaction_leftoverTxIsRolledBack() {
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").property("counter", 0).next();
+    graph.tx().commit();
+
+    graph.tx().open();
+    var v = graph.traversal().V().hasLabel("TestEntity").next();
+    v.property("counter", 1);
+
+    graph.withSuspendedTransaction(() -> {
+      graph.tx().open();
+      graph.traversal().V().hasLabel("TestEntity").next().property("counter", 99);
+      // deliberately don't commit or rollback
+      return null;
+    });
+
+    // outer still works — inner was rolled back by cleanup
+    assertEquals(1, (int) v.property("counter").value());
+    graph.tx().commit();
+
+    // verify inner's change was not persisted
+    graph.tx().open();
+    var result = graph.traversal().V().hasLabel("TestEntity").next();
+    assertEquals(1, (int) result.property("counter").value());
+    graph.tx().close();
+  }
+
+  @Test
+  public void withSuspendedTransaction_nestedSuspension() {
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").property("counter", 0).next();
+    graph.tx().commit();
+
+    graph.tx().open();
+    var v = graph.traversal().V().hasLabel("TestEntity").next();
+    v.property("counter", 1);
+
+    graph.withSuspendedTransaction(() -> {
+      graph.tx().open();
+      graph.traversal().V().hasLabel("TestEntity").next().property("counter", 10);
+
+      graph.withSuspendedTransaction(() -> {
+        graph.tx().open();
+        var innermost = graph.traversal().V().hasLabel("TestEntity").next();
+        // sees committed value (0), not outer (1) or middle (10)
+        assertEquals(0, (int) innermost.property("counter").value());
+        graph.tx().rollback();
+        return null;
+      });
+
+      // middle tx still works
+      graph.tx().commit();
+      return null;
+    });
+
+    // outer tx still works
+    assertEquals(1, (int) v.property("counter").value());
+    // outer conflicts with middle — expected
+    try {
+      graph.tx().commit();
+      fail("Expected ConcurrentModificationException");
+    } catch (ConcurrentModificationException expected) {
+      // ok
+    }
+  }
+
+  @Test
+  public void withSuspendedTransaction_noOuterTransaction() {
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    YTDBGraph graph = pool.asGraph();
+
+    // no tx open — suspension is a no-op
+    var result = graph.withSuspendedTransaction(() -> {
+      graph.tx().open();
+      graph.traversal().addV("TestEntity").property("counter", 42).next();
+      graph.tx().commit();
+      return "done";
+    });
+
+    assertEquals("done", result);
+
+    graph.tx().open();
+    var v = graph.traversal().V().hasLabel("TestEntity").next();
+    assertEquals(42, (int) v.property("counter").value());
+    graph.tx().close();
+  }
+
+  @Test
+  public void withSuspendedTransaction_divergedSessionsAreBothCleaned() {
+    // Trigger the case where activeSession and sessionEmbedded diverge:
+    // open a tx (sets both), commit (nulls both via accept(Status)),
+    // then call getUnderlyingDatabaseSession() directly (sets only sessionEmbedded).
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    var graphImpl = (YTDBGraphImplAbstract) pool.asGraph();
+
+    graphImpl.tx().open();
+    graphImpl.traversal().addV("TestEntity").property("counter", 0).next();
+    graphImpl.tx().commit();
+
+    graphImpl.tx().open();
+    var v = graphImpl.traversal().V().hasLabel("TestEntity").next();
+    v.property("counter", 1);
+
+    graphImpl.withSuspendedTransaction(() -> {
+      // Open and commit a tx — both activeSession and sessionEmbedded are set then cleared.
+      graphImpl.tx().open();
+      graphImpl.tx().commit();
+
+      // Now call getUnderlyingDatabaseSession() directly — the side effect sets
+      // sessionEmbedded but does NOT set activeSession on the transaction. They diverge.
+      // Cleanup should still close the orphaned session.
+      graphImpl.getUnderlyingDatabaseSession();
+      return null;
+    });
+
+    // outer transaction should still be usable
+    assertEquals(1, (int) v.property("counter").value());
+    graphImpl.tx().rollback();
+  }
+
+  @Test
+  public void withSuspendedTransaction_leftoverSessionAlreadyClosed_outerStillRestored() {
+    // Simulate a session that's already in a bad state when cleanup runs.
+    // The lambda opens a tx, gets the session, manually closes it, then leaves
+    // the tx/session references dangling. Cleanup should handle this gracefully.
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    var graphImpl = (YTDBGraphImplAbstract) pool.asGraph();
+
+    graphImpl.tx().open();
+    graphImpl.traversal().addV("TestEntity").property("counter", 0).next();
+    graphImpl.tx().commit();
+
+    graphImpl.tx().open();
+    var v = graphImpl.traversal().V().hasLabel("TestEntity").next();
+    v.property("counter", 1);
+
+    graphImpl.withSuspendedTransaction(() -> {
+      graphImpl.tx().open();
+      DatabaseSessionEmbedded innerSession = graphImpl.getUnderlyingDatabaseSession();
+      // Manually close the session — puts it in a bad state for cleanup
+      innerSession.rollback();
+      innerSession.close();
+      // activeSession and sessionEmbedded still reference the now-closed session
+      return null;
+    });
+
+    // outer transaction must still be restored despite messy cleanup
+    assertEquals(1, (int) v.property("counter").value());
+    graphImpl.tx().rollback();
+  }
+
+  @Test
+  public void withSuspendedTransaction_returnValuePropagated() {
+    // Verify the lambda's return value is passed through when an outer tx is active.
+    session.createVertexClass("TestEntity");
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").next();
+
+    var result = graph.withSuspendedTransaction(() -> 42);
+
+    assertEquals(42, (int) result);
+    graph.tx().commit();
+  }
+
+  @Test
+  public void withSuspendedTransaction_checkedExceptionPropagated() {
+    // Verify that a checked exception thrown inside the lambda propagates through
+    // withSuspendedTransaction without being wrapped.
+    session.createVertexClass("TestEntity");
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").next();
+
+    try {
+      graph.<Void, Exception>withSuspendedTransaction(() -> {
+        throw new java.io.IOException("checked");
+      });
+      fail("Should have thrown IOException");
+    } catch (Exception e) {
+      assertTrue("Expected IOException but got: " + e.getClass().getName(),
+          e instanceof java.io.IOException);
+      assertEquals("checked", e.getMessage());
+    }
+
+    // outer transaction should still be usable after checked exception
+    graph.tx().rollback();
+    assertFalse(graph.tx().isOpen());
+  }
+
+  @Test
+  public void withSuspendedTransaction_innerAndOuterCommitWithoutConflict() {
+    // Inner and outer transactions touch different data — both commit successfully.
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("name", PropertyType.STRING);
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").property("name", "outer").next();
+
+    graph.withSuspendedTransaction(() -> {
+      graph.tx().open();
+      graph.traversal().addV("TestEntity").property("name", "inner").next();
+      graph.tx().commit();
+      return null;
+    });
+
+    // outer commit should succeed — no conflict with inner (different records)
+    graph.tx().commit();
+
+    // verify both vertices were persisted
+    graph.tx().open();
+    var names = graph.traversal().V().hasLabel("TestEntity").values("name").toList();
+    assertTrue(names.contains("outer"));
+    assertTrue(names.contains("inner"));
+    assertEquals(2, names.size());
+    graph.tx().close();
+  }
+
+  @Test
+  public void withSuspendedTransaction_outerIsReadOnly() {
+    // Outer transaction only reads — suspension and restore should still work.
+    var cls = session.createVertexClass("TestEntity");
+    cls.createProperty("counter", PropertyType.INTEGER);
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").property("counter", 0).next();
+    graph.tx().commit();
+
+    // open outer as read-only (just read, no writes)
+    graph.tx().open();
+    var v = graph.traversal().V().hasLabel("TestEntity").next();
+    var valueBefore = (int) v.property("counter").value();
+
+    graph.withSuspendedTransaction(() -> {
+      graph.tx().open();
+      graph.traversal().V().hasLabel("TestEntity").next().property("counter", 99);
+      graph.tx().commit();
+      return null;
+    });
+
+    // outer still sees the snapshot it started with (0), not the inner's commit (99)
+    assertEquals(valueBefore, (int) v.property("counter").value());
+    // outer has no writes so commit is clean (no CME — there's nothing to conflict)
+    graph.tx().commit();
+
+    // verify inner's write was persisted
+    graph.tx().open();
+    var result = graph.traversal().V().hasLabel("TestEntity").next();
+    assertEquals(99, (int) result.property("counter").value());
+    graph.tx().close();
+  }
+
+  @Test
+  public void withSuspendedTransaction_innerListenerDoesNotFireOnOuterCommit() {
+    // A listener added inside the lambda must not fire when the outer transaction commits.
+    session.createVertexClass("TestEntity");
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").next();
+    graph.tx().commit();
+
+    List<Transaction.Status> innerEvents = new ArrayList<>();
+
+    graph.tx().open();
+    graph.traversal().V().hasLabel("TestEntity").next();
+
+    graph.withSuspendedTransaction(() -> {
+      graph.tx().addTransactionListener(innerEvents::add);
+      graph.tx().open();
+      graph.tx().commit();
+      return null;
+    });
+
+    // inner listener should have seen the inner commit
+    assertEquals(List.of(Transaction.Status.COMMIT), innerEvents);
+
+    // now commit the outer — inner listener must NOT fire again
+    innerEvents.clear();
+    graph.tx().commit();
+    assertTrue("Inner listener should not fire on outer commit", innerEvents.isEmpty());
+  }
+
+  @Test
+  public void withSuspendedTransaction_outerListenerDoesNotFireOnInnerCommit() {
+    // A listener on the outer transaction must not fire when the inner transaction commits.
+    session.createVertexClass("TestEntity");
+
+    YTDBGraph graph = pool.asGraph();
+
+    graph.tx().open();
+    graph.traversal().addV("TestEntity").next();
+    graph.tx().commit();
+
+    List<Transaction.Status> outerEvents = new ArrayList<>();
+
+    graph.tx().open();
+    graph.tx().addTransactionListener(outerEvents::add);
+    graph.traversal().V().hasLabel("TestEntity").next();
+
+    graph.withSuspendedTransaction(() -> {
+      graph.tx().open();
+      graph.tx().commit();
+      return null;
+    });
+
+    // outer listener must not have fired during the inner commit
+    assertTrue("Outer listener should not fire on inner commit", outerEvents.isEmpty());
+
+    // now commit the outer — outer listener should fire
+    graph.tx().commit();
+    assertEquals(List.of(Transaction.Status.COMMIT), outerEvents);
+  }
+}


### PR DESCRIPTION
#### Motivation:

When working through the Gremlin graph API, there are patterns where code running
inside an active transaction needs to perform independent work — reading fresh
committed data, executing a side-effect query, or running a nested operation that
must not see or interfere with the outer transaction's uncommitted state.

Previously there was no way to temporarily "park" the current transaction and
session, do independent work, and then resume where you left off. Callers had to
either restructure their code to avoid the need, or manually manage session and
transaction state — which is error-prone and tightly coupled to internal details.

`withSuspendedTransaction` solves this by saving the entire thread-local state
(transaction, session, listeners), replacing it with a fresh isolated context for
the lambda, and restoring the original state afterward. The implementation:

- Replaces the full `ThreadLocalState` rather than mutating individual fields,
  giving complete isolation of transaction listeners and monitoring state.
- Automatically rolls back and cleans up any transaction/session the lambda
  leaves open.
- Supports nesting naturally via the call stack.
- Propagates both checked and unchecked exceptions from the lambda.
- Handles edge cases: no outer transaction, manually closed sessions, diverged
  session/transaction references.

14 tests cover: transaction independence, exception recovery, leftover rollback,
nesting, no-op (no outer tx), diverged sessions, already-closed sessions, return
value propagation, checked exception propagation, non-conflicting inner/outer
commits, read-only outer transaction, and listener isolation in both directions.

