### PR TITLE
Dispatch CI Fix Agent on macOS integration-test failures

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -232,9 +232,10 @@ jobs:
     # needs: of merge-to-main (so a macOS failure does not block the
     # develop→main promotion) and from notify-fixed (so "build fixed"
     # still fires when Linux/Windows/merge recover). notify-failure
-    # still observes macOS so the team sees regressions, but the
-    # CI Fix Agent is not auto-dispatched for macOS-only failures.
-    # Promote to blocking once the leg is proven stable on develop.
+    # still observes macOS so the team sees regressions, and the CI
+    # Fix Agent is auto-dispatched on macOS failures too so the agent
+    # can attempt a fix. Promote to blocking once the leg is proven
+    # stable on develop.
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -342,11 +343,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch CI Fix Agent
-        # test-macos intentionally excluded during soak: don't auto-dispatch
-        # the agent for macOS-only failures while the leg is still proving out.
         if: >-
           needs.test-linux.result == 'failure' ||
-          needs.test-windows.result == 'failure'
+          needs.test-windows.result == 'failure' ||
+          needs.test-macos.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.CI_FIX_AGENT_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- Include `test-macos` in the `Dispatch CI Fix Agent` condition in `maven-integration-tests-pipeline.yml` so macOS-only failures now trigger `ci-failure-fix-agent.yml`, matching how Linux and Windows failures are handled.
- Update stale comments that stated the agent is intentionally not dispatched for macOS failures.
- No change needed in `maven-pipeline.yml` — its `notify-failure` uses job-level `failure()` with `test-macos` already in `needs:`, so macOS failures on develop pushes were already dispatching the agent there.

## Motivation
macOS regressions on the nightly integration-tests pipeline were not surfacing to the CI Fix Agent, so failures on that leg had to be investigated manually. The agent can still analyze failure logs even if it cannot reproduce macOS-specific issues on its Linux runner, so giving it a chance to triage is strictly better than silence.

## Test plan
- [ ] Verify that a macOS-only failure on the next nightly integration run dispatches `ci-failure-fix-agent.yml`.
- [ ] Verify that Linux/Windows failure behavior is unchanged.