### PR TITLE
Move JMH regression alerting from Grafana to CI

### DIFF
--- a/.github/workflows/jmh-alerter-tests.yml
+++ b/.github/workflows/jmh-alerter-tests.yml
@@ -16,6 +16,9 @@ on:
       - 'jmh-ldbc/jmh-regression-alert.py'
       - 'jmh-ldbc/tests/**'
       - '.github/workflows/jmh-alerter-tests.yml'
+  # Allow manual re-runs (e.g. after a transient GitHub Actions outage)
+  # without having to push an empty commit.
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/jmh-alerter-tests.yml
+++ b/.github/workflows/jmh-alerter-tests.yml
@@ -1,0 +1,35 @@
+name: JMH alerter unit tests
+
+# Run on every change that could affect the regression-detection math.
+# The alerter is the primary safety net for benchmark regressions
+# (Grafana now only does liveness) — its logic must not silently rot.
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - 'jmh-ldbc/jmh-regression-alert.py'
+      - 'jmh-ldbc/tests/**'
+      - '.github/workflows/jmh-alerter-tests.yml'
+  pull_request:
+    paths:
+      - 'jmh-ldbc/jmh-regression-alert.py'
+      - 'jmh-ldbc/tests/**'
+      - '.github/workflows/jmh-alerter-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Run unit tests
+        run: python3 -m unittest discover -s jmh-ldbc/tests -v

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -209,6 +209,25 @@ jobs:
             --commit-sha "${{ steps.commit.outputs.sha }}" \
             --timestamp "${{ steps.commit.outputs.timestamp }}"
 
+      - name: Check for benchmark regressions
+        # Intentionally no `|| true` — if the alerter crashes we want the
+        # workflow to fail loudly rather than silently drop regression signals.
+        if: success()
+        env:
+          INFLUXDB_URL: ${{ secrets.INFLUXDB_URL }}
+          INFLUXDB_TOKEN: ${{ secrets.INFLUXDB_TOKEN }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+        run: |
+          python3 jmh-ldbc/jmh-regression-alert.py \
+            --input "${{ github.workspace }}/results.json" \
+            --influxdb-url "$INFLUXDB_URL" \
+            --influxdb-token "$INFLUXDB_TOKEN" \
+            --influxdb-org youtrackdb \
+            --influxdb-bucket jmh-benchmarks \
+            --branch "${{ steps.commit.outputs.branch }}" \
+            --commit-sha "${{ steps.commit.outputs.sha }}" \
+            --zulip-api-key "$ZULIP_API_KEY"
+
       - name: Upload results artifact
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ldbc-jmh-nightly.yml
+++ b/.github/workflows/ldbc-jmh-nightly.yml
@@ -193,6 +193,16 @@ jobs:
           # Copy to workspace for artifact upload
           cp "$RESULTS" "${{ github.workspace }}/results.json"
 
+      # Push happens BEFORE the regression check, intentionally. Two reasons:
+      #   1. The regressing point itself must be visible on the Grafana
+      #      dashboard so a human investigator can compare it to history.
+      #   2. The rolling-average check (vs 14-run avg) is the primary signal
+      #      for sustained regressions, and it already tolerates one noisy
+      #      outlier — so priming the next run's baseline with the bad point
+      #      does not mask a real regression, only (at worst) a small
+      #      run-over-run rebound on the next night.
+      # If this ordering ever needs to be revisited, do it together with the
+      # alerter's math, not on its own.
       - name: Push results to InfluxDB
         if: success()
         env:

--- a/jmh-ldbc/grafana/dashboards/ldbc-jmh.json
+++ b/jmh-ldbc/grafana/dashboards/ldbc-jmh.json
@@ -17,7 +17,12 @@
         "iconColor": "rgba(96, 160, 255, 1)",
         "name": "Commits",
         "target": {
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group()\n  |> unique(column: \"commit_sha\")\n  |> keep(columns: [\"_time\", \"commit_sha\"])\n  |> rename(columns: {commit_sha: \"text\"})"
+          "query": "import \"strings\"\n\nfrom(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group()\n  |> unique(column: \"commit_sha\")\n  |> keep(columns: [\"_time\", \"commit_sha\"])\n  |> map(fn: (r) => ({\n      _time: r._time,\n      title: strings.substring(v: r.commit_sha, start: 0, end: 8),\n      text: \"[\" + strings.substring(v: r.commit_sha, start: 0, end: 8) + \"](https://github.com/JetBrains/youtrackdb/commit/\" + r.commit_sha + \")\"\n  }))"
+        },
+        "mappings": {
+          "time":  { "source": "field", "value": "_time" },
+          "title": { "source": "field", "value": "title" },
+          "text":  { "source": "field", "value": "text" }
         }
       }
     ]
@@ -47,9 +52,23 @@
             "showPoints": "always",
             "spanNulls": false
           },
-          "unit": "ops"
+          "unit": "ops",
+          "links": [
+            {
+              "title": "View commit on GitHub",
+              "url": "https://github.com/JetBrains/youtrackdb/commit/${__data.fields.commit_sha}",
+              "targetBlank": true
+            }
+          ]
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "commit_sha" },
+            "properties": [
+              { "id": "custom.hideFrom", "value": { "tooltip": false, "viz": true, "legend": true } }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "right" },
@@ -58,7 +77,7 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])",
+          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\", \"commit_sha\"])",
           "refId": "A"
         }
       ]
@@ -82,9 +101,23 @@
             "showPoints": "always",
             "spanNulls": false
           },
-          "unit": "ops"
+          "unit": "ops",
+          "links": [
+            {
+              "title": "View commit on GitHub",
+              "url": "https://github.com/JetBrains/youtrackdb/commit/${__data.fields.commit_sha}",
+              "targetBlank": true
+            }
+          ]
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "commit_sha" },
+            "properties": [
+              { "id": "custom.hideFrom", "value": { "tooltip": false, "viz": true, "legend": true } }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "right" },
@@ -93,7 +126,7 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])",
+          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\", \"commit_sha\"])",
           "refId": "A"
         }
       ]
@@ -126,9 +159,23 @@
               { "color": "yellow", "value": 1 },
               { "color": "green", "value": 4 }
             ]
-          }
+          },
+          "links": [
+            {
+              "title": "View commit on GitHub",
+              "url": "https://github.com/JetBrains/youtrackdb/commit/${__data.fields.commit_sha}",
+              "targetBlank": true
+            }
+          ]
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "commit_sha" },
+            "properties": [
+              { "id": "custom.hideFrom", "value": { "tooltip": false, "viz": true, "legend": true } }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": { "calcs": ["lastNotNull", "mean"], "displayMode": "table", "placement": "right" },
@@ -137,7 +184,7 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"scalability\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"ratio\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])",
+          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"scalability\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"ratio\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\", \"commit_sha\"])",
           "refId": "A"
         }
       ]

