### PR TITLE
Add macOS arm CI leg and move ARM tests to GitHub runners

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -220,9 +220,67 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  test-macos:
+    name: macOS arm - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
+    needs: check-changes
+    if: needs.check-changes.outputs.should_run == 'true'
+    # GitHub-hosted Apple Silicon runner. No Docker available, so the
+    # docker-images profile is intentionally omitted.
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '21', '25' ]
+        distribution: [ 'temurin' ]
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'develop' }}
+          fetch-depth: 0
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: ${{ matrix.distribution }}
+          architecture: aarch64
+          cache: 'maven'
+          overwrite-settings: false
+
+      - name: Run Maven Test
+        id: tests
+        run: ./mvnw -s .github/workflows/settings.xml clean verify -B -Dmaven.test.failure.ignore=true -P ci-integration-tests
+        env:
+          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
+          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/macos@v2
+        if: always()
+        with:
+          files: |
+            **/target/surefire-reports/TEST-*.xml
+            **/target/failsafe-reports/TEST-*.xml
+          action_fail: true
+          large_files: true
+          comment_mode: off
+          check_name: Integration Tests Results (macOS arm, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        if: "!cancelled()"
+        with:
+          name: test-diagnostics-integration-macos-jdk${{ matrix.java }}-${{ matrix.distribution }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
+
   merge-to-main:
     name: Merge develop into main
-    needs: [ test-linux, test-windows ]
+    needs: [ test-linux, test-windows, test-macos ]
     if: success() && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -261,12 +319,12 @@ jobs:
 
   notify-failure:
     name: Notify build failure on Zulip
-    needs: [ test-linux, test-windows, merge-to-main ]
-    if: always() && github.event_name != 'workflow_dispatch' && (needs.test-linux.result == 'failure' || needs.test-windows.result == 'failure' || needs.merge-to-main.result == 'failure')
+    needs: [ test-linux, test-windows, test-macos, merge-to-main ]
+    if: always() && github.event_name != 'workflow_dispatch' && (needs.test-linux.result == 'failure' || needs.test-windows.result == 'failure' || needs.test-macos.result == 'failure' || needs.merge-to-main.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch CI Fix Agent
-        if: needs.test-linux.result == 'failure' || needs.test-windows.result == 'failure'
+        if: needs.test-linux.result == 'failure' || needs.test-windows.result == 'failure' || needs.test-macos.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.CI_FIX_AGENT_TOKEN }}
         run: |
@@ -292,7 +350,7 @@ jobs:
 
   notify-fixed:
     name: Notify build fixed on Zulip
-    needs: [ test-linux, test-windows, merge-to-main ]
+    needs: [ test-linux, test-windows, test-macos, merge-to-main ]
     if: success() && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -72,9 +72,7 @@ jobs:
     name: Linux ${{ matrix.arch }} - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
-    runs-on: [ self-hosted, '${{ matrix.arch == ''x86'' && ''type-cpx42'' || ''type-cax31-cax21'' }}',
-               'image-${{ matrix.arch == ''x86'' && ''x86-system'' || ''arm-system'' }}-ubuntu-24.04',
-               in-nbg1-fsn1-hel1 ]
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,9 +81,12 @@ jobs:
         arch: [ 'x86', 'arm' ]
         include:
           - arch: x86
+            runs_on: [ self-hosted, type-cpx42, image-x86-system-ubuntu-24.04, in-nbg1-fsn1-hel1 ]
             mvn_opts: '-Dmaven.test.failure.ignore=true -P ci-integration-tests -P docker-images -Ddocker.platforms=linux/amd64'
             java_arch: x64
           - arch: arm
+            # GitHub-hosted runner — Hetzner ARM capacity is scarce.
+            runs_on: ubuntu-24.04-arm
             mvn_opts: '-Dmaven.test.failure.ignore=true -P ci-integration-tests -P docker-images -Ddocker.platforms=linux/arm64/v8'
             java_arch: aarch64
     steps:

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -224,8 +224,17 @@ jobs:
     name: macOS arm - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
-    # GitHub-hosted Apple Silicon runner. No Docker available, so the
-    # docker-images profile is intentionally omitted.
+    # GitHub-hosted Apple Silicon runner. The docker-images profile is
+    # intentionally omitted — it builds linux/amd64 and linux/arm64
+    # images, which don't belong on a macOS runner.
+    #
+    # Non-blocking during soak period: this job is excluded from the
+    # needs: of merge-to-main (so a macOS failure does not block the
+    # develop→main promotion) and from notify-fixed (so "build fixed"
+    # still fires when Linux/Windows/merge recover). notify-failure
+    # still observes macOS so the team sees regressions, but the
+    # CI Fix Agent is not auto-dispatched for macOS-only failures.
+    # Promote to blocking once the leg is proven stable on develop.
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -280,7 +289,8 @@ jobs:
 
   merge-to-main:
     name: Merge develop into main
-    needs: [ test-linux, test-windows, test-macos ]
+    # test-macos intentionally excluded: non-blocking during soak period.
+    needs: [ test-linux, test-windows ]
     if: success() && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
@@ -320,11 +330,23 @@ jobs:
   notify-failure:
     name: Notify build failure on Zulip
     needs: [ test-linux, test-windows, test-macos, merge-to-main ]
-    if: always() && github.event_name != 'workflow_dispatch' && (needs.test-linux.result == 'failure' || needs.test-windows.result == 'failure' || needs.test-macos.result == 'failure' || needs.merge-to-main.result == 'failure')
+    if: >-
+      always() &&
+      github.event_name != 'workflow_dispatch' &&
+      (
+        needs.test-linux.result == 'failure' ||
+        needs.test-windows.result == 'failure' ||
+        needs.test-macos.result == 'failure' ||
+        needs.merge-to-main.result == 'failure'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch CI Fix Agent
-        if: needs.test-linux.result == 'failure' || needs.test-windows.result == 'failure' || needs.test-macos.result == 'failure'
+        # test-macos intentionally excluded during soak: don't auto-dispatch
+        # the agent for macOS-only failures while the leg is still proving out.
+        if: >-
+          needs.test-linux.result == 'failure' ||
+          needs.test-windows.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.CI_FIX_AGENT_TOKEN }}
         run: |
