### PR TITLE
 YTDB-646 Index-assisted pre-filtering for `both()` / `bothE()` MATCH patterns

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -241,6 +241,15 @@ jobs:
             echo "Filter: (all benchmarks)"
           fi
 
+          # LdbcSingleThreadBothEBenchmark is the only class that writes to the
+          # shared on-disk DB (it installs KNOWS.creationDate for one method).
+          # Building an index over every KNOWS edge evicts hot Person/KNOWS pages
+          # that the IC/IS benchmarks measure against, and IC1 — three hops of
+          # KNOWS — regressed ~14% because of it. The class also produces no A/B
+          # signal: the fork-point side does not contain it, so every row reads
+          # as "new". Exclude it on both sides and run it on demand instead.
+          echo "jmh_exclude=-e LdbcSingleThreadBothEBenchmark" >> "$GITHUB_OUTPUT"
+
           # Default production arm only. JMH -p applies to benches that declare
           # the @Param; SQL LDBC classes without translatorEnabled are unchanged.
           ARMS="${GREMLIN_ARMS:-on}"
@@ -386,18 +395,23 @@ jobs:
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
           JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
+          JMH_EXCLUDE: ${{ steps.filter.outputs.jmh_exclude }}
         run: |
           FILTER_ARG=""
           PARAM_ARG=""
+          EXCLUDE_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
           if [ -n "$JMH_PARAM" ]; then
             PARAM_ARG="$JMH_PARAM "
           fi
+          if [ -n "$JMH_EXCLUDE" ]; then
+            EXCLUDE_ARG="$JMH_EXCLUDE "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
+            -Djmh.args="${FILTER_ARG}${EXCLUDE_ARG}${PARAM_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
             2>&1 | tee /tmp/jmh-warm-base-${{ github.run_id }}.txt
 
           # JMH exits 0 even when all benchmarks fail with -f 0.
@@ -418,18 +432,23 @@ jobs:
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
           JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
+          JMH_EXCLUDE: ${{ steps.filter.outputs.jmh_exclude }}
         run: |
           FILTER_ARG=""
           PARAM_ARG=""
+          EXCLUDE_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
           if [ -n "$JMH_PARAM" ]; then
             PARAM_ARG="$JMH_PARAM "
           fi
+          if [ -n "$JMH_EXCLUDE" ]; then
+            EXCLUDE_ARG="$JMH_EXCLUDE "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-rf json -rff /tmp/jmh-base-${{ github.run_id }}.json" \
+            -Djmh.args="${FILTER_ARG}${EXCLUDE_ARG}${PARAM_ARG}-rf json -rff /tmp/jmh-base-${{ github.run_id }}.json" \
             2>&1 | tee /tmp/jmh-base-log-${{ github.run_id }}.txt
 
           # Validate that JMH produced results (it exits 0 even on total failure)
@@ -510,18 +529,23 @@ jobs:
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
           JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
+          JMH_EXCLUDE: ${{ steps.filter.outputs.jmh_exclude }}
         run: |
           FILTER_ARG=""
           PARAM_ARG=""
+          EXCLUDE_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
           if [ -n "$JMH_PARAM" ]; then
             PARAM_ARG="$JMH_PARAM "
           fi
+          if [ -n "$JMH_EXCLUDE" ]; then
+            EXCLUDE_ARG="$JMH_EXCLUDE "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
+            -Djmh.args="${FILTER_ARG}${EXCLUDE_ARG}${PARAM_ARG}-f 0 -wi 0 -i 1 -r 5s -t 1" \
             2>&1 | tee /tmp/jmh-warm-head-${{ github.run_id }}.txt
 
           # JMH exits 0 even when all benchmarks fail with -f 0.
@@ -540,18 +564,23 @@ jobs:
         env:
           JMH_FILTER: ${{ steps.filter.outputs.jmh_filter }}
           JMH_PARAM: ${{ steps.filter.outputs.jmh_param_arg }}
+          JMH_EXCLUDE: ${{ steps.filter.outputs.jmh_exclude }}
         run: |
           FILTER_ARG=""
           PARAM_ARG=""
+          EXCLUDE_ARG=""
           if [ -n "$JMH_FILTER" ]; then
             FILTER_ARG="$JMH_FILTER "
           fi
           if [ -n "$JMH_PARAM" ]; then
             PARAM_ARG="$JMH_PARAM "
           fi
+          if [ -n "$JMH_EXCLUDE" ]; then
+            EXCLUDE_ARG="$JMH_EXCLUDE "
+          fi
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="${FILTER_ARG}${PARAM_ARG}-rf json -rff /tmp/jmh-head-${{ github.run_id }}.json" \
+            -Djmh.args="${FILTER_ARG}${EXCLUDE_ARG}${PARAM_ARG}-rf json -rff /tmp/jmh-head-${{ github.run_id }}.json" \
             2>&1 | tee /tmp/jmh-head-log-${{ github.run_id }}.txt
 
           # Validate that JMH produced results

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -146,12 +146,18 @@ jobs:
           fi
           echo "Database loaded successfully from CSV"
 
+      # LdbcSingleThreadBothEBenchmark is excluded here and in the measured run.
+      # It is the only class that writes to the shared on-disk DB (it installs
+      # KNOWS.creationDate for one method), and an index build over every KNOWS
+      # edge evicts hot Person/KNOWS pages that the IC/IS benchmarks measure
+      # against — enough to move IC1 by ~14%. A DB-mutating benchmark does not
+      # belong in a suite whose scores are tracked as a trend by the alerter.
       - name: Warm OS page cache
         run: |
           set -euo pipefail
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="-f 0 -wi 0 -i 1 -r 5s -t 1" \
+            -Djmh.args="-e LdbcSingleThreadBothEBenchmark -f 0 -wi 0 -i 1 -r 5s -t 1" \
             2>&1 | tee /tmp/jmh-warm-${{ github.run_id }}.txt
 
           # JMH exits 0 even when all benchmarks fail with -f 0.
@@ -172,7 +178,7 @@ jobs:
           set -euo pipefail
           ./mvnw -pl jmh-ldbc -am verify -P bench -DskipTests \
             -Dspotless.check.skip=true -Dcentral.skip=true \
