### PR TITLE
YTDB-626: Remove per-op SEVERE log spam on PageOperation WAL restore

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -5483,7 +5483,10 @@ public abstract class AbstractStorage
               // and must not be logged per-operation: on large restores it
               // produces millions of SEVERE entries whose stack-trace capture
               // (SLF4J fillCallerData) turns restore into a CPU bottleneck and
-              // exceeds the CI watchdog.
+              // exceeds the CI watchdog. The sibling UpdatePageRecord branch
+              // above retains an analogous log; it has the same latent issue
+              // but is not the hot path after YTDB-626 and is left as
+              // follow-up cleanup.
               pageOp.redo(durablePage);
               durablePage.setLsn(pageOp.getLsn());
             }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -5476,30 +5476,14 @@ public abstract class AbstractStorage
             var pageLsn = durablePage.getLsn();
 
             if (pageLsn.compareTo(pageOp.getLsn()) < 0) {
-              // initialLsn CAS check: detects unexpected page state. For
-              // multi-operation pages (common during B-tree splits), the 2nd+
-              // operation's initialLsn won't match pageLsn (updated by prior ops'
-              // redo), producing a false-positive error log. This matches the
-              // existing UpdatePageRecord behavior and is not a correctness issue
-              // — tracked as optional improvement (T4-3).
-              if (!pageLsn.equals(pageOp.getInitialLsn())) {
-                LogManager.instance()
-                    .error(
-                        this,
-                        "Page with index "
-                            + pageIndex
-                            + " and file "
-                            + writeCache.fileNameById(fileId)
-                            + " was changed before page restore was started. Page will"
-                            + " be restored from WAL, but it may contain changes that"
-                            + " were not present before storage crash and data may be"
-                            + " lost. Initial LSN is "
-                            + pageOp.getInitialLsn()
-                            + ", but page contains changes with LSN "
-                            + pageLsn,
-                        null);
-              }
-
+              // For multi-operation pages (common during B-tree splits), a given
+              // operation's initialLsn typically does not match the current
+              // pageLsn — prior operations in the same atomic unit have already
+              // advanced it via redo. That mismatch is not a corruption signal
+              // and must not be logged per-operation: on large restores it
+              // produces millions of SEVERE entries whose stack-trace capture
+              // (SLF4J fillCallerData) turns restore into a CPU bottleneck and
+              // exceeds the CI watchdog.
               pageOp.redo(durablePage);
               durablePage.setLsn(pageOp.getLsn());
             }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/HashJoinPlannerIntegrationTest.java