@@ -350,7 +372,9 @@ jobs:
 
   notify-fixed:
     name: Notify build fixed on Zulip
-    needs: [ test-linux, test-windows, test-macos, merge-to-main ]
+    # test-macos intentionally excluded during soak: a "fixed" signal should
+    # fire when Linux/Windows/merge recover even if macOS is still flaky.
+    needs: [ test-linux, test-windows, merge-to-main ]
     if: success() && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '21', '25' ]
-        distribution: [ 'temurin', 'oracle' ]
+        distribution: [ 'temurin' ]
         arch: [ 'x86', 'arm' ]
         include:
           - arch: x86
@@ -171,7 +171,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '21', '25' ]
-        distribution: [ 'temurin', 'oracle' ]
+        distribution: [ 'temurin' ]
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v6

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -151,11 +151,7 @@ jobs:
     name: Linux ${{ matrix.arch }} - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
     needs: [ detect-changes ]
     if: needs.detect-changes.outputs.should_build == 'true'
-    runs-on:
-      - self-hosted
-      - "${{ matrix.arch == 'x86' && 'type-cpx42' || 'type-cax31-cax21' }}"
-      - "image-${{ matrix.arch == 'x86' && 'x86-system' || 'arm-system' }}-ubuntu-24.04"
-      - in-nbg1-fsn1-hel1
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
@@ -164,13 +160,18 @@ jobs:
         arch: [ 'x86', 'arm' ]
         include:
           - arch: x86
+            runs_on: [ self-hosted, type-cpx42, image-x86-system-ubuntu-24.04, in-nbg1-fsn1-hel1 ]
             java_arch: x64
             docker_platform: 'linux/amd64'
             mvn_opts: '-Dmaven.test.failure.ignore=true -Dyoutrackdb.test.env=ci -P docker-images,coverage -Ddocker.platforms=linux/amd64'
           - arch: arm
