### PR TITLE
Phase B implementer fixes and _workflow/ scaffolding model

### DIFF
--- a/.claude/scripts/design-mechanical-checks.py
+++ b/.claude/scripts/design-mechanical-checks.py
@@ -8,13 +8,17 @@ checks (always run)`. Invoked by the `edit-design` skill after each edit to
 
 Usage:
     python3 .claude/scripts/design-mechanical-checks.py \
-        --design-path docs/adr/<dir>/design.md \
-        [--design-mechanics-path docs/adr/<dir>/design-mechanics.md] \
-        [--plan-path docs/adr/<dir>/implementation-plan.md] \
-        [--backlog-path docs/adr/<dir>/implementation-backlog.md] \
+        --design-path docs/adr/<dir>/_workflow/design.md \
+        [--design-mechanics-path docs/adr/<dir>/_workflow/design-mechanics.md] \
+        [--plan-path docs/adr/<dir>/_workflow/implementation-plan.md] \
+        [--backlog-path docs/adr/<dir>/_workflow/implementation-backlog.md] \
         [--changed-section "Section Title"] \
         [--target design|mechanics|both] \
         [--scope bounded|whole-doc]
+
+For Phase 4 the design path is `docs/adr/<dir>/design-final.md`
+(top-level, outside `_workflow/`); see edit-design/SKILL.md for the
+phase4-creation kind.
 
 Output: JSON to stdout. Exit code 0 on PASS, 1 on NEEDS REVISION (any blocker).
 """

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -27,7 +27,12 @@ Plan directory name: if "$ARGUMENTS" is non-empty, use it as the directory
 name. Otherwise, default to the current git branch name
 (`git branch --show-current`).
 
-The plan will be saved to: docs/adr/<dir-name>/implementation-plan.md
+The plan will be saved to:
+`docs/adr/<dir-name>/_workflow/implementation-plan.md`
+(the `_workflow/` subdir holds every ephemeral working file — plan,
+backlog, design, step files, reviews — and is removed in the Phase 4
+cleanup commit before merge; see `conventions.md` §1.2 and
+`workflow.md` § Final Artifacts).
 The codebase is at the current working directory.
 
 **Step 3 — Research phase (Phase 0).**
@@ -109,7 +114,7 @@ Help the user develop the plan:
    is strategic (what to test and why), not tactical (how to implement tests).
 8. Produce a **Design Document** (separate file) following the workflow rules
    in `planning.md` §Design Document. Write it to
-   `docs/adr/<dir-name>/design.md`. The design document must include:
+   `docs/adr/<dir-name>/_workflow/design.md`. The design document must include:
    - **Class diagrams** (Mermaid `classDiagram`) showing new/modified classes,
      interfaces, and their relationships
    - **Workflow diagrams** (Mermaid `sequenceDiagram` or `flowchart`) showing
@@ -123,15 +128,17 @@ Help the user develop the plan:
 Do NOT implement anything. Only research and plan.
 
 Write both the implementation plan to
-`docs/adr/<dir-name>/implementation-plan.md` AND the track-details
-backlog to `docs/adr/<dir-name>/implementation-backlog.md` using the
+`docs/adr/<dir-name>/_workflow/implementation-plan.md` AND the
+track-details backlog to
+`docs/adr/<dir-name>/_workflow/implementation-backlog.md` using the
 two structures below. The plan carries strategic context (Goals,
 Constraints, Architecture Notes, Decision Records) plus a thin
 checklist; the backlog carries each track's detailed
 `**What/How/Constraints/Interactions**` subsections and any
 track-level Mermaid diagrams. Splitting keeps `/execute-tracks`
 startup context small — see `.claude/workflow/conventions.md` §1.2 for
-the full rules (backlog file shape, lifecycle).
+the full rules (directory layout under `_workflow/`, backlog file
+shape, lifecycle).
 
 ```
 # <Feature Name>
@@ -214,8 +221,8 @@ layout exemplar; expand each track section to carry the full
 description content per planning.md §Track descriptions. -->
 ````
 
-Write the design document to `docs/adr/<dir-name>/design.md` using this
-structure:
+Write the design document to
+`docs/adr/<dir-name>/_workflow/design.md` using this structure:
 
 ```
 # <Feature Name> — Design
@@ -238,6 +245,55 @@ operations. Pair each diagram with prose explaining the flow.>
 ## <Complex Topic 2>
 <What the complex part is, why it is designed this way, gotchas/edge cases.>
 ```
+
+**Step 5 — Commit, push, and open the draft PR.**
+
+Once the user confirms the plan and design files look right, persist
+the work to GitHub so it survives local-disk loss and is visible to
+teammates as a draft PR:
+
+1. Stage and commit the `_workflow/` files in a single commit:
+   ```bash
+   git add docs/adr/<dir-name>/_workflow/
+   git commit -m "Add initial implementation plan and design"
+   ```
+2. Push the branch:
+   ```bash
+   git push -u origin <branch>
+   ```
+   (Use `git push` on subsequent pushes once upstream is set.)
+3. Ask the user **once**, before opening the PR:
+   *"Provide an issue prefix for the PR title (e.g. `YTDB-123`)?
+   Leave blank to skip."*
+   Branch names in this project often do not encode the issue
+   prefix; the user tracks it in the PR title instead.
+4. Compose the PR title:
+   - With a prefix `<P>`: `[<P>] <feature title>` — e.g.
+     `[YTDB-123] Index histogram for selective range scans`
+   - Without a prefix: `<feature title>`
+5. Compose the PR body from the plan: `## Motivation` (the plan's
+   Goals + Constraints, distilled into prose — apply the Ephemeral
+   identifier rule from `conventions-execution.md` §2.3 to the body
+   since PR titles and descriptions are durable), `## Plan` (one
+   line per track from the checklist, no internal IDs), and a
+   `## Status` line stating *"Draft — workflow scaffolding under
+   `docs/adr/<dir-name>/_workflow/` will be removed in the Phase 4
+   cleanup commit before merge."*
+6. Open the PR in **draft** mode using `gh`:
+   ```bash
+   gh pr create --draft --base develop \
+       --title "<title built above>" \
+       --body "$(cat <<'EOF'
+   ...
+   EOF
+   )"
+   ```
+   Print the resulting PR URL so the user can share it.
+
+CI does not run on draft PRs, so the per-commit pushes through the
+rest of the workflow carry no CI cost. The user manually flips the
+PR from draft to "ready for review" at the end of Phase 4 — Claude
+never runs `gh pr ready` automatically.
 
 When I'm satisfied, I'll run `/review-plan` to review the plan, then
 `/execute-tracks` to execute track by track.

--- a/.claude/skills/edit-design/SKILL.md
+++ b/.claude/skills/edit-design/SKILL.md
@@ -319,10 +319,31 @@ Outcomes when the loop exits:
 
 ### Step 7: Append to the review log
 
-Determine the plan dir from `design_path`'s parent. Append to
-`<plan-dir>/reviews/design-mutations.md` (create the directory and file if
-they don't exist). Format per `design-document-rules.md § Mutation
-discipline § Review log`:
+Resolve the log path from `mutation_kind` and `design_path` using
+the rule below. The log always lives under `_workflow/reviews/` so
+the Phase 4 cleanup commit reliably removes it; never write the log
+to the top-level `<dir>/reviews/`.
+
+- **For all mutation kinds *except* `phase4-creation`**:
+  `design_path = docs/adr/<dir>/_workflow/design.md` (or
+  `design-mechanics.md`), so the plan dir is `design_path`'s parent
+  (`docs/adr/<dir>/_workflow/`) and the log lives at
+  `docs/adr/<dir>/_workflow/reviews/design-mutations.md`.
+- **For `phase4-creation`** (special case): `design_path =
+  docs/adr/<dir>/design-final.md` (top-level, intentionally
+  outside `_workflow/` because `design-final.md` itself is a
+  durable artifact). The log path is **not** derived from
+  `design_path`'s parent — instead, it is forced to
+  `<design_path's parent>/_workflow/reviews/design-mutations.md`,
+  i.e., `docs/adr/<dir>/_workflow/reviews/design-mutations.md`.
+  This appends to the existing Phase 1 / inline-replanning log
+  under `_workflow/`, preserving the full mutation history of the
+  design and ensuring the Phase 4 cleanup commit removes the
+  entire log along with everything else under `_workflow/`.
+
+Append to the resolved path (create the `_workflow/reviews/`
+directory and file if they don't exist). Format per
+`design-document-rules.md § Mutation discipline § Review log`:
 
 ```markdown
 ## Mutation N — <ISO date YYYY-MM-DD> — <mutation kind> (<design.md | design-final.md>)

--- a/.claude/skills/execute-tracks/SKILL.md
+++ b/.claude/skills/execute-tracks/SKILL.md
@@ -44,11 +44,16 @@ Plan directory name: if "$ARGUMENTS" is non-empty, use it as the directory
 name. Otherwise, default to the current git branch name
 (`git branch --show-current`).
 
-The implementation plan is at: docs/adr/<dir-name>/implementation-plan.md
+The implementation plan is at:
+`docs/adr/<dir-name>/_workflow/implementation-plan.md`
+(every workflow file lives under `_workflow/`; the directory is
+removed in the Phase 4 cleanup commit before merge — see
+`conventions.md` §1.2 and `workflow.md` § Final Artifacts).
 
 Follow the startup protocol in `workflow.md`:
 
-1. Read the plan file at `docs/adr/<dir-name>/implementation-plan.md`.
+1. Read the plan file at
+   `docs/adr/<dir-name>/_workflow/implementation-plan.md`.
 2. Identify all tracks and their status (`[ ]` not started, `[x]` completed,
    `[~]` skipped).
 3. Determine session state and auto-resume:

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -21,10 +21,10 @@ Plan directory name: if "$ARGUMENTS" is non-empty, use it as the directory
 name. Otherwise, default to the current git branch name
 (`git branch --show-current`).
 
-Plan file: docs/adr/<dir-name>/implementation-plan.md
-Backlog file: docs/adr/<dir-name>/implementation-backlog.md
-Design document: docs/adr/<dir-name>/design.md
-Review output directory: docs/adr/<dir-name>/reviews/
+Plan file: docs/adr/<dir-name>/_workflow/implementation-plan.md
+Backlog file: docs/adr/<dir-name>/_workflow/implementation-backlog.md
+Design document: docs/adr/<dir-name>/_workflow/design.md
+Review output directory: docs/adr/<dir-name>/_workflow/reviews/
 
 The backlog file holds pending-track
 `**What/How/Constraints/Interactions**` detail and any track-level
@@ -68,7 +68,7 @@ to verify pending-track descriptions; pass its absolute path as the
    (tracks reordered, classes/flows redesigned, scope indicators changed
    substantially), re-run the full consistency review instead of the gate.
 9. When the gate is clean, save the review document to
-   docs/adr/<dir-name>/reviews/consistency.md.
+   docs/adr/<dir-name>/_workflow/reviews/consistency.md.
 
 Finding IDs are cumulative across iterations (CR1, CR2, ... CR6, CR7).
 
@@ -87,7 +87,7 @@ review without waiting for user confirmation.
     - The workflow directory path
 11. Receive the findings report.
 12. **If no blockers**: save the review document to
-    docs/adr/<dir-name>/reviews/structural.md and proceed to completion.
+    docs/adr/<dir-name>/_workflow/reviews/structural.md and proceed to completion.
 13. **If blockers found**: present findings to the user grouped by severity.
     For each finding, show:
     - The issue
@@ -108,7 +108,7 @@ review without waiting for user confirmation.
     tracks added/removed, scope indicators changed substantially), re-run
     the full structural review instead of the gate.
 18. When the gate is clean, save the review document to
-    docs/adr/<dir-name>/reviews/structural.md.
+    docs/adr/<dir-name>/_workflow/reviews/structural.md.
 
 Finding IDs are cumulative across iterations (S1, S2, ... S6, S7).
 

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -4,9 +4,33 @@ Extends the project's base commit conventions (see `CLAUDE.md` §Git
 Conventions). These conventions apply during Phase 3 execution and enable
 reliable session resume by making commit types identifiable in `git log`.
 
-Only **code changes** are committed during execution. Workflow working files
-(step files, review files, plan file) are never committed — they persist on
-disk between sessions. See `conventions.md` §1.2 for the tracking model.
+During execution both **code changes** and **workflow-file changes**
+under `docs/adr/<dir-name>/_workflow/` (the plan, backlog, design,
+step files, review files, design-mutations log) are committed.
+Workflow files are tracked under `_workflow/` for the branch lifetime
+and are removed in the Phase 4 cleanup commit before the PR is
+merged. See `conventions.md` §1.2 for the directory layout and
+`workflow.md` § Final Artifacts for the cleanup procedure.
+
+## Push every commit
+
+After every commit on the branch — code commits, workflow-file
+commits, episode commits, review-fix commits, revert commits, the
+Phase 4 final-artifacts and cleanup commits — run `git push`
+immediately. The branch carries a draft PR (created at the end of
+Phase 1 by `/create-plan`); pushing every commit keeps the draft
+in sync with local state for two reasons:
+
+1. **Team visibility.** The draft PR is how teammates see the
+   feature's progress in real time.
+2. **Disk-loss backup.** Every committed state lives on GitHub, so
+   a local crash or worktree loss never destroys progress.
+
+Use `git push` (or `git push -u origin <branch>` on the first push
+of a session). Use `git push --force-with-lease` if a rebase or
+amend has rewritten history that was already pushed — never plain
+`--force`. CI does not run on draft PRs, so the push frequency
+carries no CI cost.
 
 ---
 
@@ -17,6 +41,9 @@ disk between sessions. See `conventions.md` §1.2 for the tracking model.
 | **Step implementation** | Imperative summary of the change | `Add histogram header to leaf page` |
 | **Review fix** | `Review fix:` prefix | `Review fix: extract validation to helper method` |
 | **Step rollback** | `Revert step:` prefix | `Revert step: add histogram header to leaf page` |
+| **Workflow update** | Imperative summary of the workflow-file change (no special prefix; commit only touches paths under `_workflow/`) | `Add initial plan and design`, `Record episode for histogram leaf write step`, `Phase A review and decomposition for histogram track`, `Mark histogram-leaf track complete` |
+| **Phase 4 final** | `Add final design and ADR` (the standard final-artifacts commit) | (defined verbatim in `prompts/create-final-design.md` § Step 4) |
+| **Phase 4 cleanup** | `Remove workflow scaffolding` — single commit that runs `git rm -r docs/adr/<dir>/_workflow/` after the final-artifacts commit | (see `workflow.md` § Final Artifacts) |
 
 **Step rollback (`Revert step:`) commits** are produced **only by the
 Phase B orchestrator** when a `FIX_REVIEW_FINDINGS` respawn returns a
@@ -42,13 +69,19 @@ exclusively an orchestrator-side operation. See
 [`step-implementation.md`](step-implementation.md) §Post-Commit
 Handlers for the full procedure and resume-dispatch table.
 
-**Commit messages must not cite workflow-internal identifiers**
-(`Track N`, `Step N`, `Track N Step M`, review finding IDs like `CQ33`,
-review iteration counters, named-only plan invariants). These live in
-untracked files that are deleted with the branch. See
-[`conventions-execution.md`](conventions-execution.md) §2.3 for the full
-rule. For `Review fix:` commits, describe the fix by what changed
-(behavior, file, or class) — not by the finding ID that triggered it.
+**Branch-only commit messages may cite workflow-internal identifiers.**
+Individual commit messages on the development branch (`Track N`,
+`Step N`, `Track N Step M`, review finding IDs like `CQ33`, review
+iteration counters, named plan invariants) are squashed away on
+merge — the squashed commit message is built from the PR title and
+body, not from the individual commit messages, so these references
+do not survive into `develop`. The Ephemeral identifier rule in
+[`conventions-execution.md`](conventions-execution.md) §2.3 still
+applies to durable content (source code, tests, PR title and body,
+`design-final.md`, `adr.md`). For `Review fix:` commits, prefer
+describing the fix by what changed (behavior, file, or class) over
+citing the finding ID — but a finding-ID reference on the branch
+is permitted when it makes the commit log easier to follow.
 
 ## How these are used on resume
 

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -66,8 +66,8 @@ A blank line separates the slug from a one-sentence prose explanation
 drawn from the relevant `fix_result.{FAILURE|DESIGN_DECISION|RISK_UPGRADE}`
 field. The implementer never produces this commit type — it is
 exclusively an orchestrator-side operation. See
-[`step-implementation.md`](step-implementation.md) §Post-Commit
-Handlers for the full procedure and resume-dispatch table.
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Post-Commit Handlers for the full procedure and resume-dispatch table.
 
 **Branch-only commit messages may cite workflow-internal identifiers.**
 Individual commit messages on the development branch (`Track N`,
@@ -75,8 +75,10 @@ Individual commit messages on the development branch (`Track N`,
 iteration counters, named plan invariants) are squashed away on
 merge — the squashed commit message is built from the PR title and
 body, not from the individual commit messages, so these references
-do not survive into `develop`. The Ephemeral identifier rule in
-[`conventions-execution.md`](conventions-execution.md) §2.3 still
+do not survive into `develop`. The Ephemeral identifier rule (full
+rule in
+[`ephemeral-identifier-rule.md`](ephemeral-identifier-rule.md); stub
+in [`conventions-execution.md`](conventions-execution.md) §2.3)
 applies to durable content (source code, tests, PR title and body,
 `design-final.md`, `adr.md`). For `Review fix:` commits, prefer
 describing the fix by what changed (behavior, file, or class) over
@@ -85,44 +87,10 @@ is permitted when it makes the commit log easier to follow.
 
 ## How these are used on resume
 
-When Phase B resumes and detects orphan code commits (committed but
-the matching episode commit is missing), it scans
-`git log --oneline {base_commit}..HEAD` and uses these patterns:
-
-1. **`Revert step:` commits** — the previous session rolled the step
-   back after a non-`SUCCESS` review-fix attempt. The next `[ ]` step
-   was already cleanly returned to its pre-implementation state by
-   the revert. Read the `reason: <slug>` line in the body and
-   dispatch per the table in
-   [`step-implementation.md`](step-implementation.md) §Phase B
-   Resume — the bookkeeping differs by slug (write `[!]` for
-   `failed-review-fix`; respawn-and-rederive for
-   `late-design-decision`; verify-or-apply-upgrade for
-   `late-risk-upgrade`).
-2. **Episode commits** (`Record episode for …`, Workflow update
-   touching only `_workflow/tracks/track-<N>.md`) — mark the
-   boundary between completed and in-progress steps. The most
-   recent episode commit is the last fully-finished step.
-3. **`Review fix:` commits** — indicate the dim-review loop already
-   ran for the step they belong to. When an orphan `Review fix:`
-   commit appears after the last episode commit, resume from
-   episode production.
-4. **Implementer code commits** — touch code (paths outside
-   `_workflow/`); subject is the imperative summary of the step's
-   change. When an orphan implementer commit appears after the
-   last episode commit without any `Review fix:` siblings, resume
-   from the dimensional review loop.
-5. **Other Workflow update commits** — touch only `_workflow/`
-   but are not episode commits (Phase 1 init, Phase A
-   decomposition, Phase B base-commit recording, plan-corrections
-   application, track-completion mark, inline-replanning update).
-   They are scaffolding and **not** orphans regardless of
-   position.
-
-The step file on disk is the source of truth for which steps are complete
-(have episodes). Any implementer or `Review fix:` code commits beyond
-the last episode commit are orphans for the next `[ ]` step. A
-`Revert step:` commit cancels the implementer + `Review fix:` commits
-it reverts — together they form a self-contained "attempted and rolled
-back" group that does not count toward any `[x]` step's expected
-commits.
+The `git log` reading rules used by Phase B Resume — how to identify
+orphan implementer commits, `Review fix:` commits, episode commits,
+`Revert step:` commits, and scaffolding Workflow update commits —
+live with the resume procedure itself in
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Resume-side commit-pattern reference. They are loaded only when
+Phase B Resume runs.

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -41,7 +41,7 @@ carries no CI cost.
 | **Step implementation** | Imperative summary of the change | `Add histogram header to leaf page` |
 | **Review fix** | `Review fix:` prefix | `Review fix: extract validation to helper method` |
 | **Step rollback** | `Revert step:` prefix | `Revert step: add histogram header to leaf page` |
-| **Workflow update** | Imperative summary of the workflow-file change (no special prefix; commit only touches paths under `_workflow/`) | `Add initial plan and design`, `Record episode for histogram leaf write step`, `Phase A review and decomposition for histogram track`, `Mark histogram-leaf track complete` |
+| **Workflow update** | Imperative summary of the workflow-file change (no special prefix; commit only touches paths under `_workflow/`) | `Add initial implementation plan and design`, `Phase A review and decomposition for histogram track`, `Record Phase B base commit for histogram track`, `Record episode for histogram leaf write step`, `Apply plan corrections from histogram-leaf review`, `Mark histogram-leaf track complete`, `Inline replan after Track 2` |
 | **Phase 4 final** | `Add final design and ADR` (the standard final-artifacts commit) | (defined verbatim in `prompts/create-final-design.md` § Step 4) |
 | **Phase 4 cleanup** | `Remove workflow scaffolding` — single commit that runs `git rm -r docs/adr/<dir>/_workflow/` after the final-artifacts commit | (see `workflow.md` § Final Artifacts) |
 
@@ -85,8 +85,8 @@ is permitted when it makes the commit log easier to follow.
 
 ## How these are used on resume
 
-When Phase B resumes and detects orphan commits (code committed but episode
-not written to the step file on disk), it scans
+When Phase B resumes and detects orphan code commits (committed but
+the matching episode commit is missing), it scans
 `git log --oneline {base_commit}..HEAD` and uses these patterns:
 
 1. **`Revert step:` commits** — the previous session rolled the step
@@ -99,14 +99,30 @@ not written to the step file on disk), it scans
    `failed-review-fix`; respawn-and-rederive for
    `late-design-decision`; verify-or-apply-upgrade for
    `late-risk-upgrade`).
-2. **`Review fix:` commits** — indicate the dim-review loop already
-   ran for that step. Resume from episode production.
-3. **Implementation commits** — anything else → dim-review loop has
-   not run. Resume from review.
+2. **Episode commits** (`Record episode for …`, Workflow update
+   touching only `_workflow/tracks/track-<N>.md`) — mark the
+   boundary between completed and in-progress steps. The most
+   recent episode commit is the last fully-finished step.
+3. **`Review fix:` commits** — indicate the dim-review loop already
+   ran for the step they belong to. When an orphan `Review fix:`
+   commit appears after the last episode commit, resume from
+   episode production.
+4. **Implementer code commits** — touch code (paths outside
+   `_workflow/`); subject is the imperative summary of the step's
+   change. When an orphan implementer commit appears after the
+   last episode commit without any `Review fix:` siblings, resume
+   from the dimensional review loop.
+5. **Other Workflow update commits** — touch only `_workflow/`
+   but are not episode commits (Phase 1 init, Phase A
+   decomposition, Phase B base-commit recording, plan-corrections
+   application, track-completion mark, inline-replanning update).
+   They are scaffolding and **not** orphans regardless of
+   position.
 
 The step file on disk is the source of truth for which steps are complete
-(have episodes). Any code commits beyond the last completed step's work
-are orphans for the next `[ ]` step. A `Revert step:` commit cancels
-the implementer + `Review fix:` commits it reverts — together they form
-a self-contained "attempted and rolled back" group that does not count
-toward any `[x]` step's expected commits.
+(have episodes). Any implementer or `Review fix:` code commits beyond
+the last episode commit are orphans for the next `[ ]` step. A
+`Revert step:` commit cancels the implementer + `Review fix:` commits
+it reverts — together they form a self-contained "attempted and rolled
+back" group that does not count toward any `[x]` step's expected
+commits.

--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -11,105 +11,17 @@ Execution-specific formats and rules. Loaded only during Phase 3
 These subsections extend the plan file structure defined in
 `conventions.md` §1.2.
 
-### After track completion (user-approved)
+The phase-specific plan-entry mutations (collapse-on-completion and
+strategy-refresh-line append) live with their owning phase
+documents — they are not loaded by every Phase 3 session:
 
-The track episode is written to the plan file **only after the user
-approves** the track results, and at the same time the description is
-**collapsed** to remove implementation detail that is now superseded by
-the committed code and step episodes (see workflow.md §Track Completion
-Protocol).
-
-**Always keep** (regardless of plan shape): the **intro paragraph** (the
-first paragraph of the original description, before any `**What**:` /
-`**How**:` / `**Constraints**:` / `**Interactions**:` subsection), the
-`**Track episode:**` block (written at collapse time), the `**Step
-file:**` pointer, and the `**Strategy refresh:**` line if present — the
-next session's strategy refresh appends it per §"After strategy refresh"
-below.
-
-**Always drop**: the `**Scope:**` line and the `**Depends on:**` line.
-
-Pending-track entries in the plan are written in the thin form during
-Phase 1, so there are no `**What**:` / `**How**:` / `**Constraints**:` /
-`**Interactions**:` subsections present in the plan-file entry to drop —
-the detailed description was removed from the backlog at Phase A start
-and already lives in the step file's `## Description` section; Phase C
-does not touch the backlog.
-
-```markdown
-- [x] Track 2: <title>
-  > <intro paragraph>
-  >
-  > **Track episode:**
-  > <strategic summary — length proportional to cross-track impact>
-  >
-  > **Step file:** `tracks/track-2.md` (4 steps, 0 failed)
-```
-
-**Track episode fields:**
-- Strategic summary covering: what was built, key discoveries, plan deviations
-  with cross-track impact. Length is proportional to cross-track impact — a
-  routine track may need only a couple of sentences, while a track with
-  architectural surprises should include enough detail for the next session's
-  strategy refresh to assess downstream impact without reading the step file.
-- Reference to the step file with step count and failure count
-- This is what future track sessions read from the plan file — the step
-  file is available for deeper investigation if needed
-
-**Why collapse:** Completed tracks accumulate in the plan file and are
-re-sent to every sub-agent as strategic context. Keeping the full
-implementation detail for completed tracks inflates every code-review
-sub-agent prompt by tens of thousands of tokens. The intro paragraph plus
-track episode is sufficient strategic context for reviewers of later
-tracks. For how sub-agents render the plan, see
-[`plan-slim-rendering.md`](plan-slim-rendering.md).
-
-### After strategy refresh
-
-The strategy refresh result is appended to the same track's block in the
-plan file, after the step file reference:
-
-```markdown
-- [x] Track 2: <title>
-  > <intro paragraph>
-  >
-  > **Track episode:**
-  > <strategic summary>
-  >
-  > **Step file:** `tracks/track-2.md` (4 steps, 0 failed)
-  >
-  > **Strategy refresh:** CONTINUE — no downstream impact detected.
-```
-
-For ADJUST, include a brief summary of what was adjusted:
-
-```markdown
-  > **Strategy refresh:** ADJUST — Track 4 description updated to account
-  > for the new `IndexStatistics` API shape discovered during this track.
-```
-
-For skipped tracks (`[~]`), the strategy refresh line follows the skip
-record. The plan entry holds only the intro paragraph (the
-`**What/How/Constraints/Interactions**` detail lived in
-`implementation-backlog.md` and `track-skip` removes that section at the
-same time it marks `[~]` — see `track-skip.md`). Skipped tracks never go
-through the Phase C collapse, so nothing further trims the plan entry:
-
-```markdown
-- [~] Track 3: <title>
-  > <description>
-  >
-  > **Skipped:** <reason>
-  >
-  > **Strategy refresh:** CONTINUE — no downstream impact from skipping.
-```
-
-For how sub-agents see this — `plan-slim-rendering.md` strips the
-implementation-detail subsections at prompt-assembly time so reviewers
-get a compact view without changing what's on disk.
-
-ESCALATE triggers inline replanning (see workflow.md), which restructures
-the plan file directly — no strategy refresh line is written.
+- **Track-completion collapse** (Phase C): see
+  [`track-code-review.md`](track-code-review.md) § Track Completion
+  step 4 — the "Always keep" / "Always drop" rule, the track-episode
+  fields, and the final on-disk form.
+- **Strategy refresh line** (State A): see
+  [`strategy-refresh.md`](strategy-refresh.md) step 5 — the line
+  format for CONTINUE / ADJUST and the `[~]`-track variant.
 
 ### Session state detection
 
@@ -244,9 +156,9 @@ pending, active, and completed tracks. Phase A resume logic (see
 [`track-review.md`](track-review.md)) and inline replanning (see
 [`inline-replanning.md`](inline-replanning.md)) both read the same
 rules from here. Skipped tracks follow a separate retention rule —
-see §"After strategy refresh" above for the authoritative statement
-(the plan entry keeps only the intro paragraph; the `[~]` entry is
-never collapsed).
+see [`strategy-refresh.md`](strategy-refresh.md) step 5 for the
+authoritative statement on the `[~]`-track plan entry (intro
+paragraph + `**Skipped:**` + `**Strategy refresh:**`; never collapsed).
 
 | Phase | Authoritative location | Writer | Reader(s) |
 |---|---|---|---|
@@ -325,117 +237,41 @@ to cross-track impact.
 
 ---
 
-## 2.3 Ephemeral identifier rule — don't leak workflow IDs into durable content
+## 2.3 Ephemeral identifier rule — pointer
 
-**Authoritative statement.** This is the single source of truth for the
-rule; every phase-specific prompt that touches durable content points
-here.
+The full rule (forbidden categories with examples, allowed list,
+rewrite examples, branch-only-commit exemption) lives in
+[`ephemeral-identifier-rule.md`](ephemeral-identifier-rule.md). Load
+that file when about to author durable content — source code, tests,
+Javadoc, PR title/body, `design-final.md`, or `adr.md`.
 
-`implementation-plan.md`, `implementation-backlog.md`,
-`tracks/track-N.md`, and `reviews/**` live under
-`docs/adr/<dir-name>/_workflow/`. They are tracked on the branch during
-development, but the entire `_workflow/` directory is removed in the
-Phase 4 cleanup commit before the PR is merged — so any identifier
-that lives only in those files becomes a dangling reference the moment
-`develop` swallows the squash. The same applies to review-loop counters
-and named invariants that live only in the plan. Therefore, **anything
-that survives merge into `develop` must not cite those identifiers**.
+**Quick recap (do not rely on this list alone for borderline cases —
+read the full rule):**
 
-### Where the rule applies
+Forbidden in durable content:
+- Track / Step labels (`Track N`, `Step M`, `Track N Step M`)
+- Review finding IDs / prefixes (`CQ33`, `F-12`, `R-4`, …)
+- Review-loop iteration counters (`iteration 1`, `round 2`)
+- Named invariants cited by label only ("Single-authority invariant", …)
+- Plan-file Decision Record IDs not restated in `adr.md`
 
-- **Source code comments and Javadoc** — the most common leak. Comments
-  like `// added per Track 2 Step 1`, `// fixes CQ33`, or `// see
-  Single-authority invariant` tie the code to files that no longer
-  exist after the cleanup commit.
-- **PR titles and descriptions** — stored in GitHub, used as the body
-  of the squashed merge commit (per CLAUDE.md § Git Conventions).
-- **`design-final.md`** and **`adr.md`** — the only workflow files
-  that survive merge into `develop`; see
-  [`prompts/create-final-design.md`](prompts/create-final-design.md)
-  for Phase-4-specific examples.
-- **Tests, test names, and test descriptions** — committed alongside
-  the code.
+Allowed: file paths, class/method/field names, commit SHAs,
+`adr.md`-defined DR IDs, issue tracker IDs (e.g. `YTDB-123`).
 
-**Branch-only commit messages are exempt.** Individual commit messages
-on the development branch (Phase A/B/C session commits, step commits,
-review-fix commits, episode commits, workflow-file commits) may freely
-cite Track / Step / finding labels — they are squashed away on merge,
-the squashed message is assembled from the PR title and body (not from
-the individual commit messages), and the underlying workflow files are
-present in the branch tree at the time those commits are made. The
-forbidden list above is what lives durably on `develop`.
-
-It does **not** apply to the working files themselves: step files
-(`tracks/track-N.md`), review files, the plan, and the backlog all
-cite tracks, steps, findings, and iterations freely — that's exactly
-what those identifiers are for inside the workflow.
-
-### Forbidden
-
-- Track labels: `Track 1`, `Track N`, `Track N: <title>`
-- Step labels: `Step 1`, `Step N`, `Step M of Track N`
-- Compound labels: `Track 2 Step 1`, `Track 4 iteration 1`
-- Review finding IDs and prefixes: `CQ33`, `F-12`, `R-4`, `A-7`,
-  `S-2`, or any other `<PREFIX><number>` finding label from
-  `reviews/**`
-- Review-loop iteration counters: `iteration 1`, `round 2`, when they
-  refer to ephemeral review loops
-- Named invariants or rule names cited **by label only** —
-  "Single-authority invariant", "Load-bearing-file rule",
-  "Byte-identity discipline", etc. If the rule matters for a future
-  reader of committed content, either restate it in prose or cross-
-  reference the stable `.claude/workflow/` location that defines it
-  (e.g. `conventions.md` §1.2, `conventions-execution.md` §2.1).
-- Plan-file Decision Record IDs (`D1`, `D2`, …) that are **not**
-  restated in `adr.md`. IDs that ARE restated in `adr.md` are stable
-  (the ADR owns them post-implementation) and may be cited.
-
-### Allowed (these survive in git or are self-contained)
-
-- File paths under the project — source files, workflow docs in
-  `.claude/workflow/`, committed artifacts
-- Class, interface, method, and field names
-- Commit SHAs — the stable way to point at "where this was implemented"
-- `adr.md`-defined Decision Record IDs, when `adr.md` itself is the
-  reader's reachable context
-- Issue tracker IDs (e.g. `YTDB-123`) — these survive in the tracker
-
-### How to rewrite a forbidden reference
-
-Replace the ephemeral label with (a) a prose description of what was
-done, (b) the file/class that was modified, or (c) the commit SHA that
-implemented it.
-
-Examples:
-
-- ❌ `// added during Track 2 Step 1 to unblock Phase A resume`
-- ✅ `// part of the atomic step-file-write + backlog-section-remove
-      ordering that keeps Phase A resume idempotent`
-
-- ❌ `Review fix: address CQ72 (anchor drift in slim rendering)`
-- ✅ `Review fix: restore byte-identical phrasing at the two
-      cross-reference sites in plan-slim-rendering.md`
-
-- ❌ `// see Track 4 iteration 1 for context`
-- ✅ `// see commit abc1234 for the follow-up that restored these
-      sites; the first pass missed two of them`
-
-When in doubt: if a reader on `main` (without the branch, without the
-plan) couldn't resolve the reference, the reference is forbidden.
-
-### Self-check before commit
-
-Run a quick grep on staged files before committing — applies to code,
-tests, and the two Phase 4 artifacts (NOT to commits that only stage
-files under `_workflow/`, which are themselves ephemeral):
+**Self-check before any code/test commit:**
 
 ```bash
 git diff --cached -- ':!docs/adr/*/_workflow' | grep -nE '\b(Track|Step)[ ]?[0-9]+|\b[A-Z]{1,3}[0-9]+\b'
 ```
 
-Anything this catches is either a genuine leak to rewrite or an
-allowed exception (e.g. issue tracker IDs, class names that happen to
-match the pattern) — inspect, then proceed.
+If the grep fires zero matches, the commit is clean and
+`ephemeral-identifier-rule.md` does not need to be loaded for that
+commit. If it fires any matches — load the full rule and consult its
+"How to rewrite a forbidden reference" section before resolving.
+
+**Branch-only commit messages are exempt.** Individual commit messages
+on the development branch may cite Track / Step / finding labels —
+they are squashed away on merge.
 
 ---
 
@@ -453,8 +289,9 @@ at session startup. Load on demand:
   branch's draft PR for team visibility; see
   [`commit-conventions.md`](commit-conventions.md) for the push rule
   and the execution-specific prefixes (`Review fix:`) used during
-  session resume. The Ephemeral identifier rule (§2.3 above) applies
-  to durable content — branch-only commit messages are exempt.
+  session resume. The Ephemeral identifier rule (§2.3 stub above; full
+  rule in [`ephemeral-identifier-rule.md`](ephemeral-identifier-rule.md))
+  applies to durable content — branch-only commit messages are exempt.
 - **Two-tier dimensional code review** (step-level and track-level
   sub-agent reviews, 4 baseline + up to 6 conditional, max 3 iterations):
   [`code-review-protocol.md`](code-review-protocol.md).

--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -190,10 +190,10 @@ level measured at sub-step 6 of step-implementation.md and recorded when
 the episode is written in sub-step 7. The agent marks it `[x]` with the
 measured level (`safe`, `info`, `warning`, or `critical`). If measurement
 failed (file missing or command error), record `- [x] Context: unavailable`.
-This sub-item is written to the step file on disk alongside the episode;
-like episodes, it is not committed to git. It must be marked before the
-step is considered complete — an unmarked context check means the agent
-skipped the check.
+This sub-item is written to the step file (under `_workflow/tracks/`)
+alongside the episode and is committed and pushed with the episode
+commit. It must be marked before the step is considered complete — an
+unmarked context check means the agent skipped the check.
 
 The **Risk:** line in each step's description blockquote names the step's
 risk level (`low`, `medium`, or `high`) and the triggering category (or
@@ -268,11 +268,12 @@ corresponding description row above.
 
 **Monotonic shrinkage:** The backlog grows only during Phase 1 or inline
 replanning, and shrinks as tracks enter Phase A or are skipped. Normal
-Phase A / B / C execution never adds entries. The file itself is never
-committed to git — it is a working file that persists on disk between
-sessions and is cleaned up when the branch is deleted after PR merge
-(see `conventions.md` §1.2: "Working files persist on disk between
-sessions and are never committed").
+Phase A / B / C execution never adds entries. The file lives under
+`docs/adr/<dir-name>/_workflow/` — tracked in git during the branch
+lifetime so changes are pushed to the draft PR for team visibility and
+disk-loss backup, and removed in the Phase 4 cleanup commit before
+merge (see `conventions.md` §1.2 for the full lifecycle and
+`workflow.md` § Final Artifacts for the cleanup procedure).
 
 ### Backlog section body extraction rule
 
@@ -324,39 +325,45 @@ to cross-track impact.
 
 ---
 
-## 2.3 Ephemeral identifier rule — don't leak workflow IDs into committed content
+## 2.3 Ephemeral identifier rule — don't leak workflow IDs into durable content
 
 **Authoritative statement.** This is the single source of truth for the
-rule; every phase-specific prompt that touches committed content points
+rule; every phase-specific prompt that touches durable content points
 here.
 
 `implementation-plan.md`, `implementation-backlog.md`,
-`tracks/track-N.md`, and `reviews/**` are working files — untracked, and
-deleted together with the branch after the PR is merged. Any identifier
+`tracks/track-N.md`, and `reviews/**` live under
+`docs/adr/<dir-name>/_workflow/`. They are tracked on the branch during
+development, but the entire `_workflow/` directory is removed in the
+Phase 4 cleanup commit before the PR is merged — so any identifier
 that lives only in those files becomes a dangling reference the moment
-the branch is gone. The same applies to review-loop counters and named
-invariants that live only in the plan. Therefore, **anything that goes
-into git must not cite those identifiers**.
+`develop` swallows the squash. The same applies to review-loop counters
+and named invariants that live only in the plan. Therefore, **anything
+that survives merge into `develop` must not cite those identifiers**.
 
 ### Where the rule applies
 
 - **Source code comments and Javadoc** — the most common leak. Comments
   like `// added per Track 2 Step 1`, `// fixes CQ33`, or `// see
-  Single-authority invariant` tie the code to files that will not exist
-  on `main`.
-- **Commit messages** — even though per-commit messages are squashed on
-  merge (see CLAUDE.md §Git Conventions), the squashed commit message
-  is assembled from the PR title/description and inherits this content.
-  Individual commit messages are also visible in code review and PR
-  history before squashing.
-- **PR titles and descriptions** — stored in GitHub, keyed off by the
-  squashed commit message.
+  Single-authority invariant` tie the code to files that no longer
+  exist after the cleanup commit.
+- **PR titles and descriptions** — stored in GitHub, used as the body
+  of the squashed merge commit (per CLAUDE.md § Git Conventions).
 - **`design-final.md`** and **`adr.md`** — the only workflow files
-  committed to git; see
+  that survive merge into `develop`; see
   [`prompts/create-final-design.md`](prompts/create-final-design.md)
   for Phase-4-specific examples.
 - **Tests, test names, and test descriptions** — committed alongside
   the code.
+
+**Branch-only commit messages are exempt.** Individual commit messages
+on the development branch (Phase A/B/C session commits, step commits,
+review-fix commits, episode commits, workflow-file commits) may freely
+cite Track / Step / finding labels — they are squashed away on merge,
+the squashed message is assembled from the PR title and body (not from
+the individual commit messages), and the underlying workflow files are
+present in the branch tree at the time those commits are made. The
+forbidden list above is what lives durably on `develop`.
 
 It does **not** apply to the working files themselves: step files
 (`tracks/track-N.md`), review files, the plan, and the backlog all
@@ -419,10 +426,11 @@ plan) couldn't resolve the reference, the reference is forbidden.
 ### Self-check before commit
 
 Run a quick grep on staged files before committing — applies to code,
-tests, and the two Phase 4 artifacts:
+tests, and the two Phase 4 artifacts (NOT to commits that only stage
+files under `_workflow/`, which are themselves ephemeral):
 
 ```bash
-git diff --cached | grep -nE '\b(Track|Step)[ ]?[0-9]+|\b[A-Z]{1,3}[0-9]+\b'
+git diff --cached -- ':!docs/adr/*/_workflow' | grep -nE '\b(Track|Step)[ ]?[0-9]+|\b[A-Z]{1,3}[0-9]+\b'
 ```
 
 Anything this catches is either a genuine leak to rewrite or an
@@ -437,11 +445,16 @@ These rules are needed only when their specific phase or action runs — not
 at session startup. Load on demand:
 
 - **Commit message format** — follow the project's `CLAUDE.md` commit
-  conventions. Only code changes are committed; workflow files are never
-  committed (see §1.2 in `conventions.md`). For the execution-specific
-  prefixes (`Review fix:`) used during session resume, see
-  [`commit-conventions.md`](commit-conventions.md). Apply the Ephemeral
-  identifier rule (§2.3 above) to every commit message.
+  conventions. Both code changes and workflow-file changes (under
+  `_workflow/`) are committed during the branch lifetime; the
+  `_workflow/` directory is removed in the Phase 4 cleanup commit
+  before merge (see §1.2 in `conventions.md` and `workflow.md`
+  § Final Artifacts). Every commit is pushed immediately to the
+  branch's draft PR for team visibility; see
+  [`commit-conventions.md`](commit-conventions.md) for the push rule
+  and the execution-specific prefixes (`Review fix:`) used during
+  session resume. The Ephemeral identifier rule (§2.3 above) applies
+  to durable content — branch-only commit messages are exempt.
 - **Two-tier dimensional code review** (step-level and track-level
   sub-agent reviews, 4 baseline + up to 6 conditional, max 3 iterations):
   [`code-review-protocol.md`](code-review-protocol.md).

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -23,7 +23,7 @@ during Phase 3 execution.
 | **Sub-agent** | A spawned agent for self-contained tasks — review (technical/risk/adversarial, dimensional code review, test quality review) where fresh perspective matters, or implementation (Phase B per-step implementer) where context absorption matters. The orchestrator retains session-level state. |
 | **Orchestrator** | The session-level agent driving `/execute-tracks`. In Phase B owns sub-steps 4–7 of step implementation and all session-level decisions (cross-track impact, escalation, episode synthesis, context-level session-end gate). Distinct from the implementer. |
 | **Implementer** | A fresh sub-agent spawned per step in Phase B that performs sub-steps 1–3 of step implementation (implement, test, commit) and returns a structured handoff to the orchestrator. See [`implementer-rules.md`](implementer-rules.md). |
-| **Backlog** | `implementation-backlog.md` — the companion file to `implementation-plan.md` that holds the detailed `**What/How/Constraints/Interactions**` subsections and any track-level Mermaid diagrams for pending tracks. Written during Phase 1 alongside the plan (and extended by inline replanning); shrinks monotonically as tracks enter Phase A or are skipped; never committed to git. |
+| **Backlog** | `implementation-backlog.md` — the companion file to `implementation-plan.md` that holds the detailed `**What/How/Constraints/Interactions**` subsections and any track-level Mermaid diagrams for pending tracks. Written during Phase 1 alongside the plan (and extended by inline replanning); shrinks monotonically as tracks enter Phase A or are skipped. Lives under `_workflow/` (tracked on the branch for backup and team visibility, removed in Phase 4 cleanup before merge). |
 
 ---
 
@@ -35,16 +35,18 @@ defaulting to the current git branch name.
 
 ```
 docs/adr/<dir-name>/
-  ## Working files (untracked — on disk only, deleted with the branch)
-  implementation-plan.md          <- strategic: goals, architecture, tracks,
+  ## Ephemeral working files (tracked under _workflow/ during the branch
+  ## lifetime; removed in Phase 4 cleanup before merge)
+  _workflow/
+    implementation-plan.md        <- strategic: goals, architecture, tracks,
                                      track-level episodic summaries (thin
                                      checklist — description detail lives in
                                      implementation-backlog.md)
-  implementation-backlog.md       <- pending-track details (what/how/
+    implementation-backlog.md     <- pending-track details (what/how/
                                      constraints/interactions + any
                                      track-level diagrams); shrinks
                                      monotonically
-  design.md                       <- narrative: concept-first Overview
+    design.md                     <- narrative: concept-first Overview
                                      (first content), Core Concepts vocabulary
                                      primer (when doc has Parts or ≥3 new
                                      domain terms), class diagrams, workflow
@@ -55,7 +57,7 @@ docs/adr/<dir-name>/
                                      design-document-rules.md § Mutation
                                      discipline. Frozen between Phase 1 end
                                      and Phase 4 start.
-  design-mechanics.md             <- (optional, length-triggered) long-form
+    design-mechanics.md           <- (optional, length-triggered) long-form
                                      derivations, file:line citations,
                                      edit-list subsections, full state-
                                      machine tables. Created when design.md
@@ -63,21 +65,22 @@ docs/adr/<dir-name>/
                                      Section names match design.md so
                                      `**Full design**` refs in the plan
                                      resolve in either file.
-  tracks/
-    track-1.md                    <- tactical: decomposed steps, step episodes
-    track-2.md
-    ...
-  reviews/
-    structural.md                 <- Phase 2 structural-review output
-    consistency.md                <- Phase 2 consistency-review output
-    design-mutations.md           <- append-only log of every design.md
+    tracks/
+      track-1.md                  <- tactical: decomposed steps, step episodes
+      track-2.md
+      ...
+    reviews/
+      structural.md               <- Phase 2 structural-review output
+      consistency.md              <- Phase 2 consistency-review output
+      design-mutations.md         <- append-only log of every design.md
                                      mutation: diff summary, mechanical-check
                                      result, cold-read verdict, iteration
                                      count
-    track-1-technical.md
-    ...
+      track-1-technical.md
+      ...
 
-  ## Final artifacts (committed in Phase 4 — the only tracked files)
+  ## Final artifacts (committed in Phase 4 — the only files that survive
+  ## merge into develop)
   design-final.md                 <- post-implementation design reflecting
                                      what was actually built; same shape as
                                      design.md (mutation discipline applies)
@@ -85,9 +88,14 @@ docs/adr/<dir-name>/
                                      outcomes, aggregated from all episodes
 ```
 
-Working files persist on disk between sessions and are never committed.
-The user deletes them alongside the branch after the PR is merged.
-Only the two Phase 4 artifacts are committed to git.
+The `_workflow/` subtree is **tracked** in git during the branch lifetime —
+each session commits and pushes its workflow-file changes alongside its code
+commits, so the branch on GitHub always reflects the latest progress (useful
+for team visibility on a draft PR, and as a backup against local disk loss).
+At Phase 4, after `design-final.md` and `adr.md` are committed, the entire
+`_workflow/` directory is removed in a single cleanup commit so only the two
+durable artifacts survive the squash-merge into `develop`. See
+`workflow.md` § Final Artifacts for the cleanup procedure.
 
 ### Plan file content (`implementation-plan.md`)
 

--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -1,9 +1,11 @@
 # Design Document Rules
 
 The plan must be accompanied by a separate **design document** at
-`docs/adr/<dir-name>/design.md` that explains **what will be implemented at a
-design level** — not code, but the structural and behavioral design of the
-solution.
+`docs/adr/<dir-name>/_workflow/design.md` that explains **what will be
+implemented at a design level** — not code, but the structural and
+behavioral design of the solution. (Phase 4 promotes the post-implementation
+view of this design to the durable `docs/adr/<dir-name>/design-final.md`;
+the working `_workflow/` copy is removed in the Phase 4 cleanup commit.)
 
 ## Purpose
 
@@ -226,7 +228,7 @@ context to disambiguate.
 ### Review log
 
 Each mutation appends to
-`docs/adr/<dir-name>/reviews/design-mutations.md`. The minimum
+`docs/adr/<dir-name>/_workflow/reviews/design-mutations.md`. The minimum
 shape per entry is:
 
 ```markdown
@@ -252,8 +254,10 @@ line, a `SKIPPED` value for cold-read on `mechanics-edit`, and a
 entries. Use the skill's expanded format when writing the log;
 treat the shape above as the floor, not the ceiling.
 
-The review log is a working artifact (deleted with the branch),
-not committed — same lifecycle as other Phase working files.
+The review log is a working artifact under `_workflow/reviews/`
+(tracked on the branch for backup and visibility, removed by the
+Phase 4 cleanup commit before merge — same lifecycle as other
+working files).
 
 ### Cold-read sub-agent prompt
 
@@ -736,8 +740,9 @@ that warrant dedicated sections:
 
 ## Rules
 
-1. **Separate file** — the design document lives at `docs/adr/<dir-name>/design.md`,
-   not inside the implementation plan.
+1. **Separate file** — the design document lives at
+   `docs/adr/<dir-name>/_workflow/design.md`, not inside the
+   implementation plan.
 2. **All diagrams must be Mermaid** — use `classDiagram`, `sequenceDiagram`,
    `flowchart`, or `stateDiagram` as appropriate. No external tools or image files.
 3. **Design level, not code level** — describe classes, interfaces, relationships,

--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -792,7 +792,10 @@ that warrant dedicated sections:
     `design-mechanics.md` if it exists) is never modified after
     planning. Phase 4 produces `design-final.md` (actual design,
     same shape rules) and `adr.md` (architecture decisions with
-    actual outcomes) — the only git-tracked workflow artifacts.
+    actual outcomes) — the only workflow artifacts that survive
+    merge into `develop` (everything under `_workflow/` is tracked
+    during the branch lifetime but removed in the Phase 4 cleanup
+    commit).
     `design-final.md` goes through the mutation discipline via the
     `phase4-creation` kind; if the original had a mechanics
     companion, `design-mechanics-final.md` is created in the same

--- a/.claude/workflow/ephemeral-identifier-rule.md
+++ b/.claude/workflow/ephemeral-identifier-rule.md
@@ -1,0 +1,128 @@
+# Ephemeral Identifier Rule — Don't Leak Workflow IDs into Durable Content
+
+**Authoritative statement.** This is the single source of truth for the
+rule; every phase-specific prompt that touches durable content points
+here.
+
+`implementation-plan.md`, `implementation-backlog.md`,
+`tracks/track-N.md`, and `reviews/**` live under
+`docs/adr/<dir-name>/_workflow/`. They are tracked on the branch during
+development, but the entire `_workflow/` directory is removed in the
+Phase 4 cleanup commit before the PR is merged — so any identifier
+that lives only in those files becomes a dangling reference the moment
+`develop` swallows the squash. The same applies to review-loop counters
+and named invariants that live only in the plan. Therefore, **anything
+that survives merge into `develop` must not cite those identifiers**.
+
+## When to load this file
+
+Read this file when about to author durable content:
+
+- Implementer is about to write source code, tests, or Javadoc that
+  will be committed (see
+  [`implementer-rules.md`](implementer-rules.md)).
+- Phase C orchestrator is authoring a `Review fix:` commit's code
+  changes (see [`track-code-review.md`](track-code-review.md)).
+- Phase 4 is composing `design-final.md`, `adr.md`, or the PR title
+  and body (see
+  [`prompts/create-final-design.md`](prompts/create-final-design.md)).
+
+The §"Self-check before commit" grep below is the precondition — if
+it fires zero matches on staged files, the full rule is not needed
+for that commit.
+
+## Where the rule applies
+
+- **Source code comments and Javadoc** — the most common leak. Comments
+  like `// added per Track 2 Step 1`, `// fixes CQ33`, or `// see
+  Single-authority invariant` tie the code to files that no longer
+  exist after the cleanup commit.
+- **PR titles and descriptions** — stored in GitHub, used as the body
+  of the squashed merge commit (per CLAUDE.md § Git Conventions).
+- **`design-final.md`** and **`adr.md`** — the only workflow files
+  that survive merge into `develop`; see
+  [`prompts/create-final-design.md`](prompts/create-final-design.md)
+  for Phase-4-specific examples.
+- **Tests, test names, and test descriptions** — committed alongside
+  the code.
+
+**Branch-only commit messages are exempt.** Individual commit messages
+on the development branch (Phase A/B/C session commits, step commits,
+review-fix commits, episode commits, workflow-file commits) may freely
+cite Track / Step / finding labels — they are squashed away on merge,
+the squashed message is assembled from the PR title and body (not from
+the individual commit messages), and the underlying workflow files are
+present in the branch tree at the time those commits are made. The
+forbidden list above is what lives durably on `develop`.
+
+It does **not** apply to the working files themselves: step files
+(`tracks/track-N.md`), review files, the plan, and the backlog all
+cite tracks, steps, findings, and iterations freely — that's exactly
+what those identifiers are for inside the workflow.
+
+## Forbidden
+
+- Track labels: `Track 1`, `Track N`, `Track N: <title>`
+- Step labels: `Step 1`, `Step N`, `Step M of Track N`
+- Compound labels: `Track 2 Step 1`, `Track 4 iteration 1`
+- Review finding IDs and prefixes: `CQ33`, `F-12`, `R-4`, `A-7`,
+  `S-2`, or any other `<PREFIX><number>` finding label from
+  `reviews/**`
+- Review-loop iteration counters: `iteration 1`, `round 2`, when they
+  refer to ephemeral review loops
+- Named invariants or rule names cited **by label only** —
+  "Single-authority invariant", "Load-bearing-file rule",
+  "Byte-identity discipline", etc. If the rule matters for a future
+  reader of committed content, either restate it in prose or cross-
+  reference the stable `.claude/workflow/` location that defines it
+  (e.g. `conventions.md` §1.2, `conventions-execution.md` §2.1).
+- Plan-file Decision Record IDs (`D1`, `D2`, …) that are **not**
+  restated in `adr.md`. IDs that ARE restated in `adr.md` are stable
+  (the ADR owns them post-implementation) and may be cited.
+
+## Allowed (these survive in git or are self-contained)
+
+- File paths under the project — source files, workflow docs in
+  `.claude/workflow/`, committed artifacts
+- Class, interface, method, and field names
+- Commit SHAs — the stable way to point at "where this was implemented"
+- `adr.md`-defined Decision Record IDs, when `adr.md` itself is the
+  reader's reachable context
+- Issue tracker IDs (e.g. `YTDB-123`) — these survive in the tracker
+
+## How to rewrite a forbidden reference
+
+Replace the ephemeral label with (a) a prose description of what was
+done, (b) the file/class that was modified, or (c) the commit SHA that
+implemented it.
+
+Examples:
+
+- ❌ `// added during Track 2 Step 1 to unblock Phase A resume`
+- ✅ `// part of the atomic step-file-write + backlog-section-remove
+      ordering that keeps Phase A resume idempotent`
+
+- ❌ `Review fix: address CQ72 (anchor drift in slim rendering)`
+- ✅ `Review fix: restore byte-identical phrasing at the two
+      cross-reference sites in plan-slim-rendering.md`
+
+- ❌ `// see Track 4 iteration 1 for context`
+- ✅ `// see commit abc1234 for the follow-up that restored these
+      sites; the first pass missed two of them`
+
+When in doubt: if a reader on `main` (without the branch, without the
+plan) couldn't resolve the reference, the reference is forbidden.
+
+## Self-check before commit
+
+Run a quick grep on staged files before committing — applies to code,
+tests, and the two Phase 4 artifacts (NOT to commits that only stage
+files under `_workflow/`, which are themselves ephemeral):
+
+```bash
+git diff --cached -- ':!docs/adr/*/_workflow' | grep -nE '\b(Track|Step)[ ]?[0-9]+|\b[A-Z]{1,3}[0-9]+\b'
+```
+
+Anything this catches is either a genuine leak to rewrite or an
+allowed exception (e.g. issue tracker IDs, class names that happen to
+match the pattern) — inspect, then proceed.

--- a/.claude/workflow/episode-format-reference.md
+++ b/.claude/workflow/episode-format-reference.md
@@ -130,15 +130,18 @@ line; a step that uncovered a concurrency bug needs a full explanation.
 ## Code commit and episode ordering
 
 Code changes are committed first (including any code review fix commits).
-After all code is committed, the episode is written to the step file on
-disk. Episodes are never committed — they are working files that persist
-between sessions and are aggregated into the ADR during Phase 4.
+After all code is committed, the orchestrator writes the episode to the
+step file (under `_workflow/tracks/`) and commits the step-file change
+in a follow-up commit (e.g., `Record episode for <step description>`),
+then pushes. Episodes live under `_workflow/` for the branch lifetime
+and are aggregated into the ADR during Phase 4; the entire `_workflow/`
+directory is removed by the Phase 4 cleanup commit before merge.
 
 ---
 
 ## Where episodes live
 
-Step-level episodes: **step file** (`docs/adr/<dir-name>/tracks/track-N.md`)
+Step-level episodes: **step file** (`docs/adr/<dir-name>/_workflow/tracks/track-N.md`)
 
 Track-level episodes: **plan file** (`implementation-plan.md`) under the
 track's checklist entry — a strategic summary synthesized from step episodes.

--- a/.claude/workflow/episode-format-reference.md
+++ b/.claude/workflow/episode-format-reference.md
@@ -85,8 +85,8 @@ HEAD`) and returns `RESULT: FAILED` with a `FAILURE` block. The orchestrator
 writes the failed episode from `FAILURE` to the step file. If the failure
 arrived from a `mode=FIX_REVIEW_FINDINGS` respawn (post-commit), the
 orchestrator additionally runs the `Revert step:` rollback per
-[`step-implementation.md`](step-implementation.md) §Post-Commit Handlers
-before writing the episode.
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Post-Commit Handlers before writing the episode.
 
 The orchestrator then decides:
 - **Retry** with a different approach
@@ -95,7 +95,9 @@ The orchestrator then decides:
 - **Escalate** if the failure undermines the track's approach
 
 If the same step fails twice, stop and present the situation to the user
-(see [`step-implementation.md`](step-implementation.md) §Two-Failure Rule).
+(see
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Two-Failure Rule).
 
 Failed episodes are recorded in the step file with the `[!]` marker so
 future sessions and reviews can see what was attempted and why it didn't

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -128,7 +128,7 @@ Phase 1 (Planning) to rework the plan/design before re-entering.
 
 ### Review output
 
-Saved to `docs/adr/<dir-name>/reviews/consistency.md`.
+Saved to `docs/adr/<dir-name>/_workflow/reviews/consistency.md`.
 
 ---
 
@@ -178,7 +178,7 @@ the full structural review instead of the gate check.
 
 ### Review output
 
-Saved to `docs/adr/<dir-name>/reviews/structural.md`.
+Saved to `docs/adr/<dir-name>/_workflow/reviews/structural.md`.
 
 ---
 

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -38,8 +38,8 @@ inputs**.
 
 - `repo_root` — absolute path to the working tree.
 - `plan_slim_path` — `/tmp/claude-code-plan-slim-$PPID.md`.
-- `step_file_path` — `docs/adr/<dir-name>/tracks/track-<N>.md`.
-- `design_path` — `docs/adr/<dir-name>/design.md` (read on demand only).
+- `step_file_path` — `docs/adr/<dir-name>/_workflow/tracks/track-<N>.md`.
+- `design_path` — `docs/adr/<dir-name>/_workflow/design.md` (read on demand only).
 
 **Variable inputs** (per spawn):
 
@@ -222,13 +222,24 @@ implementer never escalates directly to the user.
 
 **Always revert before returning.** Whichever case fires below, the
 implementer must roll back its in-progress changes so the orchestrator
-observes a clean tree at the implementer's `HEAD` — but it must
-preserve any untracked files that pre-existed the spawn. The
-orchestrator keeps its working state (step files, review reports,
-the design document, the implementation backlog, baselines) as
-**untracked-on-disk files** under `docs/adr/<dir>/`. Those files
-must survive any implementer revert; otherwise the orchestrator
-loses cross-spawn state. The required sequence:
+observes a clean tree at the implementer's `HEAD` — and it must
+preserve any untracked files that pre-existed the spawn (test
+fixtures, scratch logs, anything outside the workflow's tracked
+state).
+
+The orchestrator's working state — step file, review reports,
+design document, implementation backlog, baselines — is **tracked
+under `docs/adr/<dir>/_workflow/`** and committed by the orchestrator
+on the appropriate cadence (see `commit-conventions.md` § Push every
+commit). The orchestrator commits any pending workflow-file changes
+**before** spawning the implementer, so `HEAD` at spawn time
+already reflects the orchestrator's intended state. That means the
+implementer's `git reset --hard HEAD` rolls back tracked-file
+changes only as far as the most recent commit — which is the
+state the orchestrator wants to be in if the implementer bails.
+
+The required sequence (run on every early-return case below — design
+decision, risk upgrade, fundamental failure):
 
 1. **Snapshot pre-existing untracked files at the start of every
    spawn**, before any code change. This is the first action of

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -260,13 +260,18 @@ decision, risk upgrade, fundamental failure):
    sub-step 1, before reading the step file or making any edit:
 
    ```bash
-   git ls-files --others --exclude-standard | LC_ALL=C sort \
+   git -c core.quotepath=false ls-files --others --exclude-standard \
+     | LC_ALL=C sort \
      > /tmp/claude-impl-preexisting-untracked-$PPID.txt
    ```
 
    `LC_ALL=C` keeps the sort byte-ordered so the later `comm -13`
    (which requires its inputs sorted under the same collation) is
    reliable regardless of the implementer's locale.
+   `core.quotepath=false` prevents Git from C-escaping non-ASCII
+   bytes in filenames; without it `comm -13` would compare quoted
+   strings to unquoted ones and the later `rm` would fail because
+   the path doesn't literally exist on disk.
 
    The snapshot reflects the world the orchestrator handed you.
 
@@ -281,7 +286,8 @@ decision, risk upgrade, fundamental failure):
    present in the post-snapshot but absent from the pre-snapshot:
 
    ```bash
-   git ls-files --others --exclude-standard | LC_ALL=C sort \
+   git -c core.quotepath=false ls-files --others --exclude-standard \
+     | LC_ALL=C sort \
      > /tmp/claude-impl-post-untracked-$PPID.txt
    LC_ALL=C comm -13 \
      /tmp/claude-impl-preexisting-untracked-$PPID.txt \

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -108,10 +108,12 @@ rules:
   working tree before any IDE-routed action; do not re-probe.
 - **Do not reference workflow-internal identifiers** (`Track N`,
   `Step N`, finding IDs, iteration counters, or named-only plan
-  invariants) in source code, Javadoc, test names, test
-  descriptions, or the commit message — see
+  invariants) in source code, Javadoc, test names, or test
+  descriptions — see
   [`conventions-execution.md`](conventions-execution.md) §2.3 for
   the full Ephemeral identifier rule and rewrite examples.
+  Branch-only commit messages are exempt (they are squashed away on
+  merge); the rule applies to durable content only.
 
 **Sub-step 2 — Add or update tests.** Run module tests, verify
 Spotless on affected modules (`./mvnw -pl <module> spotless:apply`),
@@ -125,12 +127,19 @@ Maven builds (full `core` test suite or coverage profile), see
 **Sub-step 3 — Stage explicit paths and commit** in one commit. No
 `git add -A`. No `--amend`. Apply the project's commit-message
 convention from `CLAUDE.md` (imperative summary under 50 chars, blank
-line, detailed why) and the Ephemeral identifier rule from
-[`conventions-execution.md`](conventions-execution.md) §2.3 (no
-`Track N` / `Step N` / finding IDs / iteration counters in the
-message body or subject). For `mode == FIX_REVIEW_FINDINGS`, prefix
-the commit subject with `Review fix:` per
-[`commit-conventions.md`](commit-conventions.md).
+line, detailed why). The Ephemeral identifier rule
+([`conventions-execution.md`](conventions-execution.md) §2.3) covers
+durable content only — branch-only commit messages may cite
+`Track N` / `Step N` / finding IDs / iteration counters when it
+makes the commit log easier to follow, since the squash-merge
+collapses them away (see
+[`commit-conventions.md`](commit-conventions.md) "Branch-only
+commit messages may cite workflow-internal identifiers"). For
+`mode == FIX_REVIEW_FINDINGS`, prefix the commit subject with
+`Review fix:` per [`commit-conventions.md`](commit-conventions.md);
+prefer describing the fix by what changed (behavior, file, class)
+over citing a finding ID, but a finding-ID reference is permitted
+when it aids review.
 
 **Return.** Emit the structured result block (see §Return contract
 below). The orchestrator parses the block; everything else in the
@@ -173,14 +182,17 @@ profile build, integration tests:
   command; for builds that may exceed that, split into stages —
   e.g., compile first, then test, then coverage report — each stage
   under 10 min).
-- If background is genuinely needed (e.g., to keep the implementer
-  responsive to other work during a long build), use Bash
-  `run_in_background` with the `Monitor` tool's "until-loop" pattern
-  inside a single Bash invocation:
-  `until grep -Eq "BUILD SUCCESS|BUILD FAILURE" "{logfile}"; do
-  sleep 10; done` — the loop runs in one Bash call, the implementer
-  waits for the loop's exit, and the runtime delivers a single
-  completion notification rather than a sequence of wake-ups.
+- If a build is long enough that the implementer should not block on
+  it (rare — the foreground 10-min path covers most module-scoped
+  runs), start it via Bash `run_in_background: true`. The runtime
+  fires a single completion notification when the command exits;
+  the implementer does not need to poll. While the build runs, the
+  implementer can do other read-only work that doesn't touch the
+  same module — re-reading the step file, the slim plan, or
+  `design.md` for context. Do **not** start a separate Bash call
+  to `tail -f` or `grep` the log file in a poll loop — `tail`/`grep`
+  return when the build finishes anyway, and the polling adds
+  nothing the completion notification doesn't already provide.
 - Do not chain multiple short `sleep`s with `ScheduleWakeup` between
   them. Each `ScheduleWakeup` is a yield-and-idle, not a wait.
 
@@ -521,8 +533,12 @@ duplicate the routing tables here. Pointers:
   raw Edit".
 - **Project conventions and PSI requirement for load-bearing audits**:
   [`conventions.md`](conventions.md) §1.4 *Tooling discipline*.
-- **Ephemeral identifier rule** for code, tests, and commit messages:
+- **Ephemeral identifier rule** for durable content (code, tests,
+  PR title/body, `design-final.md`, `adr.md`):
   [`conventions-execution.md`](conventions-execution.md) §2.3.
+  Branch-only commit messages are exempt — see
+  [`commit-conventions.md`](commit-conventions.md) "Branch-only
+  commit messages may cite workflow-internal identifiers".
 - **Risk categories** referenced in `RISK_UPGRADE.category`:
   [`risk-tagging.md`](risk-tagging.md). The implementer reads only
   the category names; full criteria and override rules stay in

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -217,22 +217,69 @@ The implementer **MUST** stop and return early — without committing —
 in three cases. The orchestrator decides what happens next; the
 implementer never escalates directly to the user.
 
-**Always revert before returning.** Whichever case fires below, run
-`git reset --hard HEAD && git clean -fd` first so the orchestrator
-always observes a clean tree at the implementer's `HEAD`. The reset
-clears the working tree and the index; `git clean -fd` removes any
-untracked files or directories the implementer created (new test
-files, scratch output) — without it, the orchestrator's `git status`
-clean-tree assertions would fire a spurious contract violation
-whenever the implementer added a new file before bailing. Use
-`git reset --hard HEAD` rather than `git checkout -- .` for the
+**Always revert before returning.** Whichever case fires below, the
+implementer must roll back its in-progress changes so the orchestrator
+observes a clean tree at the implementer's `HEAD` — but it must
+preserve any untracked files that pre-existed the spawn. The
+orchestrator keeps its working state (step files, review reports,
+the design document, the implementation backlog, baselines) as
+**untracked-on-disk files** under `docs/adr/<dir>/`. Those files
+must survive any implementer revert; otherwise the orchestrator
+loses cross-spawn state. The required sequence:
+
+1. **Snapshot pre-existing untracked files at the start of every
+   spawn**, before any code change. This is the first action of
+   sub-step 1, before reading the step file or making any edit:
+
+   ```bash
+   git ls-files --others --exclude-standard | sort \
+     > /tmp/claude-impl-preexisting-untracked-$PPID.txt
+   ```
+
+   The snapshot reflects the world the orchestrator handed you.
+
+2. **At revert time**, discard tracked-file changes and the index:
+
+   ```bash
+   git reset --hard HEAD
+   ```
+
+3. **Then surgically remove only the untracked files the implementer
+   created** in this spawn — `comm -13 <pre> <post>` lists files
+   present in the post-snapshot but absent from the pre-snapshot:
+
+   ```bash
+   git ls-files --others --exclude-standard | sort \
+     > /tmp/claude-impl-post-untracked-$PPID.txt
+   comm -13 \
+     /tmp/claude-impl-preexisting-untracked-$PPID.txt \
+     /tmp/claude-impl-post-untracked-$PPID.txt \
+     | xargs -r -d '\n' rm -v --
+   ```
+
+   `xargs -r` handles the empty-input case (no new files to remove);
+   `-d '\n'` makes the listing newline-safe for paths with spaces.
+
+**Do NOT run `git clean -fd` (or `-fdx`).** It indiscriminately
+removes every untracked file in the worktree — including the
+orchestrator's workflow state — and the orchestrator depends on
+those files persisting across spawn boundaries. Past versions of
+this rulebook used `git clean -fd`; that was a bug that destroyed
+the orchestrator's cross-spawn state on every early-return. The
+snapshot-and-diff sequence above is the supported replacement.
+
+Use `git reset --hard HEAD` rather than `git checkout -- .` for the
 tracked half — the latter leaves a dirty index if the implementer
-had staged files before bailing. The semantic scope of the revert
-differs by mode (see §"Mode-specific scope of the local revert"
-below), but the command is the same. The orchestrator's pre-revert
-assertion in [`step-implementation.md`](step-implementation.md)
-§Post-Commit Handlers depends on this — a dirty tree at hand-off is
-a contract violation.
+had staged files before bailing.
+
+The semantic scope of the revert differs by mode (see §"Mode-specific
+scope of the local revert" below), but the command sequence above
+is the same. The orchestrator's pre-revert assertion in
+[`step-implementation.md`](step-implementation.md) §Post-Commit
+Handlers depends on this — a dirty tree at hand-off is a contract
+violation, and an orphaned implementer-created untracked file at
+hand-off would also be a contract violation (it would interfere with
+the next spawn's pre-snapshot).
 
 ### Design decision detected
 
@@ -256,9 +303,11 @@ What is **NOT** a design decision (handle autonomously):
 - Implementation details fully prescribed by the plan or by Decision
   Records in `adr.md` / the plan file.
 
-When a design decision is detected, run
-`git reset --hard HEAD && git clean -fd` to discard any in-progress
-changes (per the rule at the top of this section), then return
+When a design decision is detected, run the snapshot-and-diff revert
+sequence at the top of this section (snapshot pre-existing untracked
+files first, then `git reset --hard HEAD`, then `comm -13` against a
+post-snapshot to surgically remove only files this spawn created),
+then return
 `RESULT: DESIGN_DECISION_NEEDED` with `DESIGN_DECISION` populated: `context`,
 `alternatives` (≥2, with pros/cons), `recommendation`, and
 `exploration_notes` summarising what was already investigated (API
@@ -277,9 +326,10 @@ turns out to require lock-ordering changes, or the "internal helper
 addition" tagged `medium` actually changes a public-API serialized
 form.
 
-Run `git reset --hard HEAD && git clean -fd` to discard any
-in-progress changes (per the rule at the top of this section), then
-return `RESULT: RISK_UPGRADE_REQUESTED` with `RISK_UPGRADE` populated:
+Run the snapshot-and-diff revert sequence at the top of this section
+(snapshot pre-existing untracked files first, then `git reset --hard
+HEAD`, then `comm -13` against a post-snapshot to surgically remove
+only files this spawn created), then return `RESULT: RISK_UPGRADE_REQUESTED` with `RISK_UPGRADE` populated:
 `from`, `to`, `category` (one of: `concurrency`, `crash-safety`,
 `public-API`, `security`, `architecture`, `performance-hot-path` —
 see [`risk-tagging.md`](risk-tagging.md) for the full criteria), and
@@ -298,9 +348,10 @@ tests cannot be made to pass, coverage cannot be met, architectural
 problem revealed by the implementation, repeated test failures with
 a root cause outside the step's surface area.
 
-Run `git reset --hard HEAD && git clean -fd` to discard any
-in-progress changes (per the rule at the top of this section), then
-return `RESULT: FAILED` with `FAILURE` populated: `what_was_attempted`, `why_it_failed`,
+Run the snapshot-and-diff revert sequence at the top of this section
+(snapshot pre-existing untracked files first, then `git reset --hard
+HEAD`, then `comm -13` against a post-snapshot to surgically remove
+only files this spawn created), then return `RESULT: FAILED` with `FAILURE` populated: `what_was_attempted`, `why_it_failed`,
 `impact_on_remaining_steps`, and `recommended_action` (`retry` |
 `split` | `escalate`).
 
@@ -309,12 +360,14 @@ retry/split rows, and runs the two-failure detection on its side.
 
 ### Mode-specific scope of the local revert
 
-`git reset --hard HEAD && git clean -fd` resets to the **current
-commit** (and removes any untracked artefacts the implementer
-created), not to a pre-step state. The command is the same for
-every early-return case (design decision, risk upgrade, fundamental
-failure) and every mode, but the **semantic scope** of what gets
-cleaned up differs:
+The snapshot-and-diff revert sequence at the top of this section
+(snapshot, `git reset --hard HEAD`, `comm -13` cleanup) resets to
+the **current commit** and removes only the untracked artefacts
+this spawn created — not the orchestrator's pre-existing untracked
+state, and not changes from any prior commit. The sequence is the
+same for every early-return case (design decision, risk upgrade,
+fundamental failure) and every mode, but the **semantic scope** of
+what gets reverted differs:
 
 - **`mode=INITIAL`** or **`mode=WITH_GUIDANCE`**: `HEAD` is the
   step's pre-implementation state (the orchestrator's `step_base_commit`).
@@ -331,12 +384,12 @@ cleaned up differs:
   step_base_commit` or `git revert` to undo prior commits; that
   would silently destroy work the orchestrator may need.
 
-The implementer is therefore symmetric in code
-(`git reset --hard HEAD && git clean -fd` regardless of mode and
-regardless of which early-return case fired) but the
-orchestrator-side cleanup differs: pre-commit modes need no further
-work; post-commit mode requires the orchestrator's post-commit
-rollback to remove the prior step commits as well.
+The implementer is therefore symmetric in code (the snapshot-and-diff
+revert sequence regardless of mode and regardless of which
+early-return case fired) but the orchestrator-side cleanup differs:
+pre-commit modes need no further work; post-commit mode requires
+the orchestrator's post-commit rollback to remove the prior step
+commits as well.
 
 ---
 

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -110,8 +110,10 @@ rules:
   `Step N`, finding IDs, iteration counters, or named-only plan
   invariants) in source code, Javadoc, test names, or test
   descriptions — see
-  [`conventions-execution.md`](conventions-execution.md) §2.3 for
-  the full Ephemeral identifier rule and rewrite examples.
+  [`ephemeral-identifier-rule.md`](ephemeral-identifier-rule.md) for
+  the full Ephemeral identifier rule and rewrite examples (the §2.3
+  stub in `conventions-execution.md` is a quick recap with the
+  self-check grep).
   Branch-only commit messages are exempt (they are squashed away on
   merge); the rule applies to durable content only.
 
@@ -307,8 +309,8 @@ had staged files before bailing.
 The semantic scope of the revert differs by mode (see §"Mode-specific
 scope of the local revert" below), but the command sequence above
 is the same. The orchestrator's pre-revert assertion in
-[`step-implementation.md`](step-implementation.md) §Post-Commit
-Handlers depends on this — a dirty tree at hand-off is a contract
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Post-Commit Handlers depends on this — a dirty tree at hand-off is a contract
 violation, and an orphaned implementer-created untracked file at
 hand-off would also be a contract violation (it would interfere with
 the next spawn's pre-snapshot).
@@ -411,8 +413,8 @@ what gets reverted differs:
   The implementer's reset clears only its in-progress fix attempt;
   the prior commits stay on disk. Rolling those back is the
   **orchestrator's** responsibility — see
-  [`step-implementation.md`](step-implementation.md) §Post-Commit
-  Handlers. The implementer must not run `git reset --hard
+  [`step-implementation-recovery.md`](step-implementation-recovery.md)
+  §Post-Commit Handlers. The implementer must not run `git reset --hard
   step_base_commit` or `git revert` to undo prior commits; that
   would silently destroy work the orchestrator may need.
 
@@ -535,8 +537,10 @@ duplicate the routing tables here. Pointers:
   [`conventions.md`](conventions.md) §1.4 *Tooling discipline*.
 - **Ephemeral identifier rule** for durable content (code, tests,
   PR title/body, `design-final.md`, `adr.md`):
-  [`conventions-execution.md`](conventions-execution.md) §2.3.
-  Branch-only commit messages are exempt — see
+  [`ephemeral-identifier-rule.md`](ephemeral-identifier-rule.md) is
+  the full rule; the §2.3 stub in `conventions-execution.md` carries
+  the quick recap and the self-check grep. Branch-only commit
+  messages are exempt — see
   [`commit-conventions.md`](commit-conventions.md) "Branch-only
   commit messages may cite workflow-internal identifiers".
 - **Risk categories** referenced in `RISK_UPGRADE.category`:

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -118,7 +118,9 @@ Spotless on affected modules (`./mvnw -pl <module> spotless:apply`),
 verify coverage thresholds (85% line / 70% branch on changed code
 via the coverage gate command in §"Coverage gate command" below).
 Wait for test results before proceeding — never start the commit
-while a background test run is still streaming.
+while a background test run is still streaming. For long-running
+Maven builds (full `core` test suite or coverage profile), see
+§"Pacing long-running tasks" below before deciding how to wait.
 
 **Sub-step 3 — Stage explicit paths and commit** in one commit. No
 `git add -A`. No `--amend`. Apply the project's commit-message
@@ -138,6 +140,52 @@ The implementer **MUST NOT** modify the step file, the plan file, the
 backlog, or any review file. All step-file mutations — episode write,
 risk-line rewrite, `[x]` mark, Progress count update, retry/split row
 inserts — are the orchestrator's responsibility.
+
+### Pacing long-running tasks — do not use `ScheduleWakeup`
+
+The implementer is spawned synchronously by the orchestrator via the
+Agent tool. The orchestrator parses **one** structured return block
+per spawn — the spawn either ends with a valid `RESULT: …` block or
+the orchestrator treats the return as a contract violation.
+
+`ScheduleWakeup` breaks this contract. It yields control back to the
+caller with no `RESULT` block, so the orchestrator sees the
+implementer return without a handoff — indistinguishable from a
+crash. The implementer is also left **idle** between scheduled wakes
+rather than actively running, so any subsequent SendMessage from the
+orchestrator is required to resume work — at which point the
+implementer's understanding of the prior in-flight Bash background
+task may be stale (the runtime may have garbage-collected the
+background task across the idle gap, leaving zero-byte output files
+and no live process).
+
+**Rule.** The implementer MUST NOT call `ScheduleWakeup`. Pacing is
+the orchestrator's job, not the implementer's. The implementer runs
+straight through sub-steps 1–3 and emits exactly one return block.
+
+**For long-running Maven runs** — full `core` test suite, coverage
+profile build, integration tests:
+
+- Prefer **foreground** Bash with `timeout` set to the realistic
+  upper bound (Bash `timeout` caps at 600 000 ms / 10 minutes; for
+  builds that may exceed that, split into stages — e.g., compile
+  first, then test, then coverage report — each stage under 10 min).
+- If background is genuinely needed (e.g., to keep the implementer
+  responsive to other work during a long build), use Bash
+  `run_in_background` with the `Monitor` tool's "until-loop" pattern
+  inside a single Bash invocation:
+  `until grep -q "BUILD SUCCESS\\|BUILD FAILURE" {logfile}; do sleep
+  10; done` — the loop runs in one Bash call, the implementer waits
+  for the loop's exit, and the runtime delivers a single completion
+  notification rather than a sequence of wake-ups.
+- Do not chain multiple short `sleep`s with `ScheduleWakeup` between
+  them. Each `ScheduleWakeup` is a yield-and-idle, not a wait.
+
+If a build genuinely exceeds the realistic foreground budget for the
+implementer (rare — only the full `verify -P ci-integration-tests`
+or large coverage runs), return `RESULT: FAILED` with
+`recommended_action: split` and let the orchestrator decide whether
+to break the step into smaller, individually-verifiable pieces.
 
 ### When the failure mode is opaque — consider an IDE debug session
 

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -166,18 +166,21 @@ straight through sub-steps 1–3 and emits exactly one return block.
 **For long-running Maven runs** — full `core` test suite, coverage
 profile build, integration tests:
 
-- Prefer **foreground** Bash with `timeout` set to the realistic
-  upper bound (Bash `timeout` caps at 600 000 ms / 10 minutes; for
-  builds that may exceed that, split into stages — e.g., compile
-  first, then test, then coverage report — each stage under 10 min).
+- Prefer **foreground** Bash with the Bash tool's `timeout`
+  parameter set to the realistic upper bound (the parameter is in
+  milliseconds and caps at 600 000 ms / 10 minutes — this is the
+  Claude Code Bash-tool parameter, not the GNU `timeout` shell
+  command; for builds that may exceed that, split into stages —
+  e.g., compile first, then test, then coverage report — each stage
+  under 10 min).
 - If background is genuinely needed (e.g., to keep the implementer
   responsive to other work during a long build), use Bash
   `run_in_background` with the `Monitor` tool's "until-loop" pattern
   inside a single Bash invocation:
-  `until grep -q "BUILD SUCCESS\\|BUILD FAILURE" {logfile}; do sleep
-  10; done` — the loop runs in one Bash call, the implementer waits
-  for the loop's exit, and the runtime delivers a single completion
-  notification rather than a sequence of wake-ups.
+  `until grep -Eq "BUILD SUCCESS|BUILD FAILURE" "{logfile}"; do
+  sleep 10; done` — the loop runs in one Bash call, the implementer
+  waits for the loop's exit, and the runtime delivers a single
+  completion notification rather than a sequence of wake-ups.
 - Do not chain multiple short `sleep`s with `ScheduleWakeup` between
   them. Each `ScheduleWakeup` is a yield-and-idle, not a wait.
 
@@ -232,9 +235,13 @@ loses cross-spawn state. The required sequence:
    sub-step 1, before reading the step file or making any edit:
 
    ```bash
-   git ls-files --others --exclude-standard | sort \
+   git ls-files --others --exclude-standard | LC_ALL=C sort \
      > /tmp/claude-impl-preexisting-untracked-$PPID.txt
    ```
+
+   `LC_ALL=C` keeps the sort byte-ordered so the later `comm -13`
+   (which requires its inputs sorted under the same collation) is
+   reliable regardless of the implementer's locale.
 
    The snapshot reflects the world the orchestrator handed you.
 
@@ -249,16 +256,18 @@ loses cross-spawn state. The required sequence:
    present in the post-snapshot but absent from the pre-snapshot:
 
    ```bash
-   git ls-files --others --exclude-standard | sort \
+   git ls-files --others --exclude-standard | LC_ALL=C sort \
      > /tmp/claude-impl-post-untracked-$PPID.txt
-   comm -13 \
+   LC_ALL=C comm -13 \
      /tmp/claude-impl-preexisting-untracked-$PPID.txt \
      /tmp/claude-impl-post-untracked-$PPID.txt \
-     | xargs -r -d '\n' rm -v --
+     | while IFS= read -r file; do rm -v -- "$file"; done
    ```
 
-   `xargs -r` handles the empty-input case (no new files to remove);
-   `-d '\n'` makes the listing newline-safe for paths with spaces.
+   The `while IFS= read -r` loop handles paths with spaces and is
+   portable across GNU/BSD `xargs` differences. The loop is a
+   no-op when `comm` produces no output, so the empty-diff case is
+   handled implicitly.
 
 **Do NOT run `git clean -fd` (or `-fdx`).** It indiscriminately
 removes every untracked file in the worktree — including the

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -106,8 +106,31 @@ into `implementation-backlog.md` are reachable.
 
 **6. Resume or exit:**
 
-- **Review PASS** — update the plan file with the revised plan. End the
-  session. The next session picks up the revised plan and continues.
+- **Review PASS** — update the plan file with the revised plan, then
+  commit and push the workflow changes immediately so the next
+  implementer spawn doesn't lose them via `git reset --hard HEAD`:
+
+  ```bash
+  git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
+          docs/adr/<dir-name>/_workflow/implementation-backlog.md \
+          docs/adr/<dir-name>/_workflow/tracks/track-*.md
+  git commit -m "Inline replan after Track <N>"
+  git push
+  ```
+
+  Stage only the paths that the revision actually touched (the
+  enumeration in [§Updating plan and backlog](#updating-plan-and-backlog)
+  tells you which files apply per case). Any `design.md` /
+  `design-mechanics.md` changes from step 3 land via the
+  `edit-design` skill, which writes a separate
+  `<plan-dir>/_workflow/reviews/design-mutations.md` log entry —
+  include those files in the commit too if they were touched.
+
+  This is a Workflow update commit (single-commit-per-replan; per
+  the table in `commit-conventions.md` § Commit type prefixes).
+  Resume orphan-detection treats it as scaffolding and does not
+  count it toward any `[x]` step. End the session after the push;
+  the next session picks up the revised plan and continues.
 
 - **Blockers persist after 3 iterations** — the plan is fundamentally broken
   at a level that incremental revision cannot fix. Advise the user to restart

--- a/.claude/workflow/plan-slim-rendering.md
+++ b/.claude/workflow/plan-slim-rendering.md
@@ -41,7 +41,7 @@ snapshot file; concurrent sessions do not collide.
 
 ### How the main agent generates it
 
-1. Read `docs/adr/<dir-name>/implementation-plan.md`.
+1. Read `docs/adr/<dir-name>/_workflow/implementation-plan.md`.
 2. Apply the rendering rule below, in-memory. Pending-track entries
    (`[ ]`) are already thin on disk (their detail lives in
    `implementation-backlog.md`), so the transform for that row is a
@@ -67,7 +67,7 @@ appear as title + intro paragraph + track episode (or Skipped reason) +
 strategy refresh only; the current track and other not-started tracks
 keep their title, intro paragraph, `**Scope:**`, and `**Depends on:**`.
 If this file is missing, fall back to
-  docs/adr/{dir-name}/implementation-plan.md
+  docs/adr/{dir-name}/_workflow/implementation-plan.md
 (full plan).
 ```
 

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -26,7 +26,7 @@ flowchart TD
     P1["Phase 1: Planning\nTracks + architecture notes\n+ design document"]
     P2["/review-plan\nPhase 2: Implementation Review\n1. Consistency review (interactive)\n2. Structural review (automatic)"]
     P3["/execute-tracks\nPhase 3: Execution\n(see workflow.md)\nIncludes replanning via ESCALATE"]
-    P4["Phase 4: Final Artifacts\ndesign-final.md + adr.md\n(only tracked files)"]
+    P4["Phase 4: Final Artifacts\ndesign-final.md + adr.md\n(only files that survive merge)"]
     DONE((Done))
 
     P0 -->|"user: create the plan"| P1
@@ -415,7 +415,9 @@ complex parts each following the per-section shape (TL;DR +
 mechanism overview + edge cases + References footer). All
 diagrams paired with prose. Frozen after Phase 1 —
 `design-final.md` and `adr.md` are produced in Phase 4 as the
-only git-tracked workflow artifacts.
+only workflow artifacts that survive merge into `develop`
+(everything under `_workflow/` is tracked during the branch
+lifetime but removed in the Phase 4 cleanup commit).
 
 **Mutation discipline.** Every modification to `design.md` —
 whether the initial creation in this phase, a later interactive

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -38,15 +38,18 @@ flowchart TD
     P4 --> DONE
 ```
 
-**Important:** The durable plan always lives in the **project's**
-`docs/adr/<dir-name>/` directory (e.g., `docs/adr/ytdb-123-add-auth/implementation-plan.md`).
-This is distinct from the global `~/.claude/plans/` where Claude Code stores
-ephemeral auto-named session plans. The project plan file is the single source
-of truth — it's human-readable, version-controlled, and serves as a lightweight
-ADR (Architecture Decision Record) after the feature is complete. Claude may
-internally use plan mode during any phase — that's fine, but insights must be
-captured in the project's track episodes (plan file) and step episodes (step
-files), never left only in `~/.claude/plans/`.
+**Important:** The plan and every other working file always live in the
+**project's** `docs/adr/<dir-name>/_workflow/` directory (e.g.,
+`docs/adr/ytdb-123-add-auth/_workflow/implementation-plan.md`). This is
+distinct from the global `~/.claude/plans/` where Claude Code stores
+ephemeral auto-named session plans. The project plan file is the single
+source of truth — it's human-readable, tracked in git for the branch
+lifetime so the draft PR shows progress, and removed in the Phase 4
+cleanup commit (only `design-final.md` and `adr.md` survive merge into
+`develop` as the durable lightweight ADR record). Claude may internally
+use plan mode during any phase — that's fine, but insights must be
+captured in the project's track episodes (plan file) and step episodes
+(step files), never left only in `~/.claude/plans/`.
 
 ---
 
@@ -77,13 +80,19 @@ incorporating all findings and decisions from the research phase.
 The plan file structure is defined in `conventions.md` (section 1.2). The key
 points:
 
-- `docs/adr/<dir-name>/implementation-plan.md` — strategic: goals, architecture,
+- `docs/adr/<dir-name>/_workflow/implementation-plan.md` — strategic: goals, architecture,
   tracks, track-level episodic summaries
-- `docs/adr/<dir-name>/design.md` — design-level: class diagrams, workflow
+- `docs/adr/<dir-name>/_workflow/design.md` — design-level: class diagrams, workflow
   diagrams, dedicated sections for complex/opaque parts
-- `docs/adr/<dir-name>/tracks/track-N.md` — tactical: decomposed steps, step
+- `docs/adr/<dir-name>/_workflow/tracks/track-N.md` — tactical: decomposed steps, step
   episodes (created during Phase 3)
-- `docs/adr/<dir-name>/reviews/structural.md` — structural review output
+- `docs/adr/<dir-name>/_workflow/reviews/structural.md` — structural review output
+
+The `_workflow/` directory is tracked under git for the branch
+lifetime (so the draft PR shows progress to teammates and so a
+disk-loss never destroys work) and is removed in the Phase 4
+cleanup commit before merge — see `conventions.md` §1.2 and
+`workflow.md` § Final Artifacts.
 
 Track files do not exist during Phase 1 (planning) or
 Phase 2 (structural review) — only scope indicators in the plan file exist
@@ -393,7 +402,7 @@ architecture, not premature step decomposition.
 ## Design Document
 
 The plan must be accompanied by a separate **design document** at
-`docs/adr/<dir-name>/design.md`. It explains the structural and behavioral
+`docs/adr/<dir-name>/_workflow/design.md`. It explains the structural and behavioral
 design (not code): class diagrams, workflow diagrams, and dedicated sections
 for complex/opaque parts (concurrency, crash recovery, performance paths).
 

--- a/.claude/workflow/prompts/adversarial-review.md
+++ b/.claude/workflow/prompts/adversarial-review.md
@@ -52,7 +52,7 @@ severity is `skip`) recommend skipping the track entirely.
 **Where things live during Phase A:** The track's detailed description
 (the `**What/How/Constraints/Interactions**` subsections plus any
 track-level component diagram) lives in the step file at
-`docs/adr/<dir-name>/tracks/track-N.md` under a `## Description` section —
+`docs/adr/<dir-name>/_workflow/tracks/track-N.md` under a `## Description` section —
 copied there at Phase A start. The plan file carries strategic context
 (Architecture Notes, Decision Records, Component Map) and track-level
 status + episodic memory.

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -18,9 +18,9 @@ name. Otherwise, default to the current git branch name
 (`git branch --show-current`).
 
 Read:
-- `docs/adr/<dir-name>/implementation-plan.md` — full plan with track episodes
-- `docs/adr/<dir-name>/design.md` — original design document (do NOT modify)
-- `docs/adr/<dir-name>/tracks/track-*.md` — all step files with step
+- `docs/adr/<dir-name>/_workflow/implementation-plan.md` — full plan with track episodes
+- `docs/adr/<dir-name>/_workflow/design.md` — original design document (do NOT modify)
+- `docs/adr/<dir-name>/_workflow/tracks/track-*.md` — all step files with step
   episodes. Each step file begins with a `## Description` section
   carrying the track's original description (copied there at Phase A
   start from the backlog), so "what each track was supposed to do"
@@ -64,10 +64,12 @@ authoritative source for edge cases.
 
 ### Ephemeral identifier rule (applies to BOTH artifacts)
 
-`design-final.md` and `adr.md` are the **only** workflow files committed
-to git. Every other workflow file —  `implementation-plan.md`,
-`implementation-backlog.md`, `tracks/track-N.md`, `reviews/**` — is
-untracked and deleted when the branch is deleted after PR merge. Anything
+`design-final.md` and `adr.md` are the **only** workflow files that
+survive merge into `develop`. Every other workflow file —
+`implementation-plan.md`, `implementation-backlog.md`,
+`tracks/track-N.md`, `reviews/**` — lives under
+`docs/adr/<dir-name>/_workflow/` and is removed in the cleanup commit
+at the end of Phase 4 (Step 5 below) before the PR is merged. Anything
 these final artifacts say must survive that deletion.
 
 **The authoritative rule, forbidden/allowed lists, and rewrite examples
@@ -95,7 +97,8 @@ Re-scan both artifacts before Step 4 (commit) with the grep in §2.3.
 
 ### Artifact 1: Final Design Document (`design-final.md`)
 
-Produce `docs/adr/<dir-name>/design-final.md` reflecting the **actual
+Produce `docs/adr/<dir-name>/design-final.md` (the top-level final
+artifact, not under `_workflow/`) reflecting the **actual
 implementation**. Same shape rules as the original `design.md` —
 concept-first Overview, Core Concepts vocabulary primer (when the doc
 has Parts or ≥3 new domain terms), Class Design, Workflow, per-section
@@ -231,7 +234,7 @@ Rules:
   Decision Records ("Implemented in: …" lines) and Key Discoveries,
   which are the two most frequent leak sites.
 
-**Step 4 — Commit and complete.**
+**Step 4 — Commit the final artifacts.**
 
 By this point the `edit-design` skill has already written
 `design-final.md` (and `design-mechanics-final.md` if applicable) to
@@ -239,7 +242,7 @@ disk and presented the diff + review-log entry. `adr.md` was written
 directly. Stage and commit the final artifacts in a single commit:
 
 ```
-Add final workflow artifacts
+Add final design and ADR
 
 Post-implementation artifacts:
 - design-final.md: actual design reflecting implemented code
@@ -247,7 +250,42 @@ Post-implementation artifacts:
 - adr.md: architecture decision record with actual outcomes
 ```
 
-Do **not** stage `reviews/design-mutations.md` — it's an ephemeral
-working file (deleted with the branch).
+Stage **only** the top-level final artifacts in this commit
+(`design-final.md`, `design-mechanics-final.md` if present, and
+`adr.md`). Do **not** stage anything under
+`docs/adr/<dir-name>/_workflow/` — the ephemeral
+`reviews/design-mutations.md` log and every other working file under
+`_workflow/` are removed wholesale by the cleanup commit in Step 5
+below.
 
-Inform the user that Phase 4 is complete and the workflow is done.
+Push immediately after committing:
+
+```bash
+git push
+```
+
+**Step 5 — Cleanup commit: remove the workflow scaffolding.**
+
+After the final-artifacts commit lands, remove the entire `_workflow/`
+subtree in a single second commit so only `design-final.md`,
+`design-mechanics-final.md` (if present), and `adr.md` survive merge
+into `develop`:
+
+```bash
+git rm -r docs/adr/<dir-name>/_workflow/
+git commit -m "Remove workflow scaffolding"
+git push
+```
+
+This deletes plan, backlog, design.md, design-mechanics.md, every
+step file under `tracks/`, every review file under `reviews/`, and
+the design-mutations log in one commit. The squash-merge folds this
+deletion together with the rest of the branch's history; on
+`develop`, the final state is the two (or three) durable artifacts
+plus the implemented code.
+
+**Step 6 — Inform the user.**
+
+Tell the user Phase 4 is complete and the branch is ready for review.
+The user manually flips the draft PR to "ready for review" when
+satisfied — Claude does **not** run `gh pr ready` automatically.

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -73,8 +73,10 @@ at the end of Phase 4 (Step 5 below) before the PR is merged. Anything
 these final artifacts say must survive that deletion.
 
 **The authoritative rule, forbidden/allowed lists, and rewrite examples
-live in [`../conventions-execution.md`](../conventions-execution.md)
-§2.3.** Read that section and apply it to both artifacts.
+live in [`../ephemeral-identifier-rule.md`](../ephemeral-identifier-rule.md).**
+Read that file and apply it to both artifacts. (The §2.3 stub in
+`../conventions-execution.md` is a quick recap pointing at the same
+file.)
 
 Phase-4-specific reminders that follow from the shared rule:
 
@@ -93,7 +95,10 @@ Phase-4-specific reminders that follow from the shared rule:
   only the substance, plus a file/class reference or commit SHA if
   "where" still matters.
 
-Re-scan both artifacts before Step 4 (commit) with the grep in §2.3.
+Re-scan both artifacts before Step 4 (commit) with the self-check
+grep — see [`../ephemeral-identifier-rule.md`](../ephemeral-identifier-rule.md)
+§"Self-check before commit" (also restated in the §2.3 stub of
+`../conventions-execution.md`).
 
 ### Artifact 1: Final Design Document (`design-final.md`)
 
@@ -229,10 +234,10 @@ Rules:
 - No track details — captures decisions and outcomes, not execution process.
 - Aggregate from both episode levels — do not rely on track episodes alone,
   as they may omit step-level details.
-- Apply the Ephemeral identifier rule from the top of Step 3 (and
-  `../conventions-execution.md` §2.3) to the whole file — especially to
-  Decision Records ("Implemented in: …" lines) and Key Discoveries,
-  which are the two most frequent leak sites.
+- Apply the Ephemeral identifier rule from the top of Step 3 (full
+  rule in `../ephemeral-identifier-rule.md`) to the whole file —
+  especially to Decision Records ("Implemented in: …" lines) and Key
+  Discoveries, which are the two most frequent leak sites.
 
 **Step 4 — Commit the final artifacts.**
 

--- a/.claude/workflow/prompts/design-review.md
+++ b/.claude/workflow/prompts/design-review.md
@@ -55,7 +55,8 @@ warning, or pass.
   committed to git**, so the bar is higher than Phase 1: the
   artifact must stand on its own as documentation, with no
   reliance on the working files (plan, backlog, tracks) since
-  those are deleted with the branch. **In addition to the standard
+  those live under `_workflow/` and are removed by the Phase 4
+  cleanup commit before the PR is merged. **In addition to the standard
   whole-doc cold-read**, verify (a) the doc opens with a
   concept-first Overview that names what was built and any
   high-level deviations from the original plan, (b) class /

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -44,7 +44,7 @@ reordering, or (if severity is `skip`) a recommendation to skip the track.
 **Where things live during Phase A:** The track's detailed description
 (the `**What/How/Constraints/Interactions**` subsections plus any
 track-level component diagram) lives in the step file at
-`docs/adr/<dir-name>/tracks/track-N.md` under a `## Description` section —
+`docs/adr/<dir-name>/_workflow/tracks/track-N.md` under a `## Description` section —
 copied there at Phase A start. The plan file carries strategic context
 (Architecture Notes, Decision Records, Component Map) and track-level
 status + episodic memory.

--- a/.claude/workflow/prompts/structural-review.md
+++ b/.claude/workflow/prompts/structural-review.md
@@ -144,7 +144,7 @@ DESIGN DOCUMENT *(design-file for diagram/prose checks; plan-file for
 the Architecture-Notes/Decision-Records cross-reference. The final
 bullet's "track descriptions" half is sourced backlog-for-pending,
 plan-file-for-completed/skipped.)*
-- Does the design document exist at `docs/adr/<dir-name>/design.md`?
+- Does the design document exist at `docs/adr/<dir-name>/_workflow/design.md`?
 - Does it include an Overview section summarizing the design approach?
 - Does it include class diagrams (Mermaid `classDiagram`) when the plan
   introduces 2+ new classes/interfaces or modifies class relationships?

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -45,7 +45,7 @@ your review, the main agent decomposes the track into concrete steps.
 **Where things live during Phase A:** The track's detailed description
 (the `**What/How/Constraints/Interactions**` subsections plus any
 track-level component diagram) lives in the step file at
-`docs/adr/<dir-name>/tracks/track-N.md` under a `## Description` section —
+`docs/adr/<dir-name>/_workflow/tracks/track-N.md` under a `## Description` section —
 copied there at Phase A start. The plan file carries strategic context
 (Architecture Notes, Decision Records, Component Map) and track-level
 status + episodic memory.

--- a/.claude/workflow/risk-tagging.md
+++ b/.claude/workflow/risk-tagging.md
@@ -18,11 +18,13 @@ justified.
 
 - **Phase A (`track-review.md`)** — loaded when the decomposer assigns
   risk per step. Primary reader.
-- **Phase B (`step-implementation.md`)** — loaded only on the rare
-  upgrade path, when implementation reveals a step is more invasive
-  than the plan suggested. Normal Phase B execution does NOT load this
-  file; it reads the per-step `**Risk:**` line from the step file and
-  gates sub-step 4 on the tag value alone.
+- **Phase B (`step-implementation-recovery.md`)** — loaded only on
+  the rare upgrade path, when implementation reveals a step is more
+  invasive than the plan suggested. Normal Phase B execution does NOT
+  load this file; it reads the per-step `**Risk:**` line from the
+  step file and gates sub-step 4 on the tag value alone. The recovery
+  file is itself loaded on demand and is where the upgrade handlers
+  (`apply_upgrade_then_decide`, `rollback_and_upgrade`) live.
 - **Phase C (`track-code-review.md`)** — does NOT load this file. The
   Phase C synthesizer reads the per-step risk tags from the step file
   and treats `medium` and `high` step ranges as focal points; no
@@ -163,7 +165,7 @@ The orchestrator's response depends on **when** the upgrade surfaces:
   step, `mode=INITIAL` or `mode=WITH_GUIDANCE`) — the orchestrator
   rewrites the `**Risk:**` line and respawns from `mode=INITIAL`
   BEFORE running the dimensional review for that step. See
-  [`step-implementation.md`](step-implementation.md)
+  [`step-implementation-recovery.md`](step-implementation-recovery.md)
   §`apply_upgrade_then_decide`.
 - **Post-commit** (during a `mode=FIX_REVIEW_FINDINGS` respawn — the
   upgrade surfaces only when applying review findings) — the
@@ -173,7 +175,7 @@ The orchestrator's response depends on **when** the upgrade surfaces:
   attempt re-runs implementation with full dim-review pressure from
   the start at the new risk level — not stacked on top of an
   implementation that was already reviewed under the old tag. See
-  [`step-implementation.md`](step-implementation.md)
+  [`step-implementation-recovery.md`](step-implementation-recovery.md)
   §`rollback_and_upgrade`.
 
 In both cases, `medium → high` auto-applies; `low → high` pauses

--- a/.claude/workflow/step-implementation-recovery.md
+++ b/.claude/workflow/step-implementation-recovery.md
@@ -1,0 +1,620 @@
+# Phase B Recovery — Resume, Failure, and Post-Commit Handlers
+
+This document covers the **non-happy-path** logic for Phase B (step
+implementation):
+
+- **Phase B Resume** — orphan-commit recovery when a session was
+  interrupted mid-step.
+- **Non-`SUCCESS` orchestrator handlers** —
+  `escalate_to_user_then_respawn`, `apply_upgrade_then_decide`,
+  `handle_failure`.
+- **Post-Commit Handlers** — `rollback_and_handle_failure`,
+  `rollback_and_escalate`, `rollback_and_upgrade`, plus the common
+  `git revert` rollback procedure.
+- **Step Failure**, **Two-Failure Rule**, **Track-Level Failure**.
+- **Resume-side commit-pattern reference** for interpreting `git log
+  {base_commit}..HEAD` output.
+
+It is **loaded on demand** by the Phase B orchestrator. The happy path
+in [`step-implementation.md`](step-implementation.md) handles all
+`SUCCESS` returns, the step completion gate, the per-step orchestration
+loop, the dimensional review fan-out, the cross-track impact check,
+episode production, and Phase B completion.
+
+## Loading discipline
+
+Read this file when **either** trigger fires:
+
+1. **At Phase B Startup**, after `git log {base_commit}..HEAD`: if the
+   log shows orphan implementer commits, orphan `Review fix:` commits,
+   or a `Revert step:` commit at the tip, load this file before
+   spawning the first implementer — see §Phase B Resume below.
+2. **At result dispatch**, in the `match result.RESULT` block: any
+   value other than `SUCCESS` (`DESIGN_DECISION_NEEDED`,
+   `RISK_UPGRADE_REQUESTED`, `FAILED`) — load this file before entering
+   the matching handler.
+
+The happy-path session (clean startup, every spawn returns `SUCCESS`)
+never loads this file.
+
+---
+
+## Phase B Resume — Incomplete Step Recovery
+
+When resuming Phase B (session restart), the next `[ ]` step may have
+been **partially completed** in the previous session — code committed
+but episode not yet written. This happens when a session ends between
+the implementer's commit and the orchestrator's episode write, e.g.,
+because of a context-level session-end gate or unexpected session
+termination.
+
+**Detection.** After identifying the next `[ ]` step, check for orphan
+commits — commits that exist but have no corresponding episode in
+the step file on disk:
+
+1. Scan `git log --oneline {base_commit}..HEAD` and classify each
+   commit by subject prefix and the paths it touches (per
+   [`commit-conventions.md`](commit-conventions.md) § Commit type
+   prefixes). Each `[x]` step in the step file is expected to
+   contribute exactly **three** kinds of commit, in order:
+
+   - **Implementer code commit** — touches code (paths outside
+     `_workflow/`); subject is the imperative summary of the
+     step's change. Exactly **one** per `[x]` step.
+   - **`Review fix:` commits** — code commit prefixed
+     `Review fix:`. **Zero or more** per `[x]` step (one per
+     dim-review iteration that surfaced fixes).
+   - **Episode commit** — Workflow update touching only
+     `_workflow/tracks/track-<N>.md`, subject `Record episode for
+     <step description>`. Exactly **one** per `[x]` step.
+
+   Two other commit kinds appear in the log but **do not** count
+   toward any `[x]` step's expected total:
+
+   - **`Revert step:`** — a revert commit. With the implementer +
+     `Review fix:` commits it cancels, it forms a self-contained
+     "rolled back" group that is excluded from per-step counting.
+   - **Other Workflow update** — touches only `_workflow/` but is
+     not an episode commit (Phase 1 init, Phase A decomposition,
+     Phase B base-commit recording, plan-corrections application,
+     track-completion mark, inline-replanning update). These are
+     workflow scaffolding and may appear anywhere in the log
+     between or before `[x]` steps.
+
+   For K `[x]` steps, the expected per-step set is K × (1
+   implementer + N `Review fix:` + 1 episode), plus any number of
+   non-episode Workflow update commits and rolled-back groups.
+   Anything beyond this — typically an implementer commit (and
+   possibly trailing `Review fix:` commits) without a following
+   episode commit — is orphaned and belongs to the next `[ ]`
+   step.
+
+   **Crash between sub-step 7 (episode write) and sub-step 8
+   (episode commit).** If the step file shows `[x]` for the most
+   recent completed step but the corresponding episode commit is
+   missing from the log, the previous session wrote the episode
+   to disk but died before committing it. The working tree is
+   dirty with the unwritten episode. Recovery: stage and commit
+   the step file now (using the standard episode commit subject
+   `Record episode for <step description>`), push, then proceed
+   with the rest of resume. This must happen **before** spawning
+   the next implementer — the implementer's `git reset --hard
+   HEAD` would otherwise discard the episode write.
+2. If a `Revert step:` commit is present at the tip (or near the
+   tip with no implementer commits after it), the previous session
+   rolled the next `[ ]` step back via §Post-Commit Handlers but may
+   not have finished the orchestrator-side bookkeeping (episode,
+   retry/split rows, risk-line rewrite, or user escalation).
+
+   **Read the rollback reason from the commit body.** The first
+   non-empty body line is `reason: <slug>` per §Post-Commit Handlers
+   "Body format". Branch on the slug:
+
+   **`reason: failed-review-fix`** — the review-fix respawn returned
+   `FAILED`.
+   - If the step file already has an `[!]` entry for this step,
+     the rollback was fully recorded; respawn the implementer for
+     the next `[ ]` row from `mode=INITIAL` with `step_base_commit
+     = HEAD`.
+   - If no `[!]` entry exists, write it now (reconstruct the
+     `FAILURE` fields from the prose explanation in the revert body
+     plus the git log of the reverted commits), insert retry/split
+     rows per the implied `recommended_action` (default to `retry`
+     when the revert body does not name one), update Progress, then
+     respawn from the retry/split row with `mode=INITIAL`.
+
+   **`reason: late-design-decision`** — the review-fix respawn
+   returned `DESIGN_DECISION_NEEDED` and the user had not yet chosen
+   an alternative when the session ended.
+   - The original `DESIGN_DECISION` payload (alternatives,
+     recommendation, exploration_notes) is **not recoverable** from
+     the revert body — it was held only in the prior session's
+     orchestrator state.
+   - The step file is still `[ ]` (no `[!]` is written for this
+     case). Respawn the implementer with `mode=INITIAL` and
+     `step_base_commit = HEAD`. The new implementer either lands on
+     the same design decision (and re-derives the alternatives via
+     a fresh `DESIGN_DECISION_NEEDED` return) or finds a different
+     path. Either is acceptable — re-derivation is the cost of the
+     mid-escalation crash.
+
+   **`reason: late-risk-upgrade`** — the review-fix respawn returned
+   `RISK_UPGRADE_REQUESTED`.
+   - Read the step's `**Risk:**` line. If it already names the
+     upgraded level (the prior session wrote it before dying), no
+     further bookkeeping is needed.
+   - If the line still names the original level, apply the upgrade
+     now: rewrite to the new level (auto-applied for `medium → high`,
+     paused for user confirmation on `low → high`) and append an
+     override note (`override: upgraded mid-Phase-B during dim review
+     (<reason from revert body>)`).
+   - Respawn the implementer from `mode=INITIAL` with
+     `step_base_commit = HEAD`.
+
+   **Unrecognised slug or missing `reason:` line.** Treat as a
+   contract violation: present the revert commit and the step state
+   to the user and ask how to proceed. Do not invent a slug.
+3. If implementer / `Review fix:` code commits are present after
+   the last episode commit (or after `{base_commit}` if no episode
+   commits exist yet) without a `Revert step:` at the tip:
+   - The previous session committed code for the next `[ ]` step
+     but didn't write the episode.
+   - **Resume from the appropriate orchestrator handler** by checking
+     the orphan commits' messages (see §Resume-side commit-pattern
+     reference below for the patterns):
+     - If any orphan commit message contains `Review fix:` → the
+       dimensional review loop already ran. Skip directly to
+       `on_success` from the cross-track impact check (sub-step 5)
+       onward; reconstruct an `EPISODE_DRAFT` from the diff and the
+       commit messages.
+     - If no `Review fix:` commits exist → the dimensional review
+       loop has not yet run for this step. Re-enter `on_success`
+       starting at the dimensional review (the implementer's commit
+       is already on disk; treat it as the implementer's `SUCCESS`
+       return).
+   - Then proceed to the next `[ ]` step normally.
+4. If no orphan commits exist, spawn the implementer for the next
+   `[ ]` step from `mode=INITIAL` with `step_base_commit = HEAD`.
+
+**Why this matters.** Without this check, the orchestrator would
+spawn an implementer that re-derives changes already committed,
+potentially creating duplicate or conflicting commits.
+
+### Resume-side commit-pattern reference
+
+When Phase B resumes and detects orphan code commits, it scans
+`git log --oneline {base_commit}..HEAD` and uses these patterns
+(the authoring side of the same patterns lives in
+[`commit-conventions.md`](commit-conventions.md) § Commit type
+prefixes):
+
+1. **`Revert step:` commits** — the previous session rolled the step
+   back after a non-`SUCCESS` review-fix attempt. The next `[ ]` step
+   was already cleanly returned to its pre-implementation state by
+   the revert. Read the `reason: <slug>` line in the body and
+   dispatch per §Phase B Resume above — the bookkeeping differs by
+   slug (write `[!]` for `failed-review-fix`; respawn-and-rederive
+   for `late-design-decision`; verify-or-apply-upgrade for
+   `late-risk-upgrade`).
+2. **Episode commits** (`Record episode for …`, Workflow update
+   touching only `_workflow/tracks/track-<N>.md`) — mark the
+   boundary between completed and in-progress steps. The most
+   recent episode commit is the last fully-finished step.
+3. **`Review fix:` commits** — indicate the dim-review loop already
+   ran for the step they belong to. When an orphan `Review fix:`
+   commit appears after the last episode commit, resume from
+   episode production.
+4. **Implementer code commits** — touch code (paths outside
+   `_workflow/`); subject is the imperative summary of the step's
+   change. When an orphan implementer commit appears after the
+   last episode commit without any `Review fix:` siblings, resume
+   from the dimensional review loop.
+5. **Other Workflow update commits** — touch only `_workflow/`
+   but are not episode commits (Phase 1 init, Phase A
+   decomposition, Phase B base-commit recording, plan-corrections
+   application, track-completion mark, inline-replanning update).
+   They are scaffolding and **not** orphans regardless of
+   position.
+
+The step file on disk is the source of truth for which steps are
+complete (have episodes). Any implementer or `Review fix:` code
+commits beyond the last episode commit are orphans for the next
+`[ ]` step. A `Revert step:` commit cancels the implementer +
+`Review fix:` commits it reverts — together they form a
+self-contained "attempted and rolled back" group that does not count
+toward any `[x]` step's expected commits.
+
+---
+
+## Non-`SUCCESS` orchestrator handlers
+
+Triggered from the `match result.RESULT` dispatch in
+[`step-implementation.md`](step-implementation.md) §Per-Step
+Orchestration Loop when the implementer returns one of the three
+non-`SUCCESS` results. These three handlers fire in **pre-commit**
+modes (`mode=INITIAL` or `mode=WITH_GUIDANCE`); the equivalent
+post-commit dispatch (from `mode=FIX_REVIEW_FINDINGS`) is in
+§Post-Commit Handlers below.
+
+### `escalate_to_user_then_respawn(step, result)`
+
+Triggered when `result.RESULT == DESIGN_DECISION_NEEDED`. The
+implementer has run the snapshot-and-diff revert sequence per
+[`implementer-rules.md`](implementer-rules.md) §Detection rules, so
+the working tree is clean at `step_base_commit` (no commit was
+produced, and no untracked files were left behind).
+`result.DESIGN_DECISION` is populated with `context`, `alternatives`,
+`recommendation`, and `exploration_notes`.
+
+Verify `git status` is clean before continuing — a dirty tree at
+this point is a contract violation; surface the discrepancy to the
+user instead of proceeding.
+
+1. Present `result.DESIGN_DECISION` (alternatives + trade-offs +
+   recommendation) to the user via the existing escalation protocol
+   in [`design-decision-escalation.md`](design-decision-escalation.md).
+2. On user response, respawn the implementer with:
+   - `mode=WITH_GUIDANCE`
+   - `Guidance:` set to the user's chosen alternative + any
+     additional direction
+   - `exploration_notes_echo` set to
+     `result.DESIGN_DECISION.exploration_notes` so the new
+     implementer skips re-derivation
+3. The respawn's result re-enters the main loop at the
+   `match result.RESULT` dispatch.
+
+### `apply_upgrade_then_decide(step, result)`
+
+Triggered when `result.RESULT == RISK_UPGRADE_REQUESTED`. The
+implementer has flagged that the step is more invasive than its
+tagged risk and has run the snapshot-and-diff revert sequence per
+[`implementer-rules.md`](implementer-rules.md) §Detection rules, so
+the working tree is clean at `step_base_commit` (no commit was
+produced, and no untracked files were left behind).
+`result.RISK_UPGRADE` carries `from`, `to`, `category`, and
+`evidence`.
+
+Verify `git status` is clean before continuing — a dirty tree at
+this point is a contract violation; surface the discrepancy to the
+user instead of proceeding.
+
+1. **Apply the upgrade in place** in the step file: rewrite the
+   `**Risk:**` line to the new level and append an override note
+   in the form `override: upgraded mid-Phase-B (<short reason from
+   result.RISK_UPGRADE.evidence>)`. The decomposer-time category
+   stays in the line for traceability. Downgrades are not permitted
+   — see [`risk-tagging.md`](risk-tagging.md) §Override rules.
+2. **Approval flow:**
+   - `medium → high`: auto-apply (no user prompt). Note the
+     auto-apply in the next step-file write.
+   - `low → high`: pause and confirm with the user before
+     respawning. The bigger jump is more likely a planning miss.
+3. After application/confirmation, respawn the implementer with
+   `mode=INITIAL`. The next implementer's run is identical except
+   downstream `on_success` will now run the dimensional review.
+   No `exploration_notes_echo` is carried across — risk upgrades
+   typically surface early, before substantial implementation
+   exploration, so re-derivation is cheap and `mode=INITIAL` keeps
+   the respawn contract simple. If the prior implementer's
+   `RISK_UPGRADE.evidence` already names what was discovered, that
+   text plus the rewritten `**Risk:**` line is enough context for
+   the next implementer.
+
+### `handle_failure(step, result)`
+
+Triggered when `result.RESULT == FAILED` from `mode=INITIAL` or
+`mode=WITH_GUIDANCE` (pre-commit failure). For `FAILED` returns from
+`mode=FIX_REVIEW_FINDINGS`, the dim-review loop dispatches to
+`rollback_and_handle_failure` instead — see §Post-Commit Handlers.
+
+The implementer has already reverted any uncommitted changes and
+removed any untracked artefacts
+(the snapshot-and-diff revert sequence) before returning, so the
+working tree is clean at `step_base_commit`. `result.FAILURE` carries
+`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
+and `recommended_action`.
+
+1. **Write the failed episode** to the step file from
+   `result.FAILURE` (mark the step `[!]`).
+2. **Insert `[ ]` retry/split rows** per the existing protocol — see
+   §Step Failure below for the retry/split formats.
+3. **Update the Progress section's step count** to reflect any
+   inserted rows.
+4. **Two-failure rule.** If the new `[!]` makes two consecutive
+   `[!]` entries for the same logical step, stop and present both
+   failed episodes to the user — see §Two-Failure Rule below.
+
+The implementer never escalates directly; it returns `FAILED` with
+`recommended_action: escalate`, and the orchestrator decides whether
+to enter ESCALATE per [`inline-replanning.md`](inline-replanning.md).
+
+---
+
+## Post-Commit Handlers
+
+When the dim-review loop's `mode=FIX_REVIEW_FINDINGS` respawn returns
+a non-`SUCCESS` result, the prior step commits are still on disk.
+The implementer's local revert
+(the snapshot-and-diff revert sequence) only undoes its
+in-progress fix attempt; rolling back the prior commits is the
+orchestrator's responsibility.
+
+The post-commit handlers all share a common rollback step:
+
+```bash
+# step_base_commit was captured at spawn time
+git revert -n {step_base_commit}..HEAD
+git commit -m "$(cat <<'EOF'
+Revert step: <step description>
+
+reason: <slug>
+
+<one-sentence prose explanation, drawn from
+fix_result.{FAILURE|DESIGN_DECISION|RISK_UPGRADE}>
+EOF
+)"
+git push
+```
+
+The HEREDOC form is required for any commit message containing a blank
+line — `git commit -m "…"` with literal embedded newlines is fragile
+across shells. This matches the project commit-message convention in
+the repo's user-global `CLAUDE.md` ("Committing changes with git"). The
+`git push` after the commit follows the per-commit push rule in
+`commit-conventions.md` § Push every commit (the revert is part of
+the visible branch history on the draft PR).
+
+**Body format (load-bearing for Phase B Resume).** The first
+non-empty line of the body MUST be `reason: <slug>` where `<slug>`
+is exactly one of three values, used by Phase B Resume to dispatch:
+
+| Slug | Source handler | Resume dispatch |
+|---|---|---|
+| `failed-review-fix` | `rollback_and_handle_failure` | Write `[!]` if missing, insert retry/split rows, respawn `INITIAL` |
+| `late-design-decision` | `rollback_and_escalate` | Respawn `INITIAL`; new implementer re-derives — if it returns `DESIGN_DECISION_NEEDED` again, escalate then |
+| `late-risk-upgrade` | `rollback_and_upgrade` | Verify Risk line; apply upgrade if not yet rewritten; respawn `INITIAL` |
+
+A blank line separates the slug line from the prose explanation.
+Resume parses the body by reading the first body line and matching
+against the slug table — do not vary spelling, capitalisation, or
+position.
+
+`git revert -n` stages the reversal of every commit in
+`{step_base_commit}..HEAD` (the original implementer commit plus any
+prior `Review fix:` commits in the same dim-review loop) without
+auto-committing each revert. The orchestrator then commits once with
+the `Revert step:` prefix per
+[`commit-conventions.md`](commit-conventions.md). After the revert
+commit, HEAD's tree state matches `step_base_commit` — the new HEAD
+becomes the next step's `step_base_commit` for any respawn that
+follows.
+
+The rollback preserves history (the original attempt, any review
+fixes, and the revert all stay in `git log`), so future investigators
+can see what was tried. This is the conservative choice for a
+critical-systems project; squash-merge collapses the noise at the PR
+boundary.
+
+**Pre-revert assertion.** Before running `git revert -n`, verify
+`git status` is clean. The implementer's snapshot-and-diff revert
+sequence should have left it clean;
+if not, that is a contract violation and the orchestrator surfaces
+the discrepancy to the user instead of proceeding (a dirty tree at
+this point usually means the implementer exited mid-write or the
+user has manual edits in flight).
+
+### `rollback_and_handle_failure(step, fix_result, step_base_commit)`
+
+Triggered when a `FIX_REVIEW_FINDINGS` respawn returns
+`RESULT: FAILED` — the implementer cannot apply the review findings,
+typically because the findings reveal a deeper issue than a
+mechanical fix can address. `fix_result.FAILURE` carries
+`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
+and `recommended_action`.
+
+1. **Run the rollback** (revert + `Revert step:` commit) per the
+   common procedure above. The revert lands **before** any step-file
+   write so that the only crash-recoverable state is "Revert at tip
+   with step still `[ ]`" — Phase B Resume's Detection step 2
+   handles that exact state via the `failed-review-fix` slug branch
+   (which already covers "if no `[!]` entry exists, write it now").
+   Reversing this order — writing `[!]` first — would leave a
+   window where prior commits sit unreverted at HEAD with the step
+   already marked `[!]`; Detection step 3 would then misattribute
+   those orphan commits to the next `[ ]` step.
+2. **Write the failed episode** to the step file from
+   `fix_result.FAILURE` (mark the step `[!]`). The episode's
+   `what_was_attempted` should describe both the original
+   implementation and the review-fix attempt that failed; the
+   `why_it_failed` field captures the underlying reason.
+3. **Insert `[ ]` retry/split rows** per the existing protocol —
+   see §Step Failure for the formats.
+4. **Update the Progress section's step count** to reflect the
+   inserted rows.
+5. **Two-failure rule.** If the new `[!]` makes two consecutive
+   `[!]` entries for the same logical step, stop and present both
+   failed episodes to the user — see §Two-Failure Rule.
+
+After this handler completes, `step_base_commit` for the retry/split
+row is the new HEAD (the `Revert step:` commit).
+
+### `rollback_and_escalate(step, fix_result, step_base_commit)`
+
+Triggered when a `FIX_REVIEW_FINDINGS` respawn returns
+`RESULT: DESIGN_DECISION_NEEDED` — applying the review findings
+surfaced a design decision that was not visible during the original
+implementation. `fix_result.DESIGN_DECISION` carries `context`,
+`alternatives`, `recommendation`, and `exploration_notes`.
+
+1. **Run the rollback** (revert + `Revert step:` commit) per the
+   common procedure above. The rollback removes the original
+   implementer commit and any prior `Review fix:` commits because
+   the surfaced design decision affects the step's premise — the
+   user's chosen alternative may invalidate the original approach,
+   so we start the next attempt from a clean slate.
+2. **Present** `fix_result.DESIGN_DECISION` (alternatives + trade-offs
+   + recommendation) to the user via the existing escalation protocol
+   in [`design-decision-escalation.md`](design-decision-escalation.md).
+   Include in the prose that this decision surfaced **post-commit
+   during dim review**, so the user understands the rollback context.
+3. On user response, capture the new HEAD as `step_base_commit` and
+   respawn the implementer with:
+   - `mode=WITH_GUIDANCE`
+   - `Guidance:` set to the user's chosen alternative + any
+     additional direction
+   - `exploration_notes_echo` set to
+     `fix_result.DESIGN_DECISION.exploration_notes`
+4. The respawn's result re-enters the top-level `match result.RESULT`
+   dispatch in [`step-implementation.md`](step-implementation.md)
+   §Per-Step Orchestration Loop.
+
+### `rollback_and_upgrade(step, fix_result, step_base_commit)`
+
+Triggered when a `FIX_REVIEW_FINDINGS` respawn returns
+`RESULT: RISK_UPGRADE_REQUESTED` — applying the review findings
+revealed the step is more invasive than its tagged risk.
+`fix_result.RISK_UPGRADE` carries `from`, `to`, `category`, and
+`evidence`.
+
+1. **Run the rollback** (revert + `Revert step:` commit) per the
+   common procedure above. The rollback removes the original commit
+   so that the next attempt re-runs the implementation **with full
+   dim-review pressure from the start** at the new risk level — not
+   stacked on top of an implementation that was reviewed under the
+   old risk level.
+2. **Apply the upgrade in place** in the step file: rewrite the
+   `**Risk:**` line and append an override note in the form
+   `override: upgraded mid-Phase-B during dim review (<short reason
+   from fix_result.RISK_UPGRADE.evidence>)`. The decomposer-time
+   category stays for traceability. Downgrades are not permitted —
+   see [`risk-tagging.md`](risk-tagging.md) §Override rules.
+3. **Approval flow** (same as `apply_upgrade_then_decide`):
+   - `medium → high`: auto-apply (no user prompt). Note the
+     auto-apply in the step-file write.
+   - `low → high`: pause and confirm with the user before respawning.
+4. After application/confirmation, capture the new HEAD as
+   `step_base_commit` and respawn the implementer with `mode=INITIAL`.
+   The respawn's result re-enters the top-level dispatch.
+
+### Why rollback in all three cases?
+
+The post-commit handlers always rollback rather than try to
+patch-on-top because:
+
+- **`FAILED`**: by definition the prior commit cannot be salvaged;
+  retry/split needs a clean starting point.
+- **`DESIGN_DECISION_NEEDED`**: the user's chosen alternative may
+  invalidate the prior implementation. Starting fresh avoids
+  carrying assumptions from the old approach into a new one.
+- **`RISK_UPGRADE_REQUESTED`**: the prior implementation was reviewed
+  under the wrong risk level. Re-implementing with full dim-review
+  pressure from the start is the only way to get the review pressure
+  the upgraded risk demands.
+
+The cost is one rerun of the implementation. For a database project,
+the alternative — leaving an under-reviewed commit on disk and
+trying to patch it — is the wrong tradeoff.
+
+---
+
+## Step Failure
+
+If the implementer returns `RESULT: FAILED`, the implementer has
+already reverted uncommitted changes and removed any untracked
+artefacts (the snapshot-and-diff revert sequence). For
+pre-commit failures (`mode=INITIAL` / `mode=WITH_GUIDANCE`) the
+working tree is now clean at `step_base_commit` and the orchestrator
+proceeds directly with the steps below. For post-commit failures
+(`mode=FIX_REVIEW_FINDINGS`) the orchestrator first runs the
+rollback per §Post-Commit Handlers, then proceeds with the steps
+below; the retry/split rows below apply to both. The orchestrator
+handles the rest:
+
+1. **Write a failed episode** to the step file from
+   `result.FAILURE` (see
+   [`episode-format-reference.md`](episode-format-reference.md) for
+   the failed-episode format).
+2. **Decide retry vs split** based on
+   `result.FAILURE.recommended_action`:
+   - `retry` — keep the `[!]` entry and insert one new `[ ]` step
+     immediately after it with a modified description indicating
+     the different approach.
+   - `split` — keep the `[!]` entry and insert multiple new `[ ]`
+     steps immediately after it.
+   - `escalate` — present the situation to the user and consider
+     entering ESCALATE per [`inline-replanning.md`](inline-replanning.md).
+3. **Update the Progress section's step count** to reflect inserted
+   rows.
+
+### Retry representation in the step file
+
+```markdown
+- [!] Step: Add histogram header to leaf page
+  > **What was attempted:** ...
+  > **Why it failed:** ...
+  > **Impact on remaining steps:** ...
+  > **Key files:** ...
+
+- [ ] Step: Add histogram header to leaf page (retry: use page extension API)
+```
+
+### Split representation in the step file
+
+```markdown
+- [!] Step: Add histogram header and serialization
+  > **What was attempted:** ...
+  > **Why it failed:** ...
+
+- [ ] Step: Add histogram header struct (split from failed step above)
+- [ ] Step: Add histogram serialization (split from failed step above)
+```
+
+Update the **Progress** section's step count to reflect the new
+total (e.g., `(2/6 complete)` if a 5-step track gained one retry
+step).
+
+---
+
+## Two-Failure Rule
+
+The two-failure rule triggers when two consecutive `[!]` entries
+exist for the same logical step (the retry also failed):
+
+```markdown
+- [!] Step: Add histogram header to leaf page
+  > **What was attempted:** ... (first attempt)
+
+- [!] Step: Add histogram header to leaf page (retry: use page extension API)
+  > **What was attempted:** ... (second attempt)
+```
+
+When this happens — whether during a session or detected on resume:
+
+- **Stop.** Do not spawn another implementer.
+- Present both failed episodes to the user with:
+  - What was tried each time
+  - Why it failed
+  - Your assessment of whether this is a step-level issue or a
+    track-level issue
+- The user decides: retry with specific guidance, adjust the
+  approach, skip the step, or escalate.
+
+**On resume.** When scanning the step list and encountering a `[!]`
+entry followed by another `[!]` for the same step (with `(retry:`
+in the description), this is a two-failure situation. Present both
+failed episodes to the user before proceeding.
+
+---
+
+## Track-Level Failure
+
+If a failure undermines the track's overall approach (not just one
+step — e.g., the track's foundational assumption is wrong, or
+repeated step failures trace back to a common root cause the track
+cannot address):
+
+- Present the situation to the user with full context (affected
+  steps, what was tried, the underlying issue).
+- Recommend **ESCALATE** if the approach is fundamentally wrong
+  (see [`inline-replanning.md`](inline-replanning.md)).
+- The user decides how to proceed.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -197,7 +197,7 @@ activities across steps loses all three benefits.
 
 ## Per-Step Orchestration Loop
 
-For each `[ ]` step in the step file, run sub-steps 1–7 to
+For each `[ ]` step in the step file, run sub-steps 1–8 to
 completion before moving to the next step. Sub-steps 1–3 run inside
 the implementer; sub-steps 4–7 run on the orchestrator side.
 
@@ -246,8 +246,8 @@ responsibility.
 
 repo_root: {repo_root}
 plan_slim_path: /tmp/claude-code-plan-slim-{PPID}.md
-step_file_path: docs/adr/{dir-name}/tracks/track-{N}.md
-design_path: docs/adr/{dir-name}/design.md
+step_file_path: docs/adr/{dir-name}/_workflow/tracks/track-{N}.md
+design_path: docs/adr/{dir-name}/_workflow/design.md
 
 ## Per-step variable inputs
 
@@ -338,11 +338,11 @@ finding ID prefixes, and gate format.
       intro + track episode + strategy refresh only; the current
       track and other not-started tracks are shown in full. If the
       snapshot is missing, fall back to
-      docs/adr/{dir-name}/implementation-plan.md.
+      docs/adr/{dir-name}/_workflow/implementation-plan.md.
 
       ## Track Steps (tactical context)
       Read the step file at:
-        docs/adr/{dir-name}/tracks/track-{N}.md
+        docs/adr/{dir-name}/_workflow/tracks/track-{N}.md
       The file begins with a `## Description` section carrying the
       track's original description — intro paragraph +
       **What/How/Constraints/Interactions** subsections + any
@@ -466,13 +466,30 @@ Mark the step as `[x]`. Update the **Progress** section's `Step
 implementation` count (e.g., `(3/5 complete)`). If this is the last
 step, mark `Step implementation` as `[x]`.
 
-**Session-end gate.** After writing the episode: if the context
+**Sub-step 8 — Commit and push the episode.** The step file is
+tracked under `_workflow/`, so the episode write produces a dirty
+working tree. Commit and push it as a separate workflow-update
+commit so the draft PR reflects the new state and so `HEAD` is
+clean before the next implementer is spawned (the implementer's
+revert path uses `git reset --hard HEAD`, which would otherwise
+roll back the unwritten episode):
+
+```bash
+git add docs/adr/<dir-name>/_workflow/tracks/track-<N>.md
+git commit -m "Record episode for <step description>"
+git push
+```
+
+See `commit-conventions.md` § Push every commit and § Workflow
+update for the standard message form.
+
+**Session-end gate.** After committing the episode: if the context
 level was `warning` or `critical`, do NOT spawn the implementer for
 the next step. Save all work and ask the user for a session refresh
 (see workflow.md §Context Consumption Check).
 
 **→ GATE: Step is now complete.** Do not spawn the next implementer
-until sub-steps 1–7 above are done.
+until sub-steps 1–8 above are done.
 
 ### `escalate_to_user_then_respawn(step, result)`
 
@@ -591,12 +608,16 @@ reason: <slug>
 fix_result.{FAILURE|DESIGN_DECISION|RISK_UPGRADE}>
 EOF
 )"
+git push
 ```
 
 The HEREDOC form is required for any commit message containing a blank
 line — `git commit -m "…"` with literal embedded newlines is fragile
 across shells. This matches the project commit-message convention in
-the repo's user-global `CLAUDE.md` ("Committing changes with git").
+the repo's user-global `CLAUDE.md` ("Committing changes with git"). The
+`git push` after the commit follows the per-commit push rule in
+`commit-conventions.md` § Push every commit (the revert is part of
+the visible branch history on the draft PR).
 
 **Body format (load-bearing for Phase B Resume).** The first
 non-empty line of the body MUST be `reason: <slug>` where `<slug>`

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -477,7 +477,7 @@ until sub-steps 1–7 above are done.
 ### `escalate_to_user_then_respawn(step, result)`
 
 Triggered when `result.RESULT == DESIGN_DECISION_NEEDED`. The
-implementer has run `git reset --hard HEAD && git clean -fd` per
+implementer has run the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created) per
 [`implementer-rules.md`](implementer-rules.md) §Detection rules, so
 the working tree is clean at `step_base_commit` (no commit was
 produced, and no untracked files were left behind).
@@ -505,7 +505,7 @@ user instead of proceeding.
 
 Triggered when `result.RESULT == RISK_UPGRADE_REQUESTED`. The
 implementer has flagged that the step is more invasive than its
-tagged risk and has run `git reset --hard HEAD && git clean -fd` per
+tagged risk and has run the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created) per
 [`implementer-rules.md`](implementer-rules.md) §Detection rules, so
 the working tree is clean at `step_base_commit` (no commit was
 produced, and no untracked files were left behind).
@@ -547,7 +547,7 @@ Triggered when `result.RESULT == FAILED` from `mode=INITIAL` or
 
 The implementer has already reverted any uncommitted changes and
 removed any untracked artefacts
-(`git reset --hard HEAD && git clean -fd`) before returning, so the
+(the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created)) before returning, so the
 working tree is clean at `step_base_commit`. `result.FAILURE` carries
 `what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
 and `recommended_action`.
@@ -573,7 +573,7 @@ to enter ESCALATE per [`inline-replanning.md`](inline-replanning.md).
 When the dim-review loop's `mode=FIX_REVIEW_FINDINGS` respawn returns
 a non-`SUCCESS` result, the prior step commits are still on disk.
 The implementer's local revert
-(`git reset --hard HEAD && git clean -fd`) only undoes its
+(the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created)) only undoes its
 in-progress fix attempt; rolling back the prior commits is the
 orchestrator's responsibility.
 
@@ -631,7 +631,7 @@ boundary.
 
 **Pre-revert assertion.** Before running `git revert -n`, verify
 `git status` is clean. The implementer's
-`git reset --hard HEAD && git clean -fd` should have left it clean;
+the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created) should have left it clean;
 if not, that is a contract violation and the orchestrator surfaces
 the discrepancy to the user instead of proceeding (a dirty tree at
 this point usually means the implementer exited mid-write or the
@@ -821,7 +821,7 @@ examples live in
 
 If the implementer returns `RESULT: FAILED`, the implementer has
 already reverted uncommitted changes and removed any untracked
-artefacts (`git reset --hard HEAD && git clean -fd`). For
+artefacts (the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created)). For
 pre-commit failures (`mode=INITIAL` / `mode=WITH_GUIDANCE`) the
 working tree is now clean at `step_base_commit` and the orchestrator
 proceeds directly with the steps below. For post-commit failures

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -22,6 +22,31 @@ return per step.
 The implementer rulebook is the authoritative reference for sub-steps
 1–3. This document stays focused on the orchestrator side.
 
+## Loading discipline — happy path only
+
+This document covers the **happy path** only: every implementer spawn
+returns `RESULT: SUCCESS`, no orphan commits exist at session start,
+no step is marked `[!]`. The non-happy-path logic — Phase B Resume,
+the three non-`SUCCESS` orchestrator handlers, post-commit rollback
+handlers, retry/split formats, the Two-Failure Rule, Track-Level
+Failure — lives in
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+and is loaded on demand.
+
+**Read the recovery file when either trigger fires:**
+
+1. **At Phase B Startup**, after `git log {base_commit}..HEAD`: if
+   the log shows orphan implementer commits, orphan `Review fix:`
+   commits, or a `Revert step:` commit at the tip — see §Phase B
+   Startup item 3 below.
+2. **At result dispatch** (Per-Step Orchestration Loop, on_success
+   sub-step 4c): any value other than `SUCCESS` from an implementer
+   spawn — `DESIGN_DECISION_NEEDED`, `RISK_UPGRADE_REQUESTED`,
+   `FAILED`.
+
+The recovery file is self-contained — once loaded, it carries the
+full procedure for the matching case.
+
 ---
 
 ## Phase B Startup
@@ -55,8 +80,14 @@ Before spawning the first implementer:
    spawn. Regenerate the snapshot only if inline replanning
    (ESCALATE) modifies the plan mid-session. The snapshot lives in
    `/tmp` (not under `_workflow/`) and is not committed.
-3. **Detect orphan commits** per the §Phase B Resume protocol below
-   before spawning the first implementer.
+3. **Detect orphan commits.** Run `git log --oneline
+   {base_commit}..HEAD` and inspect the result. If it shows orphan
+   implementer commits, orphan `Review fix:` commits, or a
+   `Revert step:` commit at the tip, the previous session was
+   interrupted mid-step — load
+   [`step-implementation-recovery.md`](step-implementation-recovery.md)
+   and follow §Phase B Resume there before spawning the first
+   implementer. If no orphan commits exist, continue normally.
 
 ### Per-step base commit tracking
 
@@ -75,155 +106,14 @@ The orchestrator tracks a **per-step base commit** —
 respawn returns a non-`SUCCESS` result — `git revert
 {step_base_commit}..HEAD` produces a single revert commit covering
 the original implementer commit plus any prior `Review fix:` commits
-in the same dim-review loop. See §Post-Commit Handlers.
+in the same dim-review loop. See
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Post-Commit Handlers.
 
 The orchestrator captures `step_base_commit` in-memory by running
 `git rev-parse HEAD` just before the spawn. On resume, derive it
 from git: it is the parent of the first orphan commit for the next
 `[ ]` step, or HEAD if no orphans exist.
-
----
-
-## Phase B Resume — Incomplete Step Recovery
-
-When resuming Phase B (session restart), the next `[ ]` step may have
-been **partially completed** in the previous session — code committed
-but episode not yet written. This happens when a session ends between
-the implementer's commit and the orchestrator's episode write, e.g.,
-because of a context-level session-end gate or unexpected session
-termination.
-
-**Detection.** After identifying the next `[ ]` step, check for orphan
-commits — commits that exist but have no corresponding episode in
-the step file on disk:
-
-1. Scan `git log --oneline {base_commit}..HEAD` and classify each
-   commit by subject prefix and the paths it touches (per
-   [`commit-conventions.md`](commit-conventions.md) § Commit type
-   prefixes). Each `[x]` step in the step file is expected to
-   contribute exactly **three** kinds of commit, in order:
-
-   - **Implementer code commit** — touches code (paths outside
-     `_workflow/`); subject is the imperative summary of the
-     step's change. Exactly **one** per `[x]` step.
-   - **`Review fix:` commits** — code commit prefixed
-     `Review fix:`. **Zero or more** per `[x]` step (one per
-     dim-review iteration that surfaced fixes).
-   - **Episode commit** — Workflow update touching only
-     `_workflow/tracks/track-<N>.md`, subject `Record episode for
-     <step description>`. Exactly **one** per `[x]` step.
-
-   Two other commit kinds appear in the log but **do not** count
-   toward any `[x]` step's expected total:
-
-   - **`Revert step:`** — a revert commit. With the implementer +
-     `Review fix:` commits it cancels, it forms a self-contained
-     "rolled back" group that is excluded from per-step counting.
-   - **Other Workflow update** — touches only `_workflow/` but is
-     not an episode commit (Phase 1 init, Phase A decomposition,
-     Phase B base-commit recording, plan-corrections application,
-     track-completion mark, inline-replanning update). These are
-     workflow scaffolding and may appear anywhere in the log
-     between or before `[x]` steps.
-
-   For K `[x]` steps, the expected per-step set is K × (1
-   implementer + N `Review fix:` + 1 episode), plus any number of
-   non-episode Workflow update commits and rolled-back groups.
-   Anything beyond this — typically an implementer commit (and
-   possibly trailing `Review fix:` commits) without a following
-   episode commit — is orphaned and belongs to the next `[ ]`
-   step.
-
-   **Crash between sub-step 7 (episode write) and sub-step 8
-   (episode commit).** If the step file shows `[x]` for the most
-   recent completed step but the corresponding episode commit is
-   missing from the log, the previous session wrote the episode
-   to disk but died before committing it. The working tree is
-   dirty with the unwritten episode. Recovery: stage and commit
-   the step file now (using the standard episode commit subject
-   `Record episode for <step description>`), push, then proceed
-   with the rest of resume. This must happen **before** spawning
-   the next implementer — the implementer's `git reset --hard
-   HEAD` would otherwise discard the episode write.
-2. If a `Revert step:` commit is present at the tip (or near the
-   tip with no implementer commits after it), the previous session
-   rolled the next `[ ]` step back via §Post-Commit Handlers but may
-   not have finished the orchestrator-side bookkeeping (episode,
-   retry/split rows, risk-line rewrite, or user escalation).
-
-   **Read the rollback reason from the commit body.** The first
-   non-empty body line is `reason: <slug>` per §Post-Commit Handlers
-   "Body format". Branch on the slug:
-
-   **`reason: failed-review-fix`** — the review-fix respawn returned
-   `FAILED`.
-   - If the step file already has an `[!]` entry for this step,
-     the rollback was fully recorded; respawn the implementer for
-     the next `[ ]` row from `mode=INITIAL` with `step_base_commit
-     = HEAD`.
-   - If no `[!]` entry exists, write it now (reconstruct the
-     `FAILURE` fields from the prose explanation in the revert body
-     plus the git log of the reverted commits), insert retry/split
-     rows per the implied `recommended_action` (default to `retry`
-     when the revert body does not name one), update Progress, then
-     respawn from the retry/split row with `mode=INITIAL`.
-
-   **`reason: late-design-decision`** — the review-fix respawn
-   returned `DESIGN_DECISION_NEEDED` and the user had not yet chosen
-   an alternative when the session ended.
-   - The original `DESIGN_DECISION` payload (alternatives,
-     recommendation, exploration_notes) is **not recoverable** from
-     the revert body — it was held only in the prior session's
-     orchestrator state.
-   - The step file is still `[ ]` (no `[!]` is written for this
-     case). Respawn the implementer with `mode=INITIAL` and
-     `step_base_commit = HEAD`. The new implementer either lands on
-     the same design decision (and re-derives the alternatives via
-     a fresh `DESIGN_DECISION_NEEDED` return) or finds a different
-     path. Either is acceptable — re-derivation is the cost of the
-     mid-escalation crash.
-
-   **`reason: late-risk-upgrade`** — the review-fix respawn returned
-   `RISK_UPGRADE_REQUESTED`.
-   - Read the step's `**Risk:**` line. If it already names the
-     upgraded level (the prior session wrote it before dying), no
-     further bookkeeping is needed.
-   - If the line still names the original level, apply the upgrade
-     now: rewrite to the new level (auto-applied for `medium → high`,
-     paused for user confirmation on `low → high`) and append an
-     override note (`override: upgraded mid-Phase-B during dim review
-     (<reason from revert body>)`).
-   - Respawn the implementer from `mode=INITIAL` with
-     `step_base_commit = HEAD`.
-
-   **Unrecognised slug or missing `reason:` line.** Treat as a
-   contract violation: present the revert commit and the step state
-   to the user and ask how to proceed. Do not invent a slug.
-3. If implementer / `Review fix:` code commits are present after
-   the last episode commit (or after `{base_commit}` if no episode
-   commits exist yet) without a `Revert step:` at the tip:
-   - The previous session committed code for the next `[ ]` step
-     but didn't write the episode.
-   - **Resume from the appropriate orchestrator handler** by checking
-     the orphan commits' messages (see
-     [`commit-conventions.md`](commit-conventions.md) for the patterns):
-     - If any orphan commit message contains `Review fix:` → the
-       dimensional review loop already ran. Skip directly to
-       `on_success` from the cross-track impact check (sub-step 5)
-       onward; reconstruct an `EPISODE_DRAFT` from the diff and the
-       commit messages.
-     - If no `Review fix:` commits exist → the dimensional review
-       loop has not yet run for this step. Re-enter `on_success`
-       starting at the dimensional review (the implementer's commit
-       is already on disk; treat it as the implementer's `SUCCESS`
-       return).
-   - Then proceed to the next `[ ]` step normally.
-4. If no orphan commits exist, spawn the implementer for the next
-   `[ ]` step from `mode=INITIAL` with `step_base_commit = HEAD`.
-
-**Why this matters.** Without this check, the orchestrator would
-spawn an implementer that re-derives changes already committed,
-potentially creating duplicate or conflicting commits.
 
 ---
 
@@ -260,13 +150,17 @@ the implementer; sub-steps 4–7 run on the orchestrator side.
 result = spawn_implementer(step, mode=INITIAL)
 match result.RESULT:
     SUCCESS                  -> on_success(step, result)          # sub-steps 4–7
-    DESIGN_DECISION_NEEDED   -> escalate_to_user_then_respawn(step, result)
-    RISK_UPGRADE_REQUESTED   -> apply_upgrade_then_decide(step, result)
-    FAILED                   -> handle_failure(step, result)
+    DESIGN_DECISION_NEEDED   -> [load recovery] escalate_to_user_then_respawn(step, result)
+    RISK_UPGRADE_REQUESTED   -> [load recovery] apply_upgrade_then_decide(step, result)
+    FAILED                   -> [load recovery] handle_failure(step, result)
 ```
 
-The four handlers are defined in §Orchestrator Handlers below. The
-implementer prompt template is in §Implementer Prompt Template.
+Only `on_success` is in this document. The other three handlers are
+in
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Non-`SUCCESS` orchestrator handlers — load it before entering any
+of those branches. The implementer prompt template is in
+§Implementer Prompt Template below.
 
 ---
 
@@ -454,15 +348,15 @@ finding ID prefixes, and gate format.
           SUCCESS                  -> continue iteration loop with
                                       the new Review fix: commit as
                                       the diff target
-          FAILED                   -> rollback_and_handle_failure(
+          FAILED                   -> [load recovery] rollback_and_handle_failure(
                                           step, fix_result,
                                           step_base_commit)
                                       # exits the dim-review loop
-          DESIGN_DECISION_NEEDED   -> rollback_and_escalate(
+          DESIGN_DECISION_NEEDED   -> [load recovery] rollback_and_escalate(
                                           step, fix_result,
                                           step_base_commit)
                                       # exits the dim-review loop
-          RISK_UPGRADE_REQUESTED   -> rollback_and_upgrade(
+          RISK_UPGRADE_REQUESTED   -> [load recovery] rollback_and_upgrade(
                                           step, fix_result,
                                           step_base_commit)
                                       # exits the dim-review loop
@@ -472,9 +366,12 @@ finding ID prefixes, and gate format.
       [`commit-conventions.md`](commit-conventions.md)'s
       `Review fix:` prefix; the new `result.COMMIT` becomes the
       diff target for the next gate check. On any non-`SUCCESS`
-      return, the orchestrator hands off to the post-commit handler
-      below, which rolls the prior commits back and re-enters the
-      top-level dispatch with a clean tree at `step_base_commit`.
+      return, load
+      [`step-implementation-recovery.md`](step-implementation-recovery.md)
+      and hand off to the post-commit handler defined there
+      (§Post-Commit Handlers); it rolls the prior commits back and
+      re-enters the top-level dispatch with a clean tree at
+      `step_base_commit`.
    d. **Re-run only the dimension(s) with open findings** on each
       gate-check iteration. Repeat until approved OR **max 3
       iterations** reached.
@@ -547,284 +444,6 @@ the next step. Save all work and ask the user for a session refresh
 **→ GATE: Step is now complete.** Do not spawn the next implementer
 until sub-steps 1–8 above are done.
 
-### `escalate_to_user_then_respawn(step, result)`
-
-Triggered when `result.RESULT == DESIGN_DECISION_NEEDED`. The
-implementer has run the snapshot-and-diff revert sequence per
-[`implementer-rules.md`](implementer-rules.md) §Detection rules, so
-the working tree is clean at `step_base_commit` (no commit was
-produced, and no untracked files were left behind).
-`result.DESIGN_DECISION` is populated with `context`, `alternatives`,
-`recommendation`, and `exploration_notes`.
-
-Verify `git status` is clean before continuing — a dirty tree at
-this point is a contract violation; surface the discrepancy to the
-user instead of proceeding.
-
-1. Present `result.DESIGN_DECISION` (alternatives + trade-offs +
-   recommendation) to the user via the existing escalation protocol
-   in [`design-decision-escalation.md`](design-decision-escalation.md).
-2. On user response, respawn the implementer with:
-   - `mode=WITH_GUIDANCE`
-   - `Guidance:` set to the user's chosen alternative + any
-     additional direction
-   - `exploration_notes_echo` set to
-     `result.DESIGN_DECISION.exploration_notes` so the new
-     implementer skips re-derivation
-3. The respawn's result re-enters the main loop at the
-   `match result.RESULT` dispatch.
-
-### `apply_upgrade_then_decide(step, result)`
-
-Triggered when `result.RESULT == RISK_UPGRADE_REQUESTED`. The
-implementer has flagged that the step is more invasive than its
-tagged risk and has run the snapshot-and-diff revert sequence per
-[`implementer-rules.md`](implementer-rules.md) §Detection rules, so
-the working tree is clean at `step_base_commit` (no commit was
-produced, and no untracked files were left behind).
-`result.RISK_UPGRADE` carries `from`, `to`, `category`, and
-`evidence`.
-
-Verify `git status` is clean before continuing — a dirty tree at
-this point is a contract violation; surface the discrepancy to the
-user instead of proceeding.
-
-1. **Apply the upgrade in place** in the step file: rewrite the
-   `**Risk:**` line to the new level and append an override note
-   in the form `override: upgraded mid-Phase-B (<short reason from
-   result.RISK_UPGRADE.evidence>)`. The decomposer-time category
-   stays in the line for traceability. Downgrades are not permitted
-   — see [`risk-tagging.md`](risk-tagging.md) §Override rules.
-2. **Approval flow:**
-   - `medium → high`: auto-apply (no user prompt). Note the
-     auto-apply in the next step-file write.
-   - `low → high`: pause and confirm with the user before
-     respawning. The bigger jump is more likely a planning miss.
-3. After application/confirmation, respawn the implementer with
-   `mode=INITIAL`. The next implementer's run is identical except
-   downstream `on_success` will now run the dimensional review.
-   No `exploration_notes_echo` is carried across — risk upgrades
-   typically surface early, before substantial implementation
-   exploration, so re-derivation is cheap and `mode=INITIAL` keeps
-   the respawn contract simple. If the prior implementer's
-   `RISK_UPGRADE.evidence` already names what was discovered, that
-   text plus the rewritten `**Risk:**` line is enough context for
-   the next implementer.
-
-### `handle_failure(step, result)`
-
-Triggered when `result.RESULT == FAILED` from `mode=INITIAL` or
-`mode=WITH_GUIDANCE` (pre-commit failure). For `FAILED` returns from
-`mode=FIX_REVIEW_FINDINGS`, the dim-review loop dispatches to
-`rollback_and_handle_failure` instead — see §Post-Commit Handlers.
-
-The implementer has already reverted any uncommitted changes and
-removed any untracked artefacts
-(the snapshot-and-diff revert sequence) before returning, so the
-working tree is clean at `step_base_commit`. `result.FAILURE` carries
-`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
-and `recommended_action`.
-
-1. **Write the failed episode** to the step file from
-   `result.FAILURE` (mark the step `[!]`).
-2. **Insert `[ ]` retry/split rows** per the existing protocol — see
-   §Step Failure below for the retry/split formats.
-3. **Update the Progress section's step count** to reflect any
-   inserted rows.
-4. **Two-failure rule.** If the new `[!]` makes two consecutive
-   `[!]` entries for the same logical step, stop and present both
-   failed episodes to the user — see §Two-Failure Rule below.
-
-The implementer never escalates directly; it returns `FAILED` with
-`recommended_action: escalate`, and the orchestrator decides whether
-to enter ESCALATE per [`inline-replanning.md`](inline-replanning.md).
-
----
-
-## Post-Commit Handlers
-
-When the dim-review loop's `mode=FIX_REVIEW_FINDINGS` respawn returns
-a non-`SUCCESS` result, the prior step commits are still on disk.
-The implementer's local revert
-(the snapshot-and-diff revert sequence) only undoes its
-in-progress fix attempt; rolling back the prior commits is the
-orchestrator's responsibility.
-
-The post-commit handlers all share a common rollback step:
-
-```bash
-# step_base_commit was captured at spawn time
-git revert -n {step_base_commit}..HEAD
-git commit -m "$(cat <<'EOF'
-Revert step: <step description>
-
-reason: <slug>
-
-<one-sentence prose explanation, drawn from
-fix_result.{FAILURE|DESIGN_DECISION|RISK_UPGRADE}>
-EOF
-)"
-git push
-```
-
-The HEREDOC form is required for any commit message containing a blank
-line — `git commit -m "…"` with literal embedded newlines is fragile
-across shells. This matches the project commit-message convention in
-the repo's user-global `CLAUDE.md` ("Committing changes with git"). The
-`git push` after the commit follows the per-commit push rule in
-`commit-conventions.md` § Push every commit (the revert is part of
-the visible branch history on the draft PR).
-
-**Body format (load-bearing for Phase B Resume).** The first
-non-empty line of the body MUST be `reason: <slug>` where `<slug>`
-is exactly one of three values, used by Phase B Resume to dispatch:
-
-| Slug | Source handler | Resume dispatch |
-|---|---|---|
-| `failed-review-fix` | `rollback_and_handle_failure` | Write `[!]` if missing, insert retry/split rows, respawn `INITIAL` |
-| `late-design-decision` | `rollback_and_escalate` | Respawn `INITIAL`; new implementer re-derives — if it returns `DESIGN_DECISION_NEEDED` again, escalate then |
-| `late-risk-upgrade` | `rollback_and_upgrade` | Verify Risk line; apply upgrade if not yet rewritten; respawn `INITIAL` |
-
-A blank line separates the slug line from the prose explanation.
-Resume parses the body by reading the first body line and matching
-against the slug table — do not vary spelling, capitalisation, or
-position.
-
-`git revert -n` stages the reversal of every commit in
-`{step_base_commit}..HEAD` (the original implementer commit plus any
-prior `Review fix:` commits in the same dim-review loop) without
-auto-committing each revert. The orchestrator then commits once with
-the `Revert step:` prefix per
-[`commit-conventions.md`](commit-conventions.md). After the revert
-commit, HEAD's tree state matches `step_base_commit` — the new HEAD
-becomes the next step's `step_base_commit` for any respawn that
-follows.
-
-The rollback preserves history (the original attempt, any review
-fixes, and the revert all stay in `git log`), so future investigators
-can see what was tried. This is the conservative choice for a
-critical-systems project; squash-merge collapses the noise at the PR
-boundary.
-
-**Pre-revert assertion.** Before running `git revert -n`, verify
-`git status` is clean. The implementer's snapshot-and-diff revert
-sequence should have left it clean;
-if not, that is a contract violation and the orchestrator surfaces
-the discrepancy to the user instead of proceeding (a dirty tree at
-this point usually means the implementer exited mid-write or the
-user has manual edits in flight).
-
-### `rollback_and_handle_failure(step, fix_result, step_base_commit)`
-
-Triggered when a `FIX_REVIEW_FINDINGS` respawn returns
-`RESULT: FAILED` — the implementer cannot apply the review findings,
-typically because the findings reveal a deeper issue than a
-mechanical fix can address. `fix_result.FAILURE` carries
-`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
-and `recommended_action`.
-
-1. **Run the rollback** (revert + `Revert step:` commit) per the
-   common procedure above. The revert lands **before** any step-file
-   write so that the only crash-recoverable state is "Revert at tip
-   with step still `[ ]`" — Phase B Resume's Detection step 2
-   handles that exact state via the `failed-review-fix` slug branch
-   (which already covers "if no `[!]` entry exists, write it now").
-   Reversing this order — writing `[!]` first — would leave a
-   window where prior commits sit unreverted at HEAD with the step
-   already marked `[!]`; Detection step 3 would then misattribute
-   those orphan commits to the next `[ ]` step.
-2. **Write the failed episode** to the step file from
-   `fix_result.FAILURE` (mark the step `[!]`). The episode's
-   `what_was_attempted` should describe both the original
-   implementation and the review-fix attempt that failed; the
-   `why_it_failed` field captures the underlying reason.
-3. **Insert `[ ]` retry/split rows** per the existing protocol —
-   see §Step Failure for the formats.
-4. **Update the Progress section's step count** to reflect the
-   inserted rows.
-5. **Two-failure rule.** If the new `[!]` makes two consecutive
-   `[!]` entries for the same logical step, stop and present both
-   failed episodes to the user — see §Two-Failure Rule.
-
-After this handler completes, `step_base_commit` for the retry/split
-row is the new HEAD (the `Revert step:` commit).
-
-### `rollback_and_escalate(step, fix_result, step_base_commit)`
-
-Triggered when a `FIX_REVIEW_FINDINGS` respawn returns
-`RESULT: DESIGN_DECISION_NEEDED` — applying the review findings
-surfaced a design decision that was not visible during the original
-implementation. `fix_result.DESIGN_DECISION` carries `context`,
-`alternatives`, `recommendation`, and `exploration_notes`.
-
-1. **Run the rollback** (revert + `Revert step:` commit) per the
-   common procedure above. The rollback removes the original
-   implementer commit and any prior `Review fix:` commits because
-   the surfaced design decision affects the step's premise — the
-   user's chosen alternative may invalidate the original approach,
-   so we start the next attempt from a clean slate.
-2. **Present** `fix_result.DESIGN_DECISION` (alternatives + trade-offs
-   + recommendation) to the user via the existing escalation protocol
-   in [`design-decision-escalation.md`](design-decision-escalation.md).
-   Include in the prose that this decision surfaced **post-commit
-   during dim review**, so the user understands the rollback context.
-3. On user response, capture the new HEAD as `step_base_commit` and
-   respawn the implementer with:
-   - `mode=WITH_GUIDANCE`
-   - `Guidance:` set to the user's chosen alternative + any
-     additional direction
-   - `exploration_notes_echo` set to
-     `fix_result.DESIGN_DECISION.exploration_notes`
-4. The respawn's result re-enters the top-level `match result.RESULT`
-   dispatch in §Per-Step Orchestration Loop.
-
-### `rollback_and_upgrade(step, fix_result, step_base_commit)`
-
-Triggered when a `FIX_REVIEW_FINDINGS` respawn returns
-`RESULT: RISK_UPGRADE_REQUESTED` — applying the review findings
-revealed the step is more invasive than its tagged risk.
-`fix_result.RISK_UPGRADE` carries `from`, `to`, `category`, and
-`evidence`.
-
-1. **Run the rollback** (revert + `Revert step:` commit) per the
-   common procedure above. The rollback removes the original commit
-   so that the next attempt re-runs the implementation **with full
-   dim-review pressure from the start** at the new risk level — not
-   stacked on top of an implementation that was reviewed under the
-   old risk level.
-2. **Apply the upgrade in place** in the step file: rewrite the
-   `**Risk:**` line and append an override note in the form
-   `override: upgraded mid-Phase-B during dim review (<short reason
-   from fix_result.RISK_UPGRADE.evidence>)`. The decomposer-time
-   category stays for traceability. Downgrades are not permitted —
-   see [`risk-tagging.md`](risk-tagging.md) §Override rules.
-3. **Approval flow** (same as `apply_upgrade_then_decide`):
-   - `medium → high`: auto-apply (no user prompt). Note the
-     auto-apply in the step-file write.
-   - `low → high`: pause and confirm with the user before respawning.
-4. After application/confirmation, capture the new HEAD as
-   `step_base_commit` and respawn the implementer with `mode=INITIAL`.
-   The respawn's result re-enters the top-level dispatch.
-
-### Why rollback in all three cases?
-
-The post-commit handlers always rollback rather than try to
-patch-on-top because:
-
-- **`FAILED`**: by definition the prior commit cannot be salvaged;
-  retry/split needs a clean starting point.
-- **`DESIGN_DECISION_NEEDED`**: the user's chosen alternative may
-  invalidate the prior implementation. Starting fresh avoids
-  carrying assumptions from the old approach into a new one.
-- **`RISK_UPGRADE_REQUESTED`**: the prior implementation was reviewed
-  under the wrong risk level. Re-implementing with full dim-review
-  pressure from the start is the only way to get the review pressure
-  the upgraded risk demands.
-
-The cost is one rerun of the implementation. For a database project,
-the alternative — leaving an under-reviewed commit on disk and
-trying to patch it — is the wrong tradeoff.
-
 ---
 
 ## Cross-Track Impact Check
@@ -892,109 +511,11 @@ Write the episode to the step file on disk. Detailed format and
 examples live in
 [`episode-format-reference.md`](episode-format-reference.md).
 
----
-
-## Step Failure
-
-If the implementer returns `RESULT: FAILED`, the implementer has
-already reverted uncommitted changes and removed any untracked
-artefacts (the snapshot-and-diff revert sequence). For
-pre-commit failures (`mode=INITIAL` / `mode=WITH_GUIDANCE`) the
-working tree is now clean at `step_base_commit` and the orchestrator
-proceeds directly with the steps below. For post-commit failures
-(`mode=FIX_REVIEW_FINDINGS`) the orchestrator first runs the
-rollback per §Post-Commit Handlers, then proceeds with the steps
-below; the retry/split rows below apply to both. The orchestrator
-handles the rest:
-
-1. **Write a failed episode** to the step file from
-   `result.FAILURE` (see
-   [`episode-format-reference.md`](episode-format-reference.md) for
-   the failed-episode format).
-2. **Decide retry vs split** based on
-   `result.FAILURE.recommended_action`:
-   - `retry` — keep the `[!]` entry and insert one new `[ ]` step
-     immediately after it with a modified description indicating
-     the different approach.
-   - `split` — keep the `[!]` entry and insert multiple new `[ ]`
-     steps immediately after it.
-   - `escalate` — present the situation to the user and consider
-     entering ESCALATE per [`inline-replanning.md`](inline-replanning.md).
-3. **Update the Progress section's step count** to reflect inserted
-   rows.
-
-### Retry representation in the step file
-
-```markdown
-- [!] Step: Add histogram header to leaf page
-  > **What was attempted:** ...
-  > **Why it failed:** ...
-  > **Impact on remaining steps:** ...
-  > **Key files:** ...
-
-- [ ] Step: Add histogram header to leaf page (retry: use page extension API)
-```
-
-### Split representation in the step file
-
-```markdown
-- [!] Step: Add histogram header and serialization
-  > **What was attempted:** ...
-  > **Why it failed:** ...
-
-- [ ] Step: Add histogram header struct (split from failed step above)
-- [ ] Step: Add histogram serialization (split from failed step above)
-```
-
-Update the **Progress** section's step count to reflect the new
-total (e.g., `(2/6 complete)` if a 5-step track gained one retry
-step).
-
----
-
-## Two-Failure Rule
-
-The two-failure rule triggers when two consecutive `[!]` entries
-exist for the same logical step (the retry also failed):
-
-```markdown
-- [!] Step: Add histogram header to leaf page
-  > **What was attempted:** ... (first attempt)
-
-- [!] Step: Add histogram header to leaf page (retry: use page extension API)
-  > **What was attempted:** ... (second attempt)
-```
-
-When this happens — whether during a session or detected on resume:
-
-- **Stop.** Do not spawn another implementer.
-- Present both failed episodes to the user with:
-  - What was tried each time
-  - Why it failed
-  - Your assessment of whether this is a step-level issue or a
-    track-level issue
-- The user decides: retry with specific guidance, adjust the
-  approach, skip the step, or escalate.
-
-**On resume.** When scanning the step list and encountering a `[!]`
-entry followed by another `[!]` for the same step (with `(retry:`
-in the description), this is a two-failure situation. Present both
-failed episodes to the user before proceeding.
-
----
-
-## Track-Level Failure
-
-If a failure undermines the track's overall approach (not just one
-step — e.g., the track's foundational assumption is wrong, or
-repeated step failures trace back to a common root cause the track
-cannot address):
-
-- Present the situation to the user with full context (affected
-  steps, what was tried, the underlying issue).
-- Recommend **ESCALATE** if the approach is fundamentally wrong
-  (see [`inline-replanning.md`](inline-replanning.md)).
-- The user decides how to proceed.
+The failed-episode format (`[!]` entry, `**What was attempted:**` /
+`**Why it failed:**` fields), retry/split row insertion, and the
+Two-Failure Rule live in
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+— load it when handling a `RESULT: FAILED` return.
 
 ---
 
@@ -1005,7 +526,9 @@ code changes committed to git):
 
 1. **Mark `Step implementation` as `[x]`** in the Progress section.
 2. **Inform the user** that Phase B is complete:
-   - How many steps were implemented (including any failed/retried).
+   - How many steps were implemented (including any failed/retried;
+     count from `[!]` and retry rows in the step file if recovery
+     was used).
    - Key discoveries from step episodes.
    - Any unresolved code review findings.
    - Instruct: "Clear session and re-run `/execute-tracks` to start

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -32,6 +32,20 @@ Before spawning the first implementer:
    current SHA, then write it to the step file's `## Base commit`
    section (creating the section if it doesn't exist). Skip if
    `## Base commit` already has a SHA (resume case).
+
+   The step file change must be committed before the first
+   implementer spawn — the implementer's `git reset --hard HEAD`
+   would otherwise discard the `## Base commit` write. Stage and
+   commit:
+
+   ```bash
+   git add docs/adr/<dir-name>/_workflow/tracks/track-<N>.md
+   git commit -m "Record Phase B base commit for <track>"
+   git push
+   ```
+
+   Skip the commit on resume (when `## Base commit` already had a
+   SHA and no write happened).
 2. **Generate the slim plan snapshot** at
    `/tmp/claude-code-plan-slim-$PPID.md`. Read the plan, apply the
    rendering rule in [`plan-slim-rendering.md`](plan-slim-rendering.md),
@@ -39,7 +53,8 @@ Before spawning the first implementer:
    review sub-agents read this snapshot by path — it keeps the
    orchestrator's tool-call history from accumulating a plan copy per
    spawn. Regenerate the snapshot only if inline replanning
-   (ESCALATE) modifies the plan mid-session.
+   (ESCALATE) modifies the plan mid-session. The snapshot lives in
+   `/tmp` (not under `_workflow/`) and is not committed.
 3. **Detect orphan commits** per the §Phase B Resume protocol below
    before spawning the first implementer.
 
@@ -79,17 +94,57 @@ because of a context-level session-end gate or unexpected session
 termination.
 
 **Detection.** After identifying the next `[ ]` step, check for orphan
-commits — code commits that exist but have no corresponding episode in
+commits — commits that exist but have no corresponding episode in
 the step file on disk:
 
-1. Count the `[x]` steps in the step file. Scan
-   `git log --oneline {base_commit}..HEAD` for code commits.
-   Each completed step is expected to contribute exactly **one**
-   implementer commit plus **zero or more** `Review fix:` commits.
-   `Revert step:` commits and the implementer + `Review fix:`
-   commits they cancel form a self-contained "rolled back" group
-   that does not count toward any `[x]` step's expected commits;
-   anything else beyond the expected total is orphaned.
+1. Scan `git log --oneline {base_commit}..HEAD` and classify each
+   commit by subject prefix and the paths it touches (per
+   [`commit-conventions.md`](commit-conventions.md) § Commit type
+   prefixes). Each `[x]` step in the step file is expected to
+   contribute exactly **three** kinds of commit, in order:
+
+   - **Implementer code commit** — touches code (paths outside
+     `_workflow/`); subject is the imperative summary of the
+     step's change. Exactly **one** per `[x]` step.
+   - **`Review fix:` commits** — code commit prefixed
+     `Review fix:`. **Zero or more** per `[x]` step (one per
+     dim-review iteration that surfaced fixes).
+   - **Episode commit** — Workflow update touching only
+     `_workflow/tracks/track-<N>.md`, subject `Record episode for
+     <step description>`. Exactly **one** per `[x]` step.
+
+   Two other commit kinds appear in the log but **do not** count
+   toward any `[x]` step's expected total:
+
+   - **`Revert step:`** — a revert commit. With the implementer +
+     `Review fix:` commits it cancels, it forms a self-contained
+     "rolled back" group that is excluded from per-step counting.
+   - **Other Workflow update** — touches only `_workflow/` but is
+     not an episode commit (Phase 1 init, Phase A decomposition,
+     Phase B base-commit recording, plan-corrections application,
+     track-completion mark, inline-replanning update). These are
+     workflow scaffolding and may appear anywhere in the log
+     between or before `[x]` steps.
+
+   For K `[x]` steps, the expected per-step set is K × (1
+   implementer + N `Review fix:` + 1 episode), plus any number of
+   non-episode Workflow update commits and rolled-back groups.
+   Anything beyond this — typically an implementer commit (and
+   possibly trailing `Review fix:` commits) without a following
+   episode commit — is orphaned and belongs to the next `[ ]`
+   step.
+
+   **Crash between sub-step 7 (episode write) and sub-step 8
+   (episode commit).** If the step file shows `[x]` for the most
+   recent completed step but the corresponding episode commit is
+   missing from the log, the previous session wrote the episode
+   to disk but died before committing it. The working tree is
+   dirty with the unwritten episode. Recovery: stage and commit
+   the step file now (using the standard episode commit subject
+   `Record episode for <step description>`), push, then proceed
+   with the rest of resume. This must happen **before** spawning
+   the next implementer — the implementer's `git reset --hard
+   HEAD` would otherwise discard the episode write.
 2. If a `Revert step:` commit is present at the tip (or near the
    tip with no implementer commits after it), the previous session
    rolled the next `[ ]` step back via §Post-Commit Handlers but may
@@ -144,14 +199,14 @@ the step file on disk:
    **Unrecognised slug or missing `reason:` line.** Treat as a
    contract violation: present the revert commit and the step state
    to the user and ask how to proceed. Do not invent a slug.
-3. If the commit count exceeds the expected total without a
-   `Revert step:` at the tip (one implementer commit + any
-   `Review fix:` commits per `[x]` step):
-   - The previous session committed code for this step but didn't
-     write the episode.
+3. If implementer / `Review fix:` code commits are present after
+   the last episode commit (or after `{base_commit}` if no episode
+   commits exist yet) without a `Revert step:` at the tip:
+   - The previous session committed code for the next `[ ]` step
+     but didn't write the episode.
    - **Resume from the appropriate orchestrator handler** by checking
-     commit messages (see [`commit-conventions.md`](commit-conventions.md)
-     for the patterns):
+     the orphan commits' messages (see
+     [`commit-conventions.md`](commit-conventions.md) for the patterns):
      - If any orphan commit message contains `Review fix:` → the
        dimensional review loop already ran. Skip directly to
        `on_success` from the cross-track impact check (sub-step 5)
@@ -480,8 +535,9 @@ git commit -m "Record episode for <step description>"
 git push
 ```
 
-See `commit-conventions.md` § Push every commit and § Workflow
-update for the standard message form.
+See `commit-conventions.md` § Push every commit, and the
+"Workflow update" row in § Commit type prefixes for the standard
+message form.
 
 **Session-end gate.** After committing the episode: if the context
 level was `warning` or `critical`, do NOT spawn the implementer for

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -477,7 +477,7 @@ until sub-steps 1–7 above are done.
 ### `escalate_to_user_then_respawn(step, result)`
 
 Triggered when `result.RESULT == DESIGN_DECISION_NEEDED`. The
-implementer has run the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created) per
+implementer has run the snapshot-and-diff revert sequence per
 [`implementer-rules.md`](implementer-rules.md) §Detection rules, so
 the working tree is clean at `step_base_commit` (no commit was
 produced, and no untracked files were left behind).
@@ -505,7 +505,7 @@ user instead of proceeding.
 
 Triggered when `result.RESULT == RISK_UPGRADE_REQUESTED`. The
 implementer has flagged that the step is more invasive than its
-tagged risk and has run the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created) per
+tagged risk and has run the snapshot-and-diff revert sequence per
 [`implementer-rules.md`](implementer-rules.md) §Detection rules, so
 the working tree is clean at `step_base_commit` (no commit was
 produced, and no untracked files were left behind).
@@ -547,7 +547,7 @@ Triggered when `result.RESULT == FAILED` from `mode=INITIAL` or
 
 The implementer has already reverted any uncommitted changes and
 removed any untracked artefacts
-(the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created)) before returning, so the
+(the snapshot-and-diff revert sequence) before returning, so the
 working tree is clean at `step_base_commit`. `result.FAILURE` carries
 `what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
 and `recommended_action`.
@@ -573,7 +573,7 @@ to enter ESCALATE per [`inline-replanning.md`](inline-replanning.md).
 When the dim-review loop's `mode=FIX_REVIEW_FINDINGS` respawn returns
 a non-`SUCCESS` result, the prior step commits are still on disk.
 The implementer's local revert
-(the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created)) only undoes its
+(the snapshot-and-diff revert sequence) only undoes its
 in-progress fix attempt; rolling back the prior commits is the
 orchestrator's responsibility.
 
@@ -630,8 +630,8 @@ critical-systems project; squash-merge collapses the noise at the PR
 boundary.
 
 **Pre-revert assertion.** Before running `git revert -n`, verify
-`git status` is clean. The implementer's
-the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created) should have left it clean;
+`git status` is clean. The implementer's snapshot-and-diff revert
+sequence should have left it clean;
 if not, that is a contract violation and the orchestrator surfaces
 the discrepancy to the user instead of proceeding (a dirty tree at
 this point usually means the implementer exited mid-write or the
@@ -821,7 +821,7 @@ examples live in
 
 If the implementer returns `RESULT: FAILED`, the implementer has
 already reverted uncommitted changes and removed any untracked
-artefacts (the snapshot-and-diff revert sequence (snapshot pre-existing untracked files, `git reset --hard HEAD`, then `comm -13` against a post-snapshot to surgically remove only files this spawn created)). For
+artefacts (the snapshot-and-diff revert sequence). For
 pre-commit failures (`mode=INITIAL` / `mode=WITH_GUIDANCE`) the
 working tree is now clean at `step_base_commit` and the orchestrator
 proceeds directly with the steps below. For post-commit failures

--- a/.claude/workflow/strategy-refresh.md
+++ b/.claude/workflow/strategy-refresh.md
@@ -49,11 +49,58 @@ completed or skipped a track (State A in workflow.md §Startup Protocol).
      picture. Enter inline replanning (see `inline-replanning.md`).
 
 5. **Write the `**Strategy refresh:**` line** to the plan file on disk
-   under the completed track's block (see conventions-execution.md §After
-   strategy refresh for format). For CONTINUE, a one-liner suffices. For
-   ADJUST, include a brief summary of what was adjusted. ESCALATE does not
-   write a strategy refresh line — it triggers replanning which restructures
-   the plan directly.
+   under the completed track's block. For CONTINUE, a one-liner suffices.
+   For ADJUST, include a brief summary of what was adjusted. ESCALATE
+   does not write a strategy refresh line — it triggers replanning
+   which restructures the plan directly.
+
+   The strategy refresh line is appended to the same track's block in
+   the plan file, after the step file reference:
+
+   ```markdown
+   - [x] Track 2: <title>
+     > <intro paragraph>
+     >
+     > **Track episode:**
+     > <strategic summary>
+     >
+     > **Step file:** `tracks/track-2.md` (4 steps, 0 failed)
+     >
+     > **Strategy refresh:** CONTINUE — no downstream impact detected.
+   ```
+
+   For ADJUST, include a brief summary of what was adjusted:
+
+   ```markdown
+     > **Strategy refresh:** ADJUST — Track 4 description updated to account
+     > for the new `IndexStatistics` API shape discovered during this track.
+   ```
+
+   For skipped tracks (`[~]`), the strategy refresh line follows the skip
+   record. The plan entry holds only the intro paragraph (the
+   `**What/How/Constraints/Interactions**` detail lived in
+   `implementation-backlog.md` and `track-skip` removes that section at
+   the same time it marks `[~]` — see
+   [`track-skip.md`](track-skip.md)). Skipped tracks never go through
+   the Phase C collapse, so nothing further trims the plan entry:
+
+   ```markdown
+   - [~] Track 3: <title>
+     > <description>
+     >
+     > **Skipped:** <reason>
+     >
+     > **Strategy refresh:** CONTINUE — no downstream impact from skipping.
+   ```
+
+   For how sub-agents see this, see
+   [`plan-slim-rendering.md`](plan-slim-rendering.md) — sub-agents
+   strip the implementation-detail subsections at prompt-assembly time
+   so reviewers get a compact view without changing what's on disk.
+
+   ESCALATE triggers inline replanning (see
+   [`workflow.md`](workflow.md) §Inline Replanning), which restructures
+   the plan file directly — no strategy refresh line is written.
 
 6. **Proceed** to Phase A of the next track in the same session.
 

--- a/.claude/workflow/structural-review.md
+++ b/.claude/workflow/structural-review.md
@@ -87,7 +87,7 @@ issues.
 ## Review output
 
 The structural review document is saved to
-`docs/adr/<dir-name>/reviews/structural.md`:
+`docs/adr/<dir-name>/_workflow/reviews/structural.md`:
 
 ```markdown
 # Structural Review

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -227,11 +227,12 @@ Iterate on the synthesized findings:
 
 1. If any findings need fixes:
    - Apply fixes as **additional commits** (never amend prior commits).
-     The Ephemeral identifier rule in
-     [`conventions-execution.md`](conventions-execution.md) §2.3
-     applies to durable content — no `Track N`, `Step N`, finding
-     IDs, or review iteration counters in source code, tests, or
-     code comments. Branch-only commit messages are exempt and may
+     The Ephemeral identifier rule (full rule in
+     [`ephemeral-identifier-rule.md`](ephemeral-identifier-rule.md);
+     stub recap in `conventions-execution.md` §2.3) applies to
+     durable content — no `Track N`, `Step N`, finding IDs, or
+     review iteration counters in source code, tests, or code
+     comments. Branch-only commit messages are exempt and may
      cite finding IDs when it makes the log easier to follow (per
      [`commit-conventions.md`](commit-conventions.md) "Branch-only
      commit messages may cite workflow-internal identifiers").
@@ -341,18 +342,43 @@ proceed directly to track completion **in the same session**.
      §Inline Replanning).
 
 4. **Write the track episode, collapse the description, and mark `[x]`**
-   in the plan file on disk (only after user approval):
+   in the plan file on disk (only after user approval).
 
-   Apply the collapse rule from
-   [`conventions-execution.md`](conventions-execution.md) §2.1
-   "After track completion (user-approved)". Quick form: always keep
-   the intro paragraph + `**Track episode:**` block + `**Step file:**`
-   pointer; always drop `**Scope:**` and `**Depends on:**`. (The
-   `**Strategy refresh:**` line belongs to §2.1's "Always keep"
-   clause but is never yet on disk at Phase C collapse time; the next
-   session's strategy refresh appends it.) The collapse does not touch
-   `implementation-backlog.md` — Phase A already removed Track N's
-   section at the start of this track.
+   The track episode is written **only after user approval**, and at
+   the same time the description is **collapsed** to remove
+   implementation detail that is now superseded by the committed code
+   and step episodes.
+
+   **Always keep** (regardless of plan shape): the **intro paragraph**
+   (the first paragraph of the original description, before any
+   `**What**:` / `**How**:` / `**Constraints**:` / `**Interactions**:`
+   subsection), the `**Track episode:**` block (written at collapse
+   time), the `**Step file:**` pointer, and the `**Strategy refresh:**`
+   line if present — though that line is never yet on disk at Phase C
+   collapse time; the next session's strategy refresh appends it (see
+   [`strategy-refresh.md`](strategy-refresh.md)).
+
+   **Always drop**: the `**Scope:**` line and the `**Depends on:**`
+   line.
+
+   Pending-track entries in the plan are written in the thin form
+   during Phase 1, so there are no
+   `**What**: / **How**: / **Constraints**: / **Interactions**:`
+   subsections present in the plan-file entry to drop — the detailed
+   description was removed from the backlog at Phase A start and
+   already lives in the step file's `## Description` section. Phase C
+   does not touch the backlog.
+
+   **Track episode fields:**
+   - Strategic summary covering: what was built, key discoveries, plan
+     deviations with cross-track impact. Length is proportional to
+     cross-track impact — a routine track may need only a couple of
+     sentences, while a track with architectural surprises should
+     include enough detail for the next session's strategy refresh to
+     assess downstream impact without reading the step file.
+   - Reference to the step file with step count and failure count.
+   - This is what future track sessions read from the plan file — the
+     step file is available for deeper investigation if needed.
 
    Final on-disk form:
 
@@ -366,9 +392,17 @@ proceed directly to track completion **in the same session**.
      > **Step file:** `tracks/track-N.md` (M steps, K failed)
    ```
 
-   This shrinks completed-track entries from 100+ lines to ~10–15 lines
-   and keeps the plan file lean as tracks land. The strategy-refresh
-   line is appended by the next session.
+   This shrinks completed-track entries from 100+ lines to ~10–15
+   lines and keeps the plan file lean as tracks land. The
+   strategy-refresh line is appended by the next session.
+
+   **Why collapse:** Completed tracks accumulate in the plan file and
+   are re-sent to every sub-agent as strategic context. Keeping the
+   full implementation detail for completed tracks inflates every
+   code-review sub-agent prompt by tens of thousands of tokens. The
+   intro paragraph plus track episode is sufficient strategic context
+   for reviewers of later tracks. For how sub-agents render the plan,
+   see [`plan-slim-rendering.md`](plan-slim-rendering.md).
 
 5. **Commit and push the track-completion changes** as a single
    Workflow update commit. The plan-file edit (track episode + `[x]`
@@ -384,9 +418,11 @@ proceed directly to track completion **in the same session**.
    ```
 
    This commit is registered as scaffolding in the resume orphan
-   detection (per `commit-conventions.md` § How these are used on
-   resume — entry 5, "Other Workflow update commits"). It does
-   **not** contribute to any `[x]` step's expected commit set.
+   detection (see
+   [`step-implementation-recovery.md`](step-implementation-recovery.md)
+   §Resume-side commit-pattern reference — entry 5, "Other Workflow
+   update commits"). It does **not** contribute to any `[x]` step's
+   expected commit set.
 
 6. **Session ends.** Strategy refresh happens next session.
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -227,11 +227,15 @@ Iterate on the synthesized findings:
 
 1. If any findings need fixes:
    - Apply fixes as **additional commits** (never amend prior commits).
-     Commit messages and any new code comments must follow the Ephemeral
-     identifier rule in
-     [`conventions-execution.md`](conventions-execution.md) §2.3 — no
-     `Track N`, `Step N`, finding IDs, or review iteration counters
-     in the message or the diff.
+     The Ephemeral identifier rule in
+     [`conventions-execution.md`](conventions-execution.md) §2.3
+     applies to durable content — no `Track N`, `Step N`, finding
+     IDs, or review iteration counters in source code, tests, or
+     code comments. Branch-only commit messages are exempt and may
+     cite finding IDs when it makes the log easier to follow (per
+     [`commit-conventions.md`](commit-conventions.md) "Branch-only
+     commit messages may cite workflow-internal identifiers").
+     Push each commit immediately per the per-commit push rule.
    - Run tests to verify fixes don't break anything
    - **Update the Progress section** on disk to record the completed
      iteration (e.g., `- [ ] Track-level code review (1/3 iterations)`).
@@ -279,8 +283,26 @@ implementation plan:
      indicator, and dependency notation (typically depends on the current
      track). Follow the same format as other tracks in the plan.
 
-2. **Save plan changes** — update `implementation-plan.md` on disk.
-   Note the finding IDs that motivated each plan correction.
+2. **Save plan changes** — update `implementation-plan.md` (and
+   `implementation-backlog.md` if a new track's
+   `**What/How/Constraints/Interactions**` subsections need
+   somewhere to live) on disk. Note the finding IDs that motivated
+   each plan correction.
+
+3. **Commit and push the plan corrections** as a separate Workflow
+   update commit (per `commit-conventions.md` § Commit type
+   prefixes — "Workflow update" row), distinct from the
+   `Mark <track> complete` commit below:
+
+   ```bash
+   git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
+           docs/adr/<dir-name>/_workflow/implementation-backlog.md
+   git commit -m "Apply plan corrections from <track> review"
+   git push
+   ```
+
+   Stage explicit paths only. Drop `implementation-backlog.md` from
+   the `git add` if no new track was added.
 
 If no findings were deferred, skip this section.
 
@@ -348,7 +370,25 @@ proceed directly to track completion **in the same session**.
    and keeps the plan file lean as tracks land. The strategy-refresh
    line is appended by the next session.
 
-5. **Session ends.** Strategy refresh happens next session.
+5. **Commit and push the track-completion changes** as a single
+   Workflow update commit. The plan-file edit (track episode + `[x]`
+   + collapsed description) and any final step-file Progress updates
+   from Phase C land together so the draft PR shows a clean track
+   boundary:
+
+   ```bash
+   git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
+           docs/adr/<dir-name>/_workflow/tracks/track-<N>.md
+   git commit -m "Mark <track> complete"
+   git push
+   ```
+
+   This commit is registered as scaffolding in the resume orphan
+   detection (per `commit-conventions.md` § How these are used on
+   resume — entry 5, "Other Workflow update commits"). It does
+   **not** contribute to any `[x]` step's expected commit set.
+
+6. **Session ends.** Strategy refresh happens next session.
 
 **Why deferred write:** Writing the track episode and marking `[x]` before
 user approval creates a state that cannot be reliably resumed — if the

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -69,10 +69,10 @@ of the changes.
 
 1. Read the step file's `## Base commit` section to get the SHA recorded
    at the start of Phase B.
-2. Read the **implementation plan** (`docs/adr/<dir-name>/implementation-plan.md`)
+2. Read the **implementation plan** (`docs/adr/<dir-name>/_workflow/implementation-plan.md`)
    — this provides strategic context (goals, architecture notes, decision
    records, track episodes from completed tracks).
-3. Read the **step file** (`docs/adr/<dir-name>/tracks/track-N.md`) — this
+3. Read the **step file** (`docs/adr/<dir-name>/_workflow/tracks/track-N.md`) — this
    provides the step descriptions and episodes.
 4. **Generate the slim plan snapshot** at
    `/tmp/claude-code-plan-slim-$PPID.md`. Apply the rendering rule in
@@ -123,11 +123,11 @@ Read the slim plan snapshot at:
 Filtered view of the plan — completed tracks show title + intro +
 track episode + strategy refresh only; the current track and other
 not-started tracks are shown in full. If the snapshot is missing, fall
-back to docs/adr/{dir-name}/implementation-plan.md.
+back to docs/adr/{dir-name}/_workflow/implementation-plan.md.
 
 ## Track Steps (tactical context)
 Read the step file at:
-  docs/adr/{dir-name}/tracks/track-{N}.md
+  docs/adr/{dir-name}/_workflow/tracks/track-{N}.md
 The file begins with a `## Description` section carrying the track's
 original description — intro paragraph +
 **What/How/Constraints/Interactions** subsections + any track-level

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -57,7 +57,7 @@ instruction — keep it intact when customising.
       intro paragraph.
 
    b. **Read Track N's section from the backlog**
-      (`docs/adr/<dir-name>/implementation-backlog.md`). Read the
+      (`docs/adr/<dir-name>/_workflow/implementation-backlog.md`). Read the
       track's intro paragraph from the plan-file entry and the
       `**What/How/Constraints/Interactions**` subsections + any
       track-level `mermaid` block from the backlog's `## Track N:
@@ -66,7 +66,7 @@ instruction — keep it intact when customising.
       §2.1.
 
    c. **Create the step file atomically** at
-      `docs/adr/<dir-name>/tracks/track-N.md` in a single Write call
+      `docs/adr/<dir-name>/_workflow/tracks/track-N.md` in a single Write call
       that contains: `## Description` (populated with the copied intro
       + `**What/How/Constraints/Interactions**` subsections + any
       track-level diagram from sub-step (b)), `## Progress` (with all
@@ -89,13 +89,13 @@ instruction — keep it intact when customising.
       the backlog's opening `# <Feature> — Track Details` header.
 
       When the last remaining `## Track M:` section is removed, leave
-      the backlog file on disk with only its header. Natural cleanup
-      happens when the branch is deleted after PR merge, like every
-      other working file.
+      the backlog file on disk with only its header. The whole
+      `_workflow/` directory (including the empty backlog) is deleted
+      by the Phase 4 cleanup commit; no per-track removal is needed.
 
 3. **Run track-scoped reviews** as sub-agents (technical, risk, adversarial
    as warranted). After each review completes:
-   - Write the review file to `docs/adr/<dir-name>/reviews/track-N-<type>.md`
+   - Write the review file to `docs/adr/<dir-name>/_workflow/reviews/track-N-<type>.md`
    - Update the **Reviews completed** section in the step file
      (created atomically in sub-step 2c).
    - These files persist on disk between sessions — the next session can
@@ -156,8 +156,8 @@ instead of restating them.
 
 | Input | Value |
 |---|---|
-| `plan_path` | Absolute path to `docs/adr/<dir-name>/implementation-plan.md` — the strategic context (Goals, Constraints, Architecture Notes, Decision Records, Component Map). |
-| `step_file_path` | Absolute path to `docs/adr/<dir-name>/tracks/track-N.md` — once Phase A has written the step file, its `## Description` section is the authoritative source for the track's `**What/How/Constraints/Interactions**` subsections and any track-level diagram (per the lifecycle table in `conventions-execution.md` §2.1). |
+| `plan_path` | Absolute path to `docs/adr/<dir-name>/_workflow/implementation-plan.md` — the strategic context (Goals, Constraints, Architecture Notes, Decision Records, Component Map). |
+| `step_file_path` | Absolute path to `docs/adr/<dir-name>/_workflow/tracks/track-N.md` — once Phase A has written the step file, its `## Description` section is the authoritative source for the track's `**What/How/Constraints/Interactions**` subsections and any track-level diagram (per the lifecycle table in `conventions-execution.md` §2.1). |
 | `track_name` | The track heading as it appears in the plan file's checklist (e.g., `"Track 2: Execution workflow edits"`). |
 | `codebase_path` | Absolute path to the repository root — the sub-agent may Read any file under this path to validate code references. |
 | `prior_episodes` | Summary of track episodes from already-completed tracks. The episodes themselves also appear in the slim plan snapshot pointed at by `plan_path`, but they are passed as a **separate** value so each review prompt's `{prior_episodes}` placeholder resolves without forcing the sub-agent to re-parse the plan. Used for cross-track consistency checks. |
@@ -285,7 +285,7 @@ Must not modify the same files.
 #### Output
 
 Write decomposed steps to the **step file**
-(`docs/adr/<dir-name>/tracks/track-N.md`), creating it if it doesn't exist.
+(`docs/adr/<dir-name>/_workflow/tracks/track-N.md`), creating it if it doesn't exist.
 Scope indicators in the plan file are NOT replaced — step details live only
 in the step file.
 

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -119,6 +119,31 @@ instruction — keep it intact when customising.
    blockquote. Mark `Review + decomposition` as `[x]` in the Progress
    section.
 
+6. **Commit and push the Phase A workflow updates.** All of Phase A's
+   on-disk writes — the step file (created in 2c, populated in step 5),
+   review files (written in step 3), and the backlog edit (the
+   Track N section removal in 2d) — must be committed before Phase B
+   spawns the first implementer for this track. The implementer's
+   revert path uses `git reset --hard HEAD`, which would otherwise
+   discard the uncommitted decomposition.
+
+   ```bash
+   git add docs/adr/<dir-name>/_workflow/tracks/track-<N>.md \
+           docs/adr/<dir-name>/_workflow/reviews/track-<N>-*.md \
+           docs/adr/<dir-name>/_workflow/implementation-backlog.md
+   git commit -m "Phase A review and decomposition for <track>"
+   git push
+   ```
+
+   This is a single Workflow update commit per the table in
+   `commit-conventions.md` § Commit type prefixes. Stage explicit
+   paths only — never `git add -A` — so unrelated files in the
+   working tree (e.g., scratch logs from prior debugging) don't get
+   pulled in. If a particular file does not exist (no review files
+   ran, or the backlog had no Track N section to begin with), drop
+   that path from the `git add` command rather than letting the
+   missing-path error stop the commit.
+
 ### Complexity Assessment and Which Reviews to Run
 
 Complexity determines which pre-execution reviews to run, not user
@@ -339,13 +364,20 @@ After writing the step file with all decomposed steps:
    - `Review + decomposition` marked `[x]` in Progress
    - All reviews recorded in Reviews completed
    - All steps listed as `[ ]` items
-2. **Inform the user** that Phase A is complete:
+2. **Verify the Phase A commit landed.** Run `git status --porcelain`;
+   the working tree must be clean. Run `git log -1 --oneline` and
+   confirm the tip is `Phase A review and decomposition for <track>`.
+   If the commit is missing (e.g., the session was interrupted
+   between step 5 and step 6 of §What You Do), run step 6 now —
+   the implementer's `git reset --hard HEAD` would otherwise
+   discard the decomposition.
+3. **Inform the user** that Phase A is complete:
    - How many steps were decomposed
    - Which reviews were run and key findings
    - Any concerns or risks noted during review
    - Instruct: "Clear session and re-run `/execute-tracks` to start
      Phase B (step implementation)."
-3. **End the session.** Do not proceed to Phase B in the same session.
+4. **End the session.** Do not proceed to Phase B in the same session.
 
 **Why:** Phase A is exploratory (reading code, validating assumptions).
 That "reviewer mindset" context is not helpful during implementation —

--- a/.claude/workflow/track-skip.md
+++ b/.claude/workflow/track-skip.md
@@ -50,8 +50,8 @@ A track can be skipped (`[~]`) in two situations:
 
    When the last remaining `## Track M:` section is removed, leave
    the backlog file on disk with only its header — same empty-backlog
-   final-state rule that Phase A follows. Natural cleanup happens
-   when the branch is deleted after PR merge.
+   final-state rule that Phase A follows. The whole `_workflow/`
+   directory is removed by the Phase 4 cleanup commit before merge.
 
    **Backlog deletion is terminal.** Un-skipping a track via inline
    replanning requires re-authoring the plan entry's description

--- a/.claude/workflow/track-skip.md
+++ b/.claude/workflow/track-skip.md
@@ -33,7 +33,7 @@ A track can be skipped (`[~]`) in two situations:
    removed in step 3 below.
 
    The authoritative retention rule for `[~]` entries lives in
-   `conventions-execution.md` §"After strategy refresh" — this process
+   [`strategy-refresh.md`](strategy-refresh.md) step 5 — this process
    step must not diverge from that rule.
 
    The skip record replaces both the track episode and step file

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -122,7 +122,7 @@ perspective on cross-track impact.
    | Progress section | Resume action |
    |---|---|
    | `Review + decomposition` is `[ ]` | Enter `track-review.md` §Phase A Resume — Description-move recovery (often a no-op), then re-run only missing reviews and decompose. |
-   | `Review + decomposition` is `[x]`, steps partially complete | Resume from next `[ ]` step (see step-implementation.md §Phase B Resume for orphan commit recovery) |
+   | `Review + decomposition` is `[x]`, steps partially complete | Resume from next `[ ]` step (see step-implementation-recovery.md §Phase B Resume for orphan commit recovery) |
    | Steps contain `[!]` (failed) entries | Check if a retry `[ ]` step follows — if yes, resume from retry. If no retry step, present failed episode to user |
    | All steps `[x]`, code review `[ ]` or partial | Run Phase C from current iteration (single-step tracks skip code review but still run track completion — see track-code-review.md; includes track completion after review) |
    | All steps `[x]`, code review `[x]`, track still `[ ]` in plan | Resume track completion — compile episode, present to user for approval |
@@ -288,7 +288,7 @@ Step-level failure handling (revert → failed episode → retry or split),
 the two-failure rule, and track-level failure escalation are all triggered
 inside Phase B.
 
-**Full protocol:** [`step-implementation.md`](step-implementation.md)
+**Full protocol:** [`step-implementation-recovery.md`](step-implementation-recovery.md)
 §Step Failure, §Two-Failure Rule, §Track-Level Failure.
 
 ---
@@ -364,7 +364,7 @@ For other workflow components, see:
 - **`commit-conventions.md`** — commit message type prefixes for session
   resume (review fix, episode, step file updates)
 - **`track-review.md`** — Phase A: review + decomposition
-- **`step-implementation.md`** — Phase B: step implementation
+- **`step-implementation.md`** — Phase B: step implementation (happy path)
 - **`track-code-review.md`** — Phase C: code review + track completion
 - **`research.md`** — Phase 0 (research: interactive exploration before planning)
 - **`planning.md`** — Phase 1 (planning)
@@ -383,5 +383,7 @@ On-demand reference documents (loaded only when their specific situation arises)
 - **`structural-review.md`** — structural review details (loaded by implementation-review.md)
 - **`track-skip.md`** — full track skip protocol (when `[~]` is triggered)
 - **`review-agent-selection.md`** — characteristic-based review agent selection (loaded by step-implementation.md and track-code-review.md)
-- **`risk-tagging.md`** — per-step risk criteria and lifecycle (loaded by `track-review.md` during Phase A decomposition; loaded by `step-implementation.md` only on the rare Phase B upgrade path; **not** loaded by Phase B normal execution or by Phase C — those phases consume the per-step `**Risk:**` tag from the step file directly)
+- **`risk-tagging.md`** — per-step risk criteria and lifecycle (loaded by `track-review.md` during Phase A decomposition; loaded by `step-implementation-recovery.md` only on the rare Phase B upgrade path; **not** loaded by Phase B normal execution or by Phase C — those phases consume the per-step `**Risk:**` tag from the step file directly)
 - **`implementer-rules.md`** — Phase B per-step implementer sub-agent rulebook (loaded only by the implementer; orchestrators do not load it)
+- **`step-implementation-recovery.md`** — Phase B Resume, non-`SUCCESS` orchestrator handlers, post-commit rollback handlers, Step Failure formats, Two-Failure Rule, Track-Level Failure (loaded by the Phase B orchestrator only when orphan commits are detected at startup or a non-`SUCCESS` implementer return arrives)
+- **`ephemeral-identifier-rule.md`** — full forbidden / allowed / rewrite rule for durable content (loaded only when about to author source code, tests, Javadoc, PR title/body, `design-final.md`, or `adr.md`; the §2.3 stub in `conventions-execution.md` plus the self-check grep are usually enough)

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -97,7 +97,7 @@ perspective on cross-track impact.
 
 ## Startup Protocol (Auto-Resume)
 
-1. **Read the plan file** at `docs/adr/<dir-name>/implementation-plan.md`
+1. **Read the plan file** at `docs/adr/<dir-name>/_workflow/implementation-plan.md`
    (not the backlog — startup reads only the plan;
    `implementation-backlog.md` is loaded later, when a track enters Phase A
    or is skipped).
@@ -249,8 +249,13 @@ work when context consumption is at `warning` level or above.
 ### What to do before ending a session
 
 - Ensure all code changes are committed
-- Ensure all step episodes are written to the step file on disk
-- Update the **Progress** section in the step file on disk
+- Ensure all step episodes are written to the step file under
+  `_workflow/tracks/`, the **Progress** section is up to date, and
+  every workflow-file change has been committed (workflow files are
+  tracked under `_workflow/` — see `commit-conventions.md`)
+- Run `git push` so the branch's draft PR reflects the final state
+  of the session (every commit is pushed; this is the safety net
+  for unexpected session-end interruptions)
 - Inform the user of the session state so the next `/execute-tracks`
   auto-resumes correctly
 
@@ -321,10 +326,27 @@ Completion.
 
 ## Final Artifacts (Phase 4)
 
-After all tracks are complete, a separate session produces `design-final.md`
-and `adr.md` — the only workflow files committed to git. Tracked in the
-`## Final Artifacts` section of `implementation-plan.md` (see State D
-markers in the Startup Protocol table above).
+After all tracks are complete, a separate session produces
+`design-final.md` and `adr.md` — the two artifacts that survive
+merge into `develop`. Phase 4 lands two commits on the branch:
+
+1. **Final-artifacts commit.** Stage `design-final.md`,
+   `design-mechanics-final.md` (if applicable), and `adr.md`; commit
+   with the message defined in `prompts/create-final-design.md`
+   § Step 4; push.
+2. **Cleanup commit.** Run `git rm -r docs/adr/<dir-name>/_workflow/`
+   to remove every working file under the `_workflow/` subtree
+   (plan, backlog, design.md, design-mechanics.md, step files,
+   review files, design-mutations log). Commit with a message such
+   as `Remove workflow scaffolding`. Push.
+
+After both commits land, **inform the user that Phase 4 is complete
+and stop**. The user manually flips the draft PR to "ready for
+review" when satisfied — Claude does not run `gh pr ready`.
+
+Tracked in the `## Final Artifacts` section of
+`implementation-plan.md` (see State D markers in the Startup
+Protocol table above).
 
 **Full instructions:** [`prompts/create-final-design.md`](prompts/create-final-design.md)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,8 @@ Tests configure YouTrackDB-specific system properties in `<argLine>`:
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
 
 ### Workflow Artifacts
-- Some squashed commits include `docs/adr/<dir-name>/design-final.md` and `docs/adr/<dir-name>/adr.md` — post-implementation workflow artifacts documenting the final design and architectural decisions. These are the only workflow files tracked by git; all intermediate files (implementation plan, step files, reviews) exist only on the branch during development.
+- Some squashed commits include `docs/adr/<dir-name>/design-final.md` and `docs/adr/<dir-name>/adr.md` — post-implementation workflow artifacts documenting the final design and architectural decisions. These are the only workflow files that survive merge into `develop`.
+- During the branch's lifetime the implementation plan, design draft, step files, reviews, and other working files are tracked under `docs/adr/<dir-name>/_workflow/` so the draft PR shows real-time progress and a local-disk loss never destroys planning work. The entire `_workflow/` directory is removed in a single cleanup commit at the end of Phase 4 (after `design-final.md` and `adr.md` land), so the squash-merge into `develop` carries only the durable artifacts plus the implemented code. See `.claude/workflow/conventions.md` §1.2 and `.claude/workflow/workflow.md` § Final Artifacts for the full lifecycle.
 
 ## Key Entry Points
 


### PR DESCRIPTION
## Motivation

This PR started as two Phase B per-step implementer bug fixes
observed in a single Phase B session, then grew into a broader
clean-up of the workflow doc corpus (commit cadence, scaffolding
durability, and startup-load size). Everything below is a
workflow-doc-only change — no production code, no tests touched.

### Bug 1 — `ScheduleWakeup` breaks the spawn-and-return contract

The implementer is spawned synchronously by the orchestrator via
the Agent tool and must emit exactly one structured `RESULT`
block per spawn. `ScheduleWakeup` yields control back with no
`RESULT` block, leaves the implementer idle between wake-ticks,
and lets in-flight Bash `run_in_background` tasks be
garbage-collected across the idle gap. Observed in a Phase B
step that started a `./mvnw -P coverage` background build and
self-paced via `ScheduleWakeup`: the orchestrator received
`Still running. Let me wait.` with no `RESULT`, and the Maven
process had disappeared by the time the implementer was nudged
back to life.

### Bug 2 — `git clean -fd` destroys the orchestrator's cross-spawn state

The implementer revert contract was
`git reset --hard HEAD && git clean -fd`. The clean step removes
**every** untracked file in the worktree, including the
orchestrator's working files (step files, review reports, the
design document, the implementation backlog, baselines), which
live as untracked-on-disk under `docs/adr/<dir>/`. Observed in
a `DESIGN_DECISION_NEEDED` early-return that erased 50+ workflow
files; recovered from IntelliJ Local History plus agent
transcripts, but it was an avoidable scare.

### Workflow-doc structural gaps surfaced while fixing Bug 2

Bug 2's fix made the orchestrator's working files load-bearing
across spawns, which in turn surfaced three latent issues:

1. The files lived as untracked-on-disk and were therefore lost
   on local-disk failure or branch deletion before merge.
2. Several Phase A / Phase B Startup / inline-replan / Phase C
   steps wrote workflow files but never committed them, so the
   next implementer's `git reset --hard HEAD` could discard the
   decomposition or the Base commit record.
3. Phase 3 startup loaded ~2,350 lines of workflow doc before
   reading the plan, even though most of `step-implementation.md`
   only fires on the rare non-happy paths.

## Summary

### Phase B implementer contract fixes

- **Forbid `ScheduleWakeup`.** New "Pacing long-running tasks"
  section in `implementer-rules.md`: the implementer must not
  call `ScheduleWakeup`. For long Maven runs, prefer foreground
  Bash with a realistic Bash-tool `timeout` (milliseconds); when
  background is genuinely needed, start the run via
  `run_in_background` and rely on the runtime's single
  completion notification — do not poll the log file from a
  separate Bash call. For builds whose realistic budget exceeds
  the foreground budget, return `RESULT: FAILED` with
  `recommended_action: split` and let the orchestrator break the
  step down. Cross-linked from sub-step 2 so the rule is
  reachable from where an implementer first meets a long Maven
  run.
- **Replace `git clean -fd` with a snapshot-and-diff revert.**
  Snapshot pre-existing untracked files at the start of every
  spawn under `LC_ALL=C sort` to keep `comm` happy across
  locales; at revert time, `git reset --hard HEAD` plus
  `comm -13 <pre> <post>` piped through a
  `while IFS= read -r` loop (portable to BSD/macOS, no
  `xargs -d` GNU extension). Explicit "Do NOT run
  `git clean -fd`" warning names the past-bug context so future
  readers don't reach for the old shortcut.
- **Gemini review polish:** clarify the `timeout` is the
  Bash-tool parameter (milliseconds), switch BRE alternation to
  ERE in the until-loop grep, quote the log-file path, collapse
  the duplicated parenthetical descriptions of the
  snapshot-and-diff sequence in `step-implementation.md` to a
  single link to `implementer-rules.md`.

### `_workflow/` scaffolding model + draft PR

- Workflow files (plan, backlog, design draft, step files,
  reviews, design-mutations log) now live under
  `docs/adr/<dir-name>/_workflow/` and are committed and pushed
  during the branch's lifetime. `/create-plan` opens a draft PR
  right after Phase 1 so teammates see real-time progress and a
  local-disk loss never destroys planning work; CI doesn't run
  on draft PRs, so per-commit pushes carry no CI cost.
- Phase 4 lands two commits — final artifacts
  (`design-final.md` + `adr.md`) followed by a single
  `git rm -r _workflow/` cleanup — so only the durable
  artifacts plus the implemented code survive squash-merge into
  `develop`. The user manually flips the draft to ready when
  satisfied.
- The Ephemeral-identifier rule (`conventions-execution.md`
  §2.3) is narrowed to **durable** content (source code, tests,
  PR title/body, `design-final.md`, `adr.md`); branch-only
  commit messages are exempt since squash-merge wipes them.
- `step-implementation.md` gains sub-step 8 (commit and push
  the episode) so the implementer's `git reset --hard HEAD`
  never blows away unwritten orchestrator state.
- `CLAUDE.md` § Workflow Artifacts updated to describe both
  what survives merge and what's tracked under `_workflow/`
  during the branch.

### Commit cadence tightening + Phase B Resume math fix

- **Codified explicit commits** at four places that previously
  wrote files without committing them: Phase A end-of-phase
  ("Phase A review and decomposition for <track>"), Phase B
  Startup ("Record Phase B base commit for <track>"), inline
  replanning ("Inline replan after Track <N>"), Phase C track
  completion ("Apply plan corrections from <track> review",
  "Mark <track> complete").
- **Phase B Resume orphan-detection rewritten.** The old model
  counted "1 implementer + N Review fix" per `[x]` step; the
  new model classifies five commit kinds and counts exactly
  "1 implementer + N Review fix + 1 episode" per `[x]` step,
  with a new recovery clause for the
  crash-between-episode-write-and-episode-commit window.
  Scaffolding commits (Phase 1 init, Phase A decomposition,
  Phase B base-commit recording, plan-corrections application,
  track-completion mark, inline replanning) are recognised and
  excluded.
- **`edit-design` Phase 4 special-case.** The design-mutations
  log path was derived from `design_path`'s parent; for
  `phase4-creation` this resolved to `<dir>/reviews/`, outside
  `_workflow/`, so the Phase 4 cleanup commit's
  `git rm -r _workflow/` would leave the log behind to ship
  into `develop`. Now special-cased to force the log under
  `<dir>/_workflow/reviews/`.
- **Aligned implementer-rules with §2.3.** The implementer
  rulebook contradicted the new `conventions-execution.md` §2.3
  on commit messages — branch-only commit messages are exempt
  under §2.3, but the implementer was still forbidden from
  citing Track/Step/finding IDs in any commit message.
- Plus minor cleanups: replaced "only tracked files" wording
  in three spots (the durable property is "survives merge into
  `develop`", not "tracked at all"); fixed a broken
  "§ Workflow update" cross-reference; aligned the Phase 1
  example commit subject between `create-plan/SKILL.md` and the
  commit-conventions table.

### Startup-load reduction (~28% on Phase B)

- **`step-implementation-recovery.md`** (new) gathers Phase B
  Resume, the three non-`SUCCESS` handlers, the four
  post-commit rollback handlers, the Step / Two-Failure /
  Track-Level Failure protocols, and the resume-side
  commit-pattern reference (folded in from
  `commit-conventions.md`). Loaded only when `git log` shows
  orphan commits at startup or when an implementer spawn
  returns a non-`SUCCESS` result.
- **`ephemeral-identifier-rule.md`** (new) carries the full
  forbidden / allowed / rewrite rule. The
  `conventions-execution.md` stub keeps the self-check grep so
  commits with no matches never need to load the full file.
- Two §2.1 subsections relocated to their actual readers:
  "After track completion" inlines into `track-code-review.md`
  § Track Completion; "After strategy refresh" inlines into
  `strategy-refresh.md`.
- Net effect on a Phase B startup: 2351 → 1681 lines (~28%
  savings); workflow corpus net change: +277 / -851 lines.

## Test plan

- [x] Both implementer-contract fixes apply cleanly to
      `origin/develop`.
- [x] No production source files modified (`.claude/` and
      `CLAUDE.md` only).
- [x] All references to `git clean -fd` outside the explicit
      warning paragraph are removed
      (`grep -n 'git clean -fd'` yields only the two
      warning-paragraph mentions).
- [x] Snapshot-and-diff shell snippet handles the edge cases:
      empty input (the `while read` loop is a no-op), whitespace
      in paths (`IFS=` + `read -r`), no pre-existing untracked
      files, no implementer-created files; portable to BSD/macOS
      (no `xargs -d` GNU extension).
- [ ] Reviewer confirms the `_workflow/` lifecycle reads
      cleanly across `CLAUDE.md`, `conventions.md` §1.2,
      `workflow.md` § Final Artifacts, and the per-phase docs
      that mention it.
- [ ] Reviewer sanity-checks the Phase B Resume orphan-counting
      table against the five commit kinds enumerated in
      `step-implementation-recovery.md`.
- [ ] Reviewer confirms the on-demand-load split: a Phase B
      startup that takes the happy path never loads
      `step-implementation-recovery.md` or
      `ephemeral-identifier-rule.md`.