### PR TITLE
Add human-reader cold-read additions for design docs

### DIFF
--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -357,7 +357,14 @@ current state of `design-mechanics.md`:
 The sync's cold-read sub-agent gets an extended instruction:
 *"Verify that every TL;DR and mechanism overview in design.md
 accurately summarizes the current mechanics file's content for
-the same-named section."*
+the same-named section."* It also runs the Human-reader
+cold-read additions (audience-fit, glossary-introduction,
+why-before-what, navigability — see
+[`prompts/design-review.md`](prompts/design-review.md)
+§ Human-reader cold-read additions), since the rewritten
+Overview is a freshly human-facing artifact that can drift in
+vocabulary or audience fit while mechanics evolves between
+syncs.
 
 **Staleness reconciliation.** Because `design.md` is frozen
 between syncs while mechanics evolves, the user's feedback may

--- a/.claude/workflow/prompts/design-review.md
+++ b/.claude/workflow/prompts/design-review.md
@@ -36,10 +36,15 @@ warning, or pass.
 ### Mutation-kind specific instructions
 
 - **`phase1-creation`**: `design.md` and `design-mechanics.md`
-  were just seeded together. Verify the design.md is internally
-  coherent on its own (a fresh reader can navigate it) AND that
-  every `Mechanics: design-mechanics.md §"…"` link resolves to a
-  matching section in mechanics.
+  were just seeded together. The design.md serves both human
+  readers (the user reviewing the plan, the architect during
+  structural review, the PR reviewer reading the draft) and
+  agent readers (the implementer executing the plan). Verify
+  (a) the design.md is internally coherent on its own (a fresh
+  reader can navigate it); (b) every
+  `Mechanics: design-mechanics.md §"…"` link resolves to a
+  matching section in mechanics. **Plus the Creation cold-read
+  additions (§ below).**
 - **`design-sync`**: this sync re-distilled `design.md` from the
   current state of `design-mechanics.md`. **In addition to the
   standard whole-doc cold-read**, verify that every TL;DR and
@@ -50,22 +55,95 @@ warning, or pass.
   — that's exactly what the sync was supposed to fix.
 - **`phase4-creation`**: `design-final.md` (and optionally
   `design-mechanics-final.md`) was just produced as a Phase 4
