### PR TITLE
Bump io.youtrackdb:gremlin-core from 3.8.1-fccfc5a-SNAPSHOT to 3.8.1-af9db90-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <log4j.version>2.25.4</log4j.version>
     <jackson.verson>2.21.2</jackson.verson>
     <toolchain.jdk.version>[21,)</toolchain.jdk.version>
-    <gremlin.version>3.8.1-fccfc5a-SNAPSHOT</gremlin.version>
+    <gremlin.version>3.8.1-af9db90-SNAPSHOT</gremlin.version>
     <hamcrest.version>3.0</hamcrest.version>
     <cucumber.version>7.34.3</cucumber.version>
     <docker.platforms>linux/amd64,linux/arm64/v8</docker.platforms>


### PR DESCRIPTION
#### Motivation:

Picks up the latest changes from the io.youtrackdb TinkerPop fork (commit `af9db90`, replacing `fccfc5a`).

The `gremlin.version` property is shared by all `io.youtrackdb` gremlin-* artifacts declared in `<dependencyManagement>` (gremlin-core, gremlin-groovy, tinkergraph-gremlin, gremlin-test, gremlin-driver, gremlin-server, gremlin-util, gremlin-console, gremlin-language), so a single property bump moves them all in lockstep — which is required because the fork ships them as a coordinated set.

#### Test plan:

- [ ] CI unit tests pass
- [ ] CI integration tests pass
- [ ] TinkerPop Cucumber feature tests pass in `core` and `embedded` modules