### PR TITLE
[no-test-number-check] Fix CASDiskWriteAheadLogIT WAL record ID out of range

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLogIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLogIT.java
@@ -38,6 +38,12 @@ import org.junit.experimental.categories.Category;
 @Category(SequentialTest.class)
 public class CASDiskWriteAheadLogIT {
 
+  // Must satisfy [PAGE_OPERATION_ID_BASE, ID_TABLE_SIZE) in WALRecordsFactory:
+  // currently [200, 512). 511 is picked at the top of the range to stay clear
+  // of production PageOperation IDs (200..296 today) and of the 500 used by
+  // the sibling test CASDiskWriteAheadLogCloseTest.
+  private static final int TEST_RECORD_ID = 511;
+
   private static Path testDirectory;
 
   @BeforeClass
@@ -48,7 +54,7 @@ public class CASDiskWriteAheadLogIT {
                 "buildDirectory" + File.separator + "casWALTest",
                 "." + File.separator + "target" + File.separator + "casWALTest"));
 
-    WALRecordsFactory.INSTANCE.registerNewRecord(1024, TestRecord.class);
+    WALRecordsFactory.INSTANCE.registerNewRecord(TEST_RECORD_ID, TestRecord.class);
   }
 
   @Before
@@ -5283,7 +5289,7 @@ public class CASDiskWriteAheadLogIT {
 
     @Override
     public int getId() {
-      return 1024;
+      return TEST_RECORD_ID;
     }
   }
 }


### PR DESCRIPTION
## Summary
`CASDiskWriteAheadLogIT` fails in `@BeforeClass` with `IllegalArgumentException: WAL record ID 1024 is out of range [0, 512)`, breaking the Integration Tests Pipeline on every run of `develop`. This PR replaces the stale magic id with a `TEST_RECORD_ID = 511` constant and documents the valid range so the drift cannot recur silently.

## Root Cause
PR #959 (`YTDB-626: Add physiological WAL logging`, commit `f3c15382b9`) reworked `WALRecordsFactory` from an unbounded `HashMap` into a fixed-size `AtomicReferenceArray` with `ID_TABLE_SIZE = 512` and added a hard range check in `registerNewRecord`:

```java
if (id < 0 || id >= ID_TABLE_SIZE) {
  throw new IllegalArgumentException(
      "WAL record ID " + id + " is out of range [0, " + ID_TABLE_SIZE + ")");
}
```

Two sibling CAS WAL tests used out-of-range ids (2048 and 1024). The same PR updated `CASDiskWriteAheadLogCloseTest` from `2048` -> `500`, but missed `CASDiskWriteAheadLogIT`, which still called `registerNewRecord(1024, TestRecord.class)`. Since that call runs in `@BeforeClass`, the entire integration suite fails.

Production `PageOperation` records currently occupy ids `200..296` inside the valid range `[200, 512)`, so the fix only needed to pick an unused id in that window.

## Changes
`core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLogIT.java`
- Introduced `private static final int TEST_RECORD_ID = 511;` with an explanatory comment stating the `[PAGE_OPERATION_ID_BASE, ID_TABLE_SIZE)` constraint (currently `[200, 512)`), the production id range (`200..296` today), and why `500` (used by the sibling test) is avoided.
- Replaced both occurrences of the magic `1024` (in the `@BeforeClass` registration and in the inner `TestRecord.getId()` override) with `TEST_RECORD_ID`.

No production code changes; no test behavior changes. The numeric value of the id is immaterial to what the test exercises.

## Motivation
CI failure on `develop`: https://github.com/JetBrains/youtrackdb/actions/runs/24600437917
- Workflow: Java CI/CD Integration Tests Pipeline
- Commit: `88b1e5a1289692bce3b3cdda71a4881d2400ece7`
- Failing test: `CASDiskWriteAheadLogIT.beforeClass` -> `IllegalArgumentException: WAL record ID 1024 is out of range [0, 512)`

## Test plan
- [x] `./mvnw -pl core verify -P ci-integration-tests -Dit.test=CASDiskWriteAheadLogIT -Dyoutrackdb.test.env=ci` passes locally (39 tests, 0 failures, 0 errors, 6 pre-existing skipped)
- [x] `./mvnw -pl core spotless:check` passes
- [x] Dimensional review (code-quality, bugs-concurrency, test-behavior, test-completeness, test-structure): no blocker/should-fix findings; one comment off-by-one noted and corrected

## Notes
Title includes `[no-test-number-check]` because CASDiskWriteAheadLogIT was previously failing in `@BeforeClass`, which means enricomi reported zero tests from that class on `develop`. The fix restores 39 previously uncounted tests, so the test count gate would otherwise flag the delta as a suspicious jump even though it is entirely pre-existing coverage being re-enabled.
