### PR TITLE
Raise ticker-lag tolerances for macOS arm CI

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
@@ -60,13 +60,21 @@ public class GranularTickerTest {
         prevApproxMillis = approxMillis;
       }
 
-      // The ticker can lag behind real time by at most one granularity tick
-      // at any point, so its total advancement should be close to real elapsed time.
+      // The ticker's background sampler fires at fixed-rate intervals of `granularityNanos`,
+      // but the scheduler can delay a single fire significantly. On virtualized CI
+      // environments the worst-case per-fire lag goes well beyond one granularity tick:
+      // GitHub-hosted macOS arm (virtualized Apple Silicon) has shown per-fire ticker lag
+      // up to ~75 ms for a 10 ms granularity across the tests in this package, and Windows
+      // CI has a ~15.6 ms OS timer quantum that can stack with CPU contention. A 10x
+      // multiplier (100 ms for a 10 ms granularity) covers both with some headroom while
+      // still being a meaningful lower bound on cumulative ticker advancement over 20
+      // iterations — a ticker that silently stopped advancing would still fail since
+      // totalTickerNanos would stay at zero while totalRealNanos exceeds 100 ms.
       final var totalRealNanos = System.nanoTime() - startRealNano;
       final var totalTickerNanos = prevApproxNano - startApproxNano;
       assertThat(totalTickerNanos)
           .as("ticker should advance over 20 iterations")