+            # GitHub-hosted runner (Hetzner ARM capacity is scarce). Less potent
+            # than Hetzner CAX nodes, so use the same reduced option set as the
+            # Windows matrix; keep docker-images for the arm64 image build.
+            runs_on: ubuntu-24.04-arm
             java_arch: aarch64
             docker_platform: 'linux/arm64/v8'
-            mvn_opts: '-Dmaven.test.failure.ignore=true -Dyoutrackdb.test.env=ci -P docker-images -Ddocker.platforms=linux/arm64/v8'
+            mvn_opts: '-Dmaven.test.failure.ignore=true -P docker-images -Ddocker.platforms=linux/arm64/v8'
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v6

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -165,9 +165,13 @@ jobs:
             docker_platform: 'linux/amd64'
             mvn_opts: '-Dmaven.test.failure.ignore=true -Dyoutrackdb.test.env=ci -P docker-images,coverage -Ddocker.platforms=linux/amd64'
           - arch: arm
-            # GitHub-hosted runner (Hetzner ARM capacity is scarce). Less potent
-            # than Hetzner CAX nodes, so use the same reduced option set as the
-            # Windows matrix; keep docker-images for the arm64 image build.
+            # GitHub-hosted runner (Hetzner ARM capacity is scarce). This runner
+            # is less potent than the Hetzner CAX nodes previously used, so two
+            # options from the old ARM command are intentionally dropped:
+            #   * -Dyoutrackdb.test.env=ci (disk-storage mode) — already
+            #     exercised on the x86 leg; disk-IO-heavy suites time out here.
+            #   * coverage profile — coverage is collected on x86 only.
+            # docker-images is kept for the arm64 image build.
             runs_on: ubuntu-24.04-arm
             java_arch: aarch64
             docker_platform: 'linux/arm64/v8'
@@ -317,10 +321,18 @@ jobs:
     name: macOS arm - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
     needs: [ detect-changes ]
     if: needs.detect-changes.outputs.should_build == 'true'
-    # GitHub-hosted Apple Silicon runner. No Docker available, so the
-    # docker-images profile is intentionally omitted; otherwise options
+    # GitHub-hosted Apple Silicon runner. The docker-images profile is
+    # intentionally omitted — it builds linux/amd64 and linux/arm64
+    # images, which don't belong on a macOS runner. Otherwise options
     # mirror the Windows leg (reduced, since the runner is less potent
     # than the Hetzner CPX42 nodes).
+    #
+    # Non-blocking during soak period: this job is excluded from the
+    # needs: of deploy, save-test-counts, and the ci-status blocking
+    # check, so a macOS failure does not block merge or deploy. The
+    # notify-failure/notify-fixed jobs still observe it so the team
+    # sees macOS regressions. Promote to blocking once the leg is
+    # proven stable on develop.
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -659,7 +671,8 @@ jobs:
   # ------------------------------------------------------------------
   save-test-counts:
     name: Save Test Count Baseline
-    needs: [ detect-changes, test-linux, test-windows, test-macos ]
+    # test-macos intentionally excluded: non-blocking during soak period.
+    needs: [ detect-changes, test-linux, test-windows ]
     if: >-
       github.event_name == 'push' &&
       github.ref == 'refs/heads/develop' &&
@@ -697,7 +710,8 @@ jobs:
   # Runs only if all Test jobs pass. Uses JDK 21
   # ------------------------------------------------------------------
   deploy:
-    needs: [ detect-changes, test-linux, test-windows, test-macos ]
+    # test-macos intentionally excluded: non-blocking during soak period.
+    needs: [ detect-changes, test-linux, test-windows ]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && needs.detect-changes.outputs.should_build == 'true'
 
@@ -776,11 +790,15 @@ jobs:
             echo "Build skipped — no relevant changes"
             exit 0
           fi
+          # macOS is non-blocking during soak period: we wait for it
+          # (it's in needs:) and log its result, but do not fail
+          # ci-status on a macOS-only regression. The notify-failure
+          # job observes test-macos separately and still alerts.
+          echo "macOS result (non-blocking during soak): $MACOS_RESULT"
           if [[ "$LINUX_RESULT" != "success" ]] || \
-             [[ "$WINDOWS_RESULT" != "success" ]] || \
-             [[ "$MACOS_RESULT" != "success" ]]; then
+             [[ "$WINDOWS_RESULT" != "success" ]]; then
             echo "Not all required jobs succeeded" \
