### PR TITLE
Require PR description sync on follow-up commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ Tests configure YouTrackDB-specific system properties in `<argLine>`:
 - Target branch: `develop`
 - **1 PR = 1 squashed commit** — all branch commits are squashed on merge
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made.
+- **Keep PR description (and title, if needed) in sync with every additional commit.** Because all commits are squashed on merge, the final commit message is built from the PR title and description — not from individual commit messages. Whenever you push follow-up commits to an existing PR, update the PR description (and the title if the scope changed) so the eventual squashed commit accurately reflects the full set of changes.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
 
 ### Workflow Artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ Tests configure YouTrackDB-specific system properties in `<argLine>`:
 - Target branch: `develop`
 - **1 PR = 1 squashed commit** — all branch commits are squashed on merge
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made.
-- **Keep PR description (and title, if needed) in sync with every additional commit.** Because all commits are squashed on merge, the final commit message is built from the PR title and description — not from individual commit messages. Whenever you push follow-up commits to an existing PR, update the PR description (and the title if the scope changed) so the eventual squashed commit accurately reflects the full set of changes.
+- **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
 
 ### Workflow Artifacts


### PR DESCRIPTION
#### Motivation

Squash-merge in this repo builds the final commit message from the PR title and description, not from individual branch commits. When follow-up commits are pushed to an existing PR without updating the PR metadata, the squashed commit silently loses context about what the later commits changed. Making the expectation explicit in `CLAUDE.md` keeps future squashed commits accurate and reviewable.

#### Summary

- Adds a bullet under **Git Conventions → Pull Requests** stating that every additional commit on an open PR must be accompanied by an update to the PR description (and title if scope changed), since the squashed commit is generated from PR metadata.
- Tightens the wording per Gemini review: the original phrasing repeated information from the adjacent bullet and ran long. Collapsed to a single sentence while preserving the key nuance that individual commit messages are discarded on squash.

#### Test plan

- [ ] Docs-only change — no code or tests affected.