### PR TITLE
Fix stale class/framework/repo references in agent and CLAUDE docs

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -94,7 +94,7 @@ For each modified file, examine:
 - DRY principle violations
 - Function/method length and complexity
 - Proper error handling patterns
-- Test coverage for new functionality (JUnit 4 for core/server, TestNG for tests module - don't mix)
+- Test coverage for new functionality (JUnit 4 for core/server, JUnit 5 with JUnit Platform Suite for tests module - don't mix)
 - Consistency with existing codebase patterns
 
 **Potential Bugs & Concurrency Issues:**
@@ -111,7 +111,7 @@ For each modified file, examine:
 
 **Crash Safety & Durability:**
 - WAL correctness: Are all mutations properly logged before being applied?
-- `DurableComponent` contract: Do new data structures properly implement crash recovery?
+- `StorageComponent` contract: Do new data structures (extending `StorageComponent` with `durable=true`) properly implement crash recovery?
 - Atomicity: Can a crash mid-operation leave data in an inconsistent state?
 - Page-level consistency: Are page reads/writes properly synchronized with the cache?
 - `LogSequenceNumber` handling: Correct ordering and comparison

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -59,7 +59,7 @@ Skip these files entirely:
 - **Maintainability**: Will future developers understand and modify this easily?
 - **DRY Principle**: Is there unnecessary duplication?
 - **Error Handling**: Are errors handled gracefully with informative messages?
-- **Testing**: Are there adequate tests? JUnit 4 for core/server, TestNG for tests module - don't mix
+- **Testing**: Are there adequate tests? JUnit 4 for core/server, JUnit 5 with JUnit Platform Suite for tests module - don't mix
 - **Consistency**: Does the code follow existing codebase patterns?
 
 #### Potential Bugs & Concurrency Issues
@@ -75,7 +75,7 @@ Skip these files entirely:
 
 #### Crash Safety & Durability
 - WAL correctness: Are all mutations properly logged before being applied?
-- `DurableComponent` contract: Do new data structures properly implement crash recovery?
+- `StorageComponent` contract: Do new data structures (extending `StorageComponent` with `durable=true`) properly implement crash recovery?
 - Atomicity: Can a crash mid-operation leave data in an inconsistent state?
 - Page-level consistency: Are page reads/writes properly synchronized with the cache?
 - `LogSequenceNumber` handling: Correct ordering and comparison

--- a/.claude/agents/review-crash-safety.md
+++ b/.claude/agents/review-crash-safety.md
@@ -13,7 +13,7 @@ YouTrackDB is a Java 21+ object-oriented graph database with:
 - **Two engine types**: `EngineLocalPaginated` (disk with WAL) and `EngineMemory` (in-memory)
 - **Two-tier cache**: `ReadCache` (LockFreeReadCache) + `WriteCache` (WOWCache)
 - **Write-Ahead Logging**: `LogSequenceNumber` (segment, position) pairs, atomic operations logged before page mutations
-- **DurableComponent**: Base class for all crash-recoverable data structures — new durable structures must implement recovery
+- **StorageComponent**: Base class for all storage-backed data structures; instances constructed with `durable=true` participate in WAL crash recovery — new durable structures must implement recovery
 - **Double-write log**: Prevents torn page writes on disk
 - **Transaction lifecycle**: Begin, log mutations to WAL, apply to pages in cache, commit (flush WAL), checkpoint (flush dirty pages)
 
@@ -38,9 +38,9 @@ You will receive:
 - Are WAL records written atomically (single log entry per logical operation)?
 - Is the WAL flushed (fsync) at the correct points (commit, checkpoint)?
 
-### DurableComponent Contract
-- Do new data structures that persist to disk extend `DurableComponent`?
-- Is the `startOperation()` / `completeOperation()` contract followed?
+### StorageComponent Contract
+- Do new data structures that persist to disk extend `StorageComponent` with `durable=true`?
+- Is the `startAtomicOperation()` / `endAtomicOperation()` contract (via `AtomicOperationsManager`) followed?
 - Does the component implement `redo()` for WAL replay during recovery?
 - Are all persistent state changes covered by WAL records?
 

--- a/.claude/agents/review-test-crash-safety.md
+++ b/.claude/agents/review-test-crash-safety.md
@@ -11,7 +11,7 @@ You are an expert crash safety test reviewer specializing in database storage sy
 YouTrackDB is a Java 21+ object-oriented graph database with:
 - **Page-based storage**: Default 8 KB pages, two-tier cache (ReadCache + WriteCache)
 - **WAL**: LogSequenceNumber (segment, position) pairs, atomic operations logged before page mutations
-- **DurableComponent**: Base class for crash-recoverable data structures
+- **StorageComponent**: Base class for storage-backed data structures; instances constructed with `durable=true` participate in WAL crash recovery
 - **Double-write log**: Prevents torn page writes on disk
 - **Transaction lifecycle**: Begin → log mutations to WAL → apply to pages → commit (flush WAL) → checkpoint (flush dirty pages)
 - Core and server tests use JUnit 4; the `tests` module uses JUnit 5

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -101,7 +101,7 @@ Scan the diff and assign one or more categories to each changed file:
 
 | Category | Signals |
 |---|---|
-| **storage-engine** | Files in `storage/`, `cache/`, `wal/`, `DurableComponent` subclasses, page read/write logic, `DiskStorage`, `WriteCache`, `ReadCache`, `LogSequenceNumber`, double-write log |
+| **storage-engine** | Files in `storage/`, `cache/`, `wal/`, `StorageComponent` subclasses, page read/write logic, `DiskStorage`, `WriteCache`, `ReadCache`, `LogSequenceNumber`, double-write log |
 | **concurrency** | `synchronized`, `Lock`, `Atomic*`, `volatile`, `StampedLock`, `ReentrantLock`, thread pools, `ConcurrentHashMap`, `CompletableFuture`, shared mutable state, `@GuardedBy` |
 | **index-data-structures** | Files in `index/`, B-tree, hash index, `SBTree`, `CellBTree`, histogram, `IndexEngine` |
 | **network-server** | Files in `server/`, `driver/`, Gremlin Server, protocol handling, TLS/SSL, authentication, session management |
@@ -109,7 +109,7 @@ Scan the diff and assign one or more categories to each changed file:
 | **gremlin** | Files in `gremlin/`, traversal steps, `YTDBGraph*` classes, TinkerPop integration |
 | **public-api** | Files in `com.jetbrains.youtrackdb.api`, `YourTracks`, `YouTrackDB` interface |
 | **serialization** | Record serializers, binary format, property map encoding/decoding |
-| **crash-durability** | WAL operations, crash simulation, `DurableComponent` recovery, page corruption handling, transaction atomicity under failure, `LogSequenceNumber` manipulation, double-write log, Java `assert` statements in production code |
+| **crash-durability** | WAL operations, crash simulation, durable `StorageComponent` recovery, page corruption handling, transaction atomicity under failure, `LogSequenceNumber` manipulation, double-write log, Java `assert` statements in production code |
 | **configuration** | `GlobalConfiguration`, config parameters, system properties |
 | **tests-only** | Changes exclusively in test files with no production code changes |
 | **build-config** | `pom.xml`, CI workflows, Maven profiles, Docker configs |

--- a/.claude/skills/fix-ci-failure/SKILL.md
+++ b/.claude/skills/fix-ci-failure/SKILL.md
@@ -147,9 +147,9 @@ whenever code or tests were modified.
 
    | Category | Signals |
    |---|---|
-   | **storage-engine** | Files in `storage/`, `cache/`, `wal/`, `DurableComponent` subclasses, page read/write logic, `DiskStorage`, `WriteCache`, `ReadCache`, `LogSequenceNumber`, double-write log |
+   | **storage-engine** | Files in `storage/`, `cache/`, `wal/`, `StorageComponent` subclasses, page read/write logic, `DiskStorage`, `WriteCache`, `ReadCache`, `LogSequenceNumber`, double-write log |
    | **concurrency** | `synchronized`, `Lock`, `Atomic*`, `volatile`, `StampedLock`, `ReentrantLock`, thread pools, `ConcurrentHashMap`, `CompletableFuture`, shared mutable state, `@GuardedBy`, `ConcurrentTestHelper`, `CountDownLatch`, `CyclicBarrier` |
-   | **crash-durability** | WAL operations, crash simulation, `DurableComponent` recovery, page corruption handling, transaction atomicity under failure, `LogSequenceNumber` manipulation, double-write log, Java `assert` statements in production code |
+   | **crash-durability** | WAL operations, crash simulation, durable `StorageComponent` recovery, page corruption handling, transaction atomicity under failure, `LogSequenceNumber` manipulation, double-write log, Java `assert` statements in production code |
    | **index-data-structures** | Files in `index/`, B-tree, hash index, `SBTree`, `CellBTree`, histogram, `IndexEngine` |
    | **network-server** | Files in `server/`, `driver/`, Gremlin Server, protocol handling, TLS/SSL, authentication, session management |
    | **sql-query** | Files in `sql/` (excluding `parser/`), query execution, command handlers |

--- a/.claude/skills/test-review/SKILL.md
+++ b/.claude/skills/test-review/SKILL.md
@@ -92,9 +92,9 @@ Scan the diff and assign one or more categories to **every** changed file — pr
 
 | Category | Signals |
 |---|---|
-| **storage-engine** | Files in `storage/`, `cache/`, `wal/`, `DurableComponent` subclasses, page read/write logic, `DiskStorage`, `WriteCache`, `ReadCache`, `LogSequenceNumber`, double-write log |
+| **storage-engine** | Files in `storage/`, `cache/`, `wal/`, `StorageComponent` subclasses, page read/write logic, `DiskStorage`, `WriteCache`, `ReadCache`, `LogSequenceNumber`, double-write log |
 | **concurrency** | `synchronized`, `Lock`, `Atomic*`, `volatile`, `StampedLock`, `ReentrantLock`, thread pools, `ConcurrentHashMap`, `CompletableFuture`, shared mutable state, `@GuardedBy`, `ConcurrentTestHelper`, `CountDownLatch`, `CyclicBarrier` |
-| **crash-durability** | WAL operations, crash simulation, `DurableComponent` recovery, page corruption handling, transaction atomicity under failure, `LogSequenceNumber` manipulation, double-write log, Java `assert` statements in production code |
+| **crash-durability** | WAL operations, crash simulation, durable `StorageComponent` recovery, page corruption handling, transaction atomicity under failure, `LogSequenceNumber` manipulation, double-write log, Java `assert` statements in production code |
 | **index-data-structures** | Files in `index/`, B-tree, hash index, `SBTree`, `CellBTree`, histogram, `IndexEngine` |
 | **serialization** | Record serializers, binary format, property map encoding/decoding |
 | **sql-query** | Files in `sql/` (excluding `parser/`), query execution, command handlers |

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -141,7 +141,7 @@ SPIs, callbacks, event flows.
 ```markdown
 ### Integration Points
 - Query optimizer reads histograms via `IndexStatistics.getHistogram(indexName)`
-- Histogram refresh triggered by `DurableComponent.onOpen()`
+- Histogram refresh triggered during storage open (via `AbstractStorage#open`)
 ```
 
 **5. Non-Goals** — Explicitly state what this plan does NOT attempt. Prevents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ YouTrackDB is a general-purpose object-oriented graph database developed by JetB
 - **Group ID**: `io.youtrackdb`
 - **Version**: `0.5.0-SNAPSHOT` (CI-friendly: `${revision}${sha1}${changelist}`)
 - **Issue tracker**: https://youtrack.jetbrains.com/issues/YTDB
-- **Repository**: https://github.com/youtrackdb/youtrackdb
+- **Repository**: https://github.com/JetBrains/youtrackdb
 
 ## Build Commands
 


### PR DESCRIPTION
#### Motivation

The `.claude` review agents, skills, and `CLAUDE.md` referenced names that no longer match the codebase. Future reviewers (human or agent) following those instructions would look for classes and APIs that do not exist, cite the wrong test framework when assessing coverage, and point contributors at the wrong GitHub repo. The drift was cosmetic in appearance but operationally misleading, so it needed a sweep before the next automated review cycle picks up the stale references.

#### Summary

- Replace `DurableComponent` with `StorageComponent` (the real base class, where `durable=true` in the constructor marks WAL participants) across 10 references in review agents, skills, and `CLAUDE.md`; clarify the contract in passing.
- Correct the crash-safety agent's atomic-operation contract: the actual API is `startAtomicOperation()` / `endAtomicOperation()` on `AtomicOperationsManager`, not `startOperation()` / `completeOperation()`.
- Fix two reviewer agents that claimed the `tests` module uses TestNG — it uses JUnit 5 with JUnit Platform Suite (`junit-jupiter` in `tests/pom.xml`).
- Point `CLAUDE.md` at the real remote `github.com/JetBrains/youtrackdb` instead of the non-existent `github.com/youtrackdb/youtrackdb`.

#### Test plan

- [ ] No source or test changes; docs-only update — verified via `git diff --stat` (9 files, all under `.claude/` and `CLAUDE.md`).
- [ ] Spot-checked updated class/API names against the current codebase.