### PR TITLE
Add concrete mcp-steroid invocation guidance to review prompts

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -38,6 +38,13 @@ any finding that depends on a symbol search. Before the first
 symbol audit, call `steroid_list_projects` once to confirm the open
 project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Review Modes
 
 Determine which mode to use based on the user's request. If ambiguous, ask the user.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -38,12 +38,10 @@ any finding that depends on a symbol search. Before the first
 symbol audit, call `steroid_list_projects` once to confirm the open
 project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Review Modes
 

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -36,6 +36,13 @@ depends on a symbol search. Before the first symbol audit, call
 `steroid_list_projects` once to confirm the open project matches
 the PR's checkout.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Review Process
 
 ### Step 1: Gather PR Context

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -36,12 +36,10 @@ depends on a symbol search. Before the first symbol audit, call
 `steroid_list_projects` once to confirm the open project matches
 the PR's checkout.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Review Process
 

--- a/.claude/agents/review-bugs-concurrency.md
+++ b/.claude/agents/review-bugs-concurrency.md
@@ -35,12 +35,10 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-bugs-concurrency.md
+++ b/.claude/agents/review-bugs-concurrency.md
@@ -35,6 +35,13 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review the provided code changes **only for potential bugs and concurrency issues**. Do not review for code style, security, performance, or crash safety — other reviewers handle those dimensions.

--- a/.claude/agents/review-code-quality.md
+++ b/.claude/agents/review-code-quality.md
@@ -32,6 +32,13 @@ any finding that depends on a symbol search. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open project
 matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review the provided code changes **only for code quality and conventions**. Do not review for security, performance, concurrency, or crash safety — other reviewers handle those dimensions.

--- a/.claude/agents/review-code-quality.md
+++ b/.claude/agents/review-code-quality.md
@@ -32,12 +32,10 @@ any finding that depends on a symbol search. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open project
 matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-crash-safety.md
+++ b/.claude/agents/review-crash-safety.md
@@ -36,6 +36,13 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review the provided code changes **only for crash safety and durability**. Do not review for code style, security, performance, or general bugs — other reviewers handle those dimensions.

--- a/.claude/agents/review-crash-safety.md
+++ b/.claude/agents/review-crash-safety.md
@@ -36,12 +36,10 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-performance.md
+++ b/.claude/agents/review-performance.md
@@ -33,12 +33,10 @@ accuracy caveat to any finding that depends on a caller search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-performance.md
+++ b/.claude/agents/review-performance.md
@@ -33,6 +33,13 @@ accuracy caveat to any finding that depends on a caller search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review the provided code changes **only for performance implications**. Do not review for code style, security, concurrency correctness, or crash safety — other reviewers handle those dimensions.

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -35,6 +35,13 @@ any finding that depends on a caller / reachability search. Before
 the first symbol audit, call `steroid_list_projects` once to confirm
 the open project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review the provided code changes **only for security implications**. Do not review for code style, performance, concurrency, or crash safety — other reviewers handle those dimensions.

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -35,12 +35,10 @@ any finding that depends on a caller / reachability search. Before
 the first symbol audit, call `steroid_list_projects` once to confirm
 the open project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -31,12 +31,10 @@ that depends on a caller / override search. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open project
 matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -31,6 +31,13 @@ that depends on a caller / override search. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open project
 matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review test code **only for behavior quality, assertion precision, and exception testing**. Do not review for corner case coverage, test structure, concurrency patterns, or crash safety patterns — other reviewers handle those dimensions.

--- a/.claude/agents/review-test-completeness.md
+++ b/.claude/agents/review-test-completeness.md
@@ -33,12 +33,10 @@ finding that depends on a "this is the only caller / override"
 claim. Before the first symbol audit, call `steroid_list_projects`
 once to confirm the open project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-test-completeness.md
+++ b/.claude/agents/review-test-completeness.md
@@ -33,6 +33,13 @@ finding that depends on a "this is the only caller / override"
 claim. Before the first symbol audit, call `steroid_list_projects`
 once to confirm the open project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review test code **only for missing corner cases, boundary conditions, and test data quality**. Do not review for assertion precision, test structure, concurrency, or crash safety — other reviewers handle those dimensions.

--- a/.claude/agents/review-test-concurrency.md
+++ b/.claude/agents/review-test-concurrency.md
@@ -34,6 +34,13 @@ implementer enumeration. Before the first symbol audit, call
 `steroid_list_projects` once to confirm the open project matches
 the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review test code **only for concurrency testing quality**. Do not review for assertion precision, corner cases, test structure, or crash safety — other reviewers handle those dimensions.

--- a/.claude/agents/review-test-concurrency.md
+++ b/.claude/agents/review-test-concurrency.md
@@ -34,12 +34,10 @@ implementer enumeration. Before the first symbol audit, call
 `steroid_list_projects` once to confirm the open project matches
 the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-test-crash-safety.md
+++ b/.claude/agents/review-test-crash-safety.md
@@ -34,12 +34,10 @@ producers/consumers of a WAL record type. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open
 project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/review-test-crash-safety.md
+++ b/.claude/agents/review-test-crash-safety.md
@@ -34,6 +34,13 @@ producers/consumers of a WAL record type. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open
 project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review test code **only for crash safety testing quality and production assert statements**. Do not review for assertion precision, corner cases, test structure, or concurrency — other reviewers handle those dimensions.

--- a/.claude/agents/review-test-structure.md
+++ b/.claude/agents/review-test-structure.md
@@ -26,6 +26,13 @@ in any finding that hinges on enumerating subclasses or callers.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Your Mission
 
 Review test code **only for isolation, independence, readability, and documentation quality**. Do not review for assertion precision, corner cases, concurrency, or crash safety — other reviewers handle those dimensions.

--- a/.claude/agents/review-test-structure.md
+++ b/.claude/agents/review-test-structure.md
@@ -26,12 +26,10 @@ in any finding that hinges on enumerating subclasses or callers.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Your Mission
 

--- a/.claude/agents/test-quality-reviewer.md
+++ b/.claude/agents/test-quality-reviewer.md
@@ -40,6 +40,13 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once
 to confirm the open project matches the working tree.
 
+**How to invoke:** PSI queries (find-usages, find-implementations,
+type-hierarchy) run via `steroid_execute_code`, which evaluates a
+Kotlin snippet against the PSI tree — there is no dedicated
+`find_usages` tool. mcp-steroid tools are deferred, so load schemas
+via ToolSearch first. For Kotlin recipes, fetch the
+`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+
 ## Review Modes
 
 Determine which mode to use based on the user's request. If ambiguous, ask the user.

--- a/.claude/agents/test-quality-reviewer.md
+++ b/.claude/agents/test-quality-reviewer.md
@@ -40,12 +40,10 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once
 to confirm the open project matches the working tree.
 
-**How to invoke:** PSI queries (find-usages, find-implementations,
-type-hierarchy) run via `steroid_execute_code`, which evaluates a
-Kotlin snippet against the PSI tree — there is no dedicated
-`find_usages` tool. mcp-steroid tools are deferred, so load schemas
-via ToolSearch first. For Kotlin recipes, fetch the
-`coding-with-intellij-psi` skill via `steroid_fetch_resource`.
+**How to invoke:**
+- PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ## Review Modes
 

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -87,15 +87,11 @@ string literals, and orientation. If mcp-steroid is unreachable in
 this session, fall back to grep and add an explicit reference-accuracy
 caveat to any challenge that depends on a symbol search.
 
-**How to invoke:** the MCP server is `mcp-steroid` (its tools are
-deferred — load schemas via ToolSearch first). Call
-`steroid_list_projects` once at session start to confirm the IDE has
-the right project open and matches the working tree, then run PSI
-queries (find-usages, find-implementations, type-hierarchy) via
-`steroid_execute_code`, which evaluates a Kotlin snippet against the
-PSI tree — there is no dedicated `find_usages` tool. For Kotlin
-recipes, fetch the `coding-with-intellij-psi` skill via
-`steroid_fetch_resource`.
+**How to invoke:**
+- The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
+- Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.
+- Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 DECISION CHALLENGES
 - For each Decision Record relevant to this track: argue for the best

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -87,6 +87,16 @@ string literals, and orientation. If mcp-steroid is unreachable in
 this session, fall back to grep and add an explicit reference-accuracy
 caveat to any challenge that depends on a symbol search.
 
+**How to invoke:** the MCP server is `mcp-steroid` (its tools are
+deferred — load schemas via ToolSearch first). Call
+`steroid_list_projects` once at session start to confirm the IDE has
+the right project open and matches the working tree, then run PSI
+queries (find-usages, find-implementations, type-hierarchy) via
+`steroid_execute_code`, which evaluates a Kotlin snippet against the
+PSI tree — there is no dedicated `find_usages` tool. For Kotlin
+recipes, fetch the `coding-with-intellij-psi` skill via
+`steroid_fetch_resource`.
+
 DECISION CHALLENGES
 - For each Decision Record relevant to this track: argue for the best
   rejected alternative using codebase evidence.

--- a/.claude/workflow/prompts/consistency-gate-verification.md
+++ b/.claude/workflow/prompts/consistency-gate-verification.md
@@ -46,15 +46,11 @@ unreachable. The original finding may have been generated against
 grep — verifying the fix with PSI catches subtle mismatches that grep
 missed.
 
-**How to invoke:** the MCP server is `mcp-steroid` (its tools are
-deferred — load schemas via ToolSearch first). Call
-`steroid_list_projects` once at session start to confirm the IDE has
-the right project open and matches the working tree, then run PSI
-queries (find-usages, find-implementations, type-hierarchy) via
-`steroid_execute_code`, which evaluates a Kotlin snippet against the
-PSI tree — there is no dedicated `find_usages` tool. For Kotlin
-recipes, fetch the `coding-with-intellij-psi` skill via
-`steroid_fetch_resource`.
+**How to invoke:**
+- The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
+- Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.
+- Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ```markdown
 #### Verify CR<N>: <finding title>

--- a/.claude/workflow/prompts/consistency-gate-verification.md
+++ b/.claude/workflow/prompts/consistency-gate-verification.md
@@ -46,6 +46,16 @@ unreachable. The original finding may have been generated against
 grep — verifying the fix with PSI catches subtle mismatches that grep
 missed.
 
+**How to invoke:** the MCP server is `mcp-steroid` (its tools are
+deferred — load schemas via ToolSearch first). Call
+`steroid_list_projects` once at session start to confirm the IDE has
+the right project open and matches the working tree, then run PSI
+queries (find-usages, find-implementations, type-hierarchy) via
+`steroid_execute_code`, which evaluates a Kotlin snippet against the
+PSI tree — there is no dedicated `find_usages` tool. For Kotlin
+recipes, fetch the `coding-with-intellij-psi` skill via
+`steroid_fetch_resource`.
+
 ```markdown
 #### Verify CR<N>: <finding title>
 - **Original issue**: <what was wrong — from the finding>

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -150,6 +150,16 @@ is unreachable in this session, fall back to grep and add an explicit
 reference-accuracy caveat to any finding that depends on a symbol
 search.
 
+**How to invoke:** the MCP server is `mcp-steroid` (its tools are
+deferred — load schemas via ToolSearch first). Call
+`steroid_list_projects` once at session start to confirm the IDE has
+the right project open and matches the working tree, then run PSI
+queries (find-usages, find-implementations, type-hierarchy) via
+`steroid_execute_code`, which evaluates a Kotlin snippet against the
+PSI tree — there is no dedicated `find_usages` tool. For Kotlin
+recipes, fetch the `coding-with-intellij-psi` skill via
+`steroid_fetch_resource`.
+
 1. **Read the plan, backlog, and design document** thoroughly.
 2. **Identify all code references** — every class, interface, method, SPI,
    configuration parameter, or file path mentioned in the plan, backlog,

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -150,15 +150,11 @@ is unreachable in this session, fall back to grep and add an explicit
 reference-accuracy caveat to any finding that depends on a symbol
 search.
 
-**How to invoke:** the MCP server is `mcp-steroid` (its tools are
-deferred — load schemas via ToolSearch first). Call
-`steroid_list_projects` once at session start to confirm the IDE has
-the right project open and matches the working tree, then run PSI
-queries (find-usages, find-implementations, type-hierarchy) via
-`steroid_execute_code`, which evaluates a Kotlin snippet against the
-PSI tree — there is no dedicated `find_usages` tool. For Kotlin
-recipes, fetch the `coding-with-intellij-psi` skill via
-`steroid_fetch_resource`.
+**How to invoke:**
+- The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
+- Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.
+- Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 1. **Read the plan, backlog, and design document** thoroughly.
 2. **Identify all code references** — every class, interface, method, SPI,

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -42,15 +42,11 @@ future readers of `design-final.md` and `adr.md`. Fall back to grep
 only when mcp-steroid is unreachable, and note any reference-accuracy
 caveats inline.
 
-**How to invoke:** the MCP server is `mcp-steroid` (its tools are
-deferred — load schemas via ToolSearch first). Call
-`steroid_list_projects` once at session start to confirm the IDE has
-the right project open and matches the working tree, then run PSI
-queries (find-usages, find-implementations, type-hierarchy) via
-`steroid_execute_code`, which evaluates a Kotlin snippet against the
-PSI tree — there is no dedicated `find_usages` tool. For Kotlin
-recipes, fetch the `coding-with-intellij-psi` skill via
-`steroid_fetch_resource`.
+**How to invoke:**
+- The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
+- Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.
+- Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 **Step 3 — Produce the two final artifacts.**
 

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -42,6 +42,16 @@ future readers of `design-final.md` and `adr.md`. Fall back to grep
 only when mcp-steroid is unreachable, and note any reference-accuracy
 caveats inline.
 
+**How to invoke:** the MCP server is `mcp-steroid` (its tools are
+deferred — load schemas via ToolSearch first). Call
+`steroid_list_projects` once at session start to confirm the IDE has
+the right project open and matches the working tree, then run PSI
+queries (find-usages, find-implementations, type-hierarchy) via
+`steroid_execute_code`, which evaluates a Kotlin snippet against the
+PSI tree — there is no dedicated `find_usages` tool. For Kotlin
+recipes, fetch the `coding-with-intellij-psi` skill via
+`steroid_fetch_resource`.
+
 **Step 3 — Produce the two final artifacts.**
 
 ### Ephemeral identifier rule (applies to BOTH artifacts)

--- a/.claude/workflow/prompts/review-gate-verification.md
+++ b/.claude/workflow/prompts/review-gate-verification.md
@@ -38,15 +38,11 @@ only when mcp-steroid is unreachable. The original finding may have
 been generated against grep — verifying the fix with PSI catches
 subtle mismatches that grep missed.
 
-**How to invoke:** the MCP server is `mcp-steroid` (its tools are
-deferred — load schemas via ToolSearch first). Call
-`steroid_list_projects` once at session start to confirm the IDE has
-the right project open and matches the working tree, then run PSI
-queries (find-usages, find-implementations, type-hierarchy) via
-`steroid_execute_code`, which evaluates a Kotlin snippet against the
-PSI tree — there is no dedicated `find_usages` tool. For Kotlin
-recipes, fetch the `coding-with-intellij-psi` skill via
-`steroid_fetch_resource`.
+**How to invoke:**
+- The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
+- Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.
+- Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 ```markdown
 #### Verify <PREFIX><N>: <finding title>

--- a/.claude/workflow/prompts/review-gate-verification.md
+++ b/.claude/workflow/prompts/review-gate-verification.md
@@ -38,6 +38,16 @@ only when mcp-steroid is unreachable. The original finding may have
 been generated against grep — verifying the fix with PSI catches
 subtle mismatches that grep missed.
 
+**How to invoke:** the MCP server is `mcp-steroid` (its tools are
+deferred — load schemas via ToolSearch first). Call
+`steroid_list_projects` once at session start to confirm the IDE has
+the right project open and matches the working tree, then run PSI
+queries (find-usages, find-implementations, type-hierarchy) via
+`steroid_execute_code`, which evaluates a Kotlin snippet against the
+PSI tree — there is no dedicated `find_usages` tool. For Kotlin
+recipes, fetch the `coding-with-intellij-psi` skill via
+`steroid_fetch_resource`.
+
 ```markdown
 #### Verify <PREFIX><N>: <finding title>
 - **Original issue**: <what was wrong>

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -80,15 +80,11 @@ mcp-steroid is unreachable in this session, fall back to grep and add
 an explicit reference-accuracy caveat to any finding that depends on
 a symbol search.
 
-**How to invoke:** the MCP server is `mcp-steroid` (its tools are
-deferred — load schemas via ToolSearch first). Call
-`steroid_list_projects` once at session start to confirm the IDE has
-the right project open and matches the working tree, then run PSI
-queries (find-usages, find-implementations, type-hierarchy) via
-`steroid_execute_code`, which evaluates a Kotlin snippet against the
-PSI tree — there is no dedicated `find_usages` tool. For Kotlin
-recipes, fetch the `coding-with-intellij-psi` skill via
-`steroid_fetch_resource`.
+**How to invoke:**
+- The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
+- Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.
+- Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 Review against these criteria:
 

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -80,6 +80,16 @@ mcp-steroid is unreachable in this session, fall back to grep and add
 an explicit reference-accuracy caveat to any finding that depends on
 a symbol search.
 
+**How to invoke:** the MCP server is `mcp-steroid` (its tools are
+deferred — load schemas via ToolSearch first). Call
+`steroid_list_projects` once at session start to confirm the IDE has
+the right project open and matches the working tree, then run PSI
+queries (find-usages, find-implementations, type-hierarchy) via
+`steroid_execute_code`, which evaluates a Kotlin snippet against the
+PSI tree — there is no dedicated `find_usages` tool. For Kotlin
+recipes, fetch the `coding-with-intellij-psi` skill via
+`steroid_fetch_resource`.
+
 Review against these criteria:
 
 CRITICAL PATH EXPOSURE

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -83,15 +83,11 @@ unreachable in this session, fall back to grep and add an explicit
 reference-accuracy caveat to any finding that depends on a symbol
 search.
 
-**How to invoke:** the MCP server is `mcp-steroid` (its tools are
-deferred — load schemas via ToolSearch first). Call
-`steroid_list_projects` once at session start to confirm the IDE has
-the right project open and matches the working tree, then run PSI
-queries (find-usages, find-implementations, type-hierarchy) via
-`steroid_execute_code`, which evaluates a Kotlin snippet against the
-PSI tree — there is no dedicated `find_usages` tool. For Kotlin
-recipes, fetch the `coding-with-intellij-psi` skill via
-`steroid_fetch_resource`.
+**How to invoke:**
+- The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
+- Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.
+- Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
+- For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
 Use episodes from completed tracks to inform your review — they may
 reveal codebase realities that the original plan didn't anticipate.

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -83,6 +83,16 @@ unreachable in this session, fall back to grep and add an explicit
 reference-accuracy caveat to any finding that depends on a symbol
 search.
 
+**How to invoke:** the MCP server is `mcp-steroid` (its tools are
+deferred — load schemas via ToolSearch first). Call
+`steroid_list_projects` once at session start to confirm the IDE has
+the right project open and matches the working tree, then run PSI
+queries (find-usages, find-implementations, type-hierarchy) via
+`steroid_execute_code`, which evaluates a Kotlin snippet against the
+PSI tree — there is no dedicated `find_usages` tool. For Kotlin
+recipes, fetch the `coding-with-intellij-psi` skill via
+`steroid_fetch_resource`.
+
 Use episodes from completed tracks to inform your review — they may
 reveal codebase realities that the original plan didn't anticipate.
 


### PR DESCRIPTION
## Summary

The PSI tooling sections in the workflow review prompts and agent prompts mentioned `mcp-steroid` abstractly but didn't name the actual MCP tools sub-agents need to call. Sub-agents that haven't seen the convention default to grep — defeating the reference-accuracy guarantee these blocks were meant to enforce.

This change appends a **How to invoke** paragraph to each PSI block, naming the concrete tool calls:

- `mcp-steroid` as the MCP server (workflow prompts only — the 13 agents already named it)
- `steroid_list_projects` for the session-start bootstrap (workflow prompts only — agents already named it)
- `steroid_execute_code` as the actual mechanism for PSI queries (there's no dedicated `find_usages` tool — PSI runs as a Kotlin snippet against the IDE's PSI tree)
- `steroid_fetch_resource` of the `coding-with-intellij-psi` skill for Kotlin recipes
- ToolSearch as the way to load the deferred mcp-steroid tool schemas

## Scope

- **7 workflow prompts** under `.claude/workflow/prompts/`: `adversarial-review`, `consistency-review`, `consistency-gate-verification`, `create-final-design`, `risk-review`, `review-gate-verification`, `technical-review`
- **13 agent prompts** under `.claude/agents/`: `code-reviewer`, `pr-reviewer`, all `review-*` and `test-quality-reviewer`

## Motivation

Cross-cutting code-review and design-review work in this repo relies on reference-accurate symbol audits (every caller / every override / every implementer). Grep silently misses polymorphic call sites, generic dispatch, and identifiers inside Javadoc/comments. The PSI blocks already noted this risk, but stopped one step short of telling sub-agents the actual tool names — so unfamiliar sub-agents would still route through grep. This change closes that gap.

## Out of scope

The two structural-review prompts (`structural-review.md`, `structural-gate-verification.md`) are intentionally untouched — they audit plan structure, not code, so PSI is not applicable.

## Test plan

- [ ] Spawn each affected agent on a small change and verify the PSI block now reads as actionable (server name, bootstrap, execution mechanism, skill resource all present)
- [ ] Confirm the structural-review prompts remain unchanged