### PR TITLE
[no-test-number-check] Fix GranularTickerTest.testTimeApproximation monotonicity flake

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTicker.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTicker.java
@@ -4,21 +4,70 @@ import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /// Default implementation of [Ticker] that updates its internal time at a certain granularity in a
 /// separate thread.
+///
+/// ## Concurrency
+///
+/// The `(nanoTime, nanoTimeDifference)` pair is held in a single immutable [Snapshot] stored
+/// behind one `volatile` reference so that [#approximateCurrentTimeMillis()] reads both values
+/// atomically. Two independent volatile fields would allow a reader to observe a stale
+/// `nanoTime` with a freshly recomputed `nanoTimeDifference` (or vice versa), producing a
+/// combined value that drops below a previously returned timestamp — breaking the
+/// non-decreasing contract that callers (e.g. elapsed-time measurements) rely on.
+///
+/// Both [#approximateNanoTime()] and [#approximateCurrentTimeMillis()] run their output
+/// through an [AtomicLong] high-water mark ([#lastApproxNanos] / [#lastApproxMillis]) to
+/// guarantee strict monotonicity. Two sources can otherwise produce a backward-moving
+/// reading:
+///
+/// - The nanoTime-refresh task does a read-modify-write on the `snapshot` field (reads the
+///   current `nanoTimeDifference`, then publishes a new `Snapshot` carrying a freshly
+///   sampled `nanoTime`). If the wall-clock-recalibration task publishes between those two
+///   steps with a later-sampled `nanoTime`, the nanoTime-refresh task's publish overwrites
+///   it with an earlier-sampled value. Without the clamp, a reader observing the two
+///   snapshots in sequence would see `nanoTime` decrease.
+/// - Sub-millisecond drift between `System.nanoTime()` and `System.currentTimeMillis()`
+///   can cause `nanoTimeDifference` to fluctuate by ±1 ms across recalibration fires,
+///   which would otherwise manifest as a 1 ms backward jump in
+///   `approximateCurrentTimeMillis()`.
+///
+/// Callers such as `Stopwatch.timed()` and `YTDBQueryMetricsStep` compute deltas across
+/// two reader invocations and require non-negative durations, so monotonicity on both
+/// accessors is load-bearing.
 public class GranularTicker implements Ticker, AutoCloseable {
+
+  /// Immutable view of the pair `(nanoTime, nanoTimeDifference)`. Held behind one volatile
+  /// reference so readers observe both values consistently.
+  private record Snapshot(long nanoTime, long nanoTimeDifference) {
+  }
+
+  private static final Snapshot INITIAL_SNAPSHOT = new Snapshot(0L, 0L);
 
   private final long granularity;
   private final long timestampRefreshRate;
+  private volatile boolean started;
   private volatile boolean stopped;
-  private volatile long nanoTime;
-  /// Offset between {@link System#currentTimeMillis()} and {@link System#nanoTime()} converted to
-  /// milliseconds. Since {@code nanoTime} has no defined origin (it is only meaningful for
-  /// measuring elapsed time), this difference lets us derive an approximate wall-clock timestamp
-  /// from the cached {@code nanoTime} without an extra {@code currentTimeMillis()} call. Refreshed
-  /// periodically to account for clock drift.
-  private volatile long nanoTimeDifference;
+
+  /// Combined `(nanoTime, nanoTimeDifference)` snapshot. `nanoTime` is the most recently
+  /// sampled [System#nanoTime()]. `nanoTimeDifference` is the offset between
+  /// [System#currentTimeMillis()] and [System#nanoTime()] converted to milliseconds — it lets
+  /// us derive an approximate wall-clock timestamp from the cached `nanoTime` without an extra
+  /// `currentTimeMillis()` call. The difference is refreshed periodically to account for clock
+  /// drift.
+  private volatile Snapshot snapshot = INITIAL_SNAPSHOT;
+
+  /// Highest value ever returned by [#approximateNanoTime()]. Used to clamp the output so the
+  /// method is strictly non-decreasing across concurrent readers and refresh fires. See the
+  /// class-level concurrency notes for the race that necessitates this.
+  private final AtomicLong lastApproxNanos = new AtomicLong(0L);
+
+  /// Highest value ever returned by [#approximateCurrentTimeMillis()]. Used to clamp the
+  /// output so the method is strictly non-decreasing across concurrent readers and refresh
+  /// fires.
+  private final AtomicLong lastApproxMillis = new AtomicLong(0L);
 
   private final ScheduledExecutorService executor;
   private volatile ScheduledFuture<?> nanoTimeFuture;
@@ -33,21 +82,36 @@ public class GranularTicker implements Ticker, AutoCloseable {
 
   @Override
   public void start() {
-    assert nanoTime == 0 : "Ticker is already started";
-    this.nanoTime = System.nanoTime();
-    this.nanoTimeDifference = System.currentTimeMillis() - this.nanoTime / 1_000_000;
+    assert !started : "Ticker is already started";
+    started = true;
+    final long initialNano = System.nanoTime();
+    final long initialDiff = System.currentTimeMillis() - initialNano / 1_000_000;
+    snapshot = new Snapshot(initialNano, initialDiff);
 
     nanoTimeFuture = executor.scheduleAtFixedRate(
         () -> {
           if (!stopped) {
-            nanoTime = System.nanoTime();
+            // Refresh only the nanoTime component. The snapshot's nanoTimeDifference stays
+            // valid between wall-clock recalibrations because wall clock and nanoTime advance
+            // at the same rate over short intervals.
+            //
+            // This read-modify-write is not atomic with a concurrent publish from the
+            // wall-clock-recalibration task; see the class-level concurrency notes.
+            var current = snapshot;
+            snapshot = new Snapshot(System.nanoTime(), current.nanoTimeDifference);
           }
         },
         granularity, granularity, TimeUnit.NANOSECONDS);
     nanoTimeDifferenceFuture = executor.scheduleAtFixedRate(
         () -> {
           if (!stopped) {
-            nanoTimeDifference = System.currentTimeMillis() - System.nanoTime() / 1_000_000;
+            // Read wall clock and nanoTime together so the resulting snapshot represents a
+            // consistent point in time. Sampling nanoTime here (rather than using the cached
+            // field) ensures `nanoTime/1M + nanoTimeDifference` evaluates to exactly the
+            // wall clock at recalibration fire time.
+            final long fresh = System.nanoTime();
+            final long newDiff = System.currentTimeMillis() - fresh / 1_000_000;
+            snapshot = new Snapshot(fresh, newDiff);
           }
         },
         timestampRefreshRate, timestampRefreshRate, TimeUnit.NANOSECONDS);
@@ -55,12 +119,18 @@ public class GranularTicker implements Ticker, AutoCloseable {
 
   @Override
   public long approximateNanoTime() {
-    return nanoTime;
+    // Clamp to the highest value ever returned so a losing read-modify-write publish in the
+    // nanoTime-refresh task cannot produce a backward jump. See class-level concurrency notes.
+    return lastApproxNanos.accumulateAndGet(snapshot.nanoTime, Math::max);
   }
 
   @Override
   public long approximateCurrentTimeMillis() {
-    return nanoTime / 1_000_000 + nanoTimeDifference;
+    final var s = snapshot;
+    final long computed = s.nanoTime / 1_000_000 + s.nanoTimeDifference;
+    // Clamp to the highest value ever returned so sub-ms drift at refresh fires cannot
+    // produce a backward jump.
+    return lastApproxMillis.accumulateAndGet(computed, Math::max);
   }
 
   @Override
@@ -70,7 +140,7 @@ public class GranularTicker implements Ticker, AutoCloseable {
 
   @Override
   public long getTick() {
-    return nanoTime / granularity;
+    return snapshot.nanoTime / granularity;
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTicker.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTicker.java
@@ -4,80 +4,75 @@ import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 /// Default implementation of [Ticker] that updates its internal time at a certain granularity in a
 /// separate thread.
 ///
 /// ## Concurrency
 ///
-/// The `(nanoTime, nanoTimeDifference)` pair is held in a single immutable [Snapshot] stored
-/// behind one `volatile` reference so that [#approximateCurrentTimeMillis()] reads both values
-/// atomically. Two independent volatile fields would allow a reader to observe a stale
-/// `nanoTime` with a freshly recomputed `nanoTimeDifference` (or vice versa), producing a
-/// combined value that drops below a previously returned timestamp — breaking the
-/// non-decreasing contract that callers (e.g. elapsed-time measurements) rely on.
+/// A single scheduled task samples [System#nanoTime()] every `granularity` and publishes a
+/// fresh [Snapshot] into the `volatile` reference [#snapshot]. Every *N*-th fire the same
+/// task also samples [System#currentTimeMillis()] and recomputes the wall-clock offset
+/// (`nanoTimeDifference`) where `N = timestampRefreshRate / granularity`. Readers do a single
+/// volatile read of `snapshot` and derive both accessors from it — no reader-side CAS.
 ///
-/// Both [#approximateNanoTime()] and [#approximateCurrentTimeMillis()] run their output
-/// through an [AtomicLong] high-water mark ([#lastApproxNanos] / [#lastApproxMillis]) to
-/// guarantee strict monotonicity. Two sources can otherwise produce a backward-moving
-/// reading:
+/// Monotonicity is enforced at the writer by [#nextSnapshot]: when building the next
+/// snapshot the task compares the candidate against the previously published snapshot and
+/// clamps
 ///
-/// - The nanoTime-refresh task does a read-modify-write on the `snapshot` field (reads the
-///   current `nanoTimeDifference`, then publishes a new `Snapshot` carrying a freshly
-///   sampled `nanoTime`). If the wall-clock-recalibration task publishes between those two
-///   steps with a later-sampled `nanoTime`, the nanoTime-refresh task's publish overwrites
-///   it with an earlier-sampled value. Without the clamp, a reader observing the two
-///   snapshots in sequence would see `nanoTime` decrease.
-/// - Sub-millisecond drift between `System.nanoTime()` and `System.currentTimeMillis()`
-///   can cause `nanoTimeDifference` to fluctuate by ±1 ms across recalibration fires,
-///   which would otherwise manifest as a 1 ms backward jump in
-///   `approximateCurrentTimeMillis()`.
+/// - `nanoTime` so it never regresses across publishes (insurance against cross-core clock
+///   jitter on older hardware),
+/// - the derived wall-clock millis so sub-millisecond drift between `System.nanoTime()` and
+///   `System.currentTimeMillis()` at a recalibration fire cannot produce a backward jump in
+///   [#approximateCurrentTimeMillis()].
 ///
-/// Callers such as `Stopwatch.timed()` and `YTDBQueryMetricsStep` compute deltas across
-/// two reader invocations and require non-negative durations, so monotonicity on both
-/// accessors is load-bearing.
+/// Because the refresh task is the only writer, `snapshot = nextSnapshot(...)` never races
+/// with itself and no further serialization is needed. Readers observe an atomic, monotonic
+/// `(nanoTime, nanoTimeDifference)` pair via the volatile store on `snapshot`.
+///
+/// Callers such as `Stopwatch.timed()`, `YTDBQueryMetricsStep` and
+/// `FrontendTransactionImpl.notifyMetricsListener` compute deltas across two reader
+/// invocations and rely on non-negative durations, so monotonicity on both accessors is
+/// load-bearing.
 public class GranularTicker implements Ticker, AutoCloseable {
 
   /// Immutable view of the pair `(nanoTime, nanoTimeDifference)`. Held behind one volatile
   /// reference so readers observe both values consistently.
-  private record Snapshot(long nanoTime, long nanoTimeDifference) {
+  record Snapshot(long nanoTime, long nanoTimeDifference) {
   }
 
   private static final Snapshot INITIAL_SNAPSHOT = new Snapshot(0L, 0L);
 
   private final long granularity;
-  private final long timestampRefreshRate;
+  /// How many refresh ticks happen between wall-clock recalibrations. Computed once from
+  /// `timestampRefreshRate / granularity`; floored at 1 so the refresh task still recalibrates
+  /// when the two configuration values are equal (used heavily by tests).
+  private final long recalibrationInterval;
   private volatile boolean started;
   private volatile boolean stopped;
 
   /// Combined `(nanoTime, nanoTimeDifference)` snapshot. `nanoTime` is the most recently
   /// sampled [System#nanoTime()]. `nanoTimeDifference` is the offset between
-  /// [System#currentTimeMillis()] and [System#nanoTime()] converted to milliseconds — it lets
-  /// us derive an approximate wall-clock timestamp from the cached `nanoTime` without an extra
+  /// [System#currentTimeMillis()] and `nanoTime / 1_000_000` — it lets us derive an
+  /// approximate wall-clock timestamp from the cached `nanoTime` without an extra
   /// `currentTimeMillis()` call. The difference is refreshed periodically to account for clock
   /// drift.
   private volatile Snapshot snapshot = INITIAL_SNAPSHOT;
 
-  /// Highest value ever returned by [#approximateNanoTime()]. Used to clamp the output so the
-  /// method is strictly non-decreasing across concurrent readers and refresh fires. See the
-  /// class-level concurrency notes for the race that necessitates this.
-  private final AtomicLong lastApproxNanos = new AtomicLong(0L);
-
-  /// Highest value ever returned by [#approximateCurrentTimeMillis()]. Used to clamp the
-  /// output so the method is strictly non-decreasing across concurrent readers and refresh
-  /// fires.
-  private final AtomicLong lastApproxMillis = new AtomicLong(0L);
+  /// Fire counter owned exclusively by the scheduled refresh task. `scheduleAtFixedRate`
+  /// guarantees a single task does not execute concurrently with itself, so no
+  /// synchronization is needed here.
+  private long tickCount;
 
   private final ScheduledExecutorService executor;
-  private volatile ScheduledFuture<?> nanoTimeFuture;
-  private volatile ScheduledFuture<?> nanoTimeDifferenceFuture;
+  private volatile ScheduledFuture<?> refreshFuture;
 
   public GranularTicker(long granularityNanos, long timestampRefreshRate,
       ScheduledExecutorService executor) {
     this.executor = Objects.requireNonNull(executor, "ScheduledExecutorService must not be null");
-    this.timestampRefreshRate = timestampRefreshRate;
     this.granularity = granularityNanos;
+    final long safeGranularity = Math.max(1L, granularityNanos);
+    this.recalibrationInterval = Math.max(1L, timestampRefreshRate / safeGranularity);
   }
 
   @Override
@@ -88,49 +83,62 @@ public class GranularTicker implements Ticker, AutoCloseable {
     final long initialDiff = System.currentTimeMillis() - initialNano / 1_000_000;
     snapshot = new Snapshot(initialNano, initialDiff);
 
-    nanoTimeFuture = executor.scheduleAtFixedRate(
-        () -> {
-          if (!stopped) {
-            // Refresh only the nanoTime component. The snapshot's nanoTimeDifference stays
-            // valid between wall-clock recalibrations because wall clock and nanoTime advance
-            // at the same rate over short intervals.
-            //
-            // This read-modify-write is not atomic with a concurrent publish from the
-            // wall-clock-recalibration task; see the class-level concurrency notes.
-            var current = snapshot;
-            snapshot = new Snapshot(System.nanoTime(), current.nanoTimeDifference);
-          }
-        },
-        granularity, granularity, TimeUnit.NANOSECONDS);
-    nanoTimeDifferenceFuture = executor.scheduleAtFixedRate(
-        () -> {
-          if (!stopped) {
-            // Read wall clock and nanoTime together so the resulting snapshot represents a
-            // consistent point in time. Sampling nanoTime here (rather than using the cached
-            // field) ensures `nanoTime/1M + nanoTimeDifference` evaluates to exactly the
-            // wall clock at recalibration fire time.
-            final long fresh = System.nanoTime();
-            final long newDiff = System.currentTimeMillis() - fresh / 1_000_000;
-            snapshot = new Snapshot(fresh, newDiff);
-          }
-        },
-        timestampRefreshRate, timestampRefreshRate, TimeUnit.NANOSECONDS);
+    refreshFuture = executor.scheduleAtFixedRate(
+        this::refresh, granularity, granularity, TimeUnit.NANOSECONDS);
+  }
+
+  /// Single-writer refresh. Samples `System.nanoTime()` every fire and, every
+  /// [#recalibrationInterval] fires, also samples `System.currentTimeMillis()` to recompute
+  /// the wall-clock offset. Runs on the scheduled executor's thread.
+  private void refresh() {
+    if (stopped) {
+      return;
+    }
+    tickCount++;
+    final boolean recalibrate = tickCount % recalibrationInterval == 0;
+    final long freshNano = System.nanoTime();
+    // Sample currentTimeMillis only on recalibration fires. On non-recalibration fires the
+    // previous snapshot's nanoTimeDifference is reused, so the syscall is skipped entirely.
+    final long wallMillis = recalibrate ? System.currentTimeMillis() : 0L;
+    snapshot = nextSnapshot(snapshot, freshNano, wallMillis, recalibrate);
+  }
+
+  /// Builds the next snapshot while enforcing monotonicity of both accessors. Package-private
+  /// so unit tests can exercise the clamp without timing-dependent scheduler runs.
+  ///
+  /// - `nano` is clamped to `max(prev.nanoTime, freshNano)` so successive snapshots never
+  ///   expose a regressing raw `nanoTime`.
+  /// - On a recalibration fire the new offset is bumped up if needed so
+  ///   `nano / 1_000_000 + newDiff >= prev.nanoTime / 1_000_000 + prev.nanoTimeDifference`,
+  ///   absorbing the ±1 ms drift that can arise between `System.nanoTime()` and
+  ///   `System.currentTimeMillis()`.
+  static Snapshot nextSnapshot(Snapshot prev, long freshNano, long wallMillis,
+      boolean recalibrate) {
+    final long nano = Math.max(prev.nanoTime, freshNano);
+    if (!recalibrate) {
+      return new Snapshot(nano, prev.nanoTimeDifference);
+    }
+    long newDiff = wallMillis - nano / 1_000_000;
+    final long prevMillis = prev.nanoTime / 1_000_000 + prev.nanoTimeDifference;
+    final long candidateMillis = nano / 1_000_000 + newDiff;
+    if (candidateMillis < prevMillis) {
+      // Absorb the sub-ms drift between System.nanoTime() and System.currentTimeMillis() at
+      // recalibration fires: inflate the offset so the derived wall-clock timestamp does not
+      // regress against the previously published snapshot.
+      newDiff += (prevMillis - candidateMillis);
+    }
+    return new Snapshot(nano, newDiff);
   }
 
   @Override
   public long approximateNanoTime() {
-    // Clamp to the highest value ever returned so a losing read-modify-write publish in the
-    // nanoTime-refresh task cannot produce a backward jump. See class-level concurrency notes.
-    return lastApproxNanos.accumulateAndGet(snapshot.nanoTime, Math::max);
+    return snapshot.nanoTime;
   }
 
   @Override
   public long approximateCurrentTimeMillis() {
     final var s = snapshot;
-    final long computed = s.nanoTime / 1_000_000 + s.nanoTimeDifference;
-    // Clamp to the highest value ever returned so sub-ms drift at refresh fires cannot
-    // produce a backward jump.
-    return lastApproxMillis.accumulateAndGet(computed, Math::max);
+    return s.nanoTime / 1_000_000 + s.nanoTimeDifference;
   }
 
   @Override
@@ -151,13 +159,9 @@ public class GranularTicker implements Ticker, AutoCloseable {
   @Override
   public void stop() {
     stopped = true;
-    var f1 = nanoTimeFuture;
-    if (f1 != null) {
-      f1.cancel(false);
-    }
-    var f2 = nanoTimeDifferenceFuture;
-    if (f2 != null) {
-      f2.cancel(false);
+    var f = refreshFuture;
+    if (f != null) {
+      f.cancel(false);
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.common.profiler.GranularTicker.Snapshot;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,13 +17,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-// GranularTicker now reads (nanoTime, nanoTimeDifference) as an atomic snapshot and clamps
-// both approximateNanoTime() and approximateCurrentTimeMillis() through monotonic AtomicLong
-// high-water marks, so correctness no longer depends on sequential execution. The @Category
-// marker is retained because the wall-clock timing assertions in testTimeApproximation are
-// still sensitive to CPU contention on virtualized CI runners (per-fire scheduler lag up to
-// ~75 ms has been observed on GitHub-hosted macOS arm) — this is a stability hint, not a
-// correctness requirement.
+// GranularTicker publishes a single (nanoTime, nanoTimeDifference) Snapshot behind one
+// volatile reference. A single scheduled task is the only writer, and monotonicity of both
+// accessors is enforced at publish time by GranularTicker.nextSnapshot. Readers do a plain
+// volatile read plus field access. The @Category marker is retained because the wall-clock
+// timing assertions in testTimeApproximation are still sensitive to CPU contention on
+// virtualized CI runners (per-fire scheduler lag up to ~75 ms has been observed on
+// GitHub-hosted macOS arm) — a stability hint, not a correctness requirement.
 @Category(SequentialTest.class)
 public class GranularTickerTest {
 
@@ -91,7 +92,7 @@ public class GranularTickerTest {
     try {
       var ticker = new GranularTicker(TimeUnit.MILLISECONDS.toNanos(10),
           TimeUnit.MILLISECONDS.toNanos(50), scheduler);
-      // stop() without start() — the scheduled futures are null, so nothing to cancel.
+      // stop() without start() — the scheduled future is null, so nothing to cancel.
       ticker.stop();
       // No exception means success.
     } finally {
@@ -100,7 +101,7 @@ public class GranularTickerTest {
   }
 
   /**
-   * After starting and then stopping, the ticker's scheduled futures are cancelled and the
+   * After starting and then stopping, the ticker's scheduled future is cancelled and the
    * approximate time no longer advances.
    */
   @Test
@@ -144,17 +145,17 @@ public class GranularTickerTest {
   }
 
   /**
-   * Verifies that the scheduled tasks skip updates when the ticker is stopped.
-   * Uses a very long granularity so the tasks never fire on their own, then
-   * manually invokes the captured runnables before and after stop() to exercise the
-   * {@code if (!stopped)} branches in both scheduled tasks.
+   * Verifies that the single scheduled refresh task advances the snapshot when running, that
+   * wall-clock recalibration happens on the configured cadence, and that the task skips the
+   * update after stop.
    *
-   * <p>The test observes the task effects by comparing the {@code snapshot} reference identity:
-   * while running, each task allocates a new {@code Snapshot} instance and publishes it; after
-   * stop, neither task publishes a new snapshot so the reference is preserved.
+   * <p>Uses a very long granularity so the task never fires on its own, then manually invokes
+   * the captured runnable to exercise the {@code if (!stopped)} branch. With granularity and
+   * timestampRefreshRate both set to 1 hour, the recalibration interval is 1, so every fire
+   * both refreshes nanoTime and recomputes the wall-clock offset.
    */
   @Test
-  public void scheduledTasksSkipUpdateAfterStop() throws Exception {
+  public void scheduledTaskSkipsUpdateAfterStop() throws Exception {
     List<Runnable> capturedTasks = new ArrayList<>();
     // Fake scheduler that only captures the runnables — no threads, no real scheduling.
     ScheduledExecutorService fakeScheduler = new DelegatingScheduledExecutorService(
@@ -171,65 +172,47 @@ public class GranularTickerTest {
       var ticker = new GranularTicker(
           granularityNanos, TimeUnit.HOURS.toNanos(1), fakeScheduler);
       ticker.start();
-      assertThat(capturedTasks).hasSize(2);
+      // The single refresh task is the only scheduling submission.
+      assertThat(capturedTasks).hasSize(1);
 
-      // Verify getGranularity() returns the configured value
       assertThat(ticker.getGranularity()).isEqualTo(granularityNanos);
 
       Field snapshotField = GranularTicker.class.getDeclaredField("snapshot");
       snapshotField.setAccessible(true);
 
-      // Invoke the nanoTime task while ticker is running — nanoTime must advance
-      // because real time has elapsed since start() set it, and a new snapshot must be
-      // published.
+      // First fire while running: nanoTime advances past start() and a new snapshot is
+      // published. Because recalibrationInterval == 1, this fire also recalibrates wall
+      // clock.
       var nanoBefore = ticker.approximateNanoTime();
       var snapshotBefore = snapshotField.get(ticker);
       capturedTasks.get(0).run();
-      var snapshotAfterTask0 = snapshotField.get(ticker);
+      var snapshotAfterFire = snapshotField.get(ticker);
       assertThat(ticker.approximateNanoTime())
-          .as("nanoTime task must update nanoTime when ticker is running")
+          .as("refresh task must advance nanoTime when ticker is running")
           .isGreaterThan(nanoBefore);
-      assertThat(snapshotAfterTask0)
-          .as("nanoTime task must publish a new snapshot when ticker is running")
+      assertThat(snapshotAfterFire)
+          .as("refresh task must publish a new snapshot when ticker is running")
           .isNotSameAs(snapshotBefore);
-
-      // Invoke the nanoTimeDifference task while running — it must publish a new snapshot
-      // with a freshly recalibrated offset so that approximateCurrentTimeMillis() is close
-      // to the real wall-clock time.
-      capturedTasks.get(1).run();
-      var snapshotAfterTask1 = snapshotField.get(ticker);
-      assertThat(snapshotAfterTask1)
-          .as("nanoTimeDifference task must publish a new snapshot when ticker is running")
-          .isNotSameAs(snapshotAfterTask0);
-      var millisAfterRunning = ticker.approximateCurrentTimeMillis();
-      assertThat(millisAfterRunning)
-          .as("nanoTimeDifference task must restore wall-clock offset when running")
+      assertThat(ticker.approximateCurrentTimeMillis())
+          .as("recalibration must keep approximateCurrentTimeMillis close to wall clock")
           .isCloseTo(System.currentTimeMillis(), within(100L));
 
-      // Verify getTick() returns nanoTime / granularity
       var expectedTick = ticker.approximateNanoTime() / granularityNanos;
       assertThat(ticker.getTick()).isEqualTo(expectedTick);
 
-      // Stop the ticker — sets stopped = true
       ticker.stop();
 
-      // Capture values after stop — they should be frozen.
       var nanoAfterStop = ticker.approximateNanoTime();
       var millisAfterStop = ticker.approximateCurrentTimeMillis();
       var snapshotAfterStop = snapshotField.get(ticker);
 
-      // Invoke both tasks after stop — they should see stopped == true and skip the update,
-      // leaving the published snapshot (and therefore both approximations) unchanged.
+      // Fire the task after stop — it must see stopped == true and publish nothing.
       capturedTasks.get(0).run();
-      capturedTasks.get(1).run();
 
-      // The snapshot reference must be identical (no new Snapshot allocated).
       assertThat(snapshotField.get(ticker))
-          .as("scheduled tasks must not publish a new snapshot after stop")
+          .as("refresh task must not publish a new snapshot after stop")
           .isSameAs(snapshotAfterStop);
-      // nanoTime must not have changed (task 0 skipped the update).
       assertThat(ticker.approximateNanoTime()).isEqualTo(nanoAfterStop);
-      // approximateCurrentTimeMillis must not have changed (task 1 skipped the update).
       assertThat(ticker.approximateCurrentTimeMillis()).isEqualTo(millisAfterStop);
     } finally {
       fakeScheduler.shutdownNow();
@@ -283,76 +266,82 @@ public class GranularTickerTest {
   }
 
   /**
-   * Directly verifies the monotonic clamp on {@link GranularTicker#approximateCurrentTimeMillis()}.
-   * Installs a snapshot whose computed value is high, reads it, then installs a snapshot whose
-   * computed value is strictly lower — the reader must continue to observe the previous high.
-   * This guards against a future refactor that removes or weakens the {@code lastApproxMillis}
-   * clamp: without it, sub-millisecond drift between {@code System.nanoTime()} and
-   * {@code System.currentTimeMillis()} at recalibration fires can yield a 1 ms backward jump.
+   * Non-recalibration fires must carry the previous snapshot's {@code nanoTimeDifference}
+   * forward unchanged so readers of {@link GranularTicker#approximateCurrentTimeMillis()}
+   * continue to derive the same wall-clock offset between recalibrations. Only the nanoTime
+   * component of the published pair changes on such fires.
    */
   @Test
-  public void approximateCurrentTimeMillisClampsBackwardSnapshot() throws Exception {
-    var scheduler = Executors.newScheduledThreadPool(1);
-    try (var ticker = new GranularTicker(
-        TimeUnit.HOURS.toNanos(1), TimeUnit.HOURS.toNanos(1), scheduler)) {
-      ticker.start();
-      installSnapshot(ticker, 5_000_000_000L, 5_000L);
-      long high = ticker.approximateCurrentTimeMillis();
-      assertThat(high).as("installed snapshot yields computed=10000").isEqualTo(10_000L);
+  public void nextSnapshotPreservesDiffOnNonRecalibrationTick() {
+    var prev = new Snapshot(1_000_000_000L, 5_000L);
 
-      // Install a snapshot whose computed value is 9_999 ms — a 1 ms backward drift that the
-      // clamp must absorb.
-      installSnapshot(ticker, 5_000_000_000L, 4_999L);
-      assertThat(ticker.approximateCurrentTimeMillis())
-          .as("clamp must absorb sub-ms backward drift")
-          .isEqualTo(high);
-    } finally {
-      scheduler.shutdownNow();
-    }
+    var next = GranularTicker.nextSnapshot(prev, 2_000_000_000L, /*wallMillis*/ 42L, false);
+
+    assertThat(next.nanoTime()).isEqualTo(2_000_000_000L);
+    assertThat(next.nanoTimeDifference())
+        .as("non-recalibration fire must not touch nanoTimeDifference")
+        .isEqualTo(5_000L);
   }
 
   /**
-   * Directly verifies the monotonic clamp on {@link GranularTicker#approximateNanoTime()}.
-   * The nanoTime-refresh task reads the current snapshot then publishes a new one; if the
-   * wall-clock-recalibration task wins the intermediate publish with a later nanoTime sample,
-   * the refresh task's publish carries an earlier sample and the raw {@code snapshot.nanoTime}
-   * regresses. The clamp guarantees no reader observes the regression. Installs a high
-   * nanoTime snapshot, reads it, installs a lower nanoTime snapshot, and verifies the reader
-   * continues to observe the previous high.
+   * A recalibration fire that is not subject to backward drift must compute a fresh
+   * wall-clock offset from the sampled {@code wallMillis} and {@code freshNano}. The derived
+   * wall-clock timestamp after the publish must therefore equal {@code wallMillis} exactly.
    */
   @Test
-  public void approximateNanoTimeClampsBackwardSnapshot() throws Exception {
-    var scheduler = Executors.newScheduledThreadPool(1);
-    try (var ticker = new GranularTicker(
-        TimeUnit.HOURS.toNanos(1), TimeUnit.HOURS.toNanos(1), scheduler)) {
-      ticker.start();
-      installSnapshot(ticker, 1_000_000_000L, 0L);
-      long high = ticker.approximateNanoTime();
-      assertThat(high).isEqualTo(1_000_000_000L);
+  public void nextSnapshotRecomputesDiffOnRecalibration() {
+    // prev published at nano=1_000_000_000 (=> 1000 ms), diff=5000 => derived millis = 6000.
+    var prev = new Snapshot(1_000_000_000L, 5_000L);
+    // Fresh nano=2_000_000_000 (=> 2000 ms), fresh wall clock = 7500 ms => new diff = 5500,
+    // derived millis = 7500 which is strictly greater than prev's 6000 — no clamp needed.
+    var next = GranularTicker.nextSnapshot(prev, 2_000_000_000L, 7_500L, true);
 
-      installSnapshot(ticker, 500_000_000L, 0L);
-      assertThat(ticker.approximateNanoTime())
-          .as("clamp must hold the previously-returned high nanoTime value")
-          .isEqualTo(high);
-    } finally {
-      scheduler.shutdownNow();
-    }
+    assertThat(next.nanoTime()).isEqualTo(2_000_000_000L);
+    assertThat(next.nanoTimeDifference()).isEqualTo(5_500L);
+    assertThat(next.nanoTime() / 1_000_000 + next.nanoTimeDifference())
+        .as("derived wall-clock millis must equal the freshly sampled wallMillis")
+        .isEqualTo(7_500L);
   }
 
   /**
-   * Reflectively publishes a new {@code Snapshot} instance into the ticker's private
-   * {@code snapshot} field. Used to inject known {@code (nanoTime, nanoTimeDifference)}
-   * values for clamp verification without depending on scheduler timing.
+   * Sub-millisecond drift between {@link System#nanoTime()} and
+   * {@link System#currentTimeMillis()} at a recalibration fire can yield a candidate whose
+   * derived wall-clock millis is below the previously published snapshot's derived millis.
+   * {@link GranularTicker#nextSnapshot} must inflate {@code nanoTimeDifference} to absorb the
+   * drift so {@link GranularTicker#approximateCurrentTimeMillis()} remains non-decreasing.
    */
-  private static void installSnapshot(GranularTicker ticker, long nanoTime, long diff)
-      throws Exception {
-    Class<?> snapCls = Class.forName(
-        "com.jetbrains.youtrackdb.internal.common.profiler.GranularTicker$Snapshot");
-    var ctor = snapCls.getDeclaredConstructor(long.class, long.class);
-    ctor.setAccessible(true);
-    Object instance = ctor.newInstance(nanoTime, diff);
-    Field snapshotField = GranularTicker.class.getDeclaredField("snapshot");
-    snapshotField.setAccessible(true);
-    snapshotField.set(ticker, instance);
+  @Test
+  public void nextSnapshotAbsorbsBackwardMillisDrift() {
+    // prev: nano=5_000_000_000 (=> 5000 ms), diff=5000 => derived millis = 10_000.
+    var prev = new Snapshot(5_000_000_000L, 5_000L);
+    // Fresh wall clock = 9_999 ms at nano=5_000_000_000 => candidate diff = 4_999,
+    // candidate derived millis = 9_999 which is 1 ms below prev's 10_000.
+    var next = GranularTicker.nextSnapshot(prev, 5_000_000_000L, 9_999L, true);
+
+    assertThat(next.nanoTime()).isEqualTo(5_000_000_000L);
+    assertThat(next.nanoTimeDifference())
+        .as("diff must be inflated by 1 ms to absorb backward drift")
+        .isEqualTo(5_000L);
+    assertThat(next.nanoTime() / 1_000_000 + next.nanoTimeDifference())
+        .as("derived wall-clock millis must not regress")
+        .isEqualTo(10_000L);
+  }
+
+  /**
+   * On older hardware {@link System#nanoTime()} can appear to regress across CPUs. When the
+   * freshly sampled nanoTime is below the previously published value,
+   * {@link GranularTicker#nextSnapshot} must clamp it to the previous value so the published
+   * pair — and therefore {@link GranularTicker#approximateNanoTime()} — never regresses.
+   */
+  @Test
+  public void nextSnapshotClampsBackwardNanoTime() {
+    var prev = new Snapshot(1_000_000_000L, 0L);
+
+    var next = GranularTicker.nextSnapshot(prev, 500_000_000L, 1_000L, false);
+
+    assertThat(next.nanoTime())
+        .as("clamp must hold the previous high nanoTime when freshNano regresses")
+        .isEqualTo(1_000_000_000L);
+    assertThat(next.nanoTimeDifference()).isEqualTo(0L);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
@@ -16,9 +16,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-// The testTimeApproximation() method asserts monotonicity of approximateCurrentTimeMillis(),
-// which reads two volatile fields (nanoTime, nanoTimeDifference) non-atomically. Under parallel
-// test execution, CPU contention can cause a 1ms backward jump. Sequential execution avoids this.
+// GranularTicker now reads (nanoTime, nanoTimeDifference) as an atomic snapshot and clamps
+// both approximateNanoTime() and approximateCurrentTimeMillis() through monotonic AtomicLong
+// high-water marks, so correctness no longer depends on sequential execution. The @Category
+// marker is retained because the wall-clock timing assertions in testTimeApproximation are
+// still sensitive to CPU contention on virtualized CI runners (per-fire scheduler lag up to
+// ~75 ms has been observed on GitHub-hosted macOS arm) — this is a stability hint, not a
+// correctness requirement.
 @Category(SequentialTest.class)
 public class GranularTickerTest {
 
@@ -142,8 +146,12 @@ public class GranularTickerTest {
   /**
    * Verifies that the scheduled tasks skip updates when the ticker is stopped.
    * Uses a very long granularity so the tasks never fire on their own, then
-   * manually invokes the captured runnables after stop() to exercise the
-   * {@code if (!stopped)} branches (lines 42 and 49 in GranularTicker).
+   * manually invokes the captured runnables before and after stop() to exercise the
+   * {@code if (!stopped)} branches in both scheduled tasks.
+   *
+   * <p>The test observes the task effects by comparing the {@code snapshot} reference identity:
+   * while running, each task allocates a new {@code Snapshot} instance and publishes it; after
+   * stop, neither task publishes a new snapshot so the reference is preserved.
    */
   @Test
   public void scheduledTasksSkipUpdateAfterStop() throws Exception {
@@ -168,28 +176,35 @@ public class GranularTickerTest {
       // Verify getGranularity() returns the configured value
       assertThat(ticker.getGranularity()).isEqualTo(granularityNanos);
 
+      Field snapshotField = GranularTicker.class.getDeclaredField("snapshot");
+      snapshotField.setAccessible(true);
+
       // Invoke the nanoTime task while ticker is running — nanoTime must advance
-      // because real time has elapsed since start() set it.
+      // because real time has elapsed since start() set it, and a new snapshot must be
+      // published.
       var nanoBefore = ticker.approximateNanoTime();
+      var snapshotBefore = snapshotField.get(ticker);
       capturedTasks.get(0).run();
-      var nanoAfterRunning = ticker.approximateNanoTime();
-      assertThat(nanoAfterRunning)
+      var snapshotAfterTask0 = snapshotField.get(ticker);
+      assertThat(ticker.approximateNanoTime())
           .as("nanoTime task must update nanoTime when ticker is running")
           .isGreaterThan(nanoBefore);
+      assertThat(snapshotAfterTask0)
+          .as("nanoTime task must publish a new snapshot when ticker is running")
+          .isNotSameAs(snapshotBefore);
 
-      // Corrupt nanoTimeDifference via reflection so we can verify the task restores it.
-      // Setting it to 0 makes approximateCurrentTimeMillis() = nanoTime / 1_000_000,
-      // which is NOT a valid wall-clock value.
-      Field diffField = GranularTicker.class.getDeclaredField("nanoTimeDifference");
-      diffField.setAccessible(true);
-      diffField.setLong(ticker, 0L);
-      // Invoke the nanoTimeDifference task while running — it must recalculate the offset
-      // so that approximateCurrentTimeMillis() is close to the real wall-clock time.
+      // Invoke the nanoTimeDifference task while running — it must publish a new snapshot
+      // with a freshly recalibrated offset so that approximateCurrentTimeMillis() is close
+      // to the real wall-clock time.
       capturedTasks.get(1).run();
+      var snapshotAfterTask1 = snapshotField.get(ticker);
+      assertThat(snapshotAfterTask1)
+          .as("nanoTimeDifference task must publish a new snapshot when ticker is running")
+          .isNotSameAs(snapshotAfterTask0);
       var millisAfterRunning = ticker.approximateCurrentTimeMillis();
       assertThat(millisAfterRunning)
           .as("nanoTimeDifference task must restore wall-clock offset when running")
-          .isCloseTo(System.currentTimeMillis(), within(5000L));
+          .isCloseTo(System.currentTimeMillis(), within(100L));
 
       // Verify getTick() returns nanoTime / granularity
       var expectedTick = ticker.approximateNanoTime() / granularityNanos;
@@ -198,18 +213,23 @@ public class GranularTickerTest {
       // Stop the ticker — sets stopped = true
       ticker.stop();
 
-      // Capture values after stop — they should be frozen
+      // Capture values after stop — they should be frozen.
       var nanoAfterStop = ticker.approximateNanoTime();
       var millisAfterStop = ticker.approximateCurrentTimeMillis();
+      var snapshotAfterStop = snapshotField.get(ticker);
 
-      // Invoke both tasks after stop — they should see stopped == true
-      // and skip the update, leaving nanoTime and nanoTimeDifference unchanged.
+      // Invoke both tasks after stop — they should see stopped == true and skip the update,
+      // leaving the published snapshot (and therefore both approximations) unchanged.
       capturedTasks.get(0).run();
       capturedTasks.get(1).run();
 
-      // nanoTime must not have changed (task 0 skipped the update)
+      // The snapshot reference must be identical (no new Snapshot allocated).
+      assertThat(snapshotField.get(ticker))
+          .as("scheduled tasks must not publish a new snapshot after stop")
+          .isSameAs(snapshotAfterStop);
+      // nanoTime must not have changed (task 0 skipped the update).
       assertThat(ticker.approximateNanoTime()).isEqualTo(nanoAfterStop);
-      // approximateCurrentTimeMillis must not have changed (task 1 skipped the update)
+      // approximateCurrentTimeMillis must not have changed (task 1 skipped the update).
       assertThat(ticker.approximateCurrentTimeMillis()).isEqualTo(millisAfterStop);
     } finally {
       fakeScheduler.shutdownNow();
@@ -260,5 +280,79 @@ public class GranularTickerTest {
     assertThatThrownBy(
         () -> new GranularTicker(10_000_000, 10_000_000, null))
         .isInstanceOf(NullPointerException.class);
+  }
+
+  /**
+   * Directly verifies the monotonic clamp on {@link GranularTicker#approximateCurrentTimeMillis()}.
+   * Installs a snapshot whose computed value is high, reads it, then installs a snapshot whose
+   * computed value is strictly lower — the reader must continue to observe the previous high.
+   * This guards against a future refactor that removes or weakens the {@code lastApproxMillis}
+   * clamp: without it, sub-millisecond drift between {@code System.nanoTime()} and
+   * {@code System.currentTimeMillis()} at recalibration fires can yield a 1 ms backward jump.
+   */
+  @Test
+  public void approximateCurrentTimeMillisClampsBackwardSnapshot() throws Exception {
+    var scheduler = Executors.newScheduledThreadPool(1);
+    try (var ticker = new GranularTicker(
+        TimeUnit.HOURS.toNanos(1), TimeUnit.HOURS.toNanos(1), scheduler)) {
+      ticker.start();
+      installSnapshot(ticker, 5_000_000_000L, 5_000L);
+      long high = ticker.approximateCurrentTimeMillis();
+      assertThat(high).as("installed snapshot yields computed=10000").isEqualTo(10_000L);
+
+      // Install a snapshot whose computed value is 9_999 ms — a 1 ms backward drift that the
+      // clamp must absorb.
+      installSnapshot(ticker, 5_000_000_000L, 4_999L);
+      assertThat(ticker.approximateCurrentTimeMillis())
+          .as("clamp must absorb sub-ms backward drift")
+          .isEqualTo(high);
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  /**
+   * Directly verifies the monotonic clamp on {@link GranularTicker#approximateNanoTime()}.
+   * The nanoTime-refresh task reads the current snapshot then publishes a new one; if the
+   * wall-clock-recalibration task wins the intermediate publish with a later nanoTime sample,
+   * the refresh task's publish carries an earlier sample and the raw {@code snapshot.nanoTime}
+   * regresses. The clamp guarantees no reader observes the regression. Installs a high
+   * nanoTime snapshot, reads it, installs a lower nanoTime snapshot, and verifies the reader
+   * continues to observe the previous high.
+   */
+  @Test
+  public void approximateNanoTimeClampsBackwardSnapshot() throws Exception {
+    var scheduler = Executors.newScheduledThreadPool(1);
+    try (var ticker = new GranularTicker(
+        TimeUnit.HOURS.toNanos(1), TimeUnit.HOURS.toNanos(1), scheduler)) {
+      ticker.start();
+      installSnapshot(ticker, 1_000_000_000L, 0L);
+      long high = ticker.approximateNanoTime();
+      assertThat(high).isEqualTo(1_000_000_000L);
+
+      installSnapshot(ticker, 500_000_000L, 0L);
+      assertThat(ticker.approximateNanoTime())
+          .as("clamp must hold the previously-returned high nanoTime value")
+          .isEqualTo(high);
+    } finally {
+      scheduler.shutdownNow();
+    }
+  }
+
+  /**
+   * Reflectively publishes a new {@code Snapshot} instance into the ticker's private
+   * {@code snapshot} field. Used to inject known {@code (nanoTime, nanoTimeDifference)}
+   * values for clamp verification without depending on scheduler timing.
+   */
+  private static void installSnapshot(GranularTicker ticker, long nanoTime, long diff)
+      throws Exception {
+    Class<?> snapCls = Class.forName(
+        "com.jetbrains.youtrackdb.internal.common.profiler.GranularTicker$Snapshot");
+    var ctor = snapCls.getDeclaredConstructor(long.class, long.class);
+    ctor.setAccessible(true);
+    Object instance = ctor.newInstance(nanoTime, diff);
+    Field snapshotField = GranularTicker.class.getDeclaredField("snapshot");
+    snapshotField.setAccessible(true);
+    snapshotField.set(ticker, instance);
   }
 }


### PR DESCRIPTION
## Motivation

`GranularTickerTest.testTimeApproximation` was intermittently failing on macOS arm CI with a 1 ms backward jump on `approximateCurrentTimeMillis()`:

```
Expecting actual:
  1776758391845L
to be greater than or equal to:
  1776758391846L
  at GranularTickerTest.testTimeApproximation(GranularTickerTest.java:57)
```

Two underlying races:

1. `(nanoTime, nanoTimeDifference)` were held in two independent `volatile long` fields. A reader on `approximateCurrentTimeMillis()` could observe a stale `nanoTime` paired with a freshly recomputed `nanoTimeDifference` (or vice versa) at recalibration fires, producing a combined value that drops below a previously returned timestamp.
2. Sub-millisecond drift between `System.nanoTime()` and `System.currentTimeMillis()` at the rounding boundary can make `nanoTimeDifference` fluctuate by ±1 ms across recalibration fires, manifesting as a 1 ms backward jump.

Callers — `Stopwatch.timed()`, `YTDBQueryMetricsStep`, `FrontendTransactionImpl.notifyMetricsListener` — compute non-negative deltas from paired ticker reads and rely on monotonicity of both accessors.

Failed workflow: https://github.com/JetBrains/youtrackdb/actions/runs/24709911504
Failing commit: c831f93430aede4d84fcadd627515db8bde2fec7

## Fix

`core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTicker.java`

- **Pair atomicity.** `(nanoTime, nanoTimeDifference)` is held in a single immutable `Snapshot` record behind one `volatile` reference. Readers observe the pair atomically.
- **Single writer.** One scheduled task fires at `granularity`, refreshes the cached `nanoTime` on every fire and recomputes the wall-clock offset every `recalibrationInterval = timestampRefreshRate / granularity` fires. With a single writer there is no writer-vs-writer race on the snapshot reference, and monotonicity can be enforced once at publish time rather than once per reader call.
- **Writer-side monotonicity clamp.** Snapshot construction lives in a pure, package-private `nextSnapshot(prev, freshNano, wallMillis, recalibrate)` that enforces both monotonicity guarantees at publish time:
  - clamps `nano` to `max(prev.nanoTime, freshNano)` (insurance for older hardware where cross-core `nanoTime` can jitter),
  - inflates `nanoTimeDifference` so derived wall-clock millis cannot regress when sub-ms drift appears at a recalibration fire.

Readers perform a single volatile read plus field access — no CAS, no cross-core cache-line bouncing.

`System.currentTimeMillis()` is sampled only on recalibration fires; non-recalibration fires reuse the previous snapshot's `nanoTimeDifference`.

## Tests

`core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java`

- `testTimeApproximation` — wall-clock monotonicity assertions against the live ticker.
- `scheduledTaskSkipsUpdateAfterStop` — captures the single scheduled runnable and verifies that firing it while running advances the snapshot and recalibrates wall clock, and that firing it after `stop()` publishes nothing.
- `nextSnapshotPreservesDiffOnNonRecalibrationTick` — non-recalibration fires carry `nanoTimeDifference` forward unchanged.
- `nextSnapshotRecomputesDiffOnRecalibration` — recalibration without drift produces a fresh offset whose derived millis equals `wallMillis`.
- `nextSnapshotAbsorbsBackwardMillisDrift` — a recalibration whose candidate derived millis would regress inflates the offset by exactly the drift, leaving the derived wall-clock timestamp unchanged.
- `nextSnapshotClampsBackwardNanoTime` — a regressing `freshNano` is clamped to `prev.nanoTime`.
- `stopWithoutStartIsNoOp`, `startThenStopFreezesTime`, `closeAfterStartCancelsFutures`, `constructorRejectsNullExecutor` — lifecycle and argument validation.

`[no-test-number-check]` — the test set was restructured so the monotonicity guarantees are verified as deterministic unit tests of the pure `nextSnapshot` helper rather than through timing-sensitive scheduler runs.

## Verification

- `./mvnw -pl core test -Dtest=GranularTickerTest` — 10/10 pass under both surefire and the vmlens concurrency analyzer.
- `./mvnw -pl core test -Dtest='GranularTickerTest,TimeRateTest,RatioTest'` — 29/29 pass (1 skipped is unrelated and pre-existing).
- `./mvnw -pl core spotless:check` — passes.

## Test plan

- [x] GranularTickerTest passes locally (10 tests, 0 failures) under both standard and vmlens runs
- [x] Related profiler tests (TimeRateTest, RatioTest) pass locally
- [x] Dimensional code review (concurrency, code quality, performance, test behavior, completeness, structure, concurrency-test) — all blocker and should-fix findings addressed
- [ ] CI passes on macOS arm JDK 25 (the originally-failing matrix cell)