### PR TITLE
YTDB-643: match edge chain cost fix

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -1420,9 +1420,8 @@ public enum GlobalConfiguration {
           + " vertex, so only 0 restores the schedule the planner produced"
           + " before the fold existed. Set to 0"
           + " to disable the fold entirely (rollback-only safety valve)."
-          + " Read once per plan construction: statements already in the"
-          + " execution-plan cache keep their existing schedule until the"
-          + " cache is evicted (any schema change, or a restart).",
+          + " Read once per plan construction, so it takes effect on"
+          + " restart like every other setting here.",
       Integer.class,
       10,
       true),

--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -1411,13 +1411,16 @@ public enum GlobalConfiguration {
           + " fan-outs into the first edge's cost so that the planner sorts"
           + " competing branches by their full chain selectivity, not just"
           + " the single-hop leading edge. A linear-chain walk terminates"
-          + " naturally at branch points or visited nodes, so the default"
-          + " (Integer.MAX_VALUE) is bounded by pattern shape rather than"
-          + " by this knob. Set to 1 to restrict the fold to the immediate"
-          + " downstream vertex (legacy single-hop behaviour). Set to 0 to"
-          + " disable the fold entirely (rollback-only safety valve).",
+          + " naturally at branch points or visited nodes, so this knob is"
+          + " a defense-in-depth cap rather than the typical bound. The"
+          + " default (10) matches the planner's WHILE-depth default and"
+          + " covers all realistic LDBC SNB queries; raise it for unusually"
+          + " deep linear MATCH patterns. Set to 1 to restrict the fold to"
+          + " the immediate downstream vertex (legacy single-hop behaviour)."
+          + " Set to 0 to disable the fold entirely (rollback-only safety"
+          + " valve).",
       Integer.class,
-      Integer.MAX_VALUE,
+      10,
       true),
       ;
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -1414,11 +1414,15 @@ public enum GlobalConfiguration {
           + " naturally at branch points or visited nodes, so this knob is"
           + " a defense-in-depth cap rather than the typical bound. The"
           + " default (10) matches the planner's WHILE-depth default and"
-          + " covers all realistic LDBC SNB queries; raise it for unusually"
+          + " covers the chain depths real queries reach; raise it for unusually"
           + " deep linear MATCH patterns. Set to 1 to restrict the fold to"
-          + " the immediate downstream vertex (legacy single-hop behaviour)."
-          + " Set to 0 to disable the fold entirely (rollback-only safety"
-          + " valve).",
+          + " the immediate downstream vertex; note that 1 still folds that"
+          + " vertex, so only 0 restores the schedule the planner produced"
+          + " before the fold existed. Set to 0"
+          + " to disable the fold entirely (rollback-only safety valve)."
+          + " Read once per plan construction: statements already in the"
+          + " execution-plan cache keep their existing schedule until the"
+          + " cache is evicted (any schema change, or a restart).",
       Integer.class,
       10,
       true),

--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -1401,6 +1401,24 @@ public enum GlobalConfiguration {
       Double.class,
       100.0,
       true),
+
+  // ---- MATCH chain-fold cost-model configuration ----
+
+  QUERY_MATCH_CHAIN_FOLD_MAX_HOPS(
+      "youtrackdb.query.match.chainFold.maxHops",
+      "Maximum chain depth for the cost-fold during MATCH plan optimization."
+          + " The fold propagates downstream WHERE selectivities and edge"
+          + " fan-outs into the first edge's cost so that the planner sorts"
+          + " competing branches by their full chain selectivity, not just"
+          + " the single-hop leading edge. A linear-chain walk terminates"
+          + " naturally at branch points or visited nodes, so the default"
+          + " (Integer.MAX_VALUE) is bounded by pattern shape rather than"
+          + " by this knob. Set to 1 to restrict the fold to the immediate"
+          + " downstream vertex (legacy single-hop behaviour). Set to 0 to"
+          + " disable the fold entirely (rollback-only safety valve).",
+      Integer.class,
+      Integer.MAX_VALUE,
+      true),
       ;
 
   static {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeFanOutEstimator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeFanOutEstimator.java
@@ -6,6 +6,8 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Direction;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.ImmutableSchema;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Estimates the average number of adjacent vertices reachable from one vertex of a
@@ -78,6 +80,35 @@ public final class EdgeFanOutEstimator {
       Direction direction,
       String outVertexClass,
       String inVertexClass) {
+    // Backward-compatible overload for callers with no per-plan cache in
+    // scope. A fresh map still memoizes the (edge, source) counts of this
+    // single call and yields values identical to the un-cached original.
+    return estimateFanOut(
+        session, edgeClassName, sourceClassName, direction,
+        outVertexClass, inVertexClass, new HashMap<>());
+  }
+
+  /**
+   * Cache-aware variant of
+   * {@link #estimateFanOut(DatabaseSessionEmbedded, String, String, Direction,
+   * String, String)} that memoizes each {@link SchemaClassInternal#approximateCount}
+   * lookup by class name in {@code classCountCache}. {@code approximateCount}
+   * is a deterministic O(1) read against a stable schema snapshot, so the cache
+   * is a pure memo: computed fan-out values are identical to the un-cached path,
+   * only redundant count lookups for a class already seen in the same plan are
+   * elided.
+   *
+   * @param classCountCache per-plan memo of {@code className → approximateCount};
+   *                        never {@code null}
+   */
+  public static double estimateFanOut(
+      DatabaseSessionEmbedded session,
+      String edgeClassName,
+      String sourceClassName,
+      Direction direction,
+      String outVertexClass,
+      String inVertexClass,
+      Map<String, Long> classCountCache) {
     assert MatchAssertions.checkNotNull(session, "session");
     assert MatchAssertions.checkNotNull(direction, "direction");
 
@@ -95,8 +126,8 @@ public final class EdgeFanOutEstimator {
       return defaultFanOut();
     }
 
-    long edgeCount = edgeClass.approximateCount(session);
-    long sourceCount = sourceClass.approximateCount(session);
+    long edgeCount = countFor(edgeClass, session, classCountCache);
+    long sourceCount = countFor(sourceClass, session, classCountCache);
 
     if (sourceCount == 0) {
       return 0.0;
@@ -105,7 +136,7 @@ public final class EdgeFanOutEstimator {
     if (direction == Direction.BOTH) {
       return estimateBothFanOut(
           session, schema, edgeCount, sourceCount, sourceClassName,
-          outVertexClass, inVertexClass);
+          outVertexClass, inVertexClass, classCountCache);
     }
 
     return (double) edgeCount / sourceCount;
@@ -123,7 +154,8 @@ public final class EdgeFanOutEstimator {
       long sourceCount,
       String sourceClassName,
       String outVertexClass,
-      String inVertexClass) {
+      String inVertexClass,
+      Map<String, Long> classCountCache) {
     // When neither vertex class is declared in the schema (schema-less or
     // mixed mode), fall back to a naive estimate: the source vertex can
     // appear on both sides, so fan-out ≈ 2 × edgeCount / sourceCount.
@@ -140,7 +172,7 @@ public final class EdgeFanOutEstimator {
         outVertexClass)) {
       var outClass = schema.getClassInternal(outVertexClass);
       if (outClass != null) {
-        long outCount = outClass.approximateCount(session);
+        long outCount = countFor(outClass, session, classCountCache);
         outFanOut = outCount > 0 ? (double) edgeCount / outCount : 0.0;
       }
     }
@@ -149,12 +181,26 @@ public final class EdgeFanOutEstimator {
         inVertexClass)) {
       var inClass = schema.getClassInternal(inVertexClass);
       if (inClass != null) {
-        long inCount = inClass.approximateCount(session);
+        long inCount = countFor(inClass, session, classCountCache);
         inFanOut = inCount > 0 ? (double) edgeCount / inCount : 0.0;
       }
     }
 
     return outFanOut + inFanOut;
+  }
+
+  /**
+   * Memoizes {@link SchemaClassInternal#approximateCount} by class name. Class
+   * names are unique within a schema snapshot and {@code approximateCount} is
+   * deterministic for the lifetime of one plan, so the cached value is always
+   * equal to a fresh call.
+   */
+  private static long countFor(
+      SchemaClassInternal clazz,
+      DatabaseSessionEmbedded session,
+      Map<String, Long> classCountCache) {
+    return classCountCache.computeIfAbsent(
+        clazz.getName(), k -> clazz.approximateCount(session));
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3013,48 +3013,61 @@ public class MatchExecutionPlanner {
     String effectiveTargetClass = aliasClasses != null
         ? aliasClasses.get(effectiveTargetAlias) : null;
     if (effectiveTargetClass == null) {
-      // Lazy: lower-case only on the precedence-2 fallback path, since
-      // precedence-1 (addAliases-populated aliasClasses) covers the common
-      // production case and does not need the canonical form.
-      var firstName = rawFirstName.toLowerCase(Locale.ENGLISH);
-      effectiveTargetClass = inferDownstreamVertexClassFromEdge(
-          edge.item.getMethod(), firstName, session);
+      // Precedence-2 fallback: derive class from the edge schema using the
+      // SECOND method (inV/outV/bothV). The vertex step decides which side of
+      // the edge is downstream, regardless of whether we entered via outE,
+      // inE, or bothE — so this mirrors how addAliases.inferClassFromEdgeSchema
+      // resolves a stand-alone inV/outV. bothV cannot be disambiguated from
+      // schema alone and falls through to null.
+      effectiveTargetClass = linkedVertexClassForVertexStep(
+          rawSecondName, extractEdgeClassName(edge.item.getMethod()), session);
     }
     return Optional.of(new ChainedTarget(effectiveTargetAlias, effectiveTargetClass));
   }
 
   /**
-   * Precedence-2 fallback for {@link #resolveChainedTarget}: infers the
-   * downstream vertex class from the first edge's class name + chain
-   * direction. Mirrors the explicit-alias branch of
-   * {@link #resolveTargetClass} but is direction-aware for the chain shape:
-   * outbound ({@code oute}) reads the edge class's {@code in} linked vertex
-   * class, inbound ({@code ine}) reads {@code out}, and bidirectional
-   * ({@code bothe}) returns {@code null} because no single endpoint is
-   * uniquely "downstream".
+   * Resolves the linked vertex class for a TinkerPop vertex step ({@code inV},
+   * {@code outV}, {@code bothV}) on a known edge class, using the edge's
+   * {@code in}/{@code out} LINK schema.
    *
-   * @param method     the first edge's method call
-   * @param firstName  the first method's name, lower-cased ({@code oute}/
-   *                   {@code ine}/{@code bothe})
-   * @param session    database session for schema access; if {@code null},
-   *                   the method returns {@code null}
-   * @return the inferred class name, or {@code null} if it cannot be derived
+   * <p>{@code inV} reads the edge's {@code in} linked vertex class (target
+   * side); {@code outV} reads {@code out} (source side); {@code bothV} cannot
+   * be resolved from schema alone and returns {@code null}.
+   *
+   * <p>Shared by {@link #resolveChainedTarget} (precedence-2 fallback during
+   * cost-fold class inference) and the {@code inV}/{@code outV} branch of
+   * {@link #inferClassFromEdgeSchema} (during plan construction in
+   * {@code addAliases}). Centralising the mapping here keeps the two paths in
+   * lock-step: any future addition (e.g. a new vertex-step variant) only
+   * needs editing once.
+   *
+   * @param vertexStepName the vertex step name as read from the parsed
+   *                       method call ({@code inV}/{@code outV}/{@code bothV},
+   *                       case-insensitive); {@code null} returns {@code null}
+   * @param edgeClassName  the edge class whose schema supplies the linked
+   *                       vertex class; {@code null} returns {@code null}
+   * @param session        database session for schema access; {@code null}
+   *                       returns {@code null}
+   * @return the linked vertex class name, or {@code null} when any input is
+   *         missing or the step is {@code bothV}/unrecognized
    */
-  @Nullable private static String inferDownstreamVertexClassFromEdge(
-      SQLMethodCall method,
-      String firstName,
+  @Nullable static String linkedVertexClassForVertexStep(
+      @Nullable String vertexStepName,
+      @Nullable String edgeClassName,
       @Nullable DatabaseSessionEmbedded session) {
-    if ("bothe".equals(firstName)) {
+    if (edgeClassName == null || vertexStepName == null) {
       return null;
     }
-    var edgeClassName = extractEdgeClassName(method);
-    if (edgeClassName == null) {
+    String prop;
+    if ("inV".equalsIgnoreCase(vertexStepName)) {
+      prop = "in";
+    } else if ("outV".equalsIgnoreCase(vertexStepName)) {
+      prop = "out";
+    } else {
+      // bothV or any unrecognized step: cannot disambiguate from schema
       return null;
     }
-    // outE('X').inV() reads the edge class's "in" linked vertex;
-    // inE('X').outV() reads "out".
-    var linkedPropName = "oute".equals(firstName) ? "in" : "out";
-    return lookupLinkedVertexClass(edgeClassName, linkedPropName, session);
+    return lookupLinkedVertexClass(edgeClassName, prop, session);
   }
 
   /**
@@ -5268,13 +5281,12 @@ public class MatchExecutionPlanner {
     }
 
     // inV() / outV(): look up the linked vertex class from the preceding edge.
-    // inV() reads the "in" property; outV() reads the "out" property.
+    // Delegates to the shared helper so this branch stays in lock-step with
+    // resolveChainedTarget's precedence-2 fallback (both resolve a vertex
+    // step against an edge schema; centralising avoids divergent logic).
     if ("inv".equals(dirName) || "outv".equals(dirName)) {
-      if (currentEdgeClass == null) {
-        return null;
-      }
-      var prop = "inv".equals(dirName) ? "in" : "out";
-      return lookupLinkedVertexClass(currentEdgeClass, prop, context.getDatabaseSession());
+      return linkedVertexClassForVertexStep(
+          dirName, currentEdgeClass, context.getDatabaseSession());
     }
 
     // out('X') / in('X'): infer the target vertex class from the edge LINK schema

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -77,6 +77,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -2776,6 +2777,130 @@ public class MatchExecutionPlanner {
     var linkedProp = edgeClass.getPropertyInternal(linkedPropName);
     return (linkedProp != null && linkedProp.getLinkedClass() != null)
         ? linkedProp.getLinkedClass().getName() : null;
+  }
+
+  /**
+   * Describes the downstream vertex that a recognised edge-method chain
+   * (e.g. {@code .outE('X').inV()}) folds onto for cost-model purposes.
+   *
+   * <p>Returned by {@link #resolveChainedTarget}. The planner's sort loop
+   * uses this to apply the downstream vertex's {@code WHERE} selectivity to
+   * the first edge's cost, instead of the synthetic intermediate edge alias
+   * that carries no filter.
+   *
+   * @param effectiveTargetAlias  the downstream vertex alias (the real target
+   *                              of the chain, e.g. {@code tag} in
+   *                              {@code .outE('VIHasTag').inV(){as: tag}})
+   * @param effectiveTargetClass  the downstream vertex class name, or
+   *                              {@code null} when it cannot be inferred
+   *                              (e.g. {@code bothE→bothV} without an
+   *                              explicit {@code class:} annotation)
+   */
+  record ChainedTarget(
+      String effectiveTargetAlias, @Nullable String effectiveTargetClass) {
+  }
+
+  /**
+   * Detects the edge-method chain pattern {@code .outE(X).inV()} (and its
+   * {@code inE→outV} / {@code bothE→bothV} variants) that appears as two
+   * consecutive {@link PatternEdge}s in the pattern graph.
+   *
+   * <p>The pattern graph models {@code .outE('X').inV()} as
+   * <pre>
+   *   source ── outE('X') ──▶ intermediate(edge alias) ── inV() ──▶ target
+   * </pre>
+   * Cost is computed per {@link PatternEdge}. The first edge's target is the
+   * synthetic intermediate alias (no filter, no class), so
+   * {@link #applyTargetSelectivity} returns the base cost unchanged and the
+   * {@code WHERE} on the real downstream vertex never affects scheduling.
+   *
+   * <p>This helper recognises the chain structurally and returns the
+   * downstream vertex so the caller can fold its selectivity into the first
+   * edge's cost. The pattern graph and runtime execution are left untouched.
+   *
+   * <p><b>Structural rule</b> (all must hold):
+   * <ol>
+   *   <li>{@code edge.item} and {@code edge.item.getMethod()} are non-null;</li>
+   *   <li>first edge method name (lower-cased, {@link Locale#ENGLISH}) is
+   *       one of {@code oute}, {@code ine}, {@code bothe};</li>
+   *   <li>{@code neighbor.out} has exactly one edge, and it is not in
+   *       {@code visitedEdges};</li>
+   *   <li>{@code neighbor.in} has exactly one edge, and it <b>is</b>
+   *       {@code edge} (identity comparison — guards against a user-named
+   *       intermediate alias joined from a second MATCH fragment);</li>
+   *   <li>the downstream edge's method name (lower-cased) is {@code inv},
+   *       {@code outv}, or {@code bothv}.</li>
+   * </ol>
+   *
+   * <p><b>Reverse traversals</b> (where {@code neighbor = edge.out}) are
+   * rejected naturally by clause 3 — the reverse neighbor has no
+   * {@code inV}/{@code outV}/{@code bothV} continuation.
+   *
+   * <p>The helper is pure — no schema mutation, no side effects — so it is
+   * unit-testable in isolation.
+   *
+   * @param edge           the candidate first edge of the chain
+   * @param neighbor       the direction-dependent target already computed
+   *                       by the sort loop
+   *                       ({@code entry.getValue() ? edge.in : edge.out})
+   * @param visitedEdges   DFS state — the chain is only detected while the
+   *                       intermediate edge's follow-up is still unscheduled
+   * @param aliasClasses   alias → class map; accepted for parity with
+   *                       class-inference overloads and used by Step 2
+   * @param session        database session for schema access; used by Step 2
+   * @return the downstream vertex descriptor when the chain signature
+   *         matches, otherwise {@link Optional#empty()}
+   */
+  static Optional<ChainedTarget> resolveChainedTarget(
+      PatternEdge edge,
+      PatternNode neighbor,
+      Set<PatternEdge> visitedEdges,
+      Map<String, String> aliasClasses,
+      @Nullable DatabaseSessionEmbedded session) {
+    if (edge.item == null || edge.item.getMethod() == null) {
+      return Optional.empty();
+    }
+    var firstName = edge.item.getMethod().getMethodNameString();
+    if (firstName == null) {
+      return Optional.empty();
+    }
+    firstName = firstName.toLowerCase(Locale.ENGLISH);
+    if (!"oute".equals(firstName) && !"ine".equals(firstName)
+        && !"bothe".equals(firstName)) {
+      return Optional.empty();
+    }
+
+    if (neighbor.out.size() != 1 || neighbor.in.size() != 1) {
+      return Optional.empty();
+    }
+    var downstreamEdge = neighbor.out.iterator().next();
+    if (visitedEdges.contains(downstreamEdge)) {
+      return Optional.empty();
+    }
+    // Identity check: PatternEdge has no equals() override, but we still want
+    // referential identity to guard against accidental future changes.
+    if (neighbor.in.iterator().next() != edge) {
+      return Optional.empty();
+    }
+
+    if (downstreamEdge.item == null || downstreamEdge.item.getMethod() == null) {
+      return Optional.empty();
+    }
+    var secondName = downstreamEdge.item.getMethod().getMethodNameString();
+    if (secondName == null) {
+      return Optional.empty();
+    }
+    secondName = secondName.toLowerCase(Locale.ENGLISH);
+    if (!"inv".equals(secondName) && !"outv".equals(secondName)
+        && !"bothv".equals(secondName)) {
+      return Optional.empty();
+    }
+
+    // effectiveTargetAlias is the downstream vertex alias — NOT neighbor.alias,
+    // which is the intermediate edge alias and carries no filter.
+    var effectiveTargetAlias = downstreamEdge.in.alias;
+    // Step 1: class inference lands in Step 2; leave null for now.
+    return Optional.of(new ChainedTarget(effectiveTargetAlias, null));
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2954,13 +2954,17 @@ public class MatchExecutionPlanner {
     if (edge.item == null || edge.item.getMethod() == null) {
       return Optional.empty();
     }
-    var firstName = edge.item.getMethod().getMethodNameString();
-    if (firstName == null) {
-      return Optional.empty();
-    }
-    firstName = firstName.toLowerCase(Locale.ENGLISH);
-    if (!"oute".equals(firstName) && !"ine".equals(firstName)
-        && !"bothe".equals(firstName)) {
+    var rawFirstName = edge.item.getMethod().getMethodNameString();
+    // Sort-loop hot path: invoked on every candidate edge, including the very
+    // common single-step methods (.out / .in / .both). Reject those without
+    // allocating a lower-cased copy — String.equalsIgnoreCase short-circuits
+    // on length mismatch, so .out (len 3) vs .outE (len 4) bails out before
+    // any character comparison. Only on a positive match do we cache the
+    // lower-cased canonical form for `inferDownstreamVertexClassFromEdge`.
+    if (rawFirstName == null
+        || (!"outE".equalsIgnoreCase(rawFirstName)
+            && !"inE".equalsIgnoreCase(rawFirstName)
+            && !"bothE".equalsIgnoreCase(rawFirstName))) {
       return Optional.empty();
     }
 
@@ -2984,13 +2988,11 @@ public class MatchExecutionPlanner {
     if (downstreamEdge.item == null || downstreamEdge.item.getMethod() == null) {
       return Optional.empty();
     }
-    var secondName = downstreamEdge.item.getMethod().getMethodNameString();
-    if (secondName == null) {
-      return Optional.empty();
-    }
-    secondName = secondName.toLowerCase(Locale.ENGLISH);
-    if (!"inv".equals(secondName) && !"outv".equals(secondName)
-        && !"bothv".equals(secondName)) {
+    var rawSecondName = downstreamEdge.item.getMethod().getMethodNameString();
+    if (rawSecondName == null
+        || (!"inV".equalsIgnoreCase(rawSecondName)
+            && !"outV".equalsIgnoreCase(rawSecondName)
+            && !"bothV".equalsIgnoreCase(rawSecondName))) {
       return Optional.empty();
     }
 
@@ -3011,6 +3013,10 @@ public class MatchExecutionPlanner {
     String effectiveTargetClass = aliasClasses != null
         ? aliasClasses.get(effectiveTargetAlias) : null;
     if (effectiveTargetClass == null) {
+      // Lazy: lower-case only on the precedence-2 fallback path, since
+      // precedence-1 (addAliases-populated aliasClasses) covers the common
+      // production case and does not need the canonical form.
+      var firstName = rawFirstName.toLowerCase(Locale.ENGLISH);
       effectiveTargetClass = inferDownstreamVertexClassFromEdge(
           edge.item.getMethod(), firstName, session);
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2950,25 +2950,14 @@ public class MatchExecutionPlanner {
     if ("bothe".equals(firstName)) {
       return null;
     }
-    if (session == null) {
-      return null;
-    }
     var edgeClassName = extractEdgeClassName(method);
     if (edgeClassName == null) {
       return null;
     }
-    var schema = session.getMetadata().getImmutableSchemaSnapshot();
-    if (schema == null) {
-      return null;
-    }
-    var edgeClass = schema.getClassInternal(edgeClassName);
-    if (edgeClass == null) {
-      return null;
-    }
+    // outE('X').inV() reads the edge class's "in" linked vertex;
+    // inE('X').outV() reads "out".
     var linkedPropName = "oute".equals(firstName) ? "in" : "out";
-    var linkedProp = edgeClass.getPropertyInternal(linkedPropName);
-    return (linkedProp != null && linkedProp.getLinkedClass() != null)
-        ? linkedProp.getLinkedClass().getName() : null;
+    return lookupLinkedVertexClass(edgeClassName, linkedPropName, session);
   }
 
   /**
@@ -5188,7 +5177,7 @@ public class MatchExecutionPlanner {
         return null;
       }
       var prop = "inv".equals(dirName) ? "in" : "out";
-      return lookupLinkedVertexClass(currentEdgeClass, prop, context);
+      return lookupLinkedVertexClass(currentEdgeClass, prop, context.getDatabaseSession());
     }
 
     // out('X') / in('X'): infer the target vertex class from the edge LINK schema
@@ -5203,20 +5192,30 @@ public class MatchExecutionPlanner {
 
     // out('X') targets the "in" side; in('X') targets the "out" side
     var targetPropName = "out".equals(dirName) ? "in" : "out";
-    return lookupLinkedVertexClass(edgeClassName, targetPropName, context);
+    return lookupLinkedVertexClass(edgeClassName, targetPropName, context.getDatabaseSession());
   }
 
   /**
    * Looks up the linked vertex class from an edge class's LINK property.
+   * Defensive: returns {@code null} if the session or any link in the
+   * schema-lookup chain is missing, so this is the single source of truth
+   * for the "edge-class → linked-vertex-class" resolution (also used by
+   * {@link #inferDownstreamVertexClassFromEdge}).
    *
    * @param edgeClassName the edge class to look up
    * @param propName the property name to read — must be {@code "in"} or {@code "out"}
+   * @param session the database session for schema access; {@code null} yields {@code null}
    * @return the linked class name, or {@code null} if not found
    */
   @Nullable private static String lookupLinkedVertexClass(
-      String edgeClassName, String propName, CommandContext context) {
-    var session = context.getDatabaseSession();
+      String edgeClassName, String propName, @Nullable DatabaseSessionEmbedded session) {
+    if (session == null) {
+      return null;
+    }
     var schema = session.getMetadata().getImmutableSchemaSnapshot();
+    if (schema == null) {
+      return null;
+    }
     var edgeClass = schema.getClassInternal(edgeClassName);
     if (edgeClass == null) {
       return null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2903,8 +2903,69 @@ public class MatchExecutionPlanner {
     // effectiveTargetAlias is the downstream vertex alias — NOT neighbor.alias,
     // which is the intermediate edge alias and carries no filter.
     var effectiveTargetAlias = downstreamEdge.in.alias;
-    // Step 1: class inference lands in Step 2; leave null for now.
-    return Optional.of(new ChainedTarget(effectiveTargetAlias, null));
+
+    // Class-inference precedence:
+    //   1. aliasClasses.get(effectiveTargetAlias) — the normal path for
+    //      outE→inV / inE→outV because `addAliases` pre-populates via
+    //      `inferClassFromEdgeSchema` (MatchExecutionPlanner.java:4518). Also
+    //      the only path for bothE→bothV when the user wrote {class: ...}.
+    //   2. Defensive fallback for while-expression aliases skipped by
+    //      `addAliases` at the whileAliases filter (line 4495): derive from
+    //      the first edge's class name + direction. outE→inV uses the edge
+    //      class's `in` linked vertex class; inE→outV uses `out`;
+    //      bothE→bothV cannot infer (returns null).
+    String effectiveTargetClass = aliasClasses != null
+        ? aliasClasses.get(effectiveTargetAlias) : null;
+    if (effectiveTargetClass == null) {
+      effectiveTargetClass = inferDownstreamVertexClassFromEdge(
+          edge.item.getMethod(), firstName, session);
+    }
+    return Optional.of(new ChainedTarget(effectiveTargetAlias, effectiveTargetClass));
+  }
+
+  /**
+   * Precedence-2 fallback for {@link #resolveChainedTarget}: infers the
+   * downstream vertex class from the first edge's class name + chain
+   * direction. Mirrors the explicit-alias branch of
+   * {@link #resolveTargetClass} but is direction-aware for the chain shape:
+   * outbound ({@code oute}) reads the edge class's {@code in} linked vertex
+   * class, inbound ({@code ine}) reads {@code out}, and bidirectional
+   * ({@code bothe}) returns {@code null} because no single endpoint is
+   * uniquely "downstream".
+   *
+   * @param method     the first edge's method call
+   * @param firstName  the first method's name, lower-cased ({@code oute}/
+   *                   {@code ine}/{@code bothe})
+   * @param session    database session for schema access; if {@code null},
+   *                   the method returns {@code null}
+   * @return the inferred class name, or {@code null} if it cannot be derived
+   */
+  @Nullable private static String inferDownstreamVertexClassFromEdge(
+      SQLMethodCall method,
+      String firstName,
+      @Nullable DatabaseSessionEmbedded session) {
+    if ("bothe".equals(firstName)) {
+      return null;
+    }
+    if (session == null) {
+      return null;
+    }
+    var edgeClassName = extractEdgeClassName(method);
+    if (edgeClassName == null) {
+      return null;
+    }
+    var schema = session.getMetadata().getImmutableSchemaSnapshot();
+    if (schema == null) {
+      return null;
+    }
+    var edgeClass = schema.getClassInternal(edgeClassName);
+    if (edgeClass == null) {
+      return null;
+    }
+    var linkedPropName = "oute".equals(firstName) ? "in" : "out";
+    var linkedProp = edgeClass.getPropertyInternal(linkedPropName);
+    return (linkedProp != null && linkedProp.getLinkedClass() != null)
+        ? linkedProp.getLinkedClass().getName() : null;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2500,6 +2500,14 @@ public class MatchExecutionPlanner {
    * the class from the edge schema's linked vertex property (e.g., {@code HAS_TAG.in}
    * linked to {@code Tag}).
    *
+   * <p>This 8-arg overload is used by the sort loop for single-hop edges such as
+   * {@code .out('X')}. For the edge-method chain pattern {@code .outE('X').inV()}
+   * (and its {@code inE→outV} / {@code bothE→bothV} variants), the sort loop adds
+   * a second, chain-aware call using the class-forced 6-arg overload below,
+   * which bypasses {@link #resolveTargetClass} and applies the downstream
+   * vertex's filter on top of the intermediate edge alias's filter — see the
+   * call site in {@link #updateScheduleStartingAt}.
+   *
    * @param baseCost             the fan-out-based traversal cost from
    *                             {@link #estimateEdgeCost}
    * @param targetAlias          alias of the target (neighbor) node

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -78,6 +78,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -381,6 +382,38 @@ public class MatchExecutionPlanner {
   /** Pattern for validating edge class names as valid identifiers. */
   private static final java.util.regex.Pattern VALID_EDGE_LABEL =
       java.util.regex.Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+  /**
+   * Hard upper bound applied to {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS} when
+   * it is read for plan construction. The chain-fold walk terminates
+   * structurally at the pattern graph's branch points and visited edges, so
+   * any knob value larger than the deepest linear chain a MATCH can encode
+   * is semantically equivalent to this cap — but can poison downstream
+   * arithmetic (int overflow in the walk's bookkeeping) and waste memory on
+   * upfront collection allocations sized to the raw knob value. Realistic
+   * MATCH patterns top out below 30 linear hops; 1000 leaves a 30× margin
+   * while staying far away from any int-overflow threshold.
+   */
+  private static final int MAX_CHAIN_FOLD_HOPS = 1000;
+
+  /**
+   * Tracks the last knob value that triggered an upper-bound clamp warning,
+   * so {@link #clampChainFoldMaxHops} logs at most once per <em>unique</em>
+   * out-of-range value. The sort loop reads the knob once per plan, so for
+   * a server processing thousands of queries with a misconfigured knob we
+   * would otherwise emit thousands of duplicate WARN lines.
+   *
+   * <p>Initialised to {@code 0} as a sentinel: {@code 0} is always in-range
+   * (it is the documented "fold disabled" value) so the clamp helper never
+   * compares an out-of-range raw against it as a stale match.
+   *
+   * <p>An {@link AtomicInteger#getAndSet} pair makes the warning emission
+   * thread-safe — concurrent plan constructions racing on a brand-new
+   * out-of-range value will see exactly one of them swap successfully and
+   * log; the others observe {@code previous == raw} and skip.
+   */
+  private static final AtomicInteger lastWarnedChainFoldKnob =
+      new AtomicInteger(0);
 
   /**
    * Creates a planner from a pre-built pattern IR. Bypasses SQL AST parsing entirely:
@@ -1987,8 +2020,11 @@ public class MatchExecutionPlanner {
     // re-reading the volatile configuration field per edge would amortize
     // an O(edges) configuration lookup over the planning phase, and any
     // mid-plan reconfiguration would split the plan across two knob values.
-    int chainFoldMaxHops =
-        GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger();
+    //
+    // {@link #clampChainFoldMaxHops} bounds the value to a safe range and
+    // emits a one-shot WARN if the upper cap actually fires.
+    int chainFoldMaxHops = clampChainFoldMaxHops(
+        GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger());
     // Per-plan structural-detection cache for the chain fold: the answer is
     // determined by the pattern graph plus the per-plan {@code aliasClasses}
     // and session, all stable for the lifetime of one plan. The visited-edge
@@ -2060,6 +2096,50 @@ public class MatchExecutionPlanner {
     }
 
     return resultingSchedule;
+  }
+
+  /**
+   * Bounds {@code raw} to {@code [0, MAX_CHAIN_FOLD_HOPS]}, the safe range
+   * for {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS}, and emits a one-shot WARN
+   * the first time a given out-of-range value triggers the upper cap.
+   *
+   * <p>Lower-bound clamp ({@code raw < 0}) is silent — values below zero
+   * are an obvious user error with no meaningful semantics, and the project
+   * convention (see {@link #getHashJoinThreshold}) is silent clamp at the
+   * read site.
+   *
+   * <p>Upper-bound clamp ({@code raw > MAX_CHAIN_FOLD_HOPS}) is logged
+   * because the operator's intent matters here: somebody who set the knob
+   * to e.g. {@code 100_000} probably wanted "fold everything", and a silent
+   * clamp would leave them debugging a fold depth that does not match their
+   * configuration. The warning fires at most once per unique raw value in a
+   * JVM lifetime — concurrent plans racing on the same out-of-range value
+   * agree on a single emitter via {@link AtomicInteger#getAndSet}.
+   *
+   * @param raw the raw knob value as read from {@link GlobalConfiguration}
+   * @return the clamped value, in {@code [0, MAX_CHAIN_FOLD_HOPS]}
+   */
+  static int clampChainFoldMaxHops(int raw) {
+    if (raw > MAX_CHAIN_FOLD_HOPS) {
+      // getAndSet returns the previous sentinel/value; if it equals raw,
+      // we have already warned about this exact value and stay silent.
+      // Otherwise we own the warning for this new out-of-range value.
+      int previous = lastWarnedChainFoldKnob.getAndSet(raw);
+      if (previous != raw) {
+        logger.warn(
+            "QUERY_MATCH_CHAIN_FOLD_MAX_HOPS={} exceeds the supported"
+                + " maximum {}; clamping for plan construction. The chain-fold"
+                + " walk terminates structurally at the pattern graph's branch"
+                + " points, so values above {} are equivalent to {} but risk"
+                + " int overflow in the walk's bookkeeping.",
+            raw, MAX_CHAIN_FOLD_HOPS, MAX_CHAIN_FOLD_HOPS, MAX_CHAIN_FOLD_HOPS);
+      }
+      return MAX_CHAIN_FOLD_HOPS;
+    }
+    // Negative values clamp silently (project convention; see
+    // getHashJoinThreshold). Zero is the documented "fold disabled" value
+    // and passes through unchanged.
+    return Math.max(0, raw);
   }
 
   /**
@@ -2509,13 +2589,14 @@ public class MatchExecutionPlanner {
    * the class from the edge schema's linked vertex property (e.g., {@code HAS_TAG.in}
    * linked to {@code Tag}).
    *
-   * <p>This 8-arg overload is used by the sort loop for single-hop edges such as
+   * <p>This method is used by the sort loop for single-hop edges such as
    * {@code .out('X')}. For the edge-method chain pattern {@code .outE('X').inV()}
    * (and its {@code inE→outV} / {@code bothE→bothV} variants), the sort loop adds
-   * a second, chain-aware call using the class-forced 6-arg overload below,
-   * which bypasses {@link #resolveTargetClass} and applies the downstream
-   * vertex's filter on top of the intermediate edge alias's filter — see the
-   * call site in {@link #updateScheduleStartingAt}.
+   * a second, chain-aware call using
+   * {@link #applyTargetSelectivityWithResolvedClass} below, which bypasses
+   * {@link #resolveTargetClass} and applies the downstream vertex's filter on
+   * top of the intermediate edge alias's filter — see the call site in
+   * {@link #updateScheduleStartingAt}.
    *
    * @param baseCost             the fan-out-based traversal cost from
    *                             {@link #estimateEdgeCost}
@@ -2573,23 +2654,25 @@ public class MatchExecutionPlanner {
   }
 
   /**
-   * Class-forced overload used by the sort-loop's edge-method chain fold.
-   * Bypasses {@link #resolveTargetClass} — the caller
-   * ({@link #updateScheduleStartingAt} via {@link #resolveChainedTarget})
-   * has already computed the downstream vertex class using chain-aware
-   * precedence (aliasClasses first, then direction-aware edge-schema
-   * derivation), so re-inferring with the outer edge's direction would
-   * pick the wrong endpoint for {@code inE→outV}.
+   * Class-forced sibling of {@link #applyTargetSelectivity} used by the
+   * sort-loop's edge-method chain fold. Bypasses {@link #resolveTargetClass}
+   * — the caller ({@link #updateScheduleStartingAt} via
+   * {@link #resolveChainedTarget}) has already computed the downstream
+   * vertex class using chain-aware precedence (aliasClasses first, then
+   * direction-aware edge-schema derivation), so re-inferring with the outer
+   * edge's direction would pick the wrong endpoint for {@code inE→outV}.
    *
    * <p>Short-circuits to {@code baseCost} when {@code preResolvedTargetClass}
    * is {@code null} (e.g. {@code bothE→bothV} without an explicit
-   * {@code class:} annotation) — matching the behaviour of the existing
-   * 8-arg overload when {@link #resolveTargetClass} returns {@code null}.
+   * {@code class:} annotation) — matching the behaviour of
+   * {@link #applyTargetSelectivity} when {@link #resolveTargetClass} returns
+   * {@code null}.
    *
    * @param baseCost             the fan-out-based traversal cost from
    *                             {@link #estimateEdgeCost}, already adjusted
    *                             by the intermediate alias's filter (if any)
-   *                             via the preceding 8-arg call
+   *                             via the preceding {@link #applyTargetSelectivity}
+   *                             call
    * @param targetAlias          the downstream vertex alias (from
    *                             {@link ChainedTarget#effectiveTargetAlias})
    * @param preResolvedTargetClass class name resolved by the chain helper,
@@ -2599,7 +2682,7 @@ public class MatchExecutionPlanner {
    * @param session              database session for schema access
    * @return adjusted cost
    */
-  static double applyTargetSelectivity(
+  static double applyTargetSelectivityWithResolvedClass(
       double baseCost,
       String targetAlias,
       @Nullable String preResolvedTargetClass,
@@ -2615,10 +2698,11 @@ public class MatchExecutionPlanner {
   }
 
   /**
-   * Shared body of both {@link #applyTargetSelectivity} overloads: given a
-   * non-null target class, look it up in the schema and adjust {@code baseCost}
-   * by either (a) the filter-shape heuristic on the target's WHERE clause,
-   * or (b) the estimated cardinality ratio. All null-guards on the target
+   * Shared body of {@link #applyTargetSelectivity} and
+   * {@link #applyTargetSelectivityWithResolvedClass}: given a non-null
+   * target class, look it up in the schema and adjust {@code baseCost} by
+   * either (a) the filter-shape heuristic on the target's WHERE clause, or
+   * (b) the estimated cardinality ratio. All null-guards on the target
    * class are the callers' responsibility; this helper assumes
    * {@code targetClass != null}.
    */
@@ -3163,8 +3247,14 @@ public class MatchExecutionPlanner {
    * downstream vertex's WHERE.
    *
    * <p>{@code maxHops} caps the total number of (edge, vertex) sub-chains
-   * folded. Pre-condition: {@code maxHops >= 1}; the caller's gate excludes
-   * {@code maxHops <= 0} (the rollback case).
+   * folded. Two layers gate the knob: the sort-loop call site skips
+   * {@code applyChainFold} entirely when {@code chainFoldMaxHops < 1} (full
+   * rollback to pre-YTDB-643 behaviour, no allocations), and the inner
+   * {@code maxHops <= 1} short-circuit here returns after the single-hop
+   * fold without entering the multi-hop walk. Either layer alone restricts
+   * the fold to legacy single-hop behaviour for {@code maxHops == 1}; the
+   * outer layer is the only one that can disable the fold completely. Both
+   * layers are intentional defense-in-depth: callers may rely on either.
    *
    * <p>{@code chainShapeCache} memoizes the structural part of the chain
    * detection per first-edge identity, so repeat sort-loop invocations of
@@ -3191,13 +3281,18 @@ public class MatchExecutionPlanner {
     if (firstHop == null) {
       return baseCost;
     }
+    // detectChainShape verified firstNeighbor.out.size() == 1, so this
+    // iterator yields the chain's vertex-step edge — referenced both for
+    // the visited-edge guard below and as the source of the first hop's
+    // downstream vertex when seeding the multi-hop walk.
+    var firstHopVertexStepEdge = firstNeighbor.out.iterator().next();
     // Visited-edge check is dynamic and intentionally not cached: a chain
     // whose downstream edge is already scheduled would double-count its
     // selectivity through the cached structural answer.
-    if (visitedEdges.contains(firstNeighbor.out.iterator().next())) {
+    if (visitedEdges.contains(firstHopVertexStepEdge)) {
       return baseCost;
     }
-    double cost = applyTargetSelectivity(
+    double cost = applyTargetSelectivityWithResolvedClass(
         baseCost,
         firstHop.effectiveTargetAlias(),
         firstHop.effectiveTargetClass(),
@@ -3211,15 +3306,13 @@ public class MatchExecutionPlanner {
 
     // Walk forward from the first hop's downstream vertex into any
     // additional linear sub-chains, capped at maxHops - 1 extra hops.
-    var firstDownstreamVertex =
-        firstNeighbor.out.iterator().next().in;
     var extraHops = walkLinearChainExtension(
-        firstDownstreamVertex,
+        firstHopVertexStepEdge.in,
         firstHop.effectiveTargetClass(),
         maxHops - 1,
         visitedEdges,
         firstEdge,
-        firstNeighbor,
+        firstHopVertexStepEdge,
         aliasClasses,
         session,
         chainShapeCache);
@@ -3231,17 +3324,17 @@ public class MatchExecutionPlanner {
       // Intermediate edge alias is mostly auto-generated (no WHERE), so this
       // call is typically a no-op via the no-filter short-circuit. The class
       // is the EDGE class of this hop's edge step (e.g. 'Friend' for
-      // .outE('Friend'){as: e}); without it, applyTargetSelectivity would
-      // short-circuit unconditionally and ignore user-named intermediate
-      // aliases that carry their own WHERE (e.g. {as: e, where: weight > 5}).
-      cost = applyTargetSelectivity(
+      // .outE('Friend'){as: e}); without it, the helper would short-circuit
+      // unconditionally and ignore user-named intermediate aliases that
+      // carry their own WHERE (e.g. {as: e, where: weight > 5}).
+      cost = applyTargetSelectivityWithResolvedClass(
           cost,
           hop.intermediateAlias(),
           extractEdgeClassName(hop.edgeStep().item.getMethod()),
           aliasFilters,
           estimatedRootEntries,
           session);
-      cost = applyTargetSelectivity(
+      cost = applyTargetSelectivityWithResolvedClass(
           cost,
           hop.downstreamAlias(),
           hop.downstreamClass(),
@@ -3268,11 +3361,18 @@ public class MatchExecutionPlanner {
    * fragment-join, branch-point, and visited-edge rejection identically to
    * the single-hop case.
    *
-   * <p>Visited tracking uses a local copy of {@code initialVisitedEdges}
-   * augmented with the first hop's two edges (so the walk does not loop
-   * back through them) and with each sub-chain's edges as we cross them.
-   * This local set is only used to reason about chain shape — the caller's
-   * DFS-level {@code visitedEdges} is not mutated.
+   * <p>Visited tracking uses two disjoint sets to avoid copying the DFS
+   * state: {@code initialVisitedEdges} is consulted read-only for the
+   * back-edge guard against already-scheduled edges, while a small local
+   * {@code chainEdges} set tracks just the edges this walk has crossed
+   * (the first hop's two edges plus each sub-chain's pair). Each
+   * {@code contains} check queries both sets. The walk's loop counter
+   * {@code remainingHops} is upper-bounded by {@code MAX_CHAIN_FOLD_HOPS}
+   * via the knob clamp at the read site, so {@code chainEdges} grows to
+   * at most {@code 2 * MAX_CHAIN_FOLD_HOPS + 2} entries — but in practice
+   * the structural termination at branch points keeps it well under 30
+   * for any realistic MATCH pattern. The caller's DFS-level
+   * {@code visitedEdges} is not mutated.
    *
    * @return list of additional hops (may be empty); each hop is one
    *         (edge step, vertex step) sub-chain
@@ -3283,7 +3383,7 @@ public class MatchExecutionPlanner {
       int remainingHops,
       Set<PatternEdge> initialVisitedEdges,
       PatternEdge firstHopEdge,
-      PatternNode firstHopNeighbor,
+      PatternEdge firstHopVertexStepEdge,
       @Nullable Map<String, String> aliasClasses,
       @Nullable DatabaseSessionEmbedded session,
       Map<PatternEdge, ChainedTarget> chainShapeCache) {
@@ -3291,19 +3391,25 @@ public class MatchExecutionPlanner {
       return List.of();
     }
     // Fast-path: terminal vertices and branch points cannot extend the
-    // chain. Bail out before allocating the localVisited HashSet — the
+    // chain. Bail out before allocating the chainEdges HashSet — the
     // common case in pattern graphs whose tail vertex has no outgoing
     // edges or fans out to multiple neighbors.
     if (currentVertex.out.size() != 1) {
       return List.of();
     }
     var hops = new ArrayList<ChainHop>();
-    var localVisited = new HashSet<>(initialVisitedEdges);
-    localVisited.add(firstHopEdge);
-    // Mark the first hop's vertex-step edge so the walk cannot loop back
-    // through it. firstHopNeighbor.out.size() == 1 holds by virtue of
-    // resolveChainedTarget having already accepted the first hop.
-    localVisited.add(firstHopNeighbor.out.iterator().next());
+    // Default-sized HashSet (capacity 16) is sufficient: the walk
+    // terminates structurally at branch points or visited edges, so
+    // chainEdges typically holds well under 16 entries even for
+    // MAX_CHAIN_FOLD_HOPS-sized knobs. The default knob (10) walks at
+    // most 20 entries, costing one rehash to capacity 32 — negligible
+    // in plan-construction time. Explicit pre-sizing was removed to
+    // eliminate any int-overflow surface in the sizing arithmetic; the
+    // knob is already clamped to [0, MAX_CHAIN_FOLD_HOPS] at the read
+    // site, so every entry in the loop's bookkeeping stays bounded.
+    var chainEdges = new HashSet<PatternEdge>();
+    chainEdges.add(firstHopEdge);
+    chainEdges.add(firstHopVertexStepEdge);
 
     var sourceClass = currentVertexClass;
     while (hops.size() < remainingHops) {
@@ -3311,13 +3417,17 @@ public class MatchExecutionPlanner {
         break;
       }
       var nextEdgeStep = currentVertex.out.iterator().next();
-      if (localVisited.contains(nextEdgeStep)) {
+      // Two-set check: nextEdgeStep is rejected if it's already in the
+      // DFS schedule (back-edge into scheduled territory) OR already in
+      // this walk (chain loops back on itself).
+      if (initialVisitedEdges.contains(nextEdgeStep)
+          || chainEdges.contains(nextEdgeStep)) {
         break;
       }
       var nextIntermediate = nextEdgeStep.in;
       // Reuse the structural-detection cache: identical pattern shape and
       // class-resolution inputs across plan iterations. The visited-edge
-      // check uses the local set rather than the cached value.
+      // check uses the two-set guard rather than the cached value.
       var nextSubChain = lookupOrDetectChainShape(
           nextEdgeStep, nextIntermediate, aliasClasses, session, chainShapeCache);
       if (nextSubChain == null) {
@@ -3325,11 +3435,12 @@ public class MatchExecutionPlanner {
       }
       // detectChainShape verified nextIntermediate.out.size() == 1.
       var vertexStepEdge = nextIntermediate.out.iterator().next();
-      if (localVisited.contains(vertexStepEdge)) {
+      if (initialVisitedEdges.contains(vertexStepEdge)
+          || chainEdges.contains(vertexStepEdge)) {
         break;
       }
-      localVisited.add(nextEdgeStep);
-      localVisited.add(vertexStepEdge);
+      chainEdges.add(nextEdgeStep);
+      chainEdges.add(vertexStepEdge);
 
       hops.add(new ChainHop(
           nextEdgeStep,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2649,8 +2649,8 @@ public class MatchExecutionPlanner {
       return 1.0;
     }
     return applyClassSelectivity(
-        baseCost, targetAlias, targetClass,
-        aliasFilters, estimatedRootEntries, session);
+        targetAlias, targetClass,
+        aliasFilters, estimatedRootEntries, classCountCache, session);
   }
 
   /**
@@ -2692,26 +2692,32 @@ public class MatchExecutionPlanner {
     if (preResolvedTargetClass == null) {
       return baseCost;
     }
-    return applyClassSelectivity(
-        baseCost, targetAlias, preResolvedTargetClass,
-        aliasFilters, estimatedRootEntries, session);
+    return baseCost * applyClassSelectivity(
+        targetAlias, preResolvedTargetClass,
+        aliasFilters, estimatedRootEntries, null, session);
   }
 
   /**
-   * Shared body of {@link #applyTargetSelectivity} and
+   * Shared factor body of {@link #targetSelectivityFactor} and
    * {@link #applyTargetSelectivityWithResolvedClass}: given a non-null
-   * target class, look it up in the schema and adjust {@code baseCost} by
-   * either (a) the filter-shape heuristic on the target's WHERE clause, or
-   * (b) the estimated cardinality ratio. All null-guards on the target
-   * class are the callers' responsibility; this helper assumes
-   * {@code targetClass != null}.
+   * target class, look it up in the schema and return the selectivity
+   * multiplier from either (a) the filter-shape heuristic on the target's
+   * WHERE clause, or (b) the estimated cardinality ratio. Returns {@code 1.0}
+   * (no narrowing) when the schema or class is missing, {@code approximateCount}
+   * returns ≤ 0, no usable filter heuristic exists, and no per-alias estimate is
+   * registered. Callers scale their own {@code baseCost} by the returned factor.
+   * All null-guards on the target class are the callers' responsibility; this
+   * helper assumes {@code targetClass != null}.
+   *
+   * <p>When {@code classCountCache} is non-null the class row count is memoized
+   * across calls within a single forecast pass.
    */
   private static double applyClassSelectivity(
-      double baseCost,
       String targetAlias,
       String targetClass,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, Long> estimatedRootEntries,
+      @Nullable Map<String, Long> classCountCache,
       DatabaseSessionEmbedded session) {
     var schema = session.getMetadata().getImmutableSchemaSnapshot();
     if (schema == null) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2153,6 +2153,27 @@ public class MatchExecutionPlanner {
           cost = applyTargetSelectivity(
               cost, neighbor.alias, entry.getKey(), entry.getValue(),
               aliasClasses, aliasFilters, estimatedRootEntries, session);
+          // Edge-method chain detection: when the current edge is the first hop of
+          // an outE→inV / inE→outV / bothE→bothV sequence, fold the downstream
+          // vertex's WHERE selectivity into the first edge's cost. The intermediate
+          // edge alias carries no vertex WHERE, so without this fold the branch
+          // sorts as "no selectivity" and loses to broader branches. This is the
+          // second factor of the independence multiplication; the first factor
+          // (the intermediate alias's own filter) was applied by the preceding
+          // applyTargetSelectivity call. Multiplication commutes and each call
+          // short-circuits to baseCost when its alias has no filter/class/
+          // row-estimate, so there is no double-counting.
+          var chain = resolveChainedTarget(
+              entry.getKey(), neighbor, visitedEdges, aliasClasses, session);
+          if (chain.isPresent()) {
+            cost = applyTargetSelectivity(
+                cost,
+                chain.get().effectiveTargetAlias(),
+                chain.get().effectiveTargetClass(),
+                aliasFilters,
+                estimatedRootEntries,
+                session);
+          }
           cost = applyDepthMultiplier(cost, entry.getKey());
         }
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -77,7 +77,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -1983,6 +1982,21 @@ public class MatchExecutionPlanner {
     Set<PatternNode> visitedNodes = new HashSet<>();
     Set<PatternEdge> visitedEdges = new HashSet<>();
 
+    // Read the chain-fold knob once at the top of plan construction. It is
+    // a hot-path setting consulted by every candidate edge in the sort loop;
+    // re-reading the volatile configuration field per edge would amortize
+    // an O(edges) configuration lookup over the planning phase, and any
+    // mid-plan reconfiguration would split the plan across two knob values.
+    int chainFoldMaxHops =
+        GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger();
+    // Per-plan structural-detection cache for the chain fold: the answer is
+    // determined by the pattern graph plus the per-plan {@code aliasClasses}
+    // and session, all stable for the lifetime of one plan. The visited-edge
+    // check is dynamic and is performed at each call site separately, so the
+    // cache stores only the structural shape. {@code containsKey} disambiguates
+    // a known-not-chain ({@code null} value) from an uncached entry.
+    Map<PatternEdge, ChainedTarget> chainShapeCache = new HashMap<>();
+
     // Sort the possible root vertices in order of estimated size, since we want to start with a
     // small vertex set.
     List<PairLongObject<String>> rootWeights = new ArrayList<>();
@@ -2037,7 +2051,7 @@ public class MatchExecutionPlanner {
       updateScheduleStartingAt(
           startingNode, visitedNodes, visitedEdges, remainingDependencies,
           resultingSchedule, estimatedRootEntries, aliasClasses, aliasFilters,
-          session);
+          session, chainFoldMaxHops, chainShapeCache);
     }
 
     if (resultingSchedule.size() != pattern.numOfEdges) {
@@ -2070,7 +2084,9 @@ public class MatchExecutionPlanner {
       Map<String, Long> estimatedRootEntries,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      DatabaseSessionEmbedded session) {
+      DatabaseSessionEmbedded session,
+      int chainFoldMaxHops,
+      Map<PatternEdge, ChainedTarget> chainShapeCache) {
     // YouTrackDB requires the schedule to contain all edges present in the query, which is a stronger
     // condition
     // than simply visiting all nodes in the query. Consider the following example query:
@@ -2162,11 +2178,11 @@ public class MatchExecutionPlanner {
           // branches. Each fold call short-circuits to baseCost when its alias
           // has no filter/class/row-estimate, so adding more hops does not
           // double-count when those hops have no filter.
-          int maxHops = GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger();
-          if (maxHops >= 1) {
+          if (chainFoldMaxHops >= 1) {
             cost = applyChainFold(
-                cost, entry.getKey(), neighbor, maxHops, visitedEdges,
-                aliasClasses, aliasFilters, estimatedRootEntries, session);
+                cost, entry.getKey(), neighbor, chainFoldMaxHops, visitedEdges,
+                aliasClasses, aliasFilters, estimatedRootEntries, session,
+                chainShapeCache);
           }
           cost = applyDepthMultiplier(cost, entry.getKey());
         }
@@ -2279,7 +2295,7 @@ public class MatchExecutionPlanner {
           updateScheduleStartingAt(
               neighboringNode, visitedNodes, visitedEdges, remainingDependencies,
               resultingSchedule, estimatedRootEntries, aliasClasses, aliasFilters,
-              session);
+              session, chainFoldMaxHops, chainShapeCache);
           progress = true;
         }
       }
@@ -2936,16 +2952,47 @@ public class MatchExecutionPlanner {
    *                       {@code null}, in which case the fallback returns
    *                       {@code null} for the class field
    * @return the downstream vertex descriptor when the chain signature
-   *         matches, otherwise {@link Optional#empty()}
+   *         matches, otherwise {@code null}
    */
-  static Optional<ChainedTarget> resolveChainedTarget(
+  @Nullable static ChainedTarget resolveChainedTarget(
       PatternEdge edge,
       PatternNode neighbor,
       Set<PatternEdge> visitedEdges,
       @Nullable Map<String, String> aliasClasses,
       @Nullable DatabaseSessionEmbedded session) {
+    var shape = detectChainShape(edge, neighbor, aliasClasses, session);
+    if (shape == null) {
+      return null;
+    }
+    // Visited-edge check is dynamic (DFS state); kept separate from
+    // {@link #detectChainShape} so the structural answer can be cached
+    // across plan iterations. {@code detectChainShape} already verified
+    // {@code neighbor.out.size() == 1}, so the iterator access is safe.
+    if (visitedEdges.contains(neighbor.out.iterator().next())) {
+      return null;
+    }
+    return shape;
+  }
+
+  /**
+   * Pure structural part of the chain-detection rule: applies all clauses
+   * of {@link #resolveChainedTarget} except the dynamic visited-edge check.
+   * The result depends only on the pattern graph and the per-plan
+   * {@code aliasClasses} / {@code session}, all stable for the lifetime of
+   * one plan, which makes it safe to cache by {@link PatternEdge} identity
+   * (see the {@code chainShapeCache} threaded through
+   * {@link #updateScheduleStartingAt}).
+   *
+   * <p>Callers that need the visited check (the sort loop, the multi-hop
+   * walk) apply it on top of this helper's result.
+   */
+  @Nullable private static ChainedTarget detectChainShape(
+      PatternEdge edge,
+      PatternNode neighbor,
+      @Nullable Map<String, String> aliasClasses,
+      @Nullable DatabaseSessionEmbedded session) {
     if (edge.item == null || edge.item.getMethod() == null) {
-      return Optional.empty();
+      return null;
     }
     var rawFirstName = edge.item.getMethod().getMethodNameString();
     // Sort-loop hot path: invoked on every candidate edge, including the very
@@ -2958,16 +3005,13 @@ public class MatchExecutionPlanner {
         || (!"outE".equalsIgnoreCase(rawFirstName)
             && !"inE".equalsIgnoreCase(rawFirstName)
             && !"bothE".equalsIgnoreCase(rawFirstName))) {
-      return Optional.empty();
+      return null;
     }
 
     if (neighbor.out.size() != 1 || neighbor.in.size() != 1) {
-      return Optional.empty();
+      return null;
     }
     var downstreamEdge = neighbor.out.iterator().next();
-    if (visitedEdges.contains(downstreamEdge)) {
-      return Optional.empty();
-    }
     // Defense-in-depth identity check. The size==1 guard above already
     // rejects the common fragment-join case (a user reusing {as: e} across
     // two MATCH fragments makes neighbor.in.size() >= 2). This check pins
@@ -2975,18 +3019,18 @@ public class MatchExecutionPlanner {
     // incoming edge that is not `edge` — which the DFS does not produce
     // today but may via future refactorings of pattern construction.
     if (neighbor.in.iterator().next() != edge) {
-      return Optional.empty();
+      return null;
     }
 
     if (downstreamEdge.item == null || downstreamEdge.item.getMethod() == null) {
-      return Optional.empty();
+      return null;
     }
     var rawSecondName = downstreamEdge.item.getMethod().getMethodNameString();
     if (rawSecondName == null
         || (!"inV".equalsIgnoreCase(rawSecondName)
             && !"outV".equalsIgnoreCase(rawSecondName)
             && !"bothV".equalsIgnoreCase(rawSecondName))) {
-      return Optional.empty();
+      return null;
     }
 
     // effectiveTargetAlias is the downstream vertex alias — NOT neighbor.alias,
@@ -2995,13 +3039,13 @@ public class MatchExecutionPlanner {
 
     // Class-inference precedence:
     //   1. aliasClasses.get(effectiveTargetAlias) — the normal path for
-    //      outE→inV / inE→outV because `addAliases` pre-populates via
-    //      `inferClassFromEdgeSchema` (MatchExecutionPlanner.java:4518). Also
-    //      the only path for bothE→bothV when the user wrote {class: ...}.
+    //      outE→inV / inE→outV because {@code addAliases} pre-populates via
+    //      {@code inferClassFromEdgeSchema}. Also the only path for
+    //      bothE→bothV when the user wrote {class: ...}.
     //   2. Defensive fallback for while-expression aliases skipped by
-    //      `addAliases` at the whileAliases filter (line 4495): derive from
-    //      the first edge's class name + direction. outE→inV uses the edge
-    //      class's `in` linked vertex class; inE→outV uses `out`;
+    //      {@code addAliases}'s whileAliases filter: derive from the first
+    //      edge's class name + direction. outE→inV uses the edge class's
+    //      {@code in} linked vertex class; inE→outV uses {@code out};
     //      bothE→bothV cannot infer (returns null).
     String effectiveTargetClass = aliasClasses != null
         ? aliasClasses.get(effectiveTargetAlias) : null;
@@ -3015,7 +3059,7 @@ public class MatchExecutionPlanner {
       effectiveTargetClass = linkedVertexClassForVertexStep(
           rawSecondName, extractEdgeClassName(edge.item.getMethod()), session);
     }
-    return Optional.of(new ChainedTarget(effectiveTargetAlias, effectiveTargetClass));
+    return new ChainedTarget(effectiveTargetAlias, effectiveTargetClass);
   }
 
   /**
@@ -3122,6 +3166,11 @@ public class MatchExecutionPlanner {
    * folded. Pre-condition: {@code maxHops >= 1}; the caller's gate excludes
    * {@code maxHops <= 0} (the rollback case).
    *
+   * <p>{@code chainShapeCache} memoizes the structural part of the chain
+   * detection per first-edge identity, so repeat sort-loop invocations of
+   * the same edge skip the lower-case method-name comparisons and the
+   * schema lookups. The dynamic visited-edge check is performed inline.
+   *
    * @return the cost adjusted for all detected chain hops up to
    *         {@code maxHops}; equals {@code baseCost} when no chain is
    *         detected
@@ -3132,19 +3181,26 @@ public class MatchExecutionPlanner {
       PatternNode firstNeighbor,
       int maxHops,
       Set<PatternEdge> visitedEdges,
-      Map<String, String> aliasClasses,
-      Map<String, SQLWhereClause> aliasFilters,
-      Map<String, Long> estimatedRootEntries,
-      DatabaseSessionEmbedded session) {
-    var firstHop = resolveChainedTarget(
-        firstEdge, firstNeighbor, visitedEdges, aliasClasses, session);
-    if (firstHop.isEmpty()) {
+      @Nullable Map<String, String> aliasClasses,
+      @Nullable Map<String, SQLWhereClause> aliasFilters,
+      @Nullable Map<String, Long> estimatedRootEntries,
+      @Nullable DatabaseSessionEmbedded session,
+      Map<PatternEdge, ChainedTarget> chainShapeCache) {
+    var firstHop = lookupOrDetectChainShape(
+        firstEdge, firstNeighbor, aliasClasses, session, chainShapeCache);
+    if (firstHop == null) {
+      return baseCost;
+    }
+    // Visited-edge check is dynamic and intentionally not cached: a chain
+    // whose downstream edge is already scheduled would double-count its
+    // selectivity through the cached structural answer.
+    if (visitedEdges.contains(firstNeighbor.out.iterator().next())) {
       return baseCost;
     }
     double cost = applyTargetSelectivity(
         baseCost,
-        firstHop.get().effectiveTargetAlias(),
-        firstHop.get().effectiveTargetClass(),
+        firstHop.effectiveTargetAlias(),
+        firstHop.effectiveTargetClass(),
         aliasFilters,
         estimatedRootEntries,
         session);
@@ -3159,13 +3215,14 @@ public class MatchExecutionPlanner {
         firstNeighbor.out.iterator().next().in;
     var extraHops = walkLinearChainExtension(
         firstDownstreamVertex,
-        firstHop.get().effectiveTargetClass(),
+        firstHop.effectiveTargetClass(),
         maxHops - 1,
         visitedEdges,
         firstEdge,
         firstNeighbor,
         aliasClasses,
-        session);
+        session,
+        chainShapeCache);
     for (var hop : extraHops) {
       cost *= estimateMethodFanOut(
           hop.edgeStep().item.getMethod(),
@@ -3228,8 +3285,16 @@ public class MatchExecutionPlanner {
       PatternEdge firstHopEdge,
       PatternNode firstHopNeighbor,
       @Nullable Map<String, String> aliasClasses,
-      @Nullable DatabaseSessionEmbedded session) {
+      @Nullable DatabaseSessionEmbedded session,
+      Map<PatternEdge, ChainedTarget> chainShapeCache) {
     if (remainingHops <= 0) {
+      return List.of();
+    }
+    // Fast-path: terminal vertices and branch points cannot extend the
+    // chain. Bail out before allocating the localVisited HashSet — the
+    // common case in pattern graphs whose tail vertex has no outgoing
+    // edges or fans out to multiple neighbors.
+    if (currentVertex.out.size() != 1) {
       return List.of();
     }
     var hops = new ArrayList<ChainHop>();
@@ -3250,12 +3315,19 @@ public class MatchExecutionPlanner {
         break;
       }
       var nextIntermediate = nextEdgeStep.in;
-      var nextSubChain = resolveChainedTarget(
-          nextEdgeStep, nextIntermediate, localVisited, aliasClasses, session);
-      if (nextSubChain.isEmpty()) {
+      // Reuse the structural-detection cache: identical pattern shape and
+      // class-resolution inputs across plan iterations. The visited-edge
+      // check uses the local set rather than the cached value.
+      var nextSubChain = lookupOrDetectChainShape(
+          nextEdgeStep, nextIntermediate, aliasClasses, session, chainShapeCache);
+      if (nextSubChain == null) {
         break;
       }
+      // detectChainShape verified nextIntermediate.out.size() == 1.
       var vertexStepEdge = nextIntermediate.out.iterator().next();
+      if (localVisited.contains(vertexStepEdge)) {
+        break;
+      }
       localVisited.add(nextEdgeStep);
       localVisited.add(vertexStepEdge);
 
@@ -3263,13 +3335,33 @@ public class MatchExecutionPlanner {
           nextEdgeStep,
           sourceClass,
           nextIntermediate.alias,
-          nextSubChain.get().effectiveTargetAlias(),
-          nextSubChain.get().effectiveTargetClass()));
+          nextSubChain.effectiveTargetAlias(),
+          nextSubChain.effectiveTargetClass()));
 
       currentVertex = vertexStepEdge.in;
-      sourceClass = nextSubChain.get().effectiveTargetClass();
+      sourceClass = nextSubChain.effectiveTargetClass();
     }
     return hops;
+  }
+
+  /**
+   * Cache-aware wrapper around {@link #detectChainShape}. {@code computeIfAbsent}
+   * cannot be used here because we want to memoize {@code null} results
+   * (known-not-chain edges) too; the {@code containsKey}/{@code put} pair
+   * disambiguates a missing entry from a cached negative.
+   */
+  @Nullable private static ChainedTarget lookupOrDetectChainShape(
+      PatternEdge edge,
+      PatternNode neighbor,
+      @Nullable Map<String, String> aliasClasses,
+      @Nullable DatabaseSessionEmbedded session,
+      Map<PatternEdge, ChainedTarget> chainShapeCache) {
+    if (chainShapeCache.containsKey(edge)) {
+      return chainShapeCache.get(edge);
+    }
+    var shape = detectChainShape(edge, neighbor, aliasClasses, session);
+    chainShapeCache.put(edge, shape);
+    return shape;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2877,8 +2877,12 @@ public class MatchExecutionPlanner {
     if (visitedEdges.contains(downstreamEdge)) {
       return Optional.empty();
     }
-    // Identity check: PatternEdge has no equals() override, but we still want
-    // referential identity to guard against accidental future changes.
+    // Defense-in-depth identity check. The size==1 guard above already
+    // rejects the common fragment-join case (a user reusing {as: e} across
+    // two MATCH fragments makes neighbor.in.size() >= 2). This check pins
+    // the residual case — a pattern graph whose intermediate has a single
+    // incoming edge that is not `edge` — which the DFS does not produce
+    // today but may via future refactorings of pattern construction.
     if (neighbor.in.iterator().next() != edge) {
       return Optional.empty();
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2154,26 +2154,19 @@ public class MatchExecutionPlanner {
               cost, neighbor.alias, entry.getKey(), entry.getValue(),
               aliasClasses, aliasFilters, estimatedRootEntries, session);
           // Edge-method chain detection: when the current edge is the first hop of
-          // an outE→inV / inE→outV / bothE→bothV sequence, fold the downstream
-          // vertex's WHERE selectivity into the first edge's cost. The intermediate
-          // edge alias carries no vertex WHERE, so without this fold the branch
-          // sorts as "no selectivity" and loses to broader branches. This is the
-          // second factor of the independence multiplication; the first factor
-          // (the intermediate alias's own filter) was applied by the preceding
-          // applyTargetSelectivity call. Multiplication commutes and each call
-          // short-circuits to baseCost when its alias has no filter/class/
-          // row-estimate, so there is no double-counting.
-          var chain = resolveChainedTarget(
-              entry.getKey(), neighbor, visitedEdges, aliasClasses, session);
-          if (chain.isPresent()) {
-            var target = chain.get();
-            cost = applyTargetSelectivity(
-                cost,
-                target.effectiveTargetAlias(),
-                target.effectiveTargetClass(),
-                aliasFilters,
-                estimatedRootEntries,
-                session);
+          // an outE→inV / inE→outV / bothE→bothV sequence (possibly extended into
+          // a multi-hop linear chain), fold each downstream vertex's WHERE and
+          // each subsequent edge step's fan-out into the first edge's cost. The
+          // intermediate edge alias carries no vertex WHERE, so without this
+          // fold the branch sorts as "no selectivity" and loses to broader
+          // branches. Each fold call short-circuits to baseCost when its alias
+          // has no filter/class/row-estimate, so adding more hops does not
+          // double-count when those hops have no filter.
+          int maxHops = GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger();
+          if (maxHops >= 1) {
+            cost = applyChainFold(
+                cost, entry.getKey(), neighbor, maxHops, visitedEdges,
+                aliasClasses, aliasFilters, estimatedRootEntries, session);
           }
           cost = applyDepthMultiplier(cost, entry.getKey());
         }
@@ -3068,6 +3061,212 @@ public class MatchExecutionPlanner {
       return null;
     }
     return lookupLinkedVertexClass(edgeClassName, prop, session);
+  }
+
+  /**
+   * Describes a single sub-chain in a multi-hop linear chain extension. A
+   * sub-chain is one (edge step → vertex step) pair, e.g. {@code outE('B')
+   * → inV()} appearing AFTER an initial {@code outE('A').inV()} that started
+   * the chain. The first sub-chain is handled by the existing single-hop
+   * fold and is not represented here — only the additional hops are.
+   *
+   * @param edgeStep         the {@code outE}/{@code inE}/{@code bothE} step
+   *                         that starts this sub-chain. Its fan-out from
+   *                         {@code edgeStepSourceClass} is multiplied into
+   *                         the running cost (the first edge step is part of
+   *                         {@code estimateEdgeCost}'s baseCost; subsequent
+   *                         steps are not, so we add them here)
+   * @param edgeStepSourceClass class of the vertex feeding {@code edgeStep},
+   *                         used as the cardinality denominator for fan-out
+   *                         estimation. May be {@code null} if class
+   *                         inference failed for the previous hop's
+   *                         downstream vertex
+   * @param intermediateAlias the alias of the intermediate edge alias node
+   *                         (e.g. user's {@code as: e2}). Selectivity is
+   *                         applied to it the same way the first hop does
+   *                         in the sort loop's primary
+   *                         {@code applyTargetSelectivity} call
+   * @param downstreamAlias  the alias of the vertex reached by this hop's
+   *                         vertex step. Its WHERE drives the per-hop
+   *                         selectivity contribution
+   * @param downstreamClass  class of the downstream vertex, or {@code null}
+   *                         when it cannot be inferred
+   */
+  record ChainHop(
+      PatternEdge edgeStep,
+      @Nullable String edgeStepSourceClass,
+      String intermediateAlias,
+      String downstreamAlias,
+      @Nullable String downstreamClass) {
+  }
+
+  /**
+   * Applies the multi-hop chain fold to {@code baseCost} starting from
+   * {@code firstEdge → firstNeighbor}. This is the unified entry point used
+   * by the sort loop: it composes {@link #resolveChainedTarget} (the
+   * single-hop rule) with {@link #walkLinearChainExtension} (the iterative
+   * extension into subsequent linear sub-chains, bounded by
+   * {@code maxHops}).
+   *
+   * <p>For the first hop only the downstream vertex's WHERE selectivity is
+   * applied — the first edge's fan-out is already in {@code baseCost} and
+   * the immediate intermediate alias was folded by the sort loop's primary
+   * {@code applyTargetSelectivity} call before this method runs.
+   *
+   * <p>For each additional hop (hop 2…N): multiply by the edge step's
+   * fan-out, apply the intermediate edge alias's WHERE (rare, only when the
+   * user named it with {@code as:} and gave it a filter), then apply the
+   * downstream vertex's WHERE.
+   *
+   * <p>{@code maxHops} caps the total number of (edge, vertex) sub-chains
+   * folded. Pre-condition: {@code maxHops >= 1}; the caller's gate excludes
+   * {@code maxHops <= 0} (the rollback case).
+   *
+   * @return the cost adjusted for all detected chain hops up to
+   *         {@code maxHops}; equals {@code baseCost} when no chain is
+   *         detected
+   */
+  private static double applyChainFold(
+      double baseCost,
+      PatternEdge firstEdge,
+      PatternNode firstNeighbor,
+      int maxHops,
+      Set<PatternEdge> visitedEdges,
+      Map<String, String> aliasClasses,
+      Map<String, SQLWhereClause> aliasFilters,
+      Map<String, Long> estimatedRootEntries,
+      DatabaseSessionEmbedded session) {
+    var firstHop = resolveChainedTarget(
+        firstEdge, firstNeighbor, visitedEdges, aliasClasses, session);
+    if (firstHop.isEmpty()) {
+      return baseCost;
+    }
+    double cost = applyTargetSelectivity(
+        baseCost,
+        firstHop.get().effectiveTargetAlias(),
+        firstHop.get().effectiveTargetClass(),
+        aliasFilters,
+        estimatedRootEntries,
+        session);
+
+    if (maxHops <= 1) {
+      return cost;
+    }
+
+    // Walk forward from the first hop's downstream vertex into any
+    // additional linear sub-chains, capped at maxHops - 1 extra hops.
+    var firstDownstreamVertex =
+        firstNeighbor.out.iterator().next().in;
+    var extraHops = walkLinearChainExtension(
+        firstDownstreamVertex,
+        firstHop.get().effectiveTargetClass(),
+        maxHops - 1,
+        visitedEdges,
+        firstEdge,
+        firstNeighbor,
+        aliasClasses,
+        session);
+    for (var hop : extraHops) {
+      cost *= estimateMethodFanOut(
+          hop.edgeStep().item.getMethod(),
+          hop.edgeStepSourceClass(),
+          session);
+      // Intermediate edge alias is mostly auto-generated (no WHERE), so this
+      // call is a no-op in the typical case. Required only for user-named
+      // intermediate aliases that carry their own WHERE/estimate.
+      cost = applyTargetSelectivity(
+          cost,
+          hop.intermediateAlias(),
+          (String) null,
+          aliasFilters,
+          estimatedRootEntries,
+          session);
+      cost = applyTargetSelectivity(
+          cost,
+          hop.downstreamAlias(),
+          hop.downstreamClass(),
+          aliasFilters,
+          estimatedRootEntries,
+          session);
+    }
+    return cost;
+  }
+
+  /**
+   * Iteratively extends a linear chain past its first hop. Starts from
+   * {@code currentVertex} (the downstream vertex of the first hop) and
+   * walks forward as long as:
+   * <ul>
+   *   <li>{@code currentVertex.out.size() == 1} (no branch point);</li>
+   *   <li>that single outgoing edge starts another valid sub-chain per
+   *       {@link #resolveChainedTarget}'s structural rule;</li>
+   *   <li>neither edge in the new sub-chain has been visited (back-edge
+   *       guard against pattern loops).</li>
+   * </ul>
+   * Walk terminates as soon as any condition fails, or when
+   * {@code remainingHops} reaches zero. The structural rule handles
+   * fragment-join, branch-point, and visited-edge rejection identically to
+   * the single-hop case.
+   *
+   * <p>Visited tracking uses a local copy of {@code initialVisitedEdges}
+   * augmented with the first hop's two edges (so the walk does not loop
+   * back through them) and with each sub-chain's edges as we cross them.
+   * This local set is only used to reason about chain shape — the caller's
+   * DFS-level {@code visitedEdges} is not mutated.
+   *
+   * @return list of additional hops (may be empty); each hop is one
+   *         (edge step, vertex step) sub-chain
+   */
+  private static List<ChainHop> walkLinearChainExtension(
+      PatternNode currentVertex,
+      @Nullable String currentVertexClass,
+      int remainingHops,
+      Set<PatternEdge> initialVisitedEdges,
+      PatternEdge firstHopEdge,
+      PatternNode firstHopNeighbor,
+      @Nullable Map<String, String> aliasClasses,
+      @Nullable DatabaseSessionEmbedded session) {
+    if (remainingHops <= 0) {
+      return List.of();
+    }
+    var hops = new ArrayList<ChainHop>();
+    var localVisited = new HashSet<>(initialVisitedEdges);
+    localVisited.add(firstHopEdge);
+    // Mark the first hop's vertex-step edge so the walk cannot loop back
+    // through it. firstHopNeighbor.out.size() == 1 holds by virtue of
+    // resolveChainedTarget having already accepted the first hop.
+    localVisited.add(firstHopNeighbor.out.iterator().next());
+
+    var sourceClass = currentVertexClass;
+    while (hops.size() < remainingHops) {
+      if (currentVertex.out.size() != 1) {
+        break;
+      }
+      var nextEdgeStep = currentVertex.out.iterator().next();
+      if (localVisited.contains(nextEdgeStep)) {
+        break;
+      }
+      var nextIntermediate = nextEdgeStep.in;
+      var nextSubChain = resolveChainedTarget(
+          nextEdgeStep, nextIntermediate, localVisited, aliasClasses, session);
+      if (nextSubChain.isEmpty()) {
+        break;
+      }
+      var vertexStepEdge = nextIntermediate.out.iterator().next();
+      localVisited.add(nextEdgeStep);
+      localVisited.add(vertexStepEdge);
+
+      hops.add(new ChainHop(
+          nextEdgeStep,
+          sourceClass,
+          nextIntermediate.alias,
+          nextSubChain.get().effectiveTargetAlias(),
+          nextSubChain.get().effectiveTargetClass()));
+
+      currentVertex = vertexStepEdge.in;
+      sourceClass = nextSubChain.get().effectiveTargetClass();
+    }
+    return hops;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -3172,12 +3172,15 @@ public class MatchExecutionPlanner {
           hop.edgeStepSourceClass(),
           session);
       // Intermediate edge alias is mostly auto-generated (no WHERE), so this
-      // call is a no-op in the typical case. Required only for user-named
-      // intermediate aliases that carry their own WHERE/estimate.
+      // call is typically a no-op via the no-filter short-circuit. The class
+      // is the EDGE class of this hop's edge step (e.g. 'Friend' for
+      // .outE('Friend'){as: e}); without it, applyTargetSelectivity would
+      // short-circuit unconditionally and ignore user-named intermediate
+      // aliases that carry their own WHERE (e.g. {as: e, where: weight > 5}).
       cost = applyTargetSelectivity(
           cost,
           hop.intermediateAlias(),
-          (String) null,
+          extractEdgeClassName(hop.edgeStep().item.getMethod()),
           aliasFilters,
           estimatedRootEntries,
           session);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2845,9 +2845,12 @@ public class MatchExecutionPlanner {
    *                       ({@code entry.getValue() ? edge.in : edge.out})
    * @param visitedEdges   DFS state — the chain is only detected while the
    *                       intermediate edge's follow-up is still unscheduled
-   * @param aliasClasses   alias → class map; accepted for parity with
-   *                       class-inference overloads and used by Step 2
-   * @param session        database session for schema access; used by Step 2
+   * @param aliasClasses   alias → class map; may be {@code null}, in which
+   *                       case the helper falls directly to the
+   *                       edge-schema-derivation fallback
+   * @param session        database session for schema access; may be
+   *                       {@code null}, in which case the fallback returns
+   *                       {@code null} for the class field
    * @return the downstream vertex descriptor when the chain signature
    *         matches, otherwise {@link Optional#empty()}
    */
@@ -2855,7 +2858,7 @@ public class MatchExecutionPlanner {
       PatternEdge edge,
       PatternNode neighbor,
       Set<PatternEdge> visitedEdges,
-      Map<String, String> aliasClasses,
+      @Nullable Map<String, String> aliasClasses,
       @Nullable DatabaseSessionEmbedded session) {
     if (edge.item == null || edge.item.getMethod() == null) {
       return Optional.empty();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2166,10 +2166,11 @@ public class MatchExecutionPlanner {
           var chain = resolveChainedTarget(
               entry.getKey(), neighbor, visitedEdges, aliasClasses, session);
           if (chain.isPresent()) {
+            var target = chain.get();
             cost = applyTargetSelectivity(
                 cost,
-                chain.get().effectiveTargetAlias(),
-                chain.get().effectiveTargetClass(),
+                target.effectiveTargetAlias(),
+                target.effectiveTargetClass(),
                 aliasFilters,
                 estimatedRootEntries,
                 session);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -2528,7 +2528,68 @@ public class MatchExecutionPlanner {
     if (targetClass == null) {
       return 1.0;
     }
+    return applyClassSelectivity(
+        baseCost, targetAlias, targetClass,
+        aliasFilters, estimatedRootEntries, session);
+  }
 
+  /**
+   * Class-forced overload used by the sort-loop's edge-method chain fold.
+   * Bypasses {@link #resolveTargetClass} — the caller
+   * ({@link #updateScheduleStartingAt} via {@link #resolveChainedTarget})
+   * has already computed the downstream vertex class using chain-aware
+   * precedence (aliasClasses first, then direction-aware edge-schema
+   * derivation), so re-inferring with the outer edge's direction would
+   * pick the wrong endpoint for {@code inE→outV}.
+   *
+   * <p>Short-circuits to {@code baseCost} when {@code preResolvedTargetClass}
+   * is {@code null} (e.g. {@code bothE→bothV} without an explicit
+   * {@code class:} annotation) — matching the behaviour of the existing
+   * 8-arg overload when {@link #resolveTargetClass} returns {@code null}.
+   *
+   * @param baseCost             the fan-out-based traversal cost from
+   *                             {@link #estimateEdgeCost}, already adjusted
+   *                             by the intermediate alias's filter (if any)
+   *                             via the preceding 8-arg call
+   * @param targetAlias          the downstream vertex alias (from
+   *                             {@link ChainedTarget#effectiveTargetAlias})
+   * @param preResolvedTargetClass class name resolved by the chain helper,
+   *                             or {@code null} when inference failed
+   * @param aliasFilters         alias → WHERE clause mapping
+   * @param estimatedRootEntries estimated cardinality per alias
+   * @param session              database session for schema access
+   * @return adjusted cost
+   */
+  static double applyTargetSelectivity(
+      double baseCost,
+      String targetAlias,
+      @Nullable String preResolvedTargetClass,
+      Map<String, SQLWhereClause> aliasFilters,
+      Map<String, Long> estimatedRootEntries,
+      DatabaseSessionEmbedded session) {
+    if (preResolvedTargetClass == null) {
+      return baseCost;
+    }
+    return applyClassSelectivity(
+        baseCost, targetAlias, preResolvedTargetClass,
+        aliasFilters, estimatedRootEntries, session);
+  }
+
+  /**
+   * Shared body of both {@link #applyTargetSelectivity} overloads: given a
+   * non-null target class, look it up in the schema and adjust {@code baseCost}
+   * by either (a) the filter-shape heuristic on the target's WHERE clause,
+   * or (b) the estimated cardinality ratio. All null-guards on the target
+   * class are the callers' responsibility; this helper assumes
+   * {@code targetClass != null}.
+   */
+  private static double applyClassSelectivity(
+      double baseCost,
+      String targetAlias,
+      String targetClass,
+      Map<String, SQLWhereClause> aliasFilters,
+      Map<String, Long> estimatedRootEntries,
+      DatabaseSessionEmbedded session) {
     var schema = session.getMetadata().getImmutableSchemaSnapshot();
     if (schema == null) {
       return 1.0;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.common.util.PairLongObject;
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
@@ -397,11 +398,15 @@ public class MatchExecutionPlanner {
   private static final int MAX_CHAIN_FOLD_HOPS = 1000;
 
   /**
-   * Tracks the last knob value that triggered an upper-bound clamp warning,
-   * so {@link #clampChainFoldMaxHops} logs at most once per <em>unique</em>
-   * out-of-range value. The sort loop reads the knob once per plan, so for
-   * a server processing thousands of queries with a misconfigured knob we
-   * would otherwise emit thousands of duplicate WARN lines.
+   * Tracks the last out-of-range knob value that triggered an upper-bound
+   * clamp warning, so {@link #clampChainFoldMaxHops} dedupes against the
+   * <em>immediately-preceding</em> warned value only. This is last-value
+   * dedupe, not once-per-distinct-value: a steady misconfiguration on a
+   * single value warns once, and an alternating misconfiguration between
+   * two out-of-range values (e.g. {@code 5000}, {@code 6000}, {@code 5000},
+   * …) re-warns on every change because each value differs from the one
+   * stored by the previous clamp. The common case — one misconfigured value
+   * read once per plan across many queries — collapses to a single WARN.
    *
    * <p>Initialised to {@code 0} as a sentinel: {@code 0} is always in-range
    * (it is the documented "fold disabled" value) so the clamp helper never
@@ -894,11 +899,15 @@ public class MatchExecutionPlanner {
     long estimate = estimateAliasCardinality(
         originAlias, aliasClasses, aliasFilters, aliasPinnedRids, context);
     var currentClass = aliasClasses.get(originAlias);
+    // Fresh per-call memo of class-name → approximateCount: fan-out values
+    // are unchanged, only repeated counts for the same class are elided.
+    Map<String, Long> classCountCache = new HashMap<>();
     for (var item : exp.getItems()) {
       // Estimate fan-out from schema statistics (edgeCount / sourceCount)
       // or fall back to default if schema metadata is unavailable
       var method = item.getMethod();
-      double fanOut = estimateMethodFanOut(method, currentClass, session);
+      double fanOut = estimateMethodFanOut(method, currentClass, session,
+          classCountCache);
       long fanOutLong = Math.max(1, Math.round(fanOut));
       if (estimate > Long.MAX_VALUE / fanOutLong) {
         return Long.MAX_VALUE; // overflow guard
@@ -1442,10 +1451,13 @@ public class MatchExecutionPlanner {
     // it's a filter verifying the target alias matches an already-visited node (cost 0).
     int edgeCount = Math.max(0, branchEdges.size() - 1);
     var currentClass = aliasClasses.get(branchRoot);
+    // Fresh per-call class-count memo (pure optimisation).
+    Map<String, Long> classCountCache = new HashMap<>();
     for (int i = 0; i < edgeCount; i++) {
       var edgeT = branchEdges.get(i);
       var method = edgeT.edge.item != null ? edgeT.edge.item.getMethod() : null;
-      double fanOut = estimateMethodFanOut(method, currentClass, session);
+      double fanOut = estimateMethodFanOut(method, currentClass, session,
+          classCountCache);
       long fanOutLong = Math.max(1, Math.round(fanOut));
       if (rows > Long.MAX_VALUE / fanOutLong) {
         return Long.MAX_VALUE; // overflow guard
@@ -1502,13 +1514,16 @@ public class MatchExecutionPlanner {
         rootAlias, aliasClasses, aliasFilters, aliasPinnedRids, context);
 
     var currentClass = aliasClasses.get(rootAlias);
+    // Fresh per-call class-count memo (pure optimisation).
+    Map<String, Long> classCountCache = new HashMap<>();
     for (int i = 0; i < checkIdx; i++) {
       var edgeT = scheduledEdges.get(i);
       if (branchEdgeSet.contains(edgeT)) {
         continue; // Skip branch edges — they don't contribute to upstream
       }
       var method = edgeT.edge.item != null ? edgeT.edge.item.getMethod() : null;
-      double fanOut = estimateMethodFanOut(method, currentClass, session);
+      double fanOut = estimateMethodFanOut(method, currentClass, session,
+          classCountCache);
       long fanOutLong = Math.max(1, Math.round(fanOut));
       if (rows > Long.MAX_VALUE / fanOutLong) {
         return Long.MAX_VALUE;
@@ -1548,10 +1563,13 @@ public class MatchExecutionPlanner {
     int edgeCount = Math.max(0, branchEdges.size() - 1);
     double fanOut = 1.0;
     var currentClass = aliasClasses.get(branchRoot);
+    // Fresh per-call class-count memo (pure optimisation).
+    Map<String, Long> classCountCache = new HashMap<>();
     for (int i = 0; i < edgeCount; i++) {
       var edgeT = branchEdges.get(i);
       var method = edgeT.edge.item != null ? edgeT.edge.item.getMethod() : null;
-      fanOut *= estimateMethodFanOut(method, currentClass, session);
+      fanOut *= estimateMethodFanOut(method, currentClass, session,
+          classCountCache);
       var target = targetAlias(edgeT);
       var targetFilter = aliasFilters.get(target);
       if (targetFilter != null) {
@@ -2030,8 +2048,16 @@ public class MatchExecutionPlanner {
     // and session, all stable for the lifetime of one plan. The visited-edge
     // check is dynamic and is performed at each call site separately, so the
     // cache stores only the structural shape. {@code containsKey} disambiguates
-    // a known-not-chain ({@code null} value) from an uncached entry.
-    Map<PatternEdge, ChainedTarget> chainShapeCache = new HashMap<>();
+    // a known-not-chain ({@code null} value) from an uncached entry. The key is
+    // a composite of (edge, neighbor-direction) because detectChainShape's
+    // answer depends on which side of the edge the neighbor is on; keying by
+    // edge alone would let one direction's result poison the other.
+    Map<ChainShapeKey, ChainedTarget> chainShapeCache = new HashMap<>();
+    // Per-plan memo of class-name → approximateCount, shared by the edge-cost
+    // estimator and the chain fold so each distinct class's O(1) count read
+    // happens once per plan. Pure memo of a deterministic call: values are
+    // identical to the un-cached path. Same lifetime/scope as chainShapeCache.
+    Map<String, Long> classCountCache = new HashMap<>();
 
     // Sort the possible root vertices in order of estimated size, since we want to start with a
     // small vertex set.
@@ -2087,7 +2113,7 @@ public class MatchExecutionPlanner {
       updateScheduleStartingAt(
           startingNode, visitedNodes, visitedEdges, remainingDependencies,
           resultingSchedule, estimatedRootEntries, aliasClasses, aliasFilters,
-          session, chainFoldMaxHops, chainShapeCache);
+          session, chainFoldMaxHops, chainShapeCache, classCountCache);
     }
 
     if (resultingSchedule.size() != pattern.numOfEdges) {
@@ -2112,9 +2138,12 @@ public class MatchExecutionPlanner {
    * because the operator's intent matters here: somebody who set the knob
    * to e.g. {@code 100_000} probably wanted "fold everything", and a silent
    * clamp would leave them debugging a fold depth that does not match their
-   * configuration. The warning fires at most once per unique raw value in a
-   * JVM lifetime — concurrent plans racing on the same out-of-range value
-   * agree on a single emitter via {@link AtomicInteger#getAndSet}.
+   * configuration. The warning is deduped against the immediately-preceding
+   * out-of-range value (last-value dedupe via {@link AtomicInteger#getAndSet}
+   * on {@link #lastWarnedChainFoldKnob}): a repeated single out-of-range
+   * value warns once, but alternating between two out-of-range values
+   * re-warns on each change. Concurrent plans racing on the same brand-new
+   * out-of-range value agree on a single emitter.
    *
    * @param raw the raw knob value as read from {@link GlobalConfiguration}
    * @return the clamped value, in {@code [0, MAX_CHAIN_FOLD_HOPS]}
@@ -2166,7 +2195,8 @@ public class MatchExecutionPlanner {
       Map<String, SQLWhereClause> aliasFilters,
       DatabaseSessionEmbedded session,
       int chainFoldMaxHops,
-      Map<PatternEdge, ChainedTarget> chainShapeCache) {
+      Map<ChainShapeKey, ChainedTarget> chainShapeCache,
+      Map<String, Long> classCountCache) {
     // YouTrackDB requires the schedule to contain all edges present in the query, which is a stronger
     // condition
     // than simply visiting all nodes in the query. Consider the following example query:
@@ -2244,7 +2274,8 @@ public class MatchExecutionPlanner {
         cost = 0.0;
       } else {
         cost = estimateEdgeCost(
-            entry.getKey(), sourceAlias, sourceRows, aliasClasses, session);
+            entry.getKey(), sourceAlias, sourceRows, aliasClasses, session,
+            classCountCache);
         if (cost < Double.MAX_VALUE) {
           cost = applyTargetSelectivity(
               cost, neighbor.alias, entry.getKey(), entry.getValue(),
@@ -2262,7 +2293,7 @@ public class MatchExecutionPlanner {
             cost = applyChainFold(
                 cost, entry.getKey(), neighbor, chainFoldMaxHops, visitedEdges,
                 aliasClasses, aliasFilters, estimatedRootEntries, session,
-                chainShapeCache);
+                chainShapeCache, classCountCache);
           }
           cost = applyDepthMultiplier(cost, entry.getKey());
         }
@@ -2375,7 +2406,7 @@ public class MatchExecutionPlanner {
           updateScheduleStartingAt(
               neighboringNode, visitedNodes, visitedEdges, remainingDependencies,
               resultingSchedule, estimatedRootEntries, aliasClasses, aliasFilters,
-              session, chainFoldMaxHops, chainShapeCache);
+              session, chainFoldMaxHops, chainShapeCache, classCountCache);
           progress = true;
         }
       }
@@ -2437,6 +2468,25 @@ public class MatchExecutionPlanner {
       long sourceRows,
       Map<String, String> aliasClasses,
       DatabaseSessionEmbedded session) {
+    // Backward-compatible overload for callers with no per-plan cache in
+    // scope: a fresh memo yields values identical to the un-cached path.
+    return estimateEdgeCost(
+        edge, sourceAlias, sourceRows, aliasClasses, session, new HashMap<>());
+  }
+
+  /**
+   * Cache-aware variant of {@link #estimateEdgeCost(PatternEdge, String, long,
+   * Map, DatabaseSessionEmbedded)} that threads a per-plan class-count memo
+   * into {@link EdgeFanOutEstimator#estimateFanOut}. The memo is a pure
+   * optimisation: estimated costs are identical to the un-cached path.
+   */
+  static double estimateEdgeCost(
+      PatternEdge edge,
+      String sourceAlias,
+      long sourceRows,
+      Map<String, String> aliasClasses,
+      DatabaseSessionEmbedded session,
+      Map<String, Long> classCountCache) {
     var method = edge.item.getMethod();
     if (method == null) {
       return Double.MAX_VALUE;
@@ -2476,7 +2526,7 @@ public class MatchExecutionPlanner {
 
     double fanOut = EdgeFanOutEstimator.estimateFanOut(
         session, edgeClassName, sourceClassName, direction,
-        outVertexClass, inVertexClass);
+        outVertexClass, inVertexClass, classCountCache);
 
     return CostModel.edgeTraversalCost(sourceRows, fanOut);
   }
@@ -2490,12 +2540,17 @@ public class MatchExecutionPlanner {
    * @param method         the edge's traversal method (e.g., out('KNOWS'))
    * @param sourceClassName class of the vertex we traverse FROM, or null
    * @param session        database session for schema access
+   * @param classCountCache per-call/per-plan memo of class-name →
+   *                        approximateCount, threaded into
+   *                        {@link EdgeFanOutEstimator#estimateFanOut}; a pure
+   *                        optimisation that does not change the returned value
    * @return estimated fan-out (avg neighbors per source vertex)
    */
   static double estimateMethodFanOut(
       SQLMethodCall method,
       @Nullable String sourceClassName,
-      DatabaseSessionEmbedded session) {
+      DatabaseSessionEmbedded session,
+      Map<String, Long> classCountCache) {
     if (method == null) {
       return EdgeFanOutEstimator.defaultFanOut();
     }
@@ -2524,7 +2579,7 @@ public class MatchExecutionPlanner {
     }
     return EdgeFanOutEstimator.estimateFanOut(
         session, edgeClassName, sourceClassName, direction,
-        outVertexClass, inVertexClass);
+        outVertexClass, inVertexClass, classCountCache);
   }
 
   /**
@@ -2689,12 +2744,34 @@ public class MatchExecutionPlanner {
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, Long> estimatedRootEntries,
       DatabaseSessionEmbedded session) {
+    // Backward-compatible overload with no class-count memo.
+    return applyTargetSelectivityWithResolvedClass(
+        baseCost, targetAlias, preResolvedTargetClass,
+        aliasFilters, estimatedRootEntries, null, session);
+  }
+
+  /**
+   * Cache-aware variant of
+   * {@link #applyTargetSelectivityWithResolvedClass(double, String, String,
+   * Map, Map, DatabaseSessionEmbedded)} that threads a per-plan class-count
+   * memo into {@link #applyClassSelectivity}. The memo is a pure optimisation
+   * (deterministic {@code approximateCount} keyed by class name); returned
+   * costs are identical to the un-cached path.
+   */
+  static double applyTargetSelectivityWithResolvedClass(
+      double baseCost,
+      String targetAlias,
+      @Nullable String preResolvedTargetClass,
+      Map<String, SQLWhereClause> aliasFilters,
+      Map<String, Long> estimatedRootEntries,
+      @Nullable Map<String, Long> classCountCache,
+      DatabaseSessionEmbedded session) {
     if (preResolvedTargetClass == null) {
       return baseCost;
     }
     return baseCost * applyClassSelectivity(
         targetAlias, preResolvedTargetClass,
-        aliasFilters, estimatedRootEntries, null, session);
+        aliasFilters, estimatedRootEntries, classCountCache, session);
   }
 
   /**
@@ -2882,7 +2959,8 @@ public class MatchExecutionPlanner {
 
     var method = et.edge.item.getMethod();
     String sourceClass = aliasClasses.get(sourceAlias);
-    double fanOut = estimateMethodFanOut(method, sourceClass, session);
+    double fanOut = estimateMethodFanOut(method, sourceClass, session,
+        classCountCache);
     if (!(fanOut > 0) || !Double.isFinite(fanOut)) {
       et.setForecastN(-1L);
       return;
@@ -2991,6 +3069,19 @@ public class MatchExecutionPlanner {
   }
 
   /**
+   * Composite key for {@code chainShapeCache}. {@link #detectChainShape}'s
+   * answer depends not only on the first {@link PatternEdge} but also on which
+   * side of it the neighbor sits (forward: {@code neighbor == edge.in};
+   * reverse: {@code neighbor == edge.out}) — reverse traversals are rejected by
+   * the structural rule while forward ones may match. Keying by edge alone
+   * would let a cached reverse {@code null} poison the forward lookup (and vice
+   * versa); the {@code neighborIsIn} flag keeps the two directions distinct,
+   * and a {@code null} result stays cached per (edge, direction).
+   */
+  private record ChainShapeKey(PatternEdge edge, boolean neighborIsIn) {
+  }
+
+  /**
    * Detects the edge-method chain pattern {@code .outE(X).inV()} (and its
    * {@code inE→outV} / {@code bothE→bothV} variants) that appears as two
    * consecutive {@link PatternEdge}s in the pattern graph.
@@ -3043,25 +3134,45 @@ public class MatchExecutionPlanner {
    *                       {@code null} for the class field
    * @return the downstream vertex descriptor when the chain signature
    *         matches, otherwise {@code null}
+   * @apiNote Package-visible test seam. The full structural rule — including
+   *          the clause-4 intermediate-edge identity guard — covers pattern
+   *          shapes the runtime DFS cannot construct today; this seam lets
+   *          unit tests exercise those guards directly. Production folds go
+   *          through {@link #applyChainFold} / {@link #lookupOrDetectChainShape}.
    */
+  @VisibleForTesting
   @Nullable static ChainedTarget resolveChainedTarget(
       PatternEdge edge,
       PatternNode neighbor,
       Set<PatternEdge> visitedEdges,
       @Nullable Map<String, String> aliasClasses,
-      @Nullable DatabaseSessionEmbedded session) {
-    var shape = detectChainShape(edge, neighbor, aliasClasses, session);
-    if (shape == null) {
-      return null;
-    }
-    // Visited-edge check is dynamic (DFS state); kept separate from
-    // {@link #detectChainShape} so the structural answer can be cached
-    // across plan iterations. {@code detectChainShape} already verified
-    // {@code neighbor.out.size() == 1}, so the iterator access is safe.
-    if (visitedEdges.contains(neighbor.out.iterator().next())) {
+      DatabaseSessionEmbedded session) {
+    // Route through the cached path (with a throwaway per-call cache) so the
+    // test seam exercises the exact structural detection the sort loop uses,
+    // then apply the shared dynamic visited-edge rule.
+    var shape = lookupOrDetectChainShape(
+        edge, neighbor, aliasClasses, session, new HashMap<>());
+    if (shape == null || chainVertexStepVisited(neighbor, visitedEdges)) {
       return null;
     }
     return shape;
+  }
+
+  /**
+   * Shared visited-edge rule for the edge-method chain fold: the chain is only
+   * foldable while its vertex-step edge (the single edge out of {@code neighbor},
+   * guaranteed to exist by {@link #detectChainShape}'s
+   * {@code neighbor.out.size() == 1} check) has not yet been scheduled. Folding
+   * an already-visited vertex-step edge would double-count its downstream
+   * selectivity through the cached structural answer.
+   *
+   * <p>Single source of truth for the dynamic guard shared by the cached
+   * sort-loop path ({@link #applyChainFold}) and the package-visible test seam
+   * ({@link #resolveChainedTarget}).
+   */
+  private static boolean chainVertexStepVisited(
+      PatternNode neighbor, Set<PatternEdge> visitedEdges) {
+    return visitedEdges.contains(neighbor.out.iterator().next());
   }
 
   /**
@@ -3080,7 +3191,7 @@ public class MatchExecutionPlanner {
       PatternEdge edge,
       PatternNode neighbor,
       @Nullable Map<String, String> aliasClasses,
-      @Nullable DatabaseSessionEmbedded session) {
+      DatabaseSessionEmbedded session) {
     if (edge.item == null || edge.item.getMethod() == null) {
       return null;
     }
@@ -3090,7 +3201,7 @@ public class MatchExecutionPlanner {
     // allocating a lower-cased copy — String.equalsIgnoreCase short-circuits
     // on length mismatch, so .out (len 3) vs .outE (len 4) bails out before
     // any character comparison. Only on a positive match do we cache the
-    // lower-cased canonical form for `inferDownstreamVertexClassFromEdge`.
+    // lower-cased canonical form for `linkedVertexClassForVertexStep`.
     if (rawFirstName == null
         || (!"outE".equalsIgnoreCase(rawFirstName)
             && !"inE".equalsIgnoreCase(rawFirstName)
@@ -3263,9 +3374,13 @@ public class MatchExecutionPlanner {
    * layers are intentional defense-in-depth: callers may rely on either.
    *
    * <p>{@code chainShapeCache} memoizes the structural part of the chain
-   * detection per first-edge identity, so repeat sort-loop invocations of
-   * the same edge skip the lower-case method-name comparisons and the
-   * schema lookups. The dynamic visited-edge check is performed inline.
+   * detection per (first-edge, neighbor-direction) key, so repeat sort-loop
+   * invocations of the same edge skip the lower-case method-name comparisons
+   * and the schema lookups. The dynamic visited-edge check is performed inline
+   * via {@link #chainVertexStepVisited}. {@code classCountCache} is the shared
+   * per-plan memo of class-name → approximateCount; threading it here keeps the
+   * fold's fan-out and selectivity lookups in lock-step with the sort loop's
+   * edge-cost estimator so each distinct class is counted once per plan.
    *
    * @return the cost adjusted for all detected chain hops up to
    *         {@code maxHops}; equals {@code baseCost} when no chain is
@@ -3280,30 +3395,28 @@ public class MatchExecutionPlanner {
       @Nullable Map<String, String> aliasClasses,
       @Nullable Map<String, SQLWhereClause> aliasFilters,
       @Nullable Map<String, Long> estimatedRootEntries,
-      @Nullable DatabaseSessionEmbedded session,
-      Map<PatternEdge, ChainedTarget> chainShapeCache) {
+      DatabaseSessionEmbedded session,
+      Map<ChainShapeKey, ChainedTarget> chainShapeCache,
+      Map<String, Long> classCountCache) {
     var firstHop = lookupOrDetectChainShape(
         firstEdge, firstNeighbor, aliasClasses, session, chainShapeCache);
-    if (firstHop == null) {
+    // Shared dynamic visited-edge rule (see chainVertexStepVisited): a chain
+    // whose vertex-step edge is already scheduled would double-count its
+    // selectivity through the cached structural answer.
+    if (firstHop == null || chainVertexStepVisited(firstNeighbor, visitedEdges)) {
       return baseCost;
     }
     // detectChainShape verified firstNeighbor.out.size() == 1, so this
-    // iterator yields the chain's vertex-step edge — referenced both for
-    // the visited-edge guard below and as the source of the first hop's
-    // downstream vertex when seeding the multi-hop walk.
+    // iterator yields the chain's vertex-step edge — used as the source of
+    // the first hop's downstream vertex when seeding the multi-hop walk.
     var firstHopVertexStepEdge = firstNeighbor.out.iterator().next();
-    // Visited-edge check is dynamic and intentionally not cached: a chain
-    // whose downstream edge is already scheduled would double-count its
-    // selectivity through the cached structural answer.
-    if (visitedEdges.contains(firstHopVertexStepEdge)) {
-      return baseCost;
-    }
     double cost = applyTargetSelectivityWithResolvedClass(
         baseCost,
         firstHop.effectiveTargetAlias(),
         firstHop.effectiveTargetClass(),
         aliasFilters,
         estimatedRootEntries,
+        classCountCache,
         session);
 
     if (maxHops <= 1) {
@@ -3326,7 +3439,8 @@ public class MatchExecutionPlanner {
       cost *= estimateMethodFanOut(
           hop.edgeStep().item.getMethod(),
           hop.edgeStepSourceClass(),
-          session);
+          session,
+          classCountCache);
       // Intermediate edge alias is mostly auto-generated (no WHERE), so this
       // call is typically a no-op via the no-filter short-circuit. The class
       // is the EDGE class of this hop's edge step (e.g. 'Friend' for
@@ -3339,6 +3453,7 @@ public class MatchExecutionPlanner {
           extractEdgeClassName(hop.edgeStep().item.getMethod()),
           aliasFilters,
           estimatedRootEntries,
+          classCountCache,
           session);
       cost = applyTargetSelectivityWithResolvedClass(
           cost,
@@ -3346,6 +3461,7 @@ public class MatchExecutionPlanner {
           hop.downstreamClass(),
           aliasFilters,
           estimatedRootEntries,
+          classCountCache,
           session);
     }
     return cost;
@@ -3383,6 +3499,14 @@ public class MatchExecutionPlanner {
    * @return list of additional hops (may be empty); each hop is one
    *         (edge step, vertex step) sub-chain
    */
+  // NOTE: accepted PF-residual risk. This walk only enumerates the chain's
+  // structural hops (memoized via chainShapeCache + classCountCache); it does
+  // NOT itself call estimateFilterSelectivity. The caller (applyChainFold)
+  // applies per-hop WHERE selectivity, and estimateFilterSelectivity performs
+  // uncached index/histogram lookups. At QUERY_MATCH_CHAIN_FOLD_MAX_HOPS ≈ 1000
+  // with hundreds of filtered chained hops this degrades to O(N^2) per plan.
+  // It is bounded and harmless at the default knob (10) — the realistic worst
+  // case stays under ~30 hops — so no per-hop selectivity cache is added here.
   private static List<ChainHop> walkLinearChainExtension(
       PatternNode currentVertex,
       @Nullable String currentVertexClass,
@@ -3392,7 +3516,7 @@ public class MatchExecutionPlanner {
       PatternEdge firstHopVertexStepEdge,
       @Nullable Map<String, String> aliasClasses,
       @Nullable DatabaseSessionEmbedded session,
-      Map<PatternEdge, ChainedTarget> chainShapeCache) {
+      Map<ChainShapeKey, ChainedTarget> chainShapeCache) {
     if (remainingHops <= 0) {
       return List.of();
     }
@@ -3466,18 +3590,24 @@ public class MatchExecutionPlanner {
    * cannot be used here because we want to memoize {@code null} results
    * (known-not-chain edges) too; the {@code containsKey}/{@code put} pair
    * disambiguates a missing entry from a cached negative.
+   *
+   * <p>The cache is keyed by ({@code edge}, neighbor-direction) rather than by
+   * {@code edge} alone: {@link #detectChainShape}'s answer depends on which
+   * side of the edge the neighbor sits, so a {@code null} cached for one
+   * direction must not be returned for (or poison) the opposite direction.
    */
   @Nullable private static ChainedTarget lookupOrDetectChainShape(
       PatternEdge edge,
       PatternNode neighbor,
       @Nullable Map<String, String> aliasClasses,
       @Nullable DatabaseSessionEmbedded session,
-      Map<PatternEdge, ChainedTarget> chainShapeCache) {
-    if (chainShapeCache.containsKey(edge)) {
-      return chainShapeCache.get(edge);
+      Map<ChainShapeKey, ChainedTarget> chainShapeCache) {
+    var key = new ChainShapeKey(edge, neighbor == edge.in);
+    if (chainShapeCache.containsKey(key)) {
+      return chainShapeCache.get(key);
     }
     var shape = detectChainShape(edge, neighbor, aliasClasses, session);
-    chainShapeCache.put(edge, shape);
+    chainShapeCache.put(key, shape);
     return shape;
   }
 
@@ -5720,7 +5850,7 @@ public class MatchExecutionPlanner {
    * Defensive: returns {@code null} if the session or any link in the
    * schema-lookup chain is missing, so this is the single source of truth
    * for the "edge-class → linked-vertex-class" resolution (also used by
-   * {@link #inferDownstreamVertexClassFromEdge}).
+   * {@link #linkedVertexClassForVertexStep}).
    *
    * @param edgeClassName the edge class to look up
    * @param propName the property name to read — must be {@code "in"} or {@code "out"}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -1,6 +1,5 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.common.util.PairLongObject;
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
@@ -2172,6 +2171,28 @@ public class MatchExecutionPlanner {
   }
 
   /**
+   * Test seam: resets the warn-dedupe state to its initial sentinel so a test
+   * that exercises {@link #clampChainFoldMaxHops}' upper-bound branch starts
+   * from a known state. The field is a static that outlives any single plan,
+   * so without this reset the dedupe outcome would depend on which test ran
+   * first in the JVM.
+   */
+  static void resetChainFoldWarnState() {
+    lastWarnedChainFoldKnob.set(0);
+  }
+
+  /**
+   * Test seam: the out-of-range knob value that owned the most recent
+   * upper-bound clamp warning, or {@code 0} when none has been emitted since
+   * the last {@link #resetChainFoldWarnState}. Reading it lets a test assert
+   * the dedupe state machine directly — the test log backend is
+   * {@code slf4j-nop}, so the WARN itself is not observable.
+   */
+  static int lastWarnedChainFoldKnobValue() {
+    return lastWarnedChainFoldKnob.get();
+  }
+
+  /**
    * Start a depth-first traversal from the starting node, adding all viable unscheduled edges and
    * vertices.
    *
@@ -2805,18 +2826,14 @@ public class MatchExecutionPlanner {
       return 1.0;
     }
 
-    long classCount;
-    if (classCountCache != null) {
-      Long cached = classCountCache.get(targetClass);
-      if (cached != null) {
-        classCount = cached;
-      } else {
-        classCount = schemaClass.approximateCount(session);
-        classCountCache.put(targetClass, classCount);
-      }
-    } else {
-      classCount = schemaClass.approximateCount(session);
-    }
+    // Same memo idiom as EdgeFanOutEstimator.countFor, so both writers into
+    // the shared classCountCache are read the same way. targetClass is the
+    // canonical schema name here: getClassInternal above returned non-null,
+    // and ImmutableSchema keys its class map by the exact declared name.
+    long classCount = classCountCache != null
+        ? classCountCache.computeIfAbsent(
+            targetClass, k -> schemaClass.approximateCount(session))
+        : schemaClass.approximateCount(session);
     if (classCount <= 0) {
       return 1.0;
     }
@@ -3077,8 +3094,14 @@ public class MatchExecutionPlanner {
    * would let a cached reverse {@code null} poison the forward lookup (and vice
    * versa); the {@code neighborIsIn} flag keeps the two directions distinct,
    * and a {@code null} result stays cached per (edge, direction).
+   *
+   * <p>Package-visible so a test can build a shared cache and assert that the
+   * two directions of one edge occupy separate entries. Keyed on
+   * {@link PatternEdge} identity: the class declares no
+   * {@code equals}/{@code hashCode}, and two distinct edges of the same shape
+   * must not share a cache slot.
    */
-  private record ChainShapeKey(PatternEdge edge, boolean neighborIsIn) {
+  record ChainShapeKey(PatternEdge edge, boolean neighborIsIn) {
   }
 
   /**
@@ -3140,13 +3163,12 @@ public class MatchExecutionPlanner {
    *          unit tests exercise those guards directly. Production folds go
    *          through {@link #applyChainFold} / {@link #lookupOrDetectChainShape}.
    */
-  @VisibleForTesting
   @Nullable static ChainedTarget resolveChainedTarget(
       PatternEdge edge,
       PatternNode neighbor,
       Set<PatternEdge> visitedEdges,
       @Nullable Map<String, String> aliasClasses,
-      DatabaseSessionEmbedded session) {
+      @Nullable DatabaseSessionEmbedded session) {
     // Route through the cached path (with a throwaway per-call cache) so the
     // test seam exercises the exact structural detection the sort loop uses,
     // then apply the shared dynamic visited-edge rule.
@@ -3191,7 +3213,7 @@ public class MatchExecutionPlanner {
       PatternEdge edge,
       PatternNode neighbor,
       @Nullable Map<String, String> aliasClasses,
-      DatabaseSessionEmbedded session) {
+      @Nullable DatabaseSessionEmbedded session) {
     if (edge.item == null || edge.item.getMethod() == null) {
       return null;
     }
@@ -3364,14 +3386,14 @@ public class MatchExecutionPlanner {
    * downstream vertex's WHERE.
    *
    * <p>{@code maxHops} caps the total number of (edge, vertex) sub-chains
-   * folded. Two layers gate the knob: the sort-loop call site skips
-   * {@code applyChainFold} entirely when {@code chainFoldMaxHops < 1} (full
-   * rollback to pre-YTDB-643 behaviour, no allocations), and the inner
-   * {@code maxHops <= 1} short-circuit here returns after the single-hop
-   * fold without entering the multi-hop walk. Either layer alone restricts
-   * the fold to legacy single-hop behaviour for {@code maxHops == 1}; the
-   * outer layer is the only one that can disable the fold completely. Both
-   * layers are intentional defense-in-depth: callers may rely on either.
+   * folded. Two layers gate it. The sort-loop call site skips
+   * {@code applyChainFold} entirely when {@code chainFoldMaxHops < 1},
+   * reproducing the schedule the planner produced before the fold existed
+   * and allocating nothing. The {@code maxHops <= 1} short-circuit below
+   * returns after the first hop's fold without entering the multi-hop walk.
+   * At {@code maxHops == 1} either layer alone confines the fold to one hop;
+   * only the outer layer can switch it off completely. Both are deliberate
+   * defense-in-depth, so a caller may rely on either.
    *
    * <p>{@code chainShapeCache} memoizes the structural part of the chain
    * detection per (first-edge, neighbor-direction) key, so repeat sort-loop
@@ -3498,16 +3520,21 @@ public class MatchExecutionPlanner {
    *
    * @return list of additional hops (may be empty); each hop is one
    *         (edge step, vertex step) sub-chain
+   * @apiNote Package-visible so unit tests can drive the walk directly. Its
+   *          four break conditions (branch point, back-edge into
+   *          {@code initialVisitedEdges}, loop back into {@code chainEdges},
+   *          non-chain continuation) and the {@code remainingHops} cap are
+   *          each reachable from a synthesised pattern graph but not from
+   *          every MATCH query.
    */
-  // NOTE: accepted PF-residual risk. This walk only enumerates the chain's
-  // structural hops (memoized via chainShapeCache + classCountCache); it does
-  // NOT itself call estimateFilterSelectivity. The caller (applyChainFold)
-  // applies per-hop WHERE selectivity, and estimateFilterSelectivity performs
-  // uncached index/histogram lookups. At QUERY_MATCH_CHAIN_FOLD_MAX_HOPS ≈ 1000
-  // with hundreds of filtered chained hops this degrades to O(N^2) per plan.
-  // It is bounded and harmless at the default knob (10) — the realistic worst
-  // case stays under ~30 hops — so no per-hop selectivity cache is added here.
-  private static List<ChainHop> walkLinearChainExtension(
+  // Known and accepted cost: this walk enumerates only structural hops, and
+  // both of its lookups are memoized. Per-hop WHERE selectivity is applied by
+  // the caller through estimateFilterSelectivity, which does uncached
+  // index/histogram reads. A chain of N filtered hops therefore costs O(N^2)
+  // per plan. At the maximum knob (1000) with hundreds of filtered hops that
+  // would matter; at the default (10), where the realistic worst case stays
+  // under ~30 hops, it does not, so there is no per-hop selectivity cache.
+  static List<ChainHop> walkLinearChainExtension(
       PatternNode currentVertex,
       @Nullable String currentVertexClass,
       int remainingHops,
@@ -3595,8 +3622,13 @@ public class MatchExecutionPlanner {
    * {@code edge} alone: {@link #detectChainShape}'s answer depends on which
    * side of the edge the neighbor sits, so a {@code null} cached for one
    * direction must not be returned for (or poison) the opposite direction.
+   *
+   * @apiNote Package-visible test seam. Production callers ({@link #applyChainFold},
+   *          {@link #walkLinearChainExtension}) always pass the per-plan cache
+   *          allocated in {@link #getTopologicalSortedSchedule}; tests pass their
+   *          own map so they can inspect what was memoized under which key.
    */
-  @Nullable private static ChainedTarget lookupOrDetectChainShape(
+  @Nullable static ChainedTarget lookupOrDetectChainShape(
       PatternEdge edge,
       PatternNode neighbor,
       @Nullable Map<String, String> aliasClasses,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -78,7 +78,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -337,6 +336,20 @@ public class MatchExecutionPlanner {
   private static final long THRESHOLD = 100;
 
   /**
+   * Maximum chain depth for the MATCH cost fold, bounded to
+   * {@code [0, MAX_CHAIN_FOLD_HOPS]}. Zero disables the fold. Configurable
+   * via {@link GlobalConfiguration#QUERY_MATCH_CHAIN_FOLD_MAX_HOPS};
+   * out-of-range values clamp silently, as they do for the sibling knobs
+   * below.
+   */
+  static int getChainFoldMaxHops() {
+    return Math.min(
+        MAX_CHAIN_FOLD_HOPS,
+        Math.max(0,
+            GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger()));
+  }
+
+  /**
    * Maximum estimated build-side cardinality for which the planner will choose a
    * hash-based join (anti-join, semi-join, inner join) over nested-loop evaluation.
    * If the estimated NOT-pattern result set exceeds this threshold, the planner
@@ -388,40 +401,12 @@ public class MatchExecutionPlanner {
    * it is read for plan construction. The chain-fold walk terminates
    * structurally at the pattern graph's branch points and visited edges, so
    * any knob value larger than the deepest linear chain a MATCH can encode
-   * is semantically equivalent to this cap — but can poison downstream
-   * arithmetic (int overflow in the walk's bookkeeping) and waste memory on
-   * upfront collection allocations sized to the raw knob value. Realistic
-   * MATCH patterns top out below 30 linear hops; 1000 leaves a 30× margin
-   * while staying far away from any int-overflow threshold.
+   * behaves the same as this cap. Bounding it anyway keeps the walk's loop
+   * counter in a range no later arithmetic on it can overflow. Realistic
+   * MATCH patterns top out below 30 linear hops, so 1000 leaves a wide
+   * margin.
    */
   private static final int MAX_CHAIN_FOLD_HOPS = 1000;
-
-  /**
-   * Tracks the last out-of-range knob value that triggered an upper-bound
-   * clamp warning, so {@link #clampChainFoldMaxHops} dedupes against the
-   * <em>immediately-preceding</em> warned value only. This is last-value
-   * dedupe, not once-per-distinct-value: a steady misconfiguration on a
-   * single value warns once, and an alternating misconfiguration between
-   * two out-of-range values (e.g. {@code 5000}, {@code 6000}, {@code 5000},
-   * …) re-warns on every change because each value differs from the one
-   * stored by the previous clamp. The common case — one misconfigured value
-   * read once per plan across many queries — collapses to a single WARN.
-   *
-   * <p>Initialised to {@code 0} as a sentinel: {@code 0} is always in-range
-   * (it is the documented "fold disabled" value) so the clamp helper never
-   * compares an out-of-range raw against it as a stale match.
-   *
-   * <p>An {@link AtomicInteger#getAndSet} pair makes the warning emission
-   * thread-safe — concurrent plan constructions racing on a brand-new
-   * out-of-range value will see exactly one of them swap successfully and
-   * log; the others observe {@code previous == raw} and skip.
-   *
-   * <p>This is the cell every production plan shares. The clamp also accepts a
-   * caller-supplied cell, so the dedupe rule can be exercised without touching
-   * process-wide state.
-   */
-  private static final AtomicInteger lastWarnedChainFoldKnob =
-      new AtomicInteger(0);
 
   /**
    * Creates a planner from a pre-built pattern IR. Bypasses SQL AST parsing entirely:
@@ -2036,16 +2021,12 @@ public class MatchExecutionPlanner {
     Set<PatternNode> visitedNodes = new HashSet<>();
     Set<PatternEdge> visitedEdges = new HashSet<>();
 
-    // Read the chain-fold knob once at the top of plan construction. It is
-    // a hot-path setting consulted by every candidate edge in the sort loop;
-    // re-reading the volatile configuration field per edge would amortize
-    // an O(edges) configuration lookup over the planning phase, and any
-    // mid-plan reconfiguration would split the plan across two knob values.
-    //
-    // {@link #clampChainFoldMaxHops} bounds the value to a safe range and
-    // emits a one-shot WARN if the upper cap actually fires.
-    int chainFoldMaxHops = clampChainFoldMaxHops(
-        GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger());
+    // Read the chain-fold knob once at the top of plan construction. Every
+    // candidate edge in the sort loop consults it, so re-reading the volatile
+    // configuration field per edge would spread an O(edges) lookup across the
+    // planning phase; reading once also stops a mid-plan reconfiguration from
+    // splitting one plan across two knob values.
+    int chainFoldMaxHops = getChainFoldMaxHops();
     // Per-plan structural-detection cache for the chain fold: the answer is
     // determined by the pattern graph plus the per-plan {@code aliasClasses}
     // and session, all stable for the lifetime of one plan. The visited-edge
@@ -2125,71 +2106,6 @@ public class MatchExecutionPlanner {
     }
 
     return resultingSchedule;
-  }
-
-  /**
-   * Bounds {@code raw} to {@code [0, MAX_CHAIN_FOLD_HOPS]}, the safe range
-   * for {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS}, and emits a one-shot WARN
-   * the first time a given out-of-range value triggers the upper cap.
-   *
-   * <p>Lower-bound clamp ({@code raw < 0}) is silent — values below zero
-   * are an obvious user error with no meaningful semantics, and the project
-   * convention (see {@link #getHashJoinThreshold}) is silent clamp at the
-   * read site.
-   *
-   * <p>Upper-bound clamp ({@code raw > MAX_CHAIN_FOLD_HOPS}) is logged
-   * because the operator's intent matters here: somebody who set the knob
-   * to e.g. {@code 100_000} probably wanted "fold everything", and a silent
-   * clamp would leave them debugging a fold depth that does not match their
-   * configuration. The warning is deduped against the immediately-preceding
-   * out-of-range value (last-value dedupe via {@link AtomicInteger#getAndSet}
-   * on {@link #lastWarnedChainFoldKnob}): a repeated single out-of-range
-   * value warns once, but alternating between two out-of-range values
-   * re-warns on each change. Concurrent plans racing on the same brand-new
-   * out-of-range value agree on a single emitter.
-   *
-   * @param raw the raw knob value as read from {@link GlobalConfiguration}
-   * @return the clamped value, in {@code [0, MAX_CHAIN_FOLD_HOPS]}
-   */
-  static int clampChainFoldMaxHops(int raw) {
-    return clampChainFoldMaxHops(raw, lastWarnedChainFoldKnob);
-  }
-
-  /**
-   * Clamps {@code raw} against a caller-supplied dedupe cell instead of the
-   * process-wide one.
-   *
-   * <p>The cell holds the last out-of-range value that emitted a warning.
-   * Passing it in rather than reading a static keeps the dedupe decision a
-   * function of its arguments, which is what makes it checkable: a caller that
-   * owns the cell can read the outcome afterwards. That matters because the
-   * warning itself leaves no other trace to assert on.
-   *
-   * @param lastWarned holds the last out-of-range value that warned;
-   *                   {@code 0} means none has, and is safe as a sentinel
-   *                   because {@code 0} is always in range
-   */
-  static int clampChainFoldMaxHops(int raw, AtomicInteger lastWarned) {
-    if (raw > MAX_CHAIN_FOLD_HOPS) {
-      // getAndSet returns the previous sentinel/value; if it equals raw,
-      // we have already warned about this exact value and stay silent.
-      // Otherwise we own the warning for this new out-of-range value.
-      int previous = lastWarned.getAndSet(raw);
-      if (previous != raw) {
-        logger.warn(
-            "QUERY_MATCH_CHAIN_FOLD_MAX_HOPS={} exceeds the supported"
-                + " maximum {}; clamping for plan construction. The chain-fold"
-                + " walk terminates structurally at the pattern graph's branch"
-                + " points, so values above {} are equivalent to {} but risk"
-                + " int overflow in the walk's bookkeeping.",
-            raw, MAX_CHAIN_FOLD_HOPS, MAX_CHAIN_FOLD_HOPS, MAX_CHAIN_FOLD_HOPS);
-      }
-      return MAX_CHAIN_FOLD_HOPS;
-    }
-    // Negative values clamp silently (project convention; see
-    // getHashJoinThreshold). Zero is the documented "fold disabled" value
-    // and passes through unchanged.
-    return Math.max(0, raw);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -415,6 +415,10 @@ public class MatchExecutionPlanner {
    * thread-safe — concurrent plan constructions racing on a brand-new
    * out-of-range value will see exactly one of them swap successfully and
    * log; the others observe {@code previous == raw} and skip.
+   *
+   * <p>This is the cell every production plan shares. The clamp also accepts a
+   * caller-supplied cell, so the dedupe rule can be exercised without touching
+   * process-wide state.
    */
   private static final AtomicInteger lastWarnedChainFoldKnob =
       new AtomicInteger(0);
@@ -2148,11 +2152,29 @@ public class MatchExecutionPlanner {
    * @return the clamped value, in {@code [0, MAX_CHAIN_FOLD_HOPS]}
    */
   static int clampChainFoldMaxHops(int raw) {
+    return clampChainFoldMaxHops(raw, lastWarnedChainFoldKnob);
+  }
+
+  /**
+   * Clamps {@code raw} against a caller-supplied dedupe cell instead of the
+   * process-wide one.
+   *
+   * <p>The cell holds the last out-of-range value that emitted a warning.
+   * Passing it in rather than reading a static keeps the dedupe decision a
+   * function of its arguments, which is what makes it checkable: a caller that
+   * owns the cell can read the outcome afterwards. That matters because the
+   * warning itself leaves no other trace to assert on.
+   *
+   * @param lastWarned holds the last out-of-range value that warned;
+   *                   {@code 0} means none has, and is safe as a sentinel
+   *                   because {@code 0} is always in range
+   */
+  static int clampChainFoldMaxHops(int raw, AtomicInteger lastWarned) {
     if (raw > MAX_CHAIN_FOLD_HOPS) {
       // getAndSet returns the previous sentinel/value; if it equals raw,
       // we have already warned about this exact value and stay silent.
       // Otherwise we own the warning for this new out-of-range value.
-      int previous = lastWarnedChainFoldKnob.getAndSet(raw);
+      int previous = lastWarned.getAndSet(raw);
       if (previous != raw) {
         logger.warn(
             "QUERY_MATCH_CHAIN_FOLD_MAX_HOPS={} exceeds the supported"
@@ -2168,28 +2190,6 @@ public class MatchExecutionPlanner {
     // getHashJoinThreshold). Zero is the documented "fold disabled" value
     // and passes through unchanged.
     return Math.max(0, raw);
-  }
-
-  /**
-   * Test seam: resets the warn-dedupe state to its initial sentinel so a test
-   * that exercises {@link #clampChainFoldMaxHops}' upper-bound branch starts
-   * from a known state. The field is a static that outlives any single plan,
-   * so without this reset the dedupe outcome would depend on which test ran
-   * first in the JVM.
-   */
-  static void resetChainFoldWarnState() {
-    lastWarnedChainFoldKnob.set(0);
-  }
-
-  /**
-   * Test seam: the out-of-range knob value that owned the most recent
-   * upper-bound clamp warning, or {@code 0} when none has been emitted since
-   * the last {@link #resetChainFoldWarnState}. Reading it lets a test assert
-   * the dedupe state machine directly — the test log backend is
-   * {@code slf4j-nop}, so the WARN itself is not observable.
-   */
-  static int lastWarnedChainFoldKnobValue() {
-    return lastWarnedChainFoldKnob.get();
   }
 
   /**
@@ -2826,10 +2826,10 @@ public class MatchExecutionPlanner {
       return 1.0;
     }
 
-    // Same memo idiom as EdgeFanOutEstimator.countFor, so both writers into
-    // the shared classCountCache are read the same way. targetClass is the
-    // canonical schema name here: getClassInternal above returned non-null,
-    // and ImmutableSchema keys its class map by the exact declared name.
+    // targetClass is safe as a cache key: the lookup above returned non-null,
+    // and the schema keys its class map by the exact declared name, so this
+    // string is the canonical one. Every writer into the map resolves its key
+    // the same way, which is what lets one plan share a single count per class.
     long classCount = classCountCache != null
         ? classCountCache.computeIfAbsent(
             targetClass, k -> schemaClass.approximateCount(session))

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
@@ -418,7 +418,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   /**
    * Scenario 5 — user-named intermediate edge alias with its own WHERE.
    * Pattern: {@code .outE('X'){as: e, where: weight > 5}.inV(){where: ...}}.
-   * The intermediate's filter is applied by the existing 8-arg
+   * The intermediate's filter is applied by the existing
    * {@code applyTargetSelectivity} call on alias {@code e}; the chain
    * fold then multiplies the downstream vertex's selectivity on top.
    * This exercises Design Record D3's independence-multiplication.
@@ -920,6 +920,129 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + " applyTargetSelectivity call short-circuits on null class"
             + " and the weight filter never propagates. Plan was:\n" + plan,
         selectivePos < broadPos);
+    session.commit();
+  }
+
+  /**
+   * Scenario 11 — pathological knob values must not break the planner.
+   * Pins the {@code MAX_CHAIN_FOLD_HOPS} clamp applied when the knob is
+   * read in {@code getTopologicalSortedSchedule}: a misconfigured knob of
+   * {@code Integer.MAX_VALUE} would otherwise overflow the walk's
+   * bookkeeping arithmetic ({@code 2 * remainingHops + 2} going negative)
+   * and cause the planner to throw or hang.
+   *
+   * <p>The test runs a normal multi-hop chain query with the knob set to
+   * extreme values: {@code Integer.MAX_VALUE} (overflow probe),
+   * {@code Integer.MIN_VALUE} (negative probe — clamped to 0, full
+   * rollback) and a large but in-range value (cap probe). The query must
+   * complete and return correct results in every case; ordering is checked
+   * for the {@code Integer.MAX_VALUE} case where the fold should still fire
+   * (clamped down to {@code MAX_CHAIN_FOLD_HOPS} but well above what this
+   * 2-hop pattern needs).
+   */
+  @Test
+  public void testExtremeKnobValuesDoNotBreakPlanner() {
+    session.execute("CREATE class CC12Person extends V").close();
+    session.execute("CREATE property CC12Person.name STRING").close();
+
+    session.execute("CREATE class CC12Post extends V").close();
+    session.execute("CREATE property CC12Post.title STRING").close();
+
+    session.execute("CREATE class CC12Tag extends V").close();
+    session.execute("CREATE property CC12Tag.name STRING").close();
+
+    session.execute("CREATE class CC12Wrote extends E").close();
+    session.execute("CREATE property CC12Wrote.out LINK CC12Person").close();
+    session.execute("CREATE property CC12Wrote.in LINK CC12Post").close();
+
+    session.execute("CREATE class CC12HasTag extends E").close();
+    session.execute("CREATE property CC12HasTag.out LINK CC12Post").close();
+    session.execute("CREATE property CC12HasTag.in LINK CC12Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC12Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 5; i++) {
+      session.execute("CREATE VERTEX CC12Tag set name = 'tag" + i + "'").close();
+    }
+    for (int i = 0; i < 2; i++) {
+      session.execute("CREATE VERTEX CC12Person set name = 'p" + i + "'").close();
+      session.execute("CREATE VERTEX CC12Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC12Wrote FROM"
+              + " (SELECT FROM CC12Person WHERE name = 'p" + i + "')"
+              + " TO (SELECT FROM CC12Post WHERE title = 'post" + i + "')")
+          .close();
+      session.execute(
+          "CREATE EDGE CC12HasTag FROM"
+              + " (SELECT FROM CC12Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC12Tag WHERE name = 'targetTag')")
+          .close();
+      for (int j = 0; j < 3; j++) {
+        session.execute(
+            "CREATE EDGE CC12HasTag FROM"
+                + " (SELECT FROM CC12Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC12Tag WHERE name = 'tag" + j + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    var query =
+        "MATCH {class: CC12Person, as: person}"
+            + ".outE('CC12Wrote').inV().outE('CC12HasTag').inV(){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: person}"
+            + ".outE('CC12Wrote').inV().outE('CC12HasTag').inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN person.name, broadTag.name, selectiveTag.name";
+
+    // Probe 1: Integer.MAX_VALUE — overflow surface for any
+    // arithmetic on remainingHops. Clamp must keep the planner alive
+    // and the fold should still fire (clamp value of 1000 ≫ this 2-hop
+    // chain's needs), so selective branch sorts first.
+    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(Integer.MAX_VALUE);
+    session.begin();
+    var resultMax = session.query(query).toList();
+    assertEquals(2 * 3, resultMax.size());
+    var explainMax = session.query("EXPLAIN " + query).toList();
+    String planMax = explainMax.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(planMax);
+    int selectivePosMax = aliasStepPosition(planMax, "selectiveTag");
+    int broadPosMax = aliasStepPosition(planMax, "broadTag");
+    assertTrue(planMax, selectivePosMax >= 0 && broadPosMax >= 0);
+    assertTrue(
+        "Integer.MAX_VALUE knob must be clamped to a sane upper bound; the"
+            + " fold must still fire and order selective before broad. Plan was:\n"
+            + planMax,
+        selectivePosMax < broadPosMax);
+    session.commit();
+
+    // Probe 2: Integer.MIN_VALUE — clamps to 0 (full rollback). Query
+    // must run; ordering reverts to insertion order (broad first).
+    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(Integer.MIN_VALUE);
+    session.begin();
+    var resultMin = session.query(query).toList();
+    assertEquals(2 * 3, resultMin.size());
+    session.commit();
+
+    // Probe 3: a large in-range value — exercises the clamp's ceiling
+    // path (input <= MAX_CHAIN_FOLD_HOPS, no clamping needed). Same
+    // semantics as default knob; selective branch first.
+    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(500);
+    session.begin();
+    var resultLarge = session.query(query).toList();
+    assertEquals(2 * 3, resultLarge.size());
+    var explainLarge = session.query("EXPLAIN " + query).toList();
+    String planLarge =
+        explainLarge.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(planLarge);
+    int selectivePosLarge = aliasStepPosition(planLarge, "selectiveTag");
+    int broadPosLarge = aliasStepPosition(planLarge, "broadTag");
+    assertTrue(planLarge, selectivePosLarge >= 0 && broadPosLarge >= 0);
+    assertTrue(
+        "Large but in-range knob (500) must not be clamped down and the"
+            + " fold should fire normally. Plan was:\n" + planLarge,
+        selectivePosLarge < broadPosLarge);
     session.commit();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
@@ -808,4 +808,98 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
         broadPos < selectivePos);
     session.commit();
   }
+
+  /**
+   * Scenario 11 — user-named intermediate edge alias with its own WHERE on
+   * a SECOND hop of a multi-hop chain. The fold must propagate that filter
+   * into the first edge's cost. Pins the contract that the second-hop
+   * intermediate alias's class is supplied (via {@code extractEdgeClassName}
+   * on its {@code outE} step) so {@code applyTargetSelectivity} can apply
+   * the user's WHERE — without that class, the call would short-circuit
+   * and the {@code as: e2, where: weight = 1} filter would be invisible to
+   * the cost model.
+   *
+   * <p>Both branches share identical first-hop and identical downstream
+   * vertex (no WHERE there). Selectivity difference lives ONLY in the
+   * second-hop intermediate edge alias's WHERE on the {@code weight}
+   * property. Without intermediate-alias class inference, both branches
+   * would tie on cost; with it, the selective branch sorts first.
+   */
+  @Test
+  public void testMultiHopIntermediateEdgeAliasFilterFoldsIntoCost() {
+    session.execute("CREATE class CC11Person extends V").close();
+    session.execute("CREATE property CC11Person.name STRING").close();
+
+    session.execute("CREATE class CC11Post extends V").close();
+    session.execute("CREATE property CC11Post.title STRING").close();
+
+    session.execute("CREATE class CC11Tag extends V").close();
+    session.execute("CREATE property CC11Tag.name STRING").close();
+
+    session.execute("CREATE class CC11Wrote extends E").close();
+    session.execute("CREATE property CC11Wrote.out LINK CC11Person").close();
+    session.execute("CREATE property CC11Wrote.in LINK CC11Post").close();
+
+    session.execute("CREATE class CC11HasTag extends E").close();
+    session.execute("CREATE property CC11HasTag.out LINK CC11Post").close();
+    session.execute("CREATE property CC11HasTag.in LINK CC11Tag").close();
+    session.execute("CREATE property CC11HasTag.weight INTEGER").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC11Tag set name = 'tag'").close();
+    for (int i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX CC11Person set name = 'p" + i + "'").close();
+      session.execute("CREATE VERTEX CC11Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC11Wrote FROM"
+              + " (SELECT FROM CC11Person WHERE name = 'p" + i + "')"
+              + " TO (SELECT FROM CC11Post WHERE title = 'post" + i + "')")
+          .close();
+      // 1 selective edge (weight=1) + 5 broad edges (weight=10..14)
+      session.execute(
+          "CREATE EDGE CC11HasTag FROM"
+              + " (SELECT FROM CC11Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC11Tag WHERE name = 'tag')"
+              + " SET weight = 1")
+          .close();
+      for (int w = 10; w < 15; w++) {
+        session.execute(
+            "CREATE EDGE CC11HasTag FROM"
+                + " (SELECT FROM CC11Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC11Tag WHERE name = 'tag')"
+                + " SET weight = " + w)
+            .close();
+      }
+    }
+    session.commit();
+
+    // Two two-hop chains. Diff is on the SECOND-hop intermediate edge alias's
+    // weight filter. Insertion order: broad first.
+    var query =
+        "MATCH {class: CC11Person, as: person}"
+            + ".outE('CC11Wrote').inV()"
+            + ".outE('CC11HasTag'){as: eBroad, where: (weight >= 10)}"
+            + ".inV(){as: broadTag},"
+            + " {as: person}"
+            + ".outE('CC11Wrote').inV()"
+            + ".outE('CC11HasTag'){as: eSelective, where: (weight = 1)}"
+            + ".inV(){as: selectiveTag}"
+            + " RETURN person.name, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int selectivePos = plan.indexOf("{selectiveTag}");
+    int broadPos = plan.indexOf("{broadTag}");
+    assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
+    assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
+    assertTrue(
+        "Multi-hop fold must apply the user-named intermediate edge"
+            + " alias's WHERE on hop 2 — without extractEdgeClassName, the"
+            + " applyTargetSelectivity call short-circuits on null class"
+            + " and the weight filter never propagates. Plan was:\n" + plan,
+        selectivePos < broadPos);
+    session.commit();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
@@ -44,18 +44,38 @@ import org.junit.Test;
  */
 public class MatchEdgeMethodChainCostTest extends DbTestBase {
 
-  private Object savedChainFoldMaxHops;
+  private int savedChainFoldMaxHops;
 
   @Before
   public void saveChainFoldDefault() {
+    // Pin int (not Object) so a later setValue with a wrong type would fail
+    // type-checking up front rather than silently corrupting the restore.
     savedChainFoldMaxHops =
-        GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValue();
+        GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger();
   }
 
   @After
   public void restoreChainFoldDefault() {
     GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS
         .setValue(savedChainFoldMaxHops);
+  }
+
+  /**
+   * Finds the position of an alias step in an EXPLAIN plan. Today the
+   * planner renders aliases as <code>{alias}</code>, but the regex also
+   * accepts a comma terminator so a future format addition (e.g.
+   * <code>{alias,index=...}</code>) does not silently break ordering
+   * assertions. Use in place of a literal substring search on
+   * <code>{alias}</code>.
+   *
+   * @return -1 when the alias does not appear, otherwise the position of
+   *         its opening brace
+   */
+  private static int aliasStepPosition(String plan, String alias) {
+    var pattern = java.util.regex.Pattern.compile(
+        "\\{" + java.util.regex.Pattern.quote(alias) + "[,}]");
+    var matcher = pattern.matcher(plan);
+    return matcher.find() ? matcher.start() : -1;
   }
 
   /**
@@ -129,8 +149,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
 
-    int selectivePos = plan.indexOf("{selectiveTag}");
-    int broadPos = plan.indexOf("{broadTag}");
+    int selectivePos = aliasStepPosition(plan, "selectiveTag");
+    int broadPos = aliasStepPosition(plan, "broadTag");
     assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
     assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
     assertTrue(
@@ -204,8 +224,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    int selectivePos = plan.indexOf("{selectiveTag}");
-    int broadPos = plan.indexOf("{broadTag}");
+    int selectivePos = aliasStepPosition(plan, "selectiveTag");
+    int broadPos = aliasStepPosition(plan, "broadTag");
     assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
     assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
     assertTrue(
@@ -279,8 +299,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    int selectivePos = plan.indexOf("{selectivePost}");
-    int broadPos = plan.indexOf("{broadPost}");
+    int selectivePos = aliasStepPosition(plan, "selectivePost");
+    int broadPos = aliasStepPosition(plan, "broadPost");
     assertTrue("selectivePost missing from plan:\n" + plan, selectivePos >= 0);
     assertTrue("broadPost missing from plan:\n" + plan, broadPos >= 0);
     assertTrue(
@@ -354,8 +374,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     String planWithClass =
         explainWithClass.getFirst().getProperty("executionPlanAsString");
     assertNotNull(planWithClass);
-    int selectivePosWithClass = planWithClass.indexOf("{selectiveTag}");
-    int broadPosWithClass = planWithClass.indexOf("{broadTag}");
+    int selectivePosWithClass = aliasStepPosition(planWithClass, "selectiveTag");
+    int broadPosWithClass = aliasStepPosition(planWithClass, "broadTag");
     assertTrue(planWithClass, selectivePosWithClass >= 0);
     assertTrue(planWithClass, broadPosWithClass >= 0);
     assertTrue(
@@ -383,8 +403,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     String planWithoutClass =
         explainWithoutClass.getFirst().getProperty("executionPlanAsString");
     assertNotNull(planWithoutClass);
-    int selectivePosWithoutClass = planWithoutClass.indexOf("{selectiveTag}");
-    int broadPosWithoutClass = planWithoutClass.indexOf("{broadTag}");
+    int selectivePosWithoutClass = aliasStepPosition(planWithoutClass, "selectiveTag");
+    int broadPosWithoutClass = aliasStepPosition(planWithoutClass, "broadTag");
     assertTrue(planWithoutClass, selectivePosWithoutClass >= 0);
     assertTrue(planWithoutClass, broadPosWithoutClass >= 0);
     assertTrue(
@@ -465,8 +485,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    int selectivePos = plan.indexOf("{selectiveCorp}");
-    int broadPos = plan.indexOf("{broadCorp}");
+    int selectivePos = aliasStepPosition(plan, "selectiveCorp");
+    int broadPos = aliasStepPosition(plan, "broadCorp");
     assertTrue(plan, selectivePos >= 0);
     assertTrue(plan, broadPos >= 0);
     assertTrue(
@@ -541,8 +561,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    int selectivePos = plan.indexOf("{selectiveTag}");
-    int broadPos = plan.indexOf("{broadTag}");
+    int selectivePos = aliasStepPosition(plan, "selectiveTag");
+    int broadPos = aliasStepPosition(plan, "broadTag");
     assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
     assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
     assertTrue(
@@ -628,7 +648,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 9 — multi-hop chain fold. Two competing two-hop chains from
+   * Scenario 8 — multi-hop chain fold. Two competing two-hop chains from
    * {@code post} share identical first-hop fan-out and identical
    * intermediate vertices (no WHERE on intermediates). The selectivity
    * difference lives ONLY on the FINAL vertex (2 hops away from
@@ -710,8 +730,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    int selectivePos = plan.indexOf("{selectiveTag}");
-    int broadPos = plan.indexOf("{broadTag}");
+    int selectivePos = aliasStepPosition(plan, "selectiveTag");
+    int broadPos = aliasStepPosition(plan, "broadTag");
     assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
     assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
     assertTrue(
@@ -723,7 +743,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 10 — knob {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 1}
+   * Scenario 9 — knob {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 1}
    * downgrades the fold to legacy single-hop behaviour. Same query as
    * scenario 9 (selectivity hidden 2 hops in), but with the knob set to
    * 1 the fold cannot reach the final vertex. Both branches end up with
@@ -797,8 +817,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    int selectivePos = plan.indexOf("{selectiveTag}");
-    int broadPos = plan.indexOf("{broadTag}");
+    int selectivePos = aliasStepPosition(plan, "selectiveTag");
+    int broadPos = aliasStepPosition(plan, "broadTag");
     assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
     assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
     assertTrue(
@@ -810,7 +830,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 11 — user-named intermediate edge alias with its own WHERE on
+   * Scenario 10 — user-named intermediate edge alias with its own WHERE on
    * a SECOND hop of a multi-hop chain. The fold must propagate that filter
    * into the first edge's cost. Pins the contract that the second-hop
    * intermediate alias's class is supplied (via {@code extractEdgeClassName}
@@ -890,8 +910,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    int selectivePos = plan.indexOf("{selectiveTag}");
-    int broadPos = plan.indexOf("{broadTag}");
+    int selectivePos = aliasStepPosition(plan, "selectiveTag");
+    int broadPos = aliasStepPosition(plan, "broadTag");
     assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
     assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
     assertTrue(

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
@@ -1,0 +1,612 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Regression tests for the edge-method chain-cost fold introduced in
+ * YTDB-643. The fold propagates the downstream vertex's WHERE selectivity
+ * into the first-edge cost of an {@code outE→inV} / {@code inE→outV} /
+ * {@code bothE→bothV} chain so that the planner schedules selective
+ * branches before broad ones, matching the behaviour of the equivalent
+ * single-step pattern {@code .out('X'){where: …}}.
+ *
+ * <p>Each test asserts both the runtime result-set correctness (so the
+ * scheduler change does not silently alter MATCH semantics) and the
+ * EXPLAIN plan ordering (so the cost-fold actually drives the schedule
+ * — without this check, a regression that drops the fold could go
+ * unnoticed if the broad branch happens to be slow at runtime too).
+ *
+ * <p><b>Coverage note for the {@code Double.MAX_VALUE} gate at
+ * {@code MatchExecutionPlanner.updateScheduleStartingAt}:</b> the gate
+ * {@code if (cost < Double.MAX_VALUE)} skips both
+ * {@code applyTargetSelectivity} calls (intermediate + chain fold) when
+ * {@code estimateEdgeCost} returns the unestimated sentinel. For an
+ * {@code outE}/{@code inE}/{@code bothE} first edge — the only methods
+ * the chain rule accepts — {@code parseDirection} never returns null, so
+ * {@code estimateEdgeCost} always returns a finite value and the gate
+ * is structurally unreachable through the chain-fold integration. The
+ * gate's MAX_VALUE-preservation invariant is instead pinned by
+ * {@code MatchExecutionPlannerMutationTest
+ * .applyTargetSelectivity_classForced_maxValueInputPreservedOnNullClass}
+ * and its {@code _maxValueInputPreservedOnNoFilterNoEstimate} sibling,
+ * which assert that even if the sort loop did call the fold on a
+ * MAX_VALUE input, the helper would short-circuit and preserve it.
+ */
+public class MatchEdgeMethodChainCostTest extends DbTestBase {
+
+  /**
+   * Scenario 1 — pure {@code outE.inV} chain with two branches of
+   * different selectivities. The planner should fold the downstream
+   * vertex's WHERE into the first edge's cost and schedule the
+   * selective branch ({@code name = 'targetTag'}) before the broad
+   * branch ({@code name <> 'targetTag'}).
+   *
+   * <p>Distinguishes from
+   * {@code MatchEdgeMethodInferenceAndAbortTest.testVertexClassInferenceEnablesIndexIntersection}
+   * by deliberately omitting the index on {@code VITag.name}: the
+   * filter-shape heuristic (eq vs. ne) is what the cost-fold relies on
+   * here, not index histograms. This pins the heuristic path through the
+   * fold independently of any index-based cost paths.
+   */
+  @Test
+  public void testPureOutEInVChainSchedulesSelectiveBranchFirst() {
+    session.execute("CREATE class CC1Post extends V").close();
+    session.execute("CREATE property CC1Post.title STRING").close();
+
+    session.execute("CREATE class CC1Tag extends V").close();
+    session.execute("CREATE property CC1Tag.name STRING").close();
+
+    session.execute("CREATE class CC1HasTag extends E").close();
+    session.execute("CREATE property CC1HasTag.out LINK CC1Post").close();
+    session.execute("CREATE property CC1HasTag.in LINK CC1Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC1Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC1Tag set name = 'tag" + i + "'").close();
+    }
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX CC1Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC1HasTag FROM"
+              + " (SELECT FROM CC1Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC1Tag WHERE name = 'targetTag')")
+          .close();
+      for (int j = 0; j < 5; j++) {
+        session.execute(
+            "CREATE EDGE CC1HasTag FROM"
+                + " (SELECT FROM CC1Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC1Tag WHERE name = 'tag" + j + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    var query =
+        "MATCH {class: CC1Post, as: post}"
+            + ".outE('CC1HasTag').inV(){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: post}"
+            + ".outE('CC1HasTag').inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN post.title, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var result = session.query(query).toList();
+    assertEquals(50, result.size());
+    Set<String> posts = new HashSet<>();
+    for (var r : result) {
+      assertEquals("targetTag", r.getProperty("selectiveTag.name"));
+      posts.add(r.getProperty("post.title"));
+    }
+    assertEquals(10, posts.size());
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+
+    int selectivePos = plan.indexOf("{selectiveTag}");
+    int broadPos = plan.indexOf("{broadTag}");
+    assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
+    assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
+    assertTrue(
+        "Selective branch should sort before broad branch when the"
+            + " edge-method chain fold propagates the downstream WHERE."
+            + " Plan was:\n" + plan,
+        selectivePos < broadPos);
+    session.commit();
+  }
+
+  /**
+   * Scenario 2 — mixed branch styles: one branch uses the single-step
+   * {@code .out('X'){where: p}} pattern, the other uses the two-step
+   * {@code .outE('X').inV(){where: q}} chain. With {@code q} more
+   * selective than {@code p}, cost ordering must be consistent across
+   * styles — the chain-fold has to produce the same effective
+   * selectivity for the two-step branch as the single-step branch
+   * already does, otherwise mixed queries would silently reorder
+   * depending on which style users picked.
+   */
+  @Test
+  public void testMixedStyleBranchesOrderConsistently() {
+    session.execute("CREATE class CC2Post extends V").close();
+    session.execute("CREATE property CC2Post.title STRING").close();
+
+    session.execute("CREATE class CC2Tag extends V").close();
+    session.execute("CREATE property CC2Tag.name STRING").close();
+
+    session.execute("CREATE class CC2HasTag extends E").close();
+    session.execute("CREATE property CC2HasTag.out LINK CC2Post").close();
+    session.execute("CREATE property CC2HasTag.in LINK CC2Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC2Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC2Tag set name = 'tag" + i + "'").close();
+    }
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX CC2Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC2HasTag FROM"
+              + " (SELECT FROM CC2Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC2Tag WHERE name = 'targetTag')")
+          .close();
+      for (int j = 0; j < 5; j++) {
+        session.execute(
+            "CREATE EDGE CC2HasTag FROM"
+                + " (SELECT FROM CC2Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC2Tag WHERE name = 'tag" + j + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    // Selective branch uses .outE.inV, broad branch uses .out — invert
+    // the conventional pairing so a regression that ignores the fold
+    // would order broad-before-selective and fail the assertion below.
+    var query =
+        "MATCH {class: CC2Post, as: post}"
+            + ".out('CC2HasTag'){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: post}"
+            + ".outE('CC2HasTag').inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN post.title, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var result = session.query(query).toList();
+    assertEquals(50, result.size());
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int selectivePos = plan.indexOf("{selectiveTag}");
+    int broadPos = plan.indexOf("{broadTag}");
+    assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
+    assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
+    assertTrue(
+        "Mixed-style branches must order by selectivity regardless of"
+            + " whether the user wrote .out or .outE.inV. Plan was:\n" + plan,
+        selectivePos < broadPos);
+    session.commit();
+  }
+
+  /**
+   * Scenario 3 — reverse direction: {@code inE.outV} chain. Verifies the
+   * helper picks the edge class's {@code out} property (source vertex
+   * class) when inferring the downstream alias, not the {@code in}
+   * property used for outbound chains.
+   *
+   * <p>Graph is reversed: tags fan out to posts via {@code inE} on the
+   * tag side. The selective filter is on the upstream {@code Post},
+   * not the tag side, mirroring what the reverse-direction inference
+   * has to handle when the chain fold runs on the inE→outV pair.
+   */
+  @Test
+  public void testInEOutVReverseChainSchedulesSelectiveBranchFirst() {
+    session.execute("CREATE class CC3Post extends V").close();
+    session.execute("CREATE property CC3Post.title STRING").close();
+
+    session.execute("CREATE class CC3Tag extends V").close();
+    session.execute("CREATE property CC3Tag.name STRING").close();
+
+    session.execute("CREATE class CC3HasTag extends E").close();
+    session.execute("CREATE property CC3HasTag.out LINK CC3Post").close();
+    session.execute("CREATE property CC3HasTag.in LINK CC3Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC3Tag set name = 'centralTag'").close();
+    session.execute("CREATE VERTEX CC3Post set title = 'targetPost'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC3Post set title = 'post" + i + "'").close();
+    }
+    // centralTag is incoming to targetPost (selective) and to post0..post49 (broad)
+    session.execute(
+        "CREATE EDGE CC3HasTag FROM"
+            + " (SELECT FROM CC3Post WHERE title = 'targetPost')"
+            + " TO (SELECT FROM CC3Tag WHERE name = 'centralTag')")
+        .close();
+    for (int i = 0; i < 50; i++) {
+      session.execute(
+          "CREATE EDGE CC3HasTag FROM"
+              + " (SELECT FROM CC3Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC3Tag WHERE name = 'centralTag')")
+          .close();
+    }
+    session.commit();
+
+    // Two reverse-direction branches from {tag}: selective filter on one
+    // upstream post, broad on the other. The chain-fold must use
+    // CC3HasTag.out (CC3Post) for class inference on the inE→outV chain.
+    var query =
+        "MATCH {class: CC3Tag, as: tag, where: (name = 'centralTag')}"
+            + ".inE('CC3HasTag').outV(){as: broadPost,"
+            + "  where: (title <> 'targetPost')},"
+            + " {as: tag}"
+            + ".inE('CC3HasTag').outV(){as: selectivePost,"
+            + "  where: (title = 'targetPost')}"
+            + " RETURN tag.name, broadPost.title, selectivePost.title";
+
+    session.begin();
+    var result = session.query(query).toList();
+    // 1 tag × 50 broad × 1 selective = 50
+    assertEquals(50, result.size());
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int selectivePos = plan.indexOf("{selectivePost}");
+    int broadPos = plan.indexOf("{broadPost}");
+    assertTrue("selectivePost missing from plan:\n" + plan, selectivePos >= 0);
+    assertTrue("broadPost missing from plan:\n" + plan, broadPos >= 0);
+    assertTrue(
+        "inE→outV chain fold must infer source class from the edge's"
+            + " out property and order selective before broad. Plan was:\n"
+            + plan,
+        selectivePos < broadPos);
+    session.commit();
+  }
+
+  /**
+   * Scenario 4 — bidirectional {@code bothE.bothV} chain. Edge-schema
+   * inference cannot disambiguate the downstream vertex class for a
+   * bidirectional traversal, so {@code resolveChainedTarget} returns a
+   * {@code ChainedTarget} with a null class and the class-forced overload
+   * short-circuits — unless {@code aliasClasses} already supplies the class
+   * via an explicit {@code class:} annotation.
+   *
+   * <p>The test pins this contract by running the same query twice: once
+   * with {@code class: CC4Tag} on the selective alias (fold fires,
+   * selective comes first) and once without (fold short-circuits; falls
+   * back to TimSort's stable order, so selective stays in its insertion
+   * position relative to broad).
+   */
+  @Test
+  public void testBothEBothVRequiresExplicitClassForFoldToFire() {
+    session.execute("CREATE class CC4Post extends V").close();
+    session.execute("CREATE property CC4Post.title STRING").close();
+
+    session.execute("CREATE class CC4Tag extends V").close();
+    session.execute("CREATE property CC4Tag.name STRING").close();
+
+    session.execute("CREATE class CC4HasTag extends E").close();
+    session.execute("CREATE property CC4HasTag.out LINK CC4Post").close();
+    session.execute("CREATE property CC4HasTag.in LINK CC4Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC4Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC4Tag set name = 'tag" + i + "'").close();
+    }
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX CC4Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC4HasTag FROM"
+              + " (SELECT FROM CC4Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC4Tag WHERE name = 'targetTag')")
+          .close();
+      for (int j = 0; j < 5; j++) {
+        session.execute(
+            "CREATE EDGE CC4HasTag FROM"
+                + " (SELECT FROM CC4Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC4Tag WHERE name = 'tag" + j + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    // With explicit class on the selective alias — fold fires.
+    var queryWithClass =
+        "MATCH {class: CC4Post, as: post}"
+            + ".bothE('CC4HasTag').bothV(){as: broadTag,"
+            + "  where: (name <> 'targetTag' AND @class = 'CC4Tag')},"
+            + " {as: post}"
+            + ".bothE('CC4HasTag').bothV(){class: CC4Tag, as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN post.title, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var explainWithClass = session.query("EXPLAIN " + queryWithClass).toList();
+    String planWithClass =
+        explainWithClass.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(planWithClass);
+    int selectivePosWithClass = planWithClass.indexOf("{selectiveTag}");
+    int broadPosWithClass = planWithClass.indexOf("{broadTag}");
+    assertTrue(planWithClass, selectivePosWithClass >= 0);
+    assertTrue(planWithClass, broadPosWithClass >= 0);
+    assertTrue(
+        "bothE→bothV with explicit class: should let the fold fire and"
+            + " sort the selective branch first. Plan was:\n" + planWithClass,
+        selectivePosWithClass < broadPosWithClass);
+    session.commit();
+
+    // Without explicit class on the selective alias — fold short-circuits
+    // because aliasClasses returns null and bothE inference yields null.
+    // The selective branch sits in its insertion position (second), so
+    // {selectiveTag} appears AFTER {broadTag} — proving the class
+    // annotation is what drives the scheduling change above.
+    var queryWithoutClass =
+        "MATCH {class: CC4Post, as: post}"
+            + ".bothE('CC4HasTag').bothV(){as: broadTag,"
+            + "  where: (name <> 'targetTag' AND @class = 'CC4Tag')},"
+            + " {as: post}"
+            + ".bothE('CC4HasTag').bothV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag' AND @class = 'CC4Tag')}"
+            + " RETURN post.title, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var explainWithoutClass = session.query("EXPLAIN " + queryWithoutClass).toList();
+    String planWithoutClass =
+        explainWithoutClass.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(planWithoutClass);
+    int selectivePosWithoutClass = planWithoutClass.indexOf("{selectiveTag}");
+    int broadPosWithoutClass = planWithoutClass.indexOf("{broadTag}");
+    assertTrue(planWithoutClass, selectivePosWithoutClass >= 0);
+    assertTrue(planWithoutClass, broadPosWithoutClass >= 0);
+    assertTrue(
+        "bothE→bothV without explicit class: should short-circuit the"
+            + " fold so selective falls back to insertion order (after"
+            + " broad). Plan was:\n" + planWithoutClass,
+        broadPosWithoutClass < selectivePosWithoutClass);
+    session.commit();
+  }
+
+  /**
+   * Scenario 5 — user-named intermediate edge alias with its own WHERE.
+   * Pattern: {@code .outE('X'){as: e, where: weight > 5}.inV(){where: ...}}.
+   * The intermediate's filter is applied by the existing 8-arg
+   * {@code applyTargetSelectivity} call on alias {@code e}; the chain
+   * fold then multiplies the downstream vertex's selectivity on top.
+   * This exercises Design Record D3's independence-multiplication.
+   *
+   * <p>The structural rule still matches because {@code e} has exactly
+   * one incoming pattern edge (from the current branch) — the user
+   * naming the alias does not change the graph shape.
+   */
+  @Test
+  public void testIntermediateEdgeFilterAndDownstreamFilterCombine() {
+    session.execute("CREATE class CC5Person extends V").close();
+    session.execute("CREATE property CC5Person.name STRING").close();
+
+    session.execute("CREATE class CC5Company extends V").close();
+    session.execute("CREATE property CC5Company.name STRING").close();
+
+    session.execute("CREATE class CC5WorkAt extends E").close();
+    session.execute("CREATE property CC5WorkAt.out LINK CC5Person").close();
+    session.execute("CREATE property CC5WorkAt.in LINK CC5Company").close();
+    session.execute("CREATE property CC5WorkAt.weight INTEGER").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC5Company set name = 'targetCorp'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC5Company set name = 'corp" + i + "'").close();
+    }
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX CC5Person set name = 'p" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC5WorkAt FROM"
+              + " (SELECT FROM CC5Person WHERE name = 'p" + i + "')"
+              + " TO (SELECT FROM CC5Company WHERE name = 'targetCorp')"
+              + " SET weight = 10")
+          .close();
+      for (int j = 0; j < 5; j++) {
+        session.execute(
+            "CREATE EDGE CC5WorkAt FROM"
+                + " (SELECT FROM CC5Person WHERE name = 'p" + i + "')"
+                + " TO (SELECT FROM CC5Company WHERE name = 'corp" + j + "')"
+                + " SET weight = 1")
+            .close();
+      }
+    }
+    session.commit();
+
+    // Selective: weight>5 AND name=targetCorp; broad: weight>=0 AND name<>targetCorp.
+    // Both have user-named intermediate aliases (e1, e2) with their own
+    // WHERE clauses, so the existing applyTargetSelectivity pre-multiplies
+    // the intermediate filter and the chain fold adds the downstream filter.
+    var query =
+        "MATCH {class: CC5Person, as: person}"
+            + ".outE('CC5WorkAt'){as: eBroad, where: (weight >= 0)}"
+            + ".inV(){as: broadCorp, where: (name <> 'targetCorp')},"
+            + " {as: person}"
+            + ".outE('CC5WorkAt'){as: eSelective, where: (weight > 5)}"
+            + ".inV(){as: selectiveCorp, where: (name = 'targetCorp')}"
+            + " RETURN person.name, broadCorp.name, selectiveCorp.name";
+
+    session.begin();
+    var result = session.query(query).toList();
+    // 10 persons × 5 broad × 1 selective = 50
+    assertEquals(50, result.size());
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int selectivePos = plan.indexOf("{selectiveCorp}");
+    int broadPos = plan.indexOf("{broadCorp}");
+    assertTrue(plan, selectivePos >= 0);
+    assertTrue(plan, broadPos >= 0);
+    assertTrue(
+        "User-named intermediate alias must still let the chain fold"
+            + " run, with the intermediate's WHERE multiplied by the"
+            + " downstream's WHERE. Plan was:\n" + plan,
+        selectivePos < broadPos);
+    session.commit();
+  }
+
+  /**
+   * Scenario 6 — negative case: chain rule rejects when the intermediate
+   * edge alias has multiple outgoing inV continuations (fragment join).
+   *
+   * <p>Two fragments share the intermediate alias {@code e}, both
+   * stepping {@code .outE('CC6HasTag').inV()} but to different downstream
+   * targets. This makes {@code e.out.size() == 2}, which the structural
+   * rule (clause "{@code neighbor.out.size() == 1}") rejects. Neither
+   * branch's chain folds, so the downstream WHERE selectivity does NOT
+   * propagate to the first edge.
+   *
+   * <p>To make the absence of folding observable, the broad branch is
+   * inserted FIRST and the selective branch SECOND. With the fold off,
+   * both first edges have equal cost and TimSort preserves insertion
+   * order — so {@code {broadTag}} appears before {@code {selectiveTag}}.
+   * If a regression hoisted the fold past the structural rule, the
+   * ordering would invert and this assertion would fail.
+   *
+   * <p>The query has zero runtime results because a single edge instance
+   * cannot lead to two distinct vertex targets — runtime correctness is
+   * not the focus here; the EXPLAIN ordering is.
+   */
+  @Test
+  public void testFragmentJoinBlocksChainFold() {
+    session.execute("CREATE class CC6Post extends V").close();
+    session.execute("CREATE property CC6Post.title STRING").close();
+
+    session.execute("CREATE class CC6Tag extends V").close();
+    session.execute("CREATE property CC6Tag.name STRING").close();
+
+    session.execute("CREATE class CC6HasTag extends E").close();
+    session.execute("CREATE property CC6HasTag.out LINK CC6Post").close();
+    session.execute("CREATE property CC6HasTag.in LINK CC6Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC6Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 10; i++) {
+      session.execute("CREATE VERTEX CC6Tag set name = 'tag" + i + "'").close();
+    }
+    for (int i = 0; i < 5; i++) {
+      session.execute("CREATE VERTEX CC6Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC6HasTag FROM"
+              + " (SELECT FROM CC6Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC6Tag WHERE name = 'targetTag')")
+          .close();
+    }
+    session.commit();
+
+    // Broad inserted first, selective second. With the fold blocked by
+    // the fragment-join rule, TimSort preserves this order.
+    var query =
+        "MATCH {class: CC6Post, as: post}"
+            + ".outE('CC6HasTag'){as: e}.inV(){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: post}"
+            + ".outE('CC6HasTag'){as: e}.inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN post.title, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int selectivePos = plan.indexOf("{selectiveTag}");
+    int broadPos = plan.indexOf("{broadTag}");
+    assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
+    assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
+    assertTrue(
+        "Fragment-join (e.out.size > 1) must reject the chain fold so"
+            + " insertion order is preserved (broad first, selective"
+            + " second). If selective comes first, the fold has been"
+            + " incorrectly hoisted past the structural rule. Plan was:\n"
+            + plan,
+        broadPos < selectivePos);
+    session.commit();
+  }
+
+  /**
+   * Scenario 7 — negative case: the chain fold sits inside the
+   * {@code else} branch of the visited-neighbor check. Pins that a
+   * mutation hoisting the fold outside the {@code if/else} would apply
+   * selectivity to a {@code cost = 0.0} join step and inflate
+   * {@code applyDepthMultiplier}'s input.
+   *
+   * <p>Shape: a back-reference via {@code .outE.inV} where the
+   * downstream vertex is also referenced as a standalone fragment.
+   * Whichever fragment the DFS schedules second meets an
+   * already-visited neighbor on at least one of its sort-loop
+   * iterations, so the production {@code cost = 0.0} path is taken
+   * for those iterations. The end-to-end correctness check (matching
+   * row count) ensures the join-only step still does its job.
+   */
+  @Test
+  public void testVisitedNeighborTakesZeroCostJoinPath() {
+    session.execute("CREATE class CC7Post extends V").close();
+    session.execute("CREATE property CC7Post.title STRING").close();
+
+    session.execute("CREATE class CC7Tag extends V").close();
+    session.execute("CREATE property CC7Tag.name STRING").close();
+
+    session.execute("CREATE class CC7HasTag extends E").close();
+    session.execute("CREATE property CC7HasTag.out LINK CC7Post").close();
+    session.execute("CREATE property CC7HasTag.in LINK CC7Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC7Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 5; i++) {
+      session.execute("CREATE VERTEX CC7Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC7HasTag FROM"
+              + " (SELECT FROM CC7Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC7Tag WHERE name = 'targetTag')")
+          .close();
+    }
+    session.commit();
+
+    // Fragment 1 anchors {tag}; fragment 2 reaches it via outE.inV
+    // back-reference. The DFS picks tag as a root (it has class+where
+    // → most selective). When the post-side fragment is processed, the
+    // inV edge's neighbor is the already-visited {tag}, so the
+    // visited-neighbor branch (cost = 0.0) is taken before the chain
+    // fold is even considered.
+    var query =
+        "MATCH {class: CC7Tag, as: tag, where: (name = 'targetTag')},"
+            + " {class: CC7Post, as: post}"
+            + ".outE('CC7HasTag').inV(){as: tag}"
+            + " RETURN post.title, tag.name";
+
+    session.begin();
+    var result = session.query(query).toList();
+    // 5 posts × 1 tag (back-referenced) = 5 rows
+    assertEquals(5, result.size());
+    Set<String> titles = new HashSet<>();
+    for (var r : result) {
+      assertEquals("targetTag", r.getProperty("tag.name"));
+      titles.add(r.getProperty("post.title"));
+    }
+    assertEquals(5, titles.size());
+
+    // Plan must list both aliases — confirms back-reference was wired
+    // up and the fold-gate didn't crash on the cost=0.0 path.
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue("tag alias missing from plan:\n" + plan, plan.contains("{tag}"));
+    assertTrue("post alias missing from plan:\n" + plan, plan.contains("{post}"));
+    session.commit();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
@@ -4,9 +4,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import java.util.HashSet;
 import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -40,6 +43,20 @@ import org.junit.Test;
  * MAX_VALUE input, the helper would short-circuit and preserve it.
  */
 public class MatchEdgeMethodChainCostTest extends DbTestBase {
+
+  private Object savedChainFoldMaxHops;
+
+  @Before
+  public void saveChainFoldDefault() {
+    savedChainFoldMaxHops =
+        GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValue();
+  }
+
+  @After
+  public void restoreChainFoldDefault() {
+    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS
+        .setValue(savedChainFoldMaxHops);
+  }
 
   /**
    * Scenario 1 — pure {@code outE.inV} chain with two branches of
@@ -607,6 +624,188 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     assertNotNull(plan);
     assertTrue("tag alias missing from plan:\n" + plan, plan.contains("{tag}"));
     assertTrue("post alias missing from plan:\n" + plan, plan.contains("{post}"));
+    session.commit();
+  }
+
+  /**
+   * Scenario 9 — multi-hop chain fold. Two competing two-hop chains from
+   * {@code post} share identical first-hop fan-out and identical
+   * intermediate vertices (no WHERE on intermediates). The selectivity
+   * difference lives ONLY on the FINAL vertex (2 hops away from
+   * {@code post}). Single-hop fold cannot see the final vertex's WHERE
+   * because it only looks one hop ahead — so the two branches would tie
+   * on cost and TimSort would preserve insertion order. Multi-hop fold
+   * must walk the full chain and sort the selective branch first.
+   *
+   * <p>Insertion order is broad-first, selective-second. With the
+   * multi-hop fold enabled (default), the selective branch must end up
+   * scheduled before the broad one — proving the walk reached the final
+   * vertex's WHERE through two consecutive (outE, inV) sub-chains.
+   */
+  @Test
+  public void testMultiHopChainFoldSchedulesSelectiveBranchFirst() {
+    session.execute("CREATE class CC9Person extends V").close();
+    session.execute("CREATE property CC9Person.name STRING").close();
+
+    session.execute("CREATE class CC9Post extends V").close();
+    session.execute("CREATE property CC9Post.title STRING").close();
+
+    session.execute("CREATE class CC9Tag extends V").close();
+    session.execute("CREATE property CC9Tag.name STRING").close();
+
+    session.execute("CREATE class CC9Wrote extends E").close();
+    session.execute("CREATE property CC9Wrote.out LINK CC9Person").close();
+    session.execute("CREATE property CC9Wrote.in LINK CC9Post").close();
+
+    session.execute("CREATE class CC9HasTag extends E").close();
+    session.execute("CREATE property CC9HasTag.out LINK CC9Post").close();
+    session.execute("CREATE property CC9HasTag.in LINK CC9Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC9Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC9Tag set name = 'tag" + i + "'").close();
+    }
+    for (int i = 0; i < 5; i++) {
+      session.execute("CREATE VERTEX CC9Person set name = 'person" + i + "'").close();
+    }
+    for (int p = 0; p < 5; p++) {
+      for (int q = 0; q < 3; q++) {
+        var postTitle = "p" + p + "_post" + q;
+        session.execute(
+            "CREATE VERTEX CC9Post set title = '" + postTitle + "'").close();
+        session.execute(
+            "CREATE EDGE CC9Wrote FROM"
+                + " (SELECT FROM CC9Person WHERE name = 'person" + p + "')"
+                + " TO (SELECT FROM CC9Post WHERE title = '" + postTitle + "')")
+            .close();
+        session.execute(
+            "CREATE EDGE CC9HasTag FROM"
+                + " (SELECT FROM CC9Post WHERE title = '" + postTitle + "')"
+                + " TO (SELECT FROM CC9Tag WHERE name = 'targetTag')")
+            .close();
+        for (int t = 0; t < 5; t++) {
+          session.execute(
+              "CREATE EDGE CC9HasTag FROM"
+                  + " (SELECT FROM CC9Post WHERE title = '" + postTitle + "')"
+                  + " TO (SELECT FROM CC9Tag WHERE name = 'tag" + t + "')")
+              .close();
+        }
+      }
+    }
+    session.commit();
+
+    // Two two-hop chains from {person}. WHERE differs only at the FINAL
+    // vertex (tag), 2 hops from person. Insertion order: broad first.
+    var query =
+        "MATCH {class: CC9Person, as: person}"
+            + ".outE('CC9Wrote').inV().outE('CC9HasTag').inV(){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: person}"
+            + ".outE('CC9Wrote').inV().outE('CC9HasTag').inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN person.name, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int selectivePos = plan.indexOf("{selectiveTag}");
+    int broadPos = plan.indexOf("{broadTag}");
+    assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
+    assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
+    assertTrue(
+        "Multi-hop fold should propagate the final vertex's WHERE back to"
+            + " the first edge's cost, so selectiveTag (2 hops away) sorts"
+            + " before broadTag despite insertion order. Plan was:\n" + plan,
+        selectivePos < broadPos);
+    session.commit();
+  }
+
+  /**
+   * Scenario 10 — knob {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 1}
+   * downgrades the fold to legacy single-hop behaviour. Same query as
+   * scenario 9 (selectivity hidden 2 hops in), but with the knob set to
+   * 1 the fold cannot reach the final vertex. Both branches end up with
+   * identical first-hop costs, TimSort preserves insertion order, and
+   * the broad branch (inserted first) sorts before the selective branch.
+   *
+   * <p>Pins the rollback semantics of the knob — operators can downgrade
+   * to single-hop in production without code change if multi-hop ever
+   * causes a regression.
+   */
+  @Test
+  public void testMultiHopFoldDisabledByMaxHopsKnob() {
+    session.execute("CREATE class CC10Person extends V").close();
+    session.execute("CREATE property CC10Person.name STRING").close();
+
+    session.execute("CREATE class CC10Post extends V").close();
+    session.execute("CREATE property CC10Post.title STRING").close();
+
+    session.execute("CREATE class CC10Tag extends V").close();
+    session.execute("CREATE property CC10Tag.name STRING").close();
+
+    session.execute("CREATE class CC10Wrote extends E").close();
+    session.execute("CREATE property CC10Wrote.out LINK CC10Person").close();
+    session.execute("CREATE property CC10Wrote.in LINK CC10Post").close();
+
+    session.execute("CREATE class CC10HasTag extends E").close();
+    session.execute("CREATE property CC10HasTag.out LINK CC10Post").close();
+    session.execute("CREATE property CC10HasTag.in LINK CC10Tag").close();
+
+    session.begin();
+    session.execute("CREATE VERTEX CC10Tag set name = 'targetTag'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC10Tag set name = 'tag" + i + "'").close();
+    }
+    for (int i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX CC10Person set name = 'p" + i + "'").close();
+      session.execute("CREATE VERTEX CC10Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC10Wrote FROM"
+              + " (SELECT FROM CC10Person WHERE name = 'p" + i + "')"
+              + " TO (SELECT FROM CC10Post WHERE title = 'post" + i + "')")
+          .close();
+      session.execute(
+          "CREATE EDGE CC10HasTag FROM"
+              + " (SELECT FROM CC10Post WHERE title = 'post" + i + "')"
+              + " TO (SELECT FROM CC10Tag WHERE name = 'targetTag')")
+          .close();
+      for (int j = 0; j < 5; j++) {
+        session.execute(
+            "CREATE EDGE CC10HasTag FROM"
+                + " (SELECT FROM CC10Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC10Tag WHERE name = 'tag" + j + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    // Downgrade to single-hop fold via knob
+    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(1);
+
+    var query =
+        "MATCH {class: CC10Person, as: person}"
+            + ".outE('CC10Wrote').inV().outE('CC10HasTag').inV(){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: person}"
+            + ".outE('CC10Wrote').inV().outE('CC10HasTag').inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN person.name, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int selectivePos = plan.indexOf("{selectiveTag}");
+    int broadPos = plan.indexOf("{broadTag}");
+    assertTrue("selectiveTag missing from plan:\n" + plan, selectivePos >= 0);
+    assertTrue("broadTag missing from plan:\n" + plan, broadPos >= 0);
+    assertTrue(
+        "With maxHops=1 the fold cannot see the final vertex's WHERE,"
+            + " so both branches tie and TimSort preserves insertion"
+            + " order (broad first). Plan was:\n" + plan,
+        broadPos < selectivePos);
     session.commit();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
@@ -6,15 +6,18 @@ import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.YqlExecutionPlanCache;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
- * Regression tests for the edge-method chain-cost fold introduced in
- * YTDB-643. The fold propagates the downstream vertex's WHERE selectivity
+ * Regression tests for the edge-method chain-cost fold. The fold propagates
+ * the downstream vertex's WHERE selectivity
  * into the first-edge cost of an {@code outE→inV} / {@code inE→outV} /
  * {@code bothE→bothV} chain so that the planner schedules selective
  * branches before broad ones, matching the behaviour of the equivalent
@@ -35,13 +38,19 @@ import org.junit.Test;
  * the chain rule accepts — {@code parseDirection} never returns null, so
  * {@code estimateEdgeCost} always returns a finite value and the gate
  * is structurally unreachable through the chain-fold integration. The
- * gate's MAX_VALUE-preservation invariant is instead pinned by
- * {@code MatchExecutionPlannerMutationTest
- * .applyTargetSelectivity_classForced_maxValueInputPreservedOnNullClass}
- * and its {@code _maxValueInputPreservedOnNoFilterNoEstimate} sibling,
- * which assert that even if the sort loop did call the fold on a
- * MAX_VALUE input, the helper would short-circuit and preserve it.
+ * invariant that a MAX_VALUE cost survives the fold untouched is pinned
+ * at unit level instead, by driving the class-forced selectivity helper
+ * with a MAX_VALUE input and a target that has no class, no filter and
+ * no estimate, then asserting it short-circuits and returns the input.
+ *
+ * <p>{@code @Category(SequentialTest.class)} because several tests write
+ * {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS}, which is JVM-global state. The
+ * {@code default-test} surefire execution runs classes four at a time
+ * (see {@code core/pom.xml}), so without the category a concurrently
+ * running class that plans an {@code outE→inV} MATCH would observe this
+ * class's knob writes — including the window where the fold is disabled.
  */
+@Category(SequentialTest.class)
 public class MatchEdgeMethodChainCostTest extends DbTestBase {
 
   private int savedChainFoldMaxHops;
@@ -58,6 +67,27 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   public void restoreChainFoldDefault() {
     GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS
         .setValue(savedChainFoldMaxHops);
+  }
+
+  /**
+   * Sets the chain-fold knob and evicts cached execution plans.
+   *
+   * <p>The eviction is mandatory, not hygiene. {@link YqlExecutionPlanCache}
+   * keys on the statement text and is invalidated by schema, index, function
+   * and storage-configuration updates — never by a {@code GlobalConfiguration}
+   * write. A test that runs one query text under two knob values gets the
+   * first plan handed back both times without this call, and the second
+   * assertion then measures the first knob's schedule.
+   *
+   * <p>The same holds in production: {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS}
+   * is read during plan construction, so changing it does not re-plan
+   * statements already in the cache. Operators using the documented
+   * {@code = 0} rollback need a cache eviction (any schema change, or a
+   * restart) for it to take effect on hot queries.
+   */
+  private void setChainFoldMaxHops(int maxHops) {
+    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(maxHops);
+    YqlExecutionPlanCache.instance(session).invalidate();
   }
 
   /**
@@ -79,15 +109,14 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 1 — pure {@code outE.inV} chain with two branches of
+   * Pure {@code outE.inV} chain with two branches of
    * different selectivities. The planner should fold the downstream
    * vertex's WHERE into the first edge's cost and schedule the
    * selective branch ({@code name = 'targetTag'}) before the broad
    * branch ({@code name <> 'targetTag'}).
    *
-   * <p>Distinguishes from
-   * {@code MatchEdgeMethodInferenceAndAbortTest.testVertexClassInferenceEnablesIndexIntersection}
-   * by deliberately omitting the index on {@code VITag.name}: the
+   * <p>Deliberately omits an index on the tag name, unlike the sibling
+   * test that pins index-intersection attachment: the
    * filter-shape heuristic (eq vs. ne) is what the cost-fold relies on
    * here, not index histograms. This pins the heuristic path through the
    * fold independently of any index-based cost paths.
@@ -162,7 +191,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 2 — mixed branch styles: one branch uses the single-step
+   * Mixed branch styles: one branch uses the single-step
    * {@code .out('X'){where: p}} pattern, the other uses the two-step
    * {@code .outE('X').inV(){where: q}} chain. With {@code q} more
    * selective than {@code p}, cost ordering must be consistent across
@@ -236,7 +265,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 3 — reverse direction: {@code inE.outV} chain. Verifies the
+   * Reverse direction: {@code inE.outV} chain. Verifies the
    * helper picks the edge class's {@code out} property (source vertex
    * class) when inferring the downstream alias, not the {@code in}
    * property used for outbound chains.
@@ -312,7 +341,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 4 — bidirectional {@code bothE.bothV} chain. Edge-schema
+   * Bidirectional {@code bothE.bothV} chain. Edge-schema
    * inference cannot disambiguate the downstream vertex class for a
    * bidirectional traversal, so {@code resolveChainedTarget} returns a
    * {@code ChainedTarget} with a null class and the class-forced overload
@@ -370,6 +399,16 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + " RETURN post.title, broadTag.name, selectiveTag.name";
 
     session.begin();
+    // The two query forms express the same class constraint two ways
+    // ({class: CC4Tag} vs. @class = 'CC4Tag' in the WHERE), so they must
+    // return the same rows. Captured here and compared after the second
+    // form runs — only the plan ordering is allowed to differ.
+    int rowsWithClass = session.query(queryWithClass).toList().size();
+    assertTrue(
+        "Fixture must produce rows, otherwise the row-count parity check"
+            + " below is vacuous",
+        rowsWithClass > 0);
+
     var explainWithClass = session.query("EXPLAIN " + queryWithClass).toList();
     String planWithClass =
         explainWithClass.getFirst().getProperty("executionPlanAsString");
@@ -399,6 +438,12 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + " RETURN post.title, broadTag.name, selectiveTag.name";
 
     session.begin();
+    assertEquals(
+        "Expressing the class constraint in the WHERE instead of the"
+            + " {class:} annotation must not change the result set — the"
+            + " fold only reorders the schedule",
+        rowsWithClass, session.query(queryWithoutClass).toList().size());
+
     var explainWithoutClass = session.query("EXPLAIN " + queryWithoutClass).toList();
     String planWithoutClass =
         explainWithoutClass.getFirst().getProperty("executionPlanAsString");
@@ -416,12 +461,12 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 5 — user-named intermediate edge alias with its own WHERE.
+   * User-named intermediate edge alias with its own WHERE.
    * Pattern: {@code .outE('X'){as: e, where: weight > 5}.inV(){where: ...}}.
    * The intermediate's filter is applied by the existing
    * {@code applyTargetSelectivity} call on alias {@code e}; the chain
    * fold then multiplies the downstream vertex's selectivity on top.
-   * This exercises Design Record D3's independence-multiplication.
+   * The two filters multiply, treated as independent.
    *
    * <p>The structural rule still matches because {@code e} has exactly
    * one incoming pattern edge (from the current branch) — the user
@@ -498,7 +543,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 6 — negative case: chain rule rejects when the intermediate
+   * Negative case: chain rule rejects when the intermediate
    * edge alias has multiple outgoing inV continuations (fragment join).
    *
    * <p>Two fragments share the intermediate alias {@code e}, both
@@ -515,9 +560,16 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
    * If a regression hoisted the fold past the structural rule, the
    * ordering would invert and this assertion would fail.
    *
-   * <p>The query has zero runtime results because a single edge instance
-   * cannot lead to two distinct vertex targets — runtime correctness is
-   * not the focus here; the EXPLAIN ordering is.
+   * <p><b>Positive control.</b> "Broad first" is also what you get from a
+   * globally dead fold, so the same graph is queried a second time without
+   * the shared {@code {as: e}}. That form is fold-eligible and must order
+   * selective-first. Only the pair of assertions distinguishes "the
+   * fragment-join rule rejected this chain" from "the fold does nothing
+   * any more".
+   *
+   * <p>Runtime rows separate the two forms as well: the shared-alias query
+   * returns zero rows (one edge instance cannot reach two distinct tags)
+   * while the control returns 5 posts × 2 broad tags × 1 selective tag.
    */
   @Test
   public void testFragmentJoinBlocksChainFold() {
@@ -543,12 +595,21 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
               + " (SELECT FROM CC6Post WHERE title = 'post" + i + "')"
               + " TO (SELECT FROM CC6Tag WHERE name = 'targetTag')")
           .close();
+      // Two broad tags per post so the positive control below has rows to
+      // return; the shared-alias query must still return none.
+      for (int j = 0; j < 2; j++) {
+        session.execute(
+            "CREATE EDGE CC6HasTag FROM"
+                + " (SELECT FROM CC6Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC6Tag WHERE name = 'tag" + j + "')")
+            .close();
+      }
     }
     session.commit();
 
     // Broad inserted first, selective second. With the fold blocked by
     // the fragment-join rule, TimSort preserves this order.
-    var query =
+    var sharedAliasQuery =
         "MATCH {class: CC6Post, as: post}"
             + ".outE('CC6HasTag'){as: e}.inV(){as: broadTag,"
             + "  where: (name <> 'targetTag')},"
@@ -558,7 +619,12 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + " RETURN post.title, broadTag.name, selectiveTag.name";
 
     session.begin();
-    var explainResult = session.query("EXPLAIN " + query).toList();
+    assertEquals(
+        "Sharing {as: e} across both fragments pins one edge instance to two"
+            + " distinct tags, which no row can satisfy",
+        0, session.query(sharedAliasQuery).toList().size());
+
+    var explainResult = session.query("EXPLAIN " + sharedAliasQuery).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     int selectivePos = aliasStepPosition(plan, "selectiveTag");
@@ -573,10 +639,47 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + plan,
         broadPos < selectivePos);
     session.commit();
+
+    // Positive control: same graph, same insertion order, same selectivity
+    // split — only the shared {as: e} is gone, so the chain is fold-eligible
+    // and the ordering must invert. Without this the assertion above would
+    // also hold for a fold that never fires at all.
+    var controlQuery =
+        "MATCH {class: CC6Post, as: post}"
+            + ".outE('CC6HasTag').inV(){as: broadTag,"
+            + "  where: (name <> 'targetTag')},"
+            + " {as: post}"
+            + ".outE('CC6HasTag').inV(){as: selectiveTag,"
+            + "  where: (name = 'targetTag')}"
+            + " RETURN post.title, broadTag.name, selectiveTag.name";
+
+    session.begin();
+    // 5 posts × 2 broad tags × 1 selective tag
+    assertEquals(10, session.query(controlQuery).toList().size());
+
+    var controlExplain = session.query("EXPLAIN " + controlQuery).toList();
+    String controlPlan =
+        controlExplain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(controlPlan);
+    int controlSelectivePos = aliasStepPosition(controlPlan, "selectiveTag");
+    int controlBroadPos = aliasStepPosition(controlPlan, "broadTag");
+    assertTrue(
+        "selectiveTag missing from control plan:\n" + controlPlan,
+        controlSelectivePos >= 0);
+    assertTrue(
+        "broadTag missing from control plan:\n" + controlPlan,
+        controlBroadPos >= 0);
+    assertTrue(
+        "Without the shared {as: e} the same chain must fold and order"
+            + " selective first. If this fails the fold is dead and the"
+            + " fragment-join assertion above proves nothing. Plan was:\n"
+            + controlPlan,
+        controlSelectivePos < controlBroadPos);
+    session.commit();
   }
 
   /**
-   * Scenario 7 — negative case: the chain fold sits inside the
+   * Negative case: the chain fold sits inside the
    * {@code else} branch of the visited-neighbor check. Pins that a
    * mutation hoisting the fold outside the {@code if/else} would apply
    * selectivity to a {@code cost = 0.0} join step and inflate
@@ -642,14 +745,21 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
-    assertTrue("tag alias missing from plan:\n" + plan, plan.contains("{tag}"));
-    assertTrue("post alias missing from plan:\n" + plan, plan.contains("{post}"));
+    // Use aliasStepPosition rather than a literal "{tag}" substring so a
+    // future plan-format addition (e.g. "{tag,index=…}") does not turn
+    // these into silent false negatives.
+    assertTrue(
+        "tag alias missing from plan:\n" + plan,
+        aliasStepPosition(plan, "tag") >= 0);
+    assertTrue(
+        "post alias missing from plan:\n" + plan,
+        aliasStepPosition(plan, "post") >= 0);
     session.commit();
   }
 
   /**
-   * Scenario 8 — multi-hop chain fold. Two competing two-hop chains from
-   * {@code post} share identical first-hop fan-out and identical
+   * Multi-hop chain fold. Two competing two-hop chains from
+   * {@code person} share identical first-hop fan-out and identical
    * intermediate vertices (no WHERE on intermediates). The selectivity
    * difference lives ONLY on the FINAL vertex (2 hops away from
    * {@code post}). Single-hop fold cannot see the final vertex's WHERE
@@ -727,6 +837,14 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + " RETURN person.name, broadTag.name, selectiveTag.name";
 
     session.begin();
+    // The fold reorders the schedule; it must not change what MATCH returns.
+    // 5 persons × (3 posts × 5 broad tags) × (3 posts × 1 selective tag).
+    var result = session.query(query).toList();
+    assertEquals(5 * (3 * 5) * (3 * 1), result.size());
+    for (var r : result) {
+      assertEquals("targetTag", r.getProperty("selectiveTag.name"));
+    }
+
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
@@ -743,16 +861,25 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 9 — knob {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 1}
-   * downgrades the fold to legacy single-hop behaviour. Same query as
-   * scenario 9 (selectivity hidden 2 hops in), but with the knob set to
-   * 1 the fold cannot reach the final vertex. Both branches end up with
-   * identical first-hop costs, TimSort preserves insertion order, and
-   * the broad branch (inserted first) sorts before the selective branch.
+   * Knob {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 1} restricts
+   * the fold to the immediate downstream vertex. Same two-hop shape as the
+   * multi-hop test above, with the selectivity hidden two hops in, but with
+   * the knob set to 1
+   * the fold cannot reach the final vertex. Both branches end up with
+   * identical first-hop costs, TimSort preserves insertion order, and the
+   * broad branch (inserted first) sorts before the selective branch.
    *
-   * <p>Pins the rollback semantics of the knob — operators can downgrade
-   * to single-hop in production without code change if multi-hop ever
-   * causes a regression.
+   * <p>Pins the downgrade semantics of the knob — operators can restrict
+   * the fold to one hop in production without a code change if multi-hop
+   * ever causes a regression. Note that {@code 1} is not the pre-fold
+   * planner: the first hop's downstream vertex is still folded. Only
+   * {@code 0} skips {@code applyChainFold} altogether.
+   *
+   * <p><b>Positive control.</b> The same query runs first at the default
+   * knob, where it must order selective-first. Without that leg, the
+   * knob=1 assertion would also pass against a fold that never fires.
+   * Both legs assert the row count too, so a knob change that altered
+   * MATCH semantics rather than just ordering would be caught.
    */
   @Test
   public void testMultiHopFoldDisabledByMaxHopsKnob() {
@@ -801,9 +928,6 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     }
     session.commit();
 
-    // Downgrade to single-hop fold via knob
-    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(1);
-
     var query =
         "MATCH {class: CC10Person, as: person}"
             + ".outE('CC10Wrote').inV().outE('CC10HasTag').inV(){as: broadTag,"
@@ -812,8 +936,41 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + ".outE('CC10Wrote').inV().outE('CC10HasTag').inV(){as: selectiveTag,"
             + "  where: (name = 'targetTag')}"
             + " RETURN person.name, broadTag.name, selectiveTag.name";
+    // 3 persons × 1 post each × 5 broad tags × 1 selective tag
+    int expectedRows = 3 * 5;
+
+    // Positive control at the default knob: the multi-hop fold reaches the
+    // final vertex, so selective must sort first. Establishes that the
+    // ordering flip below is caused by the knob and not by a dead fold.
+    session.begin();
+    assertEquals(expectedRows, session.query(query).toList().size());
+    var defaultExplain = session.query("EXPLAIN " + query).toList();
+    String defaultPlan =
+        defaultExplain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(defaultPlan);
+    int defaultSelectivePos = aliasStepPosition(defaultPlan, "selectiveTag");
+    int defaultBroadPos = aliasStepPosition(defaultPlan, "broadTag");
+    assertTrue(
+        "selectiveTag missing from default-knob plan:\n" + defaultPlan,
+        defaultSelectivePos >= 0);
+    assertTrue(
+        "broadTag missing from default-knob plan:\n" + defaultPlan,
+        defaultBroadPos >= 0);
+    assertTrue(
+        "At the default knob the multi-hop fold must reach the final"
+            + " vertex and order selective first. If this fails the fold is"
+            + " dead and the knob=1 assertion below proves nothing. Plan"
+            + " was:\n" + defaultPlan,
+        defaultSelectivePos < defaultBroadPos);
+    session.commit();
+
+    // Restrict the fold to the immediate downstream vertex via the knob.
+    setChainFoldMaxHops(1);
 
     session.begin();
+    assertEquals(
+        "Restricting the fold changes plan ordering only, never the result set",
+        expectedRows, session.query(query).toList().size());
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
@@ -830,7 +987,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 10 — user-named intermediate edge alias with its own WHERE on
+   * User-named intermediate edge alias with its own WHERE on
    * a SECOND hop of a multi-hop chain. The fold must propagate that filter
    * into the first edge's cost. Pins the contract that the second-hop
    * intermediate alias's class is supplied (via {@code extractEdgeClassName}
@@ -907,6 +1064,10 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
             + " RETURN person.name, broadTag.name, selectiveTag.name";
 
     session.begin();
+    // 3 persons × 1 post × 5 weight>=10 edges × 1 weight=1 edge. Pins that
+    // the intermediate-alias fold changed ordering only, not the result set.
+    assertEquals(3 * 5 * 1, session.query(query).toList().size());
+
     var explainResult = session.query("EXPLAIN " + query).toList();
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
@@ -924,21 +1085,22 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
   }
 
   /**
-   * Scenario 11 — pathological knob values must not break the planner.
+   * Pathological knob values must not break the planner.
    * Pins the {@code MAX_CHAIN_FOLD_HOPS} clamp applied when the knob is
-   * read in {@code getTopologicalSortedSchedule}: a misconfigured knob of
-   * {@code Integer.MAX_VALUE} would otherwise overflow the walk's
-   * bookkeeping arithmetic ({@code 2 * remainingHops + 2} going negative)
-   * and cause the planner to throw or hang.
+   * read in {@code getTopologicalSortedSchedule}. An unclamped
+   * {@code Integer.MAX_VALUE} becomes the walk's {@code remainingHops}
+   * loop bound, and any future bookkeeping derived from it (sizing,
+   * counters) would then sit one arithmetic operation away from wrapping.
+   * The clamp keeps that bound three orders of magnitude below the int
+   * range.
    *
    * <p>The test runs a normal multi-hop chain query with the knob set to
-   * extreme values: {@code Integer.MAX_VALUE} (overflow probe),
-   * {@code Integer.MIN_VALUE} (negative probe — clamped to 0, full
-   * rollback) and a large but in-range value (cap probe). The query must
-   * complete and return correct results in every case; ordering is checked
-   * for the {@code Integer.MAX_VALUE} case where the fold should still fire
-   * (clamped down to {@code MAX_CHAIN_FOLD_HOPS} but well above what this
-   * 2-hop pattern needs).
+   * extreme values: {@code Integer.MAX_VALUE} (clamped down, fold still
+   * fires), {@code Integer.MIN_VALUE} (clamped to 0, fold fully off) and
+   * a large but in-range value (no clamping). Each probe asserts both the
+   * result set and the resulting plan ordering, so a clamp that silently
+   * disabled or over-applied the fold would be caught rather than passing
+   * on "the query did not throw".
    */
   @Test
   public void testExtremeKnobValuesDoNotBreakPlanner() {
@@ -1000,7 +1162,7 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     // arithmetic on remainingHops. Clamp must keep the planner alive
     // and the fold should still fire (clamp value of 1000 ≫ this 2-hop
     // chain's needs), so selective branch sorts first.
-    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(Integer.MAX_VALUE);
+    setChainFoldMaxHops(Integer.MAX_VALUE);
     session.begin();
     var resultMax = session.query(query).toList();
     assertEquals(2 * 3, resultMax.size());
@@ -1009,7 +1171,8 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     assertNotNull(planMax);
     int selectivePosMax = aliasStepPosition(planMax, "selectiveTag");
     int broadPosMax = aliasStepPosition(planMax, "broadTag");
-    assertTrue(planMax, selectivePosMax >= 0 && broadPosMax >= 0);
+    assertTrue("selectiveTag missing from plan:\n" + planMax, selectivePosMax >= 0);
+    assertTrue("broadTag missing from plan:\n" + planMax, broadPosMax >= 0);
     assertTrue(
         "Integer.MAX_VALUE knob must be clamped to a sane upper bound; the"
             + " fold must still fire and order selective before broad. Plan was:\n"
@@ -1017,18 +1180,33 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
         selectivePosMax < broadPosMax);
     session.commit();
 
-    // Probe 2: Integer.MIN_VALUE — clamps to 0 (full rollback). Query
-    // must run; ordering reverts to insertion order (broad first).
-    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(Integer.MIN_VALUE);
+    // Probe 2: Integer.MIN_VALUE — clamps to 0, so the sort loop skips
+    // applyChainFold entirely. The query must still run and return the
+    // same rows, and the ordering must revert to insertion order (broad
+    // first) — asserting only the row count here would let a clamp that
+    // never disabled the fold pass unnoticed.
+    setChainFoldMaxHops(Integer.MIN_VALUE);
     session.begin();
     var resultMin = session.query(query).toList();
     assertEquals(2 * 3, resultMin.size());
+    var explainMin = session.query("EXPLAIN " + query).toList();
+    String planMin = explainMin.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(planMin);
+    int selectivePosMin = aliasStepPosition(planMin, "selectiveTag");
+    int broadPosMin = aliasStepPosition(planMin, "broadTag");
+    assertTrue("selectiveTag missing from plan:\n" + planMin, selectivePosMin >= 0);
+    assertTrue("broadTag missing from plan:\n" + planMin, broadPosMin >= 0);
+    assertTrue(
+        "Integer.MIN_VALUE clamps to 0, which disables the fold, so both"
+            + " branches tie and TimSort preserves insertion order (broad"
+            + " first). Plan was:\n" + planMin,
+        broadPosMin < selectivePosMin);
     session.commit();
 
     // Probe 3: a large in-range value — exercises the clamp's ceiling
     // path (input <= MAX_CHAIN_FOLD_HOPS, no clamping needed). Same
     // semantics as default knob; selective branch first.
-    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(500);
+    setChainFoldMaxHops(500);
     session.begin();
     var resultLarge = session.query(query).toList();
     assertEquals(2 * 3, resultLarge.size());
@@ -1038,11 +1216,167 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
     assertNotNull(planLarge);
     int selectivePosLarge = aliasStepPosition(planLarge, "selectiveTag");
     int broadPosLarge = aliasStepPosition(planLarge, "broadTag");
-    assertTrue(planLarge, selectivePosLarge >= 0 && broadPosLarge >= 0);
+    assertTrue(
+        "selectiveTag missing from plan:\n" + planLarge, selectivePosLarge >= 0);
+    assertTrue("broadTag missing from plan:\n" + planLarge, broadPosLarge >= 0);
     assertTrue(
         "Large but in-range knob (500) must not be clamped down and the"
             + " fold should fire normally. Plan was:\n" + planLarge,
         selectivePosLarge < broadPosLarge);
+    session.commit();
+  }
+
+  /**
+   * Three-hop chain, pinning the exact hop at which
+   * {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS} truncates the walk.
+   *
+   * <p>Shape: {@code person → Post → Tag → Category}, with the selectivity
+   * living only on {@code Category}, three hops from the root. Reaching it
+   * costs {@code applyChainFold} one first-hop fold plus two iterations of
+   * {@code walkLinearChainExtension}, so the fold needs {@code maxHops >= 3}.
+   * The test walks the boundary from both sides:
+   *
+   * <ul>
+   *   <li>{@code maxHops = 2} — the walk stops at {@code Tag}, which carries
+   *       no WHERE, so the branches tie and insertion order (broad first)
+   *       survives;</li>
+   *   <li>{@code maxHops = 3} — the walk reaches {@code Category} and the
+   *       selective branch sorts first;</li>
+   *   <li>default knob (10) — same as 3, confirming values above the chain
+   *       length behave like the exact fit rather than over-applying.</li>
+   * </ul>
+   *
+   * <p>The two-hop case only shows that {@code maxHops = 1} is too small,
+   * which an off-by-one in the cap would survive. Testing
+   * both sides of a boundary two hops deeper also forces the walk's loop to
+   * iterate more than once, exercising the per-hop re-seeding of
+   * {@code sourceClass} from the previous sub-chain's downstream class.
+   */
+  @Test
+  public void testChainFoldStopsAtExactlyMaxHops() {
+    session.execute("CREATE class CC13Person extends V").close();
+    session.execute("CREATE property CC13Person.name STRING").close();
+
+    session.execute("CREATE class CC13Post extends V").close();
+    session.execute("CREATE property CC13Post.title STRING").close();
+
+    session.execute("CREATE class CC13Tag extends V").close();
+    session.execute("CREATE property CC13Tag.name STRING").close();
+
+    session.execute("CREATE class CC13Category extends V").close();
+    session.execute("CREATE property CC13Category.name STRING").close();
+
+    session.execute("CREATE class CC13Wrote extends E").close();
+    session.execute("CREATE property CC13Wrote.out LINK CC13Person").close();
+    session.execute("CREATE property CC13Wrote.in LINK CC13Post").close();
+
+    session.execute("CREATE class CC13HasTag extends E").close();
+    session.execute("CREATE property CC13HasTag.out LINK CC13Post").close();
+    session.execute("CREATE property CC13HasTag.in LINK CC13Tag").close();
+
+    session.execute("CREATE class CC13InCat extends E").close();
+    session.execute("CREATE property CC13InCat.out LINK CC13Tag").close();
+    session.execute("CREATE property CC13InCat.in LINK CC13Category").close();
+
+    session.begin();
+    // One selective category plus 50 decoys, so the equality filter on
+    // {name = 'targetCat'} is markedly more selective than its negation.
+    session.execute("CREATE VERTEX CC13Category set name = 'targetCat'").close();
+    for (int i = 0; i < 50; i++) {
+      session.execute("CREATE VERTEX CC13Category set name = 'cat" + i + "'").close();
+    }
+    // tag0 leads to the selective category; tag1..tag3 to decoys.
+    for (int t = 0; t < 4; t++) {
+      session.execute("CREATE VERTEX CC13Tag set name = 'tag" + t + "'").close();
+      var categoryName = t == 0 ? "targetCat" : "cat" + t;
+      session.execute(
+          "CREATE EDGE CC13InCat FROM"
+              + " (SELECT FROM CC13Tag WHERE name = 'tag" + t + "')"
+              + " TO (SELECT FROM CC13Category WHERE name = '" + categoryName + "')")
+          .close();
+    }
+    for (int i = 0; i < 2; i++) {
+      session.execute("CREATE VERTEX CC13Person set name = 'p" + i + "'").close();
+      session.execute("CREATE VERTEX CC13Post set title = 'post" + i + "'").close();
+      session.execute(
+          "CREATE EDGE CC13Wrote FROM"
+              + " (SELECT FROM CC13Person WHERE name = 'p" + i + "')"
+              + " TO (SELECT FROM CC13Post WHERE title = 'post" + i + "')")
+          .close();
+      for (int t = 0; t < 4; t++) {
+        session.execute(
+            "CREATE EDGE CC13HasTag FROM"
+                + " (SELECT FROM CC13Post WHERE title = 'post" + i + "')"
+                + " TO (SELECT FROM CC13Tag WHERE name = 'tag" + t + "')")
+            .close();
+      }
+    }
+    session.commit();
+
+    // Insertion order is broad-first, so "selective first" can only come
+    // from the fold reaching the third hop.
+    var query =
+        "MATCH {class: CC13Person, as: person}"
+            + ".outE('CC13Wrote').inV()"
+            + ".outE('CC13HasTag').inV()"
+            + ".outE('CC13InCat').inV(){as: broadCat,"
+            + "  where: (name <> 'targetCat')},"
+            + " {as: person}"
+            + ".outE('CC13Wrote').inV()"
+            + ".outE('CC13HasTag').inV()"
+            + ".outE('CC13InCat').inV(){as: selectiveCat,"
+            + "  where: (name = 'targetCat')}"
+            + " RETURN person.name, broadCat.name, selectiveCat.name";
+    // Per person: 1 post × 3 decoy tags for the broad branch × 1 tag0 for
+    // the selective branch. Two persons.
+    int expectedRows = 2 * 3 * 1;
+
+    setChainFoldMaxHops(2);
+    assertOrdering(
+        query, expectedRows, "broadCat", "selectiveCat",
+        "maxHops=2 truncates the walk at Tag, which carries no WHERE, so"
+            + " the branches tie and insertion order survives");
+
+    setChainFoldMaxHops(3);
+    assertOrdering(
+        query, expectedRows, "selectiveCat", "broadCat",
+        "maxHops=3 is exactly enough to reach Category, so the selective"
+            + " branch must sort first");
+
+    setChainFoldMaxHops(10);
+    assertOrdering(
+        query, expectedRows, "selectiveCat", "broadCat",
+        "a knob above the chain length must behave like the exact fit,"
+            + " not fold further and reorder something else");
+  }
+
+  /**
+   * Runs {@code query}, asserts its row count, then asserts that
+   * {@code firstAlias} is scheduled before {@code secondAlias} in the
+   * EXPLAIN plan. Wraps both in one transaction.
+   *
+   * @param reason appended to the ordering failure message to say which
+   *               knob setting or structural rule the caller is pinning
+   */
+  private void assertOrdering(
+      String query, int expectedRows, String firstAlias, String secondAlias,
+      String reason) {
+    session.begin();
+    assertEquals(
+        "Fold configuration must not change the result set (" + reason + ")",
+        expectedRows, session.query(query).toList().size());
+
+    var explainResult = session.query("EXPLAIN " + query).toList();
+    String plan = explainResult.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    int firstPos = aliasStepPosition(plan, firstAlias);
+    int secondPos = aliasStepPosition(plan, secondAlias);
+    assertTrue(firstAlias + " missing from plan:\n" + plan, firstPos >= 0);
+    assertTrue(secondAlias + " missing from plan:\n" + plan, secondPos >= 0);
+    assertTrue(
+        firstAlias + " must be scheduled before " + secondAlias + " — "
+            + reason + ". Plan was:\n" + plan,
+        firstPos < secondPos);
     session.commit();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodChainCostTest.java
@@ -79,11 +79,9 @@ public class MatchEdgeMethodChainCostTest extends DbTestBase {
    * first plan handed back both times without this call, and the second
    * assertion then measures the first knob's schedule.
    *
-   * <p>The same holds in production: {@code QUERY_MATCH_CHAIN_FOLD_MAX_HOPS}
-   * is read during plan construction, so changing it does not re-plan
-   * statements already in the cache. Operators using the documented
-   * {@code = 0} rollback need a cache eviction (any schema change, or a
-   * restart) for it to take effect on hot queries.
+   * <p>Only tests need this. Production configuration is start-time only —
+   * nothing on the server or SQL surface writes {@code GlobalConfiguration}
+   * on a live instance — and a restart empties the cache anyway.
    */
   private void setChainFoldMaxHops(int maxHops) {
     GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(maxHops);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
@@ -255,12 +255,25 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
     assertNotNull(plan);
 
     // Both aliases should appear in the plan
+    int selectivePos = plan.indexOf("{selectiveTag}");
+    int broadPos = plan.indexOf("{broadTag}");
     assertTrue(
         "selectiveTag should appear in plan, but plan was:\n" + plan,
-        plan.contains("{selectiveTag}"));
+        selectivePos >= 0);
     assertTrue(
         "broadTag should appear in plan, but plan was:\n" + plan,
-        plan.contains("{broadTag}"));
+        broadPos >= 0);
+
+    // The edge-method chain fold (outE→inV) folds the downstream vertex's
+    // WHERE selectivity into the first-edge cost. The selective branch
+    // (name = 'targetTag') must schedule before the broad branch
+    // (name <> 'targetTag') — proves the planner sees their cost difference
+    // even though the filter is on the inV() target, not the outE() hop.
+    assertTrue(
+        "Selective edge (selectiveTag) should be scheduled before broad edge"
+            + " (broadTag) after the edge-method chain fold, but plan was:\n"
+            + plan,
+        selectivePos < broadPos);
 
     // The index intersection proves class inference worked end-to-end:
     // the planner inferred VITag from VIHasTag.in LINK, found the

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
@@ -169,15 +169,18 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
 
   /**
    * Verify that the planner infers the vertex class for inV() from the edge
-   * schema and applies index intersection, even without an explicit class:
-   * constraint on the vertex alias. Similar to the existing
+   * schema, applies index intersection, and schedules the selective branch
+   * before the broad one — all without an explicit class: constraint on the
+   * vertex alias. Similar to the existing
    * {@code testSelectivityInferredFromEdgeSchemaWithoutExplicitClass} but
    * using edge-method patterns (outE→inV instead of out).
    *
    * <p>Graph: posts with broad tags and a single selective tag. The selective
    * branch uses {@code name = 'targetTag'} which has an index on VITag.name.
-   * The planner must: (1) infer VITag from VIHasTag.in LINK, and (2) use the
-   * VITag_name index for intersection pre-filtering.
+   * The planner must: (1) infer VITag from VIHasTag.in LINK, (2) use the
+   * VITag_name index for intersection pre-filtering, and (3) fold the
+   * downstream vertex's WHERE into the first-edge cost via the edge-method
+   * chain-fold so the selective branch sorts before the broad one.
    */
   @Test
   public void testVertexClassInferenceEnablesIndexIntersection() {
@@ -254,7 +257,18 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
     String plan = explainResult.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
 
-    // Both aliases should appear in the plan
+    // Anchor that the query actually exercises the edge-method chain shape
+    // (.outE.inV) — a copy-paste refactor that downgraded the query to
+    // .out(...) would take the non-fold path, at which point the ordering
+    // assertion below could pass via unrelated heuristics without exercising
+    // the chain fold this test is meant to pin.
+    assertTrue(
+        "Query must exercise the .outE.inV chain shape that triggers the fold",
+        query.contains(".outE('VIHasTag').inV()"));
+
+    // Both aliases must be present — guards against a regression that drops
+    // a branch, which would otherwise make the selectivePos < broadPos check
+    // below vacuously true (indexOf returns -1 for missing substrings).
     int selectivePos = plan.indexOf("{selectiveTag}");
     int broadPos = plan.indexOf("{broadTag}");
     assertTrue(

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
@@ -291,11 +291,21 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
 
     // The index intersection proves class inference worked end-to-end:
     // the planner inferred VITag from VIHasTag.in LINK, found the
-    // VITag_name index, and attached it as an intersection descriptor
+    // VITag_name index, and attached it as an intersection descriptor.
+    // Anchor the intersection to the SELECTIVE branch (name = 'targetTag')
+    // by asserting its position falls between {selectiveTag} and {broadTag};
+    // without this positional check, the assertion could pass even if the
+    // planner mis-attached the index to the broad branch.
+    int intersectionPos = plan.indexOf("(intersection: index VITag_name)");
     assertTrue(
         "Plan should show index intersection for VITag_name (proves class"
             + " inference), but plan was:\n" + plan,
-        plan.contains("(intersection: index VITag_name"));
+        intersectionPos >= 0);
+    assertTrue(
+        "Index intersection should attach to the selective branch — the"
+            + " intersection marker must appear between {selectiveTag} and"
+            + " {broadTag} in the plan. Plan was:\n" + plan,
+        intersectionPos > selectivePos && intersectionPos < broadPos);
 
     session.commit();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/MatchEdgeMethodInferenceAndAbortTest.java
@@ -296,7 +296,9 @@ public class MatchEdgeMethodInferenceAndAbortTest extends DbTestBase {
     // by asserting its position falls between {selectiveTag} and {broadTag};
     // without this positional check, the assertion could pass even if the
     // planner mis-attached the index to the broad branch.
-    int intersectionPos = plan.indexOf("(intersection: index VITag_name)");
+    // Match the marker prefix only: the plan appends "selectivity=… estHits=…"
+    // inside the parentheses, so a trailing ")" would not match.
+    int intersectionPos = plan.indexOf("(intersection: index VITag_name");
     assertTrue(
         "Plan should show index intersection for VITag_name (proves class"
             + " inference), but plan was:\n" + plan,

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeFanOutEstimatorTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EdgeFanOutEstimatorTest.java
@@ -4,6 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
@@ -12,6 +15,8 @@ import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.ImmutableSchema;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -673,5 +678,118 @@ public class EdgeFanOutEstimatorTest {
         "Person", "Person");
 
     assertEquals(0.0, fanOut, DELTA);
+  }
+
+  // ── classCountCache: the per-plan approximateCount memo ────
+
+  /**
+   * The cache-aware overload must return exactly what the un-cached overload
+   * returns. {@code classCountCache} is documented as a pure memo, so any
+   * divergence here means the cached path computes a different fan-out and
+   * the planner would order branches differently depending on whether a
+   * cache happened to be in scope.
+   */
+  @Test
+  public void classCountCache_freshCacheMatchesUncachedResult() {
+    registerClass("Knows", 500);
+    registerClass("Person", 100);
+
+    double uncached = EdgeFanOutEstimator.estimateFanOut(
+        session, "Knows", "Person", Direction.OUT, "Person", "Person");
+    double cached = EdgeFanOutEstimator.estimateFanOut(
+        session, "Knows", "Person", Direction.OUT, "Person", "Person",
+        new HashMap<>());
+
+    assertEquals(uncached, cached, 0.0);
+  }
+
+  /**
+   * The cache must actually sit on the read path. A pre-seeded entry that
+   * disagrees with the schema is doctored test data, not a real state, but
+   * it is the only way to distinguish "reads the memo" from "ignores the
+   * memo and recomputes": with the source count forced to 250 instead of
+   * 100, the fan-out must be 500/250 = 2.0 rather than 5.0.
+   */
+  @Test
+  public void classCountCache_seededEntryIsUsedInsteadOfSchemaCount() {
+    var personClass = registerClass("Person", 100);
+    registerClass("Knows", 500);
+
+    Map<String, Long> cache = new HashMap<>();
+    cache.put("Person", 250L);
+
+    double fanOut = EdgeFanOutEstimator.estimateFanOut(
+        session, "Knows", "Person", Direction.OUT, "Person", "Person", cache);
+
+    assertEquals(2.0, fanOut, DELTA);
+    // A hit must not re-read the schema — that is the whole point of the memo.
+    verify(personClass, never()).approximateCount(session);
+  }
+
+  /**
+   * A miss must populate the cache under the canonical class name, so the
+   * next lookup for the same class inside one plan is a map hit. Both the
+   * edge class and the source class are counted, so both land in the map.
+   */
+  @Test
+  public void classCountCache_missPopulatesBothClassCounts() {
+    registerClass("Knows", 500);
+    registerClass("Person", 100);
+
+    Map<String, Long> cache = new HashMap<>();
+    EdgeFanOutEstimator.estimateFanOut(
+        session, "Knows", "Person", Direction.OUT, "Person", "Person", cache);
+
+    assertEquals(2, cache.size());
+    assertEquals(Long.valueOf(500L), cache.get("Knows"));
+    assertEquals(Long.valueOf(100L), cache.get("Person"));
+  }
+
+  /**
+   * Reusing one cache across calls — the shape the planner's sort loop
+   * produces — must read each class's count exactly once. Pins the
+   * optimisation itself: without the memo, N candidate edges over the same
+   * source class issue N counts.
+   */
+  @Test
+  public void classCountCache_sharedAcrossCallsCountsEachClassOnce() {
+    var knowsClass = registerClass("Knows", 500);
+    var personClass = registerClass("Person", 100);
+
+    Map<String, Long> cache = new HashMap<>();
+    for (int i = 0; i < 3; i++) {
+      assertEquals(
+          5.0,
+          EdgeFanOutEstimator.estimateFanOut(
+              session, "Knows", "Person", Direction.OUT, "Person", "Person",
+              cache),
+          DELTA);
+    }
+
+    verify(knowsClass, times(1)).approximateCount(session);
+    verify(personClass, times(1)).approximateCount(session);
+  }
+
+  /**
+   * BOTH direction reads the two endpoint vertex classes on top of the edge
+   * and source counts, and it does so through the same memo. Pins that the
+   * BOTH branch threads the cache rather than falling back to a fresh map,
+   * which would silently drop the optimisation for bidirectional edges.
+   */
+  @Test
+  public void classCountCache_bothDirectionSharesTheSameMemo() {
+    registerClass("Knows", 500);
+    var personClass = registerClass("Person", 100);
+
+    Map<String, Long> cache = new HashMap<>();
+    double first = EdgeFanOutEstimator.estimateFanOut(
+        session, "Knows", "Person", Direction.BOTH, "Person", "Person", cache);
+    double second = EdgeFanOutEstimator.estimateFanOut(
+        session, "Knows", "Person", Direction.BOTH, "Person", "Person", cache);
+
+    // Person is both endpoints: 500/100 OUT + 500/100 IN = 10.0
+    assertEquals(10.0, first, DELTA);
+    assertEquals(first, second, 0.0);
+    verify(personClass, times(1)).approximateCount(session);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EstimateEdgeCostTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EstimateEdgeCostTest.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
+import static com.jetbrains.youtrackdb.internal.core.sql.executor.match.MatchTestWhereBuilders.makeWhereWithOperator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -761,21 +762,6 @@ public class EstimateEdgeCostTest {
   }
 
   // -- Helper methods ---------------------------------------------------------
-
-  private SQLWhereClause makeWhereWithOperator(
-      com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCompareOperator op) {
-    var condition = new SQLBinaryCondition(-1);
-    condition.setLeft(new SQLExpression(-1));
-    condition.setOperator(op);
-    condition.setRight(new SQLExpression(-1));
-
-    var andBlock = new SQLAndBlock(-1);
-    andBlock.getSubBlocks().add(condition);
-
-    var where = new SQLWhereClause(-1);
-    where.setBaseExpression(andBlock);
-    return where;
-  }
 
   private SQLWhereClause makeWhereWithPropertyAndOperator(
       String propertyName,

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1959,11 +1959,16 @@ public class MatchExecutionPlannerMutationTest {
         .isEmpty();
   }
 
-  // ── Happy-path sanity tests (Step 1 — class field is always null) ──
+  // ── Happy-path sanity tests (structural detection + class=null fallback) ──
+  //
+  // These tests exercise the structural detection rule with no edge-class
+  // data — the precedence-2 schema lookup returns null in each case because
+  // the mocked schema has no edge class registered and/or the method has
+  // no param. Class-inference happy paths follow in the matrix below.
 
   /**
-   * outE('X') → inV() with valid structure: helper returns the downstream
-   * vertex alias. Class field is null in Step 1.
+   * outE → inV: helper returns the downstream alias. Class is null because
+   * the first edge has no class param (precedence-2 fallback returns null).
    */
   @Test
   public void resolveChainedTarget_outEinV_returnsDownstreamAlias() {
@@ -1977,8 +1982,8 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
-   * inE('X') → outV() with valid structure: helper returns the downstream
-   * vertex alias. Class field is null in Step 1.
+   * inE → outV: helper returns the downstream alias. Class null (same
+   * fallback reason as outEinV).
    */
   @Test
   public void resolveChainedTarget_inEoutV_returnsDownstreamAlias() {
@@ -1992,8 +1997,9 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
-   * bothE('X') → bothV() with valid structure: helper returns the downstream
-   * vertex alias. Class field is null in Step 1.
+   * bothE → bothV: helper returns the downstream alias. Class always null
+   * for bothE — precedence-2 returns null by design (no single endpoint is
+   * uniquely "downstream").
    */
   @Test
   public void resolveChainedTarget_bothEbothV_returnsDownstreamAlias() {
@@ -2020,6 +2026,302 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(result).contains(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  // =========================================================================
+  // resolveChainedTarget — Step 2: class-inference precedence
+  //
+  // Precedence rule:
+  //   1. aliasClasses.get(effectiveTargetAlias) — the pre-populated path
+  //      for outE→inV / inE→outV (addAliases at :4518) and the only path
+  //      for bothE→bothV when the user wrote {class: ...}.
+  //   2. Derived from the first edge's class + direction:
+  //      outE → edgeClass.in.linkedClass
+  //      inE  → edgeClass.out.linkedClass
+  //      bothE → null (no inference)
+  // =========================================================================
+
+  /**
+   * outE → inV with {@code aliasClasses.get("tag") = "VITag"}: precedence-1
+   * wins. Pins the normal post-{@code addAliases} path for outbound chains.
+   */
+  @Test
+  public void resolveChainedTarget_outEinV_precedence1_aliasClassesHit() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    var aliasClasses = Map.of("tag", "VITag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
+  }
+
+  /**
+   * outE('VIHasTag') → inV with empty aliasClasses: precedence-2 falls back
+   * to the edge-schema {@code in} linked class. Both {@code in} and
+   * {@code out} properties are registered with different classes so a
+   * direction-swap mutation (reading {@code out} instead of {@code in})
+   * would return the wrong class.
+   */
+  @Test
+  public void resolveChainedTarget_outEinV_precedence2_derivedFromSchema() {
+    registerClass("VIPost", 100);
+    var tagClass = registerClass("VITag", 10);
+    var postClass = schema.getClassInternal("VIPost");
+    var edgeClass = registerClass("VIHasTag", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(tagClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(postClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "outE");
+    var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    // outE must read the "in" property → VITag, not "out" → VIPost
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
+  }
+
+  /**
+   * inE → outV with {@code aliasClasses.get("post") = "VIPost"}:
+   * precedence-1 wins. Pins the normal post-{@code addAliases} path for
+   * inbound chains.
+   */
+  @Test
+  public void resolveChainedTarget_inEoutV_precedence1_aliasClassesHit() {
+    var chain = buildChain("inE", "outV", "tag", "e", "post");
+    var aliasClasses = Map.of("post", "VIPost");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("post", "VIPost"));
+  }
+
+  /**
+   * inE('VIHasTag') → outV with empty aliasClasses: precedence-2 falls back
+   * to the edge-schema {@code out} linked class (NOT {@code in}, which is
+   * what outE would use).
+   */
+  @Test
+  public void resolveChainedTarget_inEoutV_precedence2_derivedFromSchema() {
+    var postClass = registerClass("VIPost", 100);
+    var tagClass = registerClass("VITag", 10);
+    var edgeClass = registerClass("VIHasTag", 500);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(postClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(tagClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "inE");
+    var chain = buildChain(firstMethod, "outV", "tag", "e", "post");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    // inE must read the "out" property → VIPost, not "in" → VITag
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("post", "VIPost"));
+  }
+
+  /**
+   * bothE → bothV with {@code aliasClasses.get("vertex") = "VITag"}:
+   * precedence-1 wins. <b>Critical for Track 3 test 4</b> — this is the
+   * only way a {@code bothE→bothV} chain ever gets a non-null class, since
+   * precedence-2 returns null for bothE by design.
+   */
+  @Test
+  public void resolveChainedTarget_bothEbothV_precedence1_aliasClassesHit() {
+    var chain = buildChain("bothE", "bothV", "a", "e", "vertex");
+    var aliasClasses = Map.of("vertex", "VITag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("vertex", "VITag"));
+  }
+
+  /**
+   * bothE('VIKnows') → bothV with empty aliasClasses and a fully-registered
+   * edge schema: precedence-2 explicitly returns null for {@code bothE}
+   * because no single endpoint is uniquely "downstream".
+   */
+  @Test
+  public void resolveChainedTarget_bothEbothV_precedence2_returnsNull() {
+    var aClass = registerClass("A", 100);
+    var bClass = registerClass("B", 100);
+    var edgeClass = registerClass("VIKnows", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(bClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(aClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIKnows\"");
+    stubMethodName(firstMethod, "bothE");
+    var chain = buildChain(firstMethod, "bothV", "a", "e", "b");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("b", null));
+  }
+
+  /**
+   * outE() without a class parameter + empty aliasClasses: precedence-2
+   * fallback's {@code extractEdgeClassName} returns null, so class=null.
+   */
+  @Test
+  public void resolveChainedTarget_precedence2_missingEdgeClassName_returnsNull() {
+    // firstMethod has no params
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  /**
+   * outE('Unknown') + empty aliasClasses: edge class is not in the schema —
+   * precedence-2 returns null.
+   */
+  @Test
+  public void resolveChainedTarget_precedence2_edgeClassNotInSchema_returnsNull() {
+    when(schema.getClassInternal("Unknown")).thenReturn(null);
+
+    var firstMethod = mockMethodWithBaseExpression("\"Unknown\"");
+    stubMethodName(firstMethod, "outE");
+    var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  /**
+   * outE('VIHasTag') but the edge class has no {@code in} property: no
+   * linked vertex class exists, precedence-2 returns null.
+   */
+  @Test
+  public void resolveChainedTarget_precedence2_missingLinkedProperty_returnsNull() {
+    var edgeClass = registerClass("VIHasTag", 500);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(null);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "outE");
+    var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  /**
+   * Linked property exists but its {@code getLinkedClass()} returns null:
+   * precedence-2 returns null.
+   */
+  @Test
+  public void resolveChainedTarget_precedence2_linkedClassNull_returnsNull() {
+    var edgeClass = registerClass("VIHasTag", 500);
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(null);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "outE");
+    var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  /**
+   * Null session + empty aliasClasses: precedence-2 cannot do schema lookup
+   * and must defensively return null (not NPE).
+   */
+  @Test
+  public void resolveChainedTarget_precedence2_nullSession_returnsNull() {
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "outE");
+    var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), null);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  /**
+   * Null aliasClasses map: the helper tolerates null aliasClasses (caller
+   * is not required to pass a non-null map). Falls straight to precedence-2.
+   */
+  @Test
+  public void resolveChainedTarget_precedence1_nullAliasClasses_fallsToPrecedence2() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), null, db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  /**
+   * aliasClasses wins over schema: even when the schema provides a
+   * different class, precedence-1 short-circuits first. Pins the ordering
+   * of the two precedence clauses.
+   */
+  @Test
+  public void resolveChainedTarget_precedence1_winsOverSchema() {
+    // Set up schema to return "VITag" for outE('VIHasTag')
+    var tagClass = registerClass("VITag", 10);
+    var edgeClass = registerClass("VIHasTag", 500);
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(tagClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    // But aliasClasses says "VIExplicitTag" — that must win.
+    var aliasClasses = Map.of("tag", "VIExplicitTag");
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "outE");
+    var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", "VIExplicitTag"));
   }
 
   // ── resolveChainedTarget test helpers ──

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -2562,19 +2562,21 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   // =========================================================================
-  // applyTargetSelectivity — refactor parity + new class-forced overload
+  // applyTargetSelectivity / applyTargetSelectivityWithResolvedClass —
+  // refactor parity + new class-forced sibling
   // =========================================================================
   //
-  // These tests guard the refactor that extracts the shared body of the
-  // existing 8-arg overload into {@code applyClassSelectivity} and adds a
-  // class-forced 6-arg overload used by the sort-loop's chain fold.
+  // These tests guard the refactor that extracts the shared body of
+  // applyTargetSelectivity into {@code applyClassSelectivity} and adds the
+  // class-forced sibling {@code applyTargetSelectivityWithResolvedClass}
+  // used by the sort-loop's chain fold.
   //
-  // Parity tests (8-arg ↔ 6-arg) prove the refactor preserves behaviour for
-  // the existing call site. Short-circuit tests on the 6-arg overload pin
-  // the null-class guard and the inherited schema / classCount / filter /
+  // Parity tests prove the refactor preserves behaviour for the existing
+  // call site. Short-circuit tests on the class-forced sibling pin the
+  // null-class guard and the inherited schema / classCount / filter /
   // estimate branches, so a mutation that drops any branch is caught.
 
-  // ── 6-arg overload: short-circuit on null pre-resolved class ──
+  // ── class-forced sibling: short-circuit on null pre-resolved class ──
 
   /**
    * Kills: "if (preResolvedTargetClass == null) return baseCost;" replaced
@@ -2585,18 +2587,18 @@ public class MatchExecutionPlannerMutationTest {
    */
   @Test
   public void applyTargetSelectivity_classForced_nullClass_returnsBaseCost() {
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
-        500.0, "tag", (String) null, Map.of(), Map.of("tag", 10L), db);
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "tag", null, Map.of(), Map.of("tag", 10L), db);
     assertEquals(500.0, result, 0.0);
   }
 
-  // ── 6-arg overload: inherited schema/classCount short-circuits ──
+  // ── class-forced sibling: inherited schema/classCount short-circuits ──
 
   /**
    * Pins the sort-loop invariant that {@code Double.MAX_VALUE} (the
    * "unestimated" sentinel) survives the chain fold unchanged when the
    * pre-resolved class is null. If the null-class short-circuit at the
-   * head of the 6-arg overload is weakened or removed, the caller at
+   * head of applyTargetSelectivityWithResolvedClass is weakened or removed, the caller at
    * {@code MatchExecutionPlanner.updateScheduleStartingAt} would multiply
    * MAX_VALUE by some finite selectivity, quietly breaking the stable-sort
    * tiebreaker the sort comparator relies on for edges with no estimate.
@@ -2604,8 +2606,8 @@ public class MatchExecutionPlannerMutationTest {
   @Test
   public void applyTargetSelectivity_classForced_maxValueInputPreservedOnNullClass() {
     double result =
-        MatchExecutionPlanner.applyTargetSelectivity(
-            Double.MAX_VALUE, "tag", (String) null, Map.of(), Map.of("tag", 10L), db);
+        MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+            Double.MAX_VALUE, "tag", null, Map.of(), Map.of("tag", 10L), db);
     assertEquals(Double.MAX_VALUE, result, 0.0);
   }
 
@@ -2622,7 +2624,7 @@ public class MatchExecutionPlannerMutationTest {
     when(schema.existsClass("Tag")).thenReturn(true);
 
     double result =
-        MatchExecutionPlanner.applyTargetSelectivity(
+        MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
             Double.MAX_VALUE, "tag", "Tag", Map.of(), Map.of(), db);
     assertEquals(Double.MAX_VALUE, result, 0.0);
   }
@@ -2638,7 +2640,7 @@ public class MatchExecutionPlannerMutationTest {
   public void applyTargetSelectivity_classForced_classNotInSchema_returnsBaseCost() {
     when(schema.existsClass("Missing")).thenReturn(false);
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Missing", Map.of(), Map.of("tag", 10L), db);
     assertEquals(500.0, result, 0.0);
   }
@@ -2654,7 +2656,7 @@ public class MatchExecutionPlannerMutationTest {
   public void applyTargetSelectivity_classForced_schemaSnapshotNull_returnsBaseCost() {
     when(db.getMetadata().getImmutableSchemaSnapshot()).thenReturn(null);
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of(), Map.of("tag", 10L), db);
     assertEquals(500.0, result, 0.0);
   }
@@ -2670,12 +2672,12 @@ public class MatchExecutionPlannerMutationTest {
     registerClass("Empty", 0);
     when(schema.existsClass("Empty")).thenReturn(true);
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Empty", Map.of(), Map.of("tag", 10L), db);
     assertEquals(500.0, result, 0.0);
   }
 
-  // ── 6-arg overload: filter-heuristic vs cardinality-ratio paths ──
+  // ── class-forced sibling: filter-heuristic vs cardinality-ratio paths ──
 
   /**
    * Kills: "return baseCost * heuristic;" in the filter-heuristic branch
@@ -2690,7 +2692,7 @@ public class MatchExecutionPlannerMutationTest {
 
     var filter = makeWhereWithOperator(new SQLEqualsOperator(-1));
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
 
     // equality selectivity = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
@@ -2712,7 +2714,7 @@ public class MatchExecutionPlannerMutationTest {
 
     var filter = makeWhereWithOperator(new SQLNeOperator(-1));
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
 
     // inequality selectivity = 999/1000 → 500 × 0.999 = 499.5 (exact in IEEE-754)
@@ -2733,7 +2735,7 @@ public class MatchExecutionPlannerMutationTest {
     registerClass("Tag", 1000);
     when(schema.existsClass("Tag")).thenReturn(true);
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of(), Map.of("tag", 100L), db);
 
     // no filter → targetEstimate/classCount = 100/1000 → 500 × 0.1 = 50.0 (exact in IEEE-754)
@@ -2761,7 +2763,7 @@ public class MatchExecutionPlannerMutationTest {
     var where = new SQLWhereClause(-1);
     where.setBaseExpression(new SQLAndBlock(-1));
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of("tag", where), Map.of("tag", 1L), db);
 
     // heuristic = -1.0 → fallback to targetEstimate/classCount = 1/1000
@@ -2780,13 +2782,14 @@ public class MatchExecutionPlannerMutationTest {
     registerClass("Tag", 1000);
     when(schema.existsClass("Tag")).thenReturn(true);
 
-    double result = MatchExecutionPlanner.applyTargetSelectivity(
+    double result = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of(), Map.of(), db);
 
     assertEquals(500.0, result, 0.0);
   }
 
-  // ── 8-arg ↔ 6-arg parity (refactor regression guard) ──
+  // ── applyTargetSelectivity ↔ applyTargetSelectivityWithResolvedClass parity ──
+  // ── (refactor regression guard) ──
 
   /**
    * The refactor routes both overloads through the same private helper;
@@ -2809,7 +2812,7 @@ public class MatchExecutionPlannerMutationTest {
         500.0, "tag", edge, true,
         Map.of("tag", "Tag"), Map.of("tag", filter), Map.of("tag", 100L), db);
 
-    double classForced = MatchExecutionPlanner.applyTargetSelectivity(
+    double classForced = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
 
     // equality selectivity = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
@@ -2836,7 +2839,7 @@ public class MatchExecutionPlannerMutationTest {
         500.0, "tag", edge, true,
         Map.of("tag", "Tag"), Map.of(), Map.of("tag", 1L), db);
 
-    double classForced = MatchExecutionPlanner.applyTargetSelectivity(
+    double classForced = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
         500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), db);
 
     // no filter → targetEstimate/classCount = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
@@ -2846,23 +2849,25 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
-   * Parity for the null-class short-circuit: the 8-arg overload returns
-   * {@code baseCost} when {@code resolveTargetClass} returns null; the 6-arg
-   * overload returns {@code baseCost} when {@code preResolvedTargetClass}
-   * is null. Both paths must observe the same {@code baseCost}.
+   * Parity for the null-class short-circuit: {@code applyTargetSelectivity}
+   * returns {@code baseCost} when {@code resolveTargetClass} returns null;
+   * {@code applyTargetSelectivityWithResolvedClass} returns {@code baseCost}
+   * when {@code preResolvedTargetClass} is null. Both paths must observe
+   * the same {@code baseCost}.
    */
   @Test
   public void applyTargetSelectivity_overloadsAgree_nullClass_shortCircuit() {
-    // 8-arg path: no aliasClasses entry + no edge class → resolveTargetClass
-    // returns null. 6-arg path: pre-resolved class explicitly null.
+    // applyTargetSelectivity: no aliasClasses entry + no edge class →
+    // resolveTargetClass returns null.
+    // applyTargetSelectivityWithResolvedClass: pre-resolved class explicitly null.
     var edge = mockEdgeWithMethod("out");
 
     double legacy = MatchExecutionPlanner.applyTargetSelectivity(
         500.0, "tag", edge, true,
         Map.of(), Map.of(), Map.of("tag", 10L), db);
 
-    double classForced = MatchExecutionPlanner.applyTargetSelectivity(
-        500.0, "tag", (String) null, Map.of(), Map.of("tag", 10L), db);
+    double classForced = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "tag", null, Map.of(), Map.of("tag", 10L), db);
 
     assertEquals(500.0, legacy, 0.0);
     assertEquals(500.0, classForced, 0.0);
@@ -2963,5 +2968,60 @@ public class MatchExecutionPlannerMutationTest {
     target.in.add(downstreamEdge);
 
     return new ChainFixture(firstEdge, intermediate, downstreamEdge);
+  }
+
+  // =========================================================================
+  // clampChainFoldMaxHops — knob bounding + warn-once contract
+  // =========================================================================
+
+  /**
+   * In-range value (default knob) passes through unchanged. Pins the
+   * happy path so a mutation that always clamps would be caught.
+   */
+  @Test
+  public void clampChainFoldMaxHops_inRangeDefault_returnedUnchanged() {
+    assertEquals(10, MatchExecutionPlanner.clampChainFoldMaxHops(10));
+  }
+
+  /**
+   * The documented "fold disabled" sentinel zero passes through. Pins
+   * that the lower clamp does not accidentally bump zero to anything.
+   */
+  @Test
+  public void clampChainFoldMaxHops_zero_returnedUnchanged() {
+    assertEquals(0, MatchExecutionPlanner.clampChainFoldMaxHops(0));
+  }
+
+  /**
+   * The maximum supported value passes through. Pins the boundary of
+   * the upper clamp — a strict {@code >} comparison must let the cap
+   * through, while a {@code >=} mutation would clamp it to itself
+   * (harmless) but still trip the warning machinery.
+   */
+  @Test
+  public void clampChainFoldMaxHops_atMaxBoundary_returnedUnchanged() {
+    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(1000));
+  }
+
+  /**
+   * Negative input is silently clamped to zero per project convention
+   * (see {@code getHashJoinThreshold}). No warning, no exception.
+   */
+  @Test
+  public void clampChainFoldMaxHops_negative_clampedToZero() {
+    assertEquals(0, MatchExecutionPlanner.clampChainFoldMaxHops(-100));
+    assertEquals(0, MatchExecutionPlanner.clampChainFoldMaxHops(Integer.MIN_VALUE));
+  }
+
+  /**
+   * Above-cap input is clamped to the cap. Pins both the cap value
+   * itself and the direction of the clamp — a mutation that returned
+   * {@code raw} or {@code 0} for the over-cap branch would fail.
+   */
+  @Test
+  public void clampChainFoldMaxHops_aboveCap_clampedToMax() {
+    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(1001));
+    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(100_000));
+    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(Integer.MAX_VALUE));
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1690,6 +1690,46 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
+   * First edge method is {@code in} (vertex hop), not {@code inE}. Pins the
+   * {@code !"ine".equals(firstName)} branch so a mutation that drops it is
+   * caught. Complements {@code firstMethodIsOut_returnsEmpty}.
+   */
+  @Test
+  public void resolveChainedTarget_firstMethodIsIn_returnsEmpty() {
+    var chain = buildChain("in", "outV", "tag", "e", "post");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * First edge method is {@code both} (vertex hop), not {@code bothE}. Pins
+   * the {@code !"bothe".equals(firstName)} branch.
+   */
+  @Test
+  public void resolveChainedTarget_firstMethodIsBoth_returnsEmpty() {
+    var chain = buildChain("both", "bothV", "a", "e", "b");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * First edge method is a completely unknown name. Pins the whitelist's
+   * exhaustive rejection of non-edge methods.
+   */
+  @Test
+  public void resolveChainedTarget_firstMethodUnknown_returnsEmpty() {
+    var chain = buildChain("traverse", "inV", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
    * Intermediate node has zero outgoing edges — the chain has no downstream
    * vertex step. Return empty.
    */
@@ -1818,6 +1858,47 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
+   * The second-hop method is {@code in} (vertex hop), not {@code inV}.
+   * Pins the {@code !"inv".equals(secondName)} branch so a mutation that
+   * drops it is caught.
+   */
+  @Test
+  public void resolveChainedTarget_secondMethodIsIn_returnsEmpty() {
+    var chain = buildChain("outE", "in", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * The second-hop method is {@code both} (vertex hop), not {@code bothV}.
+   * Pins the {@code !"bothv".equals(secondName)} branch.
+   */
+  @Test
+  public void resolveChainedTarget_secondMethodIsBoth_returnsEmpty() {
+    var chain = buildChain("outE", "both", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * The second-hop method is an edge hop ({@code inE}) — wrong shape for
+   * the chain rule. Pins that the whitelist does not accept edge methods
+   * in the vertex-hop position.
+   */
+  @Test
+  public void resolveChainedTarget_secondMethodIsEdgeHop_returnsEmpty() {
+    var chain = buildChain("outE", "inE", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
    * The second-hop method name is null. Return empty.
    */
   @Test
@@ -1833,12 +1914,27 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
-   * The second-hop item (or its method) is null. Return empty.
+   * The second-hop item's method is null. Return empty.
    */
   @Test
   public void resolveChainedTarget_secondItemNullMethod_returnsEmpty() {
     var chain = buildChain("outE", "inV", "post", "e", "tag");
     when(chain.downstreamEdge().item.getMethod()).thenReturn(null);
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * The second-hop item itself is null. Pins the first operand of the
+   * {@code downstreamEdge.item == null || downstreamEdge.item.getMethod() == null}
+   * short-circuit so a mutation dropping the first null-check is caught.
+   */
+  @Test
+  public void resolveChainedTarget_secondItemNull_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    chain.downstreamEdge().item = null;
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -2163,7 +2163,7 @@ public class MatchExecutionPlannerMutationTest {
    * because no single endpoint is uniquely "downstream".
    */
   @Test
-  public void resolveChainedTarget_bothEbothV_precedence2_returnsNull() {
+  public void resolveChainedTarget_bothEbothV_precedence2_returnsNullClass() {
     var aClass = registerClass("A", 100);
     var bClass = registerClass("B", 100);
     var edgeClass = registerClass("VIKnows", 500);
@@ -2192,7 +2192,7 @@ public class MatchExecutionPlannerMutationTest {
    * fallback's {@code extractEdgeClassName} returns null, so class=null.
    */
   @Test
-  public void resolveChainedTarget_precedence2_missingEdgeClassName_returnsNull() {
+  public void resolveChainedTarget_precedence2_missingEdgeClassName_returnsNullClass() {
     // firstMethod has no params
     var chain = buildChain("outE", "inV", "post", "e", "tag");
 
@@ -2208,7 +2208,7 @@ public class MatchExecutionPlannerMutationTest {
    * precedence-2 returns null.
    */
   @Test
-  public void resolveChainedTarget_precedence2_edgeClassNotInSchema_returnsNull() {
+  public void resolveChainedTarget_precedence2_edgeClassNotInSchema_returnsNullClass() {
     when(schema.getClassInternal("Unknown")).thenReturn(null);
 
     var firstMethod = mockMethodWithBaseExpression("\"Unknown\"");
@@ -2227,7 +2227,7 @@ public class MatchExecutionPlannerMutationTest {
    * linked vertex class exists, precedence-2 returns null.
    */
   @Test
-  public void resolveChainedTarget_precedence2_missingLinkedProperty_returnsNull() {
+  public void resolveChainedTarget_precedence2_missingLinkedProperty_returnsNullClass() {
     var edgeClass = registerClass("VIHasTag", 500);
     when(edgeClass.getPropertyInternal("in")).thenReturn(null);
 
@@ -2247,7 +2247,7 @@ public class MatchExecutionPlannerMutationTest {
    * precedence-2 returns null.
    */
   @Test
-  public void resolveChainedTarget_precedence2_linkedClassNull_returnsNull() {
+  public void resolveChainedTarget_precedence2_linkedClassNull_returnsNullClass() {
     var edgeClass = registerClass("VIHasTag", 500);
     var inProp = mock(SchemaPropertyInternal.class);
     when(inProp.getLinkedClass()).thenReturn(null);
@@ -2269,7 +2269,7 @@ public class MatchExecutionPlannerMutationTest {
    * and must defensively return null (not NPE).
    */
   @Test
-  public void resolveChainedTarget_precedence2_nullSession_returnsNull() {
+  public void resolveChainedTarget_precedence2_nullSession_returnsNullClass() {
     var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
     stubMethodName(firstMethod, "outE");
     var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
@@ -2322,6 +2322,56 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(result).contains(
         new MatchExecutionPlanner.ChainedTarget("tag", "VIExplicitTag"));
+  }
+
+  /**
+   * Symmetric complement to {@link #resolveChainedTarget_precedence1_winsOverSchema}:
+   * the inE branch's precedence ordering is also pinned against a conflicting
+   * schema. Catches a mutation that selectively reorders precedence for the
+   * inbound chain only.
+   */
+  @Test
+  public void resolveChainedTarget_inE_precedence1_winsOverSchema() {
+    var postClass = registerClass("VIPost", 100);
+    var edgeClass = registerClass("VIHasTag", 500);
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(postClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var aliasClasses = Map.of("post", "VIExplicitPost");
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "inE");
+    var chain = buildChain(firstMethod, "outV", "tag", "e", "post");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("post", "VIExplicitPost"));
+  }
+
+  /**
+   * Precedence-2 short-circuits cleanly when the immutable schema snapshot
+   * itself is null (happens in narrow storage-lifecycle windows —
+   * re-open, plugin init). Exercises the
+   * {@code inferDownstreamVertexClassFromEdge} branch guarding against that
+   * case, independent of the null-session, null-edge-class, and null-edge-
+   * class-in-schema branches.
+   */
+  @Test
+  public void resolveChainedTarget_precedence2_nullSchemaSnapshot_returnsNullClass() {
+    when(db.getMetadata().getImmutableSchemaSnapshot()).thenReturn(null);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "outE");
+    var chain = buildChain(firstMethod, "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
   // ── resolveChainedTarget test helpers ──

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -27,6 +27,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMathExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMethodCall;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLModifier;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1613,4 +1614,411 @@ public class MatchExecutionPlannerMutationTest {
     return item;
   }
 
+  // =========================================================================
+  // resolveChainedTarget — Step 1: structural detection rule
+  //
+  // The helper recognises the edge-method chain pattern .outE(X).inV()
+  // (and .inE→.outV / .bothE→.bothV variants) when it appears as two
+  // consecutive PatternEdges, so the planner's sort loop can fold the
+  // downstream vertex's WHERE selectivity into the first edge's cost.
+  //
+  // In Step 1 the class field of the returned ChainedTarget is always null
+  // (class inference lands in Step 2). These tests exercise the structural
+  // rule in isolation.
+  // =========================================================================
+
+  /**
+   * When {@code edge.item} is null, the helper returns empty. Mirrors the
+   * null-guard of existing callers ({@code estimateEdgeCost} at :2297,
+   * {@code resolveTargetClass} at :2523) so the helper does not NPE on
+   * synthesised patterns.
+   */
+  @Test
+  public void resolveChainedTarget_nullItem_returnsEmpty() {
+    var edge = new PatternEdge();
+    // item intentionally left null
+    edge.out = new PatternNode();
+    edge.in = new PatternNode();
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        edge, edge.in, Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * When {@code edge.item.getMethod()} is null, the helper returns empty.
+   */
+  @Test
+  public void resolveChainedTarget_nullMethod_returnsEmpty() {
+    var edge = new PatternEdge();
+    edge.item = mock(SQLMatchPathItem.class);
+    // method intentionally null
+    edge.out = new PatternNode();
+    edge.in = new PatternNode();
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        edge, edge.in, Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * First edge method name is {@code null} (e.g. a non-parseable method
+   * call). The helper must not NPE and must return empty.
+   */
+  @Test
+  public void resolveChainedTarget_firstMethodNameNull_returnsEmpty() {
+    var method = mock(SQLMethodCall.class);
+    when(method.getMethodNameString()).thenReturn(null);
+    var chain = buildChain(method, "inV", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * First edge method is a vertex hop ({@code out}) rather than an edge hop
+   * ({@code outE}). The chain pattern does not apply — return empty.
+   */
+  @Test
+  public void resolveChainedTarget_firstMethodIsOut_returnsEmpty() {
+    var chain = buildChain("out", "inV", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * Intermediate node has zero outgoing edges — the chain has no downstream
+   * vertex step. Return empty.
+   */
+  @Test
+  public void resolveChainedTarget_noDownstreamEdge_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    chain.intermediateNode().out.clear();
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * Intermediate node has two outgoing edges — ambiguous continuation,
+   * chain rule does not apply.
+   */
+  @Test
+  public void resolveChainedTarget_multipleDownstreamEdges_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    // Inject a second outgoing edge on the intermediate node
+    var extraEdge = new PatternEdge();
+    extraEdge.item = mock(SQLMatchPathItem.class);
+    var secondMethod = mock(SQLMethodCall.class);
+    stubMethodName(secondMethod, "inV");
+    when(extraEdge.item.getMethod()).thenReturn(secondMethod);
+    extraEdge.out = chain.intermediateNode();
+    var extraTarget = new PatternNode();
+    extraTarget.alias = "tag2";
+    extraEdge.in = extraTarget;
+    chain.intermediateNode().out.add(extraEdge);
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * The downstream edge has already been visited — DFS moved past it.
+   * Chain detection must not fire.
+   */
+  @Test
+  public void resolveChainedTarget_downstreamEdgeVisited_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    var visited = new LinkedHashSet<PatternEdge>();
+    visited.add(chain.downstreamEdge());
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), visited, Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * Intermediate node has zero incoming edges — should not happen for the
+   * sort loop's candidate (the first edge always lands in intermediate.in),
+   * but defensive.
+   */
+  @Test
+  public void resolveChainedTarget_noIncomingEdge_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    chain.intermediateNode().in.clear();
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * Intermediate alias has two incoming edges — the user joined it from a
+   * second MATCH fragment (e.g. two fragments reuse the same {@code {as: e}}).
+   * The chain rule must reject to avoid folding the filter against the
+   * wrong alias.
+   */
+  @Test
+  public void resolveChainedTarget_multipleIncomingEdges_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    // Simulate a second fragment that joins the intermediate alias
+    var otherSource = new PatternNode();
+    otherSource.alias = "author";
+    var otherEdge = new PatternEdge();
+    otherEdge.item = mock(SQLMatchPathItem.class);
+    var otherMethod = mock(SQLMethodCall.class);
+    stubMethodName(otherMethod, "outE");
+    when(otherEdge.item.getMethod()).thenReturn(otherMethod);
+    otherEdge.out = otherSource;
+    otherEdge.in = chain.intermediateNode();
+    chain.intermediateNode().in.add(otherEdge);
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * Intermediate has a single incoming edge, but it is not {@code edge} —
+   * identity mismatch. This can't happen from the sort loop today but is
+   * defensive.
+   */
+  @Test
+  public void resolveChainedTarget_incomingEdgeIdentityMismatch_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    // Replace the intermediate's incoming edge with a different PatternEdge
+    var imposter = new PatternEdge();
+    imposter.item = chain.firstEdge().item;
+    imposter.out = chain.firstEdge().out;
+    imposter.in = chain.intermediateNode();
+    chain.intermediateNode().in.clear();
+    chain.intermediateNode().in.add(imposter);
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * The second-hop method is {@code out} (vertex hop), not {@code outV} —
+   * this is not a chained-edge-then-vertex shape. Return empty.
+   */
+  @Test
+  public void resolveChainedTarget_secondMethodNotVertexStep_returnsEmpty() {
+    var chain = buildChain("outE", "out", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * The second-hop method name is null. Return empty.
+   */
+  @Test
+  public void resolveChainedTarget_secondMethodNameNull_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    var secondMethod = mock(SQLMethodCall.class);
+    when(secondMethod.getMethodNameString()).thenReturn(null);
+    when(chain.downstreamEdge().item.getMethod()).thenReturn(secondMethod);
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * The second-hop item (or its method) is null. Return empty.
+   */
+  @Test
+  public void resolveChainedTarget_secondItemNullMethod_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    when(chain.downstreamEdge().item.getMethod()).thenReturn(null);
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * Reverse traversal: the sort loop passes {@code neighbor = edge.out}
+   * when traversing an edge in reverse. From the source side there is no
+   * {@code inV/outV/bothV} continuation, so the structural rule (clause on
+   * {@code neighbor.out}) naturally rejects. This verifies the design
+   * contract documented in the plan (Track 1 — reverse traversal case).
+   */
+  @Test
+  public void resolveChainedTarget_reverseTraversal_returnsEmpty() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+
+    // Pass edge.out (the source `post` node) as neighbor. From there, there
+    // is no outgoing edge that is an inV hop — the structural rule rejects.
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.firstEdge().out, Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  // ── Happy-path sanity tests (Step 1 — class field is always null) ──
+
+  /**
+   * outE('X') → inV() with valid structure: helper returns the downstream
+   * vertex alias. Class field is null in Step 1.
+   */
+  @Test
+  public void resolveChainedTarget_outEinV_returnsDownstreamAlias() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  /**
+   * inE('X') → outV() with valid structure: helper returns the downstream
+   * vertex alias. Class field is null in Step 1.
+   */
+  @Test
+  public void resolveChainedTarget_inEoutV_returnsDownstreamAlias() {
+    var chain = buildChain("inE", "outV", "tag", "e", "post");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("post", null));
+  }
+
+  /**
+   * bothE('X') → bothV() with valid structure: helper returns the downstream
+   * vertex alias. Class field is null in Step 1.
+   */
+  @Test
+  public void resolveChainedTarget_bothEbothV_returnsDownstreamAlias() {
+    var chain = buildChain("bothE", "bothV", "a", "e", "b");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("b", null));
+  }
+
+  /**
+   * Method-name lowering uses {@code Locale.ENGLISH}: {@code OUTE} → {@code oute}
+   * and {@code INV} → {@code inv} are recognised. Mirrors the case-insensitivity
+   * of {@link MatchExecutionPlanner#parseDirection}.
+   */
+  @Test
+  public void resolveChainedTarget_uppercaseMethodNames_recognised() {
+    var chain = buildChain("OUTE", "INV", "post", "e", "tag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  // ── resolveChainedTarget test helpers ──
+
+  /**
+   * A test fixture for a two-hop edge-method chain:
+   * <pre>
+   *   (source) ──firstEdge──▶ (intermediate) ──downstreamEdge──▶ (target)
+   * </pre>
+   *
+   * <p>Returned by {@link #buildChain(String, String, String, String, String)}.
+   */
+  private record ChainFixture(
+      PatternEdge firstEdge, PatternNode intermediateNode, PatternEdge downstreamEdge) {
+  }
+
+  /**
+   * Builds a structural chain fixture that matches {@code resolveChainedTarget}'s
+   * input contract: two consecutive PatternEdges with the method names given.
+   * All {@link SQLMatchPathItem}s and {@link SQLMethodCall}s are Mockito mocks
+   * stubbed so that {@code getMethodNameString()} returns the requested name.
+   *
+   * @param firstMethodName  method name on the first edge (e.g. {@code outE})
+   * @param secondMethodName method name on the second edge (e.g. {@code inV})
+   * @param sourceAlias      alias of the source vertex
+   * @param intermediateAlias alias of the intermediate edge alias
+   * @param targetAlias      alias of the downstream vertex
+   */
+  private ChainFixture buildChain(
+      String firstMethodName,
+      String secondMethodName,
+      String sourceAlias,
+      String intermediateAlias,
+      String targetAlias) {
+    var source = new PatternNode();
+    source.alias = sourceAlias;
+    var intermediate = new PatternNode();
+    intermediate.alias = intermediateAlias;
+    var target = new PatternNode();
+    target.alias = targetAlias;
+
+    var firstMethod = mock(SQLMethodCall.class);
+    stubMethodName(firstMethod, firstMethodName);
+
+    return buildChain(firstMethod, secondMethodName, source, intermediate, target);
+  }
+
+  /**
+   * Overload that accepts a pre-built {@link SQLMethodCall} for the first edge —
+   * useful when the test needs a non-standard method stubbing (e.g. null
+   * method name).
+   */
+  private ChainFixture buildChain(
+      SQLMethodCall firstMethod,
+      String secondMethodName,
+      String sourceAlias,
+      String intermediateAlias,
+      String targetAlias) {
+    var source = new PatternNode();
+    source.alias = sourceAlias;
+    var intermediate = new PatternNode();
+    intermediate.alias = intermediateAlias;
+    var target = new PatternNode();
+    target.alias = targetAlias;
+    return buildChain(firstMethod, secondMethodName, source, intermediate, target);
+  }
+
+  private ChainFixture buildChain(
+      SQLMethodCall firstMethod,
+      String secondMethodName,
+      PatternNode source,
+      PatternNode intermediate,
+      PatternNode target) {
+    var firstItem = mock(SQLMatchPathItem.class);
+    when(firstItem.getMethod()).thenReturn(firstMethod);
+
+    var firstEdge = new PatternEdge();
+    firstEdge.item = firstItem;
+    firstEdge.out = source;
+    firstEdge.in = intermediate;
+    source.out.add(firstEdge);
+    intermediate.in.add(firstEdge);
+
+    var secondMethod = mock(SQLMethodCall.class);
+    stubMethodName(secondMethod, secondMethodName);
+    var secondItem = mock(SQLMatchPathItem.class);
+    when(secondItem.getMethod()).thenReturn(secondMethod);
+
+    var downstreamEdge = new PatternEdge();
+    downstreamEdge.item = secondItem;
+    downstreamEdge.out = intermediate;
+    downstreamEdge.in = target;
+    intermediate.out.add(downstreamEdge);
+    target.in.add(downstreamEdge);
+
+    return new ChainFixture(firstEdge, intermediate, downstreamEdge);
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1899,6 +1899,34 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
+   * Same as {@code secondMethodIsEdgeHop} but with {@code outE} in vertex
+   * position — pins the {@code !"outv".equals(secondName)} branch. Without
+   * this a mutation that accepts {@code outE} as a second hop would survive
+   * even though {@code secondMethodIsEdgeHop} only exercises {@code inE}.
+   */
+  @Test
+  public void resolveChainedTarget_secondMethodIsOutE_returnsEmpty() {
+    var chain = buildChain("outE", "outE", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
+   * Same as {@code secondMethodIsEdgeHop} but with {@code bothE} in vertex
+   * position — pins the {@code !"bothv".equals(secondName)} branch.
+   */
+  @Test
+  public void resolveChainedTarget_secondMethodIsBothE_returnsEmpty() {
+    var chain = buildChain("outE", "bothE", "post", "e", "tag");
+
+    assertThat(MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
+        .isEmpty();
+  }
+
+  /**
    * The second-hop method name is null. Return empty.
    */
   @Test
@@ -1943,17 +1971,19 @@ public class MatchExecutionPlannerMutationTest {
 
   /**
    * Reverse traversal: the sort loop passes {@code neighbor = edge.out}
-   * when traversing an edge in reverse. From the source side there is no
-   * {@code inV/outV/bothV} continuation, so the structural rule (clause on
-   * {@code neighbor.out}) naturally rejects. This verifies the design
-   * contract documented in the plan (Track 1 — reverse traversal case).
+   * when traversing an edge in reverse. In this fixture the source node has
+   * no incoming edges, so the {@code neighbor.in.size() == 1} guard rejects
+   * the candidate. This pins the design contract documented in the plan
+   * (Track 1 — reverse traversal case): the structural rule rejects reverse
+   * traversals without any special-case logic.
    */
   @Test
   public void resolveChainedTarget_reverseTraversal_returnsEmpty() {
     var chain = buildChain("outE", "inV", "post", "e", "tag");
 
-    // Pass edge.out (the source `post` node) as neighbor. From there, there
-    // is no outgoing edge that is an inV hop — the structural rule rejects.
+    // Pass edge.out (the source `post` node) as neighbor. Source has
+    // source.out = {firstEdge} (size 1) and source.in = {} (size 0), so the
+    // `neighbor.in.size() != 1` clause in the combined size guard rejects.
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.firstEdge().out, Set.of(), Map.of(), db))
         .isEmpty();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -2442,6 +2442,41 @@ public class MatchExecutionPlannerMutationTest {
   // ── 6-arg overload: inherited schema/classCount short-circuits ──
 
   /**
+   * Pins the sort-loop invariant that {@code Double.MAX_VALUE} (the
+   * "unestimated" sentinel) survives the chain fold unchanged when the
+   * pre-resolved class is null. If the null-class short-circuit at the
+   * head of the 6-arg overload is weakened or removed, the caller at
+   * {@code MatchExecutionPlanner.updateScheduleStartingAt} would multiply
+   * MAX_VALUE by some finite selectivity, quietly breaking the stable-sort
+   * tiebreaker the sort comparator relies on for edges with no estimate.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_maxValueInputPreservedOnNullClass() {
+    double result =
+        MatchExecutionPlanner.applyTargetSelectivity(
+            Double.MAX_VALUE, "tag", (String) null, Map.of(), Map.of("tag", 10L), db);
+    assertEquals(Double.MAX_VALUE, result, 0.0);
+  }
+
+  /**
+   * Pins the same MAX_VALUE-preservation invariant when the pre-resolved
+   * class is present but the target lacks any filter/row-estimate: the
+   * cardinality-ratio path's {@code return baseCost} on null estimate
+   * must not silently convert MAX_VALUE into a finite cost. Complements
+   * the null-class test above.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_maxValueInputPreservedOnNoFilterNoEstimate() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    double result =
+        MatchExecutionPlanner.applyTargetSelectivity(
+            Double.MAX_VALUE, "tag", "Tag", Map.of(), Map.of(), db);
+    assertEquals(Double.MAX_VALUE, result, 0.0);
+  }
+
+  /**
    * Kills: mutation that drops the {@code !schema.existsClass(...)} half of
    * the {@code schema == null || !schema.existsClass(...)} guard. The new
    * overload must delegate to the shared helper, which short-circuits when

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -2194,6 +2194,135 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
+   * outE('VIHasTag') → outV with empty aliasClasses: precedence-2 must read
+   * the edge class's {@code out} linked vertex (source side), NOT {@code in}
+   * (target side). The downstream side is determined by the SECOND method
+   * (outV ↔ source), not the first one (outE) — a regression to a
+   * firstName-only mapping would return VITag here instead of VIPost and
+   * silently fold a wrong selectivity into the cost model.
+   */
+  @Test
+  public void resolveChainedTarget_outEoutV_precedence2_readsOutSide() {
+    var postClass = registerClass("VIPost", 100);
+    var tagClass = registerClass("VITag", 10);
+    var edgeClass = registerClass("VIHasTag", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(tagClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(postClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "outE");
+    // outE.outV — second hop loops back to source side
+    var chain = buildChain(firstMethod, "outV", "post", "e", "sourcePost");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("sourcePost", "VIPost"));
+  }
+
+  /**
+   * inE('VIHasTag') → inV with empty aliasClasses: precedence-2 must read
+   * the edge class's {@code in} linked vertex (target side), NOT {@code out}.
+   * Mirror of the outE.outV test — second-method-driven mapping pinned
+   * for the inbound-then-target direction.
+   */
+  @Test
+  public void resolveChainedTarget_inEinV_precedence2_readsInSide() {
+    var postClass = registerClass("VIPost", 100);
+    var tagClass = registerClass("VITag", 10);
+    var edgeClass = registerClass("VIHasTag", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(tagClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(postClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIHasTag\"");
+    stubMethodName(firstMethod, "inE");
+    // inE.inV — second hop loops back to target side
+    var chain = buildChain(firstMethod, "inV", "tag", "e", "targetTag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("targetTag", "VITag"));
+  }
+
+  /**
+   * bothE('VIKnows') → inV: even though the first hop is bidirectional, the
+   * second hop ({@code inV}) unambiguously selects the edge's {@code in}
+   * side. Precedence-2 returns the in-linked class. Pins that bothE no
+   * longer short-circuits to null when the second hop pins the direction —
+   * a previous version of the fallback would return null on any bothE.
+   */
+  @Test
+  public void resolveChainedTarget_bothEinV_precedence2_readsInSide() {
+    var aClass = registerClass("A", 100);
+    var bClass = registerClass("B", 50);
+    var edgeClass = registerClass("VIKnows", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(bClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(aClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIKnows\"");
+    stubMethodName(firstMethod, "bothE");
+    var chain = buildChain(firstMethod, "inV", "a", "e", "target");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    // bothE.inV → in side = B (the edge's "in" linked class)
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("target", "B"));
+  }
+
+  /**
+   * bothE('VIKnows') → outV: bothE no longer blocks inference; outV picks
+   * the {@code out} linked class. Mirror of the bothE.inV test.
+   */
+  @Test
+  public void resolveChainedTarget_bothEoutV_precedence2_readsOutSide() {
+    var aClass = registerClass("A", 100);
+    var bClass = registerClass("B", 50);
+    var edgeClass = registerClass("VIKnows", 500);
+
+    var inProp = mock(SchemaPropertyInternal.class);
+    when(inProp.getLinkedClass()).thenReturn(bClass);
+    when(edgeClass.getPropertyInternal("in")).thenReturn(inProp);
+
+    var outProp = mock(SchemaPropertyInternal.class);
+    when(outProp.getLinkedClass()).thenReturn(aClass);
+    when(edgeClass.getPropertyInternal("out")).thenReturn(outProp);
+
+    var firstMethod = mockMethodWithBaseExpression("\"VIKnows\"");
+    stubMethodName(firstMethod, "bothE");
+    var chain = buildChain(firstMethod, "outV", "a", "e", "source");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
+
+    // bothE.outV → out side = A
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("source", "A"));
+  }
+
+  /**
    * bothE → bothV with {@code aliasClasses.get("vertex") = "VITag"}:
    * precedence-1 wins. <b>Critical for Track 3 test 4</b> — this is the
    * only way a {@code bothE→bothV} chain ever gets a non-null class, since
@@ -2213,8 +2342,12 @@ public class MatchExecutionPlannerMutationTest {
 
   /**
    * bothE('VIKnows') → bothV with empty aliasClasses and a fully-registered
-   * edge schema: precedence-2 explicitly returns null for {@code bothE}
-   * because no single endpoint is uniquely "downstream".
+   * edge schema: precedence-2 returns null because the SECOND hop
+   * ({@code bothV}) cannot disambiguate which side of the edge is
+   * downstream — neither {@code in} nor {@code out} alone is correct.
+   * Note that the rejection now lives in {@code linkedVertexClassForVertexStep}'s
+   * "bothV → null" branch, not in any first-method check; bothE.inV /
+   * bothE.outV are now resolvable (see {@code bothEinV_precedence2_readsInSide}).
    */
   @Test
   public void resolveChainedTarget_bothEbothV_precedence2_returnsNullClass() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
+import static com.jetbrains.youtrackdb.internal.core.sql.executor.match.MatchTestWhereBuilders.makeWhereWithOperator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.Assert.assertEquals;
@@ -19,8 +20,6 @@ import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.CostModel;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLAndBlock;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBaseExpression;
-import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCompareOperator;
-import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCondition;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLEqualsOperator;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIdentifier;
@@ -2571,9 +2570,11 @@ public class MatchExecutionPlannerMutationTest {
   /**
    * Kills: the cardinality-ratio branch ("selectivity = targetEstimate /
    * classCount; return baseCost × selectivity;") being removed or pinned.
-   * With no filter but an estimated 1-row target on a 1000-row class,
-   * adjusted = 500 × 0.001 = 0.5 — matches the heuristic result, but
-   * reaches it via the fallback path.
+   * Uses an estimated 100-row target on a 1000-row class so the expected
+   * value (50.0) is distinct from the filter-heuristic test's 0.5 — lets a
+   * reader verify at a glance which branch produced the result, and lets a
+   * mutation that swapped the heuristic and cardinality-ratio branches be
+   * caught by either test individually rather than only by their combination.
    */
   @Test
   public void applyTargetSelectivity_classForced_cardinalityRatioPath() {
@@ -2581,10 +2582,10 @@ public class MatchExecutionPlannerMutationTest {
     when(schema.existsClass("Tag")).thenReturn(true);
 
     double result = MatchExecutionPlanner.applyTargetSelectivity(
-        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), db);
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 100L), db);
 
-    // no filter → targetEstimate/classCount = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
-    assertEquals(0.5, result, DELTA);
+    // no filter → targetEstimate/classCount = 100/1000 → 500 × 0.1 = 50.0 (exact in IEEE-754)
+    assertEquals(50.0, result, DELTA);
   }
 
   /**
@@ -2638,8 +2639,11 @@ public class MatchExecutionPlannerMutationTest {
   /**
    * The refactor routes both overloads through the same private helper;
    * with the same resolved class, the filter-heuristic path must return
-   * identical numeric results. Kills any mutation that changes the
-   * arithmetic in only one overload after the refactor.
+   * identical numeric results. Anchoring the absolute value (0.5) in addition
+   * to the legacy==classForced parity kills mutations that alter the shared
+   * helper symmetrically (e.g. {@code baseCost * heuristic} flipped to
+   * {@code baseCost / heuristic}): the relative equality still holds across
+   * both overloads, but the absolute-value assertion fails.
    */
   @Test
   public void applyTargetSelectivity_overloadsAgree_filterHeuristicPath() {
@@ -2656,13 +2660,18 @@ public class MatchExecutionPlannerMutationTest {
     double classForced = MatchExecutionPlanner.applyTargetSelectivity(
         500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
 
+    // equality selectivity = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
+    assertEquals(0.5, legacy, DELTA);
+    assertEquals(0.5, classForced, DELTA);
     assertEquals(legacy, classForced, 0.0);
   }
 
   /**
    * Parity for the cardinality-ratio branch: both overloads must produce
    * the identical double when the filter is absent and the estimate
-   * drives the selectivity.
+   * drives the selectivity. Anchors the absolute value (0.5) in addition to
+   * the legacy==classForced parity, for the same reason as the heuristic
+   * parity test above — catches symmetric mutations to the shared helper.
    */
   @Test
   public void applyTargetSelectivity_overloadsAgree_cardinalityRatioPath() {
@@ -2678,6 +2687,9 @@ public class MatchExecutionPlannerMutationTest {
     double classForced = MatchExecutionPlanner.applyTargetSelectivity(
         500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), db);
 
+    // no filter → targetEstimate/classCount = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
+    assertEquals(0.5, legacy, DELTA);
+    assertEquals(0.5, classForced, DELTA);
     assertEquals(legacy, classForced, 0.0);
   }
 
@@ -2703,27 +2715,6 @@ public class MatchExecutionPlannerMutationTest {
     assertEquals(500.0, legacy, 0.0);
     assertEquals(500.0, classForced, 0.0);
     assertEquals(legacy, classForced, 0.0);
-  }
-
-  // ── applyTargetSelectivity test helpers ──
-
-  /**
-   * Builds an AND-wrapped single-condition WHERE clause with the given
-   * binary operator. Mirrors {@code EstimateEdgeCostTest#makeWhereWithOperator}
-   * for consistent filter shapes across tests.
-   */
-  private SQLWhereClause makeWhereWithOperator(SQLBinaryCompareOperator op) {
-    var condition = new SQLBinaryCondition(-1);
-    condition.setLeft(new SQLExpression(-1));
-    condition.setOperator(op);
-    condition.setRight(new SQLExpression(-1));
-
-    var andBlock = new SQLAndBlock(-1);
-    andBlock.getSubBlocks().add(condition);
-
-    var where = new SQLWhereClause(-1);
-    where.setBaseExpression(andBlock);
-    return where;
   }
 
   // ── resolveChainedTarget test helpers ──

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1647,7 +1647,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         edge, edge.in, Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1663,7 +1663,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         edge, edge.in, Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1678,7 +1678,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1691,7 +1691,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1705,7 +1705,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1718,7 +1718,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1731,7 +1731,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1749,7 +1749,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
   }
 
@@ -1764,7 +1764,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1788,7 +1788,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1803,7 +1803,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), visited, Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1818,7 +1818,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1844,7 +1844,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1865,7 +1865,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1878,7 +1878,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1892,7 +1892,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1905,7 +1905,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1919,7 +1919,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1934,7 +1934,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1947,7 +1947,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1962,7 +1962,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1975,7 +1975,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -1990,7 +1990,7 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   /**
@@ -2010,7 +2010,7 @@ public class MatchExecutionPlannerMutationTest {
     // `neighbor.in.size() != 1` clause in the combined size guard rejects.
     assertThat(MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.firstEdge().out, Set.of(), Map.of(), db))
-        .isEmpty();
+        .isNull();
   }
 
   // ── Happy-path sanity tests (structural detection + class=null fallback) ──
@@ -2031,7 +2031,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2046,7 +2046,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("post", null));
   }
 
@@ -2062,7 +2062,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("b", null));
   }
 
@@ -2078,7 +2078,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2107,7 +2107,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
   }
 
@@ -2141,7 +2141,7 @@ public class MatchExecutionPlannerMutationTest {
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
     // outE must read the "in" property → VITag, not "out" → VIPost
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
   }
 
@@ -2158,7 +2158,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("post", "VIPost"));
   }
 
@@ -2189,7 +2189,7 @@ public class MatchExecutionPlannerMutationTest {
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
     // inE must read the "out" property → VIPost, not "in" → VITag
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("post", "VIPost"));
   }
 
@@ -2223,7 +2223,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("sourcePost", "VIPost"));
   }
 
@@ -2255,7 +2255,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("targetTag", "VITag"));
   }
 
@@ -2288,7 +2288,7 @@ public class MatchExecutionPlannerMutationTest {
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
     // bothE.inV → in side = B (the edge's "in" linked class)
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("target", "B"));
   }
 
@@ -2318,7 +2318,7 @@ public class MatchExecutionPlannerMutationTest {
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
     // bothE.outV → out side = A
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("source", "A"));
   }
 
@@ -2336,7 +2336,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("vertex", "VITag"));
   }
 
@@ -2370,7 +2370,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("b", null));
   }
 
@@ -2386,7 +2386,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2405,7 +2405,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2425,7 +2425,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2447,7 +2447,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2464,7 +2464,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), null);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2479,7 +2479,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), null, db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 
@@ -2507,7 +2507,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", "VIExplicitTag"));
   }
 
@@ -2534,7 +2534,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("post", "VIExplicitPost"));
   }
 
@@ -2557,7 +2557,7 @@ public class MatchExecutionPlannerMutationTest {
     var result = MatchExecutionPlanner.resolveChainedTarget(
         chain.firstEdge(), chain.intermediateNode(), Set.of(), Map.of(), db);
 
-    assertThat(result).contains(
+    assertThat(result).isEqualTo(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -1735,6 +1735,25 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   /**
+   * Method names arrive case-preserved from the parser, so the whitelist must
+   * be case-insensitive. Pins this for both hops jointly: a mutation that
+   * replaces the {@code equalsIgnoreCase} short-circuit with a strict
+   * {@code equals} would reject {@code OUTE}/{@code INV} variants and break
+   * any user query written in upper case.
+   */
+  @Test
+  public void resolveChainedTarget_mixedCaseMethodNames_returnsTarget() {
+    var chain = buildChain("OuTe", "InV", "post", "e", "tag");
+    var aliasClasses = Map.of("tag", "VITag");
+
+    var result = MatchExecutionPlanner.resolveChainedTarget(
+        chain.firstEdge(), chain.intermediateNode(), Set.of(), aliasClasses, db);
+
+    assertThat(result).contains(
+        new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
+  }
+
+  /**
    * Intermediate node has zero outgoing edges — the chain has no downstream
    * vertex step. Return empty.
    */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -17,7 +17,11 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInterna
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaPropertyInternal;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.CostModel;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLAndBlock;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBaseExpression;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCompareOperator;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCondition;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLEqualsOperator;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIdentifier;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchExpression;
@@ -26,6 +30,8 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchPathItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMathExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMethodCall;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLModifier;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNeOperator;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -2402,6 +2408,239 @@ public class MatchExecutionPlannerMutationTest {
 
     assertThat(result).contains(
         new MatchExecutionPlanner.ChainedTarget("tag", null));
+  }
+
+  // =========================================================================
+  // applyTargetSelectivity — refactor parity + new class-forced overload
+  // =========================================================================
+  //
+  // These tests guard the refactor that extracts the shared body of the
+  // existing 8-arg overload into {@code applyClassSelectivity} and adds a
+  // class-forced 6-arg overload used by the sort-loop's chain fold.
+  //
+  // Parity tests (8-arg ↔ 6-arg) prove the refactor preserves behaviour for
+  // the existing call site. Short-circuit tests on the 6-arg overload pin
+  // the null-class guard and the inherited schema / classCount / filter /
+  // estimate branches, so a mutation that drops any branch is caught.
+
+  // ── 6-arg overload: short-circuit on null pre-resolved class ──
+
+  /**
+   * Kills: "if (preResolvedTargetClass == null) return baseCost;" replaced
+   * with "if (true)" or "if (false)". A null class is the legitimate signal
+   * for {@code bothE→bothV} chains where edge-schema inference returns null
+   * and the user did not annotate the downstream alias — the overload must
+   * leave {@code baseCost} unchanged instead of NPEing on the schema lookup.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_nullClass_returnsBaseCost() {
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", (String) null, Map.of(), Map.of("tag", 10L), db);
+    assertEquals(500.0, result, 0.0);
+  }
+
+  // ── 6-arg overload: inherited schema/classCount short-circuits ──
+
+  /**
+   * Kills: "if (schema == null || !schema.existsClass(...)) return baseCost;"
+   * mutated to swallow the guard. The new overload must delegate to the
+   * shared helper, which short-circuits when the schema has no matching
+   * class (transient during storage open / plugin init).
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_classNotInSchema_returnsBaseCost() {
+    when(schema.existsClass("Missing")).thenReturn(false);
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Missing", Map.of(), Map.of("tag", 10L), db);
+    assertEquals(500.0, result, 0.0);
+  }
+
+  /**
+   * Kills: "if (classCount <= 0) return baseCost;" replaced with a weaker
+   * or stronger predicate. An empty downstream class has no selectivity
+   * information — we must fall back to {@code baseCost} rather than divide
+   * by zero.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_classCountZero_returnsBaseCost() {
+    registerClass("Empty", 0);
+    when(schema.existsClass("Empty")).thenReturn(true);
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Empty", Map.of(), Map.of("tag", 10L), db);
+    assertEquals(500.0, result, 0.0);
+  }
+
+  // ── 6-arg overload: filter-heuristic vs cardinality-ratio paths ──
+
+  /**
+   * Kills: "return baseCost * heuristic;" in the filter-heuristic branch
+   * replaced with a constant. With an equality filter on a 1000-row class,
+   * selectivity ≈ 1/1000, so adjusted ≈ 0.5. Also kills the
+   * "heuristic >= 0.0" guard: negating it would skip this path entirely.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_filterHeuristicPath() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    var filter = makeWhereWithOperator(new SQLEqualsOperator(-1));
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
+
+    // equality selectivity = 1/1000 → 500 × 0.001 = 0.5
+    assertEquals(0.5, result, 0.01);
+  }
+
+  /**
+   * Kills: "return baseCost * heuristic;" replaced for inequality. With a
+   * {@code <>} filter on a 1000-row class, selectivity = 999/1000. This
+   * complements the equality test so a mutation pinning heuristic to
+   * 1/classCount (equality only) is caught.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_filterHeuristicInequality() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    var filter = makeWhereWithOperator(new SQLNeOperator(-1));
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
+
+    // inequality selectivity = 999/1000 → 500 × 0.999 ≈ 499.5
+    assertEquals(499.5, result, 1.0);
+  }
+
+  /**
+   * Kills: the cardinality-ratio branch ("selectivity = targetEstimate /
+   * classCount; return baseCost × selectivity;") being removed or pinned.
+   * With no filter but an estimated 1-row target on a 1000-row class,
+   * adjusted = 500 × 0.001 = 0.5 — matches the heuristic result, but
+   * reaches it via the fallback path.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_cardinalityRatioPath() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), db);
+
+    // no filter → targetEstimate/classCount = 1/1000 → 500 × 0.001 = 0.5
+    assertEquals(0.5, result, 0.01);
+  }
+
+  /**
+   * Kills: the "targetEstimate == null → return baseCost" guard. Without
+   * a filter and without an estimate for the downstream alias, the overload
+   * must not NPE dereferencing a null Long and must not misattribute 0 as
+   * the estimate.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_noFilterNoEstimate_returnsBaseCost() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of(), Map.of(), db);
+
+    assertEquals(500.0, result, 0.0);
+  }
+
+  // ── 8-arg ↔ 6-arg parity (refactor regression guard) ──
+
+  /**
+   * The refactor routes both overloads through the same private helper;
+   * with the same resolved class, the filter-heuristic path must return
+   * identical numeric results. Kills any mutation that changes the
+   * arithmetic in only one overload after the refactor.
+   */
+  @Test
+  public void applyTargetSelectivity_overloadsAgree_filterHeuristicPath() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    var filter = makeWhereWithOperator(new SQLEqualsOperator(-1));
+    var edge = mockEdgeWithMethodAndParam("out", "\"HAS_TAG\"");
+
+    double legacy = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", edge, true,
+        Map.of("tag", "Tag"), Map.of("tag", filter), Map.of("tag", 100L), db);
+
+    double classForced = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
+
+    assertEquals(legacy, classForced, 0.0);
+  }
+
+  /**
+   * Parity for the cardinality-ratio branch: both overloads must produce
+   * the identical double when the filter is absent and the estimate
+   * drives the selectivity.
+   */
+  @Test
+  public void applyTargetSelectivity_overloadsAgree_cardinalityRatioPath() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    var edge = mockEdgeWithMethodAndParam("out", "\"HAS_TAG\"");
+
+    double legacy = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", edge, true,
+        Map.of("tag", "Tag"), Map.of(), Map.of("tag", 1L), db);
+
+    double classForced = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), db);
+
+    assertEquals(legacy, classForced, 0.0);
+  }
+
+  /**
+   * Parity for the null-class short-circuit: the 8-arg overload returns
+   * {@code baseCost} when {@code resolveTargetClass} returns null; the 6-arg
+   * overload returns {@code baseCost} when {@code preResolvedTargetClass}
+   * is null. Both paths must observe the same {@code baseCost}.
+   */
+  @Test
+  public void applyTargetSelectivity_overloadsAgree_nullClass_shortCircuit() {
+    // 8-arg path: no aliasClasses entry + no edge class → resolveTargetClass
+    // returns null. 6-arg path: pre-resolved class explicitly null.
+    var edge = mockEdgeWithMethod("out");
+
+    double legacy = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", edge, true,
+        Map.of(), Map.of(), Map.of("tag", 10L), db);
+
+    double classForced = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", (String) null, Map.of(), Map.of("tag", 10L), db);
+
+    assertEquals(500.0, legacy, 0.0);
+    assertEquals(500.0, classForced, 0.0);
+    assertEquals(legacy, classForced, 0.0);
+  }
+
+  // ── applyTargetSelectivity test helpers ──
+
+  /**
+   * Builds an AND-wrapped single-condition WHERE clause with the given
+   * binary operator. Mirrors {@code EstimateEdgeCostTest#makeWhereWithOperator}
+   * for consistent filter shapes across tests.
+   */
+  private SQLWhereClause makeWhereWithOperator(SQLBinaryCompareOperator op) {
+    var condition = new SQLBinaryCondition(-1);
+    condition.setLeft(new SQLExpression(-1));
+    condition.setOperator(op);
+    condition.setRight(new SQLExpression(-1));
+
+    var andBlock = new SQLAndBlock(-1);
+    andBlock.getSubBlocks().add(condition);
+
+    var where = new SQLWhereClause(-1);
+    where.setBaseExpression(andBlock);
+    return where;
   }
 
   // ── resolveChainedTarget test helpers ──

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -2442,10 +2442,11 @@ public class MatchExecutionPlannerMutationTest {
   // ── 6-arg overload: inherited schema/classCount short-circuits ──
 
   /**
-   * Kills: "if (schema == null || !schema.existsClass(...)) return baseCost;"
-   * mutated to swallow the guard. The new overload must delegate to the
-   * shared helper, which short-circuits when the schema has no matching
-   * class (transient during storage open / plugin init).
+   * Kills: mutation that drops the {@code !schema.existsClass(...)} half of
+   * the {@code schema == null || !schema.existsClass(...)} guard. The new
+   * overload must delegate to the shared helper, which short-circuits when
+   * the schema has no matching class (e.g. a stale pre-resolved class that
+   * no longer exists after a schema edit).
    */
   @Test
   public void applyTargetSelectivity_classForced_classNotInSchema_returnsBaseCost() {
@@ -2453,6 +2454,22 @@ public class MatchExecutionPlannerMutationTest {
 
     double result = MatchExecutionPlanner.applyTargetSelectivity(
         500.0, "tag", "Missing", Map.of(), Map.of("tag", 10L), db);
+    assertEquals(500.0, result, 0.0);
+  }
+
+  /**
+   * Kills: mutation that drops the {@code schema == null} half of the
+   * {@code schema == null || !schema.existsClass(...)} guard. During
+   * narrow storage-lifecycle windows (re-open, plugin init) the immutable
+   * snapshot may be null — calling {@code existsClass} on it would NPE, so
+   * the guard must short-circuit to {@code baseCost} first.
+   */
+  @Test
+  public void applyTargetSelectivity_classForced_schemaSnapshotNull_returnsBaseCost() {
+    when(db.getMetadata().getImmutableSchemaSnapshot()).thenReturn(null);
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 10L), db);
     assertEquals(500.0, result, 0.0);
   }
 
@@ -2490,15 +2507,17 @@ public class MatchExecutionPlannerMutationTest {
     double result = MatchExecutionPlanner.applyTargetSelectivity(
         500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
 
-    // equality selectivity = 1/1000 → 500 × 0.001 = 0.5
-    assertEquals(0.5, result, 0.01);
+    // equality selectivity = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
+    assertEquals(0.5, result, DELTA);
   }
 
   /**
    * Kills: "return baseCost * heuristic;" replaced for inequality. With a
    * {@code <>} filter on a 1000-row class, selectivity = 999/1000. This
    * complements the equality test so a mutation pinning heuristic to
-   * 1/classCount (equality only) is caught.
+   * 1/classCount (equality only) is caught. Uses {@code DELTA} because the
+   * arithmetic is exact at this magnitude — a wider tolerance would admit
+   * off-by-one mutations in the {@code (n-1)/n} fraction.
    */
   @Test
   public void applyTargetSelectivity_classForced_filterHeuristicInequality() {
@@ -2510,8 +2529,8 @@ public class MatchExecutionPlannerMutationTest {
     double result = MatchExecutionPlanner.applyTargetSelectivity(
         500.0, "tag", "Tag", Map.of("tag", filter), Map.of("tag", 100L), db);
 
-    // inequality selectivity = 999/1000 → 500 × 0.999 ≈ 499.5
-    assertEquals(499.5, result, 1.0);
+    // inequality selectivity = 999/1000 → 500 × 0.999 = 499.5 (exact in IEEE-754)
+    assertEquals(499.5, result, DELTA);
   }
 
   /**
@@ -2529,8 +2548,37 @@ public class MatchExecutionPlannerMutationTest {
     double result = MatchExecutionPlanner.applyTargetSelectivity(
         500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), db);
 
-    // no filter → targetEstimate/classCount = 1/1000 → 500 × 0.001 = 0.5
-    assertEquals(0.5, result, 0.01);
+    // no filter → targetEstimate/classCount = 1/1000 → 500 × 0.001 = 0.5 (exact in IEEE-754)
+    assertEquals(0.5, result, DELTA);
+  }
+
+  /**
+   * Kills: "if (heuristic >= 0.0) return baseCost * heuristic;" mutated to
+   * always take the heuristic branch (applying -1.0 would negate the cost)
+   * or to swallow the threshold comparison. With an unestimable WHERE
+   * (empty AND block), {@code estimateFilterSelectivity} returns -1.0; the
+   * shared helper must fall through to the cardinality-ratio branch, not
+   * short-circuit on the filter or multiply by a negative heuristic.
+   */
+  @Test
+  public void
+      applyTargetSelectivity_classForced_heuristicUnestimable_fallsBackToCardinalityRatio() {
+    registerClass("Tag", 1000);
+    when(schema.existsClass("Tag")).thenReturn(true);
+
+    // Empty SQLAndBlock: unwrapSingleCondition returns the AND block (size != 1),
+    // which is not SQLBinaryCondition and has size 0 < 1 AND-sub-blocks, so
+    // estimateFilterSelectivity returns -1.0. The helper must fall through
+    // to the cardinality-ratio branch using estimatedRootEntries.
+    var where = new SQLWhereClause(-1);
+    where.setBaseExpression(new SQLAndBlock(-1));
+
+    double result = MatchExecutionPlanner.applyTargetSelectivity(
+        500.0, "tag", "Tag", Map.of("tag", where), Map.of("tag", 1L), db);
+
+    // heuristic = -1.0 → fallback to targetEstimate/classCount = 1/1000
+    //                  → 500 × 0.001 = 0.5 (exact in IEEE-754)
+    assertEquals(0.5, result, DELTA);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
@@ -40,9 +42,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Mutation-killing tests for {@link MatchExecutionPlanner}.
@@ -65,7 +67,13 @@ import org.junit.Test;
  * pattern graph ({@link Pattern}, {@link PatternNode}, {@link PatternEdge},
  * visited-set tracking) tightly enough to need a live database, which the
  * end-to-end chain-cost tests provide instead.
+ *
+ * <p>{@code @Category(SequentialTest.class)} because the knob-bounding tests
+ * write {@code GlobalConfiguration}, which is JVM-global. The parallel
+ * surefire execution runs four classes at once, so a class that writes it
+ * belongs in the sequential one.
  */
+@Category(SequentialTest.class)
 public class MatchExecutionPlannerMutationTest {
 
   private static final double DELTA = 1e-9;
@@ -2980,152 +2988,52 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   // =========================================================================
-  // clampChainFoldMaxHops — knob bounding + warn-once contract
-  // =========================================================================
-
-  /**
-   * In-range value (default knob) passes through unchanged. Pins the
-   * happy path so a mutation that always clamps would be caught.
-   */
-  @Test
-  public void clampChainFoldMaxHops_inRangeDefault_returnedUnchanged() {
-    assertEquals(10, MatchExecutionPlanner.clampChainFoldMaxHops(10));
-  }
-
-  /**
-   * The documented "fold disabled" sentinel zero passes through. Pins
-   * that the lower clamp does not accidentally bump zero to anything.
-   */
-  @Test
-  public void clampChainFoldMaxHops_zero_returnedUnchanged() {
-    assertEquals(0, MatchExecutionPlanner.clampChainFoldMaxHops(0));
-  }
-
-  /**
-   * The maximum supported value passes through. Pins the boundary of
-   * the upper clamp — a strict {@code >} comparison must let the cap
-   * through, while a {@code >=} mutation would clamp it to itself
-   * (harmless) but still trip the warning machinery.
-   */
-  @Test
-  public void clampChainFoldMaxHops_atMaxBoundary_returnedUnchanged() {
-    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(1000));
-  }
-
-  /**
-   * Negative input is silently clamped to zero per project convention
-   * (see {@code getHashJoinThreshold}). No warning, no exception.
-   */
-  @Test
-  public void clampChainFoldMaxHops_negative_clampedToZero() {
-    assertEquals(0, MatchExecutionPlanner.clampChainFoldMaxHops(-100));
-    assertEquals(0, MatchExecutionPlanner.clampChainFoldMaxHops(Integer.MIN_VALUE));
-  }
-
-  /**
-   * Above-cap input is clamped to the cap. Pins both the cap value
-   * itself and the direction of the clamp — a mutation that returned
-   * {@code raw} or {@code 0} for the over-cap branch would fail.
-   */
-  @Test
-  public void clampChainFoldMaxHops_aboveCap_clampedToMax() {
-    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(1001));
-    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(100_000));
-    assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(Integer.MAX_VALUE));
-  }
-
-  // =========================================================================
-  // clampChainFoldMaxHops — warn dedupe rule
+  // getChainFoldMaxHops — knob bounding
   //
-  // The WARN leaves no trace to assert on: the test log backend discards it.
-  // These drive the clamp with a locally-owned dedupe cell instead and read
-  // the decision out of that cell afterwards, so no two tests can influence
-  // each other and no process-wide state is touched.
+  // Reads QUERY_MATCH_CHAIN_FOLD_MAX_HOPS and bounds it to
+  // [0, MAX_CHAIN_FOLD_HOPS], silently, the way the planner's sibling knob
+  // accessors do.
   // =========================================================================
 
   /**
-   * The first out-of-range value takes ownership of the warning, which shows
-   * up as the cell moving off its zero sentinel. Kills a change that drops the
-   * {@code getAndSet} and records nothing, after which every plan re-warns.
+   * The accessor bounds the knob to {@code [0, 1000]}.
+   *
+   * <p>Covers what the end-to-end probes cannot separate: the exact cap
+   * boundary (1000 passes, 1001 clamps), zero surviving the lower clamp, and
+   * negatives flooring at zero rather than reaching the walk as a meaningless
+   * hop budget. Zero matters most — a {@code Math.max(1, …)} would quietly
+   * remove the only setting that restores the pre-fold schedule.
    */
   @Test
-  public void clampChainFoldMaxHops_firstOutOfRangeValue_takesWarnOwnership() {
-    var lastWarned = new AtomicInteger(0);
+  public void getChainFoldMaxHops_boundsTheKnobToItsSupportedRange() {
+    int previous = GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.getValueAsInteger();
+    try {
+      assertKnobResolvesTo(10, 10);
+      assertKnobResolvesTo(1, 1);
+      assertKnobResolvesTo(0, 0);
+      assertKnobResolvesTo(1000, 1000);
 
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
+      assertKnobResolvesTo(1001, 1000);
+      assertKnobResolvesTo(100_000, 1000);
+      assertKnobResolvesTo(Integer.MAX_VALUE, 1000);
 
-    assertEquals(5000, lastWarned.get());
-  }
-
-  /**
-   * Repeating one out-of-range value leaves the cell unchanged, so every call
-   * after the first observes {@code previous == raw} and stays silent. This is
-   * the common case: one misconfigured knob read once per plan across many
-   * queries collapses to a single WARN.
-   */
-  @Test
-  public void clampChainFoldMaxHops_repeatedOutOfRangeValue_staysOwnedByFirst() {
-    var lastWarned = new AtomicInteger(0);
-
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
-
-    assertEquals(5000, lastWarned.get());
-  }
-
-  /**
-   * Alternating between two out-of-range values re-warns on each change: the
-   * dedupe is last-value, not once-per-distinct-value. Pins the documented
-   * semantics so a later switch to a set-based "warn once ever" cannot land
-   * unnoticed.
-   */
-  @Test
-  public void clampChainFoldMaxHops_alternatingOutOfRangeValues_rewarnOnChange() {
-    var lastWarned = new AtomicInteger(0);
-
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
-    assertEquals(5000, lastWarned.get());
-
-    MatchExecutionPlanner.clampChainFoldMaxHops(6000, lastWarned);
-    assertEquals(6000, lastWarned.get());
-
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
-    assertEquals(5000, lastWarned.get());
-  }
-
-  /**
-   * In-range values never touch the cell, so correcting the knob back into
-   * range leaves the previous owner recorded. Kills a change that moved the
-   * {@code getAndSet} outside the over-cap branch, which would warn on every
-   * normal plan.
-   */
-  @Test
-  public void clampChainFoldMaxHops_inRangeValues_leaveWarnStateUntouched() {
-    var lastWarned = new AtomicInteger(0);
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
-
-    MatchExecutionPlanner.clampChainFoldMaxHops(10, lastWarned);
-    MatchExecutionPlanner.clampChainFoldMaxHops(0, lastWarned);
-    MatchExecutionPlanner.clampChainFoldMaxHops(-100, lastWarned);
-    MatchExecutionPlanner.clampChainFoldMaxHops(1000, lastWarned);
-
-    assertEquals(5000, lastWarned.get());
-  }
-
-  /**
-   * The single-argument entry point clamps identically to the injected-cell
-   * overload. Pins that production keeps going through the same rule rather
-   * than drifting into a second copy of the bounds.
-   */
-  @Test
-  public void clampChainFoldMaxHops_defaultOverloadClampsLikeInjectedOverload() {
-    var lastWarned = new AtomicInteger(0);
-    for (int raw : new int[] {10, 0, 1000, -100, Integer.MIN_VALUE, 1001, 100_000}) {
-      assertEquals(
-          MatchExecutionPlanner.clampChainFoldMaxHops(raw, lastWarned),
-          MatchExecutionPlanner.clampChainFoldMaxHops(raw));
+      assertKnobResolvesTo(-1, 0);
+      assertKnobResolvesTo(-100, 0);
+      assertKnobResolvesTo(Integer.MIN_VALUE, 0);
+    } finally {
+      GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(previous);
     }
+  }
+
+  /**
+   * Writes {@code raw} to the knob and asserts the accessor resolves it to
+   * {@code expected}.
+   */
+  private static void assertKnobResolvesTo(int raw, int expected) {
+    GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS.setValue(raw);
+    assertEquals(
+        "knob " + raw + " must resolve to " + expected,
+        expected, MatchExecutionPlanner.getChainFoldMaxHops());
   }
 
   // =========================================================================

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -40,6 +40,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -79,10 +80,6 @@ public class MatchExecutionPlannerMutationTest {
     var metadata = mock(MetadataDefault.class);
     when(db.getMetadata()).thenReturn(metadata);
     when(metadata.getImmutableSchemaSnapshot()).thenReturn(schema);
-    // clampChainFoldMaxHops dedupes its WARN against a static field that
-    // outlives any single test. Reset it so the clamp tests below observe a
-    // known starting state regardless of which test ran first in this JVM.
-    MatchExecutionPlanner.resetChainFoldWarnState();
   }
 
   // ── extractEdgeClassName — instanceof String must be exercised ──
@@ -3038,80 +3035,97 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   // =========================================================================
-  // clampChainFoldMaxHops — warn dedupe state machine
+  // clampChainFoldMaxHops — warn dedupe rule
   //
-  // The WARN itself is unobservable (tests run on slf4j-nop), so these
-  // assert the dedupe decision through lastWarnedChainFoldKnobValue(): the
-  // field holds the value that owned the most recent warning, and
-  // clampChainFoldMaxHops stays silent when the incoming value already
-  // matches it.
+  // The WARN leaves no trace to assert on: the test log backend discards it.
+  // These drive the clamp with a locally-owned dedupe cell instead and read
+  // the decision out of that cell afterwards, so no two tests can influence
+  // each other and no process-wide state is touched.
   // =========================================================================
 
   /**
-   * The first out-of-range value takes ownership of the warning, recorded by
-   * the field moving off its zero sentinel. Kills a mutation that drops the
-   * {@code getAndSet} and never records the value, which would make every
-   * subsequent plan re-warn.
+   * The first out-of-range value takes ownership of the warning, which shows
+   * up as the cell moving off its zero sentinel. Kills a change that drops the
+   * {@code getAndSet} and records nothing, after which every plan re-warns.
    */
   @Test
   public void clampChainFoldMaxHops_firstOutOfRangeValue_takesWarnOwnership() {
-    assertEquals(0, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+    var lastWarned = new AtomicInteger(0);
 
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
 
-    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+    assertEquals(5000, lastWarned.get());
   }
 
   /**
-   * Repeating one out-of-range value leaves the recorded value unchanged, so
-   * the second call observes {@code previous == raw} and stays silent. This
-   * is the common case — one misconfigured knob read once per plan across
-   * many queries collapses to a single WARN.
+   * Repeating one out-of-range value leaves the cell unchanged, so every call
+   * after the first observes {@code previous == raw} and stays silent. This is
+   * the common case: one misconfigured knob read once per plan across many
+   * queries collapses to a single WARN.
    */
   @Test
   public void clampChainFoldMaxHops_repeatedOutOfRangeValue_staysOwnedByFirst() {
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+    var lastWarned = new AtomicInteger(0);
 
-    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
+
+    assertEquals(5000, lastWarned.get());
   }
 
   /**
    * Alternating between two out-of-range values re-warns on each change: the
    * dedupe is last-value, not once-per-distinct-value. Pins the documented
-   * semantics so a future switch to a Set-based "warn once ever" cannot land
-   * silently.
+   * semantics so a later switch to a set-based "warn once ever" cannot land
+   * unnoticed.
    */
   @Test
   public void clampChainFoldMaxHops_alternatingOutOfRangeValues_rewarnOnChange() {
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
-    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+    var lastWarned = new AtomicInteger(0);
 
-    MatchExecutionPlanner.clampChainFoldMaxHops(6000);
-    assertEquals(6000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
+    assertEquals(5000, lastWarned.get());
 
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
-    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+    MatchExecutionPlanner.clampChainFoldMaxHops(6000, lastWarned);
+    assertEquals(6000, lastWarned.get());
+
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
+    assertEquals(5000, lastWarned.get());
   }
 
   /**
-   * In-range values never touch the warn state, so a knob corrected back
-   * into range leaves the previous owner recorded and does not reset the
-   * dedupe. Kills a mutation that moved {@code getAndSet} outside the
-   * {@code raw > MAX_CHAIN_FOLD_HOPS} branch, which would warn on every
+   * In-range values never touch the cell, so correcting the knob back into
+   * range leaves the previous owner recorded. Kills a change that moved the
+   * {@code getAndSet} outside the over-cap branch, which would warn on every
    * normal plan.
    */
   @Test
   public void clampChainFoldMaxHops_inRangeValues_leaveWarnStateUntouched() {
-    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+    var lastWarned = new AtomicInteger(0);
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000, lastWarned);
 
-    MatchExecutionPlanner.clampChainFoldMaxHops(10);
-    MatchExecutionPlanner.clampChainFoldMaxHops(0);
-    MatchExecutionPlanner.clampChainFoldMaxHops(-100);
-    MatchExecutionPlanner.clampChainFoldMaxHops(1000);
+    MatchExecutionPlanner.clampChainFoldMaxHops(10, lastWarned);
+    MatchExecutionPlanner.clampChainFoldMaxHops(0, lastWarned);
+    MatchExecutionPlanner.clampChainFoldMaxHops(-100, lastWarned);
+    MatchExecutionPlanner.clampChainFoldMaxHops(1000, lastWarned);
 
-    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+    assertEquals(5000, lastWarned.get());
+  }
+
+  /**
+   * The single-argument entry point clamps identically to the injected-cell
+   * overload. Pins that production keeps going through the same rule rather
+   * than drifting into a second copy of the bounds.
+   */
+  @Test
+  public void clampChainFoldMaxHops_defaultOverloadClampsLikeInjectedOverload() {
+    var lastWarned = new AtomicInteger(0);
+    for (int raw : new int[] {10, 0, 1000, -100, Integer.MIN_VALUE, 1001, 100_000}) {
+      assertEquals(
+          MatchExecutionPlanner.clampChainFoldMaxHops(raw, lastWarned),
+          MatchExecutionPlanner.clampChainFoldMaxHops(raw));
+    }
   }
 
   // =========================================================================

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlannerMutationTest.java
@@ -7,6 +7,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
@@ -31,6 +34,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMethodCall;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLModifier;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLNeOperator;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -42,19 +46,24 @@ import org.junit.Test;
 /**
  * Mutation-killing tests for {@link MatchExecutionPlanner}.
  *
- * <p>Targets surviving pitest mutations in:
+ * <p>Each test states the specific code change it would catch, so a reader can
+ * tell whether a refactor has invalidated the test or merely moved it. Covered
+ * behaviours:
  * <ul>
- *   <li>{@code extractEdgeClassName} — L1153 ({@code instanceof String}) and
- *       L1170 (quote-stripping condition)</li>
- *   <li>{@code estimateEdgeCost} — L1092-L1102 (null guards on schema/edge
- *       class/properties) and L1111 (swapped outVertexClass/inVertexClass
- *       parameters in the {@code estimateFanOut} call)</li>
+ *   <li>{@code extractEdgeClassName} — the {@code instanceof String} branch and
+ *       the quote-stripping condition</li>
+ *   <li>{@code estimateEdgeCost} — the null guards on schema, edge class and
+ *       endpoint properties, and the endpoint-class argument order in the
+ *       {@code estimateFanOut} call</li>
+ *   <li>the chain fold — structural detection, class-inference precedence, the
+ *       two per-plan memos, the multi-hop walk's termination conditions, and
+ *       the knob clamp</li>
  * </ul>
  *
- * <p>The scheduling/traversal mutations (L871-L1015) are deeply coupled to the
- * pattern graph infrastructure ({@link Pattern}, {@link PatternNode},
- * {@link PatternEdge}, visited-set tracking) and would require full integration
- * test setup. They are noted but not covered here.
+ * <p>Scheduling and traversal are not covered here: they are coupled to the
+ * pattern graph ({@link Pattern}, {@link PatternNode}, {@link PatternEdge},
+ * visited-set tracking) tightly enough to need a live database, which the
+ * end-to-end chain-cost tests provide instead.
  */
 public class MatchExecutionPlannerMutationTest {
 
@@ -70,12 +79,16 @@ public class MatchExecutionPlannerMutationTest {
     var metadata = mock(MetadataDefault.class);
     when(db.getMetadata()).thenReturn(metadata);
     when(metadata.getImmutableSchemaSnapshot()).thenReturn(schema);
+    // clampChainFoldMaxHops dedupes its WARN against a static field that
+    // outlives any single test. Reset it so the clamp tests below observe a
+    // known starting state regardless of which test ran first in this JVM.
+    MatchExecutionPlanner.resetChainFoldWarnState();
   }
 
-  // ── extractEdgeClassName: L1153 — instanceof String must be exercised ──
+  // ── extractEdgeClassName — instanceof String must be exercised ──
 
   /**
-   * Kills L1153: "value instanceof String s" replaced with false.
+   * Kills: "value instanceof String s" replaced with false.
    *
    * <p>Uses a real SQLExpression built via SQLMatchPathItem.outPath so that
    * execute() returns a String ("Knows"). The toString() fallback would also
@@ -137,7 +150,7 @@ public class MatchExecutionPlannerMutationTest {
 
   /**
    * When execute() throws CommandExecutionException, the code must fall
-   * through to the toString path. Combined with L1153: if instanceof is
+   * through to the toString path. If instanceof is
    * replaced with false AND execute throws, behavior stays the same — but
    * this test ensures the exception path itself works correctly.
    */
@@ -157,10 +170,10 @@ public class MatchExecutionPlannerMutationTest {
         MatchExecutionPlanner.extractEdgeClassName(method));
   }
 
-  // ── extractEdgeClassName: L1170 — quote-stripping condition ──
+  // ── extractEdgeClassName — quote-stripping condition ──
 
   /**
-   * Kills L1170: quote-stripping condition replaced with false.
+   * Kills: quote-stripping condition replaced with false.
    *
    * <p>When execute() returns null (not a String) and the raw string is
    * double-quoted, stripping must produce the inner value. If the condition
@@ -216,10 +229,10 @@ public class MatchExecutionPlannerMutationTest {
         MatchExecutionPlanner.extractEdgeClassName(method));
   }
 
-  // ── estimateEdgeCost: L1092 — edgeClassName != null ──
+  // ── estimateEdgeCost — edgeClassName != null ──
 
   /**
-   * Kills L1092: "edgeClassName != null" replaced with true.
+   * Kills: "edgeClassName != null" replaced with true.
    *
    * <p>When edgeClassName is null, the schema lookup block should be skipped
    * entirely, so outVertexClass and inVertexClass stay null. For BOTH
@@ -246,10 +259,10 @@ public class MatchExecutionPlannerMutationTest {
     assertEquals(expected, cost, DELTA);
   }
 
-  // ── estimateEdgeCost: L1094 — schema != null ──
+  // ── estimateEdgeCost — schema != null ──
 
   /**
-   * Kills L1094: "schema != null" replaced with false.
+   * Kills: "schema != null" replaced with false.
    *
    * <p>When schema is null, the method should skip the schema block and use
    * default fan-out. If the condition is replaced with false, the method
@@ -272,10 +285,10 @@ public class MatchExecutionPlannerMutationTest {
     assertEquals(expected, cost, DELTA);
   }
 
-  // ── estimateEdgeCost: L1096 — edgeClass != null ──
+  // ── estimateEdgeCost — edgeClass != null ──
 
   /**
-   * Kills L1096: "edgeClass != null" replaced with false.
+   * Kills: "edgeClass != null" replaced with false.
    *
    * <p>When schema returns null for the edge class, the method should skip
    * property lookup and use default fan-out. Verified by exact cost equality.
@@ -294,10 +307,10 @@ public class MatchExecutionPlannerMutationTest {
     assertEquals(expected, cost, DELTA);
   }
 
-  // ── estimateEdgeCost: L1098 — outProp != null && outProp.getLinkedClass() != null ──
+  // ── estimateEdgeCost — outProp != null && outProp.getLinkedClass() != null ──
 
   /**
-   * Kills L1098: "outProp != null && outProp.getLinkedClass() != null"
+   * Kills: "outProp != null && outProp.getLinkedClass() != null"
    * replaced with false.
    *
    * <p>When outProp exists and has a linked class, outVertexClass should be
@@ -331,10 +344,10 @@ public class MatchExecutionPlannerMutationTest {
     assertEquals(expected, cost, DELTA);
   }
 
-  // ── estimateEdgeCost: L1102 — inProp != null && inProp.getLinkedClass() != null ──
+  // ── estimateEdgeCost — inProp != null && inProp.getLinkedClass() != null ──
 
   /**
-   * Kills L1102: "inProp != null && inProp.getLinkedClass() != null"
+   * Kills: "inProp != null && inProp.getLinkedClass() != null"
    * replaced with false.
    *
    * <p>When inProp exists and has a linked class, inVertexClass should be
@@ -369,9 +382,9 @@ public class MatchExecutionPlannerMutationTest {
     assertEquals(expected, cost, DELTA);
   }
 
-  // ── estimateEdgeCost: L1111 — swapped outVertexClass/inVertexClass ──
+  // ── estimateEdgeCost — swapped outVertexClass/inVertexClass ──
   //
-  // NOTE: The L1111 mutation (swapping params 5 and 6 in estimateFanOut) is
+  // NOTE: The mutation (swapping params 5 and 6 in estimateFanOut) is
   // effectively unkillable via unit test. The BOTH fan-out formula sums
   // outFanOut + inFanOut, and swapping the params merely swaps which side
   // contributes which value — but addition is commutative. When only one side
@@ -1620,22 +1633,21 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   // =========================================================================
-  // resolveChainedTarget — Step 1: structural detection rule
+  // resolveChainedTarget — the structural detection rule
   //
   // The helper recognises the edge-method chain pattern .outE(X).inV()
   // (and .inE→.outV / .bothE→.bothV variants) when it appears as two
   // consecutive PatternEdges, so the planner's sort loop can fold the
   // downstream vertex's WHERE selectivity into the first edge's cost.
   //
-  // In Step 1 the class field of the returned ChainedTarget is always null
-  // (class inference lands in Step 2). These tests exercise the structural
-  // rule in isolation.
+  // These exercise the structural rule in isolation, without alias classes,
+  // so the returned ChainedTarget always carries a null class. The
+  // class-inference section below covers the class field.
   // =========================================================================
 
   /**
    * When {@code edge.item} is null, the helper returns empty. Mirrors the
-   * null-guard of existing callers ({@code estimateEdgeCost} at :2297,
-   * {@code resolveTargetClass} at :2523) so the helper does not NPE on
+   * null-guard of existing callers ({@code estimateEdgeCost} and {@code resolveTargetClass}) so the helper does not NPE on
    * synthesised patterns.
    */
   @Test
@@ -2083,11 +2095,11 @@ public class MatchExecutionPlannerMutationTest {
   }
 
   // =========================================================================
-  // resolveChainedTarget — Step 2: class-inference precedence
+  // resolveChainedTarget — class-inference precedence
   //
   // Precedence rule:
   //   1. aliasClasses.get(effectiveTargetAlias) — the pre-populated path
-  //      for outE→inV / inE→outV (addAliases at :4518) and the only path
+  //      for outE→inV / inE→outV (pre-populated by addAliases) and the only path
   //      for bothE→bothV when the user wrote {class: ...}.
   //   2. Derived from the first edge's class + direction:
   //      outE → edgeClass.in.linkedClass
@@ -3023,5 +3035,499 @@ public class MatchExecutionPlannerMutationTest {
     assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(1001));
     assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(100_000));
     assertEquals(1000, MatchExecutionPlanner.clampChainFoldMaxHops(Integer.MAX_VALUE));
+  }
+
+  // =========================================================================
+  // clampChainFoldMaxHops — warn dedupe state machine
+  //
+  // The WARN itself is unobservable (tests run on slf4j-nop), so these
+  // assert the dedupe decision through lastWarnedChainFoldKnobValue(): the
+  // field holds the value that owned the most recent warning, and
+  // clampChainFoldMaxHops stays silent when the incoming value already
+  // matches it.
+  // =========================================================================
+
+  /**
+   * The first out-of-range value takes ownership of the warning, recorded by
+   * the field moving off its zero sentinel. Kills a mutation that drops the
+   * {@code getAndSet} and never records the value, which would make every
+   * subsequent plan re-warn.
+   */
+  @Test
+  public void clampChainFoldMaxHops_firstOutOfRangeValue_takesWarnOwnership() {
+    assertEquals(0, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+
+    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+  }
+
+  /**
+   * Repeating one out-of-range value leaves the recorded value unchanged, so
+   * the second call observes {@code previous == raw} and stays silent. This
+   * is the common case — one misconfigured knob read once per plan across
+   * many queries collapses to a single WARN.
+   */
+  @Test
+  public void clampChainFoldMaxHops_repeatedOutOfRangeValue_staysOwnedByFirst() {
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+
+    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+  }
+
+  /**
+   * Alternating between two out-of-range values re-warns on each change: the
+   * dedupe is last-value, not once-per-distinct-value. Pins the documented
+   * semantics so a future switch to a Set-based "warn once ever" cannot land
+   * silently.
+   */
+  @Test
+  public void clampChainFoldMaxHops_alternatingOutOfRangeValues_rewarnOnChange() {
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+
+    MatchExecutionPlanner.clampChainFoldMaxHops(6000);
+    assertEquals(6000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+  }
+
+  /**
+   * In-range values never touch the warn state, so a knob corrected back
+   * into range leaves the previous owner recorded and does not reset the
+   * dedupe. Kills a mutation that moved {@code getAndSet} outside the
+   * {@code raw > MAX_CHAIN_FOLD_HOPS} branch, which would warn on every
+   * normal plan.
+   */
+  @Test
+  public void clampChainFoldMaxHops_inRangeValues_leaveWarnStateUntouched() {
+    MatchExecutionPlanner.clampChainFoldMaxHops(5000);
+
+    MatchExecutionPlanner.clampChainFoldMaxHops(10);
+    MatchExecutionPlanner.clampChainFoldMaxHops(0);
+    MatchExecutionPlanner.clampChainFoldMaxHops(-100);
+    MatchExecutionPlanner.clampChainFoldMaxHops(1000);
+
+    assertEquals(5000, MatchExecutionPlanner.lastWarnedChainFoldKnobValue());
+  }
+
+  // =========================================================================
+  // chainShapeCache — structural-detection memo
+  //
+  // lookupOrDetectChainShape memoizes detectChainShape per
+  // (edge, neighbor-direction). Production shares one map across a whole
+  // plan, and the same PatternEdge is evaluated from both of its endpoints
+  // in different recursive updateScheduleStartingAt calls — so the
+  // direction half of the key is load-bearing, not decoration.
+  // =========================================================================
+
+  /**
+   * A repeat lookup on the same (edge, direction) returns the memoized
+   * instance rather than re-running detection. Identity, not equality, is
+   * asserted: two independent detections would produce equal records, so
+   * only {@code isSameAs} distinguishes a cache hit from a recompute.
+   */
+  @Test
+  public void chainShapeCache_repeatLookupReturnsMemoizedInstance() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    var cache = new HashMap<MatchExecutionPlanner.ChainShapeKey,
+        MatchExecutionPlanner.ChainedTarget>();
+
+    var first = MatchExecutionPlanner.lookupOrDetectChainShape(
+        chain.firstEdge(), chain.intermediateNode(), Map.of("tag", "VITag"),
+        db, cache);
+    var second = MatchExecutionPlanner.lookupOrDetectChainShape(
+        chain.firstEdge(), chain.intermediateNode(), Map.of("tag", "VITag"),
+        db, cache);
+
+    assertThat(first).isEqualTo(
+        new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
+    assertThat(second).isSameAs(first);
+    assertThat(cache).hasSize(1);
+  }
+
+  /**
+   * A known-not-chain edge caches its {@code null} answer. Pins the
+   * {@code containsKey}/{@code put} pair against a refactor to
+   * {@code computeIfAbsent}, which cannot store null and would re-run
+   * detection for every rejected edge — the common case in the sort loop,
+   * since most candidate edges are plain {@code .out}/{@code .in} hops.
+   */
+  @Test
+  public void chainShapeCache_negativeResultIsMemoized() {
+    var chain = buildChain("out", "inV", "post", "e", "tag");
+    var cache = new HashMap<MatchExecutionPlanner.ChainShapeKey,
+        MatchExecutionPlanner.ChainedTarget>();
+
+    var result = MatchExecutionPlanner.lookupOrDetectChainShape(
+        chain.firstEdge(), chain.intermediateNode(), Map.of(), db, cache);
+
+    assertThat(result).isNull();
+    var key = new MatchExecutionPlanner.ChainShapeKey(chain.firstEdge(), true);
+    assertThat(cache).containsKey(key);
+    assertThat(cache.get(key)).isNull();
+  }
+
+  /**
+   * The two directions of one edge occupy separate cache entries. Reverse
+   * traversal ({@code neighbor == edge.out}) is rejected structurally and
+   * caches {@code null}; the forward lookup afterwards must still detect the
+   * chain. Kills the mutation that keys the cache on the edge alone, which
+   * would return the reverse direction's cached {@code null} for the forward
+   * lookup and silently disable the fold for every edge the DFS happened to
+   * reach from its {@code in} side first.
+   */
+  @Test
+  public void chainShapeCache_reverseDirectionDoesNotPoisonForward() {
+    var chain = buildChain("outE", "inV", "post", "e", "tag");
+    var aliasClasses = Map.of("tag", "VITag");
+    var cache = new HashMap<MatchExecutionPlanner.ChainShapeKey,
+        MatchExecutionPlanner.ChainedTarget>();
+
+    // Reverse first: the sort loop passes edge.out as the neighbor when it
+    // reaches this edge from the other endpoint.
+    var reverse = MatchExecutionPlanner.lookupOrDetectChainShape(
+        chain.firstEdge(), chain.firstEdge().out, aliasClasses, db, cache);
+    assertThat(reverse).isNull();
+
+    var forward = MatchExecutionPlanner.lookupOrDetectChainShape(
+        chain.firstEdge(), chain.intermediateNode(), aliasClasses, db, cache);
+
+    assertThat(forward).isEqualTo(
+        new MatchExecutionPlanner.ChainedTarget("tag", "VITag"));
+    assertThat(cache).hasSize(2);
+  }
+
+  /**
+   * Two structurally identical edges must not share a cache slot.
+   * {@link PatternEdge} declares no {@code equals}/{@code hashCode}, so the
+   * key relies on identity; a future value-equality override on PatternEdge
+   * would collapse both edges onto one entry and hand the second edge the
+   * first one's downstream alias.
+   */
+  @Test
+  public void chainShapeCache_identicallyShapedEdgesGetSeparateEntries() {
+    var first = buildChain("outE", "inV", "post", "e1", "tagA");
+    var second = buildChain("outE", "inV", "post", "e2", "tagB");
+    var aliasClasses = Map.of("tagA", "VITag", "tagB", "VITag");
+    var cache = new HashMap<MatchExecutionPlanner.ChainShapeKey,
+        MatchExecutionPlanner.ChainedTarget>();
+
+    var firstShape = MatchExecutionPlanner.lookupOrDetectChainShape(
+        first.firstEdge(), first.intermediateNode(), aliasClasses, db, cache);
+    var secondShape = MatchExecutionPlanner.lookupOrDetectChainShape(
+        second.firstEdge(), second.intermediateNode(), aliasClasses, db, cache);
+
+    assertThat(firstShape.effectiveTargetAlias()).isEqualTo("tagA");
+    assertThat(secondShape.effectiveTargetAlias()).isEqualTo("tagB");
+    assertThat(cache).hasSize(2);
+  }
+
+  // =========================================================================
+  // classCountCache — planner-side selectivity memo
+  //
+  // The estimator's own test covers the fan-out writer; these cover the
+  // second writer, applyClassSelectivity, reached through
+  // applyTargetSelectivityWithResolvedClass. Both writers share one map per
+  // plan, so they have to agree on keys and on polymorphic-count semantics.
+  // =========================================================================
+
+  /**
+   * The cache-aware overload returns exactly what the un-cached overload
+   * returns. Guards the "pure memo" claim: a divergence would mean the same
+   * branch is costed differently depending on whether a cache is in scope.
+   */
+  @Test
+  public void classCountCache_selectivityMatchesUncachedOverload() {
+    registerClass("Tag", 1000);
+
+    double uncached = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), db);
+    double cached = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), new HashMap<>(), db);
+
+    assertEquals(0.5, uncached, DELTA);
+    assertEquals(uncached, cached, 0.0);
+  }
+
+  /**
+   * A seeded entry is read instead of the schema count. Forcing the Tag
+   * count to 500 instead of 1000 doubles the cardinality ratio, so the cost
+   * becomes 500 × (1/500) = 1.0 rather than 0.5 — the only way to tell
+   * "reads the memo" from "ignores it and recomputes".
+   */
+  @Test
+  public void classCountCache_selectivityUsesSeededCount() {
+    var tagClass = registerClass("Tag", 1000);
+
+    Map<String, Long> cache = new HashMap<>();
+    cache.put("Tag", 500L);
+
+    double cost = MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), cache, db);
+
+    assertEquals(1.0, cost, DELTA);
+    verify(tagClass, never()).approximateCount(db);
+  }
+
+  /**
+   * A miss populates the map under the canonical class name and a second
+   * call hits it, so one plan reads each class's count once no matter how
+   * many candidate edges target that class.
+   */
+  @Test
+  public void classCountCache_selectivityMissPopulatesThenHits() {
+    var tagClass = registerClass("Tag", 1000);
+
+    Map<String, Long> cache = new HashMap<>();
+    MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), cache, db);
+    MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "tag", "Tag", Map.of(), Map.of("tag", 1L), cache, db);
+
+    assertThat(cache).containsExactly(entry("Tag", 1000L));
+    verify(tagClass, times(1)).approximateCount(db);
+  }
+
+  /**
+   * The two writers into the shared map agree. The fan-out estimator seeds
+   * "Person" via {@code SchemaClassInternal#getName}, the selectivity helper
+   * reads it back via the caller-supplied class name, and the second read
+   * must be a hit — if the two ever keyed differently (canonical name vs.
+   * caller string) the plan would silently count the same class twice.
+   */
+  @Test
+  public void classCountCache_sharedBetweenFanOutAndSelectivityWriters() {
+    registerClass("Knows", 500);
+    var personClass = registerClass("Person", 100);
+
+    Map<String, Long> cache = new HashMap<>();
+    EdgeFanOutEstimator.estimateFanOut(
+        db, "Knows", "Person",
+        com.jetbrains.youtrackdb.internal.core.db.record.record.Direction.OUT,
+        "Person", "Person", cache);
+    MatchExecutionPlanner.applyTargetSelectivityWithResolvedClass(
+        500.0, "person", "Person", Map.of(), Map.of("person", 1L), cache, db);
+
+    assertEquals(Long.valueOf(100L), cache.get("Person"));
+    verify(personClass, times(1)).approximateCount(db);
+  }
+
+  // =========================================================================
+  // walkLinearChainExtension — multi-hop walk termination
+  //
+  // The walk stops on five conditions: the hop budget, a branch point, a
+  // back-edge into the DFS schedule, a loop back into the walk's own
+  // crossed edges, and a continuation that is not a chain. End-to-end MATCH
+  // queries reach the first two; the rest need a synthesised pattern graph.
+  // =========================================================================
+
+  /**
+   * Walks a linear chain to its natural end when the hop budget allows.
+   * Baseline for the termination tests below — each of those cuts the same
+   * chain short in a different way, and without this they could all pass
+   * against a walk that returns nothing.
+   */
+  @Test
+  public void walkLinearChain_runsToTheEndOfTheChain() {
+    var chain = buildLinearChain(4);
+
+    var hops = walkFrom(chain, 10, Set.of());
+
+    // Sub-chain 1 is the caller's first hop; the walk contributes 2..4.
+    assertThat(hops).hasSize(3);
+    assertThat(hops.get(0).downstreamAlias()).isEqualTo("v2");
+    assertThat(hops.get(2).downstreamAlias()).isEqualTo("v4");
+  }
+
+  /**
+   * The hop budget truncates the walk at exactly {@code remainingHops}
+   * sub-chains even though the graph could continue. Kills an off-by-one in
+   * the {@code hops.size() < remainingHops} bound.
+   */
+  @Test
+  public void walkLinearChain_stopsAtTheHopBudget() {
+    var chain = buildLinearChain(4);
+
+    assertThat(walkFrom(chain, 1, Set.of())).hasSize(1);
+    assertThat(walkFrom(chain, 2, Set.of())).hasSize(2);
+    assertThat(walkFrom(chain, 0, Set.of())).isEmpty();
+    assertThat(walkFrom(chain, -1, Set.of())).isEmpty();
+  }
+
+  /**
+   * A branch point ends the walk: the cost fold has no single continuation
+   * to attribute the downstream selectivity to. The extra edge is added to
+   * v2, so hop 2 is collected and hop 3 is not.
+   */
+  @Test
+  public void walkLinearChain_stopsAtABranchPoint() {
+    var chain = buildLinearChain(4);
+    // v2 now fans out to its own third sub-chain plus an unrelated edge.
+    var extra = new PatternEdge();
+    extra.item = mock(SQLMatchPathItem.class);
+    extra.out = chain.vertices().get(1);
+    extra.in = new PatternNode();
+    chain.vertices().get(1).out.add(extra);
+
+    assertThat(walkFrom(chain, 10, Set.of())).hasSize(1);
+  }
+
+  /**
+   * An edge step already in the DFS schedule ends the walk. Folding across
+   * it would double-count selectivity the scheduled edge already carries in
+   * its own cost.
+   */
+  @Test
+  public void walkLinearChain_stopsOnBackEdgeIntoScheduledEdgeStep() {
+    var chain = buildLinearChain(4);
+    // Third sub-chain's edge step is already scheduled.
+    var visited = Set.of(chain.edgeSteps().get(2));
+
+    assertThat(walkFrom(chain, 10, visited)).hasSize(1);
+  }
+
+  /**
+   * The vertex step of a sub-chain is guarded separately from its edge
+   * step. Here the edge step is fresh but its {@code inV} partner is already
+   * scheduled, which exercises the second of the two two-set checks — a
+   * mutation that dropped it would still pass the edge-step test above.
+   */
+  @Test
+  public void walkLinearChain_stopsOnBackEdgeIntoScheduledVertexStep() {
+    var chain = buildLinearChain(4);
+    var visited = Set.of(chain.vertexSteps().get(2));
+
+    assertThat(walkFrom(chain, 10, visited)).hasSize(1);
+  }
+
+  /**
+   * A chain that loops back onto an edge this walk already crossed ends the
+   * walk. Distinct from the scheduled-edge guard: the DFS-level set is empty
+   * here, so only the walk-local {@code chainEdges} set can stop it.
+   */
+  @Test
+  public void walkLinearChain_stopsWhenTheChainLoopsBackOnItself() {
+    var chain = buildLinearChain(2);
+    // v2's only continuation is the first hop's own edge step, which the
+    // walk seeded into chainEdges before the loop started.
+    chain.vertices().get(1).out.add(chain.edgeSteps().get(0));
+
+    assertThat(walkFrom(chain, 10, Set.of())).hasSize(1);
+  }
+
+  /**
+   * A continuation that is not an edge-method chain ends the walk. The third
+   * sub-chain's vertex step is rewritten to {@code out}, which
+   * detectChainShape rejects.
+   */
+  @Test
+  public void walkLinearChain_stopsOnANonChainContinuation() {
+    var chain = buildLinearChain(4);
+    var method = mock(SQLMethodCall.class);
+    stubMethodName(method, "out");
+    var item = mock(SQLMatchPathItem.class);
+    when(item.getMethod()).thenReturn(method);
+    chain.vertexSteps().get(2).item = item;
+
+    assertThat(walkFrom(chain, 10, Set.of())).hasSize(1);
+  }
+
+  /**
+   * The walk never mutates the caller's DFS state. It tracks its own
+   * crossed edges in a local set precisely so the sort loop's
+   * {@code visitedEdges} stays authoritative for scheduling.
+   */
+  @Test
+  public void walkLinearChain_leavesTheCallersVisitedSetUntouched() {
+    var chain = buildLinearChain(4);
+    Set<PatternEdge> visited = new LinkedHashSet<>();
+    visited.add(chain.edgeSteps().get(0));
+
+    walkFrom(chain, 10, visited);
+
+    assertThat(visited).containsExactly(chain.edgeSteps().get(0));
+  }
+
+  /**
+   * Each hop's fan-out denominator is the previous hop's downstream class,
+   * not the class the walk started from. Kills a mutation that pinned
+   * {@code sourceClass} to the initial value: hop 2 would then divide the
+   * hop-3 edge count by the wrong vertex population and mis-cost every
+   * chain deeper than two hops.
+   */
+  @Test
+  public void walkLinearChain_reseedsSourceClassFromEachDownstreamVertex() {
+    var chain = buildLinearChain(3);
+    var aliasClasses = Map.of("v1", "ClassOne", "v2", "ClassTwo", "v3", "ClassThree");
+
+    var hops = MatchExecutionPlanner.walkLinearChainExtension(
+        chain.vertices().get(0), "ClassOne", 10, Set.of(),
+        chain.edgeSteps().get(0), chain.vertexSteps().get(0),
+        aliasClasses, db, new HashMap<>());
+
+    assertThat(hops).hasSize(2);
+    assertThat(hops.get(0).edgeStepSourceClass()).isEqualTo("ClassOne");
+    assertThat(hops.get(0).downstreamClass()).isEqualTo("ClassTwo");
+    assertThat(hops.get(1).edgeStepSourceClass()).isEqualTo("ClassTwo");
+    assertThat(hops.get(1).downstreamClass()).isEqualTo("ClassThree");
+  }
+
+  // ── walkLinearChainExtension test helpers ──
+
+  /**
+   * A synthesised linear chain of {@code subChains} consecutive
+   * {@code outE→inV} pairs: {@code v0 -e1-> i1 -s1-> v1 -e2-> i2 -s2-> v2 …}.
+   * Index 0 of each list belongs to the first sub-chain, which the sort loop
+   * folds itself; the walk starts from {@code vertices[0]} and contributes
+   * the rest.
+   */
+  private record LinearChain(
+      PatternNode start,
+      List<PatternEdge> edgeSteps,
+      List<PatternEdge> vertexSteps,
+      List<PatternNode> vertices) {
+  }
+
+  private LinearChain buildLinearChain(int subChains) {
+    var start = new PatternNode();
+    start.alias = "v0";
+    var edgeSteps = new ArrayList<PatternEdge>();
+    var vertexSteps = new ArrayList<PatternEdge>();
+    var vertices = new ArrayList<PatternNode>();
+
+    var current = start;
+    for (int i = 1; i <= subChains; i++) {
+      var intermediate = new PatternNode();
+      intermediate.alias = "i" + i;
+      var target = new PatternNode();
+      target.alias = "v" + i;
+
+      var edgeMethod = mock(SQLMethodCall.class);
+      stubMethodName(edgeMethod, "outE");
+      var fixture = buildChain(edgeMethod, "inV", current, intermediate, target);
+
+      edgeSteps.add(fixture.firstEdge());
+      vertexSteps.add(fixture.downstreamEdge());
+      vertices.add(target);
+      current = target;
+    }
+    return new LinearChain(start, edgeSteps, vertexSteps, vertices);
+  }
+
+  /**
+   * Runs the walk from the first sub-chain's downstream vertex, the way
+   * {@code applyChainFold} seeds it. Uses an empty {@code aliasClasses} so
+   * class inference is out of scope for the termination tests.
+   */
+  private List<MatchExecutionPlanner.ChainHop> walkFrom(
+      LinearChain chain, int remainingHops, Set<PatternEdge> visitedEdges) {
+    return MatchExecutionPlanner.walkLinearChainExtension(
+        chain.vertices().get(0), null, remainingHops, visitedEdges,
+        chain.edgeSteps().get(0), chain.vertexSteps().get(0),
+        Map.of(), db, new HashMap<>());
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchTestWhereBuilders.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchTestWhereBuilders.java
@@ -1,0 +1,39 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLAndBlock;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCompareOperator;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCondition;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+
+/**
+ * Shared WHERE-clause AST builders for MATCH planner unit tests. Tests in this
+ * package construct {@link SQLWhereClause} fixtures directly against the
+ * planner instead of parsing SQL, to keep the tests co-located with the code
+ * under test and to isolate planner behaviour from parser changes.
+ */
+final class MatchTestWhereBuilders {
+
+  private MatchTestWhereBuilders() {
+  }
+
+  /**
+   * Builds an AND-wrapped single-condition WHERE clause with the given binary
+   * operator and empty-expression operands. Use when the test cares only about
+   * the filter's top-level shape (AND with one binary condition of a specific
+   * operator), not about the identifier or value on either side.
+   */
+  static SQLWhereClause makeWhereWithOperator(SQLBinaryCompareOperator op) {
+    var condition = new SQLBinaryCondition(-1);
+    condition.setLeft(new SQLExpression(-1));
+    condition.setOperator(op);
+    condition.setRight(new SQLExpression(-1));
+
+    var andBlock = new SQLAndBlock(-1);
+    andBlock.getSubBlocks().add(condition);
+
+    var where = new SQLWhereClause(-1);
+    where.setBaseExpression(andBlock);
+    return where;
+  }
+}

--- a/docs/adr/match-edge-chain-cost-fix/adr.md
+++ b/docs/adr/match-edge-chain-cost-fix/adr.md
@@ -1,0 +1,508 @@
+# MATCH Edge-Method Chain Cost Aggregation — Architecture Decision Record
+
+YouTrack issue: [YTDB-643](https://youtrack.jetbrains.com/issue/YTDB-643)
+
+## Summary
+
+The MATCH execution planner now folds the downstream vertex's `WHERE`
+selectivity (and, optionally, the selectivity / fan-out of subsequent
+linear hops) into the first edge's cost during the sort phase of
+`MatchExecutionPlanner.updateScheduleStartingAt`. The pattern graph,
+parser, runtime `MatchStep` pipeline, and public API are unchanged.
+
+Before this change, branches written with the edge-method pattern
+`.outE('X').inV(){where: …}` (and its `inE→outV` / `bothE→bothV`
+variants) sorted as if they had no filter, because the first edge's
+target is a synthetic intermediate edge alias (no `WHERE`, no class)
+and the second edge's method is not a recognised direction. Branches
+with very different selectivities sorted as ties, and the broad branch
+(inserted first) won via TimSort's stable-sort tiebreaker. After the
+change, the planner schedules the more selective branch first,
+matching the behaviour already in place for the equivalent
+single-step pattern `.out('X'){where: …}`.
+
+The fold is enabled by default (`QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 10`),
+clamped to `[0, 1000]`. Operators can downgrade to legacy single-hop
+behaviour with `= 1` or disable the fold entirely with `= 0`.
+
+## Goals
+
+- Close the cost-model gap between `.out('X'){where: p}` and
+  `.outE('X').inV(){where: p}` so the MATCH planner schedules
+  competing branches by their full chain selectivity, not by the
+  single-hop leading edge.
+- Preserve runtime semantics — the result set of any MATCH query is
+  identical before and after the fold; only `EXPLAIN` ordering
+  changes.
+- Keep the change strictly additive: the pattern graph, parser, and
+  `MatchStep` pipeline are untouched; the fold can be disabled at
+  runtime via `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 0` for emergency
+  rollback without a code change.
+- Cover the three direction variants (`outE→inV`, `inE→outV`,
+  `bothE→bothV`) and stay correct under user-named intermediate
+  aliases with their own `WHERE` (independence multiplication).
+- Extended during execution: the fold scales past the immediate
+  downstream vertex into multi-hop linear chains, bounded by a
+  knob and structural termination so it cannot pathologically
+  inflate plan-construction time.
+
+## Constraints
+
+- **Pattern graph, runtime, parser, and public APIs unchanged** —
+  this remains a planner-only fix. `Pattern.addExpression`,
+  `PatternEdge`, `PatternNode`, `SQLMatchPathItem`, and the
+  `MatchStep` pipeline all stay as they were.
+- **Independence multiplication only** — when the intermediate edge
+  alias has its own `WHERE`, the chain fold multiplies the downstream
+  selectivity on top. Same heuristic as
+  `estimateCompoundAndSelectivity`; correlated edge/vertex predicates
+  slightly under-estimate the true cost (acceptable; documented).
+- **Fallback on unknown cost** — if the first edge's
+  `estimateEdgeCost` returns `Double.MAX_VALUE`, the sort-loop's
+  finite-cost gate skips both the existing
+  `applyTargetSelectivity` call and the chain fold, preserving the
+  stable-sort tiebreaker for unestimated edges. The class-forced
+  overload also short-circuits a `MAX_VALUE` input through every
+  null/missing-class path as defense-in-depth (pinned by unit tests).
+- **Spotless compliance** and **coverage gate** (85% line / 70%
+  branch on changed lines) enforced by CI.
+
+## Architecture Notes
+
+### Component Map
+
+```mermaid
+flowchart LR
+    GETSCHED["getTopologicalSortedSchedule()"]
+    USA["updateScheduleStartingAt()<br/>(sort loop)"]
+    EEC[estimateEdgeCost]
+    ATS[applyTargetSelectivity]
+    ATSR[applyTargetSelectivityWithResolvedClass]
+    ACS[applyClassSelectivity]
+    RTC[resolveTargetClass]
+    RCT[resolveChainedTarget]
+    DCS[detectChainShape]
+    LDC[lookupOrDetectChainShape]
+    ACF[applyChainFold]
+    WLE[walkLinearChainExtension]
+    LVC[linkedVertexClassForVertexStep]
+    LLV[lookupLinkedVertexClass]
+    ICE[inferClassFromEdgeSchema]
+    EMF[estimateMethodFanOut]
+    GC["GlobalConfiguration<br/>QUERY_MATCH_CHAIN_FOLD_MAX_HOPS"]
+    CCFMH[clampChainFoldMaxHops]
+    CACHE[("chainShapeCache:<br/>Map&lt;PatternEdge, ChainedTarget&gt;")]
+    PE[PatternEdge]
+    PN[PatternNode]
+
+    GETSCHED --> GC
+    GETSCHED --> CCFMH
+    GETSCHED --> CACHE
+    GETSCHED --> USA
+    USA --> EEC
+    USA --> ATS
+    ATS --> RTC
+    ATS --> ACS
+    USA --> ACF
+    ACF --> LDC
+    ACF --> ATSR
+    ACF --> WLE
+    ACF --> EMF
+    LDC --> DCS
+    LDC --> CACHE
+    DCS --> LVC
+    LVC --> LLV
+    ICE --> LVC
+    ATSR --> ACS
+    DCS --> PE
+    DCS --> PN
+    WLE --> LDC
+```
+
+- **`MatchExecutionPlanner`** owns every node above except
+  `GlobalConfiguration` (api module) and `PatternEdge` /
+  `PatternNode` (read-only structural classes).
+- **Sort-loop entry point.** `updateScheduleStartingAt` runs the
+  per-edge cost computation. It calls the existing
+  `applyTargetSelectivity` on the immediate `neighbor.alias` (so
+  user-named intermediate edge aliases with their own `WHERE` keep
+  contributing), then calls the new `applyChainFold` when the knob
+  is `>= 1`, then `applyDepthMultiplier`. The chain fold is gated
+  inside the existing finite-cost branch so the visited-neighbor
+  zero-cost path and the `MAX_VALUE` short-circuit are unaffected.
+- **`applyTargetSelectivityWithResolvedClass`** is the class-forced
+  sibling of the existing `applyTargetSelectivity`. It exists because
+  the chain helper has already computed the class via chain-aware
+  precedence; re-inferring with the outer edge's direction would pick
+  the wrong endpoint for `inE→outV`. The shared body lives in
+  `applyClassSelectivity`, called by both overloads.
+- **`resolveChainedTarget`** is the public-facing chain detector
+  (`@Nullable`-returning, not `Optional`-returning). It composes
+  `detectChainShape` (pure structural rule, cacheable) with the
+  dynamic visited-edge check.
+- **`applyChainFold`** is the unified entry point for the fold.
+  Composes single-hop fold with the multi-hop walk.
+- **`walkLinearChainExtension`** iteratively extends past the first
+  hop while `currentVertex.out.size() == 1`, the structural rule
+  holds, no back-edge is taken, and `remainingHops > 0`. Uses a
+  walk-local `chainEdges` set on top of the DFS-level `visitedEdges`
+  so the caller's state is never mutated.
+- **`linkedVertexClassForVertexStep` / `lookupLinkedVertexClass`**
+  are the single source of truth for "edge class → linked vertex
+  class on a given side." Both the chain fold's class inference and
+  the standalone `inV` / `outV` branch of `inferClassFromEdgeSchema`
+  go through them, so the two paths cannot drift.
+- **`chainShapeCache`** memoises the structural-detection result
+  per first-edge identity, allocated once per plan in
+  `getTopologicalSortedSchedule` and threaded through every
+  `updateScheduleStartingAt` call.
+
+### Decision Records
+
+#### D1: Chain-cost aggregation at sort time, not pattern collapsing
+
+- **Alternatives considered:** (a) collapse `outE('X').inV()` into
+  one `PatternEdge` during `Pattern.addExpression`; (b) teach the
+  runtime a "combined hop" primitive that collapses at execution
+  time; (c) aggregate cost at sort time (chosen).
+- **Rationale:** Collapsing breaks user-named intermediate edge
+  aliases (referenced from `RETURN`, `ORDER BY`, `$matched`) and
+  forces a composite edge-filter representation through the parser,
+  planner, and runtime. The runtime `MatchStep` pipeline already
+  executes the pattern correctly — the bug is in cost ordering, not
+  execution. Sort-time aggregation is confined to the planner sort
+  loop, composes cleanly with the existing multiplicative
+  selectivity model, and is strictly additive: removing the
+  call-site gate recovers the pre-fix behaviour.
+- **Outcome:** Implemented in `applyChainFold` inside
+  `MatchExecutionPlanner.updateScheduleStartingAt`'s sort loop. No
+  parser, pattern, or runtime change.
+- **Risks:** Relies on the two `PatternEdge`s being consecutive in
+  DFS order and on the recursive DFS pass into the intermediate
+  alias seeing only one candidate edge (so its `MAX_VALUE` cost is
+  irrelevant). Both are properties of the existing pattern-graph
+  topology; documented in `design-final.md`.
+
+#### D2: Structural chain detection rule
+
+- **Alternatives considered:** (a) prefix-check the auto-generated
+  intermediate alias name; (b) add a parser flag on `PatternNode`
+  marking edge-record aliases; (c) pure structural check (chosen).
+- **Rationale:** The structural signature is unambiguous —
+  TinkerPop vertex steps (`inV` / `outV` / `bothV`) only follow an
+  edge step. Avoids coupling to the parser's naming convention or
+  adding new state to the pattern graph. The `neighbor.in.size() == 1`
+  + identity guard rejects the fragment-join case (a user reusing
+  `{as: e}` across two MATCH fragments) before it can fold the
+  filter against the wrong alias.
+- **Outcome:** Implemented in `detectChainShape` with five clauses
+  (item null-check; first-method whitelist `outE` / `inE` / `bothE`;
+  `neighbor.out.size() == 1` not visited; `neighbor.in.size() == 1`
+  identity-equal to `edge`; second-method whitelist `inV` / `outV` /
+  `bothV`). `resolveChainedTarget` adds the dynamic visited-edge
+  check on top.
+- **Risks:** New edge-traversal methods that should also be
+  chain-aware (e.g. a hypothetical `outE().filter(…).inV()`) would
+  require widening the whitelist. The rule lives in one helper, so
+  future-proofing is localised.
+
+#### D3: Independence multiplication with intermediate filters
+
+- **Alternatives considered:** (a) skip the fold when the
+  intermediate alias has its own `WHERE` / class (avoid
+  double-counting); (b) multiply the intermediate filter by the
+  downstream vertex selectivity (chosen).
+- **Rationale:** `applyTargetSelectivity` already multiplies base
+  cost by the intermediate's filter when present. The fold adds a
+  second multiplicative factor for the downstream vertex's filter.
+  This is the correct algebraic extension under the independence
+  assumption already used by `estimateCompoundAndSelectivity` — not
+  double-counting.
+- **Outcome:** The sort loop calls the existing
+  `applyTargetSelectivity` (intermediate alias) **and** the chain
+  fold (downstream alias) sequentially. Multiplication commutes;
+  call order does not matter; each call short-circuits to `baseCost`
+  when its alias has no filter / class / row estimate. The
+  pre-existing test `testEdgeAliasSchedulingOrder` (which uses an
+  intermediate alias with its own `WHERE`) continued to pass without
+  modification, proving the intermediate filter's contribution is
+  preserved.
+- **Risks:** Independence is a heuristic; correlated predicates
+  under-estimate true cost. Same approximation already accepted
+  elsewhere; documented.
+
+#### D4: Class-forced overload, not a mutable parameter
+
+- **Alternatives considered:** (a) add a new parameter to the
+  existing `applyTargetSelectivity` to carry a pre-resolved class;
+  (b) introduce a sibling overload (chosen).
+- **Rationale:** The existing 8-arg overload's `isOutbound` flag is
+  consumed only by `resolveTargetClass`, which the chain-aware path
+  bypasses. Adding a parameter would either be dead at the
+  chain-aware site or force callers to thread a meaningless flag.
+  An overload keeps each signature minimal: the 8-arg form does
+  class resolution, the 6-arg form does not.
+- **Outcome:** `applyTargetSelectivityWithResolvedClass` (6-arg).
+  The shared body (`applyClassSelectivity`) is private and accepts
+  a non-null class; null-guards are the callers' responsibility.
+  The 8-arg form's existing call site at the sort loop produces
+  byte-identical results post-refactor.
+
+#### D5: `@Nullable` return type instead of `Optional<ChainedTarget>`
+
+- **Alternatives considered:** (a) return `Optional<ChainedTarget>`
+  (originally proposed in the implementation plan); (b) return
+  `@Nullable ChainedTarget` (chosen during execution).
+- **Rationale:** The surrounding planner style uses `@Nullable`
+  consistently — `resolveTargetClass`, `inferClassFromEdgeSchema`,
+  `linkedVertexClassForVertexStep`, `lookupLinkedVertexClass` all
+  return nullable references. Routing the new helper through
+  `Optional` would have been the single dissenter, and would have
+  forced an `.isPresent()` / `.get()` pair in the hot sort loop
+  with no semantic gain. JetBrains `@Nullable` annotation gives the
+  same null-safety hint to IntelliJ and the Errorprone-equivalent
+  static analysis already in CI.
+- **Outcome:** `@Nullable static ChainedTarget resolveChainedTarget(...)`.
+
+#### D6: Multi-hop linear extension with knob and structural cache
+
+- **Alternatives considered:** (a) keep the fold strictly
+  single-hop; (b) propagate selectivity across all reachable hops
+  with full pattern traversal; (c) iterative linear extension with
+  a structural cache and a depth knob (chosen).
+- **Rationale:** Single-hop closes the most common gap but leaves
+  multi-step chains (e.g. `person.outE('Wrote').inV().outE('HasTag')
+  .inV(){where: name = 'targetTag'}`) sorting as ties when the
+  selectivity hides past the first hop. Full propagation requires
+  reasoning about branch points and cycles — the same complexity
+  that motivated the planner's per-edge cost model in the first
+  place. Linear extension is the sweet spot: it walks only as long
+  as the chain stays a single linear sequence and terminates at
+  branch points, visited edges, or the depth knob. The structural
+  rule that makes single-hop safe applies at every step of the
+  walk; correctness follows directly from D2.
+- **Outcome:** `applyChainFold` composes
+  `lookupOrDetectChainShape` (the cached structural detection) with
+  `walkLinearChainExtension`. The walk uses a two-set visited check
+  (DFS-level `visitedEdges` plus a walk-local `chainEdges`) to
+  avoid mutating DFS state. `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS`
+  (default 10, clamped to `[0, 1000]`) bounds the walk; values `<=
+  1` short-circuit to single-hop semantics; `0` disables the fold
+  entirely as the rollback safety valve.
+- **Risks:** Pathological knob values (`Integer.MAX_VALUE`,
+  negatives) could overflow the walk's bookkeeping arithmetic.
+  Mitigated by `clampChainFoldMaxHops`, which silently floors
+  negatives to 0 and emits a one-shot WARN per unique
+  out-of-range value above the ceiling. Pinned by an integration
+  test that runs the fold under `Integer.MAX_VALUE`,
+  `Integer.MIN_VALUE`, and a large in-range value.
+
+#### D7: Per-plan structural cache with negative-result memoisation
+
+- **Alternatives considered:** (a) recompute the structural answer
+  on every sort-loop iteration; (b) `Map.computeIfAbsent` keyed by
+  `PatternEdge`; (c) explicit `containsKey` / `put` keyed by
+  `PatternEdge` (chosen).
+- **Rationale:** The structural answer for any
+  given `PatternEdge` is stable for the lifetime of one plan —
+  it depends only on the pattern graph plus per-plan
+  `aliasClasses` / `session`. Recomputation is wasted work on the
+  hot path. `computeIfAbsent` cannot represent a cached
+  known-not-chain answer (`null` value) because it would re-run the
+  detector each time. Explicit `containsKey` disambiguates "cache
+  miss" from "cached negative."
+- **Outcome:** `chainShapeCache: Map<PatternEdge, ChainedTarget>`
+  allocated in `getTopologicalSortedSchedule`, threaded through
+  `updateScheduleStartingAt` and the multi-hop walk. The dynamic
+  visited-edge check stays outside the cache so a chain whose
+  vertex-step has been scheduled correctly skips the fold.
+
+#### D8: Single source of truth for vertex-step class inference
+
+- **Alternatives considered:** (a) duplicate the edge-class →
+  linked-vertex-class lookup in the chain fold and in
+  `inferClassFromEdgeSchema`; (b) extract a shared helper (chosen).
+- **Rationale:** Two callers resolving the same mapping
+  ("for an `inV` step against edge class `X`, the linked vertex
+  class is `X.in`'s linked class") must not drift. A future
+  variant (e.g. a new vertex-step name) should require editing
+  exactly one site.
+- **Outcome:** `linkedVertexClassForVertexStep` (public,
+  `@Nullable`-returning) handles vertex-step-name → property-name
+  mapping; `lookupLinkedVertexClass` (private) handles the schema
+  walk. Both the chain fold's precedence-2 fallback and
+  `inferClassFromEdgeSchema`'s `inV` / `outV` branch route through
+  them. `lookupLinkedVertexClass`'s contract was tightened to
+  accept `@Nullable DatabaseSessionEmbedded` directly (was
+  `CommandContext` plus pre-existing call sites that pulled the
+  session out manually); pre-existing callers were updated to the
+  new contract.
+
+### Invariants & Contracts
+
+- For every branch from a source node, the scheduler computes the
+  same chain cost whether the branch uses `.out('X'){where: p}` or
+  `.outE('X').inV(){where: p}`, given identical data — modulo the
+  D3 independence-multiplication caveat for correlated predicates.
+- A branch that produces strictly fewer intermediate rows than
+  another at runtime is never scheduled after that other branch,
+  given known selectivity estimates. Pinned by the
+  selective-before-broad ordering assertions in the chain-cost
+  regression tests.
+- Runtime result set for any tested MATCH query is identical
+  before and after the fix. Pinned by the `assertEquals(expected,
+  result.size())` assertions on the Cartesian-product size in
+  every chain-cost regression test.
+- The chain fold is a no-op when the downstream vertex has no
+  filter, no explicit class, and no `estimatedRootEntries` entry
+  — `applyTargetSelectivityWithResolvedClass` short-circuits to
+  `baseCost` through every null/missing-class branch. Pinned
+  through the unit suite's short-circuit-table tests, including
+  `MAX_VALUE` preservation through the null-class and
+  no-filter / no-estimate paths.
+- The chain fold is fully disabled when
+  `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 0` — the sort-loop call site's
+  `chainFoldMaxHops >= 1` gate skips `applyChainFold` entirely.
+  This is the production rollback path.
+
+### Integration Points
+
+- `MatchExecutionPlanner.getTopologicalSortedSchedule` reads
+  `GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS` once,
+  clamps via `clampChainFoldMaxHops`, allocates the structural
+  cache, and threads both into `updateScheduleStartingAt`.
+- `updateScheduleStartingAt` calls `applyChainFold` inside the
+  finite-cost branch immediately after the existing
+  `applyTargetSelectivity` call and before
+  `applyDepthMultiplier`.
+- `applyTargetSelectivityWithResolvedClass` is the new public-ish
+  entry point used by the chain fold; the existing
+  `applyTargetSelectivity` continues to handle single-hop edges.
+  Both delegate to the private `applyClassSelectivity`.
+- `linkedVertexClassForVertexStep` (with
+  `lookupLinkedVertexClass` underneath) is shared between the
+  chain fold's class inference and the standalone vertex-step
+  branch of `inferClassFromEdgeSchema`.
+- `EXPLAIN` output ordering is the observable contract used by
+  the integration regression suite (`MatchEdgeMethodChainCostTest`,
+  `MatchEdgeMethodInferenceAndAbortTest`).
+
+### Non-Goals
+
+- Collapsing the pattern graph or merging `PatternEdge`s.
+- Changing the runtime execution order independently of the
+  schedule.
+- Teaching `parseDirection` about `inV` / `outV` / `bothV`.
+- Per-edge `WHERE` selectivity propagation across pattern branch
+  points or back-edges. The walk terminates structurally at the
+  first branch / back-edge / visited edge.
+- Joint distributions for correlated predicates. The fold uses the
+  independence assumption already used elsewhere in the planner.
+
+## Key Discoveries
+
+- **`@Nullable` is the planner's idiom, not `Optional`.** The
+  initial helper signature drafted in the implementation plan
+  used `Optional<ChainedTarget>`. Aligning with the surrounding
+  planner code (`resolveTargetClass`,
+  `inferClassFromEdgeSchema`, `linkedVertexClassForVertexStep`)
+  produced a cleaner sort-loop call site and avoided allocating
+  an `Optional` wrapper on the hot path.
+
+- **`isPresent()` / `.get()` on Optional in a tight loop is worth
+  caching.** When the helper still returned `Optional`, an early
+  reviewer flagged the repeated `chain.isPresent() && chain.get().…`
+  pattern in the sort loop; extracting `var target = chain.get();`
+  removed the duplication. The `@Nullable` migration that followed
+  obviated the issue entirely — `target != null` is the natural
+  shape.
+
+- **Errorprone's `InvalidParam` matcher flags
+  `{@code paramName}` in Javadoc that resembles a parameter name.**
+  When the new overload's Javadoc mentioned `{@code resolveTargetClass}`,
+  the build failed because Errorprone considered the token similar
+  to the `preResolvedTargetClass` parameter. Switching to
+  `{@link #resolveTargetClass}` disambiguates parameter references
+  from method references and silences the false positive — a useful
+  Javadoc pattern to remember in this codebase.
+
+- **The fragment-join negative case is already blocked by
+  `neighbor.in.size() == 1`, but the identity guard
+  (`neighbor.in.iterator().next() == edge`) is worth keeping.**
+  The size-1 guard rejects the common case of a user reusing
+  `{as: e}` across two MATCH fragments. The identity guard is
+  defense-in-depth against a future pattern-construction
+  refactoring that produces an intermediate with a single
+  incoming edge that is not `edge` itself. Both clauses are
+  cheap; together they pin the rejection at the structural level.
+
+- **The `MAX_VALUE` short-circuit gate is structurally unreachable
+  through the chain-fold integration**, because the chain rule
+  restricts the first hop to `outE` / `inE` / `bothE`, all of which
+  `parseDirection` resolves to a non-null `Direction`, so
+  `estimateEdgeCost` always returns a finite value. The
+  invariant is still pinned by unit tests on the
+  `applyTargetSelectivityWithResolvedClass` short-circuit paths
+  — defense-in-depth against a future regression that bypasses
+  the gate (e.g. by hoisting the fold outside the
+  `if (cost < Double.MAX_VALUE)` branch).
+
+- **`String.equalsIgnoreCase` is faster than `toLowerCase` +
+  `equals` on the sort-loop hot path.** The chain-detection rule is
+  invoked on every candidate edge, including the very common
+  single-step methods (`.out` / `.in` / `.both`).
+  `equalsIgnoreCase` short-circuits on length mismatch, so the
+  whitelist check rejects single-step methods without a
+  `toLowerCase` allocation. Only on a positive match does the
+  code take the lower-cased canonical form for downstream
+  inference.
+
+- **Stable-sort tiebreaker is the operative semantics for
+  unestimated chains.** When the first-edge cost is `MAX_VALUE`
+  (e.g. an edge class without `in` / `out` linked-property
+  metadata), the sort-loop's `cost < MAX_VALUE` gate skips both
+  the existing `applyTargetSelectivity` call and the chain fold.
+  TimSort then preserves insertion order. Tests of this branch
+  must therefore assert insertion-order ordering, not
+  selective-before-broad.
+
+- **Negative-result caching is a real hot-path win.**
+  `lookupOrDetectChainShape` memoises both positive and negative
+  results because the very common case is "edge is not the start
+  of a chain." `Map.computeIfAbsent` cannot represent a cached
+  `null` value (it re-runs the function), so the cache uses
+  explicit `containsKey` / `put`.
+
+- **Operator-error knob configurations need explicit clamping
+  with a one-shot WARN.** The multi-hop walk's bookkeeping
+  arithmetic (`2 * remainingHops + 2` allocation hint) goes
+  negative under `Integer.MAX_VALUE`. Silent clamping would leave
+  operators debugging a fold depth that did not match their
+  configuration; the `getAndSet`-guarded WARN per unique
+  out-of-range value gives a clear signal without spamming logs
+  on a server churning through plans.
+
+- **Centralising the edge-schema → linked-vertex-class lookup is
+  load-bearing for correctness.** Two paths now resolve `inV` /
+  `outV` against an edge schema: the chain fold's precedence-2
+  fallback and `inferClassFromEdgeSchema`'s `inV` / `outV` branch.
+  Without a shared helper, a future addition (e.g. supporting a
+  hypothetical new vertex-step name) would have to update two
+  sites in lock step. Routing both through
+  `linkedVertexClassForVertexStep` reduces the lock-step risk to
+  one site.
+
+- **Existing ordering tests must be re-verified, not just the new
+  ones.** When the cost-fold landed, the pre-existing
+  `testEdgeAliasSchedulingOrder` assertion (`workEdge` before
+  `tag`) under
+  `.outE('SOWorkAt'){as: workEdge, where: workFrom = 2015}.inV()`
+  could in principle have flipped. It did not — the intermediate
+  alias `workEdge`'s filter is still applied by the preserved
+  `applyTargetSelectivity` call, and the fold's call on the
+  downstream alias `company` short-circuits because `company`
+  has no `class:`, no `WHERE`, no `estimatedRootEntries` entry.
+  A grep sweep over `core/src/test` for `{selectiveTag}`,
+  `{broadTag}`, `executionPlanAsString`, and `.outE.inV` /
+  `.inE.outV` patterns is the right pre-merge verification step
+  for this kind of cost-model change.

--- a/docs/adr/match-edge-chain-cost-fix/adr.md
+++ b/docs/adr/match-edge-chain-cost-fix/adr.md
@@ -369,16 +369,15 @@ flowchart LR
   `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 0` — the sort-loop call site's
   `chainFoldMaxHops >= 1` gate skips `applyChainFold` entirely.
   This is the production rollback path.
-- **Plan-cache caveat.** The knob is read once per plan construction,
-  and `YqlExecutionPlanCache` keys on statement text and invalidates
-  only on schema, index, function, sequence and storage-configuration
-  updates. A `GlobalConfiguration` write therefore does not re-plan
-  statements already in the cache: hot queries keep their old schedule
-  until an eviction. An operator rolling back with `= 0` needs a cache
-  eviction — any schema change, or a restart — for the change to reach
-  queries already running. `MatchEdgeMethodChainCostTest`'s
-  `setChainFoldMaxHops` helper evicts explicitly for this reason, and
-  its Javadoc is the in-repo record of the constraint.
+- **In-process knob changes need a cache eviction.** The knob is read
+  once per plan construction, and `YqlExecutionPlanCache` invalidates on
+  schema, index, function, sequence and storage-configuration updates but
+  not on a `GlobalConfiguration` write. Statements already cached keep
+  their schedule. This does not reach production, where configuration is
+  start-time only and a restart empties the cache regardless. It does
+  reach tests, which change the knob in-process: the
+  `setChainFoldMaxHops` helper evicts explicitly, because without it a
+  second query under a new knob value is handed the first value's plan.
 
 ### Integration Points
 

--- a/docs/adr/match-edge-chain-cost-fix/adr.md
+++ b/docs/adr/match-edge-chain-cost-fix/adr.md
@@ -22,8 +22,12 @@ matching the behaviour already in place for the equivalent
 single-step pattern `.out('X'){where: …}`.
 
 The fold is enabled by default (`QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 10`),
-clamped to `[0, 1000]`. Operators can downgrade to legacy single-hop
-behaviour with `= 1` or disable the fold entirely with `= 0`.
+clamped to `[0, 1000]`. Setting `= 1` restricts the fold to the first
+hop's downstream vertex; `= 0` skips `applyChainFold` altogether and is
+the only value that restores the schedule the planner produced before the
+fold existed. Both take effect
+at plan-construction time only — see the plan-cache caveat under
+Rollback.
 
 ## Goals
 
@@ -35,9 +39,9 @@ behaviour with `= 1` or disable the fold entirely with `= 0`.
   identical before and after the fold; only `EXPLAIN` ordering
   changes.
 - Keep the change strictly additive: the pattern graph, parser, and
-  `MatchStep` pipeline are untouched; the fold can be disabled at
-  runtime via `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 0` for emergency
-  rollback without a code change.
+  `MatchStep` pipeline are untouched; the fold can be disabled via
+  `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 0` for emergency rollback without
+  a code change.
 - Cover the three direction variants (`outE→inV`, `inE→outV`,
   `bothE→bothV`) and stay correct under user-named intermediate
   aliases with their own `WHERE` (independence multiplication).
@@ -197,10 +201,11 @@ flowchart LR
   filter against the wrong alias.
 - **Outcome:** Implemented in `detectChainShape` with five clauses
   (item null-check; first-method whitelist `outE` / `inE` / `bothE`;
-  `neighbor.out.size() == 1` not visited; `neighbor.in.size() == 1`
-  identity-equal to `edge`; second-method whitelist `inV` / `outV` /
-  `bothV`). `resolveChainedTarget` adds the dynamic visited-edge
-  check on top.
+  `neighbor.out.size() == 1`; `neighbor.in.size() == 1` identity-equal
+  to `edge`; second-method whitelist `inV` / `outV` / `bothV`). All
+  five are structural, which is what makes the result cacheable. The
+  dynamic visited-edge check is separate — `chainVertexStepVisited`,
+  applied on top by `applyChainFold` and `resolveChainedTarget`.
 - **Risks:** New edge-traversal methods that should also be
   chain-aware (e.g. a hypothetical `outE().filter(…).inV()`) would
   require widening the whitelist. The rule lives in one helper, so
@@ -364,6 +369,16 @@ flowchart LR
   `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS = 0` — the sort-loop call site's
   `chainFoldMaxHops >= 1` gate skips `applyChainFold` entirely.
   This is the production rollback path.
+- **Plan-cache caveat.** The knob is read once per plan construction,
+  and `YqlExecutionPlanCache` keys on statement text and invalidates
+  only on schema, index, function, sequence and storage-configuration
+  updates. A `GlobalConfiguration` write therefore does not re-plan
+  statements already in the cache: hot queries keep their old schedule
+  until an eviction. An operator rolling back with `= 0` needs a cache
+  eviction — any schema change, or a restart — for the change to reach
+  queries already running. `MatchEdgeMethodChainCostTest`'s
+  `setChainFoldMaxHops` helper evicts explicitly for this reason, and
+  its Javadoc is the in-repo record of the constraint.
 
 ### Integration Points
 

--- a/docs/adr/match-edge-chain-cost-fix/design-final.md
+++ b/docs/adr/match-edge-chain-cost-fix/design-final.md
@@ -1,0 +1,503 @@
+# MATCH Edge-Method Chain Cost Aggregation — Final Design
+
+## Overview
+
+The MATCH execution planner now folds the **downstream vertex's** `WHERE`
+selectivity (and, when enabled, the selectivity / fan-out of subsequent
+linear hops) into the **first edge's** cost during the sort phase of
+`updateScheduleStartingAt`. This closes the cost-model gap between the
+single-step pattern `.out('X'){where: …}` and the edge-method pattern
+`.outE('X').inV(){where: …}` (and its `inE→outV` / `bothE→bothV`
+variants), so branches whose true selectivity is hidden behind an
+intermediate synthetic edge alias are no longer scheduled as if they had
+no filter.
+
+The implementation went through two layers:
+
+1. **Single-hop fold** — recognise the structural pattern
+   `outE/inE/bothE → inV/outV/bothV` and apply the downstream vertex's
+   filter via a class-forced overload of `applyTargetSelectivity`. The
+   pattern graph, parser, and runtime stay untouched.
+2. **Multi-hop linear extension** — the same recognition, applied
+   iteratively past the first hop. From the downstream vertex, walk
+   forward as long as the pattern remains a single linear `(edge step,
+   vertex step)` sequence with no branch points or back-edges, and fold
+   each hop's edge fan-out + intermediate filter + downstream vertex
+   filter into the running cost. Bounded by
+   `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS` (default 10, hard-capped at 1000)
+   plus a per-plan structural cache. Set the knob to 1 to restrict the
+   fold to single-hop behaviour, or 0 to disable it entirely (rollback
+   safety valve).
+
+The fold lives entirely inside the planner sort loop. No
+`Pattern.addExpression` change, no `MatchStep` change, no
+`SQLMatchPathItem` change, no public API change.
+
+## Class Design
+
+```mermaid
+classDiagram
+    class MatchExecutionPlanner {
+        +getTopologicalSortedSchedule(...)
+        -updateScheduleStartingAt(...)
+        +estimateEdgeCost(edge, sourceAlias, sourceRows, ...) double
+        +estimateMethodFanOut(method, sourceClassName, session) double
+        +applyTargetSelectivity(baseCost, alias, edge, isOutbound, ...) double
+        +applyTargetSelectivityWithResolvedClass(baseCost, alias, class, ...) double
+        -applyClassSelectivity(baseCost, alias, class, ...) double
+        -resolveTargetClass(alias, edge, isOutbound, classes, session) String
+        +resolveChainedTarget(edge, neighbor, visitedEdges, classes, session) ChainedTarget
+        -detectChainShape(edge, neighbor, classes, session) ChainedTarget
+        -lookupOrDetectChainShape(edge, neighbor, classes, session, cache) ChainedTarget
+        -applyChainFold(cost, edge, neighbor, maxHops, visited, ...) double
+        -walkLinearChainExtension(vertex, class, hops, visited, ...) List~ChainHop~
+        +linkedVertexClassForVertexStep(stepName, edgeClass, session) String
+        -lookupLinkedVertexClass(edgeClass, propName, session) String
+        +clampChainFoldMaxHops(raw) int
+    }
+
+    class ChainedTarget {
+        <<record>>
+        +String effectiveTargetAlias
+        +String effectiveTargetClass
+    }
+
+    class ChainHop {
+        <<record>>
+        +PatternEdge edgeStep
+        +String edgeStepSourceClass
+        +String intermediateAlias
+        +String downstreamAlias
+        +String downstreamClass
+    }
+
+    class GlobalConfiguration {
+        <<enum>>
+        QUERY_MATCH_CHAIN_FOLD_MAX_HOPS
+    }
+
+    class PatternNode {
+        +String alias
+        +Set~PatternEdge~ out
+        +Set~PatternEdge~ in
+    }
+
+    class PatternEdge {
+        +PatternNode out
+        +PatternNode in
+        +SQLMatchPathItem item
+    }
+
+    MatchExecutionPlanner ..> ChainedTarget : returns @Nullable
+    MatchExecutionPlanner ..> ChainHop : iterates
+    MatchExecutionPlanner ..> GlobalConfiguration : reads knob
+    MatchExecutionPlanner ..> PatternEdge : reads
+    MatchExecutionPlanner ..> PatternNode : reads
+    PatternNode *-- PatternEdge
+```
+
+- **`MatchExecutionPlanner`** gained two records (`ChainedTarget`,
+  `ChainHop`), a class-forced
+  `applyTargetSelectivityWithResolvedClass` sibling to the existing
+  `applyTargetSelectivity`, a private shared helper
+  `applyClassSelectivity` that both overloads delegate to, and the
+  chain-detection / multi-hop family
+  (`resolveChainedTarget`, `detectChainShape`,
+  `lookupOrDetectChainShape`, `applyChainFold`,
+  `walkLinearChainExtension`). `linkedVertexClassForVertexStep` and
+  `lookupLinkedVertexClass` are shared with the pre-existing
+  `inferClassFromEdgeSchema` so the chain fold and `addAliases`
+  resolve `inV` / `outV` against the same edge schema in lock step.
+- **`ChainedTarget`** is the value returned by chain detection: the
+  downstream vertex alias plus the inferred class (nullable). The
+  helper returns `@Nullable ChainedTarget` directly rather than an
+  `Optional`, matching the surrounding `@Nullable` style in the
+  planner (`resolveTargetClass`, `inferClassFromEdgeSchema`).
+- **`ChainHop`** describes one extra `(edge step, vertex step)`
+  sub-chain past the first hop. The edge's source class is carried so
+  the multi-hop walk can compute fan-out without re-deriving it from
+  schema.
+- **`PatternNode` / `PatternEdge`** are unchanged. The chain helpers
+  read the existing `out`, `in`, `item`, `alias` fields only.
+- **`GlobalConfiguration.QUERY_MATCH_CHAIN_FOLD_MAX_HOPS`** is a new
+  enum value (default `10`, hard-capped at `MAX_CHAIN_FOLD_HOPS = 1000`
+  inside the planner). It is read once per plan in
+  `getTopologicalSortedSchedule` and threaded through
+  `updateScheduleStartingAt` along with the per-plan structural cache.
+
+## Workflow
+
+### Sort-loop cost computation
+
+```mermaid
+sequenceDiagram
+    participant USA as updateScheduleStartingAt
+    participant EEC as estimateEdgeCost
+    participant ATS as applyTargetSelectivity
+    participant ACF as applyChainFold
+    participant LDC as lookupOrDetectChainShape
+    participant ATSR as applyTargetSelectivityWithResolvedClass
+    participant WLC as walkLinearChainExtension
+    participant ADM as applyDepthMultiplier
+
+    USA->>EEC: estimate(edge1, sourceAlias, sourceRows)
+    EEC-->>USA: baseCost
+    alt baseCost is finite
+        USA->>ATS: apply(baseCost, neighbor.alias, edge1, isOutbound, ...)
+        Note over ATS: existing call — applies the intermediate<br/>alias's WHERE (rare; typically a no-op)
+        ATS-->>USA: cost
+        alt chainFoldMaxHops >= 1
+            USA->>ACF: apply(cost, edge1, neighbor, maxHops, visitedEdges, ...)
+            ACF->>LDC: lookup-or-detect(edge1, neighbor, ...)
+            LDC-->>ACF: ChainedTarget or null
+            alt chain detected and not visited
+                ACF->>ATSR: apply(cost, downstreamAlias, downstreamClass, ...)
+                ATSR-->>ACF: cost (after first-hop fold)
+                alt maxHops > 1
+                    ACF->>WLC: walk(downstreamVertex, downstreamClass, maxHops-1, ...)
+                    WLC-->>ACF: List<ChainHop>
+                    loop for each extra hop
+                        ACF->>ACF: cost *= estimateMethodFanOut(...)
+                        ACF->>ATSR: apply(cost, intermediateAlias, edgeClass, ...)
+                        ATSR-->>ACF: cost
+                        ACF->>ATSR: apply(cost, downstreamAlias, downstreamClass, ...)
+                        ATSR-->>ACF: cost
+                    end
+                end
+            end
+            ACF-->>USA: cost (or unchanged when no chain)
+        end
+        USA->>ADM: apply(cost, edge1)
+        ADM-->>USA: final cost
+    else baseCost == Double.MAX_VALUE
+        Note over USA: no fold runs; stable-sort tiebreaker preserves insertion order
+    end
+```
+
+The diagram covers the cost-estimation pass that runs once per
+candidate edge inside the sort loop. The visited-neighbor branch
+(`cost = 0.0`, taken when `visitedNodes.contains(neighbor)`) is
+omitted because the chain fold is intentionally outside that branch
+— a back-reference to an already-visited vertex is a join step with
+no traversal cost to fold.
+
+### Chain detection & multi-hop walk
+
+```mermaid
+flowchart TD
+    START([sort-loop calls applyChainFold])
+    LOOKUP{"lookupOrDetectChainShape<br/>cache hit?"}
+    DETECT["detectChainShape:<br/>structural rule clauses 1-5"]
+    PUT[("cache.put(edge, shape)")]
+    NULL_RESULT{"shape == null?"}
+    VISITED{"vertex-step edge in<br/>visitedEdges?"}
+    APPLY1["applyTargetSelectivityWithResolvedClass<br/>(downstream alias + class)"]
+    LIMIT{"maxHops <= 1?"}
+    WALK["walkLinearChainExtension<br/>iterates while<br/>vertex.out.size()==1<br/>and structural rule holds<br/>and no back-edge"]
+    HOPS{"any extra hops?"}
+    LOOP["for each hop:<br/>cost *= fanOut<br/>apply intermediate filter<br/>apply downstream filter"]
+    DONE([return cost])
+
+    START --> LOOKUP
+    LOOKUP -- "no" --> DETECT --> PUT --> NULL_RESULT
+    LOOKUP -- "yes" --> NULL_RESULT
+    NULL_RESULT -- "yes" --> DONE
+    NULL_RESULT -- "no" --> VISITED
+    VISITED -- "yes" --> DONE
+    VISITED -- "no" --> APPLY1 --> LIMIT
+    LIMIT -- "yes" --> DONE
+    LIMIT -- "no" --> WALK --> HOPS
+    HOPS -- "yes" --> LOOP --> DONE
+    HOPS -- "no" --> DONE
+```
+
+The structural-detection result for any given `PatternEdge` is stable
+across the lifetime of one plan (it depends only on the pattern graph
+plus per-plan `aliasClasses` / `session`), so
+`lookupOrDetectChainShape` memoises it in `chainShapeCache`. Negative
+answers (`null`) are cached too — a `containsKey` check disambiguates
+"unknown" from "known-not-chain". The dynamic visited-edge check is
+deliberately kept outside the cache so that a chain whose vertex-step
+is already scheduled correctly skips the fold.
+
+## Chain Detection Rule
+
+`detectChainShape` returns non-null iff **all** of the following hold.
+All method-name lookups go through `SQLMethodCall.getMethodNameString()`,
+matching the accessor used by `parseDirection`'s call sites elsewhere
+in the planner.
+
+- **Pre-check:** `edge.item != null` and `edge.item.getMethod() != null`.
+- **First method whitelist:** name (case-insensitive) is `outE`, `inE`,
+  or `bothE`. The check uses `String.equalsIgnoreCase` against each
+  literal so that the very common `.out` / `.in` / `.both` single-step
+  methods short-circuit on length mismatch without a `toLowerCase`
+  allocation — this is the sort-loop's hot path.
+- **Branch guard:** `neighbor.out.size() == 1` and `neighbor.in.size() == 1`.
+- **Identity guard:** `neighbor.in.iterator().next() == edge`. Defends
+  against a future refactoring of pattern construction that produces an
+  intermediate with a single incoming edge that is not `edge` itself.
+  Today, the size-1 guard already rejects the common fragment-join case
+  (a user reusing `{as: e}` across two MATCH fragments makes
+  `neighbor.in.size() >= 2`).
+- **Second method whitelist:** the unique outgoing edge from the
+  intermediate has `item != null`, `item.getMethod() != null`, and the
+  method name (case-insensitive) is `inV`, `outV`, or `bothV`.
+
+`resolveChainedTarget` adds one more dynamic check on top of
+`detectChainShape`'s structural answer:
+
+- The single outgoing edge from the intermediate is **not** in
+  `visitedEdges` — i.e. the chain's vertex-step has not already been
+  scheduled.
+
+Reverse traversals (where `neighbor = edge.out`) are rejected naturally
+by the branch guard: the reverse neighbor has no `inV/outV/bothV`
+continuation.
+
+### Class inference precedence
+
+```mermaid
+flowchart TD
+    INPUT[detectChainShape: structural match]
+    P1{"aliasClasses.get(<br/>effectiveTargetAlias)"}
+    P1_OUT[use that class]
+    P2["linkedVertexClassForVertexStep(<br/>secondMethodName,<br/>extractEdgeClassName(firstMethod),<br/>session)"]
+    INV_OUTV{"step is inV / outV?"}
+    LOOKUP[lookupLinkedVertexClass]
+    P2_OUT_OK[edge schema linked class]
+    P2_OUT_NULL[null — bothV unable to disambiguate;<br/>caller short-circuits to baseCost]
+
+    INPUT --> P1
+    P1 -- "non-null hit" --> P1_OUT
+    P1 -- "miss / null aliasClasses" --> P2
+    P2 --> INV_OUTV
+    INV_OUTV -- "yes" --> LOOKUP --> P2_OUT_OK
+    INV_OUTV -- "no (bothV / unknown)" --> P2_OUT_NULL
+```
+
+| Vertex step | Edge LINK property used | Result for `bothV` |
+|-------------|-------------------------|--------------------|
+| `inV()`     | edge class's `in`       | n/a                |
+| `outV()`    | edge class's `out`      | n/a                |
+| `bothV()`   | none                    | `null` — fold short-circuits unless the alias has an explicit `class:` |
+
+Precedence-1 (`aliasClasses`) is the path normally taken because
+`addAliases` pre-populates the map for `inV` / `outV` aliases via
+`inferClassFromEdgeSchema` during plan construction, and is the only
+path that supplies a non-null class for `bothV`. Precedence-2 is the
+defensive fallback used when `aliasClasses` lacks an entry — for
+example a while-expression alias skipped by `addAliases`'s
+`whileAliases` filter. Both paths converge on
+`linkedVertexClassForVertexStep`, which the standalone `inV` / `outV`
+branch of `inferClassFromEdgeSchema` also calls; centralising this
+mapping keeps the chain fold and standalone vertex-step inference in
+lock step.
+
+## Independence Multiplication Across Filters
+
+The fold composes selectivities multiplicatively under the
+independence assumption already used by
+`estimateCompoundAndSelectivity`. For a chain of `K` linear hops:
+
+```
+cost = sourceRows × fanOut(edge_1)                          [estimateEdgeCost]
+                  × selectivity(intermediateFilter_1)        [existing applyTargetSelectivity]
+                  × selectivity(downstreamFilter_1)          [first-hop fold via WithResolvedClass]
+                  × ∏(k=2..K) [fanOut(edge_k)
+                              × selectivity(intermediateFilter_k)
+                              × selectivity(downstreamFilter_k)]
+                  × depthMultiplier(edge_1)                  [applyDepthMultiplier]
+```
+
+Each factor short-circuits to 1 (i.e. leaves the running cost
+unchanged) when its alias has no filter, no estimate, and no inferable
+class. So a chain whose intermediate edge alias is auto-generated and
+whose downstream vertex is plain `as: x` collapses to the pre-fix
+baseline, while a chain with a `WHERE` anywhere along the way
+contributes that selectivity to scheduling.
+
+Concretely, the `applyTargetSelectivity` / `applyClassSelectivity`
+short-circuit table (each branch returns `baseCost` unchanged):
+
+- `preResolvedTargetClass == null`
+- `schema == null` or class not in schema
+- `classCount <= 0`
+- filter present but the heuristic returns `< 0` AND no
+  `estimatedRootEntries` entry
+- no filter AND no `estimatedRootEntries` entry
+
+Multiplication commutes, so call order does not matter — the existing
+`applyTargetSelectivity` call on the intermediate alias and the chain
+fold's calls compose into the same product regardless of which comes
+first. This is what makes the change strictly additive: removing the
+chain-fold call site recovers the pre-fix cost exactly.
+
+### Correlated predicates caveat
+
+Independence is a heuristic. When edge and vertex predicates are
+correlated (e.g. high-weight friendship edges tend to reach
+high-reputation people), the product under-estimates the true cost.
+The same approximation is already accepted elsewhere in the planner
+and the benefit on typical queries (correct ordering of branches with
+filters at different depths) dwarfs the approximation error.
+
+## Multi-Hop Walk: Termination & Knob
+
+`walkLinearChainExtension` extends the chain past its first hop with
+strict structural termination — it **never** explores branch points
+or back-edges. The walk terminates as soon as **any** of these holds:
+
+- `currentVertex.out.size() != 1` (terminal vertex or branch point)
+- the next edge step is in the DFS-level `visitedEdges`
+- the next edge step is in this walk's local `chainEdges`
+- `detectChainShape` returns null for the next sub-chain
+- the next vertex-step edge is in `visitedEdges` or `chainEdges`
+- `remainingHops` reaches zero
+
+The two-set visited check (`initialVisitedEdges` from the DFS plus a
+walk-local `chainEdges`) avoids mutating the caller's DFS state and
+prevents both back-edges into already-scheduled territory and pattern
+loops that wrap onto themselves. The fast-path `currentVertex.out.size() != 1`
+test sits before `chainEdges` is allocated, so the very common case of
+a terminal downstream vertex pays no allocation cost.
+
+`QUERY_MATCH_CHAIN_FOLD_MAX_HOPS` is read once per plan via
+`clampChainFoldMaxHops`, which:
+
+- silently clamps negatives to `0` (project convention; see
+  `getHashJoinThreshold`),
+- clamps values above `MAX_CHAIN_FOLD_HOPS = 1000` to that ceiling and
+  emits a one-shot WARN per **unique** out-of-range value via an
+  `AtomicInteger` `getAndSet` pair (so a server racing on a misconfigured
+  knob logs once, not per-plan).
+
+Two layers gate the fold:
+
+- The sort-loop call site skips `applyChainFold` entirely when
+  `chainFoldMaxHops < 1` — full rollback to pre-YTDB-643 behaviour with
+  zero allocations and zero method calls past the gate.
+- Inside `applyChainFold`, the `maxHops <= 1` short-circuit returns after
+  the first-hop fold without entering the multi-hop walk — restricts
+  the fold to legacy single-hop behaviour while keeping the cache and
+  call infrastructure live.
+
+Both gates are intentional defense-in-depth: the inner gate alone
+yields single-hop legacy semantics for `maxHops == 1`, while the outer
+gate is the only one that disables the fold completely.
+
+## Per-Plan Structural Cache
+
+`chainShapeCache: Map<PatternEdge, ChainedTarget>` is allocated once
+in `getTopologicalSortedSchedule` and threaded through every
+`updateScheduleStartingAt` call for that plan, including recursive
+sub-passes and the multi-hop walk. The cache stores only the
+structural answer from `detectChainShape` (which does **not**
+incorporate the dynamic visited-edge check); callers that need the
+visited check apply it on top of the cached value.
+
+`computeIfAbsent` is intentionally not used because we want to
+memoise negative answers (`null`) too — a known-not-chain edge is a
+useful cache hit on the sort-loop's hot path. `containsKey` /
+`get` / `put` disambiguates a missing entry from a cached negative.
+The map is per-plan (not per-server) so a query-time schema change
+between plans cannot serve a stale answer.
+
+## Why Aggregation at Sort Time, Not Pattern Collapsing
+
+Collapsing `outE('X').inV()` into a single `PatternEdge` during
+`Pattern.addExpression` was rejected because:
+
+- The user can name the intermediate edge alias (`{as: e}`) and
+  reference it from `RETURN`, `ORDER BY`, or `$matched.e`. Collapsing
+  erases the alias from the pattern graph and breaks those references.
+- The user can attach edge-level filters (`{where: weight > 5}`) to
+  the intermediate alias. Collapsing would have to either drop them
+  (incorrect results) or invent a composite edge-filter representation
+  in `SQLMatchPathItem`, which cascades into the parser, planner, and
+  runtime.
+- The runtime `MatchStep` pipeline already handles the edge-method
+  pattern correctly. The bug was a cost-ordering bug, not an execution
+  bug.
+
+Aggregation at sort time is strictly additive: remove the call-site
+gate (`chainFoldMaxHops >= 1`) and the planner falls back to today's
+behaviour. The knob's `0` value is the production rollback path.
+
+## Handling the Recursive DFS Pass on the Intermediate Alias
+
+`updateScheduleStartingAt` recurses into the intermediate edge-alias
+node after scheduling the first edge. At that point the node has
+exactly one unvisited outgoing edge — the `inV()` / `outV()` /
+`bothV()` hop — and `estimateEdgeCost` returns `Double.MAX_VALUE`
+because `parseDirection` does not recognise vertex-step methods.
+The sort then contains a single candidate, so `MAX_VALUE` is
+irrelevant; the edge is scheduled and DFS recurses into the final
+vertex.
+
+`parseDirection` is intentionally **not** taught about
+`inV` / `outV` / `bothV`: (a) it would not affect scheduling on the
+recursive pass (only one candidate), (b) a per-vertex "hop fan-out"
+model does not match the edge-class schema lookups that feed the
+estimator. The chain fold and the recursive DFS pass coexist: the
+fold runs at the source-vertex pass (where ordering matters) and the
+recursive pass runs unchanged (where ordering does not).
+
+## Empty-Downstream-WHERE Behaviour
+
+When the downstream vertex has no `WHERE`, no explicit `class:`, and
+no entry in `estimatedRootEntries`, the class-forced overload falls
+through every short-circuit and returns `baseCost` unchanged. This
+matches the non-chain fallback exactly — we have no information to
+refine the cost. The chain fold neither inflates nor deflates cost in
+that case; it is a no-op. Only branches with a `WHERE` on the
+downstream vertex (or a class with a known indexable histogram) see
+the scheduling change.
+
+## Relation to `IndexOrderedPlanner`
+
+`IndexOrderedPlanner` was extracted as a sibling planner that handles
+index-ordered execution for single-source MATCH queries. It does not
+participate in edge cost sorting — its concern is deciding whether an
+index-ordered pipeline can replace the general MATCH executor. The
+chain-cost fold lives entirely inside `MatchExecutionPlanner`'s sort
+loop and does not touch the `IndexOrderedPlanner` boundary.
+
+## EXPLAIN-Based Test Contract
+
+Regression tests assert scheduling order by searching for alias
+markers (`{selectiveTag}` vs. `{broadTag}`) in the `EXPLAIN` plan
+string. The same contract is used by
+`testSelectivityInferredFromEdgeSchemaWithoutExplicitClass` and
+`testVertexClassInferenceEnablesIndexIntersection`. A small regex
+helper (`aliasStepPosition`) accepts both `{alias}` and
+`{alias,index=…}` so a future format addition does not silently break
+ordering assertions. Each test also asserts result-set correctness
+(against the expected Cartesian product size) so a regression cannot
+silently alter MATCH semantics.
+
+The integration suite `MatchEdgeMethodChainCostTest` covers eleven
+scenarios, including:
+
+- pure `outE.inV` / `inE.outV` / `bothE.bothV` chains;
+- mixed-style branches (`.out('X')` vs `.outE('X').inV()`);
+- intermediate edge alias + downstream vertex filter combining
+  multiplicatively;
+- fragment-join negative case (rule rejects on `e.in.size() > 1`);
+- visited-neighbor zero-cost path (fold is skipped, join semantics
+  preserved);
+- multi-hop chain ordering (selectivity hidden two hops in);
+- knob `= 1` downgrades to legacy single-hop behaviour;
+- multi-hop intermediate edge alias filter folding through the
+  walk;
+- pathological knob values (`Integer.MAX_VALUE` clamps,
+  `Integer.MIN_VALUE` clamps to 0, large in-range value).
+
+The unit suite `MatchExecutionPlannerMutationTest` adds focused
+coverage of `resolveChainedTarget` rejection cases, the
+class-inference precedence matrix, and the
+`applyTargetSelectivityWithResolvedClass` short-circuit table —
+including `MAX_VALUE` preservation through the null-class and
+no-filter / no-estimate paths so a sort-loop regression that bypassed
+the gate cannot silently upgrade an unestimated cost into a finite
+value.

--- a/docs/adr/match-edge-chain-cost-fix/design-final.md
+++ b/docs/adr/match-edge-chain-cost-fix/design-final.md
@@ -423,20 +423,22 @@ Collapsing `outE('X').inV()` into a single `PatternEdge` during
 
 Aggregation at sort time is strictly additive: remove the call-site
 gate (`chainFoldMaxHops >= 1`) and the planner falls back to today's
-behaviour. The knob's `0` value is the production rollback path, subject
-to the plan-cache caveat below.
+behaviour. The knob's `0` value is the production rollback path.
 
-### Plan-Cache Caveat
+### Knob Changes and the Plan Cache
 
 The knob is read once per plan construction. `YqlExecutionPlanCache` keys
 on statement text and invalidates on schema, index, function, sequence and
-storage-configuration updates — never on a `GlobalConfiguration` write. A
-knob change therefore does not re-plan statements already in the cache, so
-an operator rolling back with `= 0` needs a cache eviction (any schema
-change, or a restart) before hot queries pick it up. The integration
-tests hit the same constraint: `setChainFoldMaxHops` evicts explicitly,
-because without it a second query under a new knob value gets the first
-value's plan handed straight back.
+storage-configuration updates — never on a `GlobalConfiguration` write, so
+a knob change does not re-plan statements already cached.
+
+Production is unaffected: configuration is start-time only (nothing in the
+server or SQL surface writes `GlobalConfiguration` on a live instance), and
+a restart empties the cache anyway. Tests are affected, because they change
+the knob in-process. `setChainFoldMaxHops` evicts explicitly for that
+reason — without it, a second query under a new knob value gets the first
+value's plan handed straight back, and the assertion silently measures the
+wrong schedule.
 
 ## Handling the Recursive DFS Pass on the Intermediate Alias
 

--- a/docs/adr/match-edge-chain-cost-fix/design-final.md
+++ b/docs/adr/match-edge-chain-cost-fix/design-final.md
@@ -26,8 +26,8 @@ The implementation went through two layers:
    filter into the running cost. Bounded by
    `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS` (default 10, hard-capped at 1000)
    plus a per-plan structural cache. Set the knob to 1 to restrict the
-   fold to single-hop behaviour, or 0 to disable it entirely (rollback
-   safety valve).
+   fold to the first hop's downstream vertex, or 0 to disable it entirely.
+   Only 0 is a true rollback; 1 still folds that first vertex.
 
 The fold lives entirely inside the planner sort loop. No
 `Pattern.addExpression` change, no `MatchStep` change, no
@@ -375,16 +375,17 @@ a terminal downstream vertex pays no allocation cost.
 Two layers gate the fold:
 
 - The sort-loop call site skips `applyChainFold` entirely when
-  `chainFoldMaxHops < 1` — full rollback to pre-YTDB-643 behaviour with
-  zero allocations and zero method calls past the gate.
+  `chainFoldMaxHops < 1`, reproducing the schedule the planner produced
+  before the fold existed, with zero allocations and zero method calls
+  past the gate.
 - Inside `applyChainFold`, the `maxHops <= 1` short-circuit returns after
-  the first-hop fold without entering the multi-hop walk — restricts
-  the fold to legacy single-hop behaviour while keeping the cache and
-  call infrastructure live.
+  the first-hop fold without entering the multi-hop walk. This confines
+  the fold to one hop while keeping the cache and call infrastructure
+  live.
 
-Both gates are intentional defense-in-depth: the inner gate alone
-yields single-hop legacy semantics for `maxHops == 1`, while the outer
-gate is the only one that disables the fold completely.
+Both gates are deliberate defense-in-depth: at `maxHops == 1` the inner
+gate alone confines the fold to one hop, while the outer gate is the only
+one that switches it off completely.
 
 ## Per-Plan Structural Cache
 
@@ -422,7 +423,20 @@ Collapsing `outE('X').inV()` into a single `PatternEdge` during
 
 Aggregation at sort time is strictly additive: remove the call-site
 gate (`chainFoldMaxHops >= 1`) and the planner falls back to today's
-behaviour. The knob's `0` value is the production rollback path.
+behaviour. The knob's `0` value is the production rollback path, subject
+to the plan-cache caveat below.
+
+### Plan-Cache Caveat
+
+The knob is read once per plan construction. `YqlExecutionPlanCache` keys
+on statement text and invalidates on schema, index, function, sequence and
+storage-configuration updates — never on a `GlobalConfiguration` write. A
+knob change therefore does not re-plan statements already in the cache, so
+an operator rolling back with `= 0` needs a cache eviction (any schema
+change, or a restart) before hot queries pick it up. The integration
+tests hit the same constraint: `setChainFoldMaxHops` evicts explicitly,
+because without it a second query under a new knob value gets the first
+value's plan handed straight back.
 
 ## Handling the Recursive DFS Pass on the Intermediate Alias
 
@@ -487,7 +501,11 @@ scenarios, including:
 - visited-neighbor zero-cost path (fold is skipped, join semantics
   preserved);
 - multi-hop chain ordering (selectivity hidden two hops in);
-- knob `= 1` downgrades to legacy single-hop behaviour;
+- knob `= 1` confines the fold to the first hop, with a default-knob
+  positive control on the same graph so the assertion cannot pass against
+  a fold that never fires;
+- a three-hop chain pinning both sides of the `maxHops` truncation
+  boundary (`2` too few, `3` exactly enough);
 - multi-hop intermediate edge alias filter folding through the
   walk;
 - pathological knob values (`Integer.MAX_VALUE` clamps,


### PR DESCRIPTION
#### Motivation:
The MATCH execution planner's cost model does not correctly estimate the cost of edge-method patterns (`outE→inV`, `inE→outV`) when multiple branches with different selectivities compete from the same node. The WHERE filter selectivity is only applied to the second edge (the `inV`/`outV` step), leaving the first edge (`outE`/`inE`) at full fan-out cost. This prevents the scheduler from distinguishing selective vs. broad branches, leading to suboptimal traversal order and unnecessary intermediate row multiplication.

This is a cost-model fix only: the planner's pattern graph and runtime traversal are unchanged. The fix only affects the order in which equally-correct edges are scheduled.

#### Changes:
- **New chain-fold cost adjustment** in `MatchExecutionPlanner.getTopologicalSortedSchedule` / `updateScheduleStartingAt`:
  - `detectChainShape` / `resolveChainedTarget` recognise the structural pattern (`outE→inV`, `inE→outV`, and equivalents) on consecutive `PatternEdge`s.
  - `applyChainFold` folds the downstream vertex's WHERE selectivity into the first edge's cost via the new `applyTargetSelectivityWithResolvedClass` overload, sharing a common `applyClassSelectivity` body with the legacy `applyTargetSelectivity` (parity tests included).
  - `walkLinearChainExtension` extends the fold across multi-hop linear chains, multiplying intermediate fan-outs and applying per-hop downstream WHEREs.
  - A per-plan `chainShapeCache` memoizes the structural detection result.
- **New configuration knob** `QUERY_MATCH_CHAIN_FOLD_MAX_HOPS` in `GlobalConfiguration`:
  - Default `10`, maximum `1000` (clamped via `clampChainFoldMaxHops`).
  - `0` fully disables the fold — the only value that restores the pre-change schedule. `1` restricts the fold to the first hop's downstream vertex, which is still new behaviour.
  - Out-of-range values clamp silently in `getChainFoldMaxHops()`, matching the shape of the planner's sibling knob accessors (`getHashJoinThreshold`).
- **Refactor**: `linkedVertexClassForVertexStep` extracts the vertex-step → linked class resolution previously duplicated across call sites; `lookupLinkedVertexClass` adds defensive null-guards for narrow storage-lifecycle windows.
- **Tests**:
  - `MatchEdgeMethodChainCostTest` — integration tests pinning EXPLAIN ordering and runtime row counts/contents for representative chain shapes, including a three-hop chain that pins the exact `maxHops` value at which the walk is truncated. `@Category(SequentialTest)` because it writes `GlobalConfiguration`. Negative cases (fragment join, `maxHops=1`, `maxHops=2`) each carry a positive control on the same graph, so a globally dead fold cannot satisfy their "insertion order preserved" assertions.
  - `MatchExecutionPlannerMutationTest` — mutation-style unit tests with explicit `Kills:` docstrings covering the structural detection, fold math and clamp invariants, plus the two per-plan memos and the multi-hop walk: `chainShapeCache` direction keying and negative memoization, `classCountCache` parity/seed/populate and agreement between its two writers, all five `walkLinearChainExtension` termination conditions, and the `clampChainFoldMaxHops` warn-dedupe state machine.
  - `MatchEdgeMethodInferenceAndAbortTest` — regression updates for non-canonical chain inference and `bothE` disambiguation.
  - `EdgeFanOutEstimatorTest` — `classCountCache` parity against the un-cached overload, seeded-entry reads, and per-class single-count verification.
  - `EstimateEdgeCostTest` — extracted the shared `makeWhereWithOperator` fixture; the legacy-vs-class-resolved parity assertions live in `MatchExecutionPlannerMutationTest.applyTargetSelectivity_overloadsAgree_*`.
  - `MatchTestWhereBuilders` — shared test helper for WHERE-clause fixtures.

#### Rollback:
Setting `query.match.chainFoldMaxHops=0` disables the new cost adjustment entirely without a code change. Setting it to `1` restricts the fold to the first hop's downstream vertex — still new behaviour, so `0` is the actual rollback value.

The knob is read once per plan construction, so it takes effect on restart like every other `GlobalConfiguration` setting. Worth knowing when changing it in-process: `YqlExecutionPlanCache` does not invalidate on a config write, so a statement already cached keeps its schedule. That only bites tests — `MatchEdgeMethodChainCostTest.setChainFoldMaxHops` evicts explicitly for that reason — since production configuration is start-time only and a restart empties the cache regardless.