-  committed artifact reflecting what was actually built. The paths
-  end in `-final.md` but the same shape rules apply. **Phase 4 is
-  committed to git**, so the bar is higher than Phase 1: the
-  artifact must stand on its own as documentation, with no
-  reliance on the working files (plan, backlog, tracks) since
-  those live under `_workflow/` and are removed by the Phase 4
-  cleanup commit before the PR is merged. **In addition to the standard
-  whole-doc cold-read**, verify (a) the doc opens with a
-  concept-first Overview that names what was built and any
-  high-level deviations from the original plan, (b) class /
-  workflow diagrams reflect actual implementation (the calling
-  prompt should have run a PSI verification pass — flag any
-  diagram element that looks aspirational rather than
-  implementation-grounded), and (c) no leaked working-file
-  identifiers (track numbers, step numbers, review-finding IDs)
-  remain in the prose.
+  committed artifact reflecting what was actually built. The
+  paths end in `-final.md` but the same shape rules apply.
+  **Phase 4 is committed to git** and read by humans (PR
+  reviewers, future re-readers, decision auditors), so the bar
+  is higher than Phase 1: the artifact must stand on its own as
+  documentation — no reliance on working files (plan, backlog,
+  tracks), since those live under `_workflow/` and are removed
+  by the Phase 4 cleanup commit before merge.
+
+  **In addition to the standard whole-doc cold-read AND the
+  Creation cold-read additions (§ below)**, verify:
+
+  (a) **Plan-deviation surfacing** — the Overview names what
+      was built and any high-level deviations from the original
+      plan (descoped goals, modified decisions, emergent
+      structure).
+
+  (b) **Implementation-grounded diagrams** — class / workflow
+      diagrams reflect actual implementation (the calling
+      prompt should have run a PSI verification pass; flag any
+      diagram element that looks aspirational rather than
+      implementation-grounded).
+
+  (c) **No leaked working-file identifiers** — no track
+      numbers, step numbers, or review-finding IDs in the
+      prose.
+
+### Creation cold-read additions
+
+Applies to mutation kinds `phase1-creation` and `phase4-creation`.
+
+These checks address human-readability gaps that the standard
+comprehension questions miss when the reviewer agent shares
+training-derived vocabulary with the doc author. Both creation
+kinds produce documents read by humans (PR reviewers, the user,
+the architect, future re-readers, decision auditors) in addition
+to agents — so the cold-read must assess prose against a human
+reader, not against the reviewer's own training.
+
+**In addition to the standard whole-doc cold-read**, verify:
+
+(a) **Audience-fit** — the Overview names (or strongly implies
+    through concrete framing) the intended reader. Assess the
+    prose against *that* reader, not against your own training
+    as a coding-aware agent. If the doc doesn't name or imply
+    an audience, flag it as a blocker and request the doc
+    author add an audience anchor in the Overview's first
+    paragraph.
+
+(b) **Glossary-introduction** — walk through the Overview and
+    list every internal API, type, or domain concept used in
+    load-bearing prose (used to make the Overview's argument,
+    not merely mentioned in passing). For each, determine
+    whether it is (i) defined inline at first use, (ii) defined
+    in a `## Core Concepts` section that the Overview points
+    to, or (iii) explicitly marked as prerequisite knowledge
+    for the named audience. Anything load-bearing that fails
+    all three is a finding. Severity: **blocker** if a reader
+    without the term cannot follow the Overview's main
+    argument; **should-fix** if the term appears in a
+    supporting clause but the main argument survives without
+    it. Apply the same check to the opening of each `##`
+    section's mechanism overview, scoped to terms newly
+    introduced in that section.
+
+(c) **Why-before-what** — for the Overview and the opening
+    paragraphs of each `##` section, motivation precedes
+    mechanism. Quote the opening 1-2 paragraphs and assess:
+    does the reader learn *why this section exists / why this
+    mechanism matters* before encountering the mechanism
+    itself? A section that opens with "this design replaces X
+    with Y" without first establishing why X needed replacing
+    is a should-fix.
+
+(d) **Navigability** — section headers communicate purpose,
+    not just a mechanism name; each section's opening sentence
+    or TL;DR lets a skimming reader decide whether to drill
+    in; cross-references to deeper detail (Mechanics links,
+    references to sibling Parts) are present where a reader
+    would need them.
+
+**Reviewer tone**: the "one sentence answers / don't pad"
+guidance under § Tone and depth is relaxed for findings under
+(a), (b), and (c). Quote the prose, list undefined terms, and
+explain *for which target audience* the prose breaks down.
+Compressed reviewer feedback under-reports these failure modes
+— a one-sentence "the Overview is hard to follow" finding is
+not actionable; a finding that lists six undefined APIs and
+identifies the absent audience anchor is.
 
 ## Reading rules
 
@@ -208,6 +286,10 @@ attempt the fix automatically.>
 ## Tone and depth
 
 - One sentence answers where one suffices. Don't pad.
+  - **Exception**: findings under the Creation cold-read
+    additions (§ above, applies to `phase1-creation` and
+    `phase4-creation`) require evidence — quote the prose, list
+    undefined terms, name the target audience the prose fails.
 - Cite, don't paraphrase the whole section.
 - If a question can't be answered from the document, say
   "Insufficient — see finding below" and add the corresponding

--- a/.claude/workflow/prompts/design-review.md
+++ b/.claude/workflow/prompts/design-review.md
@@ -43,8 +43,8 @@ warning, or pass.
   (a) the design.md is internally coherent on its own (a fresh
   reader can navigate it); (b) every
   `Mechanics: design-mechanics.md §"…"` link resolves to a
-  matching section in mechanics. **Plus the Creation cold-read
-  additions (§ below).**
+  matching section in mechanics. **Plus the Human-reader
+  cold-read additions (§ below).**
 - **`design-sync`**: this sync re-distilled `design.md` from the
   current state of `design-mechanics.md`. **In addition to the
   standard whole-doc cold-read**, verify that every TL;DR and
@@ -52,7 +52,8 @@ warning, or pass.
   current mechanics file's content for the same-named section. If
   the design.md TL;DR contradicts the mechanics, or names a
   mechanism that mechanics doesn't describe, flag it as a blocker
-  — that's exactly what the sync was supposed to fix.
+  — that's exactly what the sync was supposed to fix. **Plus the
+  Human-reader cold-read additions (§ below).**
 - **`phase4-creation`**: `design-final.md` (and optionally
   `design-mechanics-final.md`) was just produced as a Phase 4
   committed artifact reflecting what was actually built. The
@@ -65,7 +66,7 @@ warning, or pass.
   by the Phase 4 cleanup commit before merge.
 
   **In addition to the standard whole-doc cold-read AND the
-  Creation cold-read additions (§ below)**, verify:
+  Human-reader cold-read additions (§ below)**, verify:
 
   (a) **Plan-deviation surfacing** — the Overview names what
       was built and any high-level deviations from the original
