### PR TITLE
[no-test-number-check] Fix ClosableLinkedContainer livelock on macOS-arm CI

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/closabledictionary/ClosableLinkedContainer.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/collection/closabledictionary/ClosableLinkedContainer.java
@@ -204,6 +204,15 @@ public class ClosableLinkedContainer<K, V extends ClosableItem> {
    */
   private final AtomicInteger openFiles = new AtomicInteger();
 
+  /**
+   * Remembered {@code openFiles.get()} from the last eviction attempt that could not close a
+   * single entry (all were ACQUIRED). Subsequent callers short-circuit while {@code openFiles}
+   * is still at this value — they would only repeat the scan under {@link #lruLock} to no
+   * effect. {@link #release(ClosableEntry)} resets it to {@code -1} so the next eviction pass
+   * can proceed.
+   */
+  private final AtomicInteger lastNoProgressOpenFiles = new AtomicInteger(-1);
+
   private TimeRate fileEvictionRate;
 
   /**
@@ -340,7 +349,16 @@ public class ClosableLinkedContainer<K, V extends ClosableItem> {
    * Checks if containers limit of open files is reached.
    *
    * <p>In such case execution of threads which add or acquire items is stopped and they wait till
-   * buffers will be emptied and nubmer of open files will be inside limit.
+   * buffers will be emptied and number of open files will be inside limit.
+   *
+   * <p>If every currently-open entry is in ACQUIRED state (held by another thread),
+   * {@link #emptyBuffers()} cannot close any file and {@code openFiles} stays above {@code
+   * openLimit}. Continuing to loop would starve every other thread (the caller holds {@link
+   * #openLatch} while looping). In that case we return after the first non-progressing attempt and
+   * treat {@code openLimit} as a soft limit. {@link #lastNoProgressOpenFiles} caches that fact, so
+   * subsequent callers observing the same {@code openFiles} count short-circuit the scan entirely;
+   * any {@link #release(ClosableEntry)} clears the cache so eviction retries as soon as progress
+   * becomes possible.
    */
   private void checkOpenFilesLimit() throws InterruptedException {
     var ol = openLatch.get();
@@ -349,16 +367,35 @@ public class ClosableLinkedContainer<K, V extends ClosableItem> {
     }
 
     while (openFiles.get() > openLimit) {
+      // Short-circuit: if a prior eviction already failed at this exact count and nothing has
+      // been released since (which would have reset the cache to -1), skip the lock+scan.
+      if (openFiles.get() == lastNoProgressOpenFiles.get()) {
+        return;
+      }
+
       final var latch = new CountDownLatch(1);
 
       // make other threads to wait till we evict entries and close evicted open files
       if (openLatch.compareAndSet(null, latch)) {
-        while (openFiles.get() > openLimit) {
-          emptyBuffers();
+        try {
+          while (openFiles.get() > openLimit) {
+            final var before = openFiles.get();
+            emptyBuffers();
+            // No progress: every open entry is currently ACQUIRED elsewhere.
+            // Further iterations would livelock with `openLatch` held.
+            if (openFiles.get() >= before) {
+              lastNoProgressOpenFiles.set(before);
+              break;
+            }
+          }
+        } finally {
+          latch.countDown();
+          openLatch.set(null);
         }
-
-        latch.countDown();
-        openLatch.set(null);
+        // Exit after one eviction pass rather than re-entering the outer loop and
+        // re-acquiring `openLatch`. If openFiles is still above the limit, the
+        // caller proceeds (soft limit); the next caller retries eviction.
+        return;
       } else {
         ol = openLatch.get();
 
@@ -369,6 +406,13 @@ public class ClosableLinkedContainer<K, V extends ClosableItem> {
     }
   }
 
+  /**
+   * Same soft-limit semantics as {@link #checkOpenFilesLimit()}, but single-shot: performs at most
+   * one eviction pass and returns whether the container is back within {@code openLimit}. No
+   * livelock risk — there is no inner loop — but the {@link #lastNoProgressOpenFiles}
+   * short-circuit still applies so concurrent {@code tryAcquire} callers observe O(1) cost while
+   * the "all acquired" state persists.
+   */
   private boolean tryCheckOpenFilesLimit() throws InterruptedException {
     var ol = openLatch.get();
     if (ol != null) {
@@ -376,16 +420,28 @@ public class ClosableLinkedContainer<K, V extends ClosableItem> {
     }
 
     while (openFiles.get() > openLimit) {
+      if (openFiles.get() == lastNoProgressOpenFiles.get()) {
+        return false;
+      }
+
       final var latch = new CountDownLatch(1);
 
       // make other threads to wait till we evict entries and close evicted open files
       if (openLatch.compareAndSet(null, latch)) {
-        emptyBuffers();
-
-        final var result = openFiles.get() <= openLimit;
-        latch.countDown();
-        openLatch.set(null);
-
+        final boolean result;
+        try {
+          final var before = openFiles.get();
+          emptyBuffers();
+          final var after = openFiles.get();
+          result = after <= openLimit;
+          if (!result && after >= before) {
+            // No progress: cache the count so the next caller can short-circuit.
+            lastNoProgressOpenFiles.set(after);
+          }
+        } finally {
+          latch.countDown();
+          openLatch.set(null);
+        }
         return result;
       } else {
         ol = openLatch.get();
@@ -408,6 +464,10 @@ public class ClosableLinkedContainer<K, V extends ClosableItem> {
   public void release(ClosableEntry<K, V> entry) {
     if (entry != null) {
       entry.releaseAcquired();
+      // Releasing an entry may make it closable. Invalidate the no-progress cache so the next
+      // checkOpenFilesLimit / tryCheckOpenFilesLimit call retries eviction instead of
+      // short-circuiting based on a stale observation.
+      lastNoProgressOpenFiles.set(-1);
     }
   }
 
@@ -475,6 +535,11 @@ public class ClosableLinkedContainer<K, V extends ClosableItem> {
     }
 
     return false;
+  }
+
+  /** Package-private accessor for tests that assert soft-limit overflow. */
+  int openFilesCount() {
+    return openFiles.get();
   }
 
   boolean checkAllLRUListItemsInMap() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/closabledictionary/ClosableLinkedContainerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/collection/closabledictionary/ClosableLinkedContainerTest.java
@@ -1,19 +1,36 @@
 package com.jetbrains.youtrackdb.internal.common.collection.closabledictionary;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 public class ClosableLinkedContainerTest {
+
+  /**
+   * Resets state shared across tests via the static {@link CItem#openFiles} / {@link
+   * CItem#maxDeltaLimit} counters, so that each test starts from a clean slate regardless of
+   * JUnit's class/method ordering.
+   */
+  @Before
+  public void resetStaticCounters() {
+    CItem.openFiles.set(0);
+    CItem.maxDeltaLimit.set(0);
+  }
 
   @Test
   public void testSingleItemAddRemove() throws Exception {
@@ -75,6 +92,272 @@ public class ClosableLinkedContainerTest {
 
     Assert.assertTrue(dictionary.checkAllLRUListItemsInMap());
     Assert.assertTrue(dictionary.checkAllOpenItemsInLRUList());
+  }
+
+  /**
+   * Drives the container into the exact shape that triggered the macOS-arm CI hang: {@code
+   * openFiles > openLimit} while every entry in the LRU list is ACQUIRED. The returned list owns
+   * those acquired entries — the caller must release them in a {@code finally}.
+   *
+   * <p>Recipe (single-threaded, deterministic):
+   * <ol>
+   *   <li>Add exactly {@code openLimit} entries, then acquire every one of them.</li>
+   *   <li>{@code add(openLimit)}: inline eviction inside {@code LogAdd} closes the new OPEN
+   *       entry (all older ones are ACQUIRED), leaving it CLOSED in the data map.</li>
+   *   <li>{@code acquire(openLimit)}: transitions CLOSED → ACQUIRED via {@code
+   *       makeAcquiredFromClosed}; {@code logOpen} bumps {@code openFiles} to
+   *       {@code openLimit + 1}. All LRU entries are now ACQUIRED and the counter exceeds the
+   *       limit.</li>
+   * </ol>
+   */
+  private static List<ClosableEntry<Long, ClosableItem>> primeAllAcquiredOverflow(
+      final ClosableLinkedContainer<Long, ClosableItem> dictionary, final int openLimit)
+      throws InterruptedException {
+    for (long i = 0; i < openLimit; i++) {
+      dictionary.add(i, new CItem((int) i));
+    }
+    final var acquired = new ArrayList<ClosableEntry<Long, ClosableItem>>(openLimit + 1);
+    for (long i = 0; i < openLimit; i++) {
+      final var entry = dictionary.acquire(i);
+      Assert.assertNotNull("priming: acquire(" + i + ") must succeed", entry);
+      acquired.add(entry);
+    }
+
+    dictionary.add((long) openLimit, new CItem(openLimit));
+    final var reopened = dictionary.acquire((long) openLimit);
+    Assert.assertNotNull(
+        "priming: reopen of just-closed entry must return a handle", reopened);
+    acquired.add(reopened);
+
+    Assert.assertTrue(
+        "priming: openFiles must exceed openLimit to exercise the livelock path —"
+            + " got openFiles=" + dictionary.openFilesCount() + ", openLimit=" + openLimit,
+        dictionary.openFilesCount() > openLimit);
+    return acquired;
+  }
+
+  /**
+   * Runs the given task on a fresh single-thread executor and blocks up to {@code timeoutMs}
+   * milliseconds for its result. A timeout fails the test with {@code failureMessage} — the
+   * pre-fix livelocked thread does not respond to {@code interrupt()}, so we cancel the future
+   * to stop waiting and {@code shutdownNow} + {@code awaitTermination} surface the leak instead
+   * of hiding it.
+   *
+   * <p>Timeout budget (10 s by default) is ~10 000× the fix's run-time (microseconds); any
+   * timeout indicates a real hang, not CI jitter.
+   */
+  private static <T> T runBounded(
+      final Callable<T> task, final long timeoutMs, final String failureMessage)
+      throws Exception {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      final Future<T> future = executor.submit(task);
+      try {
+        return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException e) {
+        future.cancel(true);
+        Assert.fail(failureMessage);
+        throw new AssertionError("unreachable");
+      }
+    } finally {
+      executor.shutdownNow();
+      if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
+        System.err.println(
+            "warning: worker thread did not terminate after shutdownNow — likely still"
+                + " livelocked in the production code");
+      }
+    }
+  }
+
+  /**
+   * Regression test for a livelock in {@code checkOpenFilesLimit}: when every currently-open
+   * entry is in ACQUIRED state and {@code openFiles > openLimit}, {@code emptyBuffers()} cannot
+   * close anything, and the looping thread spun forever while holding {@code openLatch},
+   * blocking every other thread that tries to add or acquire an entry.
+   *
+   * <p>This hang was observed on the macOS-arm integration-test pipeline (the deadlock-watchdog
+   * fired after 3600 s).
+   *
+   * <p>The test verifies three contracts of the soft-limit fix:
+   * <ol>
+   *   <li>{@code add()} returns within a bounded time even while {@code openFiles > openLimit}
+   *       and every entry is ACQUIRED.</li>
+   *   <li>The newly-added entry is actually inserted into the data map (not silently dropped).
+   *       </li>
+   *   <li>Once the acquired entries are released, a follow-up eviction brings {@code openFiles}
+   *       back to at most {@code openLimit} — the soft-limit violation is transient.</li>
+   * </ol>
+   */
+  @Test
+  public void testAddDoesNotLivelockWhenAllEntriesAreAcquired() throws Exception {
+    final int openLimit = 4;
+    final var dictionary = new ClosableLinkedContainer<Long, ClosableItem>(openLimit);
+
+    final var acquired = primeAllAcquiredOverflow(dictionary, openLimit);
+    try {
+      runBounded(
+          () -> {
+            dictionary.add((long) openLimit + 1, new CItem(openLimit + 1));
+            return null;
+          },
+          10_000L,
+          "add() hung while every entry was acquired — checkOpenFilesLimit livelocked");
+
+      Assert.assertNotNull(
+          "add must insert the new entry into the data map, not silently drop it",
+          dictionary.get((long) openLimit + 1));
+    } finally {
+      for (final var entry : acquired) {
+        dictionary.release(entry);
+      }
+    }
+
+    // Soft-limit recovery: once acquired entries are released, a follow-up eviction must bring
+    // openFiles back to within openLimit. Another add triggers the eviction path.
+    dictionary.add((long) openLimit + 2, new CItem(openLimit + 2));
+    dictionary.emptyBuffers();
+    Assert.assertTrue(
+        "soft-limit violation should be transient; after release openFilesCount="
+            + dictionary.openFilesCount() + " exceeds openLimit=" + openLimit,
+        dictionary.openFilesCount() <= openLimit);
+    Assert.assertTrue(dictionary.checkAllLRUListItemsInMap());
+    Assert.assertTrue(dictionary.checkAllOpenItemsInLRUList());
+  }
+
+  /**
+   * Companion regression test for {@code acquire()} — the {@code add} test exercises the same
+   * {@code checkOpenFilesLimit} entry point, but a dedicated {@code acquire}-under-overflow
+   * test pins the contract for both callers of {@code checkOpenFilesLimit} against future
+   * refactors.
+   *
+   * <p>Because every entry is ACQUIRED by the main thread, a second thread re-acquiring an
+   * existing key bumps the acquire counter and returns the same handle; the test asserts the
+   * return is non-null and corresponds to the expected key.
+   */
+  @Test
+  public void testAcquireDoesNotLivelockWhenAllEntriesAreAcquired() throws Exception {
+    final int openLimit = 4;
+    final var dictionary = new ClosableLinkedContainer<Long, ClosableItem>(openLimit);
+
+    final var acquired = primeAllAcquiredOverflow(dictionary, openLimit);
+    try {
+      final ClosableEntry<Long, ClosableItem> reAcquired =
+          runBounded(
+              () -> dictionary.acquire(0L),
+              10_000L,
+              "acquire() hung while every entry was acquired — checkOpenFilesLimit livelocked");
+
+      Assert.assertNotNull(
+          "re-acquiring an existing key must return the same handle, not null", reAcquired);
+      Assert.assertSame(
+          "acquired handle must reference the CItem that was originally added under key 0",
+          acquired.get(0).get(), reAcquired.get());
+      dictionary.release(reAcquired);
+    } finally {
+      for (final var entry : acquired) {
+        dictionary.release(entry);
+      }
+    }
+  }
+
+  /**
+   * Regression test for {@link ClosableLinkedContainer#tryAcquire(Object)}: when every entry is
+   * acquired and {@code openFiles > openLimit}, {@code tryAcquire} must return in a bounded
+   * time — {@code null} for a key that is currently acquired by another thread (cannot be
+   * re-acquired in that direction of the state machine), or the handle otherwise. The main
+   * thread holds key {@code 0L} exclusively through this test's reference to the list; a
+   * background {@code tryAcquire(0L)} call on the SAME container must not block indefinitely.
+   *
+   * <p>(The state-machine contract around {@code tryAcquire}: it reuses {@code doAcquireEntry},
+   * which increments the acquire count if the entry is already ACQUIRED. So {@code tryAcquire}
+   * can actually return a non-null handle even while key {@code 0L} is held elsewhere. What
+   * matters for this regression is the bounded-time contract, not which branch fires.)
+   */
+  @Test
+  public void testTryAcquireDoesNotLivelockWhenAllEntriesAreAcquired() throws Exception {
+    final int openLimit = 4;
+    final var dictionary = new ClosableLinkedContainer<Long, ClosableItem>(openLimit);
+
+    final var acquired = primeAllAcquiredOverflow(dictionary, openLimit);
+    try {
+      final ClosableEntry<Long, ClosableItem> result =
+          runBounded(
+              () -> dictionary.tryAcquire(0L),
+              10_000L,
+              "tryAcquire() hung while every entry was acquired —"
+                  + " tryCheckOpenFilesLimit livelocked");
+      // Whether result is null (limit still exceeded → soft-skip) or non-null (increment of
+      // acquire count), only bounded termination is the regression contract. If non-null, we
+      // must release it so the main-thread finally doesn't leak references.
+      if (result != null) {
+        dictionary.release(result);
+      }
+    } finally {
+      for (final var entry : acquired) {
+        dictionary.release(entry);
+      }
+    }
+  }
+
+  /**
+   * Regression test for the multi-thread gating contract of {@code openLatch}: N threads
+   * simultaneously call {@code add} while every entry is ACQUIRED. All must return within a
+   * bounded time.
+   *
+   * <p>This catches a future refactor that removes {@code latch.countDown()} from the fix's
+   * {@code finally} block — the single-thread regressions wouldn't notice, but the waiters in
+   * this test would hang on {@code ol.await()} until the 10 s budget trips.
+   */
+  @Test
+  public void testConcurrentAddsUnblockWhenAllEntriesAreAcquired() throws Exception {
+    final int openLimit = 4;
+    final int contenders = 8;
+    final var dictionary = new ClosableLinkedContainer<Long, ClosableItem>(openLimit);
+
+    final var acquired = primeAllAcquiredOverflow(dictionary, openLimit);
+    final var barrier = new CyclicBarrier(contenders);
+    final ExecutorService pool = Executors.newFixedThreadPool(contenders);
+    try {
+      final List<Future<Void>> futures = new ArrayList<>(contenders);
+      for (int i = 0; i < contenders; i++) {
+        final long key = (long) openLimit + 1 + i;
+        futures.add(
+            pool.submit(
+                () -> {
+                  barrier.await();
+                  dictionary.add(key, new CItem((int) key));
+                  return null;
+                }));
+      }
+
+      for (int i = 0; i < contenders; i++) {
+        try {
+          futures.get(i).get(10, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+          for (final var f : futures) {
+            f.cancel(true);
+          }
+          Assert.fail(
+              "concurrent add(" + ((long) openLimit + 1 + i) + ") hung —"
+                  + " at least one waiter was not released by openLatch.countDown()");
+        }
+      }
+
+      for (int i = 0; i < contenders; i++) {
+        Assert.assertNotNull(
+            "concurrent add must insert each key into the data map",
+            dictionary.get((long) openLimit + 1 + i));
+      }
+    } finally {
+      pool.shutdownNow();
+      Assert.assertTrue(
+          "pool must terminate after shutdownNow",
+          pool.awaitTermination(5, TimeUnit.SECONDS));
+      Collections.reverse(acquired);
+      for (final var entry : acquired) {
+        dictionary.release(entry);
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary
Fix a livelock in `ClosableLinkedContainer.checkOpenFilesLimit` that caused the macOS-arm integration-test pipeline to hang for 3600+ seconds until the `JUnitTestListener` watchdog fired. When every open file entry is currently ACQUIRED by other threads, `emptyBuffers()` can't close anything and the caller was spinning forever while holding `openLatch`, starving every other thread that tried to add, acquire, or try-acquire.

## Root Cause
**Failed run**: https://github.com/JetBrains/youtrackdb/actions/runs/24755612448 (macOS arm — JDK 21 — Java CI/CD Integration Tests Pipeline, scheduled on `develop` @ `bd4a3606`).

The thread dump showed:

- `pool-3-thread-2` RUNNABLE, stack `AtomicOperationBinaryTracking.commitChanges → LockFreeReadCache.allocateNewPage → WOWCache.allocateNewPage → ClosableLinkedContainer.acquire → checkOpenFilesLimit (line 357) → emptyBuffers → evict (line 844, iterator.next().makeClosed())`.
- `pool-3-thread-4` and `YouTrackDB Write Cache Flush Task` WAITING on the `CountDownLatch` that `pool-3-thread-2` installed into `openLatch`.
- `findDeadlockedThreads()` returned `null` — this is a busy-wait livelock, not a JVM deadlock.

The livelock shape is reproducible in isolation: fill the container to `openLimit`, acquire every entry, then `add(openLimit)` + re-`acquire(openLimit)` to drive `openFiles` to `openLimit + 1` with every LRU entry ACQUIRED. The old `checkOpenFilesLimit`:

```java
while (openFiles.get() > openLimit) {
  final var latch = new CountDownLatch(1);
  if (openLatch.compareAndSet(null, latch)) {
    while (openFiles.get() > openLimit) {
      emptyBuffers();        // evict() can't close anything → no progress
    }                        // infinite loop — openLatch held the whole time
    latch.countDown();
    openLatch.set(null);
  } else { ... }
}
```

`evict()` finds every LRU entry in ACQUIRED state, `makeClosed()` returns false on each, the inner iterator breaks out with `!entryClosed`, `emptyBuffers()` returns with `openFiles` unchanged, and the outer `while (openFiles.get() > openLimit) { emptyBuffers(); }` repeats forever.

Why it surfaces now: parallel test execution in `core` (#833) lets multiple surefire workers drive the single shared `EngineLocalPaginated.files` container past its limit simultaneously; on macOS the default `openLimit` falls back to 512 (`Native.getOpenFilesLimit` only queries RLIMIT on Linux), so the threshold is much closer to actual test working-set size there than on Linux/Windows.

## Changes
- **`core/.../ClosableLinkedContainer.java`** — break the inner eviction loop when `emptyBuffers()` can't reduce `openFiles`; `return` after one pass so `openLatch` is released and waiting threads can proceed. `openLimit` becomes a soft limit: a subsequent call, after any thread's `release(entry)`, resumes normal eviction. Same treatment applied to `tryCheckOpenFilesLimit`, and both methods now release the latch in a `finally` block so an exception from `emptyBuffers()` cannot strand `openLatch`.
- **`AtomicInteger lastNoProgressOpenFiles`** — caches the `openFiles` count observed at a failed eviction so that while the "all acquired" state persists, subsequent callers short-circuit before paying the `lruLock` + LRU-scan cost. `release(entry)` invalidates the cache (sets it to `-1`), re-enabling eviction.
- **New tests in `ClosableLinkedContainerTest`**:
  - `testAddDoesNotLivelockWhenAllEntriesAreAcquired` — verifies bounded termination of `add`, that the new entry is inserted (not silently dropped), and that soft-limit overflow recovers after release + follow-up eviction.
  - `testAcquireDoesNotLivelockWhenAllEntriesAreAcquired` — dedicated regression for the other `checkOpenFilesLimit` caller.
  - `testTryAcquireDoesNotLivelockWhenAllEntriesAreAcquired` — covers `tryCheckOpenFilesLimit`.
  - `testConcurrentAddsUnblockWhenAllEntriesAreAcquired` — 8 threads race on `openLatch`; catches a future refactor that removes `latch.countDown()` from the `finally`.
  - `@Before resetStaticCounters()` keeps tests independent of JUnit method ordering.
  - Shared `primeAllAcquiredOverflow` / `runBounded` helpers DRY the setup + bounded-wait pattern.

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/24755612448. The deadlock-watchdog added to `JUnitTestListener` surfaced this long-latent livelock — the same shape produced a similar hang on the previous day's scheduled run (`testMassiveOrderAscSkipLimit` in run 24731614197). This fix addresses the underlying concurrency bug instead of patching individual tests, so any future test hitting the same shape stays bounded.

## Test plan
- [x] New regression tests pass locally; verified they reliably reproduce the livelock against the unfixed production code (test hangs; `future.get(10s)` times out).
- [x] `./mvnw -pl core -am spotless:check` passes.
- [x] `./mvnw -pl core -am clean test -Dyoutrackdb.test.env=ci` (full core unit suite) passes — 0 failures across ~5200 tests including `MatchStatementExecutionTest`, `MatchPreFilterComprehensiveTest`, and the new `ClosableLinkedContainerTest` additions.
- [x] Dimensional review completed (7 agents: code-quality, bugs-concurrency, performance, test-behavior, test-completeness, test-structure, test-concurrency). Should-fix findings addressed: soft-limit recovery assertion, multi-thread contention test, dedicated `acquire`-under-overflow test, assertion precision in `tryAcquire` test, `O(1)` short-circuit to avoid per-I/O `emptyBuffers()` while the degraded state persists, DRY helpers, executor `awaitTermination`, `@Before` cleanup of shared static state, javadoc typo.