### PR TITLE
Fix main-deploy release-notes step failing on push event

### DIFF
--- a/.github/workflows/maven-main-deploy-pipeline.yml
+++ b/.github/workflows/maven-main-deploy-pipeline.yml
@@ -154,7 +154,20 @@ jobs:
           echo "::notice title=Pre-release diff base::${PREV_REF} (${SCOPE})"
 
       - name: Generate release notes with Claude
-        uses: anthropics/claude-code-action@v1
+        # claude-code-base-action is the event-agnostic sibling of
+        # claude-code-action. The latter rejects `push` events with
+        # "Unsupported event type: push" because it expects
+        # issue/PR/comment triggers; this job runs after a main-branch
+        # push deploy, so we use the base action which just invokes
+        # Claude Code against a prompt without event validation.
+        # Pinned to an immutable commit SHA (not a tag) to prevent
+        # tag-moving supply-chain attacks; the comment lists the
+        # corresponding upstream revision the pin was taken from.
+        # If the notes step fails for any reason, continue anyway —
+        # the next step falls back to a stub release body so the tag
+        # still gets cut and artifacts remain linked.
+        continue-on-error: true
+        uses: anthropics/claude-code-base-action@c937844d71159a8f6409acb3be0d10ea3cf92042 # main @ 2026-04-20, Claude Code 2.1.116
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |


### PR DESCRIPTION
## Summary

- Swap `anthropics/claude-code-action@v1` → `anthropics/claude-code-base-action@<sha>` in the main-deploy pipeline's release-notes step. The former rejects `push` events with `Unsupported event type: push`; the latter is event-agnostic and accepts the same `prompt` / `claude_args` / `anthropic_api_key` inputs.
- Pin the action to an immutable commit SHA (`c937844d...`, `main` @ 2026-04-20, Claude Code 2.1.116) with a trailing comment identifying the revision — matches the `oven-sh/setup-bun@<sha>` pattern and closes the supply-chain window opened by the movable `@v1` tag.
- Add `continue-on-error: true` so a notes-generation failure no longer turns a successful deploy into a `DEPLOY FAILED` Zulip page. The subsequent `Create GitHub pre-release` step already has fallback logic to publish the release with a stub body when `/tmp/release-notes.md` is missing, so the tag still gets cut.

## Motivation

Every run of the `Java CI/CD Main Deploy Pipeline` since PR #986 (`Cut GitHub pre-release tag after main deploy`) has failed in the `Generate release notes with Claude` step, including the most recent run against `main` at 4f12b23ea5:

- Failing CI run: https://github.com/JetBrains/youtrackdb/actions/runs/24688419408
- Failing step: `Create GitHub pre-release tag` → `Generate release notes with Claude`
- Error: `##[error]Action failed with error: Unsupported event type: push`

### Root cause

`anthropics/claude-code-action@v1` validates `github.event_name` against a fixed allow-list: `issues`, `issue_comment`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`. The main-deploy pipeline is triggered by `push: main`, which is not on that list and is rejected before the prompt is even dispatched. Because the `create-prerelease` job ends in `failure`, the `Notify deploy failure on Zulip` job then fires, so a successful deploy is announced as a broken deploy on every push.

The step only needs to run Claude against a prompt — it doesn't need any of the PR/issue/comment wiring the `v1` action provides — so the right fix is to use the event-agnostic `claude-code-base-action`, which is the exact same Claude Code runtime published by Anthropic for non-event-bound use cases.

### Why SHA-pin + continue-on-error?

Two should-fix items from the dimensional code-quality and security review of the minimal action swap:

1. **Supply-chain hardening (security review)**: A movable tag like `@v1` or even `@v0.0.63` can be force-pushed to an attacker-controlled commit. Since this step has access to `ANTHROPIC_API_KEY` and runs alongside `contents: write` release-creation logic, pinning by SHA matches the protection already applied elsewhere (`oven-sh/setup-bun@0c5077e5...`).
2. **False-positive Zulip pages (code-quality review)**: Without `continue-on-error`, any Claude step failure (rate-limit, timeout, transient network, future `push`-style incompatibility) fails the job and pages the team even when the release tag cuts fine via the fallback. The fallback exists exactly for this scenario — so the step should be advisory, not load-bearing.

`test-quality-review.yml` also uses `claude-code-action@v1` but is triggered by `pull_request`, which the action supports, so that workflow is unaffected and needs no change.

## Test plan

This workflow runs only on `push: main` and cannot be exercised locally. Static checks done:

- [x] YAML parses (via Python `yaml.safe_load`); the step correctly references `anthropics/claude-code-base-action@c937844d71159a8f6409acb3be0d10ea3cf92042` with `continue-on-error: true`.
- [x] The pinned commit exists and is the current tip of `main` at `anthropics/claude-code-base-action`, syncing Claude Code 2.1.116 — the same version `claude-code-action@v1` was installing in the failing run.
- [x] The three inputs the step passes (`anthropic_api_key`, `prompt`, `claude_args`) are all declared in `claude-code-base-action/action.yml`.
- [ ] Next push to `main` (after merge) exercises the fixed step end-to-end.