@@ -7,9 +7,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * End-to-end SQL-level integration tests verifying that hash join optimizations
@@ -30,7 +32,13 @@ import org.junit.Test;
  * <p>The Person class has small cardinality (5 records), well below
  * {@link GlobalConfiguration#QUERY_MATCH_HASH_JOIN_THRESHOLD}, so eligible patterns
  * will use hash join instead of nested-loop evaluation.
+ *
+ * <p>Runs sequentially because several tests mutate
+ * {@link GlobalConfiguration#QUERY_MATCH_HASH_JOIN_THRESHOLD}, a JVM-wide
+ * singleton that would race with other MATCH tests reading the same entry in
+ * the parallel-classes surefire pool.
  */
+@Category(SequentialTest.class)
 public class HashJoinPlannerIntegrationTest extends DbTestBase {
 
   @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/InvertedWhileHashJoinTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/InvertedWhileHashJoinTest.java
@@ -7,9 +7,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Integration tests for the inverted-WHILE hash join optimization. Tests use a
@@ -27,7 +29,13 @@ import org.junit.Test;
  *     tag2 --HAS_TYPE--> OtherClass     (reachable from RootClass)
  *     tag3 --HAS_TYPE--> UnrelatedClass (NOT reachable from RootClass)
  * </pre>
+ *
+ * <p>Runs sequentially because tests mutate
+ * {@link GlobalConfiguration#QUERY_MATCH_HASH_JOIN_THRESHOLD}, a JVM-wide
+ * singleton that would race with other MATCH tests reading the same entry in
+ * the parallel-classes surefire pool.
  */
+@Category(SequentialTest.class)
 public class InvertedWhileHashJoinTest extends DbTestBase {
 
   @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchPlannerHelpersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchPlannerHelpersTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
@@ -27,6 +28,7 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Unit tests for the static helper methods in {@link MatchExecutionPlanner} that support
@@ -36,28 +38,44 @@ import org.junit.Test;
  * <p>These helpers inspect NOT match expressions to determine whether they can be
  * independently materialized (no {@code $matched}/{@code $parent} dependency) and which
  * aliases are shared with the positive pattern (forming the join key).
+ *
+ * <p>Runs sequentially because it pins JVM-wide {@link GlobalConfiguration}
+ * entries in {@code @Before}/{@code @After} — {@code QUERY_STATS_DEFAULT_FAN_OUT},
+ * {@code QUERY_STATS_DEFAULT_SELECTIVITY}, and {@code QUERY_MATCH_HASH_JOIN_THRESHOLD}.
+ * The last entry is also mutated by other MATCH test classes
+ * ({@code MatchStepUnitTest}, {@code HashJoinPlannerIntegrationTest},
+ * {@code InvertedWhileHashJoinTest}), so running in the parallel-classes pool
+ * would race with those classes.
  */
+@Category(SequentialTest.class)
 public class MatchPlannerHelpersTest {
 
   // Pin config values so tests don't break if defaults change
   private static final double TEST_FAN_OUT = 10.0;
   private static final double TEST_SELECTIVITY = 0.1;
+  private static final long TEST_HASH_JOIN_THRESHOLD = 10_000L;
 
   private Object savedFanOut;
   private Object savedSelectivity;
+  private Object savedHashJoinThreshold;
 
   @Before
   public void pinConfig() {
     savedFanOut = GlobalConfiguration.QUERY_STATS_DEFAULT_FAN_OUT.getValue();
     savedSelectivity = GlobalConfiguration.QUERY_STATS_DEFAULT_SELECTIVITY.getValue();
+    savedHashJoinThreshold = GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.getValue();
     GlobalConfiguration.QUERY_STATS_DEFAULT_FAN_OUT.setValue(TEST_FAN_OUT);
     GlobalConfiguration.QUERY_STATS_DEFAULT_SELECTIVITY.setValue(TEST_SELECTIVITY);
+    // Pin the hash-join threshold too so canUseHashJoin_* assertions are independent of
+    // sibling test classes that also mutate this config entry.
+    GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(TEST_HASH_JOIN_THRESHOLD);
   }
 
   @After
   public void restoreConfig() {
     GlobalConfiguration.QUERY_STATS_DEFAULT_FAN_OUT.setValue(savedFanOut);
     GlobalConfiguration.QUERY_STATS_DEFAULT_SELECTIVITY.setValue(savedSelectivity);
+    GlobalConfiguration.QUERY_MATCH_HASH_JOIN_THRESHOLD.setValue(savedHashJoinThreshold);
   }
 
   // ── notPatternDependsOnMatched ──────────────────────────────────────────

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
@@ -48,11 +49,18 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Unit tests for MATCH execution step classes that exercise copy(), prettyPrint(),
  * and other methods not covered by integration tests.
+ *
+ * <p>Runs sequentially because several tests mutate
+ * {@link GlobalConfiguration#QUERY_MATCH_HASH_JOIN_THRESHOLD}, a JVM-wide
+ * singleton that would race with other MATCH tests reading the same entry in
+ * the parallel-classes surefire pool.
  */
+@Category(SequentialTest.class)
 public class MatchStepUnitTest extends DbTestBase {
 
   // -- EdgeTraversal tests --


### PR DESCRIPTION
## Motivation

Fixes the CI failure on `develop` (run 24560902090 — commit f3c15382b9, YTDB-626).

`StorageBackupMTIT.testParallelBackup` was killed by the JUnit watchdog at 3622 s (60-min timeout). Thread dump showed the main thread stuck in `StackTraceElement.initStackTraceElements` under SLF4J's caller-data capture — the test is not deadlocked, it is **CPU-bound inside logging**.

### Root cause

YTDB-626 added the `PageOperation` WAL record type. Each `PageOperation` carries an `initialLsn` captured at operation-creation time. `AbstractStorage.restoreAtomicUnit` re-applied the op under two checks:

```java
if (pageLsn.compareTo(pageOp.getLsn()) < 0) {               // outer: skip if already applied
  if (!pageLsn.equals(pageOp.getInitialLsn())) {            // inner: diagnostic only
    LogManager.instance().error(this, "Page ... was changed before page restore was started ...");
  }
  pageOp.redo(durablePage);
  durablePage.setLsn(pageOp.getLsn());
}
```

The inner check was already documented as a false-positive source (T4-3 cleanup): for **multi-operation pages** (routine during B-tree splits), the 2nd+ op's `initialLsn` reflects the page state before the atomic unit, whereas `pageLsn` at that moment reflects the 1st op's post-redo LSN — so they never match. The code proceeds to `redo` regardless; the log adds no protection.

During restore of a DB that wrote concurrently for 15 minutes, this fires on every sub-operation of every multi-op page. Combined with SLF4J's `fillCallerData` stack-trace capture per call, restore becomes single-threaded CPU-bound and exceeds the 60-minute watchdog.

### Fix

Remove the inner check and its SEVERE log. The outer `pageLsn < pageOp.getLsn()` guard continues to make `redo` idempotent against re-replay (each op's `setLsn` advances pageLsn monotonically; any op with LSN `<=` pageLsn is skipped as already applied). No durability invariant changes — this is a pure log-suppression.

The analogous branch for legacy `UpdatePageRecord` is left untouched: same latent issue, but not the hot path after YTDB-626, and out of scope for this CI-fix. Noted in the comment as follow-up.

## Verification

- `./mvnw -pl core verify -P ci-integration-tests -Dit.test=StorageBackupMTIT#testParallelBackup`
  - **Before fix**: killed by watchdog at 3622 s.
  - **After fix**: `Tests run: 1, Failures: 0, Errors: 0 — Time elapsed: 1110 s`. `Databases match.` (restore + full DB compare succeeded).
- Dimensional review (crash-safety, bugs/concurrency, code-quality) — three agents, all clean; no findings beyond a request to cross-reference the `UpdatePageRecord` sibling in the comment (addressed).

## Test plan

- [x] `./mvnw -pl core verify -P ci-integration-tests -Dit.test=StorageBackupMTIT#testParallelBackup` (passes in 18.5 min)
- [x] Spotless check
- [ ] CI pipeline green on this PR

Automated fix by ci-fix-agent