-            -Djmh.args="-rf json -rff /tmp/jmh-results-${{ github.run_id }}.json" \
+            -Djmh.args="-e LdbcSingleThreadBothEBenchmark -rf json -rff /tmp/jmh-results-${{ github.run_id }}.json" \
             2>&1 | tee /tmp/jmh-bench-log-${{ github.run_id }}.txt
 
       - name: Validate benchmark results

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterable.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterable.java
@@ -1,0 +1,152 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ * A {@link PreFilterableLinkBagIterable} that chains multiple sub-iterables and delegates
+ * filter operations to each one independently.
+ *
+ * <p>This is used to make bidirectional traversals ({@code both()} and {@code bothE()}) eligible
+ * for the index-assisted pre-filter. For unidirectional traversals ({@code out}/{@code in},
+ * {@code outE}/{@code inE}), each traversal produces a single
+ * {@link PreFilterableLinkBagIterable} backed by one LinkBag. For bidirectional traversals, the
+ * result spans two LinkBags (one per direction), which were previously chained via
+ * {@code IterableUtils.chainedIterable()} — a type that does not implement
+ * {@code PreFilterableLinkBagIterable} and therefore silently bypasses pre-filtering in
+ * {@code MatchEdgeTraverser.applyPreFilter()} and {@code ExpandStep.nextResults()}.
+ *
+ * <p>When {@link #withClassFilter(IntSet)} or {@link #withRidFilter(Set)} is called, a new
+ * {@code PreFilterableChainedIterable} is returned with the filter applied to each sub-iterable
+ * independently. Because each sub-iterable is backed by a single LinkBag, the filter semantics
+ * are identical to the single-direction case — only in-memory RID checks, no disk I/O.
+ *
+ * <p>{@link #size()} returns the sum of sub-iterable sizes, which is the total number of records
+ * that would be loaded without any filtering. The adaptive abort guards in
+ * {@link com.jetbrains.youtrackdb.internal.core.sql.executor.match.TraversalPreFilterHelper}
+ * use this value to decide whether pre-filtering is cost-effective.
+ */
+public class PreFilterableChainedIterable
+    implements PreFilterableLinkBagIterable, Iterable<Object> {
+
+  private final PreFilterableLinkBagIterable[] subs;
+
+  /**
+   * Creates a chained iterable wrapping the given sub-iterables. The caller must ensure that at
+   * least one sub-iterable is provided.
+   *
+   * @param subs the sub-iterables to chain; must not be empty
+   */
+  public PreFilterableChainedIterable(@Nonnull PreFilterableLinkBagIterable... subs) {
+    assert subs.length > 0 : "PreFilterableChainedIterable requires at least one sub-iterable";
+    this.subs = subs.clone();
+  }
+
+  @Nonnull
+  @Override
+  public PreFilterableChainedIterable withClassFilter(@Nonnull IntSet collectionIds) {
+    var filtered = new PreFilterableLinkBagIterable[subs.length];
+    for (var i = 0; i < subs.length; i++) {
+      filtered[i] = subs[i].withClassFilter(collectionIds);
+    }
+    return new PreFilterableChainedIterable(filtered);
+  }
+
+  @Nonnull
+  @Override
+  public PreFilterableChainedIterable withRidFilter(@Nonnull Set<RID> ridSet) {
+    var filtered = new PreFilterableLinkBagIterable[subs.length];
+    for (var i = 0; i < subs.length; i++) {
+      filtered[i] = subs[i].withRidFilter(ridSet);
+    }
+    return new PreFilterableChainedIterable(filtered);
+  }
+
+  /**
+   * Returns an iterator that visits elements from each sub-iterable in order.
+   *
+   * <p>The iterator is typed as {@code Iterator<Object>} because sub-iterables may
+   * yield different concrete types (e.g. {@code Vertex} vs {@code EdgeInternal}). Callers that
+   * need typed access should cast after verifying all sub-iterables are homogeneous — which is
+   * always the case in practice (both directions of a {@code both()}/{@code bothE()} traversal
+   * yield the same element type). The unchecked cast at the call site mirrors the pre-existing
+   * pattern used by {@code IterableUtils.chainedIterable}.
+   */
+  @Nonnull
+  @Override
+  public Iterator<Object> iterator() {
+    return new ChainedIterator(subs);
+  }
+
+  /**
+   * Returns the sum of all sub-iterable sizes. This represents the total number of records that
+   * would be loaded if no pre-filter is applied.
+   */
+  @Override
+  public int size() {
+    var total = 0;
+    for (var sub : subs) {
+      total += sub.size();
+    }
+    return total;
+  }
+
+  /**
+   * Returns {@code true} when all sub-iterables report that their size is exact (i.e., all
+   * sub-iterables are backed by LinkBags with known sizes).
+   */
+  @Override
+  public boolean isSizeable() {
+    for (var sub : subs) {
+      if (!sub.isSizeable()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * A minimal iterator that drains sub-iterables in sequence without requiring them to implement
+   * {@link Iterable}. Only the {@link PreFilterableLinkBagIterable#iterator()} contract is used.
+   */
+  private static final class ChainedIterator implements Iterator<Object> {
+
+    private final PreFilterableLinkBagIterable[] subs;
+    private int subIndex = 0;
+    private Iterator<?> current;
+
+    ChainedIterator(PreFilterableLinkBagIterable[] subs) {
+      this.subs = subs;
+      this.current = subs[0].iterator();
+      advance();
+    }
+
+    /** Skips exhausted iterators until we find one with remaining elements or run out. */
+    private void advance() {
+      while (!current.hasNext() && subIndex + 1 < subs.length) {
+        current = subs[++subIndex].iterator();
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return current.hasNext();
+    }
+
+    @Override
+    public Object next() {
+      if (!current.hasNext()) {
+        throw new NoSuchElementException();
+      }
+      var value = current.next();
+      if (!current.hasNext()) {
+        advance();
+      }
+      return value;
+    }
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterable.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterable.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.record.impl;
 
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.Ratio;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.util.Iterator;
@@ -59,9 +60,19 @@ public class PreFilterableChainedIterable
   @Nonnull
   @Override
   public PreFilterableChainedIterable withRidFilter(@Nonnull Set<RID> ridSet) {
+    return withRidFilter(ridSet, Ratio.NOOP);
+  }
+
+  @Nonnull
+  @Override
+  public PreFilterableChainedIterable withRidFilter(
+      @Nonnull Set<RID> ridSet, @Nonnull Ratio effectivenessMetric) {
     var filtered = new PreFilterableLinkBagIterable[subs.length];
     for (var i = 0; i < subs.length; i++) {
-      filtered[i] = subs[i].withRidFilter(ridSet);
+      // Pass the SAME effectivenessMetric instance to every sub: the underlying Meter accumulates
+      // across record() calls, so each direction's iterator independently flushes its own
+      // (filtered, probed) pair into the shared metric.
+      filtered[i] = subs[i].withRidFilter(ridSet, effectivenessMetric);
     }
     return new PreFilterableChainedIterable(filtered);
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
@@ -133,8 +133,18 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
   public Iterable<Vertex> getVertices(Direction direction, String... type) {
     checkForBinding();
     if (direction == Direction.BOTH) {
-      return IterableUtils.chainedIterable(
-          getVertices(Direction.OUT, type), getVertices(Direction.IN, type));
+      var outVertices = getVerticesOptimized(Direction.OUT, type);
+      var inVertices = getVerticesOptimized(Direction.IN, type);
+      // When both directions yield a single PreFilterableLinkBagIterable (i.e. all edge
+      // properties for those labels are backed by a single LinkBag), wrap them in a
+      // PreFilterableChainedIterable so the MATCH engine can apply index pre-filters without
+      // touching disk. Otherwise fall back to the plain Commons chained iterable.
+      if (outVertices instanceof PreFilterableLinkBagIterable pfliOut
+          && inVertices instanceof PreFilterableLinkBagIterable pfliIn) {
+        //noinspection unchecked
+        return (Iterable<Vertex>) (Object) new PreFilterableChainedIterable(pfliOut, pfliIn);
+      }
+      return IterableUtils.chainedIterable(outVertices, inVertices);
     } else {
       return getVerticesOptimized(direction, type);
     }
@@ -363,6 +373,20 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
       return iterables.getFirst();
     } else if (iterables.isEmpty()) {
       return Collections.emptyList();
+    }
+
+    // When every iterable in the list is backed by a LinkBag (i.e. each implements
+    // PreFilterableLinkBagIterable), chain them in a PreFilterableChainedIterable so the MATCH
+    // engine can apply index pre-filters across all edge directions without touching disk.
+    // Otherwise fall back to the plain Commons chained iterable.
+    var allPreFilterable =
+        iterables.stream().allMatch(it -> it instanceof PreFilterableLinkBagIterable);
+    if (allPreFilterable) {
+      var subs = iterables.stream()
+          .map(it -> (PreFilterableLinkBagIterable) it)
+          .toArray(PreFilterableLinkBagIterable[]::new);
+      //noinspection unchecked
+      return (Iterable<EdgeInternal>) (Object) new PreFilterableChainedIterable(subs);
     }
 
     //noinspection unchecked

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
@@ -133,18 +133,13 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
   public Iterable<Vertex> getVertices(Direction direction, String... type) {
     checkForBinding();
     if (direction == Direction.BOTH) {
-      var outVertices = getVerticesOptimized(Direction.OUT, type);
-      var inVertices = getVerticesOptimized(Direction.IN, type);
-      // When both directions yield a single PreFilterableLinkBagIterable (i.e. all edge
-      // properties for those labels are backed by a single LinkBag), wrap them in a
-      // PreFilterableChainedIterable so the MATCH engine can apply index pre-filters without
-      // touching disk. Otherwise fall back to the plain Commons chained iterable.
-      if (outVertices instanceof PreFilterableLinkBagIterable pfliOut
-          && inVertices instanceof PreFilterableLinkBagIterable pfliIn) {
-        //noinspection unchecked
-        return (Iterable<Vertex>) (Object) new PreFilterableChainedIterable(pfliOut, pfliIn);
-      }
-      return IterableUtils.chainedIterable(outVertices, inVertices);
+      // Chain OUT and IN; chainIterables promotes the result to PreFilterableChainedIterable when
+      // both directions are LinkBag-backed so the MATCH engine can apply index pre-filters without
+      // touching disk.
+      return chainIterables(
+          List.of(
+              getVerticesOptimized(Direction.OUT, type),
+              getVerticesOptimized(Direction.IN, type)));
     } else {
       return getVerticesOptimized(direction, type);
     }
@@ -193,14 +188,7 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
       }
     }
 
-    if (iterables.size() == 1) {
-      return iterables.getFirst();
-    } else if (iterables.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    //noinspection unchecked
-    return IterableUtils.chainedIterable(iterables.toArray(new Iterable[0]));
+    return chainIterables(iterables);
   }
 
   @Override
@@ -369,24 +357,37 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
       }
     }
 
-    if (iterables.size() == 1) {
-      return iterables.getFirst();
-    } else if (iterables.isEmpty()) {
+    return chainIterables(iterables);
+  }
+
+  /**
+   * Chains a list of per-property edge/vertex iterables into a single iterable. When every element
+   * implements {@link PreFilterableLinkBagIterable} (i.e. each is backed by a LinkBag), they are
+   * wrapped in a {@link PreFilterableChainedIterable} so the MATCH engine can apply index
+   * pre-filters across all directions/labels without touching disk. Otherwise the method falls
+   * back to a plain Commons chained iterable. The list is walked in a single pass.
+   */
+  private static <T> Iterable<T> chainIterables(List<Iterable<T>> iterables) {
+    if (iterables.isEmpty()) {
       return Collections.emptyList();
     }
+    if (iterables.size() == 1) {
+      return iterables.getFirst();
+    }
 
-    // When every iterable in the list is backed by a LinkBag (i.e. each implements
-    // PreFilterableLinkBagIterable), chain them in a PreFilterableChainedIterable so the MATCH
-    // engine can apply index pre-filters across all edge directions without touching disk.
-    // Otherwise fall back to the plain Commons chained iterable.
-    var allPreFilterable =
-        iterables.stream().allMatch(it -> it instanceof PreFilterableLinkBagIterable);
+    var subs = new PreFilterableLinkBagIterable[iterables.size()];
+    var allPreFilterable = true;
+    for (var i = 0; i < iterables.size(); i++) {
+      if (iterables.get(i) instanceof PreFilterableLinkBagIterable pfli) {
+        subs[i] = pfli;
+      } else {
+        allPreFilterable = false;
+        break;
+      }
+    }
     if (allPreFilterable) {
-      var subs = iterables.stream()
-          .map(it -> (PreFilterableLinkBagIterable) it)
-          .toArray(PreFilterableLinkBagIterable[]::new);
       //noinspection unchecked
-      return (Iterable<EdgeInternal>) (Object) new PreFilterableChainedIterable(subs);
+      return (Iterable<T>) (Object) new PreFilterableChainedIterable(subs);
     }
 
     //noinspection unchecked

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/record/impl/VertexEntityImpl.java
@@ -132,17 +132,14 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
   @Override
   public Iterable<Vertex> getVertices(Direction direction, String... type) {
     checkForBinding();
-    if (direction == Direction.BOTH) {
-      // Chain OUT and IN; chainIterables promotes the result to PreFilterableChainedIterable when
-      // both directions are LinkBag-backed so the MATCH engine can apply index pre-filters without
-      // touching disk.
-      return chainIterables(
-          List.of(
-              getVerticesOptimized(Direction.OUT, type),
-              getVerticesOptimized(Direction.IN, type)));
-    } else {
-      return getVerticesOptimized(direction, type);
-    }
+    // For BOTH, delegate to the single flat-list path (mirroring getEdges(BOTH)/getEdgesInternal)
+    // rather than nesting two chainIterables over separate OUT/IN lists. This produces one
+    // PreFilterableChainedIterable spanning all out_/in_ properties so the MATCH engine can
+    // pre-filter even when one direction is empty (an empty OUT/IN list previously produced a
+    // non-pre-filterable result, disabling pre-filtering for asymmetric both()). Note the
+    // resulting neighbor order is out_/in_ interleaved by edge-property name, not OUT-all-then
+    // IN-all grouped; this is an intentional implementation detail (no consumer depends on order).
+    return getVerticesOptimized(direction, type);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ExpandStep.java
@@ -190,8 +190,9 @@ public class ExpandStep extends AbstractExecutionStep {
       }
       case Iterable<?> iterable -> {
         // PreFilterableLinkBagIterable covers both vertex and edge LinkBag
-        // iterables. ChainedIterable (from bothE/both) does not implement the
-        // interface, so it silently degrades to unfiltered iteration.
+        // iterables, including bidirectional both()/bothE() traversals which are
+        // wrapped in a PreFilterableChainedIterable (also implementing the
+        // interface) so pre-filtering is applied to each direction independently.
         if (iterable instanceof PreFilterableLinkBagIterable linkBagIterable
             && (acceptedCollectionIds != null || indexRidSet != null)) {
           var filtered = linkBagIterable;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3732,10 +3732,15 @@ public class MatchExecutionPlanner {
   /**
    * Infers the alias class from the edge schema LINK declarations.
    *
-   * <p>Handles seven method types:
+   * <p>Handles eight method types:
    * <ul>
    *   <li>{@code out('X')} / {@code in('X')}: target is the opposite endpoint
    *       of edge class X (vertex class)</li>
+   *   <li>{@code both('X')}: target class is inferred only when both endpoints
+   *       of edge class X resolve to the same vertex class (symmetric edges
+   *       such as {@code KNOWS}). For heterogeneous edges (e.g. in=Post,
+   *       out=Person) inference returns {@code null}, because a single alias
+   *       cannot represent both endpoint classes.</li>
    *   <li>{@code outE('X')} / {@code inE('X')} / {@code bothE('X')}: alias class
    *       is X itself (the edge class)</li>
    *   <li>{@code inV()} / {@code outV()}: alias class is the linked vertex
@@ -3773,13 +3778,30 @@ public class MatchExecutionPlanner {
       return lookupLinkedVertexClass(currentEdgeClass, prop, context);
     }
 
-    // out('X') / in('X'): infer the target vertex class from the edge LINK schema
-    if (!"in".equals(dirName) && !"out".equals(dirName)) {
+    // out('X') / in('X') / both('X'): infer the target vertex class from the
+    // edge LINK schema
+    if (!"in".equals(dirName) && !"out".equals(dirName)
+        && !"both".equals(dirName)) {
       return null;
     }
 
     var edgeClassName = extractEdgeClassName(method);
     if (edgeClassName == null) {
+      return null;
+    }
+
+    // both('X'): infer only when both endpoints resolve to the same vertex
+    // class. For symmetric edges (e.g. KNOWS: in=Person, out=Person) this
+    // returns Person; for heterogeneous edges (e.g. HAS_CREATOR: in=Post,
+    // out=Person) it returns null, because a single alias cannot safely
+    // represent both endpoint classes and an index lookup on the alias
+    // could miss records of the other class.
+    if ("both".equals(dirName)) {
+      var inClass = lookupLinkedVertexClass(edgeClassName, "in", context);
+      var outClass = lookupLinkedVertexClass(edgeClassName, "out", context);
+      if (inClass != null && inClass.equals(outClass)) {
+        return inClass;
+      }
       return null;
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3692,10 +3692,13 @@ public class MatchExecutionPlanner {
           // Update currentEdgeClass state based on the method type.
           // inV/outV is deferred: it consumes currentEdgeClass after inference below.
           var isInVOrOutV = "inv".equals(methodLower) || "outv".equals(methodLower);
-          if ("oute".equals(methodLower) || "ine".equals(methodLower)) {
+          if ("oute".equals(methodLower) || "ine".equals(methodLower)
+              || "bothe".equals(methodLower)) {
+            // bothE('X') identifies the edge class just like outE/inE — store it so that
+            // a subsequent inV/outV step can infer its linked vertex class.
             currentEdgeClass = extractEdgeClassName(method);
           } else if (!isInVOrOutV) {
-            // Any other method (out, in, both, bothE, etc.) resets the state.
+            // Any other method (out, in, both, etc.) resets the state.
             currentEdgeClass = null;
           }
 
@@ -3729,12 +3732,12 @@ public class MatchExecutionPlanner {
   /**
    * Infers the alias class from the edge schema LINK declarations.
    *
-   * <p>Handles six method types:
+   * <p>Handles seven method types:
    * <ul>
    *   <li>{@code out('X')} / {@code in('X')}: target is the opposite endpoint
    *       of edge class X (vertex class)</li>
-   *   <li>{@code outE('X')} / {@code inE('X')}: alias class is X itself
-   *       (the edge class)</li>
+   *   <li>{@code outE('X')} / {@code inE('X')} / {@code bothE('X')}: alias class
+   *       is X itself (the edge class)</li>
    *   <li>{@code inV()} / {@code outV()}: alias class is the linked vertex
    *       class from the preceding edge's LINK schema ({@code currentEdgeClass})</li>
    * </ul>
@@ -3755,8 +3758,8 @@ public class MatchExecutionPlanner {
     }
     dirName = dirName.toLowerCase(Locale.ROOT);
 
-    // outE('X') / inE('X'): the edge class itself is the alias class
-    if ("oute".equals(dirName) || "ine".equals(dirName)) {
+    // outE('X') / inE('X') / bothE('X'): the edge class itself is the alias class
+    if ("oute".equals(dirName) || "ine".equals(dirName) || "bothe".equals(dirName)) {
       return extractEdgeClassName(method);
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -6316,8 +6316,8 @@ public class MatchExecutionPlanner {
     // represent both endpoint classes and an index lookup on the alias
     // could miss records of the other class.
     if ("both".equals(dirName)) {
-      var inClass = lookupLinkedVertexClass(edgeClassName, "in", context);
-      var outClass = lookupLinkedVertexClass(edgeClassName, "out", context);
+      var inClass = lookupLinkedVertexClass(edgeClassName, "in", context.getDatabaseSession());
+      var outClass = lookupLinkedVertexClass(edgeClassName, "out", context.getDatabaseSession());
       if (inClass != null && inClass.equals(outClass)) {
         return inClass;
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -6212,10 +6212,13 @@ public class MatchExecutionPlanner {
           // Update currentEdgeClass state based on the method type.
           // inV/outV is deferred: it consumes currentEdgeClass after inference below.
           var isInVOrOutV = "inv".equals(methodLower) || "outv".equals(methodLower);
-          if ("oute".equals(methodLower) || "ine".equals(methodLower)) {
+          if ("oute".equals(methodLower) || "ine".equals(methodLower)
+              || "bothe".equals(methodLower)) {
+            // bothE('X') identifies the edge class just like outE/inE — store it so that
+            // a subsequent inV/outV step can infer its linked vertex class.
             currentEdgeClass = extractEdgeClassName(method);
           } else if (!isInVOrOutV) {
-            // Any other method (out, in, both, bothE, etc.) resets the state.
+            // Any other method (out, in, both, etc.) resets the state.
             currentEdgeClass = null;
           }
 
@@ -6249,12 +6252,12 @@ public class MatchExecutionPlanner {
   /**
    * Infers the alias class from the edge schema LINK declarations.
    *
-   * <p>Handles six method types:
+   * <p>Handles seven method types:
    * <ul>
    *   <li>{@code out('X')} / {@code in('X')}: target is the opposite endpoint
    *       of edge class X (vertex class)</li>
-   *   <li>{@code outE('X')} / {@code inE('X')}: alias class is X itself
-   *       (the edge class)</li>
+   *   <li>{@code outE('X')} / {@code inE('X')} / {@code bothE('X')}: alias class
+   *       is X itself (the edge class)</li>
    *   <li>{@code inV()} / {@code outV()}: alias class is the linked vertex
    *       class from the preceding edge's LINK schema ({@code currentEdgeClass})</li>
    * </ul>
@@ -6275,8 +6278,8 @@ public class MatchExecutionPlanner {
     }
     dirName = dirName.toLowerCase(Locale.ROOT);
 
-    // outE('X') / inE('X'): the edge class itself is the alias class
-    if ("oute".equals(dirName) || "ine".equals(dirName)) {
+    // outE('X') / inE('X') / bothE('X'): the edge class itself is the alias class
+    if ("oute".equals(dirName) || "ine".equals(dirName) || "bothe".equals(dirName)) {
       return extractEdgeClassName(method);
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -6252,10 +6252,15 @@ public class MatchExecutionPlanner {
   /**
    * Infers the alias class from the edge schema LINK declarations.
    *
-   * <p>Handles seven method types:
+   * <p>Handles eight method types:
    * <ul>
    *   <li>{@code out('X')} / {@code in('X')}: target is the opposite endpoint
    *       of edge class X (vertex class)</li>
+   *   <li>{@code both('X')}: target class is inferred only when both endpoints
+   *       of edge class X resolve to the same vertex class (symmetric edges
+   *       such as {@code KNOWS}). For heterogeneous edges (e.g. in=Post,
+   *       out=Person) inference returns {@code null}, because a single alias
+   *       cannot represent both endpoint classes.</li>
    *   <li>{@code outE('X')} / {@code inE('X')} / {@code bothE('X')}: alias class
    *       is X itself (the edge class)</li>
    *   <li>{@code inV()} / {@code outV()}: alias class is the linked vertex
@@ -6292,13 +6297,30 @@ public class MatchExecutionPlanner {
           dirName, currentEdgeClass, context.getDatabaseSession());
     }
 
-    // out('X') / in('X'): infer the target vertex class from the edge LINK schema
-    if (!"in".equals(dirName) && !"out".equals(dirName)) {
+    // out('X') / in('X') / both('X'): infer the target vertex class from the
+    // edge LINK schema
+    if (!"in".equals(dirName) && !"out".equals(dirName)
+        && !"both".equals(dirName)) {
       return null;
     }
 
     var edgeClassName = extractEdgeClassName(method);
     if (edgeClassName == null) {
+      return null;
+    }
+
+    // both('X'): infer only when both endpoints resolve to the same vertex
+    // class. For symmetric edges (e.g. KNOWS: in=Person, out=Person) this
+    // returns Person; for heterogeneous edges (e.g. HAS_CREATOR: in=Post,
+    // out=Person) it returns null, because a single alias cannot safely
+    // represent both endpoint classes and an index lookup on the alias
+    // could miss records of the other class.
+    if ("both".equals(dirName)) {
+      var inClass = lookupLinkedVertexClass(edgeClassName, "in", context);
+      var outClass = lookupLinkedVertexClass(edgeClassName, "out", context);
+      if (inClass != null && inClass.equals(outClass)) {
+        return inClass;
+      }
       return null;
     }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterableTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterableTest.java
@@ -1,0 +1,320 @@
+package com.jetbrains.youtrackdb.internal.core.record.impl;
+
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PreFilterableChainedIterable}.
+ *
+ * <p>Uses a lightweight {@link StubSub} fake implementation of
+ * {@link PreFilterableLinkBagIterable} so we can exercise {@link
+ * PreFilterableChainedIterable} contracts in isolation — {@link #size()} summation, {@link
+ * #isSizeable()} aggregation, filter delegation, and iterator behavior — without provisioning a
+ * real database. Integration tests that verify the end-to-end MATCH pre-filter wiring live in
+ * {@code MatchEdgeMethodPreFilterTest} and {@code MatchPreFilterComprehensiveTest}.
+ */
+public class PreFilterableChainedIterableTest {
+
+  // ---------- filter delegation ----------
+
+  /**
+   * {@code withClassFilter} must call {@code withClassFilter} on EVERY sub with the SAME {@link
+   * IntSet}, and the returned chained iterable must preserve sub order so iteration semantics are
+   * unchanged.
+   */
+  @Test
+  public void withClassFilterDelegatesToEachSubInOrder() {
+    var sub1 = new StubSub("first", List.of(elem("a")), 1, true);
+    var sub2 = new StubSub("second", List.of(elem("b"), elem("c")), 2, true);
+    var chained = new PreFilterableChainedIterable(sub1, sub2);
+
+    IntSet classIds = new IntOpenHashSet(new int[] {7, 9});
+    var filtered = chained.withClassFilter(classIds);
+
+    Assert.assertNotSame(
+        "withClassFilter must return a fresh PreFilterableChainedIterable, not mutate in place",
+        chained, filtered);
+    Assert.assertSame(
+        "sub1 must have been invoked with the exact IntSet passed to the chain",
+        classIds, sub1.lastClassFilter);
+    Assert.assertSame(
+        "sub2 must have been invoked with the exact IntSet passed to the chain",
+        classIds, sub2.lastClassFilter);
+    Assert.assertEquals(
+        "element order across filtered subs must match original iteration order",
+        List.of("filtered:first:a", "filtered:second:b", "filtered:second:c"),
+        drainToStrings(filtered));
+  }
+
+  /**
+   * {@code withRidFilter} must delegate identically to {@code withClassFilter} — same RID set to
+   * each sub, result is a new chain. Covers the RID-filter branch of the same pattern.
+   */
+  @Test
+  public void withRidFilterDelegatesToEachSubInOrder() {
+    var sub1 = new StubSub("left", List.of(elem("x")), 1, true);
+    var sub2 = new StubSub("right", Collections.emptyList(), 0, true);
+    var chained = new PreFilterableChainedIterable(sub1, sub2);
+
+    Set<RID> rids = Set.of(new RecordId(12, 34), new RecordId(12, 56));
+    var filtered = chained.withRidFilter(rids);
+
+    Assert.assertNotSame(
+        "withRidFilter must return a fresh PreFilterableChainedIterable, not mutate in place",
+        chained, filtered);
+    Assert.assertSame(
+        "sub1 must have been invoked with the exact Set<RID> passed to the chain",
+        rids, sub1.lastRidFilter);
+    Assert.assertSame(
+        "sub2 must have been invoked with the exact Set<RID> passed to the chain",
+        rids, sub2.lastRidFilter);
+    Assert.assertEquals(
+        "only sub1 contributes elements after filtering; sub2 was empty",
+        List.of("filtered:left:x"), drainToStrings(filtered));
+  }
+
+  // ---------- size + isSizeable ----------
+
+  /**
+   * {@code size()} returns the SUM of sub sizes. Exercises the loop body that accumulates across
+   * all sub-iterables — a unit test for the adaptive-abort guard input in {@code
+   * TraversalPreFilterHelper}.
+   */
+  @Test
+  public void sizeReturnsSumOfSubSizes() {
+    var sub1 = new StubSub("a", Collections.emptyList(), 3, true);
+    var sub2 = new StubSub("b", Collections.emptyList(), 5, true);
+    var sub3 = new StubSub("c", Collections.emptyList(), 7, true);
+    var chained = new PreFilterableChainedIterable(sub1, sub2, sub3);
+
+    Assert.assertEquals(
+        "size() must equal the sum 3 + 5 + 7 = 15 across all sub-iterables",
+        15, chained.size());
+  }
+
+  @Test
+  public void sizeOfSingleSubEqualsThatSubSize() {
+    var sub = new StubSub("only", Collections.emptyList(), 42, true);
+    var chained = new PreFilterableChainedIterable(sub);
+
+    Assert.assertEquals(
+        "with a single sub, size() must be that sub's size verbatim",
+        42, chained.size());
+  }
+
+  @Test
+  public void sizeIsZeroWhenAllSubsAreEmpty() {
+    var chained = new PreFilterableChainedIterable(
+        new StubSub("a", Collections.emptyList(), 0, true),
+        new StubSub("b", Collections.emptyList(), 0, true));
+
+    Assert.assertEquals("sum of zero sizes must be 0", 0, chained.size());
+  }
+
+  /**
+   * {@code isSizeable()} must short-circuit to {@code false} as soon as ANY sub reports
+   * non-sizeable — the guard relies on this to fall back to unconditional loading when any
+   * underlying LinkBag is of unknown size.
+   */
+  @Test
+  public void isSizeableFalseWhenAnySubIsNotSizeable() {
+    var sizeable = new StubSub("sizeable", Collections.emptyList(), 10, true);
+    var notSizeable = new StubSub("unsized", Collections.emptyList(), 0, false);
+
+    Assert.assertFalse(
+        "chain containing a non-sizeable sub must itself report non-sizeable",
+        new PreFilterableChainedIterable(sizeable, notSizeable).isSizeable());
+    Assert.assertFalse(
+        "non-sizeable sub in first position must still produce a non-sizeable chain",
+        new PreFilterableChainedIterable(notSizeable, sizeable).isSizeable());
+  }
+
+  /**
+   * {@code isSizeable()} returns {@code true} only when EVERY sub is sizeable. Covers the
+   * loop-completes-without-returning-false path.
+   */
+  @Test
+  public void isSizeableTrueWhenAllSubsAreSizeable() {
+    var chained = new PreFilterableChainedIterable(
+        new StubSub("a", Collections.emptyList(), 1, true),
+        new StubSub("b", Collections.emptyList(), 2, true),
+        new StubSub("c", Collections.emptyList(), 3, true));
+
+    Assert.assertTrue(
+        "all subs sizeable → chain is sizeable", chained.isSizeable());
+  }
+
+  // ---------- iterator ordering and exhaustion ----------
+
+  /**
+   * Iterator drains sub-iterables in the order they were passed to the constructor; elements from
+   * later subs never appear before elements from earlier subs.
+   */
+  @Test
+  public void iteratorDrainsSubsInConstructorOrder() {
+    var sub1 = new StubSub("a", List.of(elem("1"), elem("2")), 2, true);
+    var sub2 = new StubSub("b", List.of(elem("3")), 1, true);
+    var sub3 = new StubSub("c", List.of(elem("4"), elem("5")), 2, true);
+
+    var elements = drainToStrings(new PreFilterableChainedIterable(sub1, sub2, sub3));
+    Assert.assertEquals(
+        "iterator must yield sub1 elements, then sub2, then sub3, in registration order",
+        List.of("a:1", "a:2", "b:3", "c:4", "c:5"), elements);
+  }
+
+  /**
+   * Iterator correctly handles empty sub-iterables anywhere in the chain — at the start, middle,
+   * and end — without prematurely terminating or throwing.
+   */
+  @Test
+  public void iteratorSkipsEmptySubsAtAllPositions() {
+    var empty = new StubSub("empty", Collections.emptyList(), 0, true);
+    var singleton = new StubSub("single", List.of(elem("x")), 1, true);
+
+    Assert.assertEquals(
+        "empty sub at head must be skipped, yielding singleton elements only",
+        List.of("single:x"), drainToStrings(new PreFilterableChainedIterable(empty, singleton)));
+    Assert.assertEquals(
+        "empty sub between non-empty subs must not break chaining",
+        List.of("single:x", "single:x"),
+        drainToStrings(new PreFilterableChainedIterable(singleton, empty, singleton)));
+    Assert.assertEquals(
+        "empty sub at tail must leave earlier elements intact",
+        List.of("single:x"), drainToStrings(new PreFilterableChainedIterable(singleton, empty)));
+  }
+
+  /**
+   * Calling {@code next()} on an exhausted iterator must throw {@link NoSuchElementException} per
+   * the standard Iterator contract — not return {@code null}, not loop forever, not NPE.
+   */
+  @Test
+  public void nextThrowsNoSuchElementExceptionWhenExhausted() {
+    var chained = new PreFilterableChainedIterable(
+        new StubSub("a", List.of(elem("only")), 1, true));
+    var it = chained.iterator();
+
+    Assert.assertTrue("sanity: iterator has the one element", it.hasNext());
+    Assert.assertEquals(
+        "next() returns the sub-tagged element in the expected form", "a:only", it.next());
+    Assert.assertFalse("after draining the only element, iterator must be exhausted", it.hasNext());
+
+    try {
+      it.next();
+      Assert.fail("next() on exhausted iterator must throw NoSuchElementException");
+    } catch (NoSuchElementException expected) {
+      // expected
+    }
+  }
+
+  /**
+   * Calling {@code next()} on a chain where ALL subs are empty must throw immediately —
+   * {@code hasNext()} reports false from the start and {@code next()} must respect it.
+   */
+  @Test
+  public void nextThrowsImmediatelyWhenAllSubsEmpty() {
+    var chained = new PreFilterableChainedIterable(
+        new StubSub("a", Collections.emptyList(), 0, true),
+        new StubSub("b", Collections.emptyList(), 0, true));
+    var it = chained.iterator();
+
+    Assert.assertFalse("all subs empty → iterator starts already exhausted", it.hasNext());
+    try {
+      it.next();
+      Assert.fail("next() on an all-empty chain must throw NoSuchElementException");
+    } catch (NoSuchElementException expected) {
+      // expected
+    }
+  }
+
+  // ---------- test fixtures ----------
+
+  /** Build a recognizable element tag so assertions can verify order + origin. */
+  private static Object elem(String id) {
+    return new Object() {
+      @Override
+      public String toString() {
+        return id;
+      }
+    };
+  }
+
+  /** Drain a chained iterable to a list of {@code "<subName>:<element>"} strings. */
+  private static List<String> drainToStrings(PreFilterableChainedIterable chained) {
+    var out = new ArrayList<String>();
+    for (var element : chained) {
+      out.add(element.toString());
+    }
+    return out;
+  }
+
+  /**
+   * Stub {@link PreFilterableLinkBagIterable}. Captures the most-recent filter arguments so tests
+   * can assert delegation; produces elements prefixed with a sub name so iteration order is
+   * verifiable. Filter methods return a NEW stub with elements prefixed {@code "filtered:"} — this
+   * lets tests distinguish the pre-filter path from the identity path without resorting to
+   * reference equality (which would be insufficient since {@link PreFilterableChainedIterable}
+   * wraps filtered subs in a fresh array).
+   */
+  private static final class StubSub implements PreFilterableLinkBagIterable {
+    private final String name;
+    private final List<Object> elements;
+    private final int declaredSize;
+    private final boolean sizeable;
+    IntSet lastClassFilter;
+    Set<RID> lastRidFilter;
+
+    StubSub(String name, List<Object> elements, int declaredSize, boolean sizeable) {
+      this.name = name;
+      this.elements = elements;
+      this.declaredSize = declaredSize;
+      this.sizeable = sizeable;
+    }
+
+    @Nonnull
+    @Override
+    public PreFilterableLinkBagIterable withClassFilter(@Nonnull IntSet collectionIds) {
+      lastClassFilter = collectionIds;
+      return new StubSub("filtered:" + name, elements, declaredSize, sizeable);
+    }
+
+    @Nonnull
+    @Override
+    public PreFilterableLinkBagIterable withRidFilter(@Nonnull Set<RID> ridSet) {
+      lastRidFilter = ridSet;
+      return new StubSub("filtered:" + name, elements, declaredSize, sizeable);
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<?> iterator() {
+      // Tag each element with the sub name for order/origin-verification in tests.
+      var tagged = new ArrayList<String>(elements.size());
+      for (var element : elements) {
+        tagged.add(name + ":" + element);
+      }
+      return Arrays.asList(tagged.toArray()).iterator();
+    }
+
+    @Override
+    public int size() {
+      return declaredSize;
+    }
+
+    @Override
+    public boolean isSizeable() {
+      return sizeable;
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterableTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/record/impl/PreFilterableChainedIterableTest.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.record.impl;
 
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.Ratio;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -274,6 +275,7 @@ public class PreFilterableChainedIterableTest {
     private final boolean sizeable;
     IntSet lastClassFilter;
     Set<RID> lastRidFilter;
+    Ratio lastRatio;
 
     StubSub(String name, List<Object> elements, int declaredSize, boolean sizeable) {
       this.name = name;
@@ -291,8 +293,10 @@ public class PreFilterableChainedIterableTest {
 
     @Nonnull
     @Override
-    public PreFilterableLinkBagIterable withRidFilter(@Nonnull Set<RID> ridSet) {
+    public PreFilterableLinkBagIterable withRidFilter(
+        @Nonnull Set<RID> ridSet, @Nonnull Ratio effectivenessMetric) {
       lastRidFilter = ridSet;
+      lastRatio = effectivenessMetric;
       return new StubSub("filtered:" + name, elements, declaredSize, sizeable);
     }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -630,4 +630,107 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
 
     session.commit();
   }
+
+  /**
+   * Verify that {@code both('X')} with a symmetric edge (both endpoints of the
+   * same vertex class) infers the target vertex class from the edge LINK
+   * schema, enabling index pre-filter on an indexed vertex property of the
+   * target alias.
+   *
+   * <p>Setup: a standalone {@code PFKnows} edge class with both endpoints
+   * pointing at {@code PFKnownPerson}. {@code PFKnownPerson.age} has an index.
+   * The query filters the target by {@code age > 30}; the planner should
+   * resolve {@code p} to class {@code PFKnownPerson} and attach the
+   * {@code PFKnownPerson_age} index as an intersection pre-filter.
+   */
+  @Test
+  public void testBothWithSymmetricEdgeInfersClassAndAppliesPreFilter() {
+    session.execute("CREATE class PFKnownPerson extends V").close();
+    session.execute("CREATE property PFKnownPerson.name STRING").close();
+    session.execute("CREATE property PFKnownPerson.age INTEGER").close();
+    session.execute(
+        "CREATE index PFKnownPerson_age on PFKnownPerson (age) NOTUNIQUE").close();
+
+    session.execute("CREATE class PFKnows extends E").close();
+    session.execute("CREATE property PFKnows.out LINK PFKnownPerson").close();
+    session.execute("CREATE property PFKnows.in LINK PFKnownPerson").close();
+
+    session.begin();
+    session.execute(
+        "CREATE VERTEX PFKnownPerson set name = 'alice', age = 25").close();
+    session.execute(
+        "CREATE VERTEX PFKnownPerson set name = 'bob', age = 35").close();
+    session.execute(
+        "CREATE VERTEX PFKnownPerson set name = 'carol', age = 45").close();
+    session.execute(
+        "CREATE EDGE PFKnows from (select from PFKnownPerson where name='alice')"
+            + " to (select from PFKnownPerson where name='bob')")
+        .close();
+    session.execute(
+        "CREATE EDGE PFKnows from (select from PFKnownPerson where name='alice')"
+            + " to (select from PFKnownPerson where name='carol')")
+        .close();
+    session.commit();
+
+    var query =
+        "MATCH {class: PFKnownPerson, as: a, where: (name = 'alice')}"
+            + ".both('PFKnows'){as: p, where: (age > 30)}"
+            + " RETURN p.name";
+    var result = session.query(query).toList();
+
+    // alice.both(PFKnows) = {bob (age=35), carol (age=45)}; filter age > 30
+    // keeps both.
+    assertEquals(2, result.size());
+    Set<String> names = new HashSet<>();
+    for (var r : result) {
+      names.add(r.getProperty("p.name"));
+    }
+    assertTrue("Expected bob in results", names.contains("bob"));
+    assertTrue("Expected carol in results", names.contains("carol"));
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "both('PFKnows') with a symmetric edge and indexed target property "
+            + "should produce an intersection pre-filter on PFKnownPerson.age, "
+            + "but plan was:\n" + plan,
+        plan.contains("intersection:"));
+  }
+
+  /**
+   * Verify that {@code both('X')} with a heterogeneous edge (different in/out
+   * vertex classes, e.g. {@code PFWorkAt}: out=PFPerson, in=PFCompany) does
+   * NOT infer a target class — because the two endpoints cannot both be
+   * safely represented by a single alias class. The traversal must still
+   * produce correct results (via {@link
+   * com.jetbrains.youtrackdb.internal.core.record.impl.PreFilterableChainedIterable
+   * PreFilterableChainedIterable}'s class-filter fallback), but the plan
+   * must not contain a spurious intersection on a wrong class.
+   */
+  @Test
+  public void testBothWithHeterogeneousEdgeSkipsClassInference() {
+    session.begin();
+    // .both('PFWorkAt') from alice: out_PFWorkAt has company0 (alice works there).
+    // in_PFWorkAt on alice is empty. Result: company0.
+    var query =
+        "MATCH {class: PFPerson, as: a, where: (name = 'person0')}"
+            + ".both('PFWorkAt'){as: x}"
+            + " RETURN x.name";
+    var result = session.query(query).toList();
+    assertEquals(1, result.size());
+    assertEquals("company0", result.getFirst().getProperty("x.name"));
+
+    // No target class inferred ⇒ no per-target-class index lookup,
+    // so the plan must NOT claim an intersection pre-filter.
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse(
+        "both('PFWorkAt') with heterogeneous endpoints must not infer a "
+            + "target class; intersection pre-filter should be skipped. "
+            + "Plan was:\n" + plan,
+        plan.contains("intersection:"));
+    session.commit();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -522,19 +522,57 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
   }
 
   /**
-   * Verify that bothE() with an indexed edge property still produces correct
-   * results via unfiltered traversal. bothE() is intentionally out of scope
-   * for pre-filtering (returns ChainedIterable, not PreFilterableLinkBagIterable)
-   * and silently degrades to no-op. This test documents the intentional
-   * degradation and guards against regressions.
+   * Verify that bothE() with an explicit alias and an indexed edge property
+   * produces correct results AND that the planner now applies the index
+   * pre-filter (intersection descriptor). Previously bothE() silently degraded
+   * to unfiltered traversal; this test confirms the regression is fixed.
+   *
+   * <p>Pattern: Company -bothE('PFWorkAt'){as: w, where: workFrom < 2015}-> outV() as person
+   * company0 has persons 0 and 5 (workFrom 2010, 2015). workFrom < 2015 -> only person0.
    */
   @Test
-  public void testBothEDegradesToNoPreFilterButReturnsCorrectResults() {
+  public void testBothEWithAliasAppliesIndexPreFilter() {
     session.begin();
 
-    // bothE('PFWorkAt') from company0 should find persons working there.
-    // company0 has persons 0 and 5 (workFrom 2010, 2015).
-    // Filter workFrom < 2015 -> only person0 matches.
+    // Note: explicit {as: w} alias is required for the planner to infer the edge class
+    // 'PFWorkAt' and attach the PFWorkAt_workFrom index as an intersection pre-filter.
+    var query =
+        "MATCH {class: PFCompany, as: c, where: (name = 'company0')}"
+            + ".bothE('PFWorkAt'){as: w, where: (workFrom < 2015)}"
+            + ".outV(){as: p}"
+            + " RETURN p.name";
+    var result = session.query(query).toList();
+
+    assertEquals(1, result.size());
+    assertEquals("person0", result.getFirst().getProperty("p.name"));
+
+    // EXPLAIN should now show intersection pre-filter for bothE with alias
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "bothE with explicit alias should trigger intersection pre-filter "
+            + "(PFWorkAt_workFrom index), but plan was:\n" + plan,
+        plan.contains("intersection:"));
+
+    session.commit();
+  }
+
+  /**
+   * Verify that bothE() WITHOUT an explicit alias still produces correct results AND
+   * still benefits from index pre-filtering. The planner auto-assigns a default alias
+   * (e.g. $YOUTRACKDB_DEFAULT_ALIAS_0), enabling class inference and index intersection
+   * to proceed transparently even without a user-visible alias.
+   *
+   * <p>This test guards against regressions where the absence of an explicit alias
+   * would prevent the optimization from being applied.
+   */
+  @Test
+  public void testBothEWithoutAliasStillAppliesIndexPreFilter() {
+    session.begin();
+
+    // bothE('PFWorkAt') from company0: persons 0 and 5 (workFrom 2010, 2015).
+    // Filter workFrom < 2015 -> only person0.
     var query =
         "MATCH {class: PFCompany, as: c, where: (name = 'company0')}"
             + ".bothE('PFWorkAt'){where: (workFrom < 2015)}"
@@ -545,13 +583,50 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     assertEquals(1, result.size());
     assertEquals("person0", result.getFirst().getProperty("p.name"));
 
-    // EXPLAIN should NOT show intersection descriptor for bothE
+    // The planner auto-assigns a default alias for the bothE step, so class inference
+    // resolves 'PFWorkAt' and the PFWorkAt_workFrom index is used as intersection pre-filter.
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
-    assertFalse(
-        "bothE should NOT trigger pre-filter intersection, but plan was:\n"
-            + plan,
-        plan.contains("(intersection:"));
+    assertNotNull(plan);
+    assertTrue(
+        "bothE without explicit alias should still produce an intersection pre-filter "
+            + "(via auto-assigned default alias), but plan was:\n" + plan,
+        plan.contains("intersection:"));
+
+    session.commit();
+  }
+
+  /**
+   * Verify that both() (vertex-to-vertex bidirectional traversal) returns correct
+   * results after the fix that wraps its LinkBag-backed iterables in
+   * {@code PreFilterableChainedIterable}. Exercises both the OUT and IN directions.
+   *
+   * <p>both('PFWorkAt') from company0 traverses:
+   * <ul>
+   *   <li>OUT direction: no out_PFWorkAt bag on company — 0 results</li>
+   *   <li>IN direction: in_PFWorkAt bag on company — persons 0 and 5</li>
+   * </ul>
+   */
+  @Test
+  public void testBothTraversalReturnsCorrectResults() {
+    session.begin();
+
+    // PFWorkAt edges run FROM person TO company, so both('PFWorkAt') from company0
+    // finds persons 0 (workFrom=2010) and 5 (workFrom=2015).
+    var query =
+        "MATCH {class: PFCompany, as: c, where: (name = 'company0')}"
+            + ".both('PFWorkAt'){as: p}"
+            + " RETURN p.name";
+    var result = session.query(query).toList();
+
+    assertEquals(2, result.size());
+
+    Set<String> names = new HashSet<>();
+    for (var r : result) {
+      names.add(r.getProperty("p.name"));
+    }
+    assertTrue("Expected person0 in results", names.contains("person0"));
+    assertTrue("Expected person5 in results", names.contains("person5"));
 
     session.commit();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -662,6 +662,12 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
         "CREATE VERTEX PFKnownPerson set name = 'bob', age = 35").close();
     session.execute(
         "CREATE VERTEX PFKnownPerson set name = 'carol', age = 45").close();
+    // dave has age 28 (<= 30) so the age > 30 filter MUST exclude him. This
+    // guards against a pre-filter that fails to exclude non-matching neighbors
+    // (a filter that returned all neighbors would still pass a bob/carol-only
+    // assertion if dave were absent from the graph).
+    session.execute(
+        "CREATE VERTEX PFKnownPerson set name = 'dave', age = 28").close();
     session.execute(
         "CREATE EDGE PFKnows from (select from PFKnownPerson where name='alice')"
             + " to (select from PFKnownPerson where name='bob')")
@@ -669,6 +675,10 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     session.execute(
         "CREATE EDGE PFKnows from (select from PFKnownPerson where name='alice')"
             + " to (select from PFKnownPerson where name='carol')")
+        .close();
+    session.execute(
+        "CREATE EDGE PFKnows from (select from PFKnownPerson where name='alice')"
+            + " to (select from PFKnownPerson where name='dave')")
         .close();
     session.commit();
 
@@ -678,8 +688,8 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
             + " RETURN p.name";
     var result = session.query(query).toList();
 
-    // alice.both(PFKnows) = {bob (age=35), carol (age=45)}; filter age > 30
-    // keeps both.
+    // alice.both(PFKnows) = {bob (age=35), carol (age=45), dave (age=28)};
+    // filter age > 30 keeps bob and carol and EXCLUDES dave.
     assertEquals(2, result.size());
     Set<String> names = new HashSet<>();
     for (var r : result) {
@@ -687,6 +697,8 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
     }
     assertTrue("Expected bob in results", names.contains("bob"));
     assertTrue("Expected carol in results", names.contains("carol"));
+    assertFalse("dave (age=28) must be excluded by age > 30",
+        names.contains("dave"));
 
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
@@ -696,6 +708,102 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
             + "should produce an intersection pre-filter on PFKnownPerson.age, "
             + "but plan was:\n" + plan,
         plan.contains("intersection:"));
+  }
+
+  /**
+   * Regression guard for the {@link
+   * com.jetbrains.youtrackdb.internal.core.record.impl.PreFilterableChainedIterable
+   * PreFilterableChainedIterable} two-bag path: a vertex that has the SAME edge
+   * label populated in BOTH directions (some OUT neighbors AND some IN
+   * neighbors), so {@code both('LABEL')} builds a real chained iterable over two
+   * non-empty LinkBags at runtime (all other fixtures are one-directional and
+   * collapse to a single iterable).
+   *
+   * <p>Setup: a symmetric {@code PFHub} edge (both endpoints {@code PFHubNode},
+   * {@code age} indexed). A central {@code hub} vertex has OUT edges to
+   * {@code out1}(age=40)/{@code out2}(age=20) and IN edges from
+   * {@code in1}(age=50)/{@code in2}(age=15). {@code both('PFHub'){age > 30}}
+   * must return exactly {@code out1} and {@code in1} — excluding one neighbor
+   * on EACH side. If the chained {@code withClassFilter}/{@code withRidFilter}
+   * delegation dropped a valid neighbor in either sub-iterable (over-exclusion),
+   * or the {@code ChainedIterator} failed to drain both bags, this assertion
+   * would fail.
+   */
+  @Test
+  public void testBothTwoPopulatedDirectionsChainedPreFilter() {
+    session.execute("CREATE class PFHubNode extends V").close();
+    session.execute("CREATE property PFHubNode.name STRING").close();
+    session.execute("CREATE property PFHubNode.age INTEGER").close();
+    session.execute(
+        "CREATE index PFHubNode_age on PFHubNode (age) NOTUNIQUE").close();
+
+    session.execute("CREATE class PFHub extends E").close();
+    session.execute("CREATE property PFHub.out LINK PFHubNode").close();
+    session.execute("CREATE property PFHub.in LINK PFHubNode").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX PFHubNode set name = 'hub', age = 33").close();
+    session.execute("CREATE VERTEX PFHubNode set name = 'out1', age = 40").close();
+    session.execute("CREATE VERTEX PFHubNode set name = 'out2', age = 20").close();
+    session.execute("CREATE VERTEX PFHubNode set name = 'in1', age = 50").close();
+    session.execute("CREATE VERTEX PFHubNode set name = 'in2', age = 15").close();
+    // OUT edges: hub -> out1, hub -> out2  (populates out_PFHub on hub)
+    session.execute(
+        "CREATE EDGE PFHub from (select from PFHubNode where name='hub')"
+            + " to (select from PFHubNode where name='out1')")
+        .close();
+    session.execute(
+        "CREATE EDGE PFHub from (select from PFHubNode where name='hub')"
+            + " to (select from PFHubNode where name='out2')")
+        .close();
+    // IN edges: in1 -> hub, in2 -> hub  (populates in_PFHub on hub)
+    session.execute(
+        "CREATE EDGE PFHub from (select from PFHubNode where name='in1')"
+            + " to (select from PFHubNode where name='hub')")
+        .close();
+    session.execute(
+        "CREATE EDGE PFHub from (select from PFHubNode where name='in2')"
+            + " to (select from PFHubNode where name='hub')")
+        .close();
+    session.commit();
+
+    session.begin();
+    // hub.both('PFHub') = {out1(40), out2(20), in1(50), in2(15)}; filter
+    // age > 30 keeps out1 and in1 (one survivor per direction) and excludes
+    // out2 and in2 (one excluded per direction).
+    var query =
+        "MATCH {class: PFHubNode, as: h, where: (name = 'hub')}"
+            + ".both('PFHub'){as: n, where: (age > 30)}"
+            + " RETURN n.name";
+    var result = session.query(query).toList();
+
+    Set<String> names = new HashSet<>();
+    for (var r : result) {
+      names.add(r.getProperty("n.name"));
+    }
+    assertEquals("Exactly one survivor per direction expected: " + names,
+        2, result.size());
+    assertTrue("out-direction survivor out1 (age=40) must be present",
+        names.contains("out1"));
+    assertTrue("in-direction survivor in1 (age=50) must be present",
+        names.contains("in1"));
+    assertFalse("out-direction out2 (age=20) must be excluded",
+        names.contains("out2"));
+    assertFalse("in-direction in2 (age=15) must be excluded",
+        names.contains("in2"));
+
+    // Symmetric edge -> target class PFHubNode inferred; indexed age -> the
+    // planner attaches an intersection pre-filter that flows into the
+    // PreFilterableChainedIterable spanning both directions.
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue(
+        "both('PFHub') over two populated directions with an indexed target "
+            + "property should produce an intersection pre-filter, but plan "
+            + "was:\n" + plan,
+        plan.contains("intersection:"));
+    session.commit();
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodPreFilterTest.java
@@ -767,10 +767,10 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
         .close();
     session.commit();
 
-    session.begin();
     // hub.both('PFHub') = {out1(40), out2(20), in1(50), in2(15)}; filter
     // age > 30 keeps out1 and in1 (one survivor per direction) and excludes
-    // out2 and in2 (one excluded per direction).
+    // out2 and in2 (one excluded per direction). Read-only query needs no tx,
+    // matching the sibling read-only tests in this class.
     var query =
         "MATCH {class: PFHubNode, as: h, where: (name = 'hub')}"
             + ".both('PFHub'){as: n, where: (age > 30)}"
@@ -803,7 +803,6 @@ public class MatchEdgeMethodPreFilterTest extends DbTestBase {
             + "property should produce an intersection pre-filter, but plan "
             + "was:\n" + plan,
         plan.contains("intersection:"));
-    session.commit();
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterComprehensiveTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterComprehensiveTest.java
@@ -975,11 +975,13 @@ public class MatchPreFilterComprehensiveTest extends MatchPreFilterTestBase {
   }
 
   /**
-   * bothE degrades to no pre-filter but still produces correct results.
-   * This documents the intentional limitation for bothE().
+   * bothE now applies the index pre-filter, since {@code PreFilterableChainedIterable}
+   * makes bidirectional link-bag traversals eligible (YTDB-646). Previously this
+   * test documented the silent degradation — it now guards against regression by
+   * asserting that the intersection descriptor IS present.
    */
   @Test
-  public void edgeMethod_bothE_noPreFilter() {
+  public void edgeMethod_bothE_appliesPreFilter() {
     session.begin();
     // CKnows from p0: out to p1, p2. in from nobody.
     // bothE should find p1, p2
@@ -996,24 +998,13 @@ public class MatchPreFilterComprehensiveTest extends MatchPreFilterTestBase {
     // p0→p2 has since=2007 > 2006 → target p2 via outE.inV
     assertEquals(Set.of("p2"), names);
 
-    // Verify the bothE() edge step specifically has no intersection descriptor.
-    // Check only the plan line for the bothE edge, not the entire plan, to
-    // avoid false positives from unrelated edges that may have intersection.
-    String plan = explainPlan(
+    // Verify that the bothE() edge step carries an intersection descriptor.
+    assertPlanHasIntersection(
         "MATCH {class: CPerson, as: p, where: (name = 'p0')}"
             + ".bothE('CKnows'){as: k, where: (since > 2006)}"
             + ".inV(){as: target}"
-            + " RETURN target.name as name");
-    boolean bothEEdgeHasIntersection = false;
-    for (String line : plan.split("\n")) {
-      if (line.contains("bothE(") || line.contains("{k}")) {
-        bothEEdgeHasIntersection = line.contains("intersection:");
-        break;
-      }
-    }
-    assertFalse(
-        "bothE() edge should NOT have intersection descriptor:\n" + plan,
-        bothEEdgeHasIntersection);
+            + " RETURN target.name as name",
+        "bothE() with alias and indexed property should apply intersection pre-filter");
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterComprehensiveTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchPreFilterComprehensiveTest.java
@@ -976,11 +976,13 @@ public class MatchPreFilterComprehensiveTest extends MatchPreFilterTestBase {
   }
 
   /**
-   * bothE degrades to no pre-filter but still produces correct results.
-   * This documents the intentional limitation for bothE().
+   * bothE now applies the index pre-filter, since {@code PreFilterableChainedIterable}
+   * makes bidirectional link-bag traversals eligible (YTDB-646). Previously this
+   * test documented the silent degradation — it now guards against regression by
+   * asserting that the intersection descriptor IS present.
    */
   @Test
-  public void edgeMethod_bothE_noPreFilter() {
+  public void edgeMethod_bothE_appliesPreFilter() {
     session.begin();
     // CKnows from p0: out to p1, p2. in from nobody.
     // bothE should find p1, p2
@@ -997,24 +999,13 @@ public class MatchPreFilterComprehensiveTest extends MatchPreFilterTestBase {
     // p0→p2 has since=2007 > 2006 → target p2 via outE.inV
     assertEquals(Set.of("p2"), names);
 
-    // Verify the bothE() edge step specifically has no intersection descriptor.
-    // Check only the plan line for the bothE edge, not the entire plan, to
-    // avoid false positives from unrelated edges that may have intersection.
-    String plan = explainPlan(
+    // Verify that the bothE() edge step carries an intersection descriptor.
+    assertPlanHasIntersection(
         "MATCH {class: CPerson, as: p, where: (name = 'p0')}"
             + ".bothE('CKnows'){as: k, where: (since > 2006)}"
             + ".inV(){as: target}"
-            + " RETURN target.name as name");
-    boolean bothEEdgeHasIntersection = false;
-    for (String line : plan.split("\n")) {
-      if (line.contains("bothE(") || line.contains("{k}")) {
-        bothEEdgeHasIntersection = line.contains("intersection:");
-        break;
-      }
-    }
-    assertFalse(
-        "bothE() edge should NOT have intersection descriptor:\n" + plan,
-        bothEEdgeHasIntersection);
+            + " RETURN target.name as name",
+        "bothE() with alias and indexed property should apply intersection pre-filter");
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1455,12 +1455,13 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
-   * bothE resets currentEdgeClass: outE('KNOWS') followed by bothE('X') followed by
-   * inV() → inV should NOT infer a class because bothE reset the state. bothE('X')
-   * itself also gets no inference (not a recognized edge-method type).
+   * bothE('X') sets currentEdgeClass like outE/inE and the alias class is the edge
+   * class itself — mirroring outE/inE inference. When X is not registered in the
+   * schema, the subsequent inV() still cannot infer its linked vertex class
+   * (lookupLinkedVertexClass returns null), so v stays uninferred.
    */
   @Test
-  public void addAliases_bothE_resetsCurrentEdgeClass() {
+  public void addAliases_bothE_inferredLikeOutE_inVUninferredWhenUnregistered() {
     registerClass("KNOWS", 500);
 
     var expr = mockExpression(
@@ -1473,7 +1474,8 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), Set.of(), new java.util.HashSet<>());
 
-    assertThat(aliasClasses).containsOnly(entry("e1", "KNOWS"));
+    assertThat(aliasClasses)
+        .containsOnly(entry("e1", "KNOWS"), entry("e2", "X"));
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1479,12 +1479,13 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
-   * bothE resets currentEdgeClass: outE('KNOWS') followed by bothE('X') followed by
-   * inV() → inV should NOT infer a class because bothE reset the state. bothE('X')
-   * itself also gets no inference (not a recognized edge-method type).
+   * bothE('X') sets currentEdgeClass like outE/inE and the alias class is the edge
+   * class itself — mirroring outE/inE inference. When X is not registered in the
+   * schema, the subsequent inV() still cannot infer its linked vertex class
+   * (lookupLinkedVertexClass returns null), so v stays uninferred.
    */
   @Test
-  public void addAliases_bothE_resetsCurrentEdgeClass() {
+  public void addAliases_bothE_inferredLikeOutE_inVUninferredWhenUnregistered() {
     registerClass("KNOWS", 500);
 
     var expr = mockExpression(
@@ -1497,7 +1498,8 @@ public class MatchExecutionPlannerMutationTest {
         expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
         mockContext(), Set.of(), new java.util.HashSet<>());
 
-    assertThat(aliasClasses).containsOnly(entry("e1", "KNOWS"));
+    assertThat(aliasClasses)
+        .containsOnly(entry("e1", "KNOWS"), entry("e2", "X"));
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1503,6 +1503,36 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
+   * Positive counterpart to the unregistered case above: {@code bothE('KNOWS')}
+   * with a REGISTERED symmetric edge class ({@code KNOWS.in -> Person}) sets
+   * currentEdgeClass to KNOWS, and the following {@code inV()} infers its linked
+   * vertex class (Person) from the edge's "in" LINK schema — exactly like
+   * {@code outE('KNOWS').inV()}. Guards {@code bothE} downstream class inference.
+   */
+  @Test
+  public void addAliases_bothE_inVInfersRegisteredEdgeLinkedClass() {
+    var personClass = registerClass("Person", 100);
+    var edgeClass = registerClass("KNOWS", 500);
+
+    // Symmetric KNOWS.in -> Person (inV reads the "in" property linked class).
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(personClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var expr = mockExpression(
+        mockPathItem("bothE", "KNOWS", "e"),
+        mockPathItem("inV", null, "v"));
+    var aliasClasses = new HashMap<String, String>();
+
+    MatchExecutionPlanner.addAliases(
+        expr, new HashMap<>(), aliasClasses, new HashMap<>(), new HashMap<>(),
+        mockContext(), Set.of(), new java.util.HashSet<>());
+
+    assertThat(aliasClasses)
+        .containsOnly(entry("e", "KNOWS"), entry("v", "Person"));
+  }
+
+  /**
    * If aliasClasses already contains an entry for the alias (e.g., from an explicit
    * class constraint), inference must not overwrite it.
    */

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +63,16 @@ public class LdbcBenchmarkState {
 
   // Curated per-query parameters — populated by ParameterCurator after DB load
   private ParameterCurator.CuratedParams curatedParams;
+
+  // Forum IDs sorted by HAS_MEMBER link-bag size (desc). Populated once in
+  // @Setup via a single SELECT; used by the forum-recent-joiners hub bench,
+  // which exists specifically to exercise YTDB-646 pre-filter at scale where
+  // the small-bag KNOWS benchmark does not show a measurable speedup.
+  private long[] popularForumIds;
+
+  // Cached selective date (95th percentile of curated dates) so the hub bench
+  // accessor avoids re-sorting curated dates on every benchmark invocation.
+  private Date cachedSelectiveDate;
 
   private final AtomicLong counter = new AtomicLong();
 
@@ -235,6 +246,27 @@ public class LdbcBenchmarkState {
     return curatedParams.dates()[(int) (idx % curatedParams.dates().length)];
   }
 
+  // -- BothE-HAS_MEMBER (hub) extension parameters --
+
+  /**
+   * Popular Forum ID cycled across the top-100 by {@code HAS_MEMBER} bag size.
+   * These are hub vertices with thousands of incident edges — the shape where
+   * the YTDB-646 pre-filter measurably beats the pre-fix path.
+   */
+  public long forumHubId(long idx) {
+    return popularForumIds[(int) (idx % popularForumIds.length)];
+  }
+
+  /**
+   * Selective lower-bound date for the hub bench. Fixed at the 95th percentile
+   * of curated dates so that {@code HAS_MEMBER.joinDate >=} filter passes
+   * roughly ~5% of edges — narrow enough for the index-assisted pre-filter
+   * set to visibly reduce edge loads on large bags.
+   */
+  public Date forumHubMinJoinDate(long idx) {
+    return cachedSelectiveDate;
+  }
+
   /** IC13: two distinct person IDs. */
   public long ic13Person1Id(long idx) {
     return curatedParams.ic13PersonIds1()[(int) (idx
@@ -302,6 +334,26 @@ public class LdbcBenchmarkState {
         curatedParams.isMessageIds().length,
         curatedParams.ic1().length,
         curatedParams.ic3().length);
+
+    // Pre-compute a selective (95th-percentile) date once — used as a fixed
+    // lower bound by the hub bench so the filter is narrow enough for the
+    // pre-filter set to meaningfully reduce edge loads.
+    Date[] sortedDates = curatedParams.dates().clone();
+    Arrays.sort(sortedDates);
+    cachedSelectiveDate =
+        sortedDates[Math.min(sortedDates.length - 1, (int) (sortedDates.length * 0.95))];
+
+    // Pre-compute top-100 Forums by HAS_MEMBER bag size. These are the hub
+    // vertices used by bothEHasMember_recentJoiners — ordinary Forums have
+    // dozens of members, hubs have tens of thousands, which is where the
+    // pre-filter optimization is designed to shine.
+    popularForumIds = executeSql(
+        "SELECT id, outE(\"HAS_MEMBER\").size() as sz "
+            + "FROM Forum ORDER BY sz DESC LIMIT 100")
+        .stream()
+        .mapToLong(row -> ((Number) row.get("id")).longValue())
+        .toArray();
+    log.info("Top-100 popular Forum IDs cached for hub benches");
   }
 
   @TearDown(Level.Trial)

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
@@ -216,6 +216,25 @@ public class LdbcBenchmarkState {
     return p.tagClassName();
   }
 
+  // -- BothE-KNOWS extension parameters --
+
+  /**
+   * Person IDs for the BothE-KNOWS benchmark. Reuses the IS person-ID pool,
+   * which selects active persons likely to have multiple KNOWS connections.
+   */
+  public long bothEKnowsPersonId(long idx) {
+    return curatedParams.isPersonIds()[(int) (idx
+        % curatedParams.isPersonIds().length)];
+  }
+
+  /**
+   * Lower-bound date for the BothE-KNOWS benchmark. Reuses the shared dates
+   * pool (also used by IC5), which covers the KNOWS activity period in the dataset.
+   */
+  public Date bothEKnowsMinDate(long idx) {
+    return curatedParams.dates()[(int) (idx % curatedParams.dates().length)];
+  }
+
   /** IC13: two distinct person IDs. */
   public long ic13Person1Id(long idx) {
     return curatedParams.ic13PersonIds1()[(int) (idx

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
@@ -74,6 +74,11 @@ public class LdbcBenchmarkState {
   // accessor avoids re-sorting curated dates on every benchmark invocation.
   private Date cachedSelectiveDate;
 
+  // Narrower selective date (99th percentile) used by the count/exists hub
+  // benches where a ~1% selectivity makes the PreFilter savings maximally
+  // visible (more edges to skip per successful lookup).
+  private Date cachedVerySelectiveDate;
+
   private final AtomicLong counter = new AtomicLong();
 
   /**
@@ -267,6 +272,17 @@ public class LdbcBenchmarkState {
     return cachedSelectiveDate;
   }
 
+  /**
+   * Very narrow (~1% selective) lower-bound date used by the count/exists
+   * benches. At this selectivity, a hub Forum with thousands of members
+   * yields only dozens of surviving edges — the gap between "load all edges"
+   * (no pre-filter) and "load ~1% of edges via index intersection" (with
+   * pre-filter) is the dominant cost, making the optimization visible.
+   */
+  public Date forumHubVeryNarrowJoinDate(long idx) {
+    return cachedVerySelectiveDate;
+  }
+
   /** IC13: two distinct person IDs. */
   public long ic13Person1Id(long idx) {
     return curatedParams.ic13PersonIds1()[(int) (idx
@@ -338,10 +354,14 @@ public class LdbcBenchmarkState {
     // Pre-compute a selective (95th-percentile) date once — used as a fixed
     // lower bound by the hub bench so the filter is narrow enough for the
     // pre-filter set to meaningfully reduce edge loads.
+    // Also pre-compute a narrower 99th-percentile date for the count/exists
+    // benches where maximally narrow selectivity exposes the pre-filter gap.
     Date[] sortedDates = curatedParams.dates().clone();
     Arrays.sort(sortedDates);
     cachedSelectiveDate =
         sortedDates[Math.min(sortedDates.length - 1, (int) (sortedDates.length * 0.95))];
+    cachedVerySelectiveDate =
+        sortedDates[Math.min(sortedDates.length - 1, (int) (sortedDates.length * 0.99))];
 
     // Pre-compute top-100 Forums by HAS_MEMBER bag size. These are the hub
     // vertices used by bothEHasMember_recentJoiners — ordinary Forums have

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
@@ -64,20 +64,22 @@ public class LdbcBenchmarkState {
   // Curated per-query parameters — populated by ParameterCurator after DB load
   private ParameterCurator.CuratedParams curatedParams;
 
-  // Forum IDs sorted by HAS_MEMBER link-bag size (desc). Populated once in
-  // @Setup via a single SELECT; used by the forum-recent-joiners hub bench,
-  // which exists specifically to exercise YTDB-646 pre-filter at scale where
-  // the small-bag KNOWS benchmark does not show a measurable speedup.
+  // Hub-bench parameters: Forum IDs sorted by HAS_MEMBER link-bag size (desc)
+  // plus the 95th/99th-percentile joinDate bounds. Computed by
+  // computeForumHubParams() from the BothE microbench's OWN Trial setup, never
+  // from setup(). setup() is shared by every benchmark class, and the Forum scan
+  // touches every Forum's HAS_MEMBER bag — running it in every fork of every
+  // IC/IS class perturbs the page-cache state each trial inherits right before
+  // its warmup, which shifts IC/IS scores that have nothing to do with YTDB-646.
   private long[] popularForumIds;
-
-  // Cached selective date (95th percentile of curated dates) so the hub bench
-  // accessor avoids re-sorting curated dates on every benchmark invocation.
   private Date cachedSelectiveDate;
-
-  // Narrower selective date (99th percentile) used by the count/exists hub
-  // benches where a ~1% selectivity makes the PreFilter savings maximally
-  // visible (more edges to skip per successful lookup).
   private Date cachedVerySelectiveDate;
+
+  // True once the microbench installed KNOWS.creationDate on the shared on-disk
+  // DB. tearDown() consults this to drop the index before closing the session,
+  // so the DB is left exactly as found even if the microbench's own state
+  // teardown never runs (JMH does not order teardowns across @State classes).
+  private boolean knowsCreationDateIndexInstalled;
 
   private final AtomicLong counter = new AtomicLong();
 
@@ -268,6 +270,8 @@ public class LdbcBenchmarkState {
    * Popular Forum ID cycled across the top-100 by {@code HAS_MEMBER} bag size.
    * These are hub vertices with thousands of incident edges — the shape where
    * the YTDB-646 pre-filter measurably beats the pre-fix path.
+   *
+   * <p>Requires {@link #computeForumHubParams()} to have run in this trial.
    */
   public long forumHubId(long idx) {
     return popularForumIds[(int) (idx % popularForumIds.length)];
@@ -278,6 +282,8 @@ public class LdbcBenchmarkState {
    * of curated dates so that {@code HAS_MEMBER.joinDate >=} filter passes
    * roughly ~5% of edges — narrow enough for the index-assisted pre-filter
    * set to visibly reduce edge loads on large bags.
+   *
+   * <p>Requires {@link #computeForumHubParams()} to have run in this trial.
    */
   public Date forumHubMinJoinDate(long idx) {
     return cachedSelectiveDate;
@@ -289,9 +295,45 @@ public class LdbcBenchmarkState {
    * yields only dozens of surviving edges — the gap between "load all edges"
    * (no pre-filter) and "load ~1% of edges via index intersection" (with
    * pre-filter) is the dominant cost, making the optimization visible.
+   *
+   * <p>Requires {@link #computeForumHubParams()} to have run in this trial.
    */
   public Date forumHubVeryNarrowJoinDate(long idx) {
     return cachedVerySelectiveDate;
+  }
+
+  /**
+   * Computes the hub-bench parameters: the top-100 Forums by {@code HAS_MEMBER}
+   * bag size and the 95th/99th-percentile {@code joinDate} bounds.
+   *
+   * <p>Called from the BothE microbench's own Trial setup, deliberately not from
+   * {@link #setup()}. The Forum scan reads every Forum's {@code HAS_MEMBER} bag,
+   * so running it from the shared setup would make every IC/IS fork pay for it
+   * and would change the page-cache state those benchmarks measure against.
+   *
+   * <p>Idempotent, so repeated calls within one trial are free.
+   */
+  void computeForumHubParams() {
+    if (popularForumIds != null) {
+      return;
+    }
+
+    var sortedDates = curatedParams.dates().clone();
+    Arrays.sort(sortedDates);
+    cachedSelectiveDate =
+        sortedDates[Math.min(sortedDates.length - 1, (int) (sortedDates.length * 0.95))];
+    cachedVerySelectiveDate =
+        sortedDates[Math.min(sortedDates.length - 1, (int) (sortedDates.length * 0.99))];
+
+    // Ordinary Forums have dozens of members, hubs have tens of thousands; only
+    // the hubs produce link bags large enough for the pre-filter to show a gap.
+    popularForumIds = executeSql(
+        "SELECT id, outE(\"HAS_MEMBER\").size() as sz "
+            + "FROM Forum ORDER BY sz DESC LIMIT 100")
+        .stream()
+        .mapToLong(row -> ((Number) row.get("id")).longValue())
+        .toArray();
+    log.info("Top-100 popular Forum IDs cached for hub benches");
   }
 
   /** IC13: two distinct person IDs. */
@@ -322,9 +364,10 @@ public class LdbcBenchmarkState {
    * Creates {@code KNOWS.creationDate} for the BothE-KNOWS microbench.
    *
    * <p>Kept out of {@code ldbc-schema.sql}: the index is unused by IC/IS queries
-   * but still occupies cache for every KNOWS edge and regresses IC1. Dropped
-   * again in {@link #dropKnowsCreationDateIndex()} so a shared on-disk DB does
-   * not leave the index behind for later IC/IS forks in the same suite.
+   * but still occupies cache for every KNOWS edge and regresses IC1. It is
+   * dropped again by {@link #dropKnowsCreationDateIndex()} and, as a safety net,
+   * by {@link #tearDown()}, so a shared on-disk DB never keeps the index for
+   * later IC/IS forks in the same suite.
    */
   void ensureKnowsCreationDateIndex() {
     traversal.executeInTx(g -> {
@@ -333,16 +376,32 @@ public class LdbcBenchmarkState {
           "CREATE INDEX KNOWS.creationDate IF NOT EXISTS ON KNOWS(creationDate) NOTUNIQUE")
           .iterate();
     });
+    knowsCreationDateIndexInstalled = true;
     log.info("Ensured KNOWS.creationDate index for BothE-KNOWS microbench");
   }
 
-  /** Drops {@code KNOWS.creationDate} if present; see {@link #ensureKnowsCreationDateIndex()}. */
+  /**
+   * Drops {@code KNOWS.creationDate} if this trial installed it; see
+   * {@link #ensureKnowsCreationDateIndex()}.
+   *
+   * <p>Never propagates a failure. The caller is a JMH teardown, and letting an
+   * exception escape there would discard the trial's already-collected results.
+   * A failure here is reported through the log and retried by {@link #tearDown()}.
+   */
   void dropKnowsCreationDateIndex() {
-    traversal.executeInTx(g -> {
-      var ytg = (YTDBGraphTraversalSource) g;
-      ytg.yql("DROP INDEX KNOWS.creationDate IF EXISTS").iterate();
-    });
-    log.info("Dropped KNOWS.creationDate index after BothE-KNOWS microbench");
+    if (!knowsCreationDateIndexInstalled) {
+      return;
+    }
+    try {
+      traversal.executeInTx(g -> {
+        var ytg = (YTDBGraphTraversalSource) g;
+        ytg.yql("DROP INDEX KNOWS.creationDate IF EXISTS").iterate();
+      });
+      knowsCreationDateIndexInstalled = false;
+      log.info("Dropped KNOWS.creationDate index after BothE-KNOWS microbench");
+    } catch (RuntimeException e) {
+      log.warn("Failed to drop KNOWS.creationDate index; will retry on teardown", e);
+    }
   }
 
   @Setup(Level.Trial)
@@ -388,34 +447,17 @@ public class LdbcBenchmarkState {
         curatedParams.isMessageIds().length,
         curatedParams.ic1().length,
         curatedParams.ic3().length);
-
-    // Pre-compute a selective (95th-percentile) date once — used as a fixed
-    // lower bound by the hub bench so the filter is narrow enough for the
-    // pre-filter set to meaningfully reduce edge loads.
-    // Also pre-compute a narrower 99th-percentile date for the count/exists
-    // benches where maximally narrow selectivity exposes the pre-filter gap.
-    Date[] sortedDates = curatedParams.dates().clone();
-    Arrays.sort(sortedDates);
-    cachedSelectiveDate =
-        sortedDates[Math.min(sortedDates.length - 1, (int) (sortedDates.length * 0.95))];
-    cachedVerySelectiveDate =
-        sortedDates[Math.min(sortedDates.length - 1, (int) (sortedDates.length * 0.99))];
-
-    // Pre-compute top-100 Forums by HAS_MEMBER bag size. These are the hub
-    // vertices used by bothEHasMember_recentJoiners — ordinary Forums have
-    // dozens of members, hubs have tens of thousands, which is where the
-    // pre-filter optimization is designed to shine.
-    popularForumIds = executeSql(
-        "SELECT id, outE(\"HAS_MEMBER\").size() as sz "
-            + "FROM Forum ORDER BY sz DESC LIMIT 100")
-        .stream()
-        .mapToLong(row -> ((Number) row.get("id")).longValue())
-        .toArray();
-    log.info("Top-100 popular Forum IDs cached for hub benches");
   }
 
   @TearDown(Level.Trial)
   public void tearDown() {
+    // Restore the shared on-disk DB before the session goes away. The microbench
+    // state that installed the index drops it in its own teardown, but JMH gives
+    // no ordering guarantee between @State teardowns, so that drop may run after
+    // this method has already closed the session. Dropping here first makes the
+    // restore independent of that order.
+    dropKnowsCreationDateIndex();
+
     try {
       if (traversal != null) {
         traversal.close();

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
@@ -318,6 +318,33 @@ public class LdbcBenchmarkState {
     });
   }
 
+  /**
+   * Creates {@code KNOWS.creationDate} for the BothE-KNOWS microbench.
+   *
+   * <p>Kept out of {@code ldbc-schema.sql}: the index is unused by IC/IS queries
+   * but still occupies cache for every KNOWS edge and regresses IC1. Dropped
+   * again in {@link #dropKnowsCreationDateIndex()} so a shared on-disk DB does
+   * not leave the index behind for later IC/IS forks in the same suite.
+   */
+  void ensureKnowsCreationDateIndex() {
+    traversal.executeInTx(g -> {
+      var ytg = (YTDBGraphTraversalSource) g;
+      ytg.yql(
+          "CREATE INDEX KNOWS.creationDate IF NOT EXISTS ON KNOWS(creationDate) NOTUNIQUE")
+          .iterate();
+    });
+    log.info("Ensured KNOWS.creationDate index for BothE-KNOWS microbench");
+  }
+
+  /** Drops {@code KNOWS.creationDate} if present; see {@link #ensureKnowsCreationDateIndex()}. */
+  void dropKnowsCreationDateIndex() {
+    traversal.executeInTx(g -> {
+      var ytg = (YTDBGraphTraversalSource) g;
+      ytg.yql("DROP INDEX KNOWS.creationDate IF EXISTS").iterate();
+    });
+    log.info("Dropped KNOWS.creationDate index after BothE-KNOWS microbench");
+  }
+
   @Setup(Level.Trial)
   public void setup() throws Exception {
     String scaleFactor = System.getProperty("ldbc.scale.factor", "1");

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcBenchmarkState.java
@@ -251,6 +251,17 @@ public class LdbcBenchmarkState {
     return curatedParams.dates()[(int) (idx % curatedParams.dates().length)];
   }
 
+  /**
+   * Target-vertex {@code firstName} filter for the vertex {@code both('KNOWS')}
+   * benchmark. Reuses the IC1 curated first-name pool (real first names present
+   * in the dataset, backed by the {@code Person.firstName} index) so the
+   * pre-filter engages across both link-bag directions.
+   */
+  public String bothKnowsFirstName(long idx) {
+    var p = curatedParams.ic1()[(int) (idx % curatedParams.ic1().length)];
+    return p.firstName();
+  }
+
   // -- BothE-HAS_MEMBER (hub) extension parameters --
 
   /**

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
@@ -36,6 +36,15 @@ final class LdbcQuerySql {
   static final String IC12 = loadResource("ldbc-queries/IC12.sql");
   static final String IC13 = loadResource("ldbc-queries/IC13.sql");
 
+  // -- Extension queries (not part of LDBC standard) --
+
+  /**
+   * Recent KNOWS connections via bothE — targets the bidirectional pre-filter
+   * optimization introduced with {@code PreFilterableChainedIterable}.
+   * Requires {@code KNOWS.creationDate} index (added to {@code ldbc-schema.sql}).
+   */
+  static final String BOTH_E_KNOWS = loadResource("ldbc-queries/both-e-knows.sql");
+
   private LdbcQuerySql() {
   }
 

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
@@ -45,6 +45,14 @@ final class LdbcQuerySql {
    */
   static final String BOTH_E_KNOWS = loadResource("ldbc-queries/both-e-knows.sql");
 
+  /**
+   * Forum recent-joiners via bothE(HAS_MEMBER) — hub-shape variant of the
+   * pre-filter benchmark, targeting Forums with thousands of members. Requires
+   * {@code HAS_MEMBER.joinDate} index (present in {@code ldbc-schema.sql}).
+   */
+  static final String FORUM_RECENT_JOINERS =
+      loadResource("ldbc-queries/forum-recent-joiners.sql");
+
   private LdbcQuerySql() {
   }
 

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
@@ -53,6 +53,16 @@ final class LdbcQuerySql {
   static final String FORUM_RECENT_JOINERS =
       loadResource("ldbc-queries/forum-recent-joiners.sql");
 
+  /**
+   * Forum joiner-count via bothE(HAS_MEMBER) — count-only variant designed to
+   * maximise the visible speedup from the bothE pre-filter: no .inV() loads,
+   * no ORDER BY materialization, no attribute projection. The only cost is
+   * the edge scan/filter itself. Uses a narrow 99th-percentile lower-bound
+   * date so ~1% of edges survive.
+   */
+  static final String FORUM_JOINER_COUNT =
+      loadResource("ldbc-queries/forum-joiner-count.sql");
+
   private LdbcQuerySql() {
   }
 

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
@@ -46,6 +46,17 @@ final class LdbcQuerySql {
   static final String BOTH_E_KNOWS = loadResource("ldbc-queries/both-e-knows.sql");
 
   /**
+   * Named KNOWS neighbors via vertex-to-vertex {@code both('KNOWS')} — targets
+   * the {@code PreFilterableChainedIterable} vertex path
+   * ({@code VertexEntityImpl.getVertices(BOTH)}) introduced/fixed by YTDB-646.
+   * KNOWS is bidirectional in LDBC, so both {@code out_KNOWS} and
+   * {@code in_KNOWS} bags are populated — the two-direction shape that actually
+   * builds the chained iterable. Requires the {@code Person.firstName} index.
+   */
+  static final String BOTH_KNOWS_VERTEX =
+      loadResource("ldbc-queries/both-knows-vertex.sql");
+
+  /**
    * Forum recent-joiners via bothE(HAS_MEMBER) — hub-shape variant of the
    * pre-filter benchmark, targeting Forums with thousands of members. Requires
    * {@code HAS_MEMBER.joinDate} index (present in {@code ldbc-schema.sql}).

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQuerySql.java
@@ -41,7 +41,8 @@ final class LdbcQuerySql {
   /**
    * Recent KNOWS connections via bothE — targets the bidirectional pre-filter
    * optimization introduced with {@code PreFilterableChainedIterable}.
-   * Requires {@code KNOWS.creationDate} index (added to {@code ldbc-schema.sql}).
+   * Requires {@code KNOWS.creationDate}; created for the BothE microbench only
+   * (see {@link LdbcSingleThreadBothEBenchmark}), not in {@code ldbc-schema.sql}.
    */
   static final String BOTH_E_KNOWS = loadResource("ldbc-queries/both-e-knows.sql");
 

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
@@ -116,4 +116,28 @@ public class LdbcSingleThreadBothEBenchmark {
         "minDate", state.forumHubMinJoinDate(i),
         "limit", LIMIT);
   }
+
+  /**
+   * BothE-HAS_MEMBER count-only: maximises the visible speedup of the
+   * pre-filter by eliminating everything except the edge scan/filter.
+   * No {@code .inV()} vertex loads, no ORDER BY materialization, no
+   * attribute projection — the only remaining cost is
+   * "how many edges from the bag pass the joinDate filter", which maps
+   * directly to the edge-load count reduction delivered by
+   * {@code PreFilterableChainedIterable}.
+   *
+   * <p>Uses the 99th-percentile lower-bound date so selectivity is ~1%:
+   * hub Forum with thousands of members → dozens of survivors →
+   * the ratio "edges loaded without pre-filter / edges loaded with
+   * pre-filter" is maximal.
+   */
+  @Benchmark
+  public List<Map<String, Object>> bothEHasMember_joinerCount(
+      LdbcBenchmarkState state) {
+    long i = state.nextIndex();
+    return state.executeSql(
+        LdbcQuerySql.FORUM_JOINER_COUNT,
+        "forumId", state.forumHubId(i),
+        "minDate", state.forumHubVeryNarrowJoinDate(i));
+  }
 }

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
@@ -1,0 +1,95 @@
+package com.jetbrains.youtrackdb.benchmarks.ldbc;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Single-threaded benchmark for queries that exercise the {@code bothE} / {@code both}
+ * bidirectional traversal pre-filter optimization.
+ *
+ * <h2>What is measured</h2>
+ *
+ * <p>The benchmark runs the {@code BothE-KNOWS} query (see
+ * {@link LdbcQuerySql#BOTH_E_KNOWS}), which uses
+ * {@code .bothE('KNOWS'){where: (creationDate >= :minDate)}} to find recent
+ * KNOWS connections of a person in both directions.
+ *
+ * <p>With the {@code KNOWS.creationDate} index (declared in {@code ldbc-schema.sql}),
+ * the MATCH planner builds a RID set from the index and hands it to
+ * {@code MatchEdgeTraverser.applyPreFilter()}. Previously, {@code bothE()} returned
+ * a plain {@code IterableUtils.chainedIterable} which is not a
+ * {@code PreFilterableLinkBagIterable}, so the pre-filter was silently bypassed and
+ * all KNOWS edges were loaded before the date condition was checked. After the fix,
+ * both the {@code out_KNOWS} and {@code in_KNOWS} link bags are intersected against
+ * the index RID set in memory before any edge record is loaded from disk.
+ *
+ * <h2>Why this query is realistic</h2>
+ *
+ * <p>In the LDBC Social Network dataset, KNOWS edges are stored bidirectionally
+ * (A→B and B→A edges both exist). A real application might ask:
+ * "Show me all people I have connected with since I joined this organisation"
+ * without caring which side initiated the connection — a natural use case for
+ * {@code bothE}. A production implementation would add {@code DISTINCT} to
+ * deduplicate; this benchmark omits it intentionally to maximise the number of
+ * edges touched and make the pre-filter benefit more visible.
+ *
+ * <h2>Schema requirement</h2>
+ *
+ * <p>Requires the {@code KNOWS.creationDate NOTUNIQUE} index declared in
+ * {@code ldbc-schema.sql}. If running against a pre-built database that was created
+ * without this index, the benchmark will still produce correct results, but the
+ * pre-filter will not engage and throughput will reflect the unoptimised path.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 3, time = 10)
+@Fork(value = 5, jvmArgsAppend = {
+    "-Xms4g", "-Xmx4g",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED",
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+    "--add-opens=java.base/java.net=ALL-UNNAMED",
+    "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
+    "--add-opens=java.base/sun.security.x509=ALL-UNNAMED",
+    "--add-opens=jdk.unsupported/sun.misc=ALL-UNNAMED",
+})
+@Threads(1)
+public class LdbcSingleThreadBothEBenchmark {
+
+  private static final int LIMIT = 20;
+
+  /**
+   * BothE-KNOWS: recent connections via bidirectional KNOWS traversal with a
+   * date pre-filter.
+   *
+   * <p>Traverses both {@code out_KNOWS} and {@code in_KNOWS} link bags of a
+   * Person vertex and filters edges by {@code creationDate >= :minDate}. With
+   * the {@code KNOWS.creationDate} index, the MATCH engine intersects both bags
+   * against the index RID set via {@code PreFilterableChainedIterable} before
+   * loading any edge record from disk.
+   */
+  @Benchmark
+  public List<Map<String, Object>> bothEKnows_recentConnections(LdbcBenchmarkState state) {
+    long i = state.nextIndex();
+    return state.executeSql(
+        LdbcQuerySql.BOTH_E_KNOWS,
+        "personId", state.bothEKnowsPersonId(i),
+        "minDate", state.bothEKnowsMinDate(i),
+        "limit", LIMIT);
+  }
+}

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
@@ -92,4 +92,28 @@ public class LdbcSingleThreadBothEBenchmark {
         "minDate", state.bothEKnowsMinDate(i),
         "limit", LIMIT);
   }
+
+  /**
+   * BothE-HAS_MEMBER: recent joiners of a popular Forum — hub-shape variant of
+   * the pre-filter benchmark. Traverses {@code HAS_MEMBER} edges of a Forum in
+   * the top-100 by bag size (thousands of members) with a selective
+   * {@code joinDate} lower bound.
+   *
+   * <p>This is where YTDB-646 is designed to shine: the
+   * {@code HAS_MEMBER.joinDate} index lets {@code MatchEdgeTraverser}
+   * intersect the Forum's {@code out_HAS_MEMBER} link bag against a small RID
+   * set before loading any edge record, skipping most edge loads — in
+   * contrast to the small-bag {@code BothE-KNOWS} case (Person averages ~100
+   * KNOWS edges) where pre-filter overhead matches the savings.
+   */
+  @Benchmark
+  public List<Map<String, Object>> bothEHasMember_recentJoiners(
+      LdbcBenchmarkState state) {
+    long i = state.nextIndex();
+    return state.executeSql(
+        LdbcQuerySql.FORUM_RECENT_JOINERS,
+        "forumId", state.forumHubId(i),
+        "minDate", state.forumHubMinJoinDate(i),
+        "limit", LIMIT);
+  }
 }

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
@@ -94,6 +94,37 @@ public class LdbcSingleThreadBothEBenchmark {
   }
 
   /**
+   * Both-KNOWS (vertex): named KNOWS neighbors via vertex-to-vertex
+   * {@code both('KNOWS')}. Unlike {@link #bothEKnows_recentConnections} (which
+   * traverses edge records via {@code bothE}), this exercises the
+   * <em>vertex</em> {@code both()} path
+   * ({@code VertexEntityImpl.getVertices(BOTH)}) fixed by YTDB-646, which builds
+   * a single {@code PreFilterableChainedIterable} over the {@code out_KNOWS} and
+   * {@code in_KNOWS} link bags.
+   *
+   * <p>Because KNOWS is stored bidirectionally in LDBC, a Person's out_KNOWS and
+   * in_KNOWS bags are BOTH populated — the two-direction shape that actually
+   * constructs the chained iterable (single-direction shapes collapse to a
+   * single bag). KNOWS is symmetric (out=Person, in=Person), so the planner
+   * infers the target class Person and, with the {@code Person.firstName}
+   * index, intersects both bags against the index RID set before loading any
+   * neighbor vertex. A regression in the chained vertex path (broken per-sub
+   * pre-filter delegation, or reintroduction of the BG1/PF2 empty-direction
+   * fallback) would show up here as a throughput drop rather than silently
+   * degrading to unfiltered iteration.
+   */
+  @Benchmark
+  public List<Map<String, Object>> bothKnowsVertex_namedFriends(
+      LdbcBenchmarkState state) {
+    long i = state.nextIndex();
+    return state.executeSql(
+        LdbcQuerySql.BOTH_KNOWS_VERTEX,
+        "personId", state.bothEKnowsPersonId(i),
+        "firstName", state.bothKnowsFirstName(i),
+        "limit", LIMIT);
+  }
+
+  /**
    * BothE-HAS_MEMBER: recent joiners of a popular Forum — hub-shape variant of
    * the pre-filter benchmark. Traverses {@code HAS_MEMBER} edges of a Forum in
    * the top-100 by bag size (thousands of members) with a selective

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
@@ -54,7 +54,20 @@ import org.openjdk.jmh.annotations.Warmup;
  * <p>{@code bothEKnows_recentConnections} creates {@code KNOWS.creationDate} for
  * its Trial and drops it afterwards so the shared on-disk LDBC DB used by IC/IS
  * forks does not keep an unused KNOWS secondary index (which regresses IC1).
- * Other methods in this class use indexes already present in {@code ldbc-schema.sql}.
+ * {@code LdbcBenchmarkState.tearDown()} repeats the drop as a safety net, because
+ * JMH does not order teardowns across {@code @State} classes. Other methods in
+ * this class use indexes already present in {@code ldbc-schema.sql}.
+ *
+ * <h2>Why this class is excluded from the A/B compare suite</h2>
+ *
+ * <p>{@code ldbc-jmh-compare.yml} passes {@code -e} to skip this class on the
+ * full-suite path. Two reasons. It is the only benchmark class that writes to the
+ * shared on-disk DB, and an index build over every KNOWS edge evicts hot
+ * Person/KNOWS pages that the IC/IS benchmarks measure against — IC1 traverses
+ * KNOWS three hops deep and is the most exposed. It also yields no comparison
+ * signal, because the fork-point side of an A/B run does not have these
+ * benchmarks at all, so every row reads as "new". Run it on demand with
+ * {@code -Djmh.args="LdbcSingleThreadBothEBenchmark"}.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -96,6 +109,25 @@ public class LdbcSingleThreadBothEBenchmark {
     @TearDown(Level.Trial)
     public void tearDown(LdbcBenchmarkState state) {
       state.dropKnowsCreationDateIndex();
+    }
+  }
+
+  /**
+   * Trial-scoped helper that computes the hub-bench parameters (top-100 Forums by
+   * {@code HAS_MEMBER} bag size, plus the selective {@code joinDate} bounds).
+   *
+   * <p>These live behind a state class rather than in
+   * {@code LdbcBenchmarkState.setup()} because that setup is shared by every
+   * benchmark class: the Forum scan would then run in every IC/IS fork, both
+   * lengthening their setup and changing the page-cache state they measure
+   * against. Declaring it here scopes the work to forks of this class.
+   */
+  @State(Scope.Benchmark)
+  public static class ForumHubParams {
+
+    @Setup(Level.Trial)
+    public void setup(LdbcBenchmarkState state) {
+      state.computeForumHubParams();
     }
   }
 
@@ -168,7 +200,10 @@ public class LdbcSingleThreadBothEBenchmark {
    */
   @Benchmark
   public List<Map<String, Object>> bothEHasMember_recentJoiners(
-      LdbcBenchmarkState state) {
+      LdbcBenchmarkState state, ForumHubParams forumHubParams) {
+    // Parameter forces JMH to run ForumHubParams Trial setup, which populates
+    // the forumHubId / forumHubMinJoinDate pools read below.
+    Objects.requireNonNull(forumHubParams);
     long i = state.nextIndex();
     return state.executeSql(
         LdbcQuerySql.FORUM_RECENT_JOINERS,
@@ -193,7 +228,10 @@ public class LdbcSingleThreadBothEBenchmark {
    */
   @Benchmark
   public List<Map<String, Object>> bothEHasMember_joinerCount(
-      LdbcBenchmarkState state) {
+      LdbcBenchmarkState state, ForumHubParams forumHubParams) {
+    // Parameter forces JMH to run ForumHubParams Trial setup, which populates
+    // the forumHubId / forumHubVeryNarrowJoinDate pools read below.
+    Objects.requireNonNull(forumHubParams);
     long i = state.nextIndex();
     return state.executeSql(
         LdbcQuerySql.FORUM_JOINER_COUNT,

--- a/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
+++ b/jmh-ldbc/src/main/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcSingleThreadBothEBenchmark.java
@@ -2,13 +2,19 @@ package com.jetbrains.youtrackdb.benchmarks.ldbc;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
@@ -23,14 +29,15 @@ import org.openjdk.jmh.annotations.Warmup;
  * {@code .bothE('KNOWS'){where: (creationDate >= :minDate)}} to find recent
  * KNOWS connections of a person in both directions.
  *
- * <p>With the {@code KNOWS.creationDate} index (declared in {@code ldbc-schema.sql}),
- * the MATCH planner builds a RID set from the index and hands it to
- * {@code MatchEdgeTraverser.applyPreFilter()}. Previously, {@code bothE()} returned
- * a plain {@code IterableUtils.chainedIterable} which is not a
- * {@code PreFilterableLinkBagIterable}, so the pre-filter was silently bypassed and
- * all KNOWS edges were loaded before the date condition was checked. After the fix,
- * both the {@code out_KNOWS} and {@code in_KNOWS} link bags are intersected against
- * the index RID set in memory before any edge record is loaded from disk.
+ * <p>With the {@code KNOWS.creationDate} index (created for this microbench only —
+ * see {@link KnowsCreationDateIndex}), the MATCH planner builds a RID set from the
+ * index and hands it to {@code MatchEdgeTraverser.applyPreFilter()}. Previously,
+ * {@code bothE()} returned a plain {@code IterableUtils.chainedIterable} which is
+ * not a {@code PreFilterableLinkBagIterable}, so the pre-filter was silently
+ * bypassed and all KNOWS edges were loaded before the date condition was checked.
+ * After the fix, both the {@code out_KNOWS} and {@code in_KNOWS} link bags are
+ * intersected against the index RID set in memory before any edge record is loaded
+ * from disk.
  *
  * <h2>Why this query is realistic</h2>
  *
@@ -44,10 +51,10 @@ import org.openjdk.jmh.annotations.Warmup;
  *
  * <h2>Schema requirement</h2>
  *
- * <p>Requires the {@code KNOWS.creationDate NOTUNIQUE} index declared in
- * {@code ldbc-schema.sql}. If running against a pre-built database that was created
- * without this index, the benchmark will still produce correct results, but the
- * pre-filter will not engage and throughput will reflect the unoptimised path.
+ * <p>{@code bothEKnows_recentConnections} creates {@code KNOWS.creationDate} for
+ * its Trial and drops it afterwards so the shared on-disk LDBC DB used by IC/IS
+ * forks does not keep an unused KNOWS secondary index (which regresses IC1).
+ * Other methods in this class use indexes already present in {@code ldbc-schema.sql}.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -74,6 +81,25 @@ public class LdbcSingleThreadBothEBenchmark {
   private static final int LIMIT = 20;
 
   /**
+   * Trial-scoped helper that installs {@code KNOWS.creationDate} only while
+   * {@link #bothEKnows_recentConnections} runs, then removes it so later IC/IS
+   * benchmarks sharing the same DB path do not pay for the unused index.
+   */
+  @State(Scope.Benchmark)
+  public static class KnowsCreationDateIndex {
+
+    @Setup(Level.Trial)
+    public void setup(LdbcBenchmarkState state) {
+      state.ensureKnowsCreationDateIndex();
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown(LdbcBenchmarkState state) {
+      state.dropKnowsCreationDateIndex();
+    }
+  }
+
+  /**
    * BothE-KNOWS: recent connections via bidirectional KNOWS traversal with a
    * date pre-filter.
    *
@@ -84,7 +110,10 @@ public class LdbcSingleThreadBothEBenchmark {
    * loading any edge record from disk.
    */
   @Benchmark
-  public List<Map<String, Object>> bothEKnows_recentConnections(LdbcBenchmarkState state) {
+  public List<Map<String, Object>> bothEKnows_recentConnections(
+      LdbcBenchmarkState state, KnowsCreationDateIndex knowsCreationDateIndex) {
+    // Parameter forces JMH to run KnowsCreationDateIndex Trial setup/teardown.
+    Objects.requireNonNull(knowsCreationDateIndex);
     long i = state.nextIndex();
     return state.executeSql(
         LdbcQuerySql.BOTH_E_KNOWS,

--- a/jmh-ldbc/src/main/resources/ldbc-queries/both-e-knows.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-queries/both-e-knows.sql
@@ -1,0 +1,29 @@
+/* BothE-KNOWS: Recent connections of a person (bidirectional).
+
+   Given a Person and a minimum date, find all persons connected to them via
+   KNOWS edges (in either direction) where the connection was formed on or after
+   that date. Reports each KNOWS edge once regardless of which endpoint initiated
+   the connection.
+
+   In the LDBC dataset KNOWS is stored bidirectionally (A→B and B→A edges both
+   exist with the same creationDate). Using bothE traverses both the out_KNOWS
+   and in_KNOWS link bags in a single step. With the KNOWS.creationDate index,
+   the MATCH planner builds a RID set from the index and intersects it against
+   both link bags via PreFilterableChainedIterable — avoiding loading edge records
+   that fall outside the date window.
+
+   A production query would add DISTINCT to deduplicate the two edge directions;
+   this benchmark intentionally omits it to maximise the number of edges touched
+   and make the pre-filter benefit easier to measure.
+
+   Parameters:
+     :personId  — LDBC Person.id
+     :minDate   — lower bound for KNOWS.creationDate (inclusive)
+     :limit     — max rows returned */
+MATCH {class: Person, as: p, where: (id = :personId)}
+  .bothE('KNOWS'){as: k, where: (creationDate >= :minDate)}
+  .inV(){as: reachable}
+RETURN reachable.id as personId, reachable.firstName as firstName,
+  reachable.lastName as lastName, k.creationDate as since
+ORDER BY since DESC, personId ASC
+LIMIT :limit

--- a/jmh-ldbc/src/main/resources/ldbc-queries/both-knows-vertex.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-queries/both-knows-vertex.sql
@@ -1,0 +1,32 @@
+/* Both-KNOWS (vertex): Named friends of a person via vertex-to-vertex both().
+
+   Given a Person and a firstName, find all persons connected via KNOWS in
+   EITHER direction whose firstName matches. Unlike the bothE variant (which
+   traverses edge records), this uses the vertex-to-vertex both('KNOWS') step,
+   which — after YTDB-646 — resolves to VertexEntityImpl.getVertices(BOTH) and
+   builds a single PreFilterableChainedIterable spanning the out_KNOWS and
+   in_KNOWS link bags.
+
+   In the LDBC dataset KNOWS is stored bidirectionally, so a Person's out_KNOWS
+   and in_KNOWS bags are BOTH populated — this is the two-direction shape that
+   actually exercises the chained iterable (single-direction shapes collapse to
+   one bag and take the pre-existing single-bag path). KNOWS is a symmetric edge
+   (out=Person, in=Person), so the planner infers the target alias class Person;
+   with the Person.firstName index the MATCH engine intersects BOTH link bags
+   against the index RID set in memory before loading any neighbor vertex.
+
+   This benchmark exists specifically so a regression in the chained vertex
+   path (e.g. pre-filter delegation broken across the two sub-iterables, or the
+   BG1/PF2 empty-direction fallback reintroduced) becomes measurable rather than
+   silently degrading to unfiltered iteration.
+
+   Parameters:
+     :personId  — LDBC Person.id (the hub whose KNOWS neighbors we traverse)
+     :firstName — target-vertex firstName filter (indexed)
+     :limit     — max rows returned */
+MATCH {class: Person, as: p, where: (id = :personId)}
+  .both('KNOWS'){as: friend, where: (firstName = :firstName)}
+RETURN friend.id as personId, friend.firstName as firstName,
+  friend.lastName as lastName
+ORDER BY personId ASC
+LIMIT :limit

--- a/jmh-ldbc/src/main/resources/ldbc-queries/forum-joiner-count.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-queries/forum-joiner-count.sql
@@ -1,0 +1,26 @@
+/* Forum joiner-count: count-only bothE pre-filter benchmark.
+
+   Counts how many members joined a Forum since a given date, via
+   bothE('HAS_MEMBER') with a joinDate filter. This is a clean measurement
+   of the pre-filter benefit because there is no downstream work:
+     - no .inV() → no Person vertex loads
+     - no ORDER BY → no materialization of surviving edges for sorting
+     - no projection of edge properties → no per-edge attribute reads
+   The only cost is the traversal + filter itself, so the ratio
+   "edges loaded without pre-filter / edges loaded with pre-filter" maps
+   directly to the speedup.
+
+   Uses the same top-100 hub Forum pool as forum-recent-joiners, with a
+   narrower (99th-percentile) lower-bound date so only ~1% of edges pass
+   — making the savings from skipping index-filtered-out edge loads
+   maximally visible.
+
+   Semantically sensible query: "how many people joined this Forum since
+   date X" is a natural admin-dashboard / activity-report metric.
+
+   Parameters:
+     :forumId  — popular Forum.id (top-100 by HAS_MEMBER bag size)
+     :minDate  — narrow lower bound (99th percentile of curated dates) */
+MATCH {class: Forum, as: f, where: (id = :forumId)}
+  .bothE('HAS_MEMBER'){as: m, where: (joinDate >= :minDate)}
+RETURN count(*) as joinerCount

--- a/jmh-ldbc/src/main/resources/ldbc-queries/forum-recent-joiners.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-queries/forum-recent-joiners.sql
@@ -1,0 +1,18 @@
+/* Forum recent joiners: hub-shape bothE pre-filter benchmark.
+
+   Targets Forums with thousands of HAS_MEMBER edges so the YTDB-646
+   index-assisted pre-filter on HAS_MEMBER.joinDate has a meaningfully
+   large link bag to skip loads from. The complementary `both-e-knows`
+   benchmark covers the small-bag case (Person→KNOWS averages ~100 edges,
+   where pre-filter overhead matches savings and no speedup is measurable).
+
+   Parameters:
+     :forumId  — popular Forum.id (top-100 by HAS_MEMBER bag size)
+     :minDate  — lower bound for HAS_MEMBER.joinDate (inclusive, selective)
+     :limit    — max rows returned */
+MATCH {class: Forum, as: f, where: (id = :forumId)}
+  .bothE(HAS_MEMBER){as: m, where: (joinDate >= :minDate)}
+  .inV(){as: person}
+RETURN person.id as personId, m.joinDate as joined
+ORDER BY joined DESC, personId ASC
+LIMIT :limit

--- a/jmh-ldbc/src/main/resources/ldbc-schema.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-schema.sql
@@ -150,3 +150,9 @@ CREATE INDEX Message.creationDate ON Message(creationDate) NOTUNIQUE;
 CREATE INDEX Forum.creationDate ON Forum(creationDate) NOTUNIQUE;
 CREATE INDEX HAS_MEMBER.joinDate ON HAS_MEMBER(joinDate) NOTUNIQUE;
 CREATE INDEX WORK_AT.workFrom ON WORK_AT(workFrom) NOTUNIQUE;
+-- KNOWS.creationDate enables index-assisted pre-filtering for bothE('KNOWS') queries
+-- that filter by friendship date (e.g. "show all connections since date D").
+-- Without this index, bothE traversals load all KNOWS link-bag entries and
+-- filter post-load; with it, the planner uses PreFilterableChainedIterable to
+-- intersect both link-bag directions against the index RID set before any disk I/O.
+CREATE INDEX KNOWS.creationDate ON KNOWS(creationDate) NOTUNIQUE;

--- a/jmh-ldbc/src/main/resources/ldbc-schema.sql
+++ b/jmh-ldbc/src/main/resources/ldbc-schema.sql
@@ -150,9 +150,6 @@ CREATE INDEX Message.creationDate ON Message(creationDate) NOTUNIQUE;
 CREATE INDEX Forum.creationDate ON Forum(creationDate) NOTUNIQUE;
 CREATE INDEX HAS_MEMBER.joinDate ON HAS_MEMBER(joinDate) NOTUNIQUE;
 CREATE INDEX WORK_AT.workFrom ON WORK_AT(workFrom) NOTUNIQUE;
--- KNOWS.creationDate enables index-assisted pre-filtering for bothE('KNOWS') queries
--- that filter by friendship date (e.g. "show all connections since date D").
--- Without this index, bothE traversals load all KNOWS link-bag entries and
--- filter post-load; with it, the planner uses PreFilterableChainedIterable to
--- intersect both link-bag directions against the index RID set before any disk I/O.
-CREATE INDEX KNOWS.creationDate ON KNOWS(creationDate) NOTUNIQUE;
+-- KNOWS.creationDate is NOT created here. An unused secondary index on every
+-- KNOWS edge regresses IC1 (~3-hop out('KNOWS')) via cache pressure. The
+-- BothE-KNOWS microbench creates/drops it in LdbcSingleThreadBothEBenchmark.

--- a/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryCorrectnessTest.java
+++ b/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryCorrectnessTest.java
@@ -681,6 +681,63 @@ public class LdbcQueryCorrectnessTest {
     LdbcBenchmarkState.loadSqlStatements("/nonexistent-schema.sql");
   }
 
+  // ==================== BothE-KNOWS extension query ====================
+
+  /**
+   * Verifies that bothE('KNOWS') with a date filter returns the expected edges,
+   * including the correct count when KNOWS is stored bidirectionally.
+   *
+   * <p>Test graph KNOWS edges (created by createKnows — each is bidirectional):
+   * <pre>
+   *   Alice—Bob   creationDate = 2011-01-01
+   *   Alice—Carol creationDate = 2011-06-01
+   *   Bob—Dave    creationDate = 2011-03-01
+   *   Dave—Eve    creationDate = 2011-09-01
+   * </pre>
+   *
+   * <p>For Alice (KNOWS: Bob at 2011-01-01, Carol at 2011-06-01), using
+   * {@code bothE('KNOWS'){where: (creationDate >= :minDate)}.inV()} with
+   * minDate = 2011-06-01:
+   * <ul>
+   *   <li>out_KNOWS matches Alice→Carol (2011-06-01 ≥ 2011-06-01) → inV() = Carol</li>
+   *   <li>in_KNOWS matches Carol→Alice (2011-06-01 ≥ 2011-06-01) → inV() = Alice (self)</li>
+   * </ul>
+   * Both limit to 2 rows. Alice→Bob (2011-01-01 < 2011-06-01) is excluded by the pre-filter.
+   */
+  @Test
+  public void testBothEKnows_recentConnectionsFilter() {
+    // minDate = 2011-06-01: only Alice–Carol qualifies; Alice–Bob was 2011-01-01
+    var minDate = new Date(DATE_2011_06_01);
+    var rows = sql(LdbcQuerySql.BOTH_E_KNOWS,
+        "personId", ALICE, "minDate", minDate, "limit", 20);
+
+    // Both directions of Alice—Carol match, giving 2 rows:
+    // out_KNOWS(Alice→Carol).inV() = Carol, in_KNOWS(Carol→Alice).inV() = Alice (self).
+    assertEquals(
+        "bothE from Alice with minDate=2011-06-01 should return exactly 2 rows "
+            + "(one per direction of the Alice–Carol edge): " + rows,
+        2, rows.size());
+
+    // Both rows must have creationDate = 2011-06-01
+    for (var row : rows) {
+      assertEquals("since should match the KNOWS creationDate",
+          DATE_2011_06_01, ((Date) row.get("since")).getTime());
+    }
+  }
+
+  /**
+   * Verifies that a date filter that excludes all KNOWS edges returns zero rows.
+   */
+  @Test
+  public void testBothEKnows_nothingMatchesAfterAllEdges() {
+    // minDate far in the future — no KNOWS edge has this date
+    var minDate = new Date(DATE_2012_09_01);
+    var rows = sql(LdbcQuerySql.BOTH_E_KNOWS,
+        "personId", ALICE, "minDate", minDate, "limit", 20);
+
+    assertEquals("No KNOWS edges should match a future date", 0, rows.size());
+  }
+
   /** Verifies that all 20 SQL query constants are loaded and non-empty. */
   @Test
   public void testAllQuerySqlConstantsLoaded() {
@@ -704,6 +761,7 @@ public class LdbcQueryCorrectnessTest {
     assertNotNull(LdbcQuerySql.IC11);
     assertNotNull(LdbcQuerySql.IC12);
     assertNotNull(LdbcQuerySql.IC13);
+    assertNotNull(LdbcQuerySql.BOTH_E_KNOWS);
     assertTrue("IS1 should contain SQL", LdbcQuerySql.IS1.length() > 10);
   }
 

--- a/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryCorrectnessTest.java
+++ b/jmh-ldbc/src/test/java/com/jetbrains/youtrackdb/benchmarks/ldbc/LdbcQueryCorrectnessTest.java
@@ -738,6 +738,37 @@ public class LdbcQueryCorrectnessTest {
     assertEquals("No KNOWS edges should match a future date", 0, rows.size());
   }
 
+  // ==================== Forum count / exists extension queries ====================
+
+  /**
+   * FORUM_JOINER_COUNT: counts members of the Alice's-Wall Forum who joined
+   * on or after a given date. Test graph (created in loadTestData):
+   *   FORUM_ALICE_WALL HAS_MEMBER Bob   joinDate = 2012-01-01
+   *   FORUM_ALICE_WALL HAS_MEMBER Carol joinDate = 2011-01-01
+   * Verifies both a permissive and a restrictive filter, plus a future date
+   * that excludes everything.
+   */
+  @Test
+  public void testForumJoinerCount_variousDates() {
+    // minDate = 2011-01-01 (inclusive lower bound): both Bob and Carol qualify
+    var all = sql(LdbcQuerySql.FORUM_JOINER_COUNT,
+        "forumId", FORUM_ALICE_WALL, "minDate", new Date(DATE_2011_01_01));
+    assertEquals(1, all.size());
+    assertEquals(2L, toLong(all.get(0).get("joinerCount")));
+
+    // minDate = 2012-01-01: only Bob qualifies
+    var recent = sql(LdbcQuerySql.FORUM_JOINER_COUNT,
+        "forumId", FORUM_ALICE_WALL, "minDate", new Date(DATE_2012_01_01));
+    assertEquals(1, recent.size());
+    assertEquals(1L, toLong(recent.get(0).get("joinerCount")));
+
+    // minDate = future: nobody qualifies, count is 0
+    var future = sql(LdbcQuerySql.FORUM_JOINER_COUNT,
+        "forumId", FORUM_ALICE_WALL, "minDate", new Date(DATE_2012_09_01));
+    assertEquals(1, future.size());
+    assertEquals(0L, toLong(future.get(0).get("joinerCount")));
+  }
+
   /** Verifies that all 20 SQL query constants are loaded and non-empty. */
   @Test
   public void testAllQuerySqlConstantsLoaded() {
@@ -762,6 +793,8 @@ public class LdbcQueryCorrectnessTest {
     assertNotNull(LdbcQuerySql.IC12);
     assertNotNull(LdbcQuerySql.IC13);
     assertNotNull(LdbcQuerySql.BOTH_E_KNOWS);
+    assertNotNull(LdbcQuerySql.FORUM_RECENT_JOINERS);
+    assertNotNull(LdbcQuerySql.FORUM_JOINER_COUNT);
     assertTrue("IS1 should contain SQL", LdbcQuerySql.IS1.length() > 10);
   }
 


### PR DESCRIPTION
## Summary

Enables **index-assisted pre-filtering** for `both()` / `bothE()` MATCH patterns. Previously these traversals silently degraded to full, unfiltered iteration: `VertexEntityImpl` returned an Apache Commons `ChainedIterable` that did not implement `PreFilterableLinkBagIterable`, so the pre-filter machinery could not attach to it and every candidate was materialized before the `WHERE` filter ran. This PR makes the both-direction traversal pre-filterable end to end and teaches the MATCH planner to infer target classes for symmetric edges.

## Motivation

`out()` / `in()` already benefit from index-assisted pre-filtering, but `both()` / `bothE()` did not: the combined (OUT + IN) iterable was not a `PreFilterableLinkBagIterable`, so a query like `both('KNOWS'){where: creationDate >= :d}` loaded the entire adjacency before filtering. On high-degree vertices this is the difference between an index probe and a full neighbor scan.

## Implementation

- **`PreFilterableChainedIterable`** (new): wraps the per-direction sub-iterables and implements `PreFilterableLinkBagIterable` — `withClassFilter`, `withRidFilter(Set<RID>, Ratio)`, and `size()`. Iteration is single-pass via a `ChainedIterator` (no buffering; each sub-iterable is drawn exactly once). Filter operations delegate to every sub-iterable and re-chain; the shared `Ratio` effectiveness metric accumulates correctly across both directions (element-weighted via the underlying meter).
- **`VertexEntityImpl.getVertices(Direction.BOTH)`**: now delegates to `getVerticesOptimized(Direction.BOTH, type)`, producing a single flat combined list (mirroring how `getEdges(BOTH)` already works) instead of nesting two separate OUT/IN chained calls. This is what restores pre-filtering for the common **asymmetric** case (a label present in only one direction) — the old nested form injected an empty sentinel that disabled pre-filtering for the whole result.
- **`MatchExecutionPlanner`**: recognizes `bothE` as an edge-method and infers target classes — `both('X')` infers the shared endpoint class for symmetric edges (and deliberately infers **nothing** when the two endpoints differ, see Risks), and `bothE('X').inV()` / `.outV()` infer the deterministic schema endpoint class.

## Behavior notes

Neighbor iteration order for `both()` changes from *all-OUT-then-all-IN* to *interleaved by edge-property name* — the same order `getEdges(BOTH)` already produces. `both()` results are unordered by contract (no `ORDER BY`), and a sweep of the test suite and consumers confirmed nothing depends on the previous grouping.

## Testing

- **`PreFilterableChainedIterableTest`** (new): iterator boundary cases (empty head/middle/tail, all-empty, single element).
- **`MatchEdgeMethodPreFilterTest`**: a two-populated-direction regression test that builds a vertex with the same label going OUT and IN, applies a filter that excludes neighbors on each side, and asserts (a) the excluded neighbors are absent and (b) the plan contains `intersection:` — i.e. the pre-filter genuinely engaged, not just the downstream `WHERE`. Symmetric-edge test strengthened with a filter-excluded neighbor.
- **`MatchExecutionPlannerMutationTest`**: positive `bothE('X').inV()` class-inference test for a registered symmetric edge.
- **`LdbcQueryCorrectnessTest`**: end-to-end `bothE(...)` correctness.

## Benchmarks

LDBC JMH benchmarks added/extended: hub-shape `bothE(HAS_MEMBER)`, single-thread `bothE(KNOWS)`, and a two-direction `both('KNOWS')` vertex benchmark that actually exercises the chained pre-filterable path so a regression in it is detectable.

## Risks & accepted trade-offs

- **Heterogeneous `both('X')`** (endpoints of different classes, e.g. `HAS_MEMBER` = Forum↔Person) intentionally infers no target class. This is a safety guard: the worst case is a missed optimization, never a wrong-class filter or wrong results. Verified against the real heterogeneous `HAS_MEMBER` schema.