### PR TITLE
Collapse storage close into single drainAll pass

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -273,6 +273,21 @@ public class ConcurrentLongIntHashMap<V> {
     }
   }
 
+  /**
+   * Like {@link #drainAll(Consumer)} but without the per-value callback — each section is cleared
+   * and shrunk back to its constructor-time capacity without allocating a temporary list or
+   * scanning to collect values. Intended for callers that have already processed every entry via
+   * {@link #forEachValue} and only need the backing arrays released.
+   *
+   * <p>Same cross-section atomicity caveat as {@link #drainAll(Consumer)} and {@link #clear()} —
+   * a concurrent {@code put} on a not-yet-cleared section may survive the call.
+   */
+  public void clearAndShrink() {
+    for (Section<V> s : sections) {
+      s.clearAndShrink();
+    }
+  }
+
   /** Iterates all entries, passing (fileId, pageIndex, value) to the consumer. */
   public void forEach(LongIntObjConsumer<V> consumer) {
     for (Section<V> s : sections) {
@@ -834,12 +849,21 @@ public class ConcurrentLongIntHashMap<V> {
      * invoke {@code consumer} for each collected value outside the lock. The list is sized from
      * {@code size} only as a hint — an {@link ArrayList} is used so the code stays bounds-safe
      * even if a future change lets the non-null slot count diverge from the volatile counter.
+     *
+     * <p>When {@code size == 0} the scan and list allocation are skipped; the section is still
+     * shrunk to {@link #initialCapacity} if it has grown past it, so repeated drains eventually
+     * release the retained array.
      */
     @SuppressWarnings("unchecked")
     void drain(Consumer<V> consumer) {
-      ArrayList<V> collected;
+      final ArrayList<V> collected;
       long stamp = lock.writeLock();
       try {
+        if (size == 0) {
+          shrinkIfGrown();
+          return;
+        }
+
         collected = new ArrayList<>(size);
         for (int i = 0; i < capacity; i++) {
           Entry<V> e = entries[i];
@@ -850,14 +874,7 @@ public class ConcurrentLongIntHashMap<V> {
         assert collected.size() == size
             : "collected.size() (" + collected.size() + ") != size (" + size + ")";
 
-        // Reset to the constructor's initial capacity — releases the large array accumulated
-        // during normal operation while keeping enough headroom to avoid an immediate rehash
-        // chain if the map is refilled after drain.
-        entries = new Entry[initialCapacity];
-        capacity = initialCapacity;
-        resizeThreshold = (int) (initialCapacity * FILL_FACTOR);
-        size = 0;
-        usedBuckets = 0;
+        resetToInitialCapacity();
       } finally {
         lock.unlockWrite(stamp);
       }
@@ -866,6 +883,51 @@ public class ConcurrentLongIntHashMap<V> {
       // callbacks may safely re-enter the map.
       for (V v : collected) {
         consumer.accept(v);
+      }
+    }
+
+    /**
+     * Drain variant that skips the value-collection pass. Equivalent to {@link #drain(Consumer)}
+     * with a no-op consumer, but avoids the per-section {@link ArrayList} allocation and the
+     * linear scan that populates it. Intended for callers that have already processed every
+     * entry via {@link #forEachValue} and only need the section reset to its initial capacity.
+     */
+    @SuppressWarnings("unchecked")
+    void clearAndShrink() {
+      long stamp = lock.writeLock();
+      try {
+        if (size == 0) {
+          shrinkIfGrown();
+          return;
+        }
+        resetToInitialCapacity();
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    /**
+     * Reset to the constructor's initial capacity — releases the large array accumulated during
+     * normal operation while keeping enough headroom to avoid an immediate rehash chain if the
+     * map is refilled after drain. Must be called under the section write lock.
+     */
+    @SuppressWarnings("unchecked")
+    private void resetToInitialCapacity() {
+      entries = new Entry[initialCapacity];
+      capacity = initialCapacity;
+      resizeThreshold = (int) (initialCapacity * FILL_FACTOR);
+      size = 0;
+      usedBuckets = 0;
+    }
+
+    /**
+     * If the section has grown past {@link #initialCapacity}, reset it; otherwise it's already
+     * at minimum size and re-allocating the array would be pure waste. Must be called under the
+     * section write lock with {@code size == 0}.
+     */
+    private void shrinkIfGrown() {
+      if (capacity != initialCapacity) {
+        resetToInitialCapacity();
       }
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -251,11 +251,12 @@ public class ConcurrentLongIntHashMap<V> {
 
   /**
    * Drains every entry from the map, invoking {@code consumer} for each removed value. After this
-   * method returns, the map is empty and each section's capacity has been reset to the default
-   * minimum (so the large arrays accumulated during normal operation are released).
+   * method returns, the map is empty and each section's capacity has been reset to the capacity
+   * it was originally constructed with — releasing the large arrays accumulated during normal
+   * operation without forcing a rehash chain if the map is refilled later.
    *
    * <p>Each section is drained under its own write lock, with collected values copied into a
-   * temporary array. The lock is released <b>before</b> the consumer is invoked, so callbacks may
+   * temporary list. The lock is released <b>before</b> the consumer is invoked, so callbacks may
    * re-enter the map (matching the reentrancy contract of {@link #removeByFileId(long)}).
    *
    * <p>Cost is {@code O(total capacity)} regardless of how many distinct {@code fileId} values are
@@ -408,9 +409,17 @@ public class ConcurrentLongIntHashMap<V> {
     /** Resize when usedBuckets exceeds this. */
     private int resizeThreshold;
 
+    /**
+     * Capacity the section was originally constructed with. {@link #drain} resets to this value
+     * rather than the absolute minimum (2) so a map that is refilled after a drain does not pay
+     * a rehash chain (2 → 4 → 8 → … → working-set size) on the way back up.
+     */
+    private final int initialCapacity;
+
     @SuppressWarnings("unchecked")
     Section(int capacity) {
       this.capacity = alignToPowerOfTwo(Math.max(2, capacity));
+      this.initialCapacity = this.capacity;
       this.entries = new Entry[this.capacity];
       this.size = 0;
       this.usedBuckets = 0;
@@ -821,35 +830,32 @@ public class ConcurrentLongIntHashMap<V> {
     }
 
     /**
-     * Drain all live entries into a temporary array, reset the section to an empty default-sized
-     * table, then invoke {@code consumer} for each collected value outside the lock. Shrinking
-     * the table avoids retaining a large array after close — the next put() will rehash on
-     * demand.
+     * Drain all live entries into a list, reset the section to its {@link #initialCapacity}, then
+     * invoke {@code consumer} for each collected value outside the lock. The list is sized from
+     * {@code size} only as a hint — an {@link ArrayList} is used so the code stays bounds-safe
+     * even if a future change lets the non-null slot count diverge from the volatile counter.
      */
     @SuppressWarnings("unchecked")
     void drain(Consumer<V> consumer) {
-      Object[] collected;
-      int collectedCount;
+      ArrayList<V> collected;
       long stamp = lock.writeLock();
       try {
-        collected = new Object[size];
-        int k = 0;
+        collected = new ArrayList<>(size);
         for (int i = 0; i < capacity; i++) {
           Entry<V> e = entries[i];
           if (e != null) {
-            collected[k++] = e.value;
+            collected.add(e.value);
           }
         }
-        collectedCount = k;
-        assert collectedCount == size
-            : "collectedCount (" + collectedCount + ") != size (" + size + ")";
+        assert collected.size() == size
+            : "collected.size() (" + collected.size() + ") != size (" + size + ")";
 
-        // Reset to a small empty table — no reason to retain capacity accumulated during
-        // normal operation; subsequent puts will rehash on demand.
-        int newCapacity = alignToPowerOfTwo(2);
-        entries = new Entry[newCapacity];
-        capacity = newCapacity;
-        resizeThreshold = (int) (newCapacity * FILL_FACTOR);
+        // Reset to the constructor's initial capacity — releases the large array accumulated
+        // during normal operation while keeping enough headroom to avoid an immediate rehash
+        // chain if the map is refilled after drain.
+        entries = new Entry[initialCapacity];
+        capacity = initialCapacity;
+        resizeThreshold = (int) (initialCapacity * FILL_FACTOR);
         size = 0;
         usedBuckets = 0;
       } finally {
@@ -858,8 +864,8 @@ public class ConcurrentLongIntHashMap<V> {
 
       // Invoke consumer outside the section's write lock. Matches removeByFileId's contract so
       // callbacks may safely re-enter the map.
-      for (int i = 0; i < collectedCount; i++) {
-        consumer.accept((V) collected[i]);
+      for (V v : collected) {
+        consumer.accept(v);
       }
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -242,6 +242,32 @@ public class ConcurrentLongIntHashMap<V> {
     return result;
   }
 
+  /**
+   * Removes all entries whose {@code fileId} high 32 bits match {@code storageId} — i.e., every
+   * entry belonging to the storage whose {@code WriteCache.getId() == storageId}.
+   *
+   * <p>One write-locked sweep per section, matching the contract of {@link #removeByFileId(long)}:
+   * matching entries are collected into the returned list and nullified in place, then the section
+   * is rehashed at the same capacity to repair probe chains. The returned list is safe to iterate
+   * outside any segment lock.
+   *
+   * <p>Cost is {@code O(total capacity)} regardless of the number of files in the storage —
+   * intended for {@code closeStorage}/{@code deleteStorage} callers that would otherwise iterate
+   * {@link #removeByFileId(long)} once per file ({@code O(files * total capacity)}) AND must not
+   * touch entries belonging to other storages sharing the same JVM-level cache.
+   *
+   * <p>Cross-section removal is not collectively atomic, matching {@link #removeByFileId(long)}.
+   *
+   * @return a list of removed values (may be empty, never null)
+   */
+  public List<V> removeByStorageId(int storageId) {
+    var result = new ArrayList<V>();
+    for (Section<V> section : sections) {
+      section.removeByStorageId(storageId, result);
+    }
+    return result;
+  }
+
   /** Removes all entries from all sections. */
   public void clear() {
     for (Section<V> s : sections) {
@@ -684,6 +710,49 @@ public class ConcurrentLongIntHashMap<V> {
         // Since we used simple nullification (not backward-sweep per entry), there may be
         // gaps in probe chains. A same-capacity rehash restores probe chain integrity.
         rehashSameCapacity();
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+    }
+
+    /**
+     * Remove all entries whose {@code fileId} high 32 bits equal {@code storageId}. Same
+     * single-pass-per-section + same-capacity-rehash strategy as {@link #removeByFileId(long,
+     * List)}; only the match predicate differs.
+     *
+     * <p>If the section ends up empty after the sweep, additionally shrinks back to
+     * {@link #initialCapacity} to release the large backing array accumulated during normal
+     * operation. This matches the memory-return behavior of {@link #drain(Consumer)} — important
+     * for long-lived JVMs that repeatedly close storages.
+     */
+    void removeByStorageId(int storageId, List<V> removedEntries) {
+      long stamp = lock.writeLock();
+      try {
+        int removed = 0;
+        for (int i = 0; i < capacity; i++) {
+          Entry<V> e = entries[i];
+          if (e != null && ((int) (e.fileId >>> 32)) == storageId) {
+            removedEntries.add(e.value);
+            entries[i] = null;
+            removed++;
+          }
+        }
+
+        if (removed == 0) {
+          return;
+        }
+
+        size -= removed;
+        usedBuckets -= removed;
+        assert size >= 0 : "size went negative after removeByStorageId: " + size;
+        assert usedBuckets >= 0
+            : "usedBuckets went negative after removeByStorageId: " + usedBuckets;
+
+        if (size == 0) {
+          shrinkIfGrown();
+        } else {
+          rehashSameCapacity();
+        }
       } finally {
         lock.unlockWrite(stamp);
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMap.java
@@ -249,6 +249,29 @@ public class ConcurrentLongIntHashMap<V> {
     }
   }
 
+  /**
+   * Drains every entry from the map, invoking {@code consumer} for each removed value. After this
+   * method returns, the map is empty and each section's capacity has been reset to the default
+   * minimum (so the large arrays accumulated during normal operation are released).
+   *
+   * <p>Each section is drained under its own write lock, with collected values copied into a
+   * temporary array. The lock is released <b>before</b> the consumer is invoked, so callbacks may
+   * re-enter the map (matching the reentrancy contract of {@link #removeByFileId(long)}).
+   *
+   * <p>Cost is {@code O(total capacity)} regardless of how many distinct {@code fileId} values are
+   * present — intended for storage close/delete, where the caller would otherwise iterate files
+   * and call {@link #removeByFileId(long)} once per file (which is
+   * {@code O(files * total capacity)}).
+   *
+   * <p>Cross-section iteration is not collectively atomic — matching {@link #clear()} — so a
+   * concurrent {@code put} on a not-yet-drained section may survive the call.
+   */
+  public void drainAll(Consumer<V> consumer) {
+    for (Section<V> s : sections) {
+      s.drain(consumer);
+    }
+  }
+
   /** Iterates all entries, passing (fileId, pageIndex, value) to the consumer. */
   public void forEach(LongIntObjConsumer<V> consumer) {
     for (Section<V> s : sections) {
@@ -794,6 +817,49 @@ public class ConcurrentLongIntHashMap<V> {
         usedBuckets = 0;
       } finally {
         lock.unlockWrite(stamp);
+      }
+    }
+
+    /**
+     * Drain all live entries into a temporary array, reset the section to an empty default-sized
+     * table, then invoke {@code consumer} for each collected value outside the lock. Shrinking
+     * the table avoids retaining a large array after close — the next put() will rehash on
+     * demand.
+     */
+    @SuppressWarnings("unchecked")
+    void drain(Consumer<V> consumer) {
+      Object[] collected;
+      int collectedCount;
+      long stamp = lock.writeLock();
+      try {
+        collected = new Object[size];
+        int k = 0;
+        for (int i = 0; i < capacity; i++) {
+          Entry<V> e = entries[i];
+          if (e != null) {
+            collected[k++] = e.value;
+          }
+        }
+        collectedCount = k;
+        assert collectedCount == size
+            : "collectedCount (" + collectedCount + ") != size (" + size + ")";
+
+        // Reset to a small empty table — no reason to retain capacity accumulated during
+        // normal operation; subsequent puts will rehash on demand.
+        int newCapacity = alignToPowerOfTwo(2);
+        entries = new Entry[newCapacity];
+        capacity = newCapacity;
+        resizeThreshold = (int) (newCapacity * FILL_FACTOR);
+        size = 0;
+        usedBuckets = 0;
+      } finally {
+        lock.unlockWrite(stamp);
+      }
+
+      // Invoke consumer outside the section's write lock. Matches removeByFileId's contract so
+      // callbacks may safely re-enter the map.
+      for (int i = 0; i < collectedCount; i++) {
+        consumer.accept((V) collected[i]);
       }
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -659,22 +659,24 @@ public final class LockFreeReadCache implements ReadCache {
   }
 
   /**
-   * Two-phase bulk drain used by close and delete:
+   * Single-pass bulk drain used by {@code closeStorage} and {@code deleteStorage}:
    *
    * <ol>
-   *   <li>Snapshot every entry via {@code forEachValue} (section read locks).
-   *   <li>{@code freeze()} + {@code policy.onRemove()} each entry. A {@code freeze()} failure
-   *       aborts before the map is modified, matching {@link #clear()} — the caller may retry
-   *       close on a fresh attempt.
-   *   <li>{@code clearAndShrink} sweeps the map in one O(section count) pass and shrinks each
-   *       section back to its initial capacity without re-collecting values.
+   *   <li>{@code data.removeByStorageId(writeCache.getId())} — one write-locked sweep per
+   *       section, atomically removing every entry whose fileId's high 32 bits match this
+   *       storage's id. Entries from other storages sharing the same JVM cache are left intact.
+   *   <li>For each removed entry: {@code freeze()} + {@code policy.onRemove()} +
+   *       {@code cacheSize.decrementAndGet()}. If {@code freeze()} fails (entry still pinned),
+   *       throw {@link StorageException} — remaining entries in the batch are left out of the
+   *       map and not yet processed, matching the pre-existing semantics of {@link #clearFile}.
    * </ol>
    *
    * <p>This replaces the per-file {@link #clearFile} loop used by {@code closeStorage} and
    * {@code deleteStorage} before. That loop was O(files × total capacity) because every
    * {@code removeByFileId} call linearly swept all 16 sections and same-capacity rehashed any
    * section with a match — on a storage with thousands of files and a warm cache it pegged a
-   * close thread at 100 % CPU inside {@code removeByFileId} for 30+ minutes.
+   * close thread at 100 % CPU inside {@code removeByFileId} for 30+ minutes. The new
+   * {@code removeByStorageId} collapses that to a single O(total capacity) sweep per close.
    *
    * <p>The method acquires {@link #evictionLock} once for the whole drain rather than per entry
    * as {@link #clearFile} does; close has no progress obligation to other threads. The per-entry
@@ -682,15 +684,34 @@ public final class LockFreeReadCache implements ReadCache {
    * {@code writeCache.close()}/{@code writeCache.delete()} triggers a full flush, making the
    * per-entry overflow check redundant and also avoiding its latch wait (see WOWCache#1198).
    *
+   * <p><b>Critical ordering — remove from map first, freeze after:</b> freezing an entry while
+   * it is still in the map would make concurrent {@code doLoad} callers (for this OR any other
+   * live storage sharing the cache) spin forever in their {@code while (true)} loop, because
+   * {@code data.get()} would keep returning the frozen entry and {@code acquireEntry()} would
+   * keep failing. By removing entries from the map <em>before</em> freezing, concurrent loads
+   * either find nothing (and re-load fresh) or find a fresh entry inserted after us — neither
+   * can spin.
+   *
+   * <p><b>Storage-scoped filter:</b> {@link LockFreeReadCache} is a JVM singleton shared by
+   * every open storage. A bulk drain that iterates ALL entries (e.g., {@link #clear()}) would
+   * freeze entries belonging to other live storages and cause their in-flight {@code doLoad}
+   * calls to spin. {@code removeByStorageId} restricts the sweep to entries whose fileId
+   * encodes this {@code writeCache}'s id, leaving other storages untouched.
+   *
+   * <p><b>Freeze-failure handling — re-insert un-frozen entries:</b> freeze only fails when an
+   * entry is still pinned (its refcount is {@code > 0}, i.e. some caller is holding it). If we
+   * simply threw on the first failure, every already-removed entry AFTER the pinned one would
+   * leak — they would be out of the map (retry can't find them), unfrozen (never released from
+   * the policy), and their {@link CachePointer}s would never have their referrer counts
+   * decremented (pinning the direct memory until JVM exit). To avoid this, we continue the
+   * loop on failure, collect un-frozen entries, and re-insert them in the map before throwing.
+   * A subsequent retry by the caller (after the pin is released) sees a fresh map containing
+   * only the formerly-pinned pages and drains them correctly.
+   *
    * <p><b>Durability note:</b> this drain only releases the read-cache's reference on each
    * cache entry. Dirty-page memory is still held by {@link WriteCache} via its own reference
    * count and is flushed/discarded only by {@code writeCache.close()}/{@code delete()}. Do not
    * move the {@code writeCache.close()}/{@code delete()} call ahead of this drain.
-   *
-   * <p><b>Precondition:</b> no concurrent {@code doLoad} during close (same as
-   * {@code clearFile}). A concurrent load landing on the map after phase 1 would be drained in
-   * phase 3 without being frozen or counted out of {@code cacheSize} — storage lifecycle must
-   * quiesce readers at a higher level.
    */
   private void drainAllEntries(final WriteCache writeCache) {
     flushCurrentThreadReadBatch();
@@ -698,28 +719,35 @@ public final class LockFreeReadCache implements ReadCache {
     try {
       emptyBuffers();
 
-      final var currentCacheSize = cacheSize.get();
-      final var entries = new ArrayList<CacheEntry>(Math.max(0, currentCacheSize));
-      data.forEachValue(entries::add);
+      final var removedEntries = data.removeByStorageId(writeCache.getId());
 
-      for (final var entry : entries) {
-        if (!entry.freeze()) {
-          throw new StorageException(writeCache.getStorageName(),
-              "Page with index "
-                  + entry.getPageIndex()
-                  + " for file id "
-                  + entry.getFileId()
-                  + " is used and cannot be removed");
+      // First entry that freeze() rejected (still pinned). We use it to build the exception
+      // message after re-inserting every un-frozen entry. Null means every entry was frozen.
+      CacheEntry firstUnfrozen = null;
+      for (final var cacheEntry : removedEntries) {
+        if (cacheEntry.freeze()) {
+          policy.onRemove(cacheEntry);
+          cacheSize.decrementAndGet();
+        } else {
+          if (firstUnfrozen == null) {
+            firstUnfrozen = cacheEntry;
+          }
+          // Re-insert so a retry after the caller releases the pin can drain this entry
+          // through the normal path. Without this, a single pinned page would leak every
+          // remaining cache entry for the whole storage (policy zombies + direct-memory
+          // reference leak). Close holds the storage's exclusive lock at the caller level,
+          // so no concurrent doLoad is racing us on this storage's pages here.
+          data.put(cacheEntry.getFileId(), cacheEntry.getPageIndex(), cacheEntry);
         }
-        policy.onRemove(entry);
       }
-
-      // Phase 3: shrink each section back to its constructor-time capacity. Every entry was
-      // already handled above, so we use the no-collect variant — drainAll(Consumer) would
-      // allocate a temporary ArrayList per section and scan each array to collect values we do
-      // not need.
-      data.clearAndShrink();
-      cacheSize.set(0);
+      if (firstUnfrozen != null) {
+        throw new StorageException(writeCache.getStorageName(),
+            "Page with index "
+                + firstUnfrozen.getPageIndex()
+                + " for file id "
+                + firstUnfrozen.getFileId()
+                + " is used and cannot be removed");
+      }
     } finally {
       evictionLock.unlock();
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -666,8 +666,8 @@ public final class LockFreeReadCache implements ReadCache {
    *   <li>{@code freeze()} + {@code policy.onRemove()} each entry. A {@code freeze()} failure
    *       aborts before the map is modified, matching {@link #clear()} — the caller may retry
    *       close on a fresh attempt.
-   *   <li>{@code drainAll} sweeps the map in one O(total capacity) pass and shrinks each
-   *       section back to its initial capacity.
+   *   <li>{@code clearAndShrink} sweeps the map in one O(section count) pass and shrinks each
+   *       section back to its initial capacity without re-collecting values.
    * </ol>
    *
    * <p>This replaces the per-file {@link #clearFile} loop used by {@code closeStorage} and
@@ -714,10 +714,11 @@ public final class LockFreeReadCache implements ReadCache {
         policy.onRemove(entry);
       }
 
-      // Phase 3: drain the map and shrink each section back to its constructor-time capacity.
-      // Consumer is a no-op because every entry was already handled above.
-      data.drainAll(e -> {
-      });
+      // Phase 3: shrink each section back to its constructor-time capacity. Every entry was
+      // already handled above, so we use the no-collect variant — drainAll(Consumer) would
+      // allocate a temporary ArrayList per section and scan each array to collect values we do
+      // not need.
+      data.clearAndShrink();
       cacheSize.set(0);
     } finally {
       evictionLock.unlock();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -648,24 +648,58 @@ public final class LockFreeReadCache implements ReadCache {
 
   @Override
   public void deleteStorage(final WriteCache writeCache) throws IOException {
-    final var files = writeCache.files().values();
-
-    for (final long fileId : files) {
-      clearFile(fileId, writeCache);
-    }
-
+    drainAllEntries(writeCache);
     writeCache.delete();
   }
 
   @Override
   public void closeStorage(final WriteCache writeCache) throws IOException {
-    final var files = writeCache.files().values();
-
-    for (final long fileId : files) {
-      clearFile(fileId, writeCache);
-    }
-
+    drainAllEntries(writeCache);
     writeCache.close();
+  }
+
+  /**
+   * Drain every cache entry in one pass and apply the close/delete side-effects (freeze,
+   * policy.onRemove, cacheSize decrement).
+   *
+   * <p>Per-file iteration via {@link #clearFile} is O(files * total capacity) because each
+   * {@code removeByFileId} call linearly sweeps all 16 sections and same-capacity rehashes any
+   * section with a match. On a storage with thousands of files and a large cache, that cost
+   * dominates close wall time (observed pegged at 100 % CPU inside {@code removeByFileId} for
+   * 30+ minutes). This path collapses the work to a single O(total capacity) sweep.
+   *
+   * <p>Caller must already hold {@link #evictionLock} — we do not reacquire it per entry as
+   * {@code clearFile} does, because close has no progress obligation to other threads and
+   * holding the lock once is simpler than re-taking it 10 000 times.
+   */
+  private void drainAllEntries(final WriteCache writeCache) {
+    flushCurrentThreadReadBatch();
+    evictionLock.lock();
+    try {
+      emptyBuffers();
+
+      // Precondition (same as clearFile): no concurrent doLoad during close. A concurrent load
+      // landing on an already-drained section would stick; callers coordinate storage lifecycle
+      // at a higher level to prevent this.
+      data.drainAll(cacheEntry -> {
+        if (!cacheEntry.freeze()) {
+          throw new StorageException(writeCache.getStorageName(),
+              "Page with index "
+                  + cacheEntry.getPageIndex()
+                  + " for file id "
+                  + cacheEntry.getFileId()
+                  + " is used and cannot be removed");
+        }
+        policy.onRemove(cacheEntry);
+        cacheSize.decrementAndGet();
+      });
+
+      // writeCache.close()/delete() triggers a full flush, so we skip the per-entry
+      // checkCacheOverflow() call that the per-file clearFile path makes — it would be
+      // redundant work under a lock that close holds for the entire drain.
+    } finally {
+      evictionLock.unlock();
+    }
   }
 
   private void clearFile(final long fileId, final WriteCache writeCache) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCache.java
@@ -659,18 +659,38 @@ public final class LockFreeReadCache implements ReadCache {
   }
 
   /**
-   * Drain every cache entry in one pass and apply the close/delete side-effects (freeze,
-   * policy.onRemove, cacheSize decrement).
+   * Two-phase bulk drain used by close and delete:
    *
-   * <p>Per-file iteration via {@link #clearFile} is O(files * total capacity) because each
-   * {@code removeByFileId} call linearly sweeps all 16 sections and same-capacity rehashes any
-   * section with a match. On a storage with thousands of files and a large cache, that cost
-   * dominates close wall time (observed pegged at 100 % CPU inside {@code removeByFileId} for
-   * 30+ minutes). This path collapses the work to a single O(total capacity) sweep.
+   * <ol>
+   *   <li>Snapshot every entry via {@code forEachValue} (section read locks).
+   *   <li>{@code freeze()} + {@code policy.onRemove()} each entry. A {@code freeze()} failure
+   *       aborts before the map is modified, matching {@link #clear()} — the caller may retry
+   *       close on a fresh attempt.
+   *   <li>{@code drainAll} sweeps the map in one O(total capacity) pass and shrinks each
+   *       section back to its initial capacity.
+   * </ol>
    *
-   * <p>Caller must already hold {@link #evictionLock} — we do not reacquire it per entry as
-   * {@code clearFile} does, because close has no progress obligation to other threads and
-   * holding the lock once is simpler than re-taking it 10 000 times.
+   * <p>This replaces the per-file {@link #clearFile} loop used by {@code closeStorage} and
+   * {@code deleteStorage} before. That loop was O(files × total capacity) because every
+   * {@code removeByFileId} call linearly swept all 16 sections and same-capacity rehashed any
+   * section with a match — on a storage with thousands of files and a warm cache it pegged a
+   * close thread at 100 % CPU inside {@code removeByFileId} for 30+ minutes.
+   *
+   * <p>The method acquires {@link #evictionLock} once for the whole drain rather than per entry
+   * as {@link #clearFile} does; close has no progress obligation to other threads. The per-entry
+   * {@code writeCache.checkCacheOverflow()} call is intentionally not made — the subsequent
+   * {@code writeCache.close()}/{@code writeCache.delete()} triggers a full flush, making the
+   * per-entry overflow check redundant and also avoiding its latch wait (see WOWCache#1198).
+   *
+   * <p><b>Durability note:</b> this drain only releases the read-cache's reference on each
+   * cache entry. Dirty-page memory is still held by {@link WriteCache} via its own reference
+   * count and is flushed/discarded only by {@code writeCache.close()}/{@code delete()}. Do not
+   * move the {@code writeCache.close()}/{@code delete()} call ahead of this drain.
+   *
+   * <p><b>Precondition:</b> no concurrent {@code doLoad} during close (same as
+   * {@code clearFile}). A concurrent load landing on the map after phase 1 would be drained in
+   * phase 3 without being frozen or counted out of {@code cacheSize} — storage lifecycle must
+   * quiesce readers at a higher level.
    */
   private void drainAllEntries(final WriteCache writeCache) {
     flushCurrentThreadReadBatch();
@@ -678,25 +698,27 @@ public final class LockFreeReadCache implements ReadCache {
     try {
       emptyBuffers();
 
-      // Precondition (same as clearFile): no concurrent doLoad during close. A concurrent load
-      // landing on an already-drained section would stick; callers coordinate storage lifecycle
-      // at a higher level to prevent this.
-      data.drainAll(cacheEntry -> {
-        if (!cacheEntry.freeze()) {
+      final var currentCacheSize = cacheSize.get();
+      final var entries = new ArrayList<CacheEntry>(Math.max(0, currentCacheSize));
+      data.forEachValue(entries::add);
+
+      for (final var entry : entries) {
+        if (!entry.freeze()) {
           throw new StorageException(writeCache.getStorageName(),
               "Page with index "
-                  + cacheEntry.getPageIndex()
+                  + entry.getPageIndex()
                   + " for file id "
-                  + cacheEntry.getFileId()
+                  + entry.getFileId()
                   + " is used and cannot be removed");
         }
-        policy.onRemove(cacheEntry);
-        cacheSize.decrementAndGet();
-      });
+        policy.onRemove(entry);
+      }
 
-      // writeCache.close()/delete() triggers a full flush, so we skip the per-entry
-      // checkCacheOverflow() call that the per-file clearFile path makes — it would be
-      // redundant work under a lock that close holds for the entire drain.
+      // Phase 3: drain the map and shrink each section back to its constructor-time capacity.
+      // Consumer is a no-op because every entry was already handled above.
+      data.drainAll(e -> {
+      });
+      cacheSize.set(0);
     } finally {
       evictionLock.unlock();
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -765,4 +765,127 @@ public class ConcurrentLongIntHashMapConcurrentTest {
     assertThat(map.size()).as("map should be empty after all files removed").isEqualTo(0);
     assertThat(map.isEmpty()).isTrue();
   }
+
+  // ---- drainAll concurrent tests ----
+
+  /**
+   * drainAll running concurrently with readers and writers on other sections. drainAll takes
+   * each section's write lock sequentially, swapping {@code entries} to a smaller initial-capacity
+   * array while optimistic readers are in flight on the same section — this is the symmetric hazard
+   * to {@link #rehashFromMinimumCapacityUnderConcurrentAccessIsCorrect}, but with the array shrinking
+   * rather than growing.
+   *
+   * <p>Verifies: no {@link ArrayIndexOutOfBoundsException} from any reader, no torn values (every
+   * non-null result matches the canonical form for its key), and that drainAll completes all its
+   * cycles. Uses a short 2-second window per run to keep CI time bounded.
+   */
+  @Test
+  public void drainAllConcurrentWithPutsAndReadsIsSafe() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(1024);
+    int fileCount = 200;
+    int pageCount = 50;
+
+    // Prefill so the first few drains have substantial work to do
+    for (long fId = 0; fId < fileCount; fId++) {
+      for (int pIdx = 0; pIdx < pageCount; pIdx++) {
+        map.put(fId, pIdx, fId + ":" + pIdx);
+      }
+    }
+
+    int readerCount = 4;
+    int writerCount = 2;
+    int drainerCount = 1;
+    int totalThreads = readerCount + writerCount + drainerCount;
+    var executor = Executors.newFixedThreadPool(totalThreads);
+    var futures = new ArrayList<Future<Void>>();
+    var startBarrier = new CyclicBarrier(totalThreads);
+    var stop = new java.util.concurrent.atomic.AtomicBoolean(false);
+    int drainCycles = 50;
+
+    try {
+      // Readers: every non-null value must match its key's canonical form — catches any torn
+      // read during a section's array swap in drain().
+      for (int t = 0; t < readerCount; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  while (!stop.get()) {
+                    long fId = rng.nextInt(fileCount);
+                    int pIdx = rng.nextInt(pageCount);
+                    String result = map.get(fId, pIdx);
+                    if (result != null) {
+                      assertThat(result)
+                          .as("get(%d, %d) torn read during drainAll", fId, pIdx)
+                          .isEqualTo(fId + ":" + pIdx);
+                    }
+                  }
+                  return null;
+                }));
+      }
+
+      // Writers: re-populate entries so some sections are always occupied during drain.
+      for (int t = 0; t < writerCount; t++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  startBarrier.await();
+                  var rng = ThreadLocalRandom.current();
+                  while (!stop.get()) {
+                    long fId = rng.nextInt(fileCount);
+                    int pIdx = rng.nextInt(pageCount);
+                    map.put(fId, pIdx, fId + ":" + pIdx);
+                  }
+                  return null;
+                }));
+      }
+
+      // Drainer: loops through many drain cycles during contention. Uses a plain int[]-wrapped
+      // counter to verify the loop completed its target rather than returning early.
+      var completedCycles = new java.util.concurrent.atomic.AtomicInteger();
+      futures.add(
+          executor.submit(
+              () -> {
+                startBarrier.await();
+                for (int i = 0; i < drainCycles; i++) {
+                  map.drainAll(v -> {
+                  });
+                  completedCycles.incrementAndGet();
+                  Thread.yield();
+                }
+                stop.set(true);
+                return null;
+              }));
+
+      for (var future : futures) {
+        future.get(60, TimeUnit.SECONDS);
+      }
+      assertThat(completedCycles.get())
+          .as("drainer must have finished all its cycles")
+          .isEqualTo(drainCycles);
+    } finally {
+      stop.set(true);
+      executor.shutdownNow();
+      executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Final state: map is consistent. size() equals the number of entries visible via forEach,
+    // and every such entry is retrievable and matches its key's canonical form.
+    var entryCount = new AtomicLong();
+    map.forEach(
+        (fId, pIdx, value) -> {
+          assertThat(value).isNotNull();
+          assertThat(value)
+              .as("value at (%d, %d) matches canonical form", fId, pIdx)
+              .isEqualTo(fId + ":" + pIdx);
+          assertThat(map.get(fId, pIdx))
+              .as("get(%d, %d) after drainAll stress", fId, pIdx)
+              .isSameAs(value);
+          entryCount.incrementAndGet();
+        });
+    assertThat(map.size())
+        .as("size() matches forEach entry count after drainAll stress")
+        .isEqualTo(entryCount.get());
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapConcurrentTest.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 
@@ -887,5 +889,113 @@ public class ConcurrentLongIntHashMapConcurrentTest {
     assertThat(map.size())
         .as("size() matches forEach entry count after drainAll stress")
         .isEqualTo(entryCount.get());
+  }
+
+  /**
+   * {@code removeByStorageId} contention with concurrent readers and writers on ANOTHER
+   * storage. The remover sweeps the target storage's entries in write-locked section passes;
+   * meanwhile readers and writers hit the other storage's entries. The other storage's entries
+   * must (a) always be findable via {@code get} with their canonical value (no torn reads from
+   * a concurrent same-capacity rehash or {@code shrinkIfGrown} array swap), and (b) fully
+   * survive every removal cycle. This mirrors the production scenario where one storage closes
+   * while other storages continue to serve reads.
+   */
+  @Test
+  public void removeByStorageIdConcurrentWithPutsAndReadsOnOtherStorageIsSafe() throws Exception {
+    var map = new ConcurrentLongIntHashMap<String>(1024);
+    int targetStorage = 1;
+    int otherStorage = 2;
+    int fileCount = 100;
+    int pageCount = 50;
+
+    // Pre-populate both storages. The remover cycles the target storage; writers re-add
+    // target-storage entries so every cycle has real work.
+    for (int lf = 0; lf < fileCount; lf++) {
+      long targetFid = (((long) targetStorage) << 32) | lf;
+      long otherFid = (((long) otherStorage) << 32) | lf;
+      for (int p = 0; p < pageCount; p++) {
+        map.put(targetFid, p, "T:" + lf + ":" + p);
+        map.put(otherFid, p, "O:" + lf + ":" + p);
+      }
+    }
+
+    int readerCount = 4;
+    int writerCount = 2;
+    int totalThreads = readerCount + writerCount + 1;
+    var exec = Executors.newFixedThreadPool(totalThreads);
+    var barrier = new CyclicBarrier(totalThreads);
+    var stop = new AtomicBoolean(false);
+    var removeCycles = new AtomicInteger();
+    int targetCycles = 50;
+    var futures = new ArrayList<Future<Void>>();
+
+    try {
+      // Readers: every non-null result for other-storage MUST match the canonical value. A
+      // torn read would return a wrong string.
+      for (int t = 0; t < readerCount; t++) {
+        futures.add(exec.submit(() -> {
+          barrier.await();
+          var rng = ThreadLocalRandom.current();
+          while (!stop.get()) {
+            int lf = rng.nextInt(fileCount);
+            int p = rng.nextInt(pageCount);
+            long otherFid = (((long) otherStorage) << 32) | lf;
+            String v = map.get(otherFid, p);
+            if (v != null) {
+              assertThat(v).isEqualTo("O:" + lf + ":" + p);
+            }
+          }
+          return null;
+        }));
+      }
+
+      // Writers: re-insert target-storage entries so removeByStorageId has matches every cycle.
+      for (int t = 0; t < writerCount; t++) {
+        futures.add(exec.submit(() -> {
+          barrier.await();
+          var rng = ThreadLocalRandom.current();
+          while (!stop.get()) {
+            int lf = rng.nextInt(fileCount);
+            int p = rng.nextInt(pageCount);
+            long targetFid = (((long) targetStorage) << 32) | lf;
+            map.put(targetFid, p, "T:" + lf + ":" + p);
+          }
+          return null;
+        }));
+      }
+
+      // Remover: repeated sweeps of the target storage.
+      futures.add(exec.submit(() -> {
+        barrier.await();
+        for (int i = 0; i < targetCycles; i++) {
+          map.removeByStorageId(targetStorage);
+          removeCycles.incrementAndGet();
+          Thread.yield();
+        }
+        stop.set(true);
+        return null;
+      }));
+
+      for (var f : futures) {
+        f.get(60, TimeUnit.SECONDS);
+      }
+      assertThat(removeCycles.get()).isEqualTo(targetCycles);
+    } finally {
+      stop.set(true);
+      exec.shutdownNow();
+      exec.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    // Final invariant: every other-storage entry still has its canonical value. A missing or
+    // torn entry here indicates cross-storage damage from the concurrent removeByStorageId.
+    for (int lf = 0; lf < fileCount; lf++) {
+      long otherFid = (((long) otherStorage) << 32) | lf;
+      for (int p = 0; p < pageCount; p++) {
+        assertThat(map.get(otherFid, p))
+            .as("other storage entry (%d,%d) must survive concurrent removeByStorageId",
+                lf, p)
+            .isEqualTo("O:" + lf + ":" + p);
+      }
+    }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1705,19 +1705,18 @@ public class ConcurrentLongIntHashMapTest {
   @Test
   public void drainAllOnSingleSectionDeliversEveryValueExactlyOnce() {
     var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    var expected = new ArrayList<String>();
     for (int i = 0; i < 10; i++) {
-      map.put(1L, i, "v" + i);
+      var v = "v" + i;
+      map.put(1L, i, v);
+      expected.add(v);
     }
     assertThat(map.size()).isEqualTo(10);
 
     var collected = new ArrayList<String>();
     map.drainAll(collected::add);
 
-    assertThat(collected).hasSize(10);
-    var expected = new ArrayList<String>();
-    for (int i = 0; i < 10; i++) {
-      expected.add("v" + i);
-    }
+    // containsExactlyInAnyOrderElementsOf verifies both size (10) and distinct-element membership.
     assertThat(collected).containsExactlyInAnyOrderElementsOf(expected);
     assertThat(map.size()).isEqualTo(0);
     assertThat(map.isEmpty()).isTrue();
@@ -1808,6 +1807,45 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(map.size()).isEqualTo(0);
   }
 
+  /**
+   * drainAll shrinks to the ctor-time capacity even when the ctor requested a non-default
+   * {@code expectedItems} that had to be rounded up by {@code alignToPowerOfTwo}. Catches
+   * two distinct regression modes: (a) capturing {@code DEFAULT_EXPECTED_ITEMS} instead of
+   * the ctor argument; (b) storing the raw pre-alignment value instead of the aligned
+   * power-of-two, which would leave {@code bucketMask = capacity - 1} inconsistent with
+   * {@code entries.length} after the drain.
+   *
+   * <p>Arithmetic: 1600 / 16 sections = 100 per section → alignToPowerOfTwo(100) = 128 →
+   * total capacity at construction = 128 × 16 = 2048.
+   */
+  @Test
+  public void drainAllShrinksToAlignedInitialCapacityForCustomExpectedItems() {
+    var map = new ConcurrentLongIntHashMap<String>(1600, 16);
+    long initialCapacity = map.capacity();
+    assertThat(initialCapacity)
+        .as("1600 expectedItems / 16 sections = 100 per section → aligned to 128 → 128*16=2048")
+        .isEqualTo(2048L);
+
+    // Grow every section past its initial 128-slot threshold.
+    for (long fid = 0; fid < 200; fid++) {
+      for (int page = 0; page < 50; page++) {
+        map.put(fid, page, "v");
+      }
+    }
+    assertThat(map.capacity()).isGreaterThan(initialCapacity);
+
+    map.drainAll(v -> {
+    });
+
+    assertThat(map.capacity())
+        .as("drainAll must reset to the aligned 2048, not DEFAULT_EXPECTED_ITEMS (256)")
+        .isEqualTo(2048L);
+    // Each section's length is a power of two, so total capacity / 16 is also a power of two.
+    assertThat(Long.bitCount(map.capacity() / 16))
+        .as("per-section capacity must still be a power of two after drain")
+        .isEqualTo(1);
+  }
+
   /** After drainAll the map must be usable — puts and gets work as expected on a fresh table. */
   @Test
   public void drainAllLeavesMapUsableForSubsequentPutAndGet() {
@@ -1828,13 +1866,15 @@ public class ConcurrentLongIntHashMapTest {
   }
 
   /**
-   * An exception thrown by the consumer propagates out of drainAll. Because the consumer runs
-   * after each section is drained (and the lock released), the map is already fully drained by
-   * the time the exception surfaces — matching the "best effort, fail fast" semantics of the
-   * close path.
+   * An exception thrown by the consumer propagates out of drainAll. This test uses a
+   * single-section map so that once the section's write lock releases (with all entries
+   * already removed from the table) the consumer loop runs on that snapshot and the first
+   * throw surfaces — no further sections exist to leave populated. The multi-section case
+   * where later sections survive is exercised by
+   * {@link #drainAllAbortsOnConsumerExceptionLeavingLaterSectionsPopulated}.
    */
   @Test
-  public void drainAllPropagatesConsumerException() {
+  public void drainAllPropagatesConsumerExceptionOnSingleSectionMap() {
     var map = new ConcurrentLongIntHashMap<String>(16, 1);
     map.put(1L, 0, "first");
     map.put(1L, 1, "second");
@@ -1847,8 +1887,8 @@ public class ConcurrentLongIntHashMapTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("boom on");
 
-    // The map has been fully drained even though the consumer threw — entries were removed
-    // under the write lock before the consumer ran.
+    // The only section was fully drained under its write lock before any consumer call
+    // fired, so size is 0 even though the first consumer invocation threw.
     assertThat(map.size()).isEqualTo(0);
   }
 
@@ -1897,52 +1937,103 @@ public class ConcurrentLongIntHashMapTest {
 
   /**
    * drainAll invokes the consumer outside the section write lock, so a consumer that re-enters
-   * the map (e.g., to insert a new entry) must succeed without deadlock. This mirrors the close
-   * path where {@code freeze()} / policy callbacks may touch other maps.
+   * the map (e.g., to insert a new entry) must succeed without deadlock on the non-reentrant
+   * section write lock. Mirrors the close path where {@code freeze()} / policy callbacks may
+   * touch other maps. Uses distinct original values so the test also verifies both drained
+   * entries show up in {@code collected} (and the reentrant value does not, since it is
+   * inserted after the section's drain completed).
    */
   @Test
   public void drainAllConsumerCanReenterMap() {
     var map = new ConcurrentLongIntHashMap<String>(16, 1);
-    map.put(1L, 0, "original");
-    map.put(1L, 1, "original");
+    map.put(1L, 0, "original-a");
+    map.put(1L, 1, "original-b");
 
     var collected = new ArrayList<String>();
     map.drainAll(
         v -> {
           collected.add(v);
           // Re-entering the map inside the consumer: must not deadlock on the section lock.
-          if (v.equals("original") && map.get(2L, 0) == null) {
+          if (map.get(2L, 0) == null) {
             map.put(2L, 0, "reentrant");
           }
         });
 
-    assertThat(collected).hasSize(2);
+    // Both original entries were drained and seen by the consumer; the reentrant put
+    // inserted from inside the consumer was NOT itself delivered to collected because
+    // the section was already drained before its first consumer call fired.
+    assertThat(collected).containsExactlyInAnyOrder("original-a", "original-b");
+    assertThat(map.get(1L, 0)).isNull();
+    assertThat(map.get(1L, 1)).isNull();
     // The reentrant put landed after drainAll returned from that section's write lock.
     assertThat(map.get(2L, 0)).isEqualTo("reentrant");
+    assertThat(map.size()).isEqualTo(1);
   }
 
   /**
-   * drainAll resets both size and usedBuckets to zero — a subsequent fill to the original
-   * resize threshold triggers a normal rehash without corruption.
+   * drainAll resets {@code size}, {@code usedBuckets}, and {@code resizeThreshold} so a
+   * subsequent fill past the shrunken capacity triggers a normal rehash without corruption.
+   * Asserts capacity at three points — after initial construction, after drain, and after
+   * refill — so this test distinguishes drainAll's shrink-then-regrow from what {@code clear()}
+   * would produce (which preserves the current, grown capacity).
    */
   @Test
   public void drainAllResetsInternalCountersSoRefillWorks() {
     var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    long initialCapacity = map.capacity();
+    assertThat(initialCapacity).isEqualTo(16L);
+
     // Fill single section to its resize threshold (capacity 16, threshold = 10)
     for (int i = 0; i < 10; i++) {
       map.put(1L, i, "a-" + i);
     }
     map.drainAll(v -> {
     });
+    assertThat(map.capacity())
+        .as("capacity must shrink back to initialCapacity, distinguishing drain from clear")
+        .isEqualTo(initialCapacity);
 
     // Fill again past the (shrunken) capacity — this exercises rehashes on a fresh table.
     for (int i = 0; i < 100; i++) {
       map.put(1L, i, "b-" + i);
     }
+    assertThat(map.capacity())
+        .as("refill past the 16-slot initial capacity must have rehashed the section")
+        .isGreaterThanOrEqualTo(128L);
     assertThat(map.size()).isEqualTo(100);
     for (int i = 0; i < 100; i++) {
       assertThat(map.get(1L, i)).isEqualTo("b-" + i);
     }
+  }
+
+  /**
+   * A second drainAll on an already-emptied map is a true no-op: consumer zero times, size
+   * stays 0, and capacity does not change from its post-drain value. Guards that drainAll
+   * leaves the sections in a state indistinguishable from a freshly constructed map, so a
+   * pathological caller that drains twice (or the close path being invoked twice) does not
+   * re-allocate arrays or rehash.
+   */
+  @Test
+  public void secondDrainAllOnEmptiedMapIsNoOp() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    for (long fid = 0; fid < 10; fid++) {
+      for (int page = 0; page < 20; page++) {
+        map.put(fid, page, "v-" + fid + "-" + page);
+      }
+    }
+
+    map.drainAll(v -> {
+    });
+    long capacityAfterFirstDrain = map.capacity();
+
+    var collected = new ArrayList<String>();
+    map.drainAll(collected::add);
+
+    assertThat(collected).isEmpty();
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.capacity())
+        .as("second drain on empty map must leave capacity untouched")
+        .isEqualTo(capacityAfterFirstDrain);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -2179,4 +2179,254 @@ public class ConcurrentLongIntHashMapTest {
         .as("clearAndShrink must shrink an empty-but-grown section")
         .isEqualTo(initialCapacity);
   }
+
+  // ---- removeByStorageId() ----
+
+  /**
+   * {@code removeByStorageId} must drop every entry whose fileId has matching high 32 bits and
+   * leave other storages' entries untouched. This is the invariant that protects the JVM-shared
+   * {@code LockFreeReadCache} from cross-storage damage when one storage closes — without it, a
+   * bulk drain would freeze entries from live storages and cause concurrent {@code doLoad}
+   * callers to spin forever.
+   */
+  @Test
+  public void removeByStorageIdRemovesOnlyTargetStorageEntries() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    int storageA = 1;
+    int storageB = 2;
+    int pagesPerFile = 5;
+
+    // 3 files per storage, each with 5 pages. File ids differ between storages.
+    for (int localFid = 0; localFid < 3; localFid++) {
+      long fidA = (((long) storageA) << 32) | localFid;
+      long fidB = (((long) storageB) << 32) | (10 + localFid);
+      for (int p = 0; p < pagesPerFile; p++) {
+        map.put(fidA, p, "A-f" + localFid + "-p" + p);
+        map.put(fidB, p, "B-f" + localFid + "-p" + p);
+      }
+    }
+    assertThat(map.size()).isEqualTo(30);
+
+    var removed = map.removeByStorageId(storageA);
+
+    assertThat(removed).as("must collect exactly storage A's 15 entries").hasSize(15);
+    assertThat(removed).allMatch(v -> v.startsWith("A-"));
+    assertThat(map.size()).as("only storage B's 15 entries remain").isEqualTo(15);
+
+    // Every storage A entry is gone; every storage B entry is still findable.
+    for (int localFid = 0; localFid < 3; localFid++) {
+      long fidA = (((long) storageA) << 32) | localFid;
+      long fidB = (((long) storageB) << 32) | (10 + localFid);
+      for (int p = 0; p < pagesPerFile; p++) {
+        assertThat(map.get(fidA, p))
+            .as("Storage A entry (%d,%d) must be null after removeByStorageId(1)", fidA, p)
+            .isNull();
+        assertThat(map.get(fidB, p))
+            .as("Storage B entry (%d,%d) must survive removeByStorageId(1)", fidB, p)
+            .isEqualTo("B-f" + localFid + "-p" + p);
+      }
+    }
+  }
+
+  /** Empty map and missing-storage paths must both return an empty list without throwing. */
+  @Test
+  public void removeByStorageIdOnEmptyOrMissingStorageReturnsEmpty() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    assertThat(map.removeByStorageId(7))
+        .as("empty map must return empty list")
+        .isEmpty();
+
+    map.put((1L << 32) | 0L, 0, "exists");
+    assertThat(map.removeByStorageId(9))
+        .as("no entries for this storage must return empty list")
+        .isEmpty();
+    assertThat(map.size()).as("map must be unchanged").isEqualTo(1);
+  }
+
+  /**
+   * After bulk removal the section's probe chains are repaired via same-capacity rehash so
+   * surviving entries (possibly from other storages, possibly from the same one in different
+   * files) remain findable. Without the rehash, a long entry that probed past a now-removed
+   * slot would become unreachable.
+   */
+  @Test
+  public void removeByStorageIdCompactsSectionSoSurvivorsRemainFindable() {
+    // Force all entries into a single section so probe chain integrity is meaningfully tested.
+    var map = new ConcurrentLongIntHashMap<String>(32, 1);
+    int storageA = 1;
+    int storageB = 2;
+
+    // Interleave storage A and B entries — removing A may leave gaps that B entries probed past.
+    for (int i = 0; i < 16; i++) {
+      map.put((((long) storageA) << 32) | i, 0, "A" + i);
+      map.put((((long) storageB) << 32) | i, 0, "B" + i);
+    }
+    assertThat(map.size()).isEqualTo(32);
+
+    map.removeByStorageId(storageA);
+    assertThat(map.size()).isEqualTo(16);
+
+    for (int i = 0; i < 16; i++) {
+      assertThat(map.get((((long) storageB) << 32) | i, 0))
+          .as("Storage B entry %d must still be findable after storage A removal", i)
+          .isEqualTo("B" + i);
+    }
+  }
+
+  /**
+   * If the section becomes empty after removing this storage's entries, the backing array must
+   * be shrunk back to {@code initialCapacity}. This matches the memory-return behavior of
+   * {@code drainAll} and is important for long-lived JVMs that repeatedly close storages — a
+   * closed-and-reopened cache must not retain the peak array.
+   */
+  @Test
+  public void removeByStorageIdShrinksSectionThatBecomesEmpty() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    long initialCapacity = map.capacity();
+    int storageA = 1;
+
+    for (int i = 0; i < 500; i++) {
+      map.put((((long) storageA) << 32) | i, 0, "A" + i);
+    }
+    long grownCapacity = map.capacity();
+    assertThat(grownCapacity).isGreaterThan(initialCapacity);
+
+    map.removeByStorageId(storageA);
+
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.capacity())
+        .as("section that became empty must shrink back to initialCapacity")
+        .isEqualTo(initialCapacity);
+  }
+
+  /**
+   * If a section still has entries from other storages after the removal, it must NOT shrink —
+   * shrinking would either re-rehash the survivors (no perf win over same-capacity rehash) or
+   * drop them entirely (bug). The backing array stays at its grown capacity.
+   */
+  @Test
+  public void removeByStorageIdDoesNotShrinkSectionWithSurvivingEntries() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    long initialCapacity = map.capacity();
+    int storageA = 1;
+    int storageB = 2;
+
+    for (int i = 0; i < 300; i++) {
+      map.put((((long) storageA) << 32) | i, 0, "A" + i);
+    }
+    // Pin a couple of storage B entries so the section keeps a non-empty size after removing A.
+    for (int i = 0; i < 5; i++) {
+      map.put((((long) storageB) << 32) | i, 0, "B" + i);
+    }
+    long grownCapacity = map.capacity();
+    assertThat(grownCapacity).isGreaterThan(initialCapacity);
+
+    map.removeByStorageId(storageA);
+
+    assertThat(map.size()).isEqualTo(5);
+    assertThat(map.capacity())
+        .as("section with survivors must keep its grown capacity, not shrink")
+        .isEqualTo(grownCapacity);
+    for (int i = 0; i < 5; i++) {
+      assertThat(map.get((((long) storageB) << 32) | i, 0)).isEqualTo("B" + i);
+    }
+  }
+
+  /**
+   * After a multi-section {@code removeByStorageId} sweep, every survivor in every section
+   * must still be findable via {@code get()} (which follows probe chains). This is the actual
+   * production configuration — a single-section test does not catch a bug where one section's
+   * probe chain repair interacts wrongly with another's. Uses 2000 entries per storage spread
+   * across the default 16 sections so each section exercises both "has matches" and "has
+   * survivors".
+   */
+  @Test
+  public void removeByStorageIdRepairsProbeChainsAcrossAllSections() {
+    var map = new ConcurrentLongIntHashMap<String>(4096, 16);
+    int storageA = 1;
+    int storageB = 2;
+
+    for (int i = 0; i < 2000; i++) {
+      map.put((((long) storageA) << 32) | i, 0, "A" + i);
+      map.put((((long) storageB) << 32) | i, 0, "B" + i);
+    }
+
+    map.removeByStorageId(storageA);
+
+    assertThat(map.size()).isEqualTo(2000);
+    // Every surviving B entry must remain reachable via get() — a broken probe chain
+    // somewhere would surface as a null here for the affected entries.
+    for (int i = 0; i < 2000; i++) {
+      assertThat(map.get((((long) storageB) << 32) | i, 0))
+          .as("Storage B entry %d must still be findable across multi-section sweep", i)
+          .isEqualTo("B" + i);
+    }
+  }
+
+  /**
+   * Calling {@code removeByStorageId} again on the same storage after a successful drain must
+   * be a no-op: no entries to remove, no allocations, no capacity change. The remove path's
+   * early return at {@code if (removed == 0)} guarantees this, but an explicit regression
+   * test prevents a future "optimization" from accidentally re-allocating on empty sections.
+   */
+  @Test
+  public void removeByStorageIdSecondCallOnSameStorageIsNoOp() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    for (int i = 0; i < 20; i++) {
+      map.put((1L << 32) | i, 0, "v" + i);
+    }
+    map.removeByStorageId(1);
+    long capacityAfterFirst = map.capacity();
+
+    var removed = map.removeByStorageId(1);
+
+    assertThat(removed).as("second call must return empty").isEmpty();
+    assertThat(map.size()).isZero();
+    assertThat(map.capacity())
+        .as("second call must not re-allocate the backing arrays")
+        .isEqualTo(capacityAfterFirst);
+  }
+
+  /**
+   * Boundary storage ids: {@code Integer.MAX_VALUE}, {@code Integer.MIN_VALUE}, and {@code -1}
+   * must work correctly. Storage id is an {@code int}; the predicate at
+   * {@code Section.removeByStorageId} uses {@code (int) (fileId >>> 32)} (unsigned shift then
+   * narrowing cast) to match the composition used by {@code AbstractWriteCache.composeFileId}.
+   * A regression that changed the encoding (e.g. to a signed shift) would silently break
+   * storages whose id has the sign bit set.
+   */
+  @Test
+  public void removeByStorageIdWithNegativeAndMaxBoundaries() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    map.put((((long) -1) << 32) | 7L, 0, "s-neg1");
+    map.put((((long) Integer.MAX_VALUE) << 32) | 7L, 0, "s-max");
+    map.put((((long) Integer.MIN_VALUE) << 32) | 7L, 0, "s-min");
+    map.put(7L, 0, "s-zero"); // storageId = 0, kept as control
+
+    assertThat(map.removeByStorageId(-1)).containsExactly("s-neg1");
+    assertThat(map.removeByStorageId(Integer.MAX_VALUE)).containsExactly("s-max");
+    assertThat(map.removeByStorageId(Integer.MIN_VALUE)).containsExactly("s-min");
+    assertThat(map.size()).as("only storage 0 survives").isEqualTo(1);
+    assertThat(map.get(7L, 0)).isEqualTo("s-zero");
+  }
+
+  /**
+   * Storage id 0 is a valid storage id (it's what {@code MockedWriteCache} uses by default and
+   * what the first-opened storage receives). It must not be confused with empty slots whose
+   * default fileId is 0.
+   */
+  @Test
+  public void removeByStorageIdWithStorageIdZero() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    // storageId=0: composed fileId == localFid, so the entry's high 32 bits are zero.
+    map.put(0L, 0, "s0-f0-p0");
+    map.put(0L, 1, "s0-f0-p1");
+    // storageId=5: high 32 bits are 5.
+    map.put((5L << 32) | 3L, 0, "s5-f3-p0");
+
+    var removed = map.removeByStorageId(0);
+    assertThat(removed).containsExactlyInAnyOrder("s0-f0-p0", "s0-f0-p1");
+    assertThat(map.size()).as("storage 5 entry must survive").isEqualTo(1);
+    assertThat(map.get((5L << 32) | 3L, 0)).isEqualTo("s5-f3-p0");
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -1775,28 +1775,36 @@ public class ConcurrentLongIntHashMapTest {
   }
 
   /**
-   * drainAll shrinks each section back to the minimum capacity — avoids retaining a large array
-   * after storage close. Per-section minimum is 2 slots, so total capacity for the default 16
-   * sections is 32.
+   * drainAll shrinks each section back to the capacity it was constructed with — releases the
+   * large Entry[] accumulated during growth while keeping enough headroom that a refill does
+   * not pay a rehash chain from the 2-slot absolute minimum.
+   *
+   * <p>Default constructor: expectedItems=256, sectionCount=16 → 16 slots per section × 16
+   * sections = 256 total capacity at construction time. After growth and drainAll, the map
+   * should shrink back to exactly that.
    */
   @Test
-  public void drainAllShrinksCapacityToMinimum() {
+  public void drainAllShrinksCapacityToInitialCapacity() {
     var map = new ConcurrentLongIntHashMap<String>();
-    // Grow the map past its initial capacity so sections actually have non-default size.
+    long initialCapacity = map.capacity();
+    assertThat(initialCapacity)
+        .as("constructor default: 256 expectedItems / 16 sections = 16 per section * 16 = 256")
+        .isEqualTo(256L);
+
+    // Grow the map far past its initial capacity.
     for (long fid = 0; fid < 100; fid++) {
       for (int page = 0; page < 100; page++) {
         map.put(fid, page, "v");
       }
     }
-    long grownCapacity = map.capacity();
-    assertThat(grownCapacity).isGreaterThan(32L);
+    assertThat(map.capacity()).isGreaterThan(initialCapacity);
 
     map.drainAll(v -> {
     });
 
     assertThat(map.capacity())
-        .as("drainAll must shrink capacity to the minimum (2 slots per section * 16 sections)")
-        .isEqualTo(32L);
+        .as("drainAll must reset capacity back to the constructor-time value")
+        .isEqualTo(initialCapacity);
     assertThat(map.size()).isEqualTo(0);
   }
 
@@ -1845,6 +1853,49 @@ public class ConcurrentLongIntHashMapTest {
   }
 
   /**
+   * When the consumer throws mid-iteration, later sections must NOT have been drained. The
+   * throw aborts the outer section loop, so sections with an index greater than the failing
+   * section still hold their entries.
+   *
+   * <p>Uses two sections and picks one key for each by consulting the package-private
+   * {@link ConcurrentLongIntHashMap#hash} helper, so section assignment is deterministic.
+   */
+  @Test
+  public void drainAllAbortsOnConsumerExceptionLeavingLaterSectionsPopulated() {
+    var map = new ConcurrentLongIntHashMap<String>(4, 2);
+
+    // Find two fileIds that fall into different sections — sectionMask = 1, so bit 32 of the
+    // mixed hash picks the section.
+    long keyInSection0 = -1L;
+    long keyInSection1 = -1L;
+    for (long fid = 1L; keyInSection0 == -1L || keyInSection1 == -1L; fid++) {
+      int sectionIdx = (int) (ConcurrentLongIntHashMap.hash(fid, 0) >>> 32) & 1;
+      if (sectionIdx == 0 && keyInSection0 == -1L) {
+        keyInSection0 = fid;
+      } else if (sectionIdx == 1 && keyInSection1 == -1L) {
+        keyInSection1 = fid;
+      }
+    }
+    map.put(keyInSection0, 0, "A");
+    map.put(keyInSection1, 0, "B");
+    assertThat(map.size()).isEqualTo(2);
+
+    assertThatThrownBy(
+        () -> map.drainAll(
+            v -> {
+              throw new IllegalStateException("boom on " + v);
+            }))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("boom on A");
+
+    // drainAll iterates sections in index order. The first consumer call (for the entry in
+    // section 0) threw, so section 1 was never drained — its entry survives.
+    assertThat(map.size()).isEqualTo(1);
+    assertThat(map.get(keyInSection1, 0)).isEqualTo("B");
+    assertThat(map.get(keyInSection0, 0)).isNull();
+  }
+
+  /**
    * drainAll invokes the consumer outside the section write lock, so a consumer that re-enters
    * the map (e.g., to insert a new entry) must succeed without deadlock. This mirrors the close
    * path where {@code freeze()} / policy callbacks may touch other maps.
@@ -1885,10 +1936,8 @@ public class ConcurrentLongIntHashMapTest {
     });
 
     // Fill again past the (shrunken) capacity — this exercises rehashes on a fresh table.
-    var seen = new HashSet<String>();
     for (int i = 0; i < 100; i++) {
       map.put(1L, i, "b-" + i);
-      seen.add("b-" + i);
     }
     assertThat(map.size()).isEqualTo(100);
     for (int i = 0; i < 100; i++) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -2054,4 +2054,129 @@ public class ConcurrentLongIntHashMapTest {
     assertThat(collected).containsExactlyInAnyOrder("a", "b", "c");
     assertThat(map.size()).isEqualTo(0);
   }
+
+  // ---- clearAndShrink ----
+
+  /**
+   * clearAndShrink on a populated map must drop every entry and shrink capacity back to the
+   * constructor-time value — the same post-state as drainAll but without invoking any consumer.
+   * Use a small per-section expected-items value so repeated puts force a resize we can observe.
+   */
+  @Test
+  public void clearAndShrinkEmptiesMapAndShrinksCapacityToInitialValue() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    long initialCapacity = map.capacity();
+
+    for (int i = 0; i < 200; i++) {
+      map.put(1L, i, "v" + i);
+    }
+    assertThat(map.capacity())
+        .as("sanity: inserts must have grown the section past initial capacity")
+        .isGreaterThan(initialCapacity);
+
+    map.clearAndShrink();
+
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+    assertThat(map.capacity())
+        .as("clearAndShrink must reset capacity back to the constructor-time value")
+        .isEqualTo(initialCapacity);
+  }
+
+  /**
+   * clearAndShrink on an empty map whose sections are at their initial capacity must be a true
+   * no-op — size stays 0, capacity does not change. Guards the size==0 + capacity==initial fast
+   * path that skips array reallocation for repeated close calls.
+   */
+  @Test
+  public void clearAndShrinkOnEmptyMapAtInitialCapacityIsNoOp() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    long initialCapacity = map.capacity();
+
+    map.clearAndShrink();
+
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.capacity())
+        .as("clearAndShrink on empty map must not change capacity")
+        .isEqualTo(initialCapacity);
+  }
+
+  /**
+   * After clearAndShrink the map must be usable — a refill populates a fresh table without
+   * surfacing stale entries from before the clear.
+   */
+  @Test
+  public void clearAndShrinkLeavesMapUsableForSubsequentPutAndGet() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    for (int i = 0; i < 50; i++) {
+      map.put(1L, i, "old-" + i);
+    }
+
+    map.clearAndShrink();
+
+    for (int i = 0; i < 50; i++) {
+      map.put(1L, i, "new-" + i);
+    }
+    assertThat(map.size()).isEqualTo(50);
+    for (int i = 0; i < 50; i++) {
+      assertThat(map.get(1L, i)).isEqualTo("new-" + i);
+    }
+  }
+
+  /**
+   * clearAndShrink must return the map to a state where get returns null for every previously
+   * present key. Guards against a bug that resets counters but leaves a stale Entry in the array
+   * (which get would still surface).
+   */
+  @Test
+  public void clearAndShrinkClearsEveryEntryFromGet() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 4);
+    for (long fid = 0; fid < 8; fid++) {
+      for (int page = 0; page < 16; page++) {
+        map.put(fid, page, "v-" + fid + "-" + page);
+      }
+    }
+
+    map.clearAndShrink();
+
+    for (long fid = 0; fid < 8; fid++) {
+      for (int page = 0; page < 16; page++) {
+        assertThat(map.get(fid, page))
+            .as("Entry (%d, %d) must be null after clearAndShrink", fid, page)
+            .isNull();
+      }
+    }
+  }
+
+  /**
+   * clearAndShrink on a map that has grown but was drained back to empty must still release the
+   * large arrays. Verifies the size==0 path shrinks when capacity has diverged from initial —
+   * without this, a drained map that is drained again would leak the large arrays forever.
+   */
+  @Test
+  public void clearAndShrinkReleasesGrownArraysOnAlreadyEmptyMap() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    long initialCapacity = map.capacity();
+
+    for (int i = 0; i < 500; i++) {
+      map.put(1L, i, "v" + i);
+    }
+    long grownCapacity = map.capacity();
+    assertThat(grownCapacity).isGreaterThan(initialCapacity);
+
+    // Manually remove every entry (does not shrink — matching real-world wear patterns).
+    for (int i = 0; i < 500; i++) {
+      map.remove(1L, i);
+    }
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.capacity())
+        .as("sanity: remove does not shrink the section")
+        .isEqualTo(grownCapacity);
+
+    map.clearAndShrink();
+
+    assertThat(map.capacity())
+        .as("clearAndShrink must shrink an empty-but-grown section")
+        .isEqualTo(initialCapacity);
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/ConcurrentLongIntHashMapTest.java
@@ -3,7 +3,9 @@ package com.jetbrains.youtrackdb.internal.common.collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import org.junit.Test;
 
 /**
@@ -1684,5 +1686,232 @@ public class ConcurrentLongIntHashMapTest {
     // Integer.MIN_VALUE * 31 overflows and wraps to Integer.MIN_VALUE in int arithmetic
     assertThat(ConcurrentLongIntHashMap.hashForFrequencySketch(Long.MAX_VALUE, 0))
         .isEqualTo(-2147483648);
+  }
+
+  // ---- drainAll ----
+
+  /** drainAll on an empty map must not invoke the consumer and must leave size at zero. */
+  @Test
+  public void drainAllOnEmptyMapInvokesConsumerZeroTimes() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    var collected = new ArrayList<String>();
+    map.drainAll(collected::add);
+    assertThat(collected).isEmpty();
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+  }
+
+  /** drainAll on a single-section map delivers every value exactly once, then empties the map. */
+  @Test
+  public void drainAllOnSingleSectionDeliversEveryValueExactlyOnce() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    for (int i = 0; i < 10; i++) {
+      map.put(1L, i, "v" + i);
+    }
+    assertThat(map.size()).isEqualTo(10);
+
+    var collected = new ArrayList<String>();
+    map.drainAll(collected::add);
+
+    assertThat(collected).hasSize(10);
+    var expected = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      expected.add("v" + i);
+    }
+    assertThat(collected).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(map.size()).isEqualTo(0);
+    assertThat(map.isEmpty()).isTrue();
+  }
+
+  /**
+   * drainAll across many sections collects entries from every section — verifies the iteration
+   * covers all sections, not just the first.
+   */
+  @Test
+  public void drainAllAcrossAllSectionsCollectsEveryEntry() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    int filesCount = 20;
+    int pagesPerFile = 30;
+    var expected = new ArrayList<String>();
+    for (long fid = 0; fid < filesCount; fid++) {
+      for (int page = 0; page < pagesPerFile; page++) {
+        var v = "f" + fid + "-p" + page;
+        map.put(fid, page, v);
+        expected.add(v);
+      }
+    }
+    assertThat(map.size()).isEqualTo(filesCount * pagesPerFile);
+
+    var collected = new ArrayList<String>();
+    map.drainAll(collected::add);
+
+    assertThat(collected).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  /**
+   * drainAll must return the map to a state where get returns null for every previously present
+   * key. Guards against partial drains that leave stale entries.
+   */
+  @Test
+  public void drainAllClearsEveryEntryFromGet() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    for (long fid = 0; fid < 5; fid++) {
+      for (int page = 0; page < 10; page++) {
+        map.put(fid, page, "v-" + fid + "-" + page);
+      }
+    }
+
+    map.drainAll(v -> {
+    });
+
+    for (long fid = 0; fid < 5; fid++) {
+      for (int page = 0; page < 10; page++) {
+        assertThat(map.get(fid, page))
+            .as("Entry (%d, %d) must be null after drainAll", fid, page)
+            .isNull();
+      }
+    }
+  }
+
+  /**
+   * drainAll shrinks each section back to the minimum capacity — avoids retaining a large array
+   * after storage close. Per-section minimum is 2 slots, so total capacity for the default 16
+   * sections is 32.
+   */
+  @Test
+  public void drainAllShrinksCapacityToMinimum() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    // Grow the map past its initial capacity so sections actually have non-default size.
+    for (long fid = 0; fid < 100; fid++) {
+      for (int page = 0; page < 100; page++) {
+        map.put(fid, page, "v");
+      }
+    }
+    long grownCapacity = map.capacity();
+    assertThat(grownCapacity).isGreaterThan(32L);
+
+    map.drainAll(v -> {
+    });
+
+    assertThat(map.capacity())
+        .as("drainAll must shrink capacity to the minimum (2 slots per section * 16 sections)")
+        .isEqualTo(32L);
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  /** After drainAll the map must be usable — puts and gets work as expected on a fresh table. */
+  @Test
+  public void drainAllLeavesMapUsableForSubsequentPutAndGet() {
+    var map = new ConcurrentLongIntHashMap<String>();
+    for (int i = 0; i < 50; i++) {
+      map.put(1L, i, "old-" + i);
+    }
+    map.drainAll(v -> {
+    });
+
+    for (int i = 0; i < 50; i++) {
+      map.put(1L, i, "new-" + i);
+    }
+    for (int i = 0; i < 50; i++) {
+      assertThat(map.get(1L, i)).isEqualTo("new-" + i);
+    }
+    assertThat(map.size()).isEqualTo(50);
+  }
+
+  /**
+   * An exception thrown by the consumer propagates out of drainAll. Because the consumer runs
+   * after each section is drained (and the lock released), the map is already fully drained by
+   * the time the exception surfaces — matching the "best effort, fail fast" semantics of the
+   * close path.
+   */
+  @Test
+  public void drainAllPropagatesConsumerException() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    map.put(1L, 0, "first");
+    map.put(1L, 1, "second");
+
+    assertThatThrownBy(
+        () -> map.drainAll(
+            v -> {
+              throw new IllegalStateException("boom on " + v);
+            }))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("boom on");
+
+    // The map has been fully drained even though the consumer threw — entries were removed
+    // under the write lock before the consumer ran.
+    assertThat(map.size()).isEqualTo(0);
+  }
+
+  /**
+   * drainAll invokes the consumer outside the section write lock, so a consumer that re-enters
+   * the map (e.g., to insert a new entry) must succeed without deadlock. This mirrors the close
+   * path where {@code freeze()} / policy callbacks may touch other maps.
+   */
+  @Test
+  public void drainAllConsumerCanReenterMap() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    map.put(1L, 0, "original");
+    map.put(1L, 1, "original");
+
+    var collected = new ArrayList<String>();
+    map.drainAll(
+        v -> {
+          collected.add(v);
+          // Re-entering the map inside the consumer: must not deadlock on the section lock.
+          if (v.equals("original") && map.get(2L, 0) == null) {
+            map.put(2L, 0, "reentrant");
+          }
+        });
+
+    assertThat(collected).hasSize(2);
+    // The reentrant put landed after drainAll returned from that section's write lock.
+    assertThat(map.get(2L, 0)).isEqualTo("reentrant");
+  }
+
+  /**
+   * drainAll resets both size and usedBuckets to zero — a subsequent fill to the original
+   * resize threshold triggers a normal rehash without corruption.
+   */
+  @Test
+  public void drainAllResetsInternalCountersSoRefillWorks() {
+    var map = new ConcurrentLongIntHashMap<String>(16, 1);
+    // Fill single section to its resize threshold (capacity 16, threshold = 10)
+    for (int i = 0; i < 10; i++) {
+      map.put(1L, i, "a-" + i);
+    }
+    map.drainAll(v -> {
+    });
+
+    // Fill again past the (shrunken) capacity — this exercises rehashes on a fresh table.
+    var seen = new HashSet<String>();
+    for (int i = 0; i < 100; i++) {
+      map.put(1L, i, "b-" + i);
+      seen.add("b-" + i);
+    }
+    assertThat(map.size()).isEqualTo(100);
+    for (int i = 0; i < 100; i++) {
+      assertThat(map.get(1L, i)).isEqualTo("b-" + i);
+    }
+  }
+
+  /**
+   * drainAll on a map whose sections have mixed populations (some empty, some nearly full) must
+   * visit only live entries — never an empty slot.
+   */
+  @Test
+  public void drainAllSkipsEmptySlots() {
+    var map = new ConcurrentLongIntHashMap<String>(64, 1);
+    // Insert only 3 entries into a 64-slot section so most slots remain empty.
+    map.put(1L, 0, "a");
+    map.put(1L, 5, "b");
+    map.put(1L, 10, "c");
+
+    List<String> collected = new ArrayList<>();
+    map.drainAll(collected::add);
+
+    assertThat(collected).containsExactlyInAnyOrder("a", "b", "c");
+    assertThat(map.size()).isEqualTo(0);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
@@ -515,7 +515,7 @@ public class LockFreeReadCacheBatchingTest {
    * Happy-path: {@code closeStorage} populates the read cache, then drains every entry in one
    * pass, resets {@code cacheSize} to zero, and closes the underlying write cache exactly once.
    * This covers the sequencing {@code flushCurrentThreadReadBatch → evictionLock → emptyBuffers
-   * → forEachValue → freeze → policy.onRemove → drainAll → cacheSize.set(0) → writeCache.close()}
+   * → forEachValue → freeze → policy.onRemove → clearAndShrink → cacheSize.set(0) → writeCache.close()}
    * that motivates the whole branch.
    */
   @Test
@@ -584,7 +584,7 @@ public class LockFreeReadCacheBatchingTest {
   }
 
   /**
-   * The third drainAllEntries phase ({@code data.drainAll}) shrinks each section back to its
+   * The third drainAllEntries phase ({@code data.clearAndShrink}) shrinks each section back to its
    * constructor-time capacity. After loading many more pages than the initial per-section
    * capacity, the map total capacity grows; closeStorage must then shrink it back, freeing the
    * retained Entry[] arrays. Without this phase, a long-lived storage that is closed and reopened

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
@@ -21,10 +21,15 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -63,13 +68,16 @@ public class LockFreeReadCacheBatchingTest {
 
   @After
   public void tearDown() {
-    // Tolerant of a cache that was already drained by closeStorage/deleteStorage, or left in
-    // an un-clearable state by a freeze()-failure test (pinned/frozen entries). The direct
-    // memory is reclaimed on GC or on process exit; individual tests are self-isolating.
+    // readCache.clear() iterates the whole shared map regardless of storage id, so
+    // cross-storage tests that fail mid-way still reclaim all unpinned direct memory.
+    // A StorageException from clear() only surfaces when an entry is still pinned — in that
+    // case, the test harness's direct-memory tracker will flag any leaked allocations at JVM
+    // exit, but the individual test is self-isolating.
     try {
       readCache.clear();
-    } catch (Exception ignored) {
-      // Expected when drainAllEntries aborted mid-way or the cache was already closed.
+    } catch (StorageException ignored) {
+      // A freeze()-failure test may leave a pinned entry that blocks clear; tolerate and
+      // move on. Any non-StorageException here indicates a regression and must surface.
     }
   }
 
@@ -512,11 +520,13 @@ public class LockFreeReadCacheBatchingTest {
   // --- drainAllEntries / closeStorage / deleteStorage tests ---
 
   /**
-   * Happy-path: {@code closeStorage} populates the read cache, then drains every entry in one
-   * pass, resets {@code cacheSize} to zero, and closes the underlying write cache exactly once.
-   * This covers the sequencing {@code flushCurrentThreadReadBatch → evictionLock → emptyBuffers
-   * → forEachValue → freeze → policy.onRemove → clearAndShrink → cacheSize.set(0) → writeCache.close()}
-   * that motivates the whole branch.
+   * Happy-path: {@code closeStorage} populates the read cache, then drains every entry
+   * belonging to this storage in one pass, decrements {@code cacheSize} for each drained
+   * entry, and closes the underlying write cache exactly once. Covers the sequencing
+   * {@code flushCurrentThreadReadBatch → evictionLock → emptyBuffers →
+   * data.removeByStorageId(writeCache.getId()) → (per entry: freeze → policy.onRemove →
+   * cacheSize.decrementAndGet) → writeCache.close()} implemented in
+   * {@code LockFreeReadCache.drainAllEntries}.
    */
   @Test
   public void testCloseStorageDrainsAllEntriesAndClosesWriteCacheExactlyOnce() throws Exception {
@@ -584,14 +594,17 @@ public class LockFreeReadCacheBatchingTest {
   }
 
   /**
-   * The third drainAllEntries phase ({@code data.clearAndShrink}) shrinks each section back to its
-   * constructor-time capacity. After loading many more pages than the initial per-section
-   * capacity, the map total capacity grows; closeStorage must then shrink it back, freeing the
-   * retained Entry[] arrays. Without this phase, a long-lived storage that is closed and reopened
-   * would leak the large arrays accumulated during normal operation.
+   * When {@code removeByStorageId} leaves a section empty, it calls {@code shrinkIfGrown} to
+   * reset the section's backing array to its constructor-time capacity, releasing the large
+   * arrays accumulated during normal operation. After loading many more pages than the initial
+   * per-section capacity, sections grow; closeStorage must shrink them back. Without this, a
+   * long-lived JVM that closes and reopens storages would retain the peak array sizes forever.
    */
   @Test
   public void testCloseStorageShrinksMapCapacityAfterDrain() throws Exception {
+    // Capture capacity of a fresh, empty map to assert growth later.
+    long initialCapacity = getDataMap().capacity();
+
     // Load enough distinct pages to force sections to grow beyond their initial capacity.
     int pageCount = 2000;
     for (int i = 0; i < pageCount; i++) {
@@ -601,80 +614,382 @@ public class LockFreeReadCacheBatchingTest {
 
     long preCloseCapacity = getDataMap().capacity();
     Assert.assertTrue(
-        "sanity: sections must have grown beyond initial capacity (pre=" + preCloseCapacity + ")",
-        preCloseCapacity > 0);
+        "sanity: 2000 loads must have grown the map past its initial capacity "
+            + "(initial=" + initialCapacity + ", grown=" + preCloseCapacity + ")",
+        preCloseCapacity > initialCapacity);
 
     readCache.closeStorage(writeCache);
 
-    long postCloseCapacity = getDataMap().capacity();
-    Assert.assertTrue(
-        "closeStorage must shrink map capacity (pre=" + preCloseCapacity
-            + ", post=" + postCloseCapacity + ")",
-        postCloseCapacity < preCloseCapacity);
+    Assert.assertEquals(
+        "closeStorage must shrink map capacity back to its constructor-time value",
+        initialCapacity, getDataMap().capacity());
     Assert.assertEquals(
         "map must be empty after closeStorage", 0L, getDataMap().size());
   }
 
   /**
-   * Freeze-failure contract: when {@code freeze()} fails on a pinned entry during
-   * drainAllEntries, the method throws {@link StorageException} <em>before</em> the map is
-   * mutated, so the caller can retry close on a fresh attempt. Verified end-to-end by:
+   * Freeze-failure contract (remove-first-then-freeze, with re-insertion on failure):
+   * {@code drainAllEntries} atomically removes this storage's entries from the map via
+   * {@code removeByStorageId} <em>before</em> attempting to freeze them. When {@code freeze()}
+   * fails on a pinned entry, the un-frozen entry is re-inserted into the map so that a retry
+   * after the caller releases the pin can drain it; the method then throws {@link
+   * StorageException}. Without the re-insertion, a single pinned page would leak every
+   * already-removed cache entry of this storage (out-of-map, unfrozen, policy zombies, direct
+   * memory pinned). Verified end-to-end by:
    * <ol>
    *   <li>Loading a single entry and holding its read lock (pin).</li>
-   *   <li>Asserting {@code closeStorage} throws StorageException.</li>
-   *   <li>Asserting the map still contains the entry, {@code cacheSize} is unchanged, and
+   *   <li>Asserting {@code closeStorage} throws StorageException with a message that names the
+   *       offending page index and fileId.</li>
+   *   <li>Asserting the pinned entry is BACK in the map after the abort (re-inserted so retry
+   *       can see it), the pinned entry is NOT frozen, {@code cacheSize} is unchanged, and
    *       {@code writeCache.close()} was not invoked.</li>
-   *   <li>Releasing the pin and re-invoking {@code closeStorage} — the retry must succeed and
-   *       must close the write cache exactly once (not twice across both attempts).</li>
+   *   <li>Releasing the pin and re-invoking {@code closeStorage} — the retry must drain the
+   *       re-inserted entry (cacheSize back to 0, map empty) and close the write cache
+   *       exactly once in the retry attempt.</li>
    * </ol>
-   * Using a single entry guarantees the only iterated entry is the pinned one, so no other entry
-   * is frozen before the abort — the retry therefore reaches a clean state.
    */
   @Test
   public void testCloseStorageAbortsOnFreezeFailureAndIsRetryable() throws Exception {
     var pinnedEntry = readCache.loadForRead(0, 0, writeCache, false);
     // Do NOT release — the entry's use count stays at 1, so freeze() returns false.
 
-    long preCacheSize = getCacheSizeCounter();
-    long preMapSize = getDataMap().size();
-    Assert.assertEquals("sanity: exactly one entry in the map", 1L, preMapSize);
+    int preCacheSize = getCacheSizeCounter();
+    Assert.assertEquals("sanity: exactly one entry in the map", 1L, getDataMap().size());
+    Assert.assertEquals("sanity: cacheSize accounts for the loaded entry", 1, preCacheSize);
 
     try {
       readCache.closeStorage(writeCache);
       Assert.fail("closeStorage must throw StorageException when an entry cannot be frozen");
     } catch (StorageException expected) {
-      // The exception message must name the entry that blocked the close so operators can
-      // identify the leaking caller.
+      // The exception message must name the exact page index and file id that blocked the
+      // close so operators can identify the leaking caller — loose contains("Page with index")
+      // would pass a buggy format like "Page with index null...".
+      Assert.assertNotNull("exception message must not be null", expected.getMessage());
       Assert.assertTrue(
-          "exception message must reference the blocking page: " + expected.getMessage(),
-          expected.getMessage() != null
-              && expected.getMessage().contains("Page with index"));
+          "exception message must name page index 0 and file id 0: " + expected.getMessage(),
+          expected.getMessage().contains("Page with index 0")
+              && expected.getMessage().contains("for file id 0")
+              && expected.getMessage().contains("cannot be removed"));
     }
 
+    // Re-insertion contract: the pinned entry is BACK in the map after the abort so that a
+    // retry (after the pin is released) can drain it. If we left it out, every remaining cache
+    // entry for this storage would be silently leaked.
     Assert.assertEquals(
-        "cacheSize must be unchanged after aborted close",
-        preCacheSize, getCacheSizeCounter());
-    Assert.assertEquals(
-        "map must still contain the entry after aborted close",
-        preMapSize, getDataMap().size());
-    Assert.assertEquals(
-        "writeCache.close() must NOT be called when drainAllEntries aborts",
-        0, writeCache.closeCount.get());
+        "pinned entry must be re-inserted after freeze failure — retry needs to see it",
+        1L, getDataMap().size());
     Assert.assertFalse(
         "pinned entry must NOT be frozen when drainAllEntries aborts on it",
         pinnedEntry.isFrozen());
+    Assert.assertEquals(
+        "cacheSize must be unchanged after aborted close (entry was re-inserted)",
+        preCacheSize, getCacheSizeCounter());
+    Assert.assertEquals(
+        "writeCache.close() must NOT be called when drainAllEntries aborts",
+        0, writeCache.closeCount.get());
 
-    // Retry: once the pin is released, closeStorage must succeed on a fresh attempt.
+    // Retry: once the pin is released, closeStorage must drain the re-inserted entry and
+    // close the write cache.
     readCache.releaseFromRead(pinnedEntry);
     readCache.closeStorage(writeCache);
 
     Assert.assertEquals(
-        "retry must reset cacheSize", 0, getCacheSizeCounter());
+        "retry must drain the re-inserted entry", 0L, getDataMap().size());
     Assert.assertEquals(
-        "retry must drain the map", 0L, getDataMap().size());
+        "retry must decrement cacheSize back to zero", 0, getCacheSizeCounter());
     Assert.assertEquals(
-        "retry must close writeCache exactly once across both attempts",
+        "retry must close writeCache exactly once in the retry attempt",
         1, writeCache.closeCount.get());
+  }
+
+  /**
+   * Cross-storage isolation: {@code LockFreeReadCache} is a JVM singleton shared by every open
+   * storage. Closing ONE storage must leave entries belonging to OTHER live storages untouched;
+   * otherwise concurrent {@code doLoad} calls on other storages would observe a frozen entry and
+   * spin forever. This was the root cause of the CI hang that preceded this test.
+   *
+   * <p>Populates the cache from two write caches with distinct storage ids (0 and 42), closes
+   * storage 0, and asserts that storage 42's entries remain present, alive, and loadable via
+   * cache-hit semantics (no re-insertion as a miss).
+   */
+  @Test
+  public void testCloseStorageDoesNotAffectOtherStorages() throws Exception {
+    var otherWriteCache = new MockedWriteCache(bufferPool, 42);
+
+    // Populate: 5 pages in this writeCache (storageId=0), 5 pages in otherWriteCache.
+    int pages = 5;
+    for (int p = 0; p < pages; p++) {
+      readCache.releaseFromRead(readCache.loadForRead(0, p, writeCache, false));
+      readCache.releaseFromRead(readCache.loadForRead(0, p, otherWriteCache, false));
+    }
+
+    Assert.assertEquals(
+        "sanity: 2 storages * 5 pages = 10 entries before close",
+        10L, getDataMap().size());
+
+    readCache.closeStorage(writeCache);
+
+    Assert.assertEquals(
+        "closeStorage must only remove its own storage's entries — the other storage's 5 pages "
+            + "must still be in the map",
+        5L, getDataMap().size());
+    Assert.assertEquals(
+        "cacheSize must reflect only the surviving entries",
+        5, getCacheSizeCounter());
+
+    // Cache-hit semantics check: loading an already-cached page on the OTHER storage must hit
+    // the cache, so cacheSize does not grow. A regression that accidentally evicted other
+    // storages' entries would turn this into a cache miss and bump cacheSize.
+    int cacheSizeBeforeReloads = getCacheSizeCounter();
+    for (int p = 0; p < pages; p++) {
+      var entry = readCache.loadForRead(0, p, otherWriteCache, false);
+      Assert.assertFalse(
+          "entry for other storage's page " + p + " must not be frozen by the other close",
+          entry.isFrozen());
+      readCache.releaseFromRead(entry);
+    }
+    Assert.assertEquals(
+        "reloading other-storage pages after close must be cache hits (cacheSize unchanged)",
+        cacheSizeBeforeReloads, getCacheSizeCounter());
+
+    // Cleanup: drain the other storage so @After doesn't leak pointers.
+    readCache.closeStorage(otherWriteCache);
+  }
+
+  /**
+   * Cross-storage isolation under a freeze failure: closing storage A fails because one of A's
+   * pages is pinned. The exception must not touch storage B's entries — they must still be
+   * present, alive, and unpinned. A subsequent retry (after releasing A's pin) must drain A
+   * without touching B, and B can then close cleanly. This is the critical invariant that
+   * makes the CI-hang fix safe: even when close aborts mid-way, other live storages keep
+   * functioning.
+   */
+  @Test
+  public void testCloseStorageFreezeFailureDoesNotAffectOtherStorages() throws Exception {
+    var otherWriteCache = new MockedWriteCache(bufferPool, 99);
+
+    // One pinned page in storageId=0.
+    var pinnedEntry = readCache.loadForRead(0, 0, writeCache, false);
+    // Three clean pages in storageId=99 (otherWriteCache).
+    for (int p = 0; p < 3; p++) {
+      readCache.releaseFromRead(readCache.loadForRead(0, p, otherWriteCache, false));
+    }
+
+    try {
+      try {
+        readCache.closeStorage(writeCache);
+        Assert.fail("closeStorage must throw StorageException when a page is pinned");
+      } catch (StorageException expected) {
+        // Exception must name the blocking page so operators can diagnose the leak.
+        Assert.assertNotNull(expected.getMessage());
+        Assert.assertTrue(
+            "exception must name storage 0's pinned page: " + expected.getMessage(),
+            expected.getMessage().contains("Page with index 0")
+                && expected.getMessage().contains("cannot be removed"));
+      }
+
+      // 3 storage-99 entries + 1 re-inserted pinned storage-0 entry = 4.
+      Assert.assertEquals(
+          "after freeze failure: 3 surviving storage-99 + 1 re-inserted pinned = 4",
+          4L, getDataMap().size());
+      Assert.assertEquals(
+          "cacheSize must be unchanged by a freeze failure",
+          4, getCacheSizeCounter());
+
+      // Other storage's entries must still be loadable (cache-hit, not re-inserted).
+      int cacheSizeBeforeReloads = getCacheSizeCounter();
+      for (int p = 0; p < 3; p++) {
+        var entry = readCache.loadForRead(0, p, otherWriteCache, false);
+        Assert.assertFalse(
+            "other storage's entry " + p + " must not be frozen",
+            entry.isFrozen());
+        readCache.releaseFromRead(entry);
+      }
+      Assert.assertEquals(
+          "reloading other-storage pages must be cache hits",
+          cacheSizeBeforeReloads, getCacheSizeCounter());
+    } finally {
+      // Always release the pin so tearDown doesn't fail to clear the cache.
+      readCache.releaseFromRead(pinnedEntry);
+    }
+
+    // Retry closing storageId=0 after releasing the pin — must drain only storage 0's entry
+    // (the re-inserted one), leaving storage 99's 3 entries intact.
+    readCache.closeStorage(writeCache);
+    Assert.assertEquals(
+        "retry must not touch other storage's 3 entries",
+        3L, getDataMap().size());
+    Assert.assertEquals(
+        "retry must decrement cacheSize by 1 (the formerly-pinned entry)",
+        3, getCacheSizeCounter());
+
+    readCache.closeStorage(otherWriteCache);
+    Assert.assertEquals(
+        "final close of storage 99 must empty the cache",
+        0, getCacheSizeCounter());
+  }
+
+  /**
+   * Empty-storage close: closing a storage that never loaded any pages must still invoke
+   * {@code writeCache.close()} exactly once. A regression that guarded
+   * {@code writeCache.close()} behind "drain loop did some work" would silently skip the
+   * file-close I/O and corrupt shutdown.
+   */
+  @Test
+  public void testCloseStorageOnEmptyStorageStillClosesWriteCacheExactlyOnce() throws Exception {
+    Assert.assertEquals(
+        "sanity: cache is empty before closeStorage", 0, readCache.getUsedMemory());
+    Assert.assertEquals(
+        "sanity: writeCache has not been closed", 0, writeCache.closeCount.get());
+
+    readCache.closeStorage(writeCache);
+
+    Assert.assertEquals(
+        "closeStorage on an empty storage must still invoke writeCache.close() exactly once",
+        1, writeCache.closeCount.get());
+    Assert.assertEquals(0, getCacheSizeCounter());
+    Assert.assertEquals(0L, getDataMap().size());
+  }
+
+  /**
+   * Partial freeze failure across many entries: loads 5 clean pages + 1 pinned page for the
+   * same storage, then calls {@code closeStorage}. The 5 frozen-successfully entries must be
+   * fully processed (out of map, policy.onRemove called, cacheSize decremented) while the
+   * single pinned entry is re-inserted so a retry can handle it. A regression that threw on
+   * the first failure without continuing the loop would leak the other 4 clean entries of the
+   * batch (un-frozen, policy-zombies, direct memory pinned until JVM exit).
+   */
+  @Test
+  public void testCloseStoragePartialFreezeFailureProcessesAllNonPinnedEntries() throws Exception {
+    int cleanPages = 5;
+    for (int p = 0; p < cleanPages; p++) {
+      readCache.releaseFromRead(readCache.loadForRead(0, p, writeCache, false));
+    }
+    // Pin the 6th page. Freeze will fail on it.
+    var pinnedEntry = readCache.loadForRead(0, cleanPages, writeCache, false);
+
+    Assert.assertEquals(
+        "sanity: 6 entries in the map before close",
+        cleanPages + 1L, getDataMap().size());
+    Assert.assertEquals(
+        "sanity: cacheSize matches map size",
+        cleanPages + 1, getCacheSizeCounter());
+
+    try {
+      try {
+        readCache.closeStorage(writeCache);
+        Assert.fail("closeStorage must throw StorageException on the pinned entry");
+      } catch (StorageException expected) {
+        // expected
+      }
+
+      // Exactly 1 entry remains (the re-inserted pinned one); the 5 clean entries were fully
+      // processed: frozen, onRemove'd, and decremented from cacheSize.
+      Assert.assertEquals(
+          "5 clean entries must be fully removed from the map; only the pinned one survives "
+              + "via re-insertion",
+          1L, getDataMap().size());
+      Assert.assertEquals(
+          "cacheSize must have been decremented for each of the 5 successfully-frozen entries",
+          1, getCacheSizeCounter());
+      Assert.assertFalse(
+          "the re-inserted pinned entry must NOT be frozen",
+          pinnedEntry.isFrozen());
+      // Cross-check the invariant eden + probation + protection == cacheSize == data.size().
+      // The re-inserted un-frozen entry was never removed from the policy's LRU lists, so
+      // policy state must still match cacheSize / data.size(). A regression that decremented
+      // cacheSize for the failed entry (or called policy.onRemove on the un-frozen re-inserted
+      // one) would be caught here.
+      readCache.assertSize();
+      readCache.assertConsistency();
+    } finally {
+      readCache.releaseFromRead(pinnedEntry);
+    }
+
+    // Retry after unpinning must drain the formerly-pinned entry cleanly.
+    readCache.closeStorage(writeCache);
+    Assert.assertEquals("retry must empty the map", 0L, getDataMap().size());
+    Assert.assertEquals(
+        "retry must decrement cacheSize to zero", 0, getCacheSizeCounter());
+    Assert.assertEquals(
+        "writeCache.close() must be invoked exactly once across the failed attempt + retry",
+        1, writeCache.closeCount.get());
+  }
+
+  /**
+   * Reproducer / live-check for the CI-hang root cause: a reader thread on storage B keeps
+   * calling {@code loadForRead} while storage A closes on the main thread. In the buggy
+   * implementation (pre-fix, unfiltered drain), storage B's entries became frozen mid-close
+   * and the reader's {@code doLoad} would spin forever in its {@code while (true)} loop.
+   *
+   * <p>With the fix, the reader must keep making progress during and after the close — this
+   * is the only test shape that witnesses the absence of the spin at runtime. A regression
+   * that froze other storages' entries (or left a frozen-in-map window) would hang the reader
+   * and fail the 10s join timeout below.
+   */
+  @Test
+  public void testCloseStorageDoesNotHangConcurrentReadsOnOtherStorages() throws Exception {
+    var otherWriteCache = new MockedWriteCache(bufferPool, 42);
+    int pages = 50;
+    for (int p = 0; p < pages; p++) {
+      readCache.releaseFromRead(readCache.loadForRead(0, p, writeCache, false));
+      readCache.releaseFromRead(readCache.loadForRead(0, p, otherWriteCache, false));
+    }
+
+    var readerStarted = new CountDownLatch(1);
+    var stopReader = new AtomicBoolean(false);
+    var readsCompleted = new AtomicLong();
+    var readerFailure = new AtomicReference<Throwable>();
+
+    Thread reader = new Thread(() -> {
+      try {
+        var rng = ThreadLocalRandom.current();
+        readerStarted.countDown();
+        while (!stopReader.get()) {
+          int p = rng.nextInt(pages);
+          var entry = readCache.loadForRead(0, p, otherWriteCache, false);
+          Assert.assertFalse(
+              "other storage's entry " + p + " must never be frozen during unrelated close",
+              entry.isFrozen());
+          readCache.releaseFromRead(entry);
+          readsCompleted.incrementAndGet();
+        }
+      } catch (Throwable t) {
+        readerFailure.set(t);
+      }
+    }, "other-storage-reader");
+    reader.start();
+
+    Assert.assertTrue("reader thread must start within 5s",
+        readerStarted.await(5, TimeUnit.SECONDS));
+    long preCloseReads = readsCompleted.get();
+
+    // Close storage 0 while reader hammers storage 42. If the fix regresses and any storage-42
+    // entry becomes frozen-in-map (or otherwise unacquirable) the reader's doLoad would spin
+    // forever; this line and the subsequent join would not return.
+    readCache.closeStorage(writeCache);
+
+    // Give the reader 2 s to accumulate at least 1000 additional reads post-close — a spinning
+    // reader would make zero progress.
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+    while (System.nanoTime() < deadline && readsCompleted.get() - preCloseReads < 1000) {
+      Thread.yield();
+    }
+
+    stopReader.set(true);
+    reader.join(TimeUnit.SECONDS.toMillis(10));
+    Assert.assertFalse(
+        "reader thread must terminate within 10s — a spin regression would leave it alive",
+        reader.isAlive());
+    Assert.assertNull(
+        "reader thread must not have observed a frozen/stale storage-42 entry",
+        readerFailure.get());
+    Assert.assertTrue(
+        "reader must make forward progress during and after close (post-close reads: "
+            + (readsCompleted.get() - preCloseReads) + ")",
+        readsCompleted.get() - preCloseReads >= 1000);
+
+    readCache.closeStorage(otherWriteCache);
   }
 
   /**
@@ -841,11 +1156,20 @@ public class LockFreeReadCacheBatchingTest {
   private static final class MockedWriteCache implements WriteCache {
 
     private final ByteBufferPool byteBufferPool;
+    private final int storageId;
     final AtomicInteger closeCount = new AtomicInteger();
     final AtomicInteger deleteCount = new AtomicInteger();
 
     MockedWriteCache(final ByteBufferPool byteBufferPool) {
+      this(byteBufferPool, 0);
+    }
+
+    // Tests that exercise storage isolation in drainAllEntries populate the cache from two
+    // different writeCache instances and need distinct storage ids in the composed fileId
+    // (high 32 bits), so a single-storage close leaves the other storage's entries intact.
+    MockedWriteCache(final ByteBufferPool byteBufferPool, final int storageId) {
       this.byteBufferPool = byteBufferPool;
+      this.storageId = storageId;
     }
 
     ByteBufferPool byteBufferPool() {
@@ -1007,7 +1331,7 @@ public class LockFreeReadCacheBatchingTest {
 
     @Override
     public int getId() {
-      return 0;
+      return storageId;
     }
 
     @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/LockFreeReadCacheBatchingTest.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.storage.cache.chm;
 
+import com.jetbrains.youtrackdb.internal.common.collection.ConcurrentLongIntHashMap;
 import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator;
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
@@ -7,6 +8,7 @@ import com.jetbrains.youtrackdb.internal.common.profiler.metrics.Ratio;
 import com.jetbrains.youtrackdb.internal.common.types.ModifiableBoolean;
 import com.jetbrains.youtrackdb.internal.core.YouTrackDBEnginesManager;
 import com.jetbrains.youtrackdb.internal.core.command.CommandOutputListener;
+import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.PageDataVerificationError;
@@ -47,7 +49,7 @@ public class LockFreeReadCacheBatchingTest {
   private DirectMemoryAllocator allocator;
   private ByteBufferPool bufferPool;
   private LockFreeReadCache readCache;
-  private WriteCache writeCache;
+  private MockedWriteCache writeCache;
 
   @Before
   public void setUp() {
@@ -61,7 +63,14 @@ public class LockFreeReadCacheBatchingTest {
 
   @After
   public void tearDown() {
-    readCache.clear();
+    // Tolerant of a cache that was already drained by closeStorage/deleteStorage, or left in
+    // an un-clearable state by a freeze()-failure test (pinned/frozen entries). The direct
+    // memory is reclaimed on GC or on process exit; individual tests are self-isolating.
+    try {
+      readCache.clear();
+    } catch (Exception ignored) {
+      // Expected when drainAllEntries aborted mid-way or the cache was already closed.
+    }
   }
 
   /**
@@ -500,6 +509,268 @@ public class LockFreeReadCacheBatchingTest {
     Assert.assertEquals("Used memory must be 0 after clear()", 0, readCache.getUsedMemory());
   }
 
+  // --- drainAllEntries / closeStorage / deleteStorage tests ---
+
+  /**
+   * Happy-path: {@code closeStorage} populates the read cache, then drains every entry in one
+   * pass, resets {@code cacheSize} to zero, and closes the underlying write cache exactly once.
+   * This covers the sequencing {@code flushCurrentThreadReadBatch → evictionLock → emptyBuffers
+   * → forEachValue → freeze → policy.onRemove → drainAll → cacheSize.set(0) → writeCache.close()}
+   * that motivates the whole branch.
+   */
+  @Test
+  public void testCloseStorageDrainsAllEntriesAndClosesWriteCacheExactlyOnce() throws Exception {
+    int fileCount = 3;
+    int pagesPerFile = 10;
+    for (int fileId = 0; fileId < fileCount; fileId++) {
+      for (int pageIdx = 0; pageIdx < pagesPerFile; pageIdx++) {
+        var entry = readCache.loadForRead(fileId, pageIdx, writeCache, false);
+        readCache.releaseFromRead(entry);
+      }
+    }
+
+    Assert.assertEquals(
+        "sanity: cache must be populated before closeStorage",
+        (long) fileCount * pagesPerFile * PAGE_SIZE, readCache.getUsedMemory());
+    Assert.assertEquals(
+        "sanity: writeCache must not be closed before closeStorage",
+        0, writeCache.closeCount.get());
+
+    readCache.closeStorage(writeCache);
+
+    Assert.assertEquals(
+        "closeStorage must reset used memory", 0, readCache.getUsedMemory());
+    Assert.assertEquals(
+        "closeStorage must reset the internal cacheSize counter",
+        0, getCacheSizeCounter());
+    Assert.assertEquals(
+        "closeStorage must drain the internal map", 0L, getDataMap().size());
+    Assert.assertEquals(
+        "closeStorage must close writeCache exactly once",
+        1, writeCache.closeCount.get());
+    Assert.assertEquals(
+        "closeStorage must not invoke writeCache.delete()",
+        0, writeCache.deleteCount.get());
+  }
+
+  /**
+   * Happy-path: {@code deleteStorage} follows the same drain sequencing as closeStorage but
+   * invokes {@code writeCache.delete()} rather than {@code close()}.
+   */
+  @Test
+  public void testDeleteStorageDrainsAllEntriesAndDeletesWriteCacheExactlyOnce() throws Exception {
+    for (int i = 0; i < 16; i++) {
+      var entry = readCache.loadForRead(0, i, writeCache, false);
+      readCache.releaseFromRead(entry);
+    }
+
+    Assert.assertEquals(
+        "sanity: cache populated", 16L * PAGE_SIZE, readCache.getUsedMemory());
+
+    readCache.deleteStorage(writeCache);
+
+    Assert.assertEquals(
+        "deleteStorage must reset used memory", 0, readCache.getUsedMemory());
+    Assert.assertEquals(
+        "deleteStorage must reset cacheSize", 0, getCacheSizeCounter());
+    Assert.assertEquals(
+        "deleteStorage must drain the map", 0L, getDataMap().size());
+    Assert.assertEquals(
+        "deleteStorage must call writeCache.delete() exactly once",
+        1, writeCache.deleteCount.get());
+    Assert.assertEquals(
+        "deleteStorage must not invoke writeCache.close()",
+        0, writeCache.closeCount.get());
+  }
+
+  /**
+   * The third drainAllEntries phase ({@code data.drainAll}) shrinks each section back to its
+   * constructor-time capacity. After loading many more pages than the initial per-section
+   * capacity, the map total capacity grows; closeStorage must then shrink it back, freeing the
+   * retained Entry[] arrays. Without this phase, a long-lived storage that is closed and reopened
+   * would leak the large arrays accumulated during normal operation.
+   */
+  @Test
+  public void testCloseStorageShrinksMapCapacityAfterDrain() throws Exception {
+    // Load enough distinct pages to force sections to grow beyond their initial capacity.
+    int pageCount = 2000;
+    for (int i = 0; i < pageCount; i++) {
+      var entry = readCache.loadForRead(0, i, writeCache, false);
+      readCache.releaseFromRead(entry);
+    }
+
+    long preCloseCapacity = getDataMap().capacity();
+    Assert.assertTrue(
+        "sanity: sections must have grown beyond initial capacity (pre=" + preCloseCapacity + ")",
+        preCloseCapacity > 0);
+
+    readCache.closeStorage(writeCache);
+
+    long postCloseCapacity = getDataMap().capacity();
+    Assert.assertTrue(
+        "closeStorage must shrink map capacity (pre=" + preCloseCapacity
+            + ", post=" + postCloseCapacity + ")",
+        postCloseCapacity < preCloseCapacity);
+    Assert.assertEquals(
+        "map must be empty after closeStorage", 0L, getDataMap().size());
+  }
+
+  /**
+   * Freeze-failure contract: when {@code freeze()} fails on a pinned entry during
+   * drainAllEntries, the method throws {@link StorageException} <em>before</em> the map is
+   * mutated, so the caller can retry close on a fresh attempt. Verified end-to-end by:
+   * <ol>
+   *   <li>Loading a single entry and holding its read lock (pin).</li>
+   *   <li>Asserting {@code closeStorage} throws StorageException.</li>
+   *   <li>Asserting the map still contains the entry, {@code cacheSize} is unchanged, and
+   *       {@code writeCache.close()} was not invoked.</li>
+   *   <li>Releasing the pin and re-invoking {@code closeStorage} — the retry must succeed and
+   *       must close the write cache exactly once (not twice across both attempts).</li>
+   * </ol>
+   * Using a single entry guarantees the only iterated entry is the pinned one, so no other entry
+   * is frozen before the abort — the retry therefore reaches a clean state.
+   */
+  @Test
+  public void testCloseStorageAbortsOnFreezeFailureAndIsRetryable() throws Exception {
+    var pinnedEntry = readCache.loadForRead(0, 0, writeCache, false);
+    // Do NOT release — the entry's use count stays at 1, so freeze() returns false.
+
+    long preCacheSize = getCacheSizeCounter();
+    long preMapSize = getDataMap().size();
+    Assert.assertEquals("sanity: exactly one entry in the map", 1L, preMapSize);
+
+    try {
+      readCache.closeStorage(writeCache);
+      Assert.fail("closeStorage must throw StorageException when an entry cannot be frozen");
+    } catch (StorageException expected) {
+      // The exception message must name the entry that blocked the close so operators can
+      // identify the leaking caller.
+      Assert.assertTrue(
+          "exception message must reference the blocking page: " + expected.getMessage(),
+          expected.getMessage() != null
+              && expected.getMessage().contains("Page with index"));
+    }
+
+    Assert.assertEquals(
+        "cacheSize must be unchanged after aborted close",
+        preCacheSize, getCacheSizeCounter());
+    Assert.assertEquals(
+        "map must still contain the entry after aborted close",
+        preMapSize, getDataMap().size());
+    Assert.assertEquals(
+        "writeCache.close() must NOT be called when drainAllEntries aborts",
+        0, writeCache.closeCount.get());
+    Assert.assertFalse(
+        "pinned entry must NOT be frozen when drainAllEntries aborts on it",
+        pinnedEntry.isFrozen());
+
+    // Retry: once the pin is released, closeStorage must succeed on a fresh attempt.
+    readCache.releaseFromRead(pinnedEntry);
+    readCache.closeStorage(writeCache);
+
+    Assert.assertEquals(
+        "retry must reset cacheSize", 0, getCacheSizeCounter());
+    Assert.assertEquals(
+        "retry must drain the map", 0L, getDataMap().size());
+    Assert.assertEquals(
+        "retry must close writeCache exactly once across both attempts",
+        1, writeCache.closeCount.get());
+  }
+
+  /**
+   * Concurrency contract: the drainAllEntries precondition says "no concurrent doLoad during
+   * close" — but the method must still handle the state left behind by concurrent reads that
+   * <em>have already quiesced</em>. Multiple reader threads accumulate per-thread ReadBatch
+   * state and outstanding write-buffer entries; once they finish, {@code closeStorage} from a
+   * different thread must flush the batches of all threads (via emptyBuffers on the write buffer
+   * + drainReadBuffers on the striped read buffer), drain every entry, and close the write cache
+   * exactly once. Without the {@code flushCurrentThreadReadBatch → emptyBuffers} sequencing,
+   * pending read events would reference cache entries after drainAll freed them.
+   */
+  @Test
+  public void testCloseStorageAfterConcurrentReadsDrainsEverything() throws Exception {
+    int fileCount = 4;
+    int pageLimit = 200;
+    int threadCount = 4;
+    int readsPerThread = 5_000;
+
+    // Pre-load pages single-threaded so readers see cache hits.
+    for (int f = 0; f < fileCount; f++) {
+      for (int p = 0; p < pageLimit; p++) {
+        var entry = readCache.loadForRead(f, p, writeCache, false);
+        readCache.releaseFromRead(entry);
+      }
+    }
+
+    var executor = Executors.newFixedThreadPool(threadCount);
+    List<Future<Void>> futures = new ArrayList<>();
+    try {
+      for (int t = 0; t < threadCount; t++) {
+        futures.add(executor.submit(() -> {
+          var rng = ThreadLocalRandom.current();
+          for (int i = 0; i < readsPerThread; i++) {
+            int fileId = rng.nextInt(fileCount);
+            int pageIndex = rng.nextInt(pageLimit);
+            var entry = readCache.loadForRead(fileId, pageIndex, writeCache, false);
+            readCache.releaseFromRead(entry);
+          }
+          return null;
+        }));
+      }
+      for (var future : futures) {
+        future.get();
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    // Pre-close sanity: cache has entries, writeCache has not been closed.
+    Assert.assertTrue(
+        "sanity: cache must be populated after concurrent reads",
+        readCache.getUsedMemory() > 0);
+    Assert.assertEquals(
+        "sanity: writeCache.close() must not have run yet",
+        0, writeCache.closeCount.get());
+
+    // closeStorage from the main thread — a different thread than the readers. It must flush the
+    // entries accumulated in every thread's ReadBatch and every pending write-buffer entry.
+    readCache.closeStorage(writeCache);
+
+    Assert.assertEquals(
+        "closeStorage must reset used memory to zero after concurrent reads",
+        0, readCache.getUsedMemory());
+    Assert.assertEquals(
+        "closeStorage must reset cacheSize after concurrent reads",
+        0, getCacheSizeCounter());
+    Assert.assertEquals(
+        "closeStorage must drain the map after concurrent reads",
+        0L, getDataMap().size());
+    Assert.assertEquals(
+        "closeStorage must invoke writeCache.close() exactly once",
+        1, writeCache.closeCount.get());
+  }
+
+  /**
+   * Reflection helper: returns the current value of {@code LockFreeReadCache.cacheSize}, used
+   * to assert that drainAllEntries resets the counter (and, on abort, does not).
+   */
+  private int getCacheSizeCounter() throws Exception {
+    var cacheSizeField = LockFreeReadCache.class.getDeclaredField("cacheSize");
+    cacheSizeField.setAccessible(true);
+    return ((AtomicInteger) cacheSizeField.get(readCache)).get();
+  }
+
+  /**
+   * Reflection helper: returns the internal {@link ConcurrentLongIntHashMap} backing the cache,
+   * so tests can observe map size and capacity directly (both public methods on the map).
+   */
+  @SuppressWarnings("unchecked")
+  private ConcurrentLongIntHashMap<CacheEntry> getDataMap() throws Exception {
+    var dataField = LockFreeReadCache.class.getDeclaredField("data");
+    dataField.setAccessible(true);
+    return (ConcurrentLongIntHashMap<CacheEntry>) dataField.get(readCache);
+  }
+
   // --- resolveCacheHitRatio tests ---
 
   /**
@@ -562,8 +833,24 @@ public class LockFreeReadCacheBatchingTest {
   }
 
   // --- MockedWriteCache (same pattern as AsyncReadCacheTestIT) ---
+  //
+  // Non-record class so the `close()` / `delete()` / `closeFile()` call counts are visible to
+  // tests that verify drainAllEntries sequencing (closeStorage/deleteStorage must only close the
+  // write cache after the read-cache drain succeeds).
 
-  private record MockedWriteCache(ByteBufferPool byteBufferPool) implements WriteCache {
+  private static final class MockedWriteCache implements WriteCache {
+
+    private final ByteBufferPool byteBufferPool;
+    final AtomicInteger closeCount = new AtomicInteger();
+    final AtomicInteger deleteCount = new AtomicInteger();
+
+    MockedWriteCache(final ByteBufferPool byteBufferPool) {
+      this.byteBufferPool = byteBufferPool;
+    }
+
+    ByteBufferPool byteBufferPool() {
+      return byteBufferPool;
+    }
 
     @Override
     public void addPageIsBrokenListener(final PageIsBrokenListener listener) {
@@ -688,6 +975,7 @@ public class LockFreeReadCacheBatchingTest {
 
     @Override
     public long[] close() {
+      closeCount.incrementAndGet();
       return new long[0];
     }
 
@@ -703,6 +991,7 @@ public class LockFreeReadCacheBatchingTest {
 
     @Override
     public long[] delete() {
+      deleteCount.incrementAndGet();
       return new long[0];
     }
 


### PR DESCRIPTION
## Motivation

`closeStorage`/`deleteStorage` iterated every file and called `ConcurrentLongIntHashMap.removeByFileId` for each one. Each `removeByFileId` linearly sweeps all 16 sections and same-capacity rehashes any section with a match, giving a total cost of `O(N_files * total_capacity)`. On storages with thousands of clusters and a warm read cache this pegged a single close thread at 100% CPU inside `removeByFileId` for 30+ minutes.

Close already removes every entry, so per-file granularity is wasted work. This PR collapses the close/delete path into a single `O(total_capacity)` sweep.

## Summary

- Add `ConcurrentLongIntHashMap.drainAll(Consumer<V>)` — one pass over every section that collects live values, resets the section to its original constructor capacity, then invokes the consumer outside the section write lock (preserving `removeByFileId`'s reentrancy contract).
- Each `Section` remembers its `initialCapacity` at construction; `drain` resets to that instead of the absolute minimum (2), so a refill after drain doesn't pay a rehash chain (2 → 4 → 8 → …) on the way back up.
- Rework `LockFreeReadCache.drainAllEntries` into a two-phase flow mirroring `clear()`: `forEachValue` snapshot → `freeze + policy.onRemove` per entry → `data.drainAll` shrink pass → `cacheSize.set(0)`. A `freeze()` failure now aborts before the map is modified, so close is retryable. Also closes a `cacheSize` drift gap that `clear()` already guards against.
- `closeStorage` / `deleteStorage` now call `drainAllEntries` once instead of `removeByFileId` per file. `closeFile`, `truncateFile`, and `deleteFile` still use `removeByFileId` since they legitimately target a single file.
- Drop the per-entry `writeCache.checkCacheOverflow()` call — redundant since `writeCache.close()`/`delete()` already flushes everything.

## Tests

- `ConcurrentLongIntHashMapTest`: `drainAll` happy path + single-section, multi-section with rehash/shrink, consumer reentrancy (distinct values so `v.equals` isn't a tautology), shrink to aligned custom `expectedItems`, second drain is no-op, counters reset so refill works, consumer-exception stops at current section (later sections retain entries).
- `ConcurrentLongIntHashMapConcurrentTest`: `drainAll` under 4 readers + 2 writers + 1 drainer, mirroring existing rehash/shrink stress coverage — exercises the array-swap hazard in `Section.drain`.
- `LockFreeReadCacheBatchingTest`: five tests pin the full `closeStorage`/`deleteStorage` contract — close drains across files and calls `writeCache.close()` exactly once, delete symmetric, map shrinks after drain (2000 pages → sections grow past initial capacity → capacity returns to initial), `freeze()` failure aborts with `StorageException` and leaves state untouched so retry succeeds, and close after concurrent reads drains every per-thread `ReadBatch` without leaking.

## Test plan

- [x] `./mvnw -pl core clean test` — unit tests pass (`ConcurrentLongIntHashMap*`, `LockFreeReadCacheBatchingTest`)
- [x] Spotless applied
- [ ] CI green on this PR