--- a/jmh-ldbc/grafana/dashboards/ldbc-jmh.json
+++ b/jmh-ldbc/grafana/dashboards/ldbc-jmh.json
@@ -9,6 +9,16 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(96, 160, 255, 1)",
+        "name": "Commits",
+        "target": {
+          "query": "from(bucket: \"jmh-benchmarks\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group()\n  |> unique(column: \"commit_sha\")\n  |> keep(columns: [\"_time\", \"commit_sha\"])\n  |> rename(columns: {commit_sha: \"text\"})"
+        }
       }
     ]
   },
@@ -176,6 +186,19 @@
             "properties": [
               { "id": "displayName", "value": "Query" }
             ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "commit_sha" },
+            "properties": [
+              { "id": "displayName", "value": "Commit" },
+              { "id": "links", "value": [
+                {
+                  "title": "View commit on GitHub",
+                  "url": "https://github.com/JetBrains/youtrackdb/commit/${__value.raw}",
+                  "targetBlank": true
+                }
+              ]}
+            ]
           }
         ]
       },
@@ -186,7 +209,7 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "base = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -90d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> tail(n: 15)\n\nscores = base\n  |> tail(n: 14)\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\ndiffs = base\n  |> difference(columns: [\"_value\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\njoin(tables: {s: scores, d: diffs}, on: [\"_time\", \"query\"])\n  |> map(fn: (r) => ({\n      _time: r._time,\n      query: r.query,\n      score: r._value_s,\n      delta_pct: if (r._value_s - r._value_d) > 0.0 then r._value_d / (r._value_s - r._value_d) * 100.0 else 0.0\n  }))\n  |> sort(columns: [\"query\", \"_time\"], desc: false)",
+          "query": "base = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -90d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"SingleThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> tail(n: 15)\n\nscores = base\n  |> tail(n: 14)\n  |> keep(columns: [\"_time\", \"_value\", \"query\", \"commit_sha\"])\n  |> group()\n\ndiffs = base\n  |> difference(columns: [\"_value\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\njoin(tables: {s: scores, d: diffs}, on: [\"_time\", \"query\"])\n  |> map(fn: (r) => ({\n      _time: r._time,\n      query: r.query,\n      commit_sha: r.commit_sha,\n      score: r._value_s,\n      delta_pct: if (r._value_s - r._value_d) > 0.0 then r._value_d / (r._value_s - r._value_d) * 100.0 else 0.0\n  }))\n  |> sort(columns: [\"query\", \"_time\"], desc: false)",
           "refId": "A"
         }
       ]
@@ -235,6 +258,19 @@
             "properties": [
               { "id": "displayName", "value": "Query" }
             ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "commit_sha" },
+            "properties": [
+              { "id": "displayName", "value": "Commit" },
+              { "id": "links", "value": [
+                {
+                  "title": "View commit on GitHub",
+                  "url": "https://github.com/JetBrains/youtrackdb/commit/${__value.raw}",
+                  "targetBlank": true
+                }
+              ]}
+            ]
           }
         ]
       },
@@ -245,7 +281,7 @@
       "targets": [
         {
           "datasource": { "type": "influxdb", "uid": "${DS_INFLUXDB}" },
-          "query": "base = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -90d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> tail(n: 15)\n\nscores = base\n  |> tail(n: 14)\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\ndiffs = base\n  |> difference(columns: [\"_value\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\njoin(tables: {s: scores, d: diffs}, on: [\"_time\", \"query\"])\n  |> map(fn: (r) => ({\n      _time: r._time,\n      query: r.query,\n      score: r._value_s,\n      delta_pct: if (r._value_s - r._value_d) > 0.0 then r._value_d / (r._value_s - r._value_d) * 100.0 else 0.0\n  }))\n  |> sort(columns: [\"query\", \"_time\"], desc: false)",
+          "query": "base = from(bucket: \"jmh-benchmarks\")\n  |> range(start: -90d)\n  |> filter(fn: (r) => r._measurement == \"jmh_benchmark\")\n  |> filter(fn: (r) => r.suite == \"MultiThread\")\n  |> filter(fn: (r) => r.branch =~ /${branch}/)\n  |> filter(fn: (r) => r.query =~ /${query:regex}/)\n  |> filter(fn: (r) => r._field == \"score\")\n  |> group(columns: [\"query\"])\n  |> sort(columns: [\"_time\"])\n  |> tail(n: 15)\n\nscores = base\n  |> tail(n: 14)\n  |> keep(columns: [\"_time\", \"_value\", \"query\", \"commit_sha\"])\n  |> group()\n\ndiffs = base\n  |> difference(columns: [\"_value\"])\n  |> keep(columns: [\"_time\", \"_value\", \"query\"])\n  |> group()\n\njoin(tables: {s: scores, d: diffs}, on: [\"_time\", \"query\"])\n  |> map(fn: (r) => ({\n      _time: r._time,\n      query: r.query,\n      commit_sha: r.commit_sha,\n      score: r._value_s,\n      delta_pct: if (r._value_s - r._value_d) > 0.0 then r._value_d / (r._value_s - r._value_d) * 100.0 else 0.0\n  }))\n  |> sort(columns: [\"query\", \"_time\"], desc: false)",
           "refId": "A"
         }
       ]

--- a/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
+++ b/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
@@ -1,33 +1,50 @@
 apiVersion: 1
 
+# Regression detection has moved to jmh-ldbc/jmh-regression-alert.py, invoked
+# from the nightly benchmark workflow. That path runs against the JSON the
+# benchmark just produced, has unit tests, and fails the workflow loudly if it
+# crashes — avoiding the silent "alert rule with buggy math returns OK" class
+# of failure that used to live here.
+#
+# Grafana keeps one job only: a liveness probe. If the Python alerter stops
+# running (workflow disabled, runner dead, secret rotated, etc.), the Python
+# path cannot alert on its own absence. This rule does.
+
 groups:
   - orgId: 1
-    name: jmh-benchmark-regressions
+    name: jmh-benchmark-freshness
     folder: JMH Alerts
     interval: 1h
     rules:
-      # ── Run-over-run regression (>10% drop vs previous nightly) ──
-      - uid: jmh-run-over-run-regression
-        title: "JMH run-over-run regression (>10% drop)"
+      # Fires when the most recent jmh_benchmark point on `develop` is older
+      # than 36 hours. Nightly benchmarks run every 24h, so a 36h threshold
+      # tolerates one missed run before paging (avoids noise from routine
+      # single-night glitches) while still catching a pipeline that has
+      # genuinely stopped producing data.
+      - uid: jmh-data-freshness
+        title: "JMH benchmark pipeline stalled (no fresh data)"
         condition: C
         for: 0s
         annotations:
           summary: >-
-            Benchmark {{ $labels.query }} ({{ $labels.suite }}) dropped
-            {{ printf "%.1f" $values.B.Value }}% vs the previous run.
+            No JMH benchmark data for {{ printf "%.1f" $values.B.Value }}h
+            on branch `develop` — the nightly pipeline may be broken.
           description: >-
