### PR TITLE
Reduce AsyncReadCacheTestIT iterations to fit macOS arm CI watchdog

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/AsyncReadCacheTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/AsyncReadCacheTestIT.java
@@ -47,7 +47,13 @@ public class AsyncReadCacheTestIT {
 
     final var fileLimit = 10;
     final var pageLimit = (int) (5L * 1024 * 1024 * 1024 / pageSize / fileLimit);
-    final var pageCount = (int) (1024L * 1024 * 1024 * 1024 / pageSize / 8);
+    // 8M ops per worker × 8 workers = 64M total page accesses. Kept an order of
+    // magnitude above what any concurrency bug needs to surface, but sized so the
+    // test fits inside the 60-minute per-test watchdog on the slowest CI runner
+    // (GitHub-hosted Apple Silicon on macOS arm JDK 25 — see JUnitTestListener).
+    // The working set (pageLimit × fileLimit) is unchanged, so eviction pressure
+    // against the 1 GiB cap stays identical — only the number of iterations shrinks.
+    final var pageCount = (int) (1024L * 1024 * 1024 * 1024 / pageSize / 8 / 4);
     final var timer = new Timer();
 
     final var memoryAboveLimit = new AtomicBoolean();
@@ -121,7 +127,13 @@ public class AsyncReadCacheTestIT {
     final List<Future<Void>> futures = new ArrayList<>();
 
     final var pageLimit = (int) (5 * 1024L * 1024 * 1024 / pageSize);
-    final var pageCount = (int) (1024L * 1024 * 1024 * 1024 / pageSize / 8);
+    // 8M ops per worker × 8 workers = 64M total page accesses under a Zipfian
+    // distribution. Reduced by 4× from the pre-existing 32M/worker for the same
+    // reason as testEvenDistribution — the test must fit inside the 60-minute
+    // per-test watchdog on the slowest CI runner (GitHub-hosted Apple Silicon on
+    // macOS arm JDK 25). Skew and working-set size are unchanged, so the Zipfian
+    // access pattern and eviction pressure remain identical.
+    final var pageCount = (int) (1024L * 1024 * 1024 * 1024 / pageSize / 8 / 4);
     final var timer = new Timer();
 
     final var memoryAboveLimit = new AtomicBoolean();


### PR DESCRIPTION
## Summary

- `testEvenDistribution` and `testZiphianDistribution` now run 8M ops per worker × 8 workers (64M total page accesses) instead of 32M × 8 = 256M. Working set, cache cap, Zipfian skew, and thread count are unchanged.
- Added a comment at both sites documenting the CI-watchdog rationale and the preserved invariants (eviction pressure, access-pattern skew).

## Motivation

The `macOS arm - JDK 25 - temurin` leg of the [integration-tests pipeline](https://github.com/JetBrains/youtrackdb/actions/runs/24672100968) failed. Surefire reported a \"forked VM terminated without properly saying goodbye\", but the \`deadlock-report.txt\` artifact shows the real cause: the per-test watchdog in \`JUnitTestListener\` fired with \`TEST TIMEOUT (testEvenDistribution ... running for 3617 seconds)\` and called \`Runtime.halt(1)\`.

The thread dump shows forward progress on every worker — this is not a deadlock, and \`findDeadlockedThreads()\` returned null. The test is just doing far more work than the weakest CI runner can finish inside the 60-minute watchdog:

| Runner                       | AsyncReadCacheTestIT (both tests) |
|------------------------------|-----------------------------------|
| Linux arm JDK 21 (self-hosted) | 1471 s (~25 min) ✅              |
| macOS arm JDK 25 (GitHub-hosted) | testEvenDistribution alone hit 60 min ❌ |

The GitHub-hosted Apple Silicon runner introduced in #987 is substantially slower than the Hetzner self-hosted nodes. 256M page accesses is much more than needed to surface any concurrency bug in \`LockFreeReadCache\` (the cache still churns ~244× its capacity after the cut), so the fix is to bring the iteration budget back in line with what the slowest runner can finish.

The fix is in the test (not the production code or the CI config) because:
- Production code is fine — no deadlock, no hang, no wrong assertion.
- Raising the watchdog on macOS would slow every future run without adding coverage.
- 64M total ops is still two orders of magnitude above what any deterministic assertion needs.

Verified locally: \`./mvnw -pl core -am verify -P ci-integration-tests -Dit.test=AsyncReadCacheTestIT\` passes both tests in 126.6 s on x86 Linux. Spotless clean.

## Test plan

- [ ] macOS arm JDK 25 leg of the integration-tests pipeline completes \`AsyncReadCacheTestIT\` inside the 60-min per-test watchdog.
- [ ] Linux x86/arm and Windows x64 legs still pass; no regression in \`AsyncReadCacheTestIT\` on any platform.
- [ ] No new failures in neighbouring concurrency tests (\`LockFreeReadCacheConcurrentTestIT\`, \`ConcurrentLongIntHashMap*Test\`).