### PR TITLE
Grant Claude release-notes step the tools it needs

### DIFF
--- a/.github/workflows/maven-main-deploy-pipeline.yml
+++ b/.github/workflows/maven-main-deploy-pipeline.yml
@@ -197,7 +197,15 @@ jobs:
                separately. Start directly with the section headings.
             6. If the diff is empty, write a single line:
                `No source changes since the previous pre-release.`
-          claude_args: "--model claude-sonnet-4-6 --max-turns 25"
+          # The base-action doesn't grant any tool permissions by default;
+          # without `--allowed-tools` Claude can't run `git log`/`git diff` or
+          # write `/tmp/release-notes.md`, and the next step silently falls
+          # back to the stub body. Scope Bash to the git subcommands the
+          # prompt actually uses, and allow writing only to the notes file.
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 25
+            --allowed-tools "Bash(git log:*),Bash(git diff:*),Bash(git rev-parse:*),Bash(git show:*),Read,Write(/tmp/release-notes.md)"
 
       - name: Create GitHub pre-release
         # Run even if the Claude step failed, so the tag still gets cut and


### PR DESCRIPTION
#### Motivation

The `Generate release notes with Claude` step in `maven-main-deploy-pipeline.yml` invokes `claude-code-base-action` with `claude_args`, but no `--allowed-tools` flag. Without it, Claude Code has no permission to run `git log`/`git diff` or to `Write` `/tmp/release-notes.md`. The step completes without writing the file, and the next step (`Create GitHub pre-release`) silently falls back to the stub body, so every recent pre-release tag has been cut with the stub description instead of the AI-generated release notes.

#### Summary

- Add `--allowed-tools` to `claude_args` on the notes step.
- Scope `Bash` to the git subcommands the prompt actually uses (`git log`, `git diff`, `git rev-parse`, `git show`).
- Restrict `Write` to `/tmp/release-notes.md` so the permission surface is exactly what the step needs.
- Add a comment above the args explaining why the flag is required, so the next person doesn't strip it.

#### Test plan

- [ ] Merge to `develop`, let it flow into `main`, and confirm the next main-deploy run produces a pre-release whose description is the Claude-generated notes rather than the stub body.