### PR TITLE
Drop ephemeral reviews/ folder from workflow docs

### DIFF
--- a/.claude/skills/edit-design/SKILL.md
+++ b/.claude/skills/edit-design/SKILL.md
@@ -155,7 +155,7 @@ Sync re-distills `design.md` from the current state of
 `design-mechanics.md`. The agent does the distillation:
 
 1. Read the most recent `design-sync` entry in
-   `<plan-dir>/reviews/design-mutations.md` to find the last sync point.
+   `<plan-dir>/design-mutations.md` to find the last sync point.
 2. Walk every `mechanics-edit` entry after that point — each entry's "Diff
    summary" tells you what changed in mechanics.
 3. For each section in mechanics whose content moved since the last sync,
@@ -317,32 +317,32 @@ Outcomes when the loop exits:
   proceed to Step 7. The mutation can stand; the residual findings
   carry forward to the next mutation as known debt.
 
-### Step 7: Append to the review log
+### Step 7: Append to the mutation log
 
 Resolve the log path from `mutation_kind` and `design_path` using
-the rule below. The log always lives under `_workflow/reviews/` so
-the Phase 4 cleanup commit reliably removes it; never write the log
-to the top-level `<dir>/reviews/`.
+the rule below. The log always lives under `_workflow/` so the
+Phase 4 cleanup commit reliably removes it; never write the log to
+the top-level `<dir>/`.
 
 - **For all mutation kinds *except* `phase4-creation`**:
   `design_path = docs/adr/<dir>/_workflow/design.md` (or
   `design-mechanics.md`), so the plan dir is `design_path`'s parent
   (`docs/adr/<dir>/_workflow/`) and the log lives at
-  `docs/adr/<dir>/_workflow/reviews/design-mutations.md`.
+  `docs/adr/<dir>/_workflow/design-mutations.md`.
 - **For `phase4-creation`** (special case): `design_path =
   docs/adr/<dir>/design-final.md` (top-level, intentionally
   outside `_workflow/` because `design-final.md` itself is a
   durable artifact). The log path is **not** derived from
   `design_path`'s parent — instead, it is forced to
-  `<design_path's parent>/_workflow/reviews/design-mutations.md`,
-  i.e., `docs/adr/<dir>/_workflow/reviews/design-mutations.md`.
+  `<design_path's parent>/_workflow/design-mutations.md`,
+  i.e., `docs/adr/<dir>/_workflow/design-mutations.md`.
   This appends to the existing Phase 1 / inline-replanning log
   under `_workflow/`, preserving the full mutation history of the
   design and ensuring the Phase 4 cleanup commit removes the
   entire log along with everything else under `_workflow/`.
 
