### PR TITLE
Improve JMH compare workflow: configurable base branch and history preservation

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -441,32 +441,13 @@ jobs:
             const fullBody = `${HEADER}\n${body}`;
 
             for (const pr of prs) {
-              // Look for an existing benchmark comment to update
-              const { data: comments } = await github.rest.issues.listComments({
+              await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
+                body: fullBody,
               });
-
-              const existing = comments.find(c => c.body.startsWith(HEADER));
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body: fullBody,
-                });
-                console.log(`Updated benchmark comment on PR #${pr.number}`);
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  body: fullBody,
-                });
-                console.log(`Created benchmark comment on PR #${pr.number}`);
-              }
+              console.log(`Created benchmark comment on PR #${pr.number}`);
             }
 
       # ── Cleanup temp files ──────────────────────────────────────────────

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -14,6 +14,13 @@ on:
         required: false
         type: string
         default: ''
+      base_branch:
+        description: >
+          Base branch to compare against (fork-point is computed with
+          `git merge-base HEAD origin/<base_branch>`).
+        required: false
+        type: string
+        default: 'develop'
 
 # Prevent duplicate runs for the same branch; different branches run in parallel
 # on separate ephemeral runners provisioned by TestFlows.
@@ -55,16 +62,18 @@ jobs:
 
       - name: Resolve commits
         id: commits
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
           set -euo pipefail
 
           HEAD_SHA=$(git rev-parse HEAD)
           BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-          # Ensure we have the develop branch ref for merge-base
-          git fetch origin develop:refs/remotes/origin/develop --no-tags
+          # Ensure we have the base branch ref for merge-base
+          git fetch origin "$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH" --no-tags
 
-          FORK_POINT=$(git merge-base HEAD origin/develop)
+          FORK_POINT=$(git merge-base HEAD "origin/$BASE_BRANCH")
 
           if [ "$HEAD_SHA" = "$FORK_POINT" ]; then
             echo "::error::Fork-point equals HEAD — nothing to compare."
@@ -76,10 +85,12 @@ jobs:
           echo "fork_point=$FORK_POINT" >> "$GITHUB_OUTPUT"
           echo "fork_short=$(git rev-parse --short $FORK_POINT)" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-          echo "Branch:     $BRANCH"
-          echo "HEAD:       $HEAD_SHA"
-          echo "Fork-point: $FORK_POINT"
+          echo "Base branch: $BASE_BRANCH"
+          echo "Branch:      $BRANCH"
+          echo "HEAD:        $HEAD_SHA"
+          echo "Fork-point:  $FORK_POINT"
 
       - name: Build JMH filter from query list
         id: filter

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -83,7 +83,7 @@ jobs:
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
           echo "head_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "fork_point=$FORK_POINT" >> "$GITHUB_OUTPUT"
-          echo "fork_short=$(git rev-parse --short $FORK_POINT)" >> "$GITHUB_OUTPUT"
+          echo "fork_short=$(git rev-parse --short "$FORK_POINT")" >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
 
@@ -403,6 +403,7 @@ jobs:
             --head "/tmp/jmh-head-${{ github.run_id }}.json" \
             --base-sha "${{ steps.commits.outputs.fork_point }}" \
             --head-sha "${{ steps.commits.outputs.head_sha }}" \
+            --base-branch "${{ steps.commits.outputs.base_branch }}" \
             --repo-url "${{ github.server_url }}/${{ github.repository }}" \
             --base-load-time "${{ steps.base_load.outputs.load_time }}" \
             --head-load-time "${{ steps.head_load.outputs.load_time }}" \

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -437,17 +437,20 @@ jobs:
               return;
             }
 
+            // Marker kept so future tooling can locate prior benchmark
+            // comments (e.g. to collapse them into <details> blocks).
             const HEADER = '<!-- jmh-ldbc-compare -->';
             const fullBody = `${HEADER}\n${body}`;
 
             for (const pr of prs) {
-              await github.rest.issues.createComment({
+              const { data: created } = await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,
                 body: fullBody,
               });
-              console.log(`Created benchmark comment on PR #${pr.number}`);
+              console.log(
+                `Posted benchmark comment #${created.id} on PR #${pr.number}`);
             }
 
       # ── Cleanup temp files ──────────────────────────────────────────────

--- a/jmh-ldbc/jmh-compare.py
+++ b/jmh-ldbc/jmh-compare.py
@@ -269,6 +269,8 @@ def main():
     parser.add_argument("--head", required=True, help="Head (branch tip) results JSON")
     parser.add_argument("--base-sha", required=True, help="Base commit SHA")
     parser.add_argument("--head-sha", required=True, help="Head commit SHA")
+    parser.add_argument("--base-branch", default="develop",
+                        help="Name of the base branch the fork-point was taken from")
     parser.add_argument("--repo-url", default="",
                         help="Repository URL for commit links (e.g. https://github.com/owner/repo)")
     parser.add_argument("--base-load-time", type=float, default=None,
@@ -303,7 +305,7 @@ def main():
     lines.append("## JMH LDBC Benchmark Comparison")
     lines.append("")
     lines.append(
-        f"**Base:** {fmt_sha(args.base_sha)} (fork-point with develop) "
+        f"**Base:** {fmt_sha(args.base_sha)} (fork-point with `{args.base_branch}`) "
         f"| **Head:** {fmt_sha(args.head_sha)}"
     )
     has_throughput = regressions > 0 or improvements > 0 or suppressed > 0


### PR DESCRIPTION
#### Motivation:

The JMH LDBC compare workflow had two usability limitations that this PR addresses:

1. **Hard-coded base branch**: The fork-point was always computed against `origin/develop`, so there was no way to benchmark a branch that was forked from a different base (e.g. a feature branch or `main`). The base branch is now a workflow input (default `develop`) and is plumbed through to `jmh-compare.py` so the comparison comment shows the actual base branch it was compared against.

2. **Overwritten comment history**: The previous logic looked for an existing `<!-- jmh-ldbc-compare -->` comment and updated it in place, which silently destroyed the history of prior benchmark runs on the PR. Each run now posts a new comment so every benchmark result is preserved. The HEADER marker is retained so future tooling can still locate the benchmark comments (e.g. to collapse older ones into `<details>` blocks).

Also includes a small robustness fix: the `$FORK_POINT` variable is now quoted when passed to `git rev-parse --short`.

## Summary

- Add `base_branch` workflow_dispatch input (default `develop`); use it in `git fetch` and `git merge-base`.
- Thread the resolved base branch into `jmh-compare.py` via a new `--base-branch` flag and surface it in the comparison comment header.
- Always post a new benchmark comment on the associated PR instead of updating the existing one, preserving run history. Log the created comment id.

## Test plan

- [ ] Trigger the workflow manually on a branch with default inputs — verify comparison runs against `origin/develop` and a new comment is posted.
- [ ] Trigger the workflow with a non-default `base_branch` — verify the fork-point is computed against that branch and the comment header shows it.
- [ ] Re-run the workflow on the same PR — verify a second comment is created rather than overwriting the first.