### PR TITLE
YTDB-661 Graph Traversal Memoization in Per-Record LET Subqueries

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -842,6 +842,23 @@ public enum GlobalConfiguration {
       Integer.class,
       1000),
 
+  QUERY_TRAVERSAL_CACHE_ENABLED(
+      "youtrackdb.query.traversalCache.enabled",
+      "Cache repeated graph traversals (out/in/both/outE/inE/bothE) within a single query"
+          + " execution. Eliminates redundant traversals when the same entity is visited"
+          + " repeatedly across per-record LET subquery executions.",
+      Boolean.class,
+      true,
+      true),
+
+  QUERY_TRAVERSAL_CACHE_MAX_ENTRIES(
+      "youtrackdb.query.traversalCache.maxEntries",
+      "Maximum number of cached traversal results per query execution. When the limit is"
+          + " reached, the least-recently-used entry is evicted.",
+      Integer.class,
+      1024,
+      true),
+
   QUERY_LET_MATERIALIZATION_MAX_SIZE(
       "youtrackdb.query.letMaterialization.maxSize",
       "Maximum number of records to materialize when sharing a common inner subquery"

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/BasicCommandContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/BasicCommandContext.java
@@ -70,6 +70,8 @@ public class BasicCommandContext implements CommandContext {
 
   private boolean skipExpandPushDown;
 
+  @Nullable private TraversalCache traversalCache;
+
   public BasicCommandContext() {
   }
 
@@ -608,6 +610,19 @@ public class BasicCommandContext implements CommandContext {
   @Override
   public void setSkipExpandPushDown(boolean skip) {
     this.skipExpandPushDown = skip;
+  }
+
+  @Override
+  @Nullable public TraversalCache getTraversalCache() {
+    if (traversalCache != null) {
+      return traversalCache;
+    }
+    return parent != null ? parent.getTraversalCache() : null;
+  }
+
+  @Override
+  public void setTraversalCache(@Nullable TraversalCache cache) {
+    this.traversalCache = cache;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/CommandContext.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/CommandContext.java
@@ -135,6 +135,20 @@ public interface CommandContext {
 
   void setSkipExpandPushDown(boolean skip);
 
+  /**
+   * Returns the traversal cache for this query execution, or {@code null} if none has been
+   * installed. Implementations should walk the parent chain when no local cache is set, so that
+   * child contexts created by {@code LetQueryStep} transparently share the cache of the outermost
+   * query context.
+   */
+  @Nullable TraversalCache getTraversalCache();
+
+  /**
+   * Installs a traversal cache on this context. Called once per query execution by
+   * {@code LetQueryStep} when per-record LET subqueries are detected and caching is enabled.
+   */
+  void setTraversalCache(@Nullable TraversalCache cache);
+
   void startProfiling(ExecutionStep step);
 
   void endProfiling(ExecutionStep step);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCache.java
@@ -1,0 +1,181 @@
+package com.jetbrains.youtrackdb.internal.core.command;
+
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+
+/**
+ * Per-query-execution LRU cache for graph traversal results (out, in, both, outE, inE, bothE).
+ *
+ * <p>Within a single read-consistent SQL statement, traversing the same vertex via the same
+ * function and labels always yields the same result. This cache eliminates redundant traversals
+ * when the same source entity appears repeatedly across LET subquery executions.
+ *
+ * <p>This cache is <b>not thread-safe</b>. It is created per query execution and accessed only
+ * from the single thread executing that query.
+ *
+ * <p>Results are materialized before caching: graph functions return lazy iterables that can only
+ * be consumed once, so the cache stores {@link ArrayList} copies that can be iterated multiple
+ * times.
+ *
+ * <p>Null results are not cached, so traversals that return null (e.g. record not found or not a
+ * vertex) are always re-executed. These cases are uncommon and inexpensive.
+ *
+ * @see TraversalCacheKey
+ */
+public class TraversalCache {
+
+  /**
+   * Thread-local hit counter incremented every time {@link #get} finds an entry. Isolated per
+   * thread so that concurrent queries do not interfere with each other. Intended only for
+   * observability in tests; production code should not depend on this counter.
+   */
+  static final ThreadLocal<AtomicLong> THREAD_HIT_COUNT =
+      ThreadLocal.withInitial(AtomicLong::new);
+
+  private final Map<TraversalCacheKey, Object> cache;
+
+  /** Number of times {@link #get} found an entry. */
+  private long hitCount;
+
+  /** Number of times {@link #get} found no entry. */
+  private long missCount;
+
+  public TraversalCache(int maxEntries) {
+    if (maxEntries < 1) {
+      throw new IllegalArgumentException(
+          "maxEntries must be >= 1, got " + maxEntries
+              + ". Use QUERY_TRAVERSAL_CACHE_ENABLED=false to disable caching.");
+    }
+    // Access-order LinkedHashMap with removeEldestEntry evicts the LRU entry when the cache
+    // exceeds maxEntries. Uses > (not >=) so that exactly maxEntries entries are retained.
+    this.cache =
+        new LinkedHashMap<>(16, 0.75f, true) {
+          @Override
+          protected boolean removeEldestEntry(Map.Entry<TraversalCacheKey, Object> eldest) {
+            return size() > maxEntries;
+          }
+        };
+  }
+
+  /**
+   * Returns the cached result for the given key, or {@code null} if not present.
+   *
+   * <p>A {@code null} return always means a cache miss — null traversal results are not stored.
+   */
+  @Nullable public Object get(TraversalCacheKey key) {
+    var value = cache.get(key);
+    if (value != null) {
+      hitCount++;
+      THREAD_HIT_COUNT.get().incrementAndGet();
+    } else {
+      missCount++;
+    }
+    return value;
+  }
+
+  /** Returns the number of cache lookups that found an entry since this instance was created. */
+  public long getHitCount() {
+    return hitCount;
+  }
+
+  /** Returns the number of cache lookups that found no entry since this instance was created. */
+  public long getMissCount() {
+    return missCount;
+  }
+
+  /**
+   * Resets the thread-local hit counter to zero. Call this before running a query in a test to
+   * isolate hit counts from prior queries in the same thread.
+   */
+  public static void resetThreadLocalHitCount() {
+    THREAD_HIT_COUNT.get().set(0);
+  }
+
+  /**
+   * Returns the number of cache hits recorded on this thread since the last {@link
+   * #resetThreadLocalHitCount} call. Each {@link #get} that returns a non-null value increments
+   * this counter.
+   */
+  public static long getThreadLocalHitCount() {
+    return THREAD_HIT_COUNT.get().get();
+  }
+
+  /**
+   * Materializes {@code result}, stores it under {@code key}, and returns the materialized copy.
+   * Returns {@code null} without storing if {@code result} is {@code null}.
+   *
+   * <p>Callers should use the returned value rather than calling {@link #get} after {@code put},
+   * because the returned value is guaranteed to be the materialized copy regardless of eviction.
+   */
+  @Nullable public Object put(TraversalCacheKey key, Object result) {
+    if (result == null) {
+      return null;
+    }
+    var materialized = materialize(result);
+    cache.put(key, materialized);
+    return materialized;
+  }
+
+  /**
+   * Converts a graph traversal result into a reusable form. Graph functions return lazy iterables
+   * (e.g. {@code MultiCollectionIterator}) that can only be consumed once; this method drains them
+   * into an {@link ArrayList} so subsequent cache hits can iterate the result freely.
+   */
+  private static Object materialize(Object result) {
+    if (result instanceof Collection<?> col) {
+      return new ArrayList<>(col);
+    }
+    if (result instanceof Iterable<?> iter) {
+      var list = new ArrayList<>();
+      iter.forEach(list::add);
+      return list;
+    }
+    // Single value (e.g. a single Vertex) — already immutable after loading.
+    return result;
+  }
+
+  /**
+   * Installs a traversal cache on the given context if caching is enabled in the database
+   * configuration and no cache has been installed yet (on this context or any ancestor). Called once
+   * per query execution by {@code LetQueryStep} and {@code MaterializedLetGroupStep}.
+   */
+  public static void installIfNeeded(CommandContext ctx) {
+    if (ctx.getTraversalCache() != null) {
+      return;
+    }
+    var db = ctx.getDatabaseSession();
+    if (db == null) {
+      return;
+    }
+    var config = db.getConfiguration();
+    if (!config.getValueAsBoolean(GlobalConfiguration.QUERY_TRAVERSAL_CACHE_ENABLED)) {
+      return;
+    }
+    var maxEntries =
+        config.getValueAsInteger(GlobalConfiguration.QUERY_TRAVERSAL_CACHE_MAX_ENTRIES);
+    ctx.setTraversalCache(new TraversalCache(maxEntries));
+  }
+
+  /**
+   * Extracts an {@link Identifiable} from a graph-function target for use as the cache key source.
+   * Graph functions can be called with either a raw {@link Identifiable} (direct traversal) or a
+   * {@link Result} that wraps a persistent entity (projection context). Returns {@code null} when
+   * the target cannot be reduced to a single persistent entity.
+   */
+  @Nullable public static Identifiable extractSourceIdentifiable(Object target) {
+    if (target instanceof Identifiable id) {
+      return id;
+    }
+    if (target instanceof Result result && result.isEntity()) {
+      return result.asEntity();
+    }
+    return null;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCache.java
@@ -6,12 +6,15 @@ import com.jetbrains.youtrackdb.internal.core.query.Result;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
- * Per-query-execution LRU cache for graph traversal results (out, in, both, outE, inE, bothE).
+ * Per-query-execution LRU cache for graph traversal results (out, in, both, outE, inE, bothE,
+ * outV, inV, bothV).
  *
  * <p>Within a single read-consistent SQL statement, traversing the same vertex via the same
  * function and labels always yields the same result. This cache eliminates redundant traversals
@@ -55,8 +58,10 @@ public class TraversalCache {
     }
     // Access-order LinkedHashMap with removeEldestEntry evicts the LRU entry when the cache
     // exceeds maxEntries. Uses > (not >=) so that exactly maxEntries entries are retained.
+    // Pre-size the initial capacity to avoid rehashing as the cache fills up.
+    int initialCapacity = (int) (maxEntries / 0.75f) + 1;
     this.cache =
-        new LinkedHashMap<>(16, 0.75f, true) {
+        new LinkedHashMap<>(initialCapacity, 0.75f, true) {
           @Override
           protected boolean removeEldestEntry(Map.Entry<TraversalCacheKey, Object> eldest) {
             return size() > maxEntries;
@@ -139,6 +144,46 @@ public class TraversalCache {
     }
     // Single value (e.g. a single Vertex) — already immutable after loading.
     return result;
+  }
+
+  /**
+   * Looks up a cached graph traversal result for the given source entity, function name, and
+   * parameter values. On a cache miss, invokes the {@code compute} supplier to obtain the result,
+   * materializes and stores it, and returns the materialized copy. Returns {@code null} and
+   * delegates to {@code compute} without caching when the source cannot be identified by a
+   * persistent RID.
+   *
+   * <p>This method encapsulates the cache lookup + populate pattern used by both
+   * {@code SQLFunctionCall} and {@code SQLMethodCall} to avoid duplicating the caching logic.
+   *
+   * @param cache the traversal cache (must not be null)
+   * @param source the graph-function target (Identifiable or Result wrapping an entity)
+   * @param functionName the traversal function name (e.g. "out", "inE")
+   * @param paramValues the raw parameter values (edge-class labels)
+   * @param compute supplier that executes the actual graph traversal on a cache miss
+   * @return the cached or freshly computed result, or {@code null} if the traversal returned null
+   */
+  @Nullable public static Object getOrCompute(
+      TraversalCache cache, Object source, String functionName,
+      List<Object> paramValues, Supplier<Object> compute) {
+    var sourceId = extractSourceIdentifiable(source);
+    if (sourceId != null) {
+      var rid = sourceId.getIdentity();
+      if (rid != null && !rid.isNew()) {
+        var key = new TraversalCacheKey(
+            rid, functionName, TraversalCacheKey.toStringLabels(paramValues));
+        var cached = cache.get(key);
+        if (cached != null) {
+          return cached;
+        }
+        var result = compute.get();
+        if (result != null) {
+          return cache.put(key, result);
+        }
+        return null;
+      }
+    }
+    return compute.get();
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheKey.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheKey.java
@@ -3,7 +3,6 @@ package com.jetbrains.youtrackdb.internal.core.command;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 /**
  * Immutable key for {@link TraversalCache}. Uniquely identifies a graph traversal result by the
@@ -28,6 +27,6 @@ public record TraversalCacheKey(RID sourceRid, String functionName, List<String>
     return paramValues.stream()
         .filter(Objects::nonNull)
         .map(Object::toString)
-        .collect(Collectors.toList());
+        .toList();
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheKey.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheKey.java
@@ -1,0 +1,33 @@
+package com.jetbrains.youtrackdb.internal.core.command;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Immutable key for {@link TraversalCache}. Uniquely identifies a graph traversal result by the
+ * source entity, the traversal function name (e.g. "out", "in", "both"), and the edge-class labels
+ * passed as arguments.
+ *
+ * <p>The labels list is defensively copied to an unmodifiable list in the compact constructor, so
+ * callers cannot break HashMap invariants by mutating the list after key construction.
+ */
+public record TraversalCacheKey(RID sourceRid, String functionName, List<String> labels) {
+
+  public TraversalCacheKey {
+    labels = List.copyOf(labels);
+  }
+
+  /**
+   * Converts raw parameter values (edge-class label arguments) to a list of strings for use as the
+   * labels component of a cache key. Null entries (no label filter) are omitted so that {@code
+   * out()} and {@code out(null)} produce the same key.
+   */
+  public static List<String> toStringLabels(List<Object> paramValues) {
+    return paramValues.stream()
+        .filter(Objects::nonNull)
+        .map(Object::toString)
+        .collect(Collectors.toList());
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/LetQueryStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/LetQueryStep.java
@@ -167,7 +167,7 @@ public class LetQueryStep extends AbstractExecutionStep {
   /**
    * Returns {@code true} when the traversal-result cache is enabled in the database configuration.
    * Used only for EXPLAIN display — the actual cache is created at execution time in {@link
-   * #initTraversalCache}.
+   * #internalStart} via {@link TraversalCache#installIfNeeded}.
    */
   private boolean isCacheEnabled() {
     if (ctx == null) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/LetQueryStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/LetQueryStep.java
@@ -1,8 +1,10 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor;
 
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.command.TraversalCache;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionPlan;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
@@ -139,6 +141,7 @@ public class LetQueryStep extends AbstractExecutionStep {
       throw new CommandExecutionException(ctx.getDatabaseSession(),
           "Cannot execute a local LET on a query without a target");
     }
+    TraversalCache.installIfNeeded(ctx);
     return prev.start(ctx).map(this::mapResult);
   }
 
@@ -149,13 +152,33 @@ public class LetQueryStep extends AbstractExecutionStep {
   @Override
   public String prettyPrint(int depth, int indent) {
     var spaces = ExecutionStepInternal.getIndent(depth, indent);
+    var cacheTag = isCacheEnabled() ? " [traversal-cache=enabled]" : " [traversal-cache=disabled]";
     return spaces
-        + "+ LET (for each record)\n"
+        + "+ LET (for each record)"
+        + cacheTag
+        + "\n"
         + spaces
         + "  "
         + varName
         + " = \n"
         + box(spaces + "    ", getPreviewPlan().prettyPrint(0, indent));
+  }
+
+  /**
+   * Returns {@code true} when the traversal-result cache is enabled in the database configuration.
+   * Used only for EXPLAIN display — the actual cache is created at execution time in {@link
+   * #initTraversalCache}.
+   */
+  private boolean isCacheEnabled() {
+    if (ctx == null) {
+      return false;
+    }
+    var db = ctx.getDatabaseSession();
+    if (db == null) {
+      return false;
+    }
+    return db.getConfiguration()
+        .getValueAsBoolean(GlobalConfiguration.QUERY_TRAVERSAL_CACHE_ENABLED);
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MaterializedLetGroupStep.java
@@ -4,6 +4,7 @@ import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.command.TraversalCache;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.query.ExecutionStep;
@@ -89,6 +90,7 @@ public class MaterializedLetGroupStep extends AbstractExecutionStep {
       throw new CommandExecutionException(ctx.getDatabaseSession(),
           "Cannot execute a local LET on a query without a target");
     }
+    TraversalCache.installIfNeeded(ctx);
     return prev.start(ctx).map(this::mapResult);
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLFunctionCall.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLFunctionCall.java
@@ -4,7 +4,6 @@ package com.jetbrains.youtrackdb.internal.core.sql.parser;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.TraversalCache;
-import com.jetbrains.youtrackdb.internal.core.command.TraversalCacheKey;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
@@ -153,32 +152,16 @@ public final class SQLFunctionCall extends SimpleNode {
       ctx.setVariable("aggregation", false);
       var session = ctx.getDatabaseSession();
 
-      // Graph navigation functions (out, in, both, outE, inE, bothE) have deterministic results for
-      // a given source entity + labels within a single read-consistent query. Cache them when a
-      // per-query TraversalCache is active so that repeated traversals of the same vertex are
-      // served from memory rather than re-traversing the graph.
+      // Graph navigation functions (out, in, both, outE, inE, bothE, outV, inV, bothV) have
+      // deterministic results for a given source entity + labels within a single read-consistent
+      // query. Cache them when a per-query TraversalCache is active so that repeated traversals
+      // of the same vertex are served from memory rather than re-traversing the graph.
       if (function instanceof SQLGraphNavigationFunction) {
         var cache = ctx.getTraversalCache();
         if (cache != null) {
-          var sourceId = TraversalCache.extractSourceIdentifiable(record);
-          if (sourceId != null) {
-            var rid = sourceId.getIdentity();
-            if (rid != null && !rid.isNew()) {
-              var key = new TraversalCacheKey(
-                  rid, function.getName(session),
-                  TraversalCacheKey.toStringLabels(paramValues));
-              var cached = cache.get(key);
-              if (cached != null) {
-                return cached;
-              }
-              var result = computeFunctionResult(function, targetObjects, record, paramValues, ctx,
-                  session);
-              if (result != null) {
-                return cache.put(key, result);
-              }
-              return null;
-            }
-          }
+          var rec = record;
+          return TraversalCache.getOrCompute(cache, rec, function.getName(session), paramValues,
+              () -> computeFunctionResult(function, targetObjects, rec, paramValues, ctx, session));
         }
       }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLFunctionCall.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLFunctionCall.java
@@ -3,6 +3,8 @@
 package com.jetbrains.youtrackdb.internal.core.sql.parser;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.command.TraversalCache;
+import com.jetbrains.youtrackdb.internal.core.command.TraversalCacheKey;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
@@ -150,26 +152,61 @@ public final class SQLFunctionCall extends SimpleNode {
 
       ctx.setVariable("aggregation", false);
       var session = ctx.getDatabaseSession();
-      return switch (record) {
-        case Identifiable identifiable -> {
-          var transaction = session.getActiveTransaction();
-          yield function.execute(targetObjects, transaction.loadEntity(identifiable), null,
-              paramValues.toArray(),
-              ctx);
+
+      // Graph navigation functions (out, in, both, outE, inE, bothE) have deterministic results for
+      // a given source entity + labels within a single read-consistent query. Cache them when a
+      // per-query TraversalCache is active so that repeated traversals of the same vertex are
+      // served from memory rather than re-traversing the graph.
+      if (function instanceof SQLGraphNavigationFunction) {
+        var cache = ctx.getTraversalCache();
+        if (cache != null) {
+          var sourceId = TraversalCache.extractSourceIdentifiable(record);
+          if (sourceId != null) {
+            var rid = sourceId.getIdentity();
+            if (rid != null && !rid.isNew()) {
+              var key = new TraversalCacheKey(
+                  rid, function.getName(session),
+                  TraversalCacheKey.toStringLabels(paramValues));
+              var cached = cache.get(key);
+              if (cached != null) {
+                return cached;
+              }
+              var result = computeFunctionResult(function, targetObjects, record, paramValues, ctx,
+                  session);
+              if (result != null) {
+                return cache.put(key, result);
+              }
+              return null;
+            }
+          }
         }
-        case Result result -> function.execute(
-            targetObjects,
-            result,
-            null,
-            paramValues.toArray(),
-            ctx);
-        case null -> function.execute(targetObjects, null, null, paramValues.toArray(), ctx);
-        default ->
-            throw new CommandExecutionException(session, "Invalid value for $current: " + record);
-      };
+      }
+
+      return computeFunctionResult(function, targetObjects, record, paramValues, ctx, session);
     } else {
       throw new CommandExecutionException(ctx.getDatabaseSession(), "Funciton not found: " + name);
     }
+  }
+
+  private static Object computeFunctionResult(
+      SQLFunction function,
+      Object targetObjects,
+      Object record,
+      List<Object> paramValues,
+      CommandContext ctx,
+      DatabaseSessionEmbedded session) {
+    return switch (record) {
+      case Identifiable identifiable -> {
+        var transaction = session.getActiveTransaction();
+        yield function.execute(targetObjects, transaction.loadEntity(identifiable), null,
+            paramValues.toArray(), ctx);
+      }
+      case Result result -> function.execute(targetObjects, result, null, paramValues.toArray(),
+          ctx);
+      case null -> function.execute(targetObjects, null, null, paramValues.toArray(), ctx);
+      default ->
+          throw new CommandExecutionException(session, "Invalid value for $current: " + record);
+    };
   }
 
   private static void validateFunctionParams(DatabaseSessionEmbedded session, SQLFunction function,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLMethodCall.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLMethodCall.java
@@ -3,6 +3,8 @@
 package com.jetbrains.youtrackdb.internal.core.sql.parser;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.command.TraversalCache;
+import com.jetbrains.youtrackdb.internal.core.command.TraversalCacheKey;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
@@ -156,6 +158,45 @@ public class SQLMethodCall extends SimpleNode {
   }
 
   private static Object invokeGraphFunction(
+      SQLFunction graphFunction,
+      Object targetObjects,
+      CommandContext ctx,
+      Iterable<Identifiable> iPossibleResults,
+      List<Object> paramValues) {
+    // Cache only unfiltered traversals on a single persistent source.
+    // When iPossibleResults is set, the result depends on the candidate set and cannot be keyed
+    // by source RID alone.
+    //
+    // Two call sites supply different types for targetObjects:
+    //   - MATCH-style traversal: targetObjects is already an Identifiable (e.g. a Vertex).
+    //   - ProjectionCalculationStep: targetObjects is a Result wrapping an entity. We unwrap
+    //     it here so that both call sites get the same caching benefit.
+    var cache = ctx.getTraversalCache();
+    if (cache != null && iPossibleResults == null) {
+      var sourceId = TraversalCache.extractSourceIdentifiable(targetObjects);
+      if (sourceId != null) {
+        var rid = sourceId.getIdentity();
+        if (rid != null && !rid.isNew()) {
+          var key = new TraversalCacheKey(
+              rid,
+              graphFunction.getName(ctx.getDatabaseSession()),
+              TraversalCacheKey.toStringLabels(paramValues));
+          var cached = cache.get(key);
+          if (cached != null) {
+            return cached;
+          }
+          var result = doInvokeGraphFunction(graphFunction, targetObjects, ctx, null, paramValues);
+          if (result != null) {
+            return cache.put(key, result);
+          }
+          return null;
+        }
+      }
+    }
+    return doInvokeGraphFunction(graphFunction, targetObjects, ctx, iPossibleResults, paramValues);
+  }
+
+  private static Object doInvokeGraphFunction(
       SQLFunction graphFunction,
       Object targetObjects,
       CommandContext ctx,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLMethodCall.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLMethodCall.java
@@ -4,7 +4,6 @@ package com.jetbrains.youtrackdb.internal.core.sql.parser;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.TraversalCache;
-import com.jetbrains.youtrackdb.internal.core.command.TraversalCacheKey;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
@@ -166,32 +165,11 @@ public class SQLMethodCall extends SimpleNode {
     // Cache only unfiltered traversals on a single persistent source.
     // When iPossibleResults is set, the result depends on the candidate set and cannot be keyed
     // by source RID alone.
-    //
-    // Two call sites supply different types for targetObjects:
-    //   - MATCH-style traversal: targetObjects is already an Identifiable (e.g. a Vertex).
-    //   - ProjectionCalculationStep: targetObjects is a Result wrapping an entity. We unwrap
-    //     it here so that both call sites get the same caching benefit.
     var cache = ctx.getTraversalCache();
     if (cache != null && iPossibleResults == null) {
-      var sourceId = TraversalCache.extractSourceIdentifiable(targetObjects);
-      if (sourceId != null) {
-        var rid = sourceId.getIdentity();
-        if (rid != null && !rid.isNew()) {
-          var key = new TraversalCacheKey(
-              rid,
-              graphFunction.getName(ctx.getDatabaseSession()),
-              TraversalCacheKey.toStringLabels(paramValues));
-          var cached = cache.get(key);
-          if (cached != null) {
-            return cached;
-          }
-          var result = doInvokeGraphFunction(graphFunction, targetObjects, ctx, null, paramValues);
-          if (result != null) {
-            return cache.put(key, result);
-          }
-          return null;
-        }
-      }
+      return TraversalCache.getOrCompute(
+          cache, targetObjects, graphFunction.getName(ctx.getDatabaseSession()), paramValues,
+          () -> doInvokeGraphFunction(graphFunction, targetObjects, ctx, null, paramValues));
     }
     return doInvokeGraphFunction(graphFunction, targetObjects, ctx, iPossibleResults, paramValues);
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheTest.java
@@ -1,0 +1,286 @@
+package com.jetbrains.youtrackdb.internal.core.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link TraversalCache}: materialization of lazy results, LRU eviction, and null
+ * handling.
+ */
+public class TraversalCacheTest {
+
+  private static final RecordId RID_A = new RecordId(1, 1);
+  private static final RecordId RID_B = new RecordId(1, 2);
+  private static final RecordId RID_C = new RecordId(1, 3);
+
+  private static TraversalCacheKey key(RecordId rid, String fn, String... labels) {
+    return new TraversalCacheKey(rid, fn, List.of(labels));
+  }
+
+  /**
+   * A Collection result is materialized into a new ArrayList so that subsequent cache hits do not
+   * share the original mutable collection.
+   */
+  @Test
+  public void putMaterializesCollectionResult() {
+    var cache = new TraversalCache(10);
+    var original = new ArrayList<>(List.of("v1", "v2"));
+    var k = key(RID_A, "out", "KNOWS");
+
+    cache.put(k, original);
+    var retrieved = cache.get(k);
+
+    assertThat(retrieved).isInstanceOf(List.class).asList().containsExactly("v1", "v2");
+    // Modifying the original must not affect the cached copy.
+    original.add("v3");
+    assertThat(cache.get(k)).asList().containsExactly("v1", "v2");
+  }
+
+  /**
+   * An Iterable result (e.g. lazy MultiCollectionIterator) is drained into an ArrayList so it can
+   * be iterated multiple times from the cache.
+   */
+  @Test
+  public void putMaterializesIterableResult() {
+    var cache = new TraversalCache(10);
+    Iterable<String> lazyIterable = List.of("e1", "e2", "e3");
+    var k = key(RID_A, "outE", "LIKES");
+
+    cache.put(k, lazyIterable);
+    var first = cache.get(k);
+    var second = cache.get(k);
+
+    assertThat(first).isInstanceOf(List.class).asList().containsExactly("e1", "e2", "e3");
+    // Cache can be read multiple times — the result is a reusable list.
+    assertThat(second).isSameAs(first);
+  }
+
+  /**
+   * A null result is not stored: subsequent get calls return null (cache miss), so the caller
+   * re-executes the traversal. This avoids sentinel-value complexity in the cache API.
+   */
+  @Test
+  public void putSkipsNullResult() {
+    var cache = new TraversalCache(10);
+    var k = key(RID_A, "out");
+
+    cache.put(k, null);
+
+    assertThat(cache.get(k)).isNull();
+  }
+
+  /**
+   * get returns null for a key that was never put, and the same materialized object for a key that
+   * was put.
+   */
+  @Test
+  public void getReturnsCachedValue() {
+    var cache = new TraversalCache(10);
+    var k = key(RID_A, "in", "KNOWS");
+
+    assertThat(cache.get(k)).isNull();
+
+    cache.put(k, List.of("neighbor"));
+    assertThat(cache.get(k)).isNotNull();
+  }
+
+  /**
+   * When the cache reaches its capacity limit, the least-recently-used entry is evicted. The most
+   * recently accessed entry is retained.
+   */
+  @Test
+  public void lruEvictionRemovesOldestNotMostRecentlyUsed() {
+    // Capacity of 2: only the two most-recently-used entries survive.
+    var cache = new TraversalCache(2);
+    var k1 = key(RID_A, "out");
+    var k2 = key(RID_B, "out");
+    var k3 = key(RID_C, "out");
+
+    cache.put(k1, List.of("a"));
+    cache.put(k2, List.of("b"));
+    // Access k1 to make it the most recently used.
+    cache.get(k1);
+    // Adding k3 should evict k2 (LRU), not k1 (recently accessed).
+    cache.put(k3, List.of("c"));
+
+    assertThat(cache.get(k1)).isNotNull();
+    assertThat(cache.get(k2)).isNull();
+    assertThat(cache.get(k3)).isNotNull();
+  }
+
+  /**
+   * Keys with the same RID and function name but different label lists are distinct cache entries.
+   * Keys with the same RID, function name, and labels are equal.
+   */
+  @Test
+  public void keyEqualityDependsOnAllThreeComponents() {
+    var cache = new TraversalCache(10);
+    var kKnows = key(RID_A, "out", "KNOWS");
+    var kLikes = key(RID_A, "out", "LIKES");
+    var kKnows2 = key(RID_A, "out", "KNOWS");
+
+    cache.put(kKnows, List.of("n1"));
+    cache.put(kLikes, List.of("n2"));
+
+    assertThat(cache.get(kKnows)).asList().containsExactly("n1");
+    assertThat(cache.get(kLikes)).asList().containsExactly("n2");
+    // kKnows2 is a different object instance but equal by value.
+    assertThat(cache.get(kKnows2)).asList().containsExactly("n1");
+  }
+
+  /**
+   * Verifies that the parent-chain delegation in BasicCommandContext works: a child context with no
+   * local cache delegates getTraversalCache() to its parent, enabling LET subquery child contexts
+   * to share the cache installed on the outermost context.
+   */
+  @Test
+  public void childContextDelegatesToParentCache() {
+    var parent = new BasicCommandContext();
+    var cache = new TraversalCache(10);
+    parent.setTraversalCache(cache);
+
+    var child = new BasicCommandContext();
+    child.setParentWithoutOverridingChild(parent);
+
+    assertThat(child.getTraversalCache()).isSameAs(cache);
+  }
+
+  /**
+   * A child context that has its own local cache does not delegate to the parent.
+   */
+  @Test
+  public void childLocalCacheTakesPrecedenceOverParent() {
+    var parent = new BasicCommandContext();
+    parent.setTraversalCache(new TraversalCache(10));
+
+    var child = new BasicCommandContext();
+    var childCache = new TraversalCache(5);
+    child.setTraversalCache(childCache);
+    child.setParentWithoutOverridingChild(parent);
+
+    assertThat(child.getTraversalCache()).isSameAs(childCache);
+  }
+
+  /**
+   * getHitCount() and getMissCount() track cache lookups. A hit is counted when get() returns a
+   * non-null value; a miss is counted when get() returns null (either the key is absent or the
+   * stored value was null — but we never store null, so absence is the only miss case).
+   */
+  @Test
+  public void hitAndMissCountersTrackLookups() {
+    var cache = new TraversalCache(10);
+    var key = key(RID_A, "out");
+
+    // Two misses before any value is stored.
+    cache.get(key);
+    cache.get(key);
+    assertThat(cache.getMissCount()).isEqualTo(2);
+    assertThat(cache.getHitCount()).isZero();
+
+    cache.put(key, List.of("x"));
+
+    // Two hits after the value is stored.
+    cache.get(key);
+    cache.get(key);
+    assertThat(cache.getHitCount()).isEqualTo(2);
+    assertThat(cache.getMissCount()).isEqualTo(2);
+  }
+
+  /**
+   * The thread-local hit counter is independent of the per-instance counter. It accumulates hits
+   * across all TraversalCache instances on the current thread and can be reset between tests.
+   */
+  @Test
+  public void threadLocalHitCountAccumulatesAcrossInstances() {
+    TraversalCache.resetThreadLocalHitCount();
+
+    var cache1 = new TraversalCache(10);
+    var cache2 = new TraversalCache(10);
+    var key = key(RID_A, "out");
+
+    cache1.put(key, List.of("a"));
+    cache2.put(key, List.of("b"));
+
+    cache1.get(key); // hit in cache1
+    cache2.get(key); // hit in cache2
+    cache1.get(new TraversalCacheKey(RID_B, "out", List.of())); // miss
+
+    assertThat(TraversalCache.getThreadLocalHitCount())
+        .as("thread-local counter should sum hits from both caches")
+        .isEqualTo(2);
+  }
+
+  /**
+   * Constructing a TraversalCache with maxEntries < 1 throws IllegalArgumentException. Use
+   * QUERY_TRAVERSAL_CACHE_ENABLED=false to disable caching; zero-capacity caches are not supported
+   * because the put-then-get pattern would silently lose results.
+   */
+  @Test
+  public void constructorRejectsZeroMaxEntries() {
+    assertThatThrownBy(() -> new TraversalCache(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxEntries must be >= 1");
+  }
+
+  /** Negative maxEntries is also rejected. */
+  @Test
+  public void constructorRejectsNegativeMaxEntries() {
+    assertThatThrownBy(() -> new TraversalCache(-1))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /**
+   * put() returns the materialized copy of the stored result. Callers use this return value instead
+   * of a separate get() call, which avoids data loss if the entry were immediately evicted.
+   */
+  @Test
+  public void putReturnsMaterializedCopy() {
+    var cache = new TraversalCache(10);
+    var original = new ArrayList<>(List.of("v1", "v2"));
+    var k = key(RID_A, "out", "KNOWS");
+
+    var returned = cache.put(k, original);
+
+    assertThat(returned).isInstanceOf(List.class).asList().containsExactly("v1", "v2");
+    // The returned value is the same object stored in the cache.
+    assertThat(cache.get(k)).isSameAs(returned);
+  }
+
+  /** put() returns null without storing when the result is null. */
+  @Test
+  public void putReturnsNullForNullResult() {
+    var cache = new TraversalCache(10);
+    var k = key(RID_A, "out");
+
+    var returned = cache.put(k, null);
+
+    assertThat(returned).isNull();
+    assertThat(cache.get(k)).isNull();
+  }
+
+  /**
+   * With maxEntries=1, the cache retains exactly one entry. Adding a second entry evicts the first.
+   * The put return value is always the materialized result, regardless of eviction.
+   */
+  @Test
+  public void maxEntriesOneBehavesCorrectly() {
+    var cache = new TraversalCache(1);
+    var k1 = key(RID_A, "out");
+    var k2 = key(RID_B, "out");
+
+    var r1 = cache.put(k1, List.of("a"));
+    assertThat(r1).asList().containsExactly("a");
+    assertThat(cache.get(k1)).isNotNull();
+
+    // Adding k2 evicts k1.
+    var r2 = cache.put(k2, List.of("b"));
+    assertThat(r2).asList().containsExactly("b");
+    assertThat(cache.get(k1)).isNull();
+    assertThat(cache.get(k2)).isNotNull();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheTest.java
@@ -86,7 +86,7 @@ public class TraversalCacheTest {
     assertThat(cache.get(k)).isNull();
 
     cache.put(k, List.of("neighbor"));
-    assertThat(cache.get(k)).isNotNull();
+    assertThat(cache.get(k)).asList().containsExactly("neighbor");
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/command/TraversalCacheTest.java
@@ -216,6 +216,40 @@ public class TraversalCacheTest {
   }
 
   /**
+   * Keys with multiple labels (e.g. out('KNOWS', 'LIKES')) produce distinct cache entries from keys
+   * with a single label. Label order matters: out('KNOWS', 'LIKES') and out('LIKES', 'KNOWS') are
+   * different keys.
+   */
+  @Test
+  public void multiLabelKeysAreDistinctAndOrderDependent() {
+    var cache = new TraversalCache(10);
+    var kKnowsLikes = new TraversalCacheKey(RID_A, "out", List.of("KNOWS", "LIKES"));
+    var kLikesKnows = new TraversalCacheKey(RID_A, "out", List.of("LIKES", "KNOWS"));
+    var kKnowsOnly = key(RID_A, "out", "KNOWS");
+
+    cache.put(kKnowsLikes, List.of("n1", "n2"));
+    cache.put(kLikesKnows, List.of("n3", "n4"));
+    cache.put(kKnowsOnly, List.of("n5"));
+
+    // All three keys are distinct: different label lists produce different entries.
+    assertThat(cache.get(kKnowsLikes)).asList().containsExactly("n1", "n2");
+    assertThat(cache.get(kLikesKnows)).asList().containsExactly("n3", "n4");
+    assertThat(cache.get(kKnowsOnly)).asList().containsExactly("n5");
+  }
+
+  /**
+   * {@link TraversalCacheKey#toStringLabels} filters out null entries, converts remaining values to
+   * strings, and returns an unmodifiable list suitable for use as the labels component of a cache
+   * key.
+   */
+  @Test
+  public void toStringLabelsFiltersNullsAndConvertsToStrings() {
+    var labels = TraversalCacheKey.toStringLabels(
+        java.util.Arrays.asList("KNOWS", null, "LIKES", null));
+    assertThat(labels).containsExactly("KNOWS", "LIKES");
+  }
+
+  /**
    * Constructing a TraversalCache with maxEntries < 1 throws IllegalArgumentException. Use
    * QUERY_TRAVERSAL_CACHE_ENABLED=false to disable caching; zero-capacity caches are not supported
    * because the put-then-get pattern would silently lose results.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/graph/TraversalMemoizationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/graph/TraversalMemoizationTest.java
@@ -1,0 +1,303 @@
+package com.jetbrains.youtrackdb.internal.core.db.graph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.command.TraversalCache;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Integration tests verifying that the per-query traversal memoization cache produces correct
+ * results for LET subqueries that invoke graph traversal functions.
+ *
+ * <p>Graph shape used in all tests:
+ *
+ * <pre>
+ *   start --HAS_INTEREST--> interest1 ("java")
+ *   start --HAS_INTEREST--> interest2 ("databases")
+ *
+ *   fof1 --KNOWS--> start
+ *   fof2 --KNOWS--> start
+ *
+ *   post1 --HAS_CREATOR--> fof1   post1 --HAS_TAG--> interest1
+ *   post2 --HAS_CREATOR--> fof1   post2 --HAS_TAG--> interest2
+ *   post3 --HAS_CREATOR--> fof2   (no tags)
+ * </pre>
+ */
+public class TraversalMemoizationTest extends DbTestBase {
+
+  @Before
+  public void setUpGraph() {
+    session.createEdgeClass("HAS_INTEREST");
+    session.createEdgeClass("KNOWS");
+    session.createEdgeClass("HAS_CREATOR");
+    session.createEdgeClass("HAS_TAG");
+    session.getSchema().createVertexClass("Person");
+    session.getSchema().createVertexClass("Post");
+    session.getSchema().createVertexClass("Tag");
+
+    var tx = session.begin();
+
+    var start = tx.newVertex("Person");
+    start.setProperty("name", "start");
+
+    var interest1 = tx.newVertex("Tag");
+    interest1.setProperty("name", "java");
+    var interest2 = tx.newVertex("Tag");
+    interest2.setProperty("name", "databases");
+
+    start.addEdge(interest1, "HAS_INTEREST");
+    start.addEdge(interest2, "HAS_INTEREST");
+
+    var fof1 = tx.newVertex("Person");
+    fof1.setProperty("name", "fof1");
+    var fof2 = tx.newVertex("Person");
+    fof2.setProperty("name", "fof2");
+
+    fof1.addEdge(start, "KNOWS");
+    fof2.addEdge(start, "KNOWS");
+
+    var post1 = tx.newVertex("Post");
+    post1.setProperty("title", "post1");
+    var post2 = tx.newVertex("Post");
+    post2.setProperty("title", "post2");
+    var post3 = tx.newVertex("Post");
+    post3.setProperty("title", "post3");
+
+    post1.addEdge(fof1, "HAS_CREATOR");
+    post2.addEdge(fof1, "HAS_CREATOR");
+    post3.addEdge(fof2, "HAS_CREATOR");
+
+    post1.addEdge(interest1, "HAS_TAG");
+    post2.addEdge(interest2, "HAS_TAG");
+
+    tx.commit();
+  }
+
+  /**
+   * Verifies that a LET subquery using out() graph traversal produces correct results. For each
+   * Post, the subquery resolves its creator via out('HAS_CREATOR'). The traversal cache is active
+   * (default configuration), so the result for each Post is memoized by its RID. Despite possible
+   * caching, all three Posts must resolve their creators correctly.
+   */
+  @Test
+  public void letSubqueryGraphTraversalProducesCorrectResults() {
+    var tx = session.begin();
+    var creatorNames = new ArrayList<String>();
+    try (var rs =
+        tx.query(
+            "SELECT $creator[0].name as creatorName FROM Post "
+                + "LET $creator = (SELECT name FROM "
+                + "  (SELECT expand(out('HAS_CREATOR')) FROM Post WHERE @rid = $parent.$current.@rid)) "
+                + "ORDER BY creatorName ASC")) {
+      while (rs.hasNext()) {
+        creatorNames.add(rs.next().getProperty("creatorName"));
+      }
+    }
+    // post1 and post2 were created by fof1, post3 by fof2.
+    assertThat(creatorNames).containsExactly("fof1", "fof1", "fof2");
+  }
+
+  /**
+   * Verifies that each Person's KNOWS neighbors (resolved via a LET subquery with out('KNOWS'))
+   * are the correct vertices. For fof1 and fof2, the sole KNOWS neighbor is 'start'. Running the
+   * query over multiple Person rows exercises the cache per source RID and confirms the cache does
+   * not mix results across different source vertices.
+   */
+  @Test
+  public void letSubqueryKnowsNeighborsAreCorrectPerSourceVertex() {
+    var tx = session.begin();
+    // Collect the name of each Person and the names of their KNOWS neighbors from the LET subquery.
+    var personNames = new ArrayList<String>();
+    var knowsNeighborNames = new ArrayList<List<String>>();
+    try (var rs =
+        tx.query(
+            "SELECT name, $knows as knows FROM Person "
+                + "LET $knows = (SELECT name FROM "
+                + "  (SELECT expand(out('KNOWS')) FROM Person WHERE @rid = $parent.$current.@rid)) "
+                + "WHERE name <> 'start' "
+                + "ORDER BY name ASC")) {
+      while (rs.hasNext()) {
+        var row = rs.next();
+        personNames.add(row.getProperty("name"));
+        var knows = (List<?>) row.getProperty("knows");
+        var names = new ArrayList<String>();
+        if (knows != null) {
+          for (var item : knows) {
+            names.add(((Result) item).getProperty("name"));
+          }
+        }
+        knowsNeighborNames.add(names);
+      }
+    }
+    // fof1 and fof2 each KNOW exactly one vertex: 'start'.
+    // This confirms that the cache returns the correct per-source-RID result for each Person,
+    // without mixing results between different source vertices.
+    assertThat(personNames).containsExactly("fof1", "fof2");
+    assertThat(knowsNeighborNames).hasSize(2);
+    assertThat(knowsNeighborNames.get(0)).containsExactly("start");
+    assertThat(knowsNeighborNames.get(1)).containsExactly("start");
+  }
+
+  /**
+   * Verifies that a LET subquery using in() traversal correctly navigates incoming edges.
+   * Each Person who KNOWs 'start' should appear with 'start' in their KNOWS neighbors.
+   */
+  @Test
+  public void letSubqueryWithInTraversalProducesCorrectResults() {
+    // For each fof Person, find the names of vertices they KNOW (should be 'start').
+    var tx = session.begin();
+    var knowsNames = new ArrayList<String>();
+    try (var rs =
+        tx.query(
+            "SELECT name, $knows[0].name as knowsName FROM Person "
+                + "LET $knows = (SELECT name FROM "
+                + "  (SELECT expand(out('KNOWS')) FROM Person WHERE @rid = $parent.$current.@rid)) "
+                + "WHERE name <> 'start' "
+                + "ORDER BY name ASC")) {
+      while (rs.hasNext()) {
+        knowsNames.add(rs.next().getProperty("knowsName"));
+      }
+    }
+    // fof1 and fof2 both KNOW the 'start' vertex.
+    assertThat(knowsNames).containsExactly("start", "start");
+  }
+
+  /**
+   * Verifies via EXPLAIN that a LET subquery with graph traversal produces an execution plan
+   * containing a "LET (for each record)" step, and that the step is annotated with
+   * "[traversal-cache=enabled]" when the cache is enabled in the database configuration. This
+   * confirms that the code path responsible for initializing the traversal cache will be exercised
+   * at query execution time.
+   */
+  @Test
+  public void explainLetWithGraphTraversalAnnotatesCacheStatus() {
+    var tx = session.begin();
+    var explain =
+        tx.query(
+            "EXPLAIN SELECT name, $knows FROM Person "
+                + "LET $knows = (SELECT expand(out('KNOWS')) FROM Person "
+                + "  WHERE @rid = $parent.$current.@rid) "
+                + "WHERE name <> 'start'")
+            .toList();
+    var plan = (String) explain.getFirst().getProperty("executionPlanAsString");
+    // The plan must contain the LET step header ...
+    assertThat(plan)
+        .as("EXPLAIN plan should show a per-record LET step")
+        .contains("LET (for each record)");
+    // ... annotated with the cache status so operators know it is active.
+    assertThat(plan)
+        .as("LET step should be annotated with traversal-cache=enabled")
+        .contains("[traversal-cache=enabled]");
+  }
+
+  /**
+   * Verifies that the traversal cache is actually hit at runtime when the same source vertex
+   * appears in multiple outer rows.
+   *
+   * <p>Graph shape used: fof1 and fof2 both KNOW 'start', so expanding out('KNOWS') from all
+   * Persons yields two rows that both have 'start' as the result vertex. The LET subquery then
+   * calls out('HAS_INTEREST') on 'start' for each of those two rows. The first call is a cache
+   * miss; the second is a cache hit because the source RID is identical.
+   *
+   * <p>The test verifies:
+   *
+   * <ol>
+   *   <li>At least one cache hit is recorded on this thread (the optimization ran).
+   *   <li>Both rows return the same correct interest names (the cached list is properly
+   *       re-iterable, proving that materialization worked correctly).
+   * </ol>
+   */
+  @Test
+  public void cacheIsHitWhenSameSourceVertexAppearsInMultipleOuterRows() {
+    TraversalCache.resetThreadLocalHitCount();
+
+    var tx = session.begin();
+    var interestRows = new ArrayList<List<String>>();
+    try (var rs =
+        tx.query(
+            "SELECT $interests FROM (SELECT expand(out('KNOWS')) FROM Person) "
+                + "LET $interests = (SELECT name FROM "
+                + "  (SELECT expand(out('HAS_INTEREST')) FROM Person "
+                + "  WHERE @rid = $parent.$current.@rid))")) {
+      while (rs.hasNext()) {
+        var row = rs.next();
+        var interests = (List<?>) row.getProperty("$interests");
+        var names = new ArrayList<String>();
+        if (interests != null) {
+          for (var item : interests) {
+            names.add(((Result) item).getProperty("name"));
+          }
+        }
+        interestRows.add(names);
+      }
+    }
+
+    // fof1 KNOWS start → row 1; fof2 KNOWS start → row 2.
+    // Both rows resolve out('HAS_INTEREST') from 'start' → [java, databases].
+    // The second resolution is a cache hit.
+    assertThat(interestRows).as("both outer rows should resolve 'start' interests").hasSize(2);
+    assertThat(interestRows.get(0))
+        .as("first row: interests of 'start'")
+        .containsExactlyInAnyOrder("java", "databases");
+    assertThat(interestRows.get(1))
+        .as("second row: interests of 'start' (from cache)")
+        .containsExactlyInAnyOrder("java", "databases");
+
+    assertThat(TraversalCache.getThreadLocalHitCount())
+        .as("traversal cache should have been hit at least once")
+        .isGreaterThanOrEqualTo(1);
+  }
+
+  /**
+   * When QUERY_TRAVERSAL_CACHE_ENABLED is set to false, queries still produce correct results but
+   * no cache hits are recorded. This confirms the feature can be safely disabled in production.
+   */
+  @Test
+  public void queryProducesCorrectResultsWithCacheDisabled() {
+    var oldValue =
+        GlobalConfiguration.QUERY_TRAVERSAL_CACHE_ENABLED.getValueAsBoolean();
+    try {
+      GlobalConfiguration.QUERY_TRAVERSAL_CACHE_ENABLED.setValue(false);
+      TraversalCache.resetThreadLocalHitCount();
+
+      var tx = session.begin();
+      var interestRows = new ArrayList<List<String>>();
+      try (var rs =
+          tx.query(
+              "SELECT $interests FROM (SELECT expand(out('KNOWS')) FROM Person) "
+                  + "LET $interests = (SELECT name FROM "
+                  + "  (SELECT expand(out('HAS_INTEREST')) FROM Person "
+                  + "  WHERE @rid = $parent.$current.@rid))")) {
+        while (rs.hasNext()) {
+          var row = rs.next();
+          var interests = (List<?>) row.getProperty("$interests");
+          var names = new ArrayList<String>();
+          if (interests != null) {
+            for (var item : interests) {
+              names.add(((Result) item).getProperty("name"));
+            }
+          }
+          interestRows.add(names);
+        }
+      }
+
+      // Results must be correct even without caching.
+      assertThat(interestRows).hasSize(2);
+      assertThat(interestRows.get(0)).containsExactlyInAnyOrder("java", "databases");
+      assertThat(interestRows.get(1)).containsExactlyInAnyOrder("java", "databases");
+
+      // No cache hits should be recorded when caching is disabled.
+      assertThat(TraversalCache.getThreadLocalHitCount())
+          .as("no cache hits expected when cache is disabled")
+          .isZero();
+    } finally {
+      GlobalConfiguration.QUERY_TRAVERSAL_CACHE_ENABLED.setValue(oldValue);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/graph/TraversalMemoizationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/graph/TraversalMemoizationTest.java
@@ -145,11 +145,12 @@ public class TraversalMemoizationTest extends DbTestBase {
   }
 
   /**
-   * Verifies that a LET subquery using in() traversal correctly navigates incoming edges.
-   * Each Person who KNOWs 'start' should appear with 'start' in their KNOWS neighbors.
+   * Verifies that a LET subquery using out('KNOWS') traversal correctly resolves the KNOWS neighbor
+   * for each fof Person. Each fof Person KNOWs 'start', so expanding out('KNOWS') from fof1 and
+   * fof2 should both yield 'start'.
    */
   @Test
-  public void letSubqueryWithInTraversalProducesCorrectResults() {
+  public void letSubqueryWithOutTraversalResolvesKnowsNeighbor() {
     // For each fof Person, find the names of vertices they KNOW (should be 'start').
     var tx = session.begin();
     var knowsNames = new ArrayList<String>();
@@ -251,6 +252,52 @@ public class TraversalMemoizationTest extends DbTestBase {
 
     assertThat(TraversalCache.getThreadLocalHitCount())
         .as("traversal cache should have been hit at least once")
+        .isGreaterThanOrEqualTo(1);
+  }
+
+  /**
+   * Verifies that the method-call-syntax traversal path ({@code $current.out('KNOWS')}) through
+   * {@code SQLMethodCall.invokeGraphFunction} also benefits from the traversal cache. MATCH-style
+   * queries route graph traversals through the method-call path rather than the function-call path,
+   * so this test confirms the caching logic is exercised on both code paths.
+   *
+   * <p>The query uses MATCH to expand out('KNOWS') from Persons who are not 'start', which yields
+   * fof1 → start and fof2 → start. The 'start' vertex has two HAS_INTEREST edges, so the second
+   * traversal of out('HAS_INTEREST') from 'start' is a cache hit.
+   */
+  @Test
+  public void methodCallSyntaxTraversalBenefitsFromCache() {
+    TraversalCache.resetThreadLocalHitCount();
+
+    var tx = session.begin();
+    var interestNames = new ArrayList<String>();
+    try (var rs =
+        tx.query(
+            "SELECT $interests FROM "
+                + "(MATCH {class: Person, as: p, where: (name <> 'start')}"
+                + ".out('KNOWS'){as: friend} RETURN friend) "
+                + "LET $interests = (SELECT name FROM "
+                + "  (SELECT expand(out('HAS_INTEREST')) FROM Person "
+                + "  WHERE @rid = $parent.$current.friend.@rid))")) {
+      while (rs.hasNext()) {
+        var row = rs.next();
+        var interests = (List<?>) row.getProperty("$interests");
+        if (interests != null) {
+          for (var item : interests) {
+            interestNames.add(((Result) item).getProperty("name"));
+          }
+        }
+      }
+    }
+
+    // Both fof1 and fof2 KNOW 'start', so we get 'start's interests twice (4 names total).
+    // The order within each pair depends on the storage engine, so check count and contents.
+    assertThat(interestNames)
+        .as("both MATCH rows resolve HAS_INTEREST from 'start'")
+        .hasSize(4)
+        .containsOnly("java", "databases");
+    assertThat(TraversalCache.getThreadLocalHitCount())
+        .as("second out('HAS_INTEREST') from 'start' should be a cache hit")
         .isGreaterThanOrEqualTo(1);
   }
 


### PR DESCRIPTION
#### PR Title:

YTDB-661 Graph Traversal Memoization in Per-Record LET Subqueries

#### Motivation:

Per-record LET subqueries often reference fields from the outer row via
$parent.$current.field. When field resolves to the same entity for many (or
all) outer rows, every graph traversal on that entity is repeated identically.
Within a read transaction the graph is immutable, so these repeated traversals
always produce the same result.