-Append to the resolved path (create the `_workflow/reviews/`
-directory and file if they don't exist). Format per
+Append to the resolved path (create the `_workflow/` directory and
+file if they don't exist). Format per
 `design-document-rules.md § Mutation discipline § Review log`:
 
 ```markdown

--- a/.claude/skills/edit-design/SKILL.md
+++ b/.claude/skills/edit-design/SKILL.md
@@ -317,7 +317,7 @@ Outcomes when the loop exits:
   proceed to Step 7. The mutation can stand; the residual findings
   carry forward to the next mutation as known debt.
 
-### Step 7: Append to the mutation log
+### Step 7: Append to the review log
 
 Resolve the log path from `mutation_kind` and `design_path` using
 the rule below. The log always lives under `_workflow/` so the

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -24,7 +24,12 @@ name. Otherwise, default to the current git branch name
 Plan file: docs/adr/<dir-name>/_workflow/implementation-plan.md
 Backlog file: docs/adr/<dir-name>/_workflow/implementation-backlog.md
 Design document: docs/adr/<dir-name>/_workflow/design.md
-Review output directory: docs/adr/<dir-name>/_workflow/reviews/
+
+Phase 2 reviews are not persisted to disk. Findings ride in the
+conversation context during the iteration loop, accepted fixes are
+applied to the plan/backlog/design document via `Edit`, and the
+durable trace is the resulting plan/design state plus the workflow-update
+commit that lands once the gates pass.
 
 The backlog file holds pending-track
 `**What/How/Constraints/Interactions**` detail and any track-level
@@ -67,8 +72,9 @@ to verify pending-track descriptions; pass its absolute path as the
    If fixes significantly restructure the plan or design document
    (tracks reordered, classes/flows redesigned, scope indicators changed
    substantially), re-run the full consistency review instead of the gate.
-9. When the gate is clean, save the review document to
-   docs/adr/<dir-name>/_workflow/reviews/consistency.md.
+9. When the gate is clean, summarise the consistency-review outcome in
+   the conversation (findings count, accepted/rejected, gate verdict)
+   and proceed to Step 2.
 
 Finding IDs are cumulative across iterations (CR1, CR2, ... CR6, CR7).
 
@@ -86,8 +92,8 @@ review without waiting for user confirmation.
     - The design document path
     - The workflow directory path
 11. Receive the findings report.
-12. **If no blockers**: save the review document to
-    docs/adr/<dir-name>/_workflow/reviews/structural.md and proceed to completion.
+12. **If no blockers**: summarise the structural-review outcome in the
+    conversation (no findings) and proceed to completion.
 13. **If blockers found**: present findings to the user grouped by severity.
     For each finding, show:
     - The issue
@@ -107,8 +113,8 @@ review without waiting for user confirmation.
     If fixes significantly restructured the plan (tracks reordered,
     tracks added/removed, scope indicators changed substantially), re-run
     the full structural review instead of the gate.
-18. When the gate is clean, save the review document to
-    docs/adr/<dir-name>/_workflow/reviews/structural.md.
+18. When the gate is clean, summarise the structural-review outcome
+    in the conversation (findings count, accepted/rejected, gate verdict).
 
 Finding IDs are cumulative across iterations (S1, S2, ... S6, S7).
 

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -6,11 +6,11 @@ reliable session resume by making commit types identifiable in `git log`.
 
 During execution both **code changes** and **workflow-file changes**
 under `docs/adr/<dir-name>/_workflow/` (the plan, backlog, design,
-step files, review files, design-mutations log) are committed.
-Workflow files are tracked under `_workflow/` for the branch lifetime
-and are removed in the Phase 4 cleanup commit before the PR is
-merged. See `conventions.md` §1.2 for the directory layout and
-`workflow.md` § Final Artifacts for the cleanup procedure.
+step files, design-mutations log) are committed. Workflow files are
+tracked under `_workflow/` for the branch lifetime and are removed in
+the Phase 4 cleanup commit before the PR is merged. See
+`conventions.md` §1.2 for the directory layout and `workflow.md`
+§ Final Artifacts for the cleanup procedure.
 
 ## Push every commit
 

--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -48,8 +48,8 @@ for authoritative-location rules across phases.>
 `abc1234`
 
 ## Reviews completed
-- [x] Technical
-- [x] Risk
+- [x] Technical: PASS at iteration 2 (3 findings, 2 accepted, 1 rejected)
+- [x] Risk: PASS at iteration 1 (1 finding, 1 accepted)
 
 ## Steps
 - [x] Step: <description>

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -65,18 +65,15 @@ docs/adr/<dir-name>/
                                      Section names match design.md so
                                      `**Full design**` refs in the plan
                                      resolve in either file.
+    design-mutations.md           <- append-only log of every design.md
+                                     mutation: diff summary, mechanical-check
+                                     result, cold-read verdict, iteration
+                                     count. Read by `edit-design`'s
+                                     `design-sync` step to find the last
+                                     sync point.
     tracks/
       track-1.md                  <- tactical: decomposed steps, step episodes
       track-2.md
-      ...
-    reviews/
-      structural.md               <- Phase 2 structural-review output
-      consistency.md              <- Phase 2 consistency-review output
-      design-mutations.md         <- append-only log of every design.md
-                                     mutation: diff summary, mechanical-check
-                                     result, cold-read verdict, iteration
-                                     count
-      track-1-technical.md
       ...
 
   ## Final artifacts (committed in Phase 4 — the only files that survive

--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -228,7 +228,7 @@ context to disambiguate.
 ### Review log
 
 Each mutation appends to
-`docs/adr/<dir-name>/_workflow/reviews/design-mutations.md`. The minimum
+`docs/adr/<dir-name>/_workflow/design-mutations.md`. The minimum
 shape per entry is:
 
 ```markdown
@@ -254,10 +254,12 @@ line, a `SKIPPED` value for cold-read on `mechanics-edit`, and a
 entries. Use the skill's expanded format when writing the log;
 treat the shape above as the floor, not the ceiling.
 
-The review log is a working artifact under `_workflow/reviews/`
-(tracked on the branch for backup and visibility, removed by the
-Phase 4 cleanup commit before merge — same lifecycle as other
-working files).
+The mutation log is a working artifact under `_workflow/` (tracked
+on the branch for backup and visibility, removed by the Phase 4
+cleanup commit before merge — same lifecycle as other working
+files). It is the only on-disk review artifact the workflow keeps,
+because `edit-design`'s `design-sync` step re-reads it to find the
+last sync point and walk every `mechanics-edit` since then.
 
 ### Cold-read sub-agent prompt
 

--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -254,7 +254,7 @@ line, a `SKIPPED` value for cold-read on `mechanics-edit`, and a
 entries. Use the skill's expanded format when writing the log;
 treat the shape above as the floor, not the ceiling.
 
-The mutation log is a working artifact under `_workflow/` (tracked
+The review log is a working artifact under `_workflow/` (tracked
 on the branch for backup and visibility, removed by the Phase 4
 cleanup commit before merge — same lifecycle as other working
 files). It is the only on-disk review artifact the workflow keeps,

--- a/.claude/workflow/ephemeral-identifier-rule.md
+++ b/.claude/workflow/ephemeral-identifier-rule.md
@@ -5,7 +5,7 @@ rule; every phase-specific prompt that touches durable content points
 here.
 
 `implementation-plan.md`, `implementation-backlog.md`,
-`tracks/track-N.md`, and `reviews/**` live under
+`tracks/track-N.md`, and `design-mutations.md` live under
 `docs/adr/<dir-name>/_workflow/`. They are tracked on the branch during
 development, but the entire `_workflow/` directory is removed in the
 Phase 4 cleanup commit before the PR is merged — so any identifier
@@ -56,9 +56,13 @@ present in the branch tree at the time those commits are made. The
 forbidden list above is what lives durably on `develop`.
 
 It does **not** apply to the working files themselves: step files
-(`tracks/track-N.md`), review files, the plan, and the backlog all
-cite tracks, steps, findings, and iterations freely — that's exactly
-what those identifiers are for inside the workflow.
+(`tracks/track-N.md`), the plan, and the backlog all cite tracks,
+steps, findings, and iterations freely — that's exactly what those
+identifiers are for inside the workflow. Review findings themselves
+no longer have a separate on-disk home (they ride in the orchestrator's
+conversation context for the iteration loop), so the rule against
+citing finding IDs in durable content remains, just without a working
+file to cite from.
 
 ## Forbidden
 
@@ -66,8 +70,8 @@ what those identifiers are for inside the workflow.
 - Step labels: `Step 1`, `Step N`, `Step M of Track N`
 - Compound labels: `Track 2 Step 1`, `Track 4 iteration 1`
 - Review finding IDs and prefixes: `CQ33`, `F-12`, `R-4`, `A-7`,
-  `S-2`, or any other `<PREFIX><number>` finding label from
-  `reviews/**`
+  `S-2`, or any other `<PREFIX><number>` finding label produced by
+  the workflow's review loops
 - Review-loop iteration counters: `iteration 1`, `round 2`, when they
   refer to ephemeral review loops
 - Named invariants or rule names cited **by label only** —

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -128,7 +128,12 @@ Phase 1 (Planning) to rework the plan/design before re-entering.
 
 ### Review output
 
-Saved to `docs/adr/<dir-name>/_workflow/reviews/consistency.md`.
+Findings are presented to the user inline during the iteration loop;
+plan and design fixes are applied via `Edit` to
+`implementation-plan.md`, `implementation-backlog.md`, and the design
+document. The review itself is not persisted to disk — once the gate
+passes, the conversation is the only record, and the durable trace is
+the resulting plan/design state plus the gate-PASS commit.
 
 ---
 
@@ -178,7 +183,9 @@ the full structural review instead of the gate check.
 
 ### Review output
 
-Saved to `docs/adr/<dir-name>/_workflow/reviews/structural.md`.
+Same as the consistency review above — findings ride in the conversation
+during the loop; the durable trace is the plan-file edits and the
+gate-PASS state, not a saved review document.
 
 ---
 

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -150,10 +150,10 @@ when it aids review.
 below). The orchestrator parses the block; everything else in the
 implementer's output is ignored.
 
-The implementer **MUST NOT** modify the step file, the plan file, the
-backlog, or any review file. All step-file mutations — episode write,
-risk-line rewrite, `[x]` mark, Progress count update, retry/split row
-inserts — are the orchestrator's responsibility.
+The implementer **MUST NOT** modify the step file, the plan file, or
+the backlog. All step-file mutations — episode write, risk-line
+rewrite, `[x]` mark, Progress count update, retry/split row inserts —
+are the orchestrator's responsibility.
 
 ### Pacing long-running tasks — foreground only
 

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -123,8 +123,8 @@ into `implementation-backlog.md` are reachable.
   tells you which files apply per case). Any `design.md` /
   `design-mechanics.md` changes from step 3 land via the
   `edit-design` skill, which writes a separate
-  `<plan-dir>/_workflow/reviews/design-mutations.md` log entry —
-  include those files in the commit too if they were touched.
+  `<plan-dir>/_workflow/design-mutations.md` log entry — include those
+  files in the commit too if they were touched.
 
   This is a Workflow update commit (single-commit-per-replan; per
   the table in `commit-conventions.md` § Commit type prefixes).

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -86,7 +86,9 @@ points:
   diagrams, dedicated sections for complex/opaque parts
 - `docs/adr/<dir-name>/_workflow/tracks/track-N.md` — tactical: decomposed steps, step
   episodes (created during Phase 3)
-- `docs/adr/<dir-name>/_workflow/reviews/structural.md` — structural review output
+- `docs/adr/<dir-name>/_workflow/design-mutations.md` — append-only mutation log
+  for `design.md` / `design-mechanics.md`; read by `edit-design`'s
+  `design-sync` step
 
 The `_workflow/` directory is tracked under git for the branch
 lifetime (so the draft PR shows progress to teammates and so a

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -67,7 +67,7 @@ authoritative source for edge cases.
 `design-final.md` and `adr.md` are the **only** workflow files that
 survive merge into `develop`. Every other workflow file —
 `implementation-plan.md`, `implementation-backlog.md`,
-`tracks/track-N.md`, `reviews/**` — lives under
+`tracks/track-N.md`, `design-mutations.md` — lives under
 `docs/adr/<dir-name>/_workflow/` and is removed in the cleanup commit
 at the end of Phase 4 (Step 5 below) before the PR is merged. Anything
 these final artifacts say must survive that deletion.
@@ -259,7 +259,7 @@ Stage **only** the top-level final artifacts in this commit
 (`design-final.md`, `design-mechanics-final.md` if present, and
 `adr.md`). Do **not** stage anything under
 `docs/adr/<dir-name>/_workflow/` — the ephemeral
-`reviews/design-mutations.md` log and every other working file under
+`design-mutations.md` log and every other working file under
 `_workflow/` are removed wholesale by the cleanup commit in Step 5
 below.
 
@@ -283,11 +283,10 @@ git push
 ```
 
 This deletes plan, backlog, design.md, design-mechanics.md, every
-step file under `tracks/`, every review file under `reviews/`, and
-the design-mutations log in one commit. The squash-merge folds this
-deletion together with the rest of the branch's history; on
-`develop`, the final state is the two (or three) durable artifacts
-plus the implemented code.
+step file under `tracks/`, and the design-mutations log in one commit.
+The squash-merge folds this deletion together with the rest of the
+branch's history; on `develop`, the final state is the two (or three)
+durable artifacts plus the implemented code.
 
 **Step 6 — Inform the user.**
 

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -210,8 +210,7 @@ orchestrator. Read the rulebook before starting any work:
 The rulebook defines what you do, the three early-return cases
 (design decision, risk upgrade, failure), and the return contract
 your output must end with. Do not modify the step file, the plan,
-the backlog, or any review file — those are the orchestrator's
-responsibility.
+or the backlog — those are the orchestrator's responsibility.
 
 ## Stable inputs (static)
 

--- a/.claude/workflow/structural-review.md
+++ b/.claude/workflow/structural-review.md
@@ -86,34 +86,21 @@ issues.
 
 ## Review output
 
-The structural review document is saved to
-`docs/adr/<dir-name>/_workflow/reviews/structural.md`:
+The structural review is not persisted to disk. Findings are presented
+inline during the iteration loop, accepted fixes are applied directly
+to `implementation-plan.md` (and `implementation-backlog.md` when
+relevant), and the gate-PASS state plus the resulting commit are the
+durable trace. A typical iteration looks like:
 
-```markdown
-# Structural Review
+```
+Iteration 1
+  Finding S1 [blocker]  → ACCEPTED → reorder Track 3 before Track 2
+  Finding S2 [should-fix] → REJECTED — Tracks 1 and 3 are independent
 
-## Iteration 1
-
-### Finding S1 [blocker] → FIXED
-**Location**: Track 2 scope indicator
-**Issue**: Track 2's scope mentions "wiring IndexStatistics" but
-IndexStatistics is introduced in Track 3 — ordering violation.
-**Proposed fix**: Reorder Track 3 before Track 2, or extract the
-IndexStatistics interface into Track 1's scope.
-**Resolution**: Accepted — moved IndexStatistics to Track 1's scope.
-
-### Finding S2 [should-fix] → REJECTED
-**Location**: Track 1 description
-**Issue**: Missing interaction note with Track 3.
-**Proposed fix**: Add interaction note.
-**Resolution**: Rejected — Tracks 1 and 3 are independent.
-
-## Iteration 2 (Gate Verification)
-
-- S1: VERIFIED
-- S2: REJECTED (no action needed)
-- No new findings.
-- **Summary: PASS**
+Iteration 2 (Gate Verification)
+  S1: VERIFIED
+  S2: REJECTED (no action needed)
+  No new findings → PASS
 ```
 
 When the structural review passes, proceed to Phase 3 execution

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -21,8 +21,8 @@ Phase C includes both the track-level code review and track completion
 > **In this phase, you are a reviewer and planner, not an implementer. You
 > NEVER edit source code, test files, or build files. You explore the
 > codebase (read-only) to validate the track's approach and decompose it
-> into steps. The only files you write are: the step file
-> (`tracks/track-N.md`) and review files (`reviews/track-N-*.md`).**
+> into steps. The only file you write is the step file
+> (`tracks/track-N.md`).**
 
 ### Tooling — PSI is required for symbol audits in Phase A
 
@@ -95,11 +95,19 @@ instruction — keep it intact when customising.
 
 3. **Run track-scoped reviews** as sub-agents (technical, risk, adversarial
    as warranted). After each review completes:
-   - Write the review file to `docs/adr/<dir-name>/_workflow/reviews/track-N-<type>.md`
    - Update the **Reviews completed** section in the step file
-     (created atomically in sub-step 2c).
-   - These files persist on disk between sessions — the next session can
-     skip completed reviews and only re-run missing ones.
+     (created atomically in sub-step 2c) with a one-line summary —
+     review type, iteration count at PASS, and a brief tally of
+     findings that drove plan/step edits (e.g.,
+     `- [x] Technical: PASS at iteration 2 (3 findings, 2 accepted, 1 rejected)`).
+   - The findings themselves are not persisted to a separate file —
+     they ride in the orchestrator's conversation context for the
+     iteration loop, and the durable trace is the resulting step-file
+     edits (decomposition, risk tags, description tweaks). Phase A
+     resume gates on the **Reviews completed** checkboxes in the step
+     file: a checkbox is `[x]` only after the gate for that review type
+     has passed, so an interrupted iteration leaves the entry `[ ]` and
+     the next session re-runs that review type from iteration 1.
    - **Context consumption check** (mandatory after each review, except
      after the last action of the phase): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
@@ -120,16 +128,14 @@ instruction — keep it intact when customising.
    section.
 
 6. **Commit and push the Phase A workflow updates.** All of Phase A's
-   on-disk writes — the step file (created in 2c, populated in step 5),
-   review files (written in step 3), and the backlog edit (the
-   Track N section removal in 2d) — must be committed before Phase B
-   spawns the first implementer for this track. The implementer's
-   revert path uses `git reset --hard HEAD`, which would otherwise
-   discard the uncommitted decomposition.
+   on-disk writes — the step file (created in 2c, populated in step 5)
+   and the backlog edit (the Track N section removal in 2d) — must be
+   committed before Phase B spawns the first implementer for this
+   track. The implementer's revert path uses `git reset --hard HEAD`,
+   which would otherwise discard the uncommitted decomposition.
 
    ```bash
    git add docs/adr/<dir-name>/_workflow/tracks/track-<N>.md \
-           docs/adr/<dir-name>/_workflow/reviews/track-<N>-*.md \
            docs/adr/<dir-name>/_workflow/implementation-backlog.md
    git commit -m "Phase A review and decomposition for <track>"
    git push
@@ -139,10 +145,10 @@ instruction — keep it intact when customising.
    `commit-conventions.md` § Commit type prefixes. Stage explicit
    paths only — never `git add -A` — so unrelated files in the
    working tree (e.g., scratch logs from prior debugging) don't get
-   pulled in. If a particular file does not exist (no review files
-   ran, or the backlog had no Track N section to begin with), drop
-   that path from the `git add` command rather than letting the
-   missing-path error stop the commit.
+   pulled in. If a particular file does not exist (e.g., the backlog
+   had no Track N section to begin with), drop that path from the
+   `git add` command rather than letting the missing-path error stop
+   the commit.
 
 ### Complexity Assessment and Which Reviews to Run
 

--- a/.claude/workflow/track-skip.md
+++ b/.claude/workflow/track-skip.md
@@ -61,10 +61,7 @@ A track can be skipped (`[~]`) in two situations:
 4. **Delete the step file** (`tracks/track-N.md`) from disk if one
    exists (e.g., Phase A created it before the skip was decided).
 
-5. **Delete review files** (`reviews/track-N-*.md`) from disk if any
-   exist.
-
-6. **Strategy refresh** treats `[~]` tracks the same as `[x]` tracks
+5. **Strategy refresh** treats `[~]` tracks the same as `[x]` tracks
    for State A detection (see workflow.md §Startup Protocol). A
    skipped track's `**Skipped:**` line serves as its episode — the
    next session's strategy refresh reads it to assess downstream
@@ -83,7 +80,7 @@ user confirms):
 - Write the `[~]` marker and skip record to the plan file on disk
 - Remove Track N's section from `implementation-backlog.md` (no-op
   if the section is already gone)
-- Delete any partially-created step file and review files from disk
+- Delete any partially-created step file from disk
 - The session continues: if strategy refresh was already done, proceed to
   the next `[ ]` track's Phase A. If no more tracks remain, proceed to
   Phase 4 detection.
@@ -97,5 +94,5 @@ If the user says "skip Track N" at session start:
 - Write the `[~]` marker and skip record on disk (user provides the reason)
 - Remove Track N's section from `implementation-backlog.md` (no-op
   if the section is already gone)
-- Delete any step file and review files for that track from disk
+- Delete any step file for that track from disk
 - Continue with normal startup protocol for the next track

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -236,7 +236,7 @@ yet.
    next review iteration (Phase C), no further decomposition (Phase A).
 2. **Save all work:**
    - Ensure all code changes are committed
-   - Ensure all progress is written to the step/review files on disk
+   - Ensure all progress is written to the step file on disk
    - Update the **Progress** section in the step file on disk
 3. **Ask the user for a session refresh:**
    - Inform them of current progress and what remains
@@ -337,7 +337,7 @@ merge into `develop`. Phase 4 lands two commits on the branch:
 2. **Cleanup commit.** Run `git rm -r docs/adr/<dir-name>/_workflow/`
    to remove every working file under the `_workflow/` subtree
    (plan, backlog, design.md, design-mechanics.md, step files,
-   review files, design-mutations log). Commit with a message such
+   design-mutations log). Commit with a message such
    as `Remove workflow scaffolding`. Push.
 
 After both commits land, **inform the user that Phase 4 is complete


### PR DESCRIPTION
## Motivation

The `_workflow/reviews/` folder stored six file types (`consistency.md`, `structural.md`, `track-N-{technical,risk,adversarial}.md`, `design-mutations.md`), all deleted in the Phase 4 cleanup commit before merge. Five of the six had zero downstream readers:

- Phase 4's ADR/design-final composition reads track episodes, not review files.
- Phase A resume gates on the `Reviews completed` checkbox in the step file, not on review-file contents.
- Review-loop iteration's `previous_findings` rides in the orchestrator's conversation context, not on disk.

The folder paid doc-surface complexity, leak risk (11/11 plans on `develop` today still carry their old flat `reviews/` because the cleanup is a doc that hasn't been exercised end-to-end), and a delete-target dance for benefits the workflow never consumed.

Only `design-mutations.md` is genuinely load-bearing — `edit-design`'s `design-sync` step re-reads it across sessions to find the last sync point. It's an edit log, not a review artifact, so it now sits at the `_workflow/` top level alongside `design.md` / `design-mechanics.md`.

## Summary

- Drop the `_workflow/reviews/` folder from workflow conventions; review findings now ride in conversation context for the iteration loop, and the durable trace is the plan/step-file edits plus the gate-PASS workflow-update commit.
- Promote `design-mutations.md` to the `_workflow/` top level — it's the one review-folder file with a real downstream reader.
- Add a one-line PASS summary under each step's `Reviews completed` checkbox so the audit trail still tells you which reviews ran and at what iteration count.
- Sync the step-file template example in `conventions-execution.md` so it matches the new one-line summary format that `track-review.md` now requires.

## Compatibility

In-flight branches are unaffected — they keep their populated `reviews/` folder until merge; the Phase 4 cleanup commit deletes everything under `_workflow/` either way. This change is writer-side only.

## Test plan

- [ ] Skim updated workflow docs for internal consistency (`conventions.md`, `track-review.md`, `structural-review.md`, `track-skip.md`, `step-implementation.md`, `conventions-execution.md`).
- [ ] Confirm no remaining `reviews/` references survive outside intentional comparisons / examples (`grep -nR 'reviews/' .claude/workflow .claude/skills`).
- [ ] Confirm `design-mutations.md` is referenced only at its new top-level location (`grep -nR 'design-mutations.md' .claude`).