-          .isGreaterThanOrEqualTo(totalRealNanos - 2 * granularityNanos);
+          .isGreaterThanOrEqualTo(totalRealNanos - 10 * granularityNanos);
     } finally {
       scheduler.shutdownNow();
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
@@ -39,21 +39,27 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
 
   private static long TICKER_POSSIBLE_LAG_NANOS;
   private static long TICKER_POSSIBLE_LAG_MILLIS;
+  private static long TICKER_GRANULARITY_MILLIS;
 
   @BeforeClass
   public static void beforeClass() {
     var granularity =
         YouTrackDBEnginesManager.instance().getTicker().getGranularity();
+    TICKER_GRANULARITY_MILLIS = granularity / 1_000_000;
 
     // The ticker background thread fires at fixed-rate intervals of `granularity`, but actual
-    // scheduling jitter can be significant — especially on Windows CI where the OS timer
-    // resolution is ~15.6 ms and ScheduledExecutorService.scheduleAtFixedRate(10ms) actually
-    // fires at ~15.6 ms intervals. Under CPU contention a tick can be delayed by an additional
-    // timer quantum, pushing worst-case staleness to ~31 ms for a 10 ms configured granularity.
-    // A 5x multiplier (50 ms) provides enough headroom for two missed Windows timer quanta plus
-    // additional scheduling jitter, while still being a meaningful upper bound on ticker
-    // staleness.
-    TICKER_POSSIBLE_LAG_NANOS = granularity * 5;
+    // scheduling jitter can be significant on virtualized CI environments:
+    //   * Windows: the OS timer resolution is ~15.6 ms, so scheduleAtFixedRate(10 ms) actually
+    //     fires at ~15.6 ms intervals; under CPU contention a tick can be delayed by another
+    //     timer quantum, pushing worst-case staleness to ~31 ms for a 10 ms granularity.
+    //   * GitHub-hosted macOS arm (virtualized Apple Silicon): per-fire ticker lag up to
+    //     ~75 ms observed for a 10 ms granularity. The scheduler is noticeably less
+    //     predictable than the Hetzner bare-metal nodes the Linux legs run on.
+    // A 10x multiplier (100 ms for a 10 ms granularity) covers both worst cases with some
+    // headroom, while still being a meaningful upper bound on ticker staleness — the tight
+    // "ticker never runs ahead of wall-clock" direction is guarded independently below by
+    // a bound at one granularity + ALLOWED_TICKER_JITTER_MS, which is not relaxed.
+    TICKER_POSSIBLE_LAG_NANOS = granularity * 10;
     TICKER_POSSIBLE_LAG_MILLIS = TICKER_POSSIBLE_LAG_NANOS / 1_000_000;
   }
 
@@ -983,11 +989,21 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
       }
 
       if (mode == QueryMonitoringMode.LIGHTWEIGHT) {
-        // Ticker should not run ahead of real time.
+        // Ticker must never run ahead of real wall-clock time. The ticker exposes a past
+        // nanoTime sample, so forward drift can only come from nanoTimeDifference
+        // recalibration and integer truncation — one granularity plus ALLOWED_TICKER_JITTER_MS
+        // covers both. This tight bound is independent of scheduler noise on virtualized
+        // CI and therefore is not multiplied by the TICKER_POSSIBLE_LAG factor.
         assertThat(listener.startedAtMillis)
+            .as("ticker must not run ahead of wall clock")
+            .isLessThanOrEqualTo(
+                afterMillis + TICKER_GRANULARITY_MILLIS + ALLOWED_TICKER_JITTER_MS);
+        assertThat(listener.startedAtMillis)
+            // The lag-behind upper bound (reused from TICKER_POSSIBLE_LAG_MILLIS) absorbs
+            // scheduler starvation, which can push staleness well beyond one granularity
+            // on noisy CI. Approximate monotonicity allows the ≤1 ms dip that can come
+            // from independent recalibration of volatile fields and integer truncation.
             .isLessThanOrEqualTo(afterMillis + TICKER_POSSIBLE_LAG_MILLIS)
-            // Approximate monotonicity: allow for ticker jitter caused by independent
-            // recalibration of volatile fields and integer truncation.
             .isGreaterThanOrEqualTo(prevStartedAtMillis - ALLOWED_TICKER_JITTER_MS);
         // The ticker-measured window [nano, endNano] sits inside the System.nanoTime
         // window [beforeNanos, afterNanos], so the measured duration is at most the real

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
@@ -38,7 +38,6 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
   private static final long ALLOWED_TICKER_JITTER_MS = 1;
 
   private static long TICKER_POSSIBLE_LAG_NANOS;
-  private static long TICKER_POSSIBLE_LAG_MILLIS;
   private static long TICKER_GRANULARITY_MILLIS;
 
   @BeforeClass
@@ -47,20 +46,23 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
         YouTrackDBEnginesManager.instance().getTicker().getGranularity();
     TICKER_GRANULARITY_MILLIS = granularity / 1_000_000;
 
-    // The ticker background thread fires at fixed-rate intervals of `granularity`, but actual
-    // scheduling jitter can be significant on virtualized CI environments:
-    //   * Windows: the OS timer resolution is ~15.6 ms, so scheduleAtFixedRate(10 ms) actually
-    //     fires at ~15.6 ms intervals; under CPU contention a tick can be delayed by another
-    //     timer quantum, pushing worst-case staleness to ~31 ms for a 10 ms granularity.
-    //   * GitHub-hosted macOS arm (virtualized Apple Silicon): per-fire ticker lag up to
-    //     ~75 ms observed for a 10 ms granularity. The scheduler is noticeably less
-    //     predictable than the Hetzner bare-metal nodes the Linux legs run on.
-    // A 10x multiplier (100 ms for a 10 ms granularity) covers both worst cases with some
-    // headroom, while still being a meaningful upper bound on ticker staleness — the tight
-    // "ticker never runs ahead of wall-clock" direction is guarded independently below by
-    // a bound at one granularity + ALLOWED_TICKER_JITTER_MS, which is not relaxed.
+    // Used as the upper bound on `executionTimeNanos = endNano - nano`, i.e., the
+    // allowance for how much more than the real elapsed time the ticker-measured
+    // duration can be. Both `endNano` and `nano` are past `System.nanoTime()` samples
+    // captured by the ticker's scheduled thread, so the ticker-measured duration can
+    // exceed real time by at most one scheduler period. On virtualized CI that period
+    // can stretch well beyond the configured granularity:
+    //   * Windows: ~15.6 ms OS timer quantum; scheduleAtFixedRate(10 ms) actually fires
+    //     at ~15.6 ms intervals, plus CPU contention adds another quantum — worst-case
+    //     staleness ~31 ms for a 10 ms granularity.
+    //   * GitHub-hosted macOS arm (virtualized Apple Silicon): per-fire ticker lag up
+    //     to ~75 ms observed for a 10 ms granularity. Less predictable than the
+    //     Hetzner bare-metal nodes the Linux legs run on.
+    // A 10x multiplier (100 ms for a 10 ms granularity) covers both worst cases with
+    // headroom while still catching a ticker that drifts much further behind real time.
+    // The tight "ticker never runs ahead of wall-clock" direction on `startedAtMillis`
+    // is guarded independently by a bound at one granularity + ALLOWED_TICKER_JITTER_MS.
     TICKER_POSSIBLE_LAG_NANOS = granularity * 10;
-    TICKER_POSSIBLE_LAG_MILLIS = TICKER_POSSIBLE_LAG_NANOS / 1_000_000;
   }
 
   @Before
