### PR TITLE
Clarify mcp-steroid routing rules as non-exhaustive

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -38,6 +38,13 @@ any finding that depends on a symbol search. Before the first
 symbol audit, call `steroid_list_projects` once to confirm the open
 project matches the working tree.
 
+The reference-accuracy facts and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a
+finding wrong? When in doubt, route through PSI.
+`~/.claude/CLAUDE.md` (sections "MCP Steroid" and "Grep vs PSI —
+when to switch") is the last authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/pr-reviewer.md
+++ b/.claude/agents/pr-reviewer.md
@@ -36,6 +36,13 @@ depends on a symbol search. Before the first symbol audit, call
 `steroid_list_projects` once to confirm the open project matches
 the PR's checkout.
 
+The reference-accuracy facts and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a
+finding wrong? When in doubt, route through PSI.
+`~/.claude/CLAUDE.md` (sections "MCP Steroid" and "Grep vs PSI —
+when to switch") is the last authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-bugs-concurrency.md
+++ b/.claude/agents/review-bugs-concurrency.md
@@ -35,6 +35,14 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+The reference-accuracy facts and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a
+thread-safety, race-condition, or resource-leak claim wrong? When
+in doubt, route through PSI. `~/.claude/CLAUDE.md` (sections "MCP
+Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-code-quality.md
+++ b/.claude/agents/review-code-quality.md
@@ -32,6 +32,14 @@ any finding that depends on a symbol search. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open project
 matches the working tree.
 
+The check categories listed above are **illustrative, not
+exhaustive**. The operative criterion is reference accuracy —
+would a missed or spurious match make an API-boundary,
+duplication, or consistency finding wrong? When in doubt, route
+through PSI. `~/.claude/CLAUDE.md` (sections "MCP Steroid" and
+"Grep vs PSI — when to switch") is the last authoritative source
+for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-crash-safety.md
+++ b/.claude/agents/review-crash-safety.md
@@ -36,6 +36,14 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+The reference-accuracy questions and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a
+WAL-coverage, redo-completeness, or atomic-boundary claim wrong?
+When in doubt, route through PSI. `~/.claude/CLAUDE.md` (sections
+"MCP Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-performance.md
+++ b/.claude/agents/review-performance.md
@@ -33,6 +33,14 @@ accuracy caveat to any finding that depends on a caller search.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+The triage questions and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious caller make a
+hot-path, allocation-frequency, or lock-contention claim wrong?
+When in doubt, route through PSI. `~/.claude/CLAUDE.md` (sections
+"MCP Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -35,6 +35,14 @@ any finding that depends on a caller / reachability search. Before
 the first symbol audit, call `steroid_list_projects` once to confirm
 the open project matches the working tree.
 
+The taint-analysis questions and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious caller make a
+reachability, sink-coverage, or input-validation claim wrong?
+When in doubt, route through PSI. `~/.claude/CLAUDE.md` (sections
+"MCP Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-test-behavior.md
+++ b/.claude/agents/review-test-behavior.md
@@ -31,6 +31,14 @@ that depends on a caller / override search. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open project
 matches the working tree.
 
+The reference-accuracy questions and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a
+contract-coverage or assertion-precision finding wrong? When in
+doubt, route through PSI. `~/.claude/CLAUDE.md` (sections "MCP
+Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-test-completeness.md
+++ b/.claude/agents/review-test-completeness.md
@@ -33,6 +33,13 @@ finding that depends on a "this is the only caller / override"
 claim. Before the first symbol audit, call `steroid_list_projects`
 once to confirm the open project matches the working tree.
 
+The questions and grep-miss cases listed above are **illustrative,
+not exhaustive**. The operative criterion is reference accuracy —
+would a missed or spurious match make a corner-case or
+boundary-coverage gap claim wrong? When in doubt, route through
+PSI. `~/.claude/CLAUDE.md` (sections "MCP Steroid" and "Grep vs PSI
+— when to switch") is the last authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-test-concurrency.md
+++ b/.claude/agents/review-test-concurrency.md
@@ -34,6 +34,14 @@ implementer enumeration. Before the first symbol audit, call
 `steroid_list_projects` once to confirm the open project matches
 the working tree.
 
+The questions and grep-miss cases listed above are **illustrative,
+not exhaustive**. The operative criterion is reference accuracy —
+would a missed or spurious match make a thread-reachability,
+synchronizer-implementer, or lock-site claim wrong? When in doubt,
+route through PSI. `~/.claude/CLAUDE.md` (sections "MCP Steroid"
+and "Grep vs PSI — when to switch") is the last authoritative
+source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-test-crash-safety.md
+++ b/.claude/agents/review-test-crash-safety.md
@@ -34,6 +34,14 @@ producers/consumers of a WAL record type. Before the first symbol
 audit, call `steroid_list_projects` once to confirm the open
 project matches the working tree.
 
+The enumeration questions and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a
+redo-test, WAL-replay, or recovery-coverage claim wrong? When in
+doubt, route through PSI. `~/.claude/CLAUDE.md` (sections "MCP
+Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/review-test-structure.md
+++ b/.claude/agents/review-test-structure.md
@@ -26,6 +26,13 @@ in any finding that hinges on enumerating subclasses or callers.
 Before the first symbol audit, call `steroid_list_projects` once to
 confirm the open project matches the working tree.
 
+The questions listed above are **illustrative, not exhaustive**.
+The operative criterion is reference accuracy — would a missed or
+spurious match make an isolation, fixture-sharing, or
+base-class-fanout claim wrong? When in doubt, route through PSI.
+`~/.claude/CLAUDE.md` (sections "MCP Steroid" and "Grep vs PSI —
+when to switch") is the last authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/agents/test-quality-reviewer.md
+++ b/.claude/agents/test-quality-reviewer.md
@@ -40,6 +40,14 @@ accuracy caveat to any finding that depends on a symbol search.
 Before the first symbol audit, call `steroid_list_projects` once
 to confirm the open project matches the working tree.
 
+The reference-accuracy questions and grep-miss cases listed above
+are **illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a
+contract-coverage or behavior-completeness claim wrong? When in
+doubt, route through PSI. `~/.claude/CLAUDE.md` (sections "MCP
+Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - PSI queries (find-usages, find-implementations, type-hierarchy) run via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - `mcp-steroid` tools are deferred, so load their schemas via ToolSearch first.

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -260,7 +260,7 @@ polymorphic call site is "tests pass at the deletion commit but
 production breaks at runtime" — exactly the failure mode PSI exists to
 prevent.
 
-The bullet list above is **illustrative, not exhaustive**. The
+The examples listed above are **illustrative, not exhaustive**. The
 operative test is the criterion ("would a missed or spurious reference
 corrupt the result?"), not the example set. When a case isn't listed,
 apply the criterion; when in doubt, treat the audit as load-bearing

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -260,6 +260,14 @@ polymorphic call site is "tests pass at the deletion commit but
 production breaks at runtime" — exactly the failure mode PSI exists to
 prevent.
 
+The bullet list above is **illustrative, not exhaustive**. The
+operative test is the criterion ("would a missed or spurious reference
+corrupt the result?"), not the example set. When a case isn't listed,
+apply the criterion; when in doubt, treat the audit as load-bearing
+and route through PSI. `~/.claude/CLAUDE.md` (sections "MCP Steroid"
+and "Grep vs PSI — when to switch") is the last authoritative source
+for edge cases.
+
 This rule applies to design and research sessions too. Design
 conclusions often hinge on reference-accuracy facts that grep can
 silently miss — so research, Phase 1 planning, and Phase A track
@@ -296,6 +304,14 @@ refactors through the IDE. Two project-relevant defaults:
   `Edit`. After an IDE refactor, run Spotless on the affected modules
   and re-run the relevant tests — the engine doesn't enforce project
   formatting.
+
+The two examples above are **illustrative, not exhaustive** — they
+name the project-relevant defaults, not the full set of cases where
+mcp-steroid is the right route. The full Maven and refactoring
+routing tables live in `~/.claude/CLAUDE.md` (sections "Maven — when
+to route through mcp-steroid" and "Refactoring — IDE refactor vs raw
+Edit"); when a situation isn't covered here, that file is the last
+authoritative source.
 
 Both routes require the same `steroid_list_projects` preflight as PSI
 audits.

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -87,6 +87,13 @@ string literals, and orientation. If mcp-steroid is unreachable in
 this session, fall back to grep and add an explicit reference-accuracy
 caveat to any challenge that depends on a symbol search.
 
+The cases listed above are **illustrative, not exhaustive**. The
+operative criterion is reference accuracy — would a missed or
+spurious reference change the challenge's verdict? When in doubt,
+route through PSI. `~/.claude/CLAUDE.md` (sections "MCP Steroid" and
+"Grep vs PSI — when to switch") is the last authoritative source
+for edge cases.
+
 **How to invoke:**
 - The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
 - Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.

--- a/.claude/workflow/prompts/consistency-gate-verification.md
+++ b/.claude/workflow/prompts/consistency-gate-verification.md
@@ -46,6 +46,13 @@ unreachable. The original finding may have been generated against
 grep — verifying the fix with PSI catches subtle mismatches that grep
 missed.
 
+The re-check examples above are **illustrative, not exhaustive**. The
+operative criterion is reference accuracy — would a missed or spurious
+match make a verification verdict (VERIFIED / STILL OPEN / REGRESSION)
+wrong? When in doubt, route through PSI. `~/.claude/CLAUDE.md`
+(sections "MCP Steroid" and "Grep vs PSI — when to switch") is the
+last authoritative source for edge cases.
+
 **How to invoke:**
 - The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
 - Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -150,6 +150,13 @@ is unreachable in this session, fall back to grep and add an explicit
 reference-accuracy caveat to any finding that depends on a symbol
 search.
 
+The grep-miss cases listed above are **illustrative, not exhaustive**.
+The operative criterion is reference accuracy — would a missed or
+spurious match make a finding wrong (phantom reference reported, or
+real mismatch hidden)? When in doubt, route through PSI.
+`~/.claude/CLAUDE.md` (sections "MCP Steroid" and "Grep vs PSI — when
+to switch") is the last authoritative source for edge cases.
+
 **How to invoke:**
 - The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
 - Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -42,6 +42,14 @@ future readers of `design-final.md` and `adr.md`. Fall back to grep
 only when mcp-steroid is unreachable, and note any reference-accuracy
 caveats inline.
 
+The verification cases listed above are **illustrative, not
+exhaustive**. The operative criterion is reference accuracy — would
+a missed or spurious match make a diagram, signature, caller list,
+or "Implemented in" reference in the committed artifacts wrong?
+When in doubt, route through PSI. `~/.claude/CLAUDE.md` (sections
+"MCP Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
 - Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.

--- a/.claude/workflow/prompts/review-gate-verification.md
+++ b/.claude/workflow/prompts/review-gate-verification.md
@@ -38,6 +38,13 @@ only when mcp-steroid is unreachable. The original finding may have
 been generated against grep — verifying the fix with PSI catches
 subtle mismatches that grep missed.
 
+The re-check examples above are **illustrative, not exhaustive**. The
+operative criterion is reference accuracy — would a missed or spurious
+match make a verification verdict (VERIFIED / STILL OPEN / REGRESSION)
+wrong? When in doubt, route through PSI. `~/.claude/CLAUDE.md`
+(sections "MCP Steroid" and "Grep vs PSI — when to switch") is the
+last authoritative source for edge cases.
+
 **How to invoke:**
 - The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
 - Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -80,6 +80,14 @@ mcp-steroid is unreachable in this session, fall back to grep and add
 an explicit reference-accuracy caveat to any finding that depends on
 a symbol search.
 
+The exposure questions listed above are **illustrative, not
+exhaustive**. The operative criterion is reference accuracy — would a
+missed or spurious match change the risk verdict (under-counting blast
+radius, missing an existing safeguard, mis-locating a hot caller)?
+When in doubt, route through PSI. `~/.claude/CLAUDE.md` (sections
+"MCP Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
 - Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -83,6 +83,14 @@ unreachable in this session, fall back to grep and add an explicit
 reference-accuracy caveat to any finding that depends on a symbol
 search.
 
+The reference-accuracy questions and grep-miss cases listed above are
+**illustrative, not exhaustive**. The operative criterion is
+reference accuracy — would a missed or spurious match make a Phase A
+premise, edge-case trace, or integration finding wrong? When in
+doubt, route through PSI. `~/.claude/CLAUDE.md` (sections "MCP
+Steroid" and "Grep vs PSI — when to switch") is the last
+authoritative source for edge cases.
+
 **How to invoke:**
 - The MCP server is `mcp-steroid`. Its tools are deferred, so load their schemas via ToolSearch first.
 - Call `steroid_list_projects` once at session start to confirm the IDE has the right project open and matches the working tree.


### PR DESCRIPTION
#### Motivation

The PSI tooling sections in `.claude/workflow/conventions.md` (§1.4) and in
the workflow review prompts / dimensional review agents listed example use
cases — load-bearing audit shapes, grep-miss cases, Maven and refactoring
routing defaults — and trailed off with "etc." A reader skimming under
time pressure could plausibly treat the bullets as a *closed* set rather
than the *criterion* as load-bearing, which would cause grep to be used
for cases the criterion clearly covers but the example list happens not to
mention.

This PR makes the lists explicitly illustrative. After each example list,
a short paragraph now:

- States that the listed cases are **illustrative, not exhaustive**.
- Restates the operative criterion (e.g., "would a missed or spurious
  reference corrupt the result?", "would a missed or spurious caller
  change the verdict?") so readers can apply it to cases not in the
  list.
- Points at `~/.claude/CLAUDE.md` (sections "MCP Steroid" and "Grep vs
  PSI — when to switch") as the **last authoritative source** for edge
  cases — keeping a single canonical home for the routing rules and
  preventing the project-level reminders from drifting out of sync with
  the user-global rules.

This is a documentation-only change — no code, no behavior change for any
agent's deterministic logic. It tightens the prompts so the routing rule
is harder to misapply.

#### Changes

Modified 21 files (168 insertions, 0 deletions):

- `.claude/workflow/conventions.md` — added illustrative-not-exhaustive
  paragraphs after the load-bearing examples list (§1.4 "When PSI is
  required") and after the Maven/refactoring defaults block.
- `.claude/workflow/prompts/` (7 files) — `adversarial-review.md`,
  `consistency-review.md`, `consistency-gate-verification.md`,
  `risk-review.md`, `technical-review.md`, `create-final-design.md`,
  `review-gate-verification.md`. The two remaining workflow prompts
  (`structural-review.md`, `structural-gate-verification.md`) are
  plan-quality only — they explicitly do not read code, so PSI guidance
  doesn't apply to them.
- `.claude/agents/` (13 files) — every dimensional review agent
  (`code-reviewer`, `pr-reviewer`, `review-bugs-concurrency`,
  `review-code-quality`, `review-crash-safety`, `review-performance`,
  `review-security`, `review-test-behavior`, `review-test-completeness`,
  `review-test-concurrency`, `review-test-crash-safety`,
  `review-test-structure`, `test-quality-reviewer`).

#### Test plan

- [x] No code changes — no unit/integration tests required.
- [x] Manually verified each touched file contains both the
  "illustrative, not exhaustive" framing and a `~/.claude/CLAUDE.md`
  pointer.
- [x] Verified the two structural review files were intentionally
  skipped (they don't read the codebase).