-            The latest nightly benchmark score is more than 10% below
-            the previous run. Check the dashboard for details.
+            The freshest jmh_benchmark point on develop is older than 36h.
+            This usually means the nightly workflow failed, was disabled,
+            or the self-hosted runner is offline. Regression detection
+            relies on fresh data — investigate before more nights pass.
           dashboard_url: https://bench.youtrackdb.io
         labels:
           severity: warning
-        noDataState: OK
-        execErrState: OK
+        # If the bucket has no data in the last 7 days at all, treat it as a
+        # firing condition: a completely empty history is worse than stale.
+        noDataState: Alerting
+        execErrState: Alerting
         data:
-          # Query B: compute delta_pct per query+suite in Flux
           - refId: B
             relativeTimeRange:
-              from: 7776000  # 90 days in seconds
+              from: 604800  # 7 days in seconds
               to: 0
             datasourceUid: "P951FEA4DE68E13C5"
             model:
@@ -36,64 +53,22 @@ groups:
                 type: influxdb
                 uid: "P951FEA4DE68E13C5"
               query: |
-                // Noise suppression: exclude benchmarks where score_error > 10% of score
-                noise = from(bucket: "jmh-benchmarks")
-                  |> range(start: -30d)
+                from(bucket: "jmh-benchmarks")
+                  |> range(start: -7d)
                   |> filter(fn: (r) => r._measurement == "jmh_benchmark")
-                  |> filter(fn: (r) => r.branch == "develop")
-                  |> filter(fn: (r) => r._field == "score" or r._field == "score_error")
-                  |> group(columns: ["query", "suite"])
-                  |> sort(columns: ["_time"], desc: true)
-                  |> limit(n: 2)
-                  |> first()
-                  |> group(columns: ["query", "suite"])
-                  |> pivot(rowKey: ["query", "suite"], columnKey: ["_field"], valueColumn: "_value")
-                  |> filter(fn: (r) => r.score > 0.0 and r.score_error / r.score <= 0.10)
-                  |> keep(columns: ["query", "suite"])
-                  |> group()
-
-                base = from(bucket: "jmh-benchmarks")
-                  |> range(start: -30d)
-                  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
-                  |> filter(fn: (r) => r.branch == "develop")
                   |> filter(fn: (r) => r._field == "score")
-                  |> group(columns: ["query", "suite"])
-                  |> sort(columns: ["_time"], desc: true)
-                  |> limit(n: 2)
-
-                latest = base
-                  |> first()
-                  |> keep(columns: ["_value", "query", "suite"])
+                  |> filter(fn: (r) => r.branch == "develop")
                   |> group()
-
-                previous = base
                   |> last()
-                  |> keep(columns: ["_value", "query", "suite"])
-                  |> group()
-
-                delta = join(tables: {l: latest, p: previous}, on: ["query", "suite"])
                   |> map(fn: (r) => ({
                     _time: now(),
-                    query: r.query,
-                    suite: r.suite,
-                    _value: if r._value_p > 0.0
-                      then (r._value_l - r._value_p) / r._value_p * 100.0
-                      else 0.0,
+                    _value: float(v: int(v: now()) - int(v: r._time))
+                            / 3600000000000.0,
                   }))
-
-                // Keep only non-noisy benchmarks
-                join(tables: {d: delta, n: noise}, on: ["query", "suite"])
-                  |> map(fn: (r) => ({
-                    _time: r._time,
-                    query: r.query,
-                    suite: r.suite,
-                    _value: r._value_d,
-                  }))
-                  |> group(columns: ["query", "suite"])
-          # Reduce: extract the single value from each series
+                  |> keep(columns: ["_time", "_value"])
           - refId: A
             relativeTimeRange:
-              from: 7776000
+              from: 604800
               to: 0
             datasourceUid: __expr__
             model:
@@ -117,10 +92,10 @@ groups:
               reducer: last
               settings:
                 mode: ""
-          # Threshold: fire if delta_pct < -10 (more than 10% regression)
+          # Fire if age_hours > 36
           - refId: C
             relativeTimeRange:
-              from: 7776000
+              from: 604800
               to: 0
             datasourceUid: __expr__
             model:
@@ -132,147 +107,8 @@ groups:
               conditions:
                 - evaluator:
                     params:
-                      - -10
-                    type: lt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - C
-                  reducer:
-                    type: last
-              expression: A
-
-      # ── Below 14-run rolling average (>5% drop) ──
-      - uid: jmh-below-rolling-average
-        title: "JMH below 14-run average (>5% drop)"
-        condition: C
-        for: 0s
-        annotations:
-          summary: >-
-            Benchmark {{ $labels.query }} ({{ $labels.suite }}) is
-            {{ printf "%.1f" $values.B.Value }}% below the 14-run average.
-          description: >-
-            The latest nightly benchmark score is more than 5% below
-            the 14-run rolling average. This may indicate a gradual
-            regression. Check the dashboard for details.
-          dashboard_url: https://bench.youtrackdb.io
-        labels:
-          severity: warning
-        noDataState: OK
-        execErrState: OK
-        data:
-          # Query B: compute delta_pct (latest vs 14-run avg) per query+suite
-          - refId: B
-            relativeTimeRange:
-              from: 7776000
-              to: 0
-            datasourceUid: "P951FEA4DE68E13C5"
-            model:
-              refId: B
-              datasource:
-                type: influxdb
-                uid: "P951FEA4DE68E13C5"
-              query: |
-                // Noise suppression: exclude benchmarks where score_error > 10% of score
-                noise = from(bucket: "jmh-benchmarks")
-                  |> range(start: -90d)
-                  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
-                  |> filter(fn: (r) => r.branch == "develop")
-                  |> filter(fn: (r) => r._field == "score" or r._field == "score_error")
-                  |> group(columns: ["query", "suite"])
-                  |> sort(columns: ["_time"], desc: true)
-                  |> limit(n: 2)
-                  |> first()
-                  |> group(columns: ["query", "suite"])
-                  |> pivot(rowKey: ["query", "suite"], columnKey: ["_field"], valueColumn: "_value")
-                  |> filter(fn: (r) => r.score > 0.0 and r.score_error / r.score <= 0.10)
-                  |> keep(columns: ["query", "suite"])
-                  |> group()
-
-                base = from(bucket: "jmh-benchmarks")
-                  |> range(start: -90d)
-                  |> filter(fn: (r) => r._measurement == "jmh_benchmark")
-                  |> filter(fn: (r) => r.branch == "develop")
-                  |> filter(fn: (r) => r._field == "score")
-                  |> group(columns: ["query", "suite"])
-                  |> sort(columns: ["_time"], desc: true)
-                  |> limit(n: 15)
-
-                latest = base
-                  |> first()
-                  |> keep(columns: ["_value", "query", "suite"])
-                  |> group()
-
-                avg14 = base
-                  |> tail(n: 14)
-                  |> mean()
-                  |> keep(columns: ["_value", "query", "suite"])
-                  |> group()
-
-                delta = join(tables: {l: latest, a: avg14}, on: ["query", "suite"])
-                  |> map(fn: (r) => ({
-                    _time: now(),
-                    query: r.query,
-                    suite: r.suite,
-                    _value: if r._value_a > 0.0
-                      then (r._value_l - r._value_a) / r._value_a * 100.0
-                      else 0.0,
-                  }))
-
-                // Keep only non-noisy benchmarks
-                join(tables: {d: delta, n: noise}, on: ["query", "suite"])
-                  |> map(fn: (r) => ({
-                    _time: r._time,
-                    query: r.query,
-                    suite: r.suite,
-                    _value: r._value_d,
-                  }))
-                  |> group(columns: ["query", "suite"])
-          # Reduce: extract the single value from each series
-          - refId: A
-            relativeTimeRange:
-              from: 7776000
-              to: 0
-            datasourceUid: __expr__
-            model:
-              refId: A
-              type: reduce
-              datasource:
-                type: __expr__
-                uid: __expr__
-              conditions:
-                - evaluator:
-                    params: []
+                      - 36
                     type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - A