@@ -997,13 +999,10 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
         assertThat(listener.startedAtMillis)
             .as("ticker must not run ahead of wall clock")
             .isLessThanOrEqualTo(
-                afterMillis + TICKER_GRANULARITY_MILLIS + ALLOWED_TICKER_JITTER_MS);
-        assertThat(listener.startedAtMillis)
-            // The lag-behind upper bound (reused from TICKER_POSSIBLE_LAG_MILLIS) absorbs
-            // scheduler starvation, which can push staleness well beyond one granularity
-            // on noisy CI. Approximate monotonicity allows the ≤1 ms dip that can come
-            // from independent recalibration of volatile fields and integer truncation.
-            .isLessThanOrEqualTo(afterMillis + TICKER_POSSIBLE_LAG_MILLIS)
+                afterMillis + TICKER_GRANULARITY_MILLIS + ALLOWED_TICKER_JITTER_MS)
+            // Approximate monotonicity allows the ≤1 ms dip that can come from
+            // independent recalibration of the two volatile fields plus integer
+            // truncation in nanoTime / 1_000_000.
             .isGreaterThanOrEqualTo(prevStartedAtMillis - ALLOWED_TICKER_JITTER_MS);
         // The ticker-measured window [nano, endNano] sits inside the System.nanoTime
         // window [beforeNanos, afterNanos], so the measured duration is at most the real

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBTransactionMetricsListenerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBTransactionMetricsListenerTest.java
@@ -237,8 +237,7 @@ public class YTDBTransactionMetricsListenerTest extends YTDBAbstractGremlinTest 
     // In lightweight mode, timestamps come from the ticker and may lag behind real time
     // by up to TICKER_POSSIBLE_LAG_MILLIS due to scheduler starvation on virtualized CI.
     assertThat(listener.commitAtMillis)
-        .isGreaterThanOrEqualTo(beforeMillis - TICKER_POSSIBLE_LAG_MILLIS)
-        .isLessThanOrEqualTo(afterMillis + TICKER_POSSIBLE_LAG_MILLIS);
+        .isGreaterThanOrEqualTo(beforeMillis - TICKER_POSSIBLE_LAG_MILLIS);
     // In LIGHTWEIGHT mode, if the commit is faster than the ticker granularity, both the
     // start and end approximate nano times can be identical, yielding a zero duration.
     assertThat(listener.commitTimeNanos).isGreaterThanOrEqualTo(0);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBTransactionMetricsListenerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBTransactionMetricsListenerTest.java
@@ -24,13 +24,30 @@ import org.junit.runner.RunWith;
 @RunWith(GremlinProcessRunner.class)
 public class YTDBTransactionMetricsListenerTest extends YTDBAbstractGremlinTest {
 
+  // The ticker-based millis timestamp is derived from two independently-refreshed volatile
+  // fields (nanoTime and nanoTimeDifference). When nanoTimeDifference is recalibrated,
+  // integer truncation in nanoTime/1_000_000 can cause the result to dip by up to 1 ms.
+  private static final long ALLOWED_TICKER_JITTER_MS = 1;
+
   private static long TICKER_POSSIBLE_LAG_MILLIS;
+  private static long TICKER_GRANULARITY_MILLIS;
 
   @BeforeClass
   public static void beforeClass() throws InterruptedException {
     var granularity =
         YouTrackDBEnginesManager.instance().getTicker().getGranularity();
-    TICKER_POSSIBLE_LAG_MILLIS = granularity * 3 / 1_000_000;
+    TICKER_GRANULARITY_MILLIS = granularity / 1_000_000;
+    // The ticker's background sampler fires at fixed-rate intervals of `granularity`, but
+    // on virtualized CI the scheduler can delay a fire far beyond one granularity — Windows
+    // has a ~15.6 ms OS timer quantum, and GitHub-hosted macOS arm (virtualized Apple
+    // Silicon) has shown per-fire ticker lag up to ~75 ms for a 10 ms granularity across
+    // the tests in this package. A 10x multiplier (100 ms for a 10 ms granularity) covers
+    // both environments with headroom while still catching a ticker that drifts much
+    // farther behind real wall-clock time. The tight "ticker never runs ahead of
+    // wall-clock" direction is guarded independently in the assertion below at one
+    // granularity + ALLOWED_TICKER_JITTER_MS, which is not relaxed.
+    var tickerPossibleLagNanos = granularity * 10;
+    TICKER_POSSIBLE_LAG_MILLIS = tickerPossibleLagNanos / 1_000_000;
 
     // Ensure ticker has had time to stabilize after graph setup.
     Thread.sleep(100);
@@ -209,8 +226,16 @@ public class YTDBTransactionMetricsListenerTest extends YTDBAbstractGremlinTest 
     var afterMillis = System.currentTimeMillis();
 
     assertThat(listener.callCount).isEqualTo(1);
-    // In lightweight mode, timestamps come from the ticker and may lag by up to
-    // TICKER_POSSIBLE_LAG_MILLIS.
+    // Ticker must never run ahead of real wall-clock time. The ticker exposes a past
+    // nanoTime sample, so forward drift can only come from nanoTimeDifference
+    // recalibration and integer truncation — one granularity plus ALLOWED_TICKER_JITTER_MS
+    // covers both. This tight bound is independent of scheduler noise on virtualized CI.
+    assertThat(listener.commitAtMillis)
+        .as("ticker must not run ahead of wall clock")
+        .isLessThanOrEqualTo(
+            afterMillis + TICKER_GRANULARITY_MILLIS + ALLOWED_TICKER_JITTER_MS);
+    // In lightweight mode, timestamps come from the ticker and may lag behind real time
+    // by up to TICKER_POSSIBLE_LAG_MILLIS due to scheduler starvation on virtualized CI.
     assertThat(listener.commitAtMillis)
         .isGreaterThanOrEqualTo(beforeMillis - TICKER_POSSIBLE_LAG_MILLIS)
         .isLessThanOrEqualTo(afterMillis + TICKER_POSSIBLE_LAG_MILLIS);


### PR DESCRIPTION
## Summary
- Raise the ticker-lag tolerance to `10 × granularity` (100 ms for a 10 ms granularity) in three timing tests — `GranularTickerTest.testTimeApproximation`, `YTDBTransactionMetricsListenerTest.lightweightModeUsesApproximateTimestamps`, and `YTDBQueryMetricsStrategyTest.testQueryMonitoringLightweight`. GitHub-hosted macOS arm runners (virtualized Apple Silicon) exhibit per-fire `ScheduledExecutorService` lag up to ~75 ms for a 10 ms granularity — well beyond the Windows worst case (~31 ms) the pre-existing 2×/3×/5× multipliers were sized for. Update the tolerance comments in all three places to document both Windows and macOS arm jitter sources and cite the same observed worst case.
- Add an independent tight forward-direction assertion (`≤ afterMillis + granularity + ALLOWED_TICKER_JITTER_MS`) in both Gremlin tests, so that relaxing the lag bound does not weaken detection of a "ticker ahead of wall clock" regression. The tight bound is safe regardless of scheduler noise because `approximateCurrentTimeMillis()` derives from a past `System.nanoTime()` sample — the ticker physically cannot report a future wall-clock time beyond truncation and volatile-field recalibration jitter.
- No production code changed. The underlying `GranularTicker` is correct; the root cause is environment scheduling, not a bug.

## Motivation
On [PR #987](https://github.com/JetBrains/youtrackdb/pull/987) (which introduced the macOS arm CI leg and has since merged), the new leg failed on JDK 25 with three timing assertions. Failing run: https://github.com/JetBrains/youtrackdb/actions/runs/24656576102/job/72091557922

The same failures will reproduce on `develop` now that #987 is merged, so this follow-up restores a green macOS arm leg. Dimensional review (code-quality, bugs/concurrency, test-behavior, test-completeness, test-structure) flagged no blocker/should-fix findings; recommended comment reconciliation and tight forward-direction checks are included.

## Test plan
- [x] `./mvnw -pl core test -Dtest=GranularTickerTest` — 6 passed locally on Linux.
- [x] `./mvnw -pl core test-compile` — BUILD SUCCESS.
- [x] `./mvnw -pl core spotless:check` — clean.
- [ ] The two Gremlin-suite tests require `GremlinProcessRunner` and cannot be run standalone; will be verified on CI, including the new macOS arm leg.
- [ ] Full CI pipeline (Linux x86/arm, Windows, macOS arm) on this PR.