-              "(linux=$LINUX_RESULT, windows=$WINDOWS_RESULT, macos=$MACOS_RESULT)"
+              "(linux=$LINUX_RESULT, windows=$WINDOWS_RESULT)"
             exit 1
           fi
           # coverage-gate and test-count-gate only run on PRs;
@@ -834,7 +852,9 @@ jobs:
             :robot: Automated fix agent has been dispatched and is investigating...
   notify-fixed:
     name: Notify build fixed on Zulip
-    needs: [ detect-changes, test-linux, test-windows, test-macos, deploy ]
+    # test-macos intentionally excluded during soak: a "fixed" signal should
+    # fire when Linux/Windows/deploy recover even if macOS is still flaky.
+    needs: [ detect-changes, test-linux, test-windows, deploy ]
     if: >-
       always() &&
       needs.detect-changes.outputs.should_build == 'true' &&

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -313,6 +313,62 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  test-macos:
+    name: macOS arm - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
+    needs: [ detect-changes ]
+    if: needs.detect-changes.outputs.should_build == 'true'
+    # GitHub-hosted Apple Silicon runner. No Docker available, so the
+    # docker-images profile is intentionally omitted; otherwise options
+    # mirror the Windows leg (reduced, since the runner is less potent
+    # than the Hetzner CPX42 nodes).
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '21', '25' ]
+        distribution: [ 'temurin' ]
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: ${{ matrix.distribution }}
+          architecture: aarch64
+          cache: 'maven'
+          overwrite-settings: false
+      - name: Run Unit Tests
+        id: tests
+        run: ./mvnw -s .github/workflows/settings.xml clean package -B -Dmaven.test.failure.ignore=true
+        env:
+          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
+          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/macos@v2
+        if: always()
+        with:
+          files: |
+            **/target/surefire-reports/TEST-*.xml
+            **/target/failsafe-reports/TEST-*.xml
+          action_fail: true
+          large_files: true
+          comment_mode: off
+          check_name: Tests Results (macOS arm, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        if: "!cancelled()"
+        with:
+          name: test-diagnostics-macos-jdk${{ matrix.java }}-${{ matrix.distribution }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
+
   # ------------------------------------------------------------------
   # JOB: SMALL CACHE INTEGRATION TESTS (advisory, not in ci-status gate)
   # Runs StorageComponent ITs with 4 MB disk cache to exercise
@@ -603,7 +659,7 @@ jobs:
   # ------------------------------------------------------------------
   save-test-counts:
     name: Save Test Count Baseline
-    needs: [ detect-changes, test-linux, test-windows ]
+    needs: [ detect-changes, test-linux, test-windows, test-macos ]
     if: >-
       github.event_name == 'push' &&
       github.ref == 'refs/heads/develop' &&
@@ -641,7 +697,7 @@ jobs:
   # Runs only if all Test jobs pass. Uses JDK 21
   # ------------------------------------------------------------------
   deploy:
-    needs: [ detect-changes, test-linux, test-windows ]
+    needs: [ detect-changes, test-linux, test-windows, test-macos ]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && needs.detect-changes.outputs.should_build == 'true'
 
@@ -693,7 +749,7 @@ jobs:
   ci-status:
     name: CI Status
     if: always() && github.event.pull_request.draft != true
-    needs: [ detect-changes, test-linux, test-windows, coverage-gate, test-count-gate ]
+    needs: [ detect-changes, test-linux, test-windows, test-macos, coverage-gate, test-count-gate ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
@@ -708,6 +764,7 @@ jobs:
           SHOULD_BUILD: ${{ needs.detect-changes.outputs.should_build }}
           LINUX_RESULT: ${{ needs.test-linux.result }}
           WINDOWS_RESULT: ${{ needs.test-windows.result }}
+          MACOS_RESULT: ${{ needs.test-macos.result }}
           COVERAGE_RESULT: ${{ needs.coverage-gate.result }}
           TEST_COUNT_RESULT: ${{ needs.test-count-gate.result }}
         run: |
@@ -720,9 +777,10 @@ jobs:
             exit 0
           fi
           if [[ "$LINUX_RESULT" != "success" ]] || \
-             [[ "$WINDOWS_RESULT" != "success" ]]; then
+             [[ "$WINDOWS_RESULT" != "success" ]] || \
+             [[ "$MACOS_RESULT" != "success" ]]; then
             echo "Not all required jobs succeeded" \
-              "(linux=$LINUX_RESULT, windows=$WINDOWS_RESULT)"
+              "(linux=$LINUX_RESULT, windows=$WINDOWS_RESULT, macos=$MACOS_RESULT)"
             exit 1
           fi
           # coverage-gate and test-count-gate only run on PRs;
@@ -739,7 +797,7 @@ jobs:
 
   notify-failure:
     name: Notify build failure on Zulip
-    needs: [ detect-changes, test-linux, test-windows, deploy ]
+    needs: [ detect-changes, test-linux, test-windows, test-macos, deploy ]
     if: >-
       failure() &&
       needs.detect-changes.outputs.should_build == 'true' &&
@@ -776,7 +834,7 @@ jobs:
             :robot: Automated fix agent has been dispatched and is investigating...
   notify-fixed:
     name: Notify build fixed on Zulip
-    needs: [ detect-changes, test-linux, test-windows, deploy ]
+    needs: [ detect-changes, test-linux, test-windows, test-macos, deploy ]
     if: >-
       always() &&
       needs.detect-changes.outputs.should_build == 'true' &&

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -160,7 +160,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '21', '25' ]
-        distribution: [ 'temurin', 'oracle' ]
+        distribution: [ 'temurin' ]
         arch: [ 'x86', 'arm' ]
         include:
           - arch: x86
@@ -268,7 +268,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '21', '25' ]
-        distribution: [ 'temurin', 'oracle' ]
+        distribution: [ 'temurin' ]
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Motivation

The previous CI setup ran ARM Linux tests on self-hosted Hetzner CAX nodes, whose capacity has become scarce and unreliable. In addition, the matrix exercised both Temurin and Oracle JDK distributions, doubling the cost with no meaningful coverage gain since the two behave identically for our purposes. Finally, we had no coverage of macOS (Apple Silicon), which is a common developer platform and a growing source of platform-specific regression reports.

This PR:

- Restricts the JDK distribution matrix to **temurin** only on Linux and Windows legs (drops Oracle), halving runner usage on those legs.
- Moves the **ARM Linux** legs from self-hosted Hetzner CAX to GitHub-hosted `ubuntu-24.04-arm` runners in both the unit-test and integration-test pipelines. The runner is less potent than the Hetzner CAX nodes, so two options are intentionally dropped from the ARM command: `-Dyoutrackdb.test.env=ci` (disk-storage mode, already covered on the x86 leg) and the `coverage` profile (collected on x86 only). `docker-images` is kept to continue building the arm64 image.
- Adds a **macOS arm** leg (`macos-latest`, Apple Silicon) to both pipelines, running temurin JDK 21 and 25. The `docker-images` profile is intentionally omitted on macOS (the profile builds linux images).
- Makes the macOS leg **non-blocking during the soak period**: it is excluded from the `needs:` of `deploy`, `save-test-counts`, and the blocking `ci-status` check, so a macOS-only failure does not block merge or deploy. `notify-failure` still observes it so regressions are visible in Zulip. `notify-fixed` excludes it so a "fixed" signal fires when Linux/Windows/deploy recover even if macOS is still flaky. Intent: promote macOS to blocking once it is proven stable on develop.

## Test plan

- [ ] CI pipeline green on Linux x86 (JDK 21/25, temurin)
- [ ] CI pipeline green on Linux arm via GitHub-hosted `ubuntu-24.04-arm` (JDK 21/25, temurin)
- [ ] CI pipeline green on Windows (JDK 21/25, temurin)
- [ ] macOS arm leg runs and publishes results (failures tolerated during soak)
- [ ] Integration-tests pipeline exercises the same matrix changes
- [ ] `ci-status` job still blocks on Linux + Windows + coverage + test-count and ignores macOS result
- [ ] `notify-failure` observes macOS so macOS regressions are announced