-                  reducer:
-                    type: last
-              expression: B
-              reducer: last
-              settings:
-                mode: ""
-          # Threshold: fire if delta_pct < -5 (more than 5% below average)
-          - refId: C
-            relativeTimeRange:
-              from: 7776000
-              to: 0
-            datasourceUid: __expr__
-            model:
-              refId: C
-              type: threshold
-              datasource:
-                type: __expr__
-                uid: __expr__
-              conditions:
-                - evaluator:
-                    params:
-                      - -5
-                    type: lt
                   operator:
                     type: and
                   query:

--- a/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
+++ b/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
@@ -66,6 +66,10 @@ groups:
                             / 3600000000000.0,
                   }))
                   |> keep(columns: ["_time", "_value"])
+          # `reduce` collapses refId B's output (one row with the age in hours)
+          # into a single scalar for the threshold step to compare against.
+          # No `conditions:` block here: the firing decision is made by
+          # refId C (the threshold step below), not by this reducer.
           - refId: A
             relativeTimeRange:
               from: 604800
@@ -77,17 +81,6 @@ groups:
               datasource:
                 type: __expr__
                 uid: __expr__
-              conditions:
-                - evaluator:
-                    params: []
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - A
-                  reducer:
-                    type: last
               expression: B
               reducer: last
               settings:

--- a/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
+++ b/jmh-ldbc/grafana/provisioning/alerting/alert-rules.yaml
@@ -26,8 +26,12 @@ groups:
         condition: C
         for: 0s
         annotations:
+          # Use $values.A.Value (the reduced scalar) rather than $values.B.Value
+          # (the raw query series). Refid A is the single value that refId C's
+          # threshold actually compares against, so the annotation stays
+          # consistent with the firing decision even if B's shape changes.
           summary: >-
-            No JMH benchmark data for {{ printf "%.1f" $values.B.Value }}h
+            No JMH benchmark data for {{ printf "%.1f" $values.A.Value }}h
             on branch `develop` — the nightly pipeline may be broken.
           description: >-
             The freshest jmh_benchmark point on develop is older than 36h.

--- a/jmh-ldbc/jmh-regression-alert.py
+++ b/jmh-ldbc/jmh-regression-alert.py
@@ -90,11 +90,14 @@ from(bucket: "{_flux_escape(bucket)}")
         with urllib.request.urlopen(req) as resp:
             csv_data = resp.read().decode("utf-8")
     except urllib.error.HTTPError as e:
-        # Exit non-zero instead of returning {}: an empty history would
-        # masquerade as "no regressions" and silently drop alerts.
+        # Raise instead of returning {}: an empty history would masquerade as
+        # "no regressions" and silently drop alerts. Raising (rather than
+        # sys.exit) keeps this function reusable and unit-testable — main()
+        # translates the exception into a non-zero process exit.
         body_text = e.read().decode("utf-8", errors="replace")
-        print(f"InfluxDB query failed: {e.code} - {body_text}", file=sys.stderr)
-        sys.exit(1)
+        raise RuntimeError(
+            f"InfluxDB query failed: {e.code} - {body_text}"
+        ) from e
 
     return parse_influx_csv(csv_data)
 
@@ -364,15 +367,19 @@ def main():
     history = {}
     total_points_all_suites = 0
     for suite in ("SingleThread", "MultiThread"):
-        hist = query_influxdb(
-            args.influxdb_url,
-            args.influxdb_token,
-            args.influxdb_org,
-            args.influxdb_bucket,
-            suite,
-            args.branch,
-            args.history_size,
-        )
+        try:
+            hist = query_influxdb(
+                args.influxdb_url,
+                args.influxdb_token,
+                args.influxdb_org,
+                args.influxdb_bucket,
+                suite,
+                args.branch,
+                args.history_size,
+            )
+        except RuntimeError as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)
         history[suite] = hist
         total_points = sum(len(v) for v in hist.values())
         total_points_all_suites += total_points

--- a/jmh-ldbc/jmh-regression-alert.py
+++ b/jmh-ldbc/jmh-regression-alert.py
@@ -14,7 +14,17 @@ def parse_latest_results(data):
     """Parse JMH JSON into {(query, suite): {score, score_error}} dict."""
     results = {}
     for entry in data:
-        parts = entry["benchmark"].rsplit(".", 2)
+        benchmark_name = entry.get("benchmark", "")
+        parts = benchmark_name.rsplit(".", 2)
+        # Defensive: JMH always produces fully-qualified names, but if a
+        # benchmark entry is malformed (fewer than 2 dots) skip it with a
+        # warning rather than raising IndexError on parts[-2].
+        if len(parts) < 2:
+            print(
+                f"WARNING: skipping malformed benchmark name {benchmark_name!r}",
+                file=sys.stderr,
+            )
+            continue
         class_name = parts[-2]
         method_name = parts[-1]
 
@@ -36,19 +46,31 @@ def parse_latest_results(data):
     return results
 
 
+def _flux_escape(s):
+    """Escape a value for safe interpolation into a Flux string literal.
+
+    Flux string literals are double-quoted with backslash escapes. Without
+    escaping, a branch name containing a `"` or `\\` would break the query
+    syntax (and in the wrong hands, would be an injection vector).
+    """
+    return str(s).replace("\\", "\\\\").replace('"', '\\"')
+
+
 def query_influxdb(url, token, org, bucket, suite, branch, limit):
     """Query InfluxDB for the last N scores per query (excluding the latest push)."""
-    # Get historical data: last `limit` runs before the most recent
+    # Get historical data: last `limit` runs before the most recent.
+    # Escape interpolated values so unusual but legal branch names (e.g.
+    # containing `"`) cannot break the Flux syntax.
     flux = f'''
-from(bucket: "{bucket}")
+from(bucket: "{_flux_escape(bucket)}")
   |> range(start: -90d)
   |> filter(fn: (r) => r._measurement == "jmh_benchmark")
-  |> filter(fn: (r) => r.suite == "{suite}")
-  |> filter(fn: (r) => r.branch == "{branch}")
+  |> filter(fn: (r) => r.suite == "{_flux_escape(suite)}")
+  |> filter(fn: (r) => r.branch == "{_flux_escape(branch)}")
   |> filter(fn: (r) => r._field == "score")
   |> group(columns: ["query"])
   |> sort(columns: ["_time"], desc: true)
-  |> limit(n: {limit})
+  |> limit(n: {int(limit)})
   |> sort(columns: ["_time"])
   |> keep(columns: ["_time", "_value", "query"])
 '''
@@ -85,7 +107,6 @@ def parse_influx_csv(csv_data):
       ,_result,0,2026-03-21T03:48:00Z,56216.45,is1_personProfile
     """
     history = {}
-    header_cols = None
     value_idx = None
     query_idx = None
 
@@ -101,7 +122,6 @@ def parse_influx_csv(csv_data):
 
         # Detect header row (contains column names)
         if "_value" in parts and "query" in parts:
-            header_cols = parts
             value_idx = parts.index("_value")
             query_idx = parts.index("query")
             continue
@@ -122,8 +142,15 @@ def parse_influx_csv(csv_data):
 
 
 def check_regressions(latest, history, run_over_run_pct, avg_pct, noise_threshold):
-    """Check for regressions. Returns list of regression dicts."""
+    """Check for regressions. Returns (regressions, skipped_noisy) tuple.
+
+    `regressions` is a list of regression dicts; `skipped_noisy` is a list of
+    (query, suite, noise_pct) tuples for benchmarks excluded due to high
+    score_error. Callers print skipped benchmarks so a permanently-noisy
+    query cannot silently turn into a permanently-unmonitored query.
+    """
     regressions = []
+    skipped_noisy = []
 
     for (query, suite), data in latest.items():
         score = data["score"]
@@ -131,6 +158,7 @@ def check_regressions(latest, history, run_over_run_pct, avg_pct, noise_threshol
 
         # Skip noisy benchmarks (score_error > noise_threshold% of score)
         if score > 0 and (score_error / score) > (noise_threshold / 100.0):
+            skipped_noisy.append((query, suite, score_error / score * 100.0))
             continue
 
         hist = history.get(suite, {}).get(query, [])
@@ -168,7 +196,7 @@ def check_regressions(latest, history, run_over_run_pct, avg_pct, noise_threshol
                         "threshold": -avg_pct,
                     })
 
-    return regressions
+    return regressions, skipped_noisy
 
 
 def format_zulip_message(regressions, branch, commit_sha, dashboard_url):
@@ -313,6 +341,17 @@ def main():
     parser.add_argument(
         "--dry-run", action="store_true", help="Print message without sending"
     )
+    parser.add_argument(
+        "--allow-empty-history",
+        action="store_true",
+        help=(
+            "Do not fail when InfluxDB returns zero historical points. "
+            "Use ONLY for the very first nightly run on a new branch/bucket; "
+            "otherwise an empty response usually means the query filter "
+            "(branch, bucket, org) is wrong, which would silently mask "
+            "every subsequent regression."
+        ),
+    )
     args = parser.parse_args()
 
     with open(args.input) as f:
@@ -323,6 +362,7 @@ def main():
 
     # Query historical data per suite
     history = {}
+    total_points_all_suites = 0
     for suite in ("SingleThread", "MultiThread"):
         hist = query_influxdb(
             args.influxdb_url,
@@ -335,15 +375,45 @@ def main():
         )
         history[suite] = hist
         total_points = sum(len(v) for v in hist.values())
+        total_points_all_suites += total_points
         print(f"Fetched {total_points} historical data points for {suite}")
 
-    regressions = check_regressions(
+    # Empty-history sanity guard. A 200 OK with zero rows looks identical to
+    # "no regressions", which is exactly the silent-drop failure mode the
+    # rewrite was meant to eliminate (cf. the 2026-04-14 Grafana incident).
+    # The most likely causes are a bucket/org typo, a branch-filter mismatch,
+    # or a retention-policy purge — all of which would mask every subsequent
+    # regression until noticed manually.
+    if total_points_all_suites == 0 and not args.allow_empty_history:
+        print(
+            "ERROR: InfluxDB returned zero historical points across all "
+            f"suites (branch={args.branch!r}, bucket={args.influxdb_bucket!r}, "
+            f"org={args.influxdb_org!r}). Refusing to proceed — this is "
+            "almost always a misconfiguration, and treating it as 'no "
+            "regressions' would silently suppress every future alert. "
+            "If this really is the first run on a new branch/bucket, "
+            "re-invoke with --allow-empty-history.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    regressions, skipped_noisy = check_regressions(
         latest,
         history,
         args.run_over_run_threshold,
         args.avg_threshold,
         args.noise_threshold,
     )
+
+    # Surface noisy skips so a permanently-noisy benchmark doesn't silently
+    # turn into a permanently-unmonitored benchmark.
+    if skipped_noisy:
+        print(
+            f"Skipped {len(skipped_noisy)} benchmark(s) with score_error "
+            f"> {args.noise_threshold}% of score:"
+        )
+        for query, suite, noise_pct in sorted(skipped_noisy):
+            print(f"  - {query} ({suite}): {noise_pct:.1f}% noise")
 
     if not regressions:
         print("No regressions detected. All clear.")

--- a/jmh-ldbc/jmh-regression-alert.py
+++ b/jmh-ldbc/jmh-regression-alert.py
@@ -68,9 +68,11 @@ from(bucket: "{bucket}")
         with urllib.request.urlopen(req) as resp:
             csv_data = resp.read().decode("utf-8")
     except urllib.error.HTTPError as e:
+        # Exit non-zero instead of returning {}: an empty history would
+        # masquerade as "no regressions" and silently drop alerts.
         body_text = e.read().decode("utf-8", errors="replace")
         print(f"InfluxDB query failed: {e.code} - {body_text}", file=sys.stderr)
-        return {}
+        sys.exit(1)
 
     return parse_influx_csv(csv_data)
 

--- a/jmh-ldbc/tests/test_jmh_regression_alert.py
+++ b/jmh-ldbc/tests/test_jmh_regression_alert.py
@@ -14,8 +14,11 @@ or, with discovery:
 """
 
 import importlib.util
+import io
 import unittest
+import urllib.error
 from pathlib import Path
+from unittest import mock
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "jmh-regression-alert.py"
 _spec = importlib.util.spec_from_file_location("jmh_regression_alert", SCRIPT_PATH)
@@ -242,6 +245,40 @@ class TestFluxEscape(unittest.TestCase):
 
     def test_non_string_coerced(self):
         self.assertEqual(alerter._flux_escape(42), "42")
+
+
+class TestQueryInfluxdbErrorHandling(unittest.TestCase):
+    """Pin that an HTTP failure raises RuntimeError (instead of sys.exit).
+
+    Raising lets main() decide how to exit and, more importantly, keeps the
+    function reusable from tests. If this ever regresses to sys.exit(1), the
+    test suite itself would be terminated by the call — which is exactly the
+    failure mode we want to prevent.
+    """
+
+    def test_http_error_raises_runtime_error(self):
+        http_error = urllib.error.HTTPError(
+            url="http://example/api/v2/query",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,
+            fp=io.BytesIO(b"influx is down"),
+        )
+        with mock.patch.object(alerter.urllib.request, "urlopen", side_effect=http_error):
+            with self.assertRaises(RuntimeError) as cm:
+                alerter.query_influxdb(
+                    url="http://example",
+                    token="t",
+                    org="o",
+                    bucket="b",
+                    suite="SingleThread",
+                    branch="develop",
+                    limit=14,
+                )
+        # Error message should carry the status code and body so operators
+        # can diagnose without rerunning with extra logging.
+        self.assertIn("503", str(cm.exception))
+        self.assertIn("influx is down", str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/jmh-ldbc/tests/test_jmh_regression_alert.py
+++ b/jmh-ldbc/tests/test_jmh_regression_alert.py
@@ -42,23 +42,24 @@ def _history(scores, suite="SingleThread", query="q1"):
 
 class TestCheckRegressions(unittest.TestCase):
     def test_clean_run_no_regressions(self):
-        """Score matches previous run and 14-run mean → no alert."""
+        """Score matches previous run and 14-run mean → no alert, no skip."""
         # Previous score and mean are both 100 → 0% delta.
         latest = _latest(score=100.0, score_error=1.0)
         history = _history([100.0] * 14)
-        self.assertEqual(
-            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
-        )
+        regs, skipped = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertEqual(regs, [])
+        self.assertEqual(skipped, [])
 
     def test_run_over_run_regression_fires(self):
-        """Latest score 15% below previous → run-over-run alert fires."""
+        """Latest score 15% below previous → BOTH run-over-run and vs-avg fire."""
         latest = _latest(score=85.0, score_error=1.0)
         # hist[-1] is the most recent previous run (script reads in chrono order).
         history = _history([100.0, 100.0, 100.0])
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         types = sorted(r["type"] for r in regs)
-        # Both checks should trigger: 15% < -10 (run-over-run) and < -5 (vs avg).
-        self.assertIn("run-over-run", types)
+        # Pin both: 15% < -10 (run-over-run) and < -5 (vs 3-run avg). If a
+        # refactor ever drops one silently, this assertion catches it.
+        self.assertEqual(types, ["run-over-run", "vs 3-run avg"])
         ror = [r for r in regs if r["type"] == "run-over-run"][0]
         self.assertAlmostEqual(ror["delta_pct"], -15.0, places=3)
         self.assertEqual(ror["query"], "q1")
@@ -68,14 +69,14 @@ class TestCheckRegressions(unittest.TestCase):
         """A 9% drop should NOT fire run-over-run (strict > threshold)."""
         latest = _latest(score=91.0, score_error=1.0)
         history = _history([100.0])  # only 1 point → avg check is skipped
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         self.assertEqual([r for r in regs if r["type"] == "run-over-run"], [])
 
     def test_exact_threshold_does_not_fire(self):
         """Exactly -10% drop is NOT a run-over-run regression (delta < -10 strict)."""
         latest = _latest(score=90.0, score_error=1.0)
         history = _history([100.0])
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         self.assertEqual([r for r in regs if r["type"] == "run-over-run"], [])
 
     def test_rolling_avg_regression_fires_without_run_over_run(self):
@@ -83,53 +84,66 @@ class TestCheckRegressions(unittest.TestCase):
         latest = _latest(score=94.0, score_error=1.0)
         # Average is 100; previous run is 96 → run-over-run delta is -2.08%.
         history = _history([100.0] * 13 + [96.0])
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         types = [r["type"] for r in regs]
         self.assertNotIn("run-over-run", types)
         self.assertTrue(any("-run avg" in t for t in types))
         avg_reg = [r for r in regs if "-run avg" in r["type"]][0]
         self.assertLess(avg_reg["delta_pct"], -AVG)
 
-    def test_noisy_benchmark_is_skipped(self):
-        """score_error / score > noise threshold → benchmark excluded entirely."""
-        # 40% score error on a 50% drop — we must NOT silently drop the alert
-        # when the underlying signal is noisy, but the script's contract is
-        # "skip noisy" — pin that behaviour explicitly so it can't drift.
+    def test_noisy_benchmark_is_skipped_with_warning(self):
+        """score_error / score > noise threshold → excluded AND surfaced.
+
+        The script's contract is "skip noisy", but a permanently-noisy
+        benchmark must not silently become a permanently-unmonitored one.
+        Pin that check_regressions reports skipped benchmarks in a second
+        return value so the caller can log them.
+        """
+        # 40% score error on a 50% drop — gets skipped by design, but the
+        # skip itself must be reported.
         latest = _latest(score=50.0, score_error=20.0)  # 40% noise
         history = _history([100.0] * 14)
-        self.assertEqual(
-            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
-        )
+        regs, skipped = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertEqual(regs, [])
+        self.assertEqual(len(skipped), 1)
+        query, suite, noise_pct = skipped[0]
+        self.assertEqual(query, "q1")
+        self.assertEqual(suite, "SingleThread")
+        self.assertAlmostEqual(noise_pct, 40.0, places=3)
 
-    def test_empty_history_skipped(self):
-        """No historical data for this (query, suite) → no alert."""
+    def test_empty_history_returns_empty_list(self):
+        """No historical data → check_regressions returns [] for this (query, suite).
+
+        The silent-drop protection itself lives in main() (empty-history
+        sanity guard with --allow-empty-history escape hatch); this unit
+        test only pins the per-entry behaviour.
+        """
         latest = _latest(score=1.0, score_error=0.01)
         history = {"SingleThread": {}, "MultiThread": {}}
-        self.assertEqual(
-            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
-        )
+        regs, skipped = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertEqual(regs, [])
+        self.assertEqual(skipped, [])
 
     def test_missing_suite_in_history_skipped(self):
         """Suite key absent from history → check returns nothing (no KeyError)."""
         latest = _latest(score=1.0, score_error=0.01, suite="SingleThread")
         history = {}  # no suites at all
-        self.assertEqual(
-            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
-        )
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertEqual(regs, [])
 
     def test_prev_score_zero_skips_run_over_run(self):
         """prev_score == 0 must not raise ZeroDivisionError."""
         latest = _latest(score=10.0, score_error=0.1)
         history = _history([0.0])
         # Should not raise; run-over-run is skipped for prev=0.
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         self.assertEqual([r for r in regs if r["type"] == "run-over-run"], [])
 
     def test_short_history_skips_avg_but_keeps_run_over_run(self):
         """< 3 historical points → avg check skipped, run-over-run still runs."""
         latest = _latest(score=50.0, score_error=0.1)
         history = _history([100.0, 100.0])  # only 2 points
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         types = [r["type"] for r in regs]
         self.assertIn("run-over-run", types)
         self.assertFalse(any("-run avg" in t for t in types))
@@ -138,7 +152,7 @@ class TestCheckRegressions(unittest.TestCase):
         """The 'vs N-run avg' label should reflect the real history size."""
         latest = _latest(score=80.0, score_error=0.1)
         history = _history([100.0, 100.0, 100.0, 100.0])  # 4 points
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         avg_regs = [r for r in regs if "-run avg" in r["type"]]
         self.assertEqual(len(avg_regs), 1)
         self.assertEqual(avg_regs[0]["type"], "vs 4-run avg")
@@ -147,7 +161,7 @@ class TestCheckRegressions(unittest.TestCase):
         """Regression dicts carry the fields the Zulip formatter depends on."""
         latest = _latest(score=70.0, score_error=0.1, query="ic5", suite="MultiThread")
         history = _history([100.0] * 14, suite="MultiThread", query="ic5")
-        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        regs, _ = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
         self.assertTrue(regs)
         required = {"query", "suite", "type", "score", "baseline", "delta_pct", "threshold"}
         for r in regs:
@@ -182,6 +196,52 @@ class TestParseLatestResults(unittest.TestCase):
         }]
         out = alerter.parse_latest_results(data)
         self.assertIn(("queryA", "SomeOtherBench"), out)
+
+    def test_malformed_benchmark_name_skipped(self):
+        """Benchmark names without at least one dot are skipped, not crashed on.
+
+        JMH always produces fully-qualified names, but a defensive guard
+        prevents an unexpected input shape from crashing the whole alerter
+        with IndexError before any regression is even checked.
+        """
+        data = [
+            {"benchmark": "noDots", "primaryMetric": {"score": 1.0, "scoreError": 0.0}},
+            {"benchmark": "", "primaryMetric": {"score": 1.0, "scoreError": 0.0}},
+            # A well-formed entry alongside the malformed ones should still parse.
+            {
+                "benchmark": "com.example.SomeBench.queryOk",
+                "primaryMetric": {"score": 2.0, "scoreError": 0.0},
+            },
+        ]
+        out = alerter.parse_latest_results(data)
+        self.assertIn(("queryOk", "SomeBench"), out)
+        # Malformed entries must be absent from the output.
+        self.assertNotIn(("noDots", "noDots"), out)
+        self.assertEqual(len(out), 1)
+
+
+class TestFluxEscape(unittest.TestCase):
+    """Pin that interpolated Flux values are escaped against syntax breakage.
+
+    If a branch name ever contains `"` or `\\`, unescaped interpolation would
+    corrupt the query. These tests are small, but they'd have prevented a
+    real outage on a weirdly-named branch.
+    """
+
+    def test_plain_string_unchanged(self):
+        self.assertEqual(alerter._flux_escape("develop"), "develop")
+
+    def test_double_quote_escaped(self):
+        self.assertEqual(alerter._flux_escape('weird"branch'), 'weird\\"branch')
+
+    def test_backslash_escaped_before_quote(self):
+        # Must escape `\` first, otherwise escaping `"` → `\"` creates an
+        # ambiguous sequence. Check the doubled-backslash output explicitly.
+        self.assertEqual(alerter._flux_escape("a\\b"), "a\\\\b")
+        self.assertEqual(alerter._flux_escape('a\\"b'), 'a\\\\\\"b')
+
+    def test_non_string_coerced(self):
+        self.assertEqual(alerter._flux_escape(42), "42")
 
 
 if __name__ == "__main__":

--- a/jmh-ldbc/tests/test_jmh_regression_alert.py
+++ b/jmh-ldbc/tests/test_jmh_regression_alert.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Unit tests for jmh-regression-alert.check_regressions().
+
+The script filename contains a dash, so we load it via importlib instead of a
+normal import. These tests pin the regression-detection math so a future
+refactor cannot silently break alert firing (cf. the 2026-04-14 incident where
+the Grafana Flux rule was mathematically incapable of firing for months
+without anyone noticing).
+
+Run locally:
+    python3 -m unittest jmh-ldbc/tests/test_jmh_regression_alert.py
+or, with discovery:
+    python3 -m unittest discover -s jmh-ldbc/tests
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "jmh-regression-alert.py"
+_spec = importlib.util.spec_from_file_location("jmh_regression_alert", SCRIPT_PATH)
+alerter = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(alerter)
+
+
+# Shorthand: default thresholds matching the CLI defaults (10% run-over-run,
+# 5% rolling avg, 10% score-error noise threshold).
+ROR = 10.0
+AVG = 5.0
+NOISE = 10.0
+
+
+def _latest(score, score_error, query="q1", suite="SingleThread"):
+    """Build a one-entry `latest` dict as parse_latest_results() would."""
+    return {(query, suite): {"score": score, "score_error": score_error}}
+
+
+def _history(scores, suite="SingleThread", query="q1"):
+    """Build a history dict keyed by suite then query, oldest first."""
+    return {suite: {query: list(scores)}}
+
+
+class TestCheckRegressions(unittest.TestCase):
+    def test_clean_run_no_regressions(self):
+        """Score matches previous run and 14-run mean → no alert."""
+        # Previous score and mean are both 100 → 0% delta.
+        latest = _latest(score=100.0, score_error=1.0)
+        history = _history([100.0] * 14)
+        self.assertEqual(
+            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
+        )
+
+    def test_run_over_run_regression_fires(self):
+        """Latest score 15% below previous → run-over-run alert fires."""
+        latest = _latest(score=85.0, score_error=1.0)
+        # hist[-1] is the most recent previous run (script reads in chrono order).
+        history = _history([100.0, 100.0, 100.0])
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        types = sorted(r["type"] for r in regs)
+        # Both checks should trigger: 15% < -10 (run-over-run) and < -5 (vs avg).
+        self.assertIn("run-over-run", types)
+        ror = [r for r in regs if r["type"] == "run-over-run"][0]
+        self.assertAlmostEqual(ror["delta_pct"], -15.0, places=3)
+        self.assertEqual(ror["query"], "q1")
+        self.assertEqual(ror["suite"], "SingleThread")
+
+    def test_below_threshold_does_not_fire(self):
+        """A 9% drop should NOT fire run-over-run (strict > threshold)."""
+        latest = _latest(score=91.0, score_error=1.0)
+        history = _history([100.0])  # only 1 point → avg check is skipped
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertEqual([r for r in regs if r["type"] == "run-over-run"], [])
+
+    def test_exact_threshold_does_not_fire(self):
+        """Exactly -10% drop is NOT a run-over-run regression (delta < -10 strict)."""
+        latest = _latest(score=90.0, score_error=1.0)
+        history = _history([100.0])
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertEqual([r for r in regs if r["type"] == "run-over-run"], [])
+
+    def test_rolling_avg_regression_fires_without_run_over_run(self):
+        """Latest is 6% below the 14-run avg but only 2% below the last run."""
+        latest = _latest(score=94.0, score_error=1.0)
+        # Average is 100; previous run is 96 → run-over-run delta is -2.08%.
+        history = _history([100.0] * 13 + [96.0])
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        types = [r["type"] for r in regs]
+        self.assertNotIn("run-over-run", types)
+        self.assertTrue(any("-run avg" in t for t in types))
+        avg_reg = [r for r in regs if "-run avg" in r["type"]][0]
+        self.assertLess(avg_reg["delta_pct"], -AVG)
+
+    def test_noisy_benchmark_is_skipped(self):
+        """score_error / score > noise threshold → benchmark excluded entirely."""
+        # 40% score error on a 50% drop — we must NOT silently drop the alert
+        # when the underlying signal is noisy, but the script's contract is
+        # "skip noisy" — pin that behaviour explicitly so it can't drift.
+        latest = _latest(score=50.0, score_error=20.0)  # 40% noise
+        history = _history([100.0] * 14)
+        self.assertEqual(
+            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
+        )
+
+    def test_empty_history_skipped(self):
+        """No historical data for this (query, suite) → no alert."""
+        latest = _latest(score=1.0, score_error=0.01)
+        history = {"SingleThread": {}, "MultiThread": {}}
+        self.assertEqual(
+            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
+        )
+
+    def test_missing_suite_in_history_skipped(self):
+        """Suite key absent from history → check returns nothing (no KeyError)."""
+        latest = _latest(score=1.0, score_error=0.01, suite="SingleThread")
+        history = {}  # no suites at all
+        self.assertEqual(
+            alerter.check_regressions(latest, history, ROR, AVG, NOISE), []
+        )
+
+    def test_prev_score_zero_skips_run_over_run(self):
+        """prev_score == 0 must not raise ZeroDivisionError."""
+        latest = _latest(score=10.0, score_error=0.1)
+        history = _history([0.0])
+        # Should not raise; run-over-run is skipped for prev=0.
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertEqual([r for r in regs if r["type"] == "run-over-run"], [])
+
+    def test_short_history_skips_avg_but_keeps_run_over_run(self):
+        """< 3 historical points → avg check skipped, run-over-run still runs."""
+        latest = _latest(score=50.0, score_error=0.1)
+        history = _history([100.0, 100.0])  # only 2 points
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        types = [r["type"] for r in regs]
+        self.assertIn("run-over-run", types)
+        self.assertFalse(any("-run avg" in t for t in types))
+
+    def test_avg_type_includes_actual_history_length(self):
+        """The 'vs N-run avg' label should reflect the real history size."""
+        latest = _latest(score=80.0, score_error=0.1)
+        history = _history([100.0, 100.0, 100.0, 100.0])  # 4 points
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        avg_regs = [r for r in regs if "-run avg" in r["type"]]
+        self.assertEqual(len(avg_regs), 1)
+        self.assertEqual(avg_regs[0]["type"], "vs 4-run avg")
+
+    def test_regression_record_shape(self):
+        """Regression dicts carry the fields the Zulip formatter depends on."""
+        latest = _latest(score=70.0, score_error=0.1, query="ic5", suite="MultiThread")
+        history = _history([100.0] * 14, suite="MultiThread", query="ic5")
+        regs = alerter.check_regressions(latest, history, ROR, AVG, NOISE)
+        self.assertTrue(regs)
+        required = {"query", "suite", "type", "score", "baseline", "delta_pct", "threshold"}
+        for r in regs:
+            self.assertTrue(required.issubset(r.keys()),
+                            msg=f"missing fields in {r.keys()}")
+            self.assertEqual(r["query"], "ic5")
+            self.assertEqual(r["suite"], "MultiThread")
+
+
+class TestParseLatestResults(unittest.TestCase):
+    def test_single_thread_suite_detection(self):
+        data = [{
+            "benchmark": "com.jetbrains.youtrackdb.benchmarks.ldbc.LdbcSingleThreadBenchmark.is1_personProfile",
+            "primaryMetric": {"score": 42.0, "scoreError": 1.0},
+        }]
+        out = alerter.parse_latest_results(data)
+        self.assertIn(("is1_personProfile", "SingleThread"), out)
+
+    def test_multi_thread_suite_detection(self):
+        data = [{
+            "benchmark": "com.jetbrains.youtrackdb.benchmarks.ldbc.LdbcMultiThreadBenchmark.ic5_newGroups",
+            "primaryMetric": {"score": 7.0, "scoreError": 0.1},
+        }]
+        out = alerter.parse_latest_results(data)
+        self.assertIn(("ic5_newGroups", "MultiThread"), out)
+
+    def test_fallback_suite_uses_class_name(self):
+        """Class names without SingleThread/MultiThread fall back to the raw class."""
+        data = [{
+            "benchmark": "com.example.SomeOtherBench.queryA",
+            "primaryMetric": {"score": 1.0, "scoreError": 0.0},
+        }]
+        out = alerter.parse_latest_results(data)
+        self.assertIn(("queryA", "SomeOtherBench"), out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The two Grafana regression rules (run-over-run and below-14-run-avg) were silently green: their Flux noise-suppression step ran `limit(n: 2) |> first()` over a grouped stream where `score` and `score_error` lived on separate rows at the same timestamp, so after pivot one column was always NULL and the predicate dropped every row. The join against that empty noise table left the alert with no data for any benchmark, and `noDataState=OK` resolved the whole thing as healthy — which is exactly what we saw on 2026-04-14 when a real regression landed unnoticed.

Rather than rewrite the Flux (where any silent-data-shape change in the pipeline can mute alerts again), make Python-in-CI the source of truth. The alerter already understands our benchmark shape, is trivially unit-testable, and fails loudly when it breaks.

## Summary

- Wire `jmh-regression-alert.py` into the nightly workflow right after the InfluxDB push (ordering is deliberate and documented inline). No `|| true` — an alerter crash fails the job.
- Tighten the alerter against silent-drop failure modes:
  - Refuse to treat an empty InfluxDB response as "no regressions" (bucket typo / org drift / wrong branch filter was the exact mode the rewrite was meant to eliminate). Opt-in via `--allow-empty-history` for legitimate first-run-on-a-new-branch cases.
  - Escape Flux string interpolation of bucket/suite/branch so unusual-but-legal branch names cannot break query syntax.
  - `check_regressions` now returns skipped-noisy benchmarks alongside regressions, and `main()` logs each skip so a permanently-noisy query cannot become a permanently-unmonitored one.
  - `parse_latest_results` guards `rsplit` length so a malformed benchmark entry warns-and-skips instead of crashing the whole alerter.
- Reduce Grafana to a single liveness probe (`jmh-data-freshness`): if the newest `jmh_benchmark` point on develop is older than 36h the pipeline itself is broken — Python cannot alert on its own absence. `noDataState=Alerting` guards against an empty bucket.
- Add a `jmh-alerter-tests.yml` workflow (with `workflow_dispatch` for manual re-runs) and 20 unit tests covering signal / noise / boundary / shape cases, plus the flux-escape helper, malformed-benchmark guard, and skipped-noisy return channel.

## Test plan

- [x] `python3 -m unittest discover -s jmh-ldbc/tests -v` — 20 tests pass locally
- [ ] New `jmh-alerter-tests` workflow runs green on this PR
- [ ] After merge: next nightly `ldbc-jmh-nightly` run successfully pushes results, runs the alerter step, and Grafana `jmh-data-freshness` probe stays green