### PR TITLE
Guard JMH compare workflow against concurrent runs

### DIFF
--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -92,6 +92,84 @@ jobs:
           echo "HEAD:        $HEAD_SHA"
           echo "Fork-point:  $FORK_POINT"
 
+      # Post a placeholder comment on every open PR for this branch to signal
+      # that a run is starting. If a placeholder already exists, exit early —
+      # another run is in progress. Cleaned up by "Remove in-progress
+      # placeholder" below (runs on success, failure, or cancel). Base/Head
+      # are rendered in the same format as the final comparison comment.
+      - name: Check for in-progress benchmark and post placeholder
+        id: placeholder
+        uses: actions/github-script@v9
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BASE_SHA: ${{ steps.commits.outputs.fork_point }}
+          HEAD_SHA: ${{ steps.commits.outputs.head_sha }}
+          BASE_BRANCH: ${{ steps.commits.outputs.base_branch }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        with:
+          script: |
+            const branch = process.env.GITHUB_REF_NAME;
+            const IN_PROGRESS_MARKER = '<!-- jmh-ldbc-compare-in-progress -->';
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open',
+            });
+
+            if (prs.length === 0) {
+              console.log(`No open PRs for branch ${branch}; skipping placeholder.`);
+              core.setOutput('posted', 'false');
+              return;
+            }
+
+            for (const pr of prs) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                });
+              const existing = comments.find(
+                c => c.body && c.body.includes(IN_PROGRESS_MARKER));
+              if (existing) {
+                core.setOutput('posted', 'false');
+                core.setFailed(
+                  `Another JMH LDBC compare run is already in progress for ` +
+                  `PR #${pr.number} (comment #${existing.id}: ${existing.html_url}). ` +
+                  `Exiting.`);
+                return;
+              }
+            }
+
+            // Matches the `fmt_sha` helper in jmh-ldbc/jmh-compare.py:
+            // [`<short10>`](<repo>/commit/<sha>)
+            const fmtSha = sha =>
+              `[\`${sha.slice(0, 10)}\`](${process.env.REPO_URL}/commit/${sha})`;
+            const commits =
+              `**Base:** ${fmtSha(process.env.BASE_SHA)} ` +
+              `(fork-point with \`${process.env.BASE_BRANCH}\`) ` +
+              `| **Head:** ${fmtSha(process.env.HEAD_SHA)}`;
+
+            const body = `${IN_PROGRESS_MARKER}\n` +
+              `## JMH LDBC Benchmark Comparison\n\n` +
+              `${commits}\n\n` +
+              `⏳ **Run in progress** on branch \`${branch}\`. ` +
+              `Follow the run: ${process.env.RUN_URL}`;
+            for (const pr of prs) {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+              console.log(
+                `Posted in-progress placeholder #${created.id} on PR #${pr.number}`);
+            }
+            core.setOutput('posted', 'true');
+
       - name: Build JMH filter from query list
         id: filter
         run: |
@@ -463,6 +541,45 @@ jobs:
               });
               console.log(
                 `Posted benchmark comment #${created.id} on PR #${pr.number}`);
+            }
+
+      # Always remove our in-progress placeholder so the next run is not
+      # blocked. Skipped when the placeholder step itself bailed out (posted=false)
+      # so we never delete another run's placeholder.
+      - name: Remove in-progress placeholder
+        if: always() && steps.placeholder.outputs.posted == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const branch = process.env.GITHUB_REF_NAME;
+            const IN_PROGRESS_MARKER = '<!-- jmh-ldbc-compare-in-progress -->';
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.repo.owner}:${branch}`,
+              state: 'open',
+            });
+
+            for (const pr of prs) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                });
+              for (const comment of comments) {
+                if (comment.body && comment.body.includes(IN_PROGRESS_MARKER)) {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: comment.id,
+                  });
+                  console.log(
+                    `Deleted placeholder #${comment.id} on PR #${pr.number}`);
+                }
+              }
             }
 
       # ── Cleanup temp files ──────────────────────────────────────────────

--- a/.github/workflows/ldbc-jmh-compare.yml
+++ b/.github/workflows/ldbc-jmh-compare.yml
@@ -30,6 +30,10 @@ concurrency:
 
 env:
   LDBC_SCALE_FACTOR: '1'
+  # Shared marker for the in-progress placeholder comment. Referenced by
+  # both the "Check for in-progress benchmark" and "Remove in-progress
+  # placeholder" steps via `process.env.IN_PROGRESS_MARKER`.
+  IN_PROGRESS_MARKER: '<!-- jmh-ldbc-compare-in-progress -->'
 
 jobs:
   compare:
@@ -97,10 +101,19 @@ jobs:
       # another run is in progress. Cleaned up by "Remove in-progress
       # placeholder" below (runs on success, failure, or cancel). Base/Head
       # are rendered in the same format as the final comparison comment.
+      #
+      # Best-effort belt-and-suspenders guard on top of the job-level
+      # `concurrency:` block: the API check+post is not atomic, so two runs
+      # racing within API latency could both post. In practice the top-level
+      # concurrency block already cancels same-ref duplicates; this PR-scoped
+      # guard covers only the remaining windows (rapid re-dispatch, or
+      # multiple refs pointing at the same PR), which are rare enough that a
+      # strict mutex isn't worth the complexity.
       - name: Check for in-progress benchmark and post placeholder
         id: placeholder
         uses: actions/github-script@v9
         env:
+          BRANCH: ${{ steps.commits.outputs.branch }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BASE_SHA: ${{ steps.commits.outputs.fork_point }}
           HEAD_SHA: ${{ steps.commits.outputs.head_sha }}
@@ -108,8 +121,8 @@ jobs:
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         with:
           script: |
-            const branch = process.env.GITHUB_REF_NAME;
-            const IN_PROGRESS_MARKER = '<!-- jmh-ldbc-compare-in-progress -->';
+            const branch = process.env.BRANCH;
+            const IN_PROGRESS_MARKER = process.env.IN_PROGRESS_MARKER;
 
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
@@ -119,6 +132,8 @@ jobs:
             });
 
             if (prs.length === 0) {
+              // No PR → nothing to guard here; the top-level `concurrency:`
+              // block still prevents same-ref duplicates.
               console.log(`No open PRs for branch ${branch}; skipping placeholder.`);
               core.setOutput('posted', 'false');
               return;
@@ -135,6 +150,9 @@ jobs:
               const existing = comments.find(
                 c => c.body && c.body.includes(IN_PROGRESS_MARKER));
               if (existing) {
+                // Set posted=false BEFORE setFailed so the cleanup step's
+                // `posted == 'true'` guard evaluates to false and we do not
+                // delete the other run's marker.
                 core.setOutput('posted', 'false');
                 core.setFailed(
                   `Another JMH LDBC compare run is already in progress for ` +
@@ -153,10 +171,13 @@ jobs:
               `(fork-point with \`${process.env.BASE_BRANCH}\`) ` +
               `| **Head:** ${fmtSha(process.env.HEAD_SHA)}`;
 
+            // Strip backticks so a branch name containing them cannot break
+            // out of the code span in the rendered markdown body.
+            const branchLabel = branch.replace(/`/g, '');
             const body = `${IN_PROGRESS_MARKER}\n` +
               `## JMH LDBC Benchmark Comparison\n\n` +
               `${commits}\n\n` +
-              `⏳ **Run in progress** on branch \`${branch}\`. ` +
+              `⏳ **Run in progress** on branch \`${branchLabel}\`. ` +
               `Follow the run: ${process.env.RUN_URL}`;
             for (const pr of prs) {
               const { data: created } = await github.rest.issues.createComment({
@@ -549,10 +570,12 @@ jobs:
       - name: Remove in-progress placeholder
         if: always() && steps.placeholder.outputs.posted == 'true'
         uses: actions/github-script@v9
+        env:
+          BRANCH: ${{ steps.commits.outputs.branch }}
         with:
           script: |
-            const branch = process.env.GITHUB_REF_NAME;
-            const IN_PROGRESS_MARKER = '<!-- jmh-ldbc-compare-in-progress -->';
+            const branch = process.env.BRANCH;
+            const IN_PROGRESS_MARKER = process.env.IN_PROGRESS_MARKER;
 
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
@@ -571,13 +594,22 @@ jobs:
                 });
               for (const comment of comments) {
                 if (comment.body && comment.body.includes(IN_PROGRESS_MARKER)) {
-                  await github.rest.issues.deleteComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: comment.id,
-                  });
-                  console.log(
-                    `Deleted placeholder #${comment.id} on PR #${pr.number}`);
+                  // Catch per-comment delete failures so one transient error
+                  // does not leave stale markers on the remaining PRs (which
+                  // would block all future runs until manually cleaned).
+                  try {
+                    await github.rest.issues.deleteComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: comment.id,
+                    });
+                    console.log(
+                      `Deleted placeholder #${comment.id} on PR #${pr.number}`);
+                  } catch (err) {
+                    console.warn(
+                      `Failed to delete placeholder #${comment.id} on PR ` +
+                      `#${pr.number}: ${err.message}`);
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Motivation

The `ldbc-jmh-compare.yml` workflow posts a comparison comment to every open PR for the branch at the end of a run. The existing job-level `concurrency:` block cancels same-ref duplicates, but leaves a few windows open:

- Rapid re-dispatches where the cancel races the start of the next run.
- Multiple refs (e.g. a branch plus a tag) pointing at the same PR.

When two runs overlap, both eventually post — the PR ends up with duplicate or out-of-order benchmark comments, which is noisy and confusing to review.

This change adds a best-effort belt-and-suspenders PR-scoped guard on top of the existing concurrency block: post an in-progress placeholder comment on every open PR at the start of the run, and bail out if one is already present so two runs cannot silently overlap. The placeholder is always removed at the end (success, failure, or cancel), but **only** by the run that posted it — an exit-because-another-run-exists never deletes the live run's marker.

The second commit applies review feedback:
- Wrap `deleteComment` in try/catch so a single transient API failure does not leave stale markers on the remaining PRs (which would block all future runs until cleaned manually).
- Lift `IN_PROGRESS_MARKER` to workflow-level `env` so both scripts share one literal.
- Use `steps.commits.outputs.branch` everywhere (matching the existing comparison step) instead of mixing in `GITHUB_REF_NAME`.
- Strip backticks from the branch name before embedding in the markdown code span so an exotic refname cannot inject markdown.
- Add inline comments for the load-bearing `posted=false`-before-`setFailed` ordering.

## Summary

- Post a placeholder comment with Base/Head commits at the start of the run; bail out if another placeholder already exists on any open PR for the branch.
- Always remove the placeholder posted by the current run, even on failure or cancellation.
- Harden the cleanup against per-comment delete failures and share the marker literal between the two scripts.

## Test plan

- [ ] Trigger a run, confirm an in-progress placeholder appears on the open PR with Base/Head rendered in the same format as the final comment.
- [ ] Trigger a second run while the first is still running; confirm it exits early and does not delete the first run's placeholder.
- [ ] Let the first run complete; confirm the placeholder is removed and the final comparison comment is posted.
- [ ] Cancel a run mid-flight; confirm the placeholder it posted is removed.