@@ -82,17 +83,31 @@ warning, or pass.
       numbers, step numbers, or review-finding IDs in the
       prose.
 
-### Creation cold-read additions
+### Human-reader cold-read additions
 
-Applies to mutation kinds `phase1-creation` and `phase4-creation`.
+Applies to mutation kinds `phase1-creation`, `phase4-creation`,
+and `design-sync`. All three produce a freshly-written
+`design.md` (or `design-final.md`) Overview that humans will
+read.
 
 These checks address human-readability gaps that the standard
 comprehension questions miss when the reviewer agent shares
-training-derived vocabulary with the doc author. Both creation
-kinds produce documents read by humans (PR reviewers, the user,
-the architect, future re-readers, decision auditors) in addition
-to agents — so the cold-read must assess prose against a human
-reader, not against the reviewer's own training.
+training-derived vocabulary with the doc author. The documents
+produced by these mutation kinds are read by humans (PR
+reviewers, the user, the architect, future re-readers, decision
+auditors) in addition to agents — so the cold-read must assess
+prose against a human reader, not against the reviewer's own
+training.
+
+`design-sync` is included because mechanics evolves freely
+between syncs while `design.md` stays frozen; when sync
+re-distills the Overview, it can introduce undefined domain
+terms, lose an audience anchor, or shift to mechanism-first
+ordering without any single working-mode edit visibly causing
+the drift. The TL;DR-vs-mechanics instruction in the
+`design-sync` block above catches alignment drift between the
+two files; these checks catch human-readability drift in the
+freshly-rewritten Overview itself.
 
 **In addition to the standard whole-doc cold-read**, verify:
 
@@ -110,40 +125,52 @@ reader, not against the reviewer's own training.
     not merely mentioned in passing). For each, determine
     whether it is (i) defined inline at first use, (ii) defined
     in a `## Core Concepts` section that the Overview points
-    to, or (iii) explicitly marked as prerequisite knowledge
-    for the named audience. Anything load-bearing that fails
-    all three is a finding. Severity: **blocker** if a reader
-    without the term cannot follow the Overview's main
-    argument; **should-fix** if the term appears in a
-    supporting clause but the main argument survives without
-    it. Apply the same check to the opening of each `##`
-    section's mechanism overview, scoped to terms newly
-    introduced in that section.
+    to, or (iii) explicitly listed as assumed knowledge in the
+    audience anchor or a prerequisites bullet (e.g., *"Audience:
+    storage engineers familiar with WAL and page caches"* — the
+    listed prerequisites count as defined-by-reference for that
+    audience). Anything load-bearing that fails all three is a
+    finding. Severity: **blocker** if a reader without the term
+    cannot follow the Overview's main argument; **should-fix**
+    if the term appears in a supporting clause but the main
+    argument survives without it. Apply the same check to the
+    opening of each `##` section's mechanism overview, scoped
+    to terms newly introduced in that section.
 
-(c) **Why-before-what** — for the Overview and the opening
-    paragraphs of each `##` section, motivation precedes
-    mechanism. Quote the opening 1-2 paragraphs and assess:
-    does the reader learn *why this section exists / why this
-    mechanism matters* before encountering the mechanism
-    itself? A section that opens with "this design replaces X
-    with Y" without first establishing why X needed replacing
-    is a should-fix.
+(c) **Why-before-what** — the Overview and the opening
+    paragraphs of each `##` section open with motivation
+    before mechanism. **Excluded** from this check: shape-exempt
+    reference sections (Core Concepts, Class Design, Workflow,
+    Part-level TL;DR per design-document-rules.md § Mechanical
+    checks) — these are intentionally mechanism-first and
+    naming a motivation paragraph in them adds noise rather
+    than clarity. For everything else, quote the opening 1-2
+    paragraphs and assess: does the reader learn *why this
+    section exists / why this mechanism matters* before
+    encountering the mechanism itself? A section that opens
+    with "this design replaces X with Y" without first
+    establishing why X needed replacing is a should-fix.
 
 (d) **Navigability** — section headers communicate purpose,
     not just a mechanism name; each section's opening sentence
     or TL;DR lets a skimming reader decide whether to drill
     in; cross-references to deeper detail (Mechanics links,
     references to sibling Parts) are present where a reader
-    would need them.
+    would need them. Severity: **should-fix** — these are
+    quality concerns, not comprehension blockers (a reader can
+    still follow an opaquely-named section by reading its
+    body, but the doc is harder to scan).
 
 **Reviewer tone**: the "one sentence answers / don't pad"
 guidance under § Tone and depth is relaxed for findings under
-(a), (b), and (c). Quote the prose, list undefined terms, and
-explain *for which target audience* the prose breaks down.
-Compressed reviewer feedback under-reports these failure modes
-— a one-sentence "the Overview is hard to follow" finding is
-not actionable; a finding that lists six undefined APIs and
-identifies the absent audience anchor is.
+(a), (b), (c), and (d). Quote the prose, list undefined terms,
+name the section whose header reads opaquely or whose
+cross-references are missing, and explain *for which target
+audience* the prose breaks down. Compressed reviewer feedback
+under-reports these failure modes — a one-sentence "the
+Overview is hard to follow" finding is not actionable; a
+finding that lists six undefined APIs and identifies the
+absent audience anchor is.
 
 ## Reading rules
 
@@ -247,6 +274,13 @@ Produce exactly the following Markdown, no preamble:
 - [<severity>] <description>
 ...
 
+(For `phase1-creation`, `phase4-creation`, and `design-sync`,
+findings under the Human-reader cold-read additions go in the
+same list but prefix each with the dimension label and use
+multi-line bullets to fit the evidence required by the Tone
+exception — e.g. `[blocker] (a) Audience-fit: <quoted prose +
+named audience + why it breaks down>`.)
+
 ## Verdict
 
 [PASS / NEEDS REVISION]
@@ -286,10 +320,13 @@ attempt the fix automatically.>
 ## Tone and depth
 
 - One sentence answers where one suffices. Don't pad.
-  - **Exception**: findings under the Creation cold-read
-    additions (§ above, applies to `phase1-creation` and
-    `phase4-creation`) require evidence — quote the prose, list
-    undefined terms, name the target audience the prose fails.
+  - **Exception**: findings under the Human-reader cold-read
+    additions (§ above, applies to `phase1-creation`,
+    `phase4-creation`, and `design-sync`) require evidence —
+    quote the prose, list undefined terms, name the target
+    audience the prose fails, and (for navigability findings)
+    name the section whose header reads opaquely or whose
+    cross-references are missing.
 - Cite, don't paraphrase the whole section.
 - If a question can't be answered from the document, say
   "Insufficient — see finding below" and add the corresponding

--- a/.claude/workflow/prompts/design-review.md
+++ b/.claude/workflow/prompts/design-review.md
@@ -102,10 +102,11 @@ training.
 `design-sync` is included because mechanics evolves freely
 between syncs while `design.md` stays frozen; when sync
 re-distills the Overview, it can introduce undefined domain
-terms, lose an audience anchor, or shift to mechanism-first
-ordering without any single working-mode edit visibly causing
-the drift. The TL;DR-vs-mechanics instruction in the
-`design-sync` block above catches alignment drift between the
+terms, lose its audience framing (the prose cues that signal
+the intended reader), or shift to mechanism-first ordering
+without any single working-mode edit visibly causing the drift.
+The TL;DR-vs-mechanics instruction in the `design-sync` block
+above catches alignment drift between the
 two files; these checks catch human-readability drift in the
 freshly-rewritten Overview itself.
 
@@ -116,8 +117,11 @@ freshly-rewritten Overview itself.
     prose against *that* reader, not against your own training
     as a coding-aware agent. If the doc doesn't name or imply
     an audience, flag it as a blocker and request the doc
-    author add an audience anchor in the Overview's first
-    paragraph.
+    author establish the intended reader within the prose of
+    the Overview's first paragraph. **Not** a standalone
+    `Audience:` block — per design-document-rules.md § Overview,
+    the audience model must be self-evident from the prose; a
+    metadata-style audience block is forbidden.
 
 (b) **Glossary-introduction** — walk through the Overview and
     list every internal API, type, or domain concept used in
@@ -125,13 +129,15 @@ freshly-rewritten Overview itself.
     not merely mentioned in passing). For each, determine
     whether it is (i) defined inline at first use, (ii) defined
     in a `## Core Concepts` section that the Overview points
-    to, or (iii) explicitly listed as assumed knowledge in the
-    audience anchor or a prerequisites bullet (e.g., *"Audience:
-    storage engineers familiar with WAL and page caches"* — the
-    listed prerequisites count as defined-by-reference for that
-    audience). Anything load-bearing that fails all three is a
-    finding. Severity: **blocker** if a reader without the term
-    cannot follow the Overview's main argument; **should-fix**
+    to, or (iii) named as prerequisite knowledge in the
+    Overview's prose (e.g., a sentence like *"This design
+    assumes familiarity with WAL semantics and the disk-cache
+    layer"* makes those terms defined-by-reference for the
+    implied audience — same prose-only constraint as (a); no
+    standalone `Audience:` or `Prerequisites:` block).
+    Anything load-bearing that fails all three is a finding.
+    Severity: **blocker** if a reader without the term cannot
+    follow the Overview's main argument; **should-fix**
     if the term appears in a supporting clause but the main
     argument survives without it. Apply the same check to the
     opening of each `##` section's mechanism overview, scoped
@@ -170,7 +176,7 @@ audience* the prose breaks down. Compressed reviewer feedback
 under-reports these failure modes — a one-sentence "the
 Overview is hard to follow" finding is not actionable; a
 finding that lists six undefined APIs and identifies the
-absent audience anchor is.
+absent audience framing is.
 
 ## Reading rules
 


### PR DESCRIPTION
## Motivation

The cold-read sub-agent that auto-reviews design-document mutations
shares training-derived vocabulary with the doc author. As a result,
it can label an Overview "comprehensible" that a fresh human reader
genuinely can't follow — undefined APIs in load-bearing prose, no
audience anchor, mechanism described before the motivation that
makes the mechanism interesting. Workflow-doc only — no production
code, no tests touched.

Add four human-readability dimensions to the cold-read prompt and
require them to fire wherever a freshly-written Overview is produced:

- `phase1-creation` — initial seed of `design.md` (and optionally
  `design-mechanics.md`).
- `phase4-creation` — production of the committed `design-final.md`
  artifact.
- `design-sync` — re-distillation of `design.md` from the current
  state of `design-mechanics.md` after a batch of working-mode
  mechanics edits.

`design-sync` matters here because mechanics evolves freely between
syncs while `design.md` stays frozen as the user-facing reference;
when sync re-distills the Overview, it can introduce undefined
domain terms, lose an audience anchor, or shift to mechanism-first
ordering — without any single working-mode edit visibly causing the
drift. The TL;DR-vs-mechanics instruction the sync's cold-read
already carries catches alignment drift between the two files; the
new checks catch human-readability drift in the freshly-rewritten
Overview itself.

The reviewer tone for these dimensions is deliberately verbose:
findings must quote the prose, list undefined terms, name the
target audience the prose fails. Compressed reviewer feedback
under-reports this failure mode — a one-sentence "the Overview is
hard to follow" finding is not actionable, while a finding that
lists six undefined APIs and identifies the absent audience anchor
is.

## Summary

- Add **four cold-read dimensions** with explicit severity rubrics:
  - **(a) Audience-fit** — Overview names or strongly implies the
    intended reader (blocker if absent).
  - **(b) Glossary-introduction** — every load-bearing internal API,
    type, or domain concept in the Overview is defined inline, in
    Core Concepts, or listed as assumed knowledge in the audience
    anchor (blocker / should-fix split).
  - **(c) Why-before-what** — Overview and `##` section openings
    motivate before describing mechanism (should-fix). Scoped to
    non-shape-exempt sections; Core Concepts, Class Design,
    Workflow, and Part-level TL;DRs are intentionally
    mechanism-first reference material and are excluded.
  - **(d) Navigability** — section headers communicate purpose;
    opening sentence / TL;DR enables skimming; cross-references
    present where readers would need them (should-fix).
- Define all four in a shared **"Human-reader cold-read additions"**
  block that fires for `phase1-creation`, `phase4-creation`, and
  `design-sync` — keeps the three lifecycle moments aligned and
  prevents drift on future refinements.
- **Reviewer tone exception** for these findings: quote the prose,
  list undefined terms, name the target audience, name sections
  whose headers read opaquely. Multi-line bullets prefixed with the
  dimension label (e.g. `[blocker] (a) Audience-fit: ...`) are
  expected.
- Update `design-document-rules.md § Working / sync` so the
  canonical description of the sync's cold-read names the new
  checks alongside the existing TL;DR-vs-mechanics instruction.

## Test plan

- [x] Cross-reference rename sweep: every "Creation cold-read
      additions" mention in the prompt updated to "Human-reader
      cold-read additions"; all reference sites in
      `design-review.md` plus the new pointer added to the
      `design-sync` block resolve to the same heading.
- [x] No production code touched; `.claude/workflow/` doc-only
      change.
- [ ] Reviewer sanity-check: (c) Why-before-what's exclusion list
      (Core Concepts, Class Design, Workflow, Part-level TL;DR)
      matches the shape-exempt list in `design-document-rules.md`
      § Mechanical checks.
- [ ] First post-merge `phase1-creation` and `design-sync` runs
      exercise the new dimensions end-to-end and produce findings
      in the expected multi-line evidence format.