### PR TITLE
Delegate Phase C review fixes to implementer

### DIFF
--- a/.claude/skills/analyze-changes/SKILL.md
+++ b/.claude/skills/analyze-changes/SKILL.md
@@ -186,6 +186,6 @@ concerns raised, or alternatives discussed.>
 
 8. **Be honest about limitations.** If a feature is only exercised by synthetic tests and not by any production query, say so. If a pattern never actually filters in symmetric cases, explain what the real win is (cost reduction, not filtering).
 
-9. **Use the Agent tool** with `subagent_type: "Explore"` if you need to understand surrounding code context that isn't in the diff — e.g., to find which real queries trigger a new optimization, or to understand the old behavior being replaced.
+9. **Use the Agent tool** with `subagent_type: "Explore"` if you need to understand surrounding code context that isn't in the diff — e.g., to find which real queries trigger a new optimization, or to understand the old behavior being replaced. When the question is reference-accuracy (callers/overrides/usages of a Java symbol, "is this slot consumed anywhere", "which classes implement this interface"), instruct the Explore sub-agent in its prompt to **use mcp-steroid PSI find-usages / find-implementations / type-hierarchy via `steroid_execute_code`, not grep**, when the mcp-steroid MCP server is reachable per the SessionStart hook. Sub-agents default to grep otherwise; an unannotated delegation routes through grep and silently misses polymorphic call sites and identifiers in Javadoc/comments. See `~/.claude/CLAUDE.md` "MCP Steroid" / "Grep vs PSI — when to switch" for the full routing rule.
 
 10. The output file goes in the **project root directory** (the current working directory).

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -172,6 +172,21 @@ Review the following code changes from your specialized perspective.
 - Any files under generated-sources/ or generated-test-sources/
 - Generated Gremlin DSL classes
 
+## Tooling
+Use **mcp-steroid PSI find-usages / find-implementations / type-hierarchy
+via `steroid_execute_code`, not grep**, for any reference-accuracy
+question about a Java symbol in this diff (callers/overrides/usages of
+a method, field, class, or annotation; whether a slot is genuinely
+unused; whether a renamed symbol still has stale references). Grep is
+acceptable for filename globs, unique string literals, and orientation
+reads, but the load-bearing answer behind a finding must be PSI-backed
+when the mcp-steroid MCP server is reachable per the SessionStart hook
+(`steroid_list_projects` once at the start confirms the open project
+matches the working tree). Fall back to grep with an explicit
+reference-accuracy caveat in the finding only when mcp-steroid is
+unreachable. See `~/.claude/CLAUDE.md` "MCP Steroid" / "Grep vs PSI —
+when to switch" for the full routing rule.
+
 ## Diff
 {DIFF}
 ```

--- a/.claude/skills/fix-ci-failure/SKILL.md
+++ b/.claude/skills/fix-ci-failure/SKILL.md
@@ -215,6 +215,23 @@ whenever code or tests were modified.
    ## Skip These Files (generated code)
    - core/.../sql/parser/*, generated-sources/*, Gremlin DSL
 
+   ## Tooling
+   Use **mcp-steroid PSI find-usages / find-implementations / type-
+   hierarchy via `steroid_execute_code`, not grep**, for any reference-
+   accuracy question about a Java symbol in this fix (callers/overrides
+   /usages of a method, field, class, or annotation; whether the fix
+   leaves stale references; whether a new helper duplicates an existing
+   one; whether a test exercises the same code path the production fix
+   touches). Grep is acceptable for filename globs, unique string
+   literals, and orientation reads, but the load-bearing answer behind
+   a finding must be PSI-backed when the mcp-steroid MCP server is
+   reachable per the SessionStart hook (`steroid_list_projects` once at
+   the start confirms the open project matches the working tree). Fall
+   back to grep with an explicit reference-accuracy caveat in the
+   finding only when mcp-steroid is unreachable. See
+   `~/.claude/CLAUDE.md` "MCP Steroid" / "Grep vs PSI — when to switch"
+   for the full routing rule.
+
    ## Diff
    {git diff develop...HEAD}
    ```

--- a/.claude/skills/test-review/SKILL.md
+++ b/.claude/skills/test-review/SKILL.md
@@ -160,6 +160,22 @@ Review the following code changes from your specialized test quality perspective
 - Any files under generated-sources/ or generated-test-sources/
 - Generated Gremlin DSL classes
 
+## Tooling
+Use **mcp-steroid PSI find-usages / find-implementations / type-hierarchy
+via `steroid_execute_code`, not grep**, for any reference-accuracy
+question while reviewing test quality (which production methods this
+test exercises and where else they're called; whether an assertion's
+expected value matches the contract observed at every override of an
+SPI; whether a test fixture's helper has additional consumers that
+constrain its shape). Grep is acceptable for filename globs, unique
+string literals, and orientation reads, but the load-bearing answer
+behind a finding must be PSI-backed when the mcp-steroid MCP server is
+reachable per the SessionStart hook (`steroid_list_projects` once at
+the start confirms the open project matches the working tree). Fall
+back to grep with an explicit reference-accuracy caveat in the finding
+only when mcp-steroid is unreachable. See `~/.claude/CLAUDE.md` "MCP
+Steroid" / "Grep vs PSI — when to switch" for the full routing rule.
+
 ## Diff
 {DIFF}
 ```

--- a/.claude/workflow/code-review-protocol.md
+++ b/.claude/workflow/code-review-protocol.md
@@ -45,9 +45,14 @@ See [`track-code-review.md`](track-code-review.md) §Single-Step Track.
 
 - **Step-level:** see [`step-implementation.md`](step-implementation.md)
   §Per-Step Orchestration Loop sub-step 4 — the dimensional review
-  loop, run by the orchestrator on the implementer's commit.
+  loop, run by the orchestrator on the implementer's commit. Fixes
+  for findings are delegated to a respawn of the per-step
+  implementer at `level=step, mode=FIX_REVIEW_FINDINGS`.
 - **Track-level:** see [`track-code-review.md`](track-code-review.md)
-  (includes track completion).
+  (includes track completion). Fixes for findings are delegated to a
+  fresh per-iteration implementer at
+  `level=track, mode=FIX_REVIEW_FINDINGS`; the orchestrator never
+  edits source files itself in Phase C.
 
 ---
 

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -39,19 +39,25 @@ carries no CI cost.
 | Commit type | Message pattern | Example |
 |---|---|---|
 | **Step implementation** | Imperative summary of the change | `Add histogram header to leaf page` |
-| **Review fix** | `Review fix:` prefix | `Review fix: extract validation to helper method` |
+| **Review fix** | `Review fix:` prefix — produced by the implementer at both `level=step` (Phase B dim-review fix) and `level=track` (Phase C track-level fix). Phase B vs Phase C is distinguished by **position** (Phase C fix commits appear strictly after the last episode commit). | `Review fix: extract validation to helper method` |
 | **Step rollback** | `Revert step:` prefix | `Revert step: add histogram header to leaf page` |
-| **Workflow update** | Imperative summary of the workflow-file change (no special prefix; commit only touches paths under `_workflow/`) | `Add initial implementation plan and design`, `Phase A review and decomposition for histogram track`, `Record Phase B base commit for histogram track`, `Record episode for histogram leaf write step`, `Apply plan corrections from histogram-leaf review`, `Mark histogram-leaf track complete`, `Inline replan after Track 2` |
+| **Workflow update** | Imperative summary of the workflow-file change (no special prefix; commit only touches paths under `_workflow/`) | `Add initial implementation plan and design`, `Phase A review and decomposition for histogram track`, `Record Phase B base commit for histogram track`, `Record episode for histogram leaf write step`, `Apply plan corrections from histogram-leaf review`, `Mark histogram-leaf track complete`, `Inline replan after Track 2`, `Record Phase C iteration 1 for histogram track`, `Record Phase C iteration failure for histogram track` |
 | **Phase 4 final** | `Add final design and ADR` (the standard final-artifacts commit) | (defined verbatim in `prompts/create-final-design.md` § Step 4) |
 | **Phase 4 cleanup** | `Remove workflow scaffolding` — single commit that runs `git rm -r docs/adr/<dir>/_workflow/` after the final-artifacts commit | (see `workflow.md` § Final Artifacts) |
 
 **Step rollback (`Revert step:`) commits** are produced **only by the
-Phase B orchestrator** when a `FIX_REVIEW_FINDINGS` respawn returns a
-non-`SUCCESS` result. The orchestrator runs
+Phase B orchestrator** when a `FIX_REVIEW_FINDINGS` respawn at
+`level=step` returns a non-`SUCCESS` result. The orchestrator runs
 `git revert -n {step_base_commit}..HEAD` to stage the reversal of all
 step-related commits (the original implementer commit plus any prior
 `Review fix:` commits from the same dim-review loop), then commits
-once with the `Revert step:` prefix.
+once with the `Revert step:` prefix. **Phase C never produces
+`Revert step:` commits** — Phase C does not roll back across
+iterations on a `FAILED` return; the failed iteration is treated as
+a no-op and the loop exits with the unfixed findings surfaced to the
+user at track completion (see
+[`track-code-review.md`](track-code-review.md) §Phase C Implementer
+Handlers).
 
 The body is load-bearing for Phase B Resume. The **first non-empty
 body line MUST be** `reason: <slug>` where `<slug>` is one of:

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -1,25 +1,46 @@
-# Phase B Implementer — Rulebook
+# Implementer — Rulebook
 
-This document is the rulebook for the **per-step implementer sub-agent**
-spawned by the Phase B orchestrator. The implementer performs sub-steps
-1–3 of step implementation (implement code, write/run tests, commit) and
-returns a structured handoff to the orchestrator. The orchestrator owns
-sub-steps 4–7 and all session-level decisions.
+This document is the rulebook for the **implementer sub-agent**
+spawned by the orchestrator at two distinct levels:
 
-The rulebook for the orchestrator side — startup, per-step orchestration
-loop, dimensional review fan-out, episode finalisation — lives in
-[`step-implementation.md`](step-implementation.md). The two documents are
-the only Phase B entry points; everything else is loaded on demand.
+- **`level: step`** — the per-step implementer spawned by the Phase B
+  orchestrator (`step-implementation.md`). Performs sub-steps 1–3 of
+  step implementation (implement code, write/run tests, commit) and
+  returns a structured handoff. The Phase B orchestrator owns
+  sub-steps 4–7 and all session-level decisions.
+- **`level: track`** — the per-iteration implementer spawned by the
+  Phase C orchestrator (`track-code-review.md`) to apply track-level
+  code-review fixes (and user-requested fixes during track
+  completion). Operates only in `mode=FIX_REVIEW_FINDINGS` or
+  `mode=WITH_GUIDANCE` — the cumulative track diff already exists at
+  HEAD, so there is no `INITIAL` mode at this level. The Phase C
+  orchestrator owns the review fan-out, gate verification, plan
+  corrections, and track completion.
+
+Most of the rulebook is shared across both levels. Where the two
+diverge — diff target, allowed return values, episode draft shape — the
+divergence is called out inline as "Phase B (level=step)" /
+"Phase C (level=track)" rather than split into parallel sections.
+
+The rulebook for the orchestrator side — Phase B startup, per-step
+orchestration loop, dimensional review fan-out, episode finalisation,
+Phase C review loop, track completion — lives in
+[`step-implementation.md`](step-implementation.md) and
+[`track-code-review.md`](track-code-review.md). Together with this
+rulebook they are the only entry points; everything else is loaded on
+demand.
 
 ---
 
 ## Loading discipline
 
-This file is read **only by the per-step implementer sub-agent** on
-each spawn. Orchestrators do not load it. The orchestrator's
-specification — including the implementer prompt template and how this
-rulebook is referenced from each spawn — lives in
-[`step-implementation.md`](step-implementation.md).
+This file is read **only by the implementer sub-agent** on each spawn,
+at either level. Orchestrators do not load it. The orchestrator
+specifications — including the prompt template and how this rulebook
+is referenced from each spawn — live in
+[`step-implementation.md`](step-implementation.md) (Phase B,
+`level=step`) and [`track-code-review.md`](track-code-review.md)
+(Phase C, `level=track`).
 
 The implementer's environment auto-loads the user-global rules in
 `~/.claude/CLAUDE.md` and the project rules in the repo's `CLAUDE.md`.
@@ -31,10 +52,10 @@ slim plan snapshot, and `design.md` (only if the step requires it).
 ## Inputs the orchestrator passes on each spawn
 
 The implementer prompt has a **stable static prefix** (workflow context
-+ rulebook path + project paths) followed by **per-step variable
++ rulebook path + project paths) followed by **per-spawn variable
 inputs**.
 
-**Stable inputs** (same across spawns within a Phase B session):
+**Stable inputs** (same across spawns within a session):
 
 - `repo_root` — absolute path to the working tree.
 - `plan_slim_path` — `/tmp/claude-code-plan-slim-$PPID.md`.
@@ -43,18 +64,22 @@ inputs**.
 
 **Variable inputs** (per spawn):
 
-- `step_index` — the integer N identifying which step in the file is
-  being implemented.
-- `step_description` — copied inline from the step file's
-  `- [ ] Step: …` line.
-- `risk_tag` — `low` | `medium` | `high`.
-- `base_commit` — SHA recorded at Phase B startup.
+- `level` — `step` (Phase B per-step implementation) or `track` (Phase
+  C per-iteration fix application). Selects which fields below are
+  populated and which `mode` values are valid.
+- `base_commit` — SHA recorded at Phase B startup. Used at both levels:
+  Phase B reads it for orchestrator bookkeeping; Phase C also derives
+  the cumulative track diff from `git diff {base_commit}..HEAD`.
 - `mode` — one of:
-  - `INITIAL` — first attempt at the step.
+  - `INITIAL` — first attempt at the step. Valid only at `level=step`.
   - `WITH_GUIDANCE` — respawn after a design-decision escalation.
-    `Guidance:` and `exploration_notes_echo` are populated.
-  - `FIX_REVIEW_FINDINGS` — respawn to apply dimensional review
-    findings on top of the existing commit. `findings:` is populated.
+    Valid at both levels. `Guidance:` and `exploration_notes_echo`
+    are populated.
+  - `FIX_REVIEW_FINDINGS` — respawn to apply review findings on top
+    of the existing HEAD. Valid at both levels. `findings:` is
+    populated. At `level=step` the fixes apply on top of the prior
+    step's commit; at `level=track` they apply on top of the most
+    recent commit on the track (the cumulative track HEAD).
 - `Guidance:` (only in `WITH_GUIDANCE`) — the user's chosen
   alternative + any additional direction.
 - `exploration_notes_echo` (only in `WITH_GUIDANCE`) — the
@@ -62,28 +87,60 @@ inputs**.
   `DESIGN_DECISION_NEEDED` return, so the new implementer skips
   re-derivation.
 - `findings:` (only in `FIX_REVIEW_FINDINGS`) — the synthesised
-  dimensional-review findings the implementer must address.
+  review findings the implementer must address. At `level=step` these
+  are dimensional-review findings against the step's commit; at
+  `level=track` they are cross-step findings synthesised from the
+  track-level review fan-out.
+
+**Step-level-only inputs** (populated only when `level=step`):
+
+- `step_index` — the integer N identifying which step in the file is
+  being implemented.
+- `step_description` — copied inline from the step file's
+  `- [ ] Step: …` line.
+- `risk_tag` — `low` | `medium` | `high`.
+
+At `level=track` these three fields are absent. The track-level
+implementer reads the step file for cross-step context (episodes,
+risk tags, descriptions) but does not focus on a single step.
+
+**Mode/level validity matrix:**
+
+| Level | `INITIAL` | `WITH_GUIDANCE` | `FIX_REVIEW_FINDINGS` |
+|---|---|---|---|
+| `step` | yes | yes | yes |
+| `track` | **no** (the cumulative diff already exists at HEAD) | yes | yes |
 
 ---
 
 ## What the implementer does (sub-steps 1–3, expanded)
 
-The orchestrator's per-step workflow has seven sub-steps; the
-implementer owns sub-steps 1–3 below. Reading the step file and the
-slim plan are **preconditions** to sub-step 1, not separate sub-steps.
-Run sub-steps 1–3 in order, to completion, then emit the return
-contract. Any detection rule in the next section may interrupt the
-flow with an early return — in that case skip the remaining sub-steps
-and emit the return contract instead of continuing.
+The Phase B orchestrator's per-step workflow has seven sub-steps and
+the Phase C orchestrator's review iteration is a parallel three-step
+loop; the implementer owns sub-steps 1–3 at both levels — read the
+target, change/fix the code, run tests + spotless + coverage gate,
+commit. Reading the step file and the slim plan are **preconditions**
+to sub-step 1, not separate sub-steps. Run sub-steps 1–3 in order, to
+completion, then emit the return contract. Any detection rule in the
+next section may interrupt the flow with an early return — in that
+case skip the remaining sub-steps and emit the return contract
+instead of continuing.
 
 **Preconditions.**
 
-- Read the step file at `step_file_path`; locate the step at
-  `step_index`; confirm intent and check the `**Risk:**` line. If
-  `mode == FIX_REVIEW_FINDINGS`, also locate the prior commit's diff
-  so the fixes land on top of it.
+- Read the step file at `step_file_path`.
+  - At `level=step`: locate the step at `step_index`; confirm intent
+    and check the `**Risk:**` line. If `mode == FIX_REVIEW_FINDINGS`,
+    also locate the prior commit's diff so the fixes land on top of
+    it.
+  - At `level=track`: read the file for cross-step context — the
+    `## Description` section (track intent), the per-step `**Risk:**`
+    lines (focal points), and the step episodes (what each step did
+    and discovered). Then read `git diff {base_commit}..HEAD` to load
+    the cumulative track diff that the findings refer to. There is no
+    `step_index` to focus on.
 - Read the slim plan at `plan_slim_path` for strategic context. Read
-  `design_path` only if the step requires it.
+  `design_path` only if the change requires it.
 
 **Sub-step 1 — Implement the change.** Apply the existing project
 rules:
@@ -140,20 +197,31 @@ makes the commit log easier to follow, since the squash-merge
 collapses them away (see
 [`commit-conventions.md`](commit-conventions.md) "Branch-only
 commit messages may cite workflow-internal identifiers"). For
-`mode == FIX_REVIEW_FINDINGS`, prefix the commit subject with
+`mode == FIX_REVIEW_FINDINGS` or `mode == WITH_GUIDANCE` with a
+fix-applied outcome at `level=track`, prefix the commit subject with
 `Review fix:` per [`commit-conventions.md`](commit-conventions.md);
 prefer describing the fix by what changed (behavior, file, class)
 over citing a finding ID, but a finding-ID reference is permitted
-when it aids review.
+when it aids review. The same `Review fix:` prefix applies at both
+levels — Phase B Resume distinguishes Phase B vs Phase C fix commits
+by **position** (Phase C fix commits appear strictly after the last
+episode commit, since Phase B is fully done before Phase C runs);
+see [`commit-conventions.md`](commit-conventions.md) and
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§Resume-side commit-pattern reference.
 
 **Return.** Emit the structured result block (see §Return contract
 below). The orchestrator parses the block; everything else in the
 implementer's output is ignored.
 
 The implementer **MUST NOT** modify the step file, the plan file, or
-the backlog. All step-file mutations — episode write, risk-line
-rewrite, `[x]` mark, Progress count update, retry/split row inserts —
-are the orchestrator's responsibility.
+the backlog. At `level=step` all step-file
+mutations — episode write, risk-line rewrite, `[x]` mark, Progress
+count update, retry/split row inserts — are the Phase B
+orchestrator's responsibility. At `level=track` all plan/backlog
+mutations — Progress section iteration count, plan corrections from
+deferred findings, track episode, `[x]` mark on the plan track entry —
+are the Phase C orchestrator's responsibility.
 
 ### Pacing long-running tasks — foreground only
 
@@ -199,8 +267,9 @@ profile build, integration tests:
   invocation — each stage under 10 min. The split keeps every
   invocation foreground; do not work around the timeout by
   switching to `run_in_background`.
-- **Test-additive steps skip the coverage-profile build entirely.**
-  When the step adds only test code (no production-source changes
+- **Test-additive spawns skip the coverage-profile build entirely.**
+  When the spawn (a step at `level=step` or a fix iteration at
+  `level=track`) adds only test code (no production-source changes
   in `git diff origin/develop -- '**/src/main/**'`), the coverage gate
   trivially passes on changed lines because there are no changed
   production lines. Run the targeted tests in foreground, confirm
@@ -211,8 +280,9 @@ profile build, integration tests:
 If even a staged sequence cannot fit the foreground budget (rare —
 only large `-P ci-integration-tests` runs or full multi-module
 coverage on a slow host), return `RESULT: FAILED` with
-`recommended_action: split` and let the orchestrator decide whether
-to break the step into smaller, individually-verifiable pieces.
+`recommended_action: split` (at `level=step`) or
+`recommended_action: escalate` (at `level=track`, where step-level
+splits do not apply) and let the orchestrator decide how to proceed.
 
 ### When the failure mode is opaque — consider an IDE debug session
 
@@ -368,13 +438,24 @@ and respawns the implementer with `mode=WITH_GUIDANCE` and the
 `exploration_notes_echo` populated, so the new implementer does not
 redo the exploration.
 
-### Risk upgrade required
+### Risk upgrade required (level=step only)
 
 Implementation reveals that the step is more invasive than its
 tagged risk — for example, the "trivial refactor" tagged `low`
 turns out to require lock-ordering changes, or the "internal helper
 addition" tagged `medium` actually changes a public-API serialized
 form.
+
+**This case is `level=step` only.** At `level=track` there is no
+per-step risk to upgrade — risk tags are locked at the end of
+Phase B per [`risk-tagging.md`](risk-tagging.md) §Risk locking.
+Returning `RESULT: RISK_UPGRADE_REQUESTED` from a `level=track`
+spawn is a contract violation; the orchestrator surfaces the
+return to the user instead of dispatching. If applying a Phase C
+fix surfaces an issue that genuinely demands re-running an earlier
+step's implementation under heavier review, return `RESULT: FAILED`
+with `recommended_action: escalate` and let the orchestrator
+trigger inline replanning.
 
 Run the snapshot-and-diff revert sequence at the top of this section
 (snapshot pre-existing untracked files first, then `git reset --hard
@@ -419,27 +500,39 @@ same for every early-return case (design decision, risk upgrade,
 fundamental failure) and every mode, but the **semantic scope** of
 what gets reverted differs:
 
-- **`mode=INITIAL`** or **`mode=WITH_GUIDANCE`**: `HEAD` is the
-  step's pre-implementation state (the orchestrator's `step_base_commit`).
-  The reset returns the working tree to that pristine state — the
-  orchestrator sees a clean tree at `step_base_commit`. Correct.
-- **`mode=FIX_REVIEW_FINDINGS`**: `HEAD` is the prior `SUCCESS`
-  commit (the original implementer commit, possibly with earlier
-  `Review fix:` commits on top from prior dim-review iterations).
-  The implementer's reset clears only its in-progress fix attempt;
-  the prior commits stay on disk. Rolling those back is the
-  **orchestrator's** responsibility — see
+- **`level=step`, `mode=INITIAL`** or **`mode=WITH_GUIDANCE`**: `HEAD`
+  is the step's pre-implementation state (the orchestrator's
+  `step_base_commit`). The reset returns the working tree to that
+  pristine state — the orchestrator sees a clean tree at
+  `step_base_commit`. Correct.
+- **`level=step`, `mode=FIX_REVIEW_FINDINGS`**: `HEAD` is the prior
+  `SUCCESS` commit (the original implementer commit, possibly with
+  earlier `Review fix:` commits on top from prior dim-review
+  iterations). The implementer's reset clears only its in-progress
+  fix attempt; the prior commits stay on disk. Rolling those back
+  is the Phase B **orchestrator's** responsibility — see
   [`step-implementation-recovery.md`](step-implementation-recovery.md)
   §Post-Commit Handlers. The implementer must not run `git reset --hard
   step_base_commit` or `git revert` to undo prior commits; that
   would silently destroy work the orchestrator may need.
+- **`level=track`, `mode=FIX_REVIEW_FINDINGS`** or **`mode=WITH_GUIDANCE`**:
+  `HEAD` is the most recent commit on the track — typically the
+  last episode commit from Phase B, or a prior iteration's
+  `Review fix:` commit if this is iteration 2 or 3. The implementer's
+  reset clears only its in-progress fix attempt; nothing else is
+  rolled back. Phase C does **not** roll back prior iterations'
+  successful `Review fix:` commits on a `FAILED` return — the
+  earlier fixes remain valid (they passed their gate check) and
+  the failed iteration is treated as a no-op. See
+  [`track-code-review.md`](track-code-review.md) §Review loop and
+  the `level=track` row in §Return contract field rules below.
 
 The implementer is therefore symmetric in code (the snapshot-and-diff
-revert sequence regardless of mode and regardless of which
-early-return case fired) but the orchestrator-side cleanup differs:
-pre-commit modes need no further work; post-commit mode requires
-the orchestrator's post-commit rollback to remove the prior step
-commits as well.
+revert sequence regardless of level, mode, and early-return case)
+but the orchestrator-side cleanup differs: pre-commit modes (Phase B
+`INITIAL`/`WITH_GUIDANCE`) need no further work; Phase B
+`FIX_REVIEW_FINDINGS` requires the post-commit rollback to remove
+the prior step commits; Phase C never rolls back across spawns.
 
 ---
 
@@ -471,7 +564,7 @@ TOOLING_NOTES:
   psi_audits: <N>
   notes: <one-liner if anything unusual happened, otherwise "none">
 
-EPISODE_DRAFT:
+EPISODE_DRAFT:                    # populated only at level=step
   what_was_done: |
     <factual summary, 2–6 sentences>
   what_was_discovered: |
@@ -481,9 +574,26 @@ EPISODE_DRAFT:
   critical_context: |
     <or "none". Use sparingly.>
 
+FIX_NOTES:                        # populated only at level=track
+  what_was_fixed: |
+    <factual summary of which findings the iteration addressed,
+    1–4 sentences. Cite finding IDs (CQ7, BC3, …) freely — these
+    are branch-only-commit-message-scope identifiers and never
+    leak into durable content.>
+  what_was_skipped: |
+    <or "none". Findings the implementer chose not to address
+    inside this iteration — typically because they would expand
+    the fix beyond track scope. The Phase C orchestrator may fold
+    these into plan corrections.>
+  what_was_discovered: |
+    <or "none". Cross-step or cross-track observations surfaced
+    while applying fixes.>
+
 CROSS_TRACK_HINTS: |
-  <free-form: anything that might affect upcoming tracks. The
-  orchestrator consumes this in sub-step 5. Empty is fine.>
+  <free-form: anything that might affect upcoming tracks. At
+  level=step the Phase B orchestrator consumes this in sub-step 5.
+  At level=track the Phase C orchestrator folds this into the
+  eventual track episode. Empty is fine.>
 
 # --- Conditional sections, only present when relevant ---
 
@@ -496,6 +606,7 @@ DESIGN_DECISION:                  # only if RESULT == DESIGN_DECISION_NEEDED
   exploration_notes: ...          # echoed back on respawn
 
 RISK_UPGRADE:                     # only if RESULT == RISK_UPGRADE_REQUESTED
+                                  # — forbidden at level=track
   from: low | medium
   to: medium | high
   category: concurrency | crash-safety | public-API | security |
@@ -505,17 +616,22 @@ RISK_UPGRADE:                     # only if RESULT == RISK_UPGRADE_REQUESTED
 FAILURE:                          # only if RESULT == FAILED
   what_was_attempted: |
   why_it_failed: |
-  impact_on_remaining_steps: |
+  impact_on_remaining_steps: |    # at level=track this is
+                                  # "impact on remaining findings /
+                                  # remaining iterations"
   recommended_action: retry | split | escalate
 ```
 
 ### Field rules
 
 - `RESULT` is the dispatch tag — the orchestrator routes on it. Pick
-  exactly one value.
+  exactly one value. `RISK_UPGRADE_REQUESTED` is **forbidden at
+  `level=track`** (see §Risk upgrade required above).
 - `COMMIT` is empty when `RESULT != SUCCESS`. On `SUCCESS`, it is the
-  SHA of the implementer's commit (or, for `mode=FIX_REVIEW_FINDINGS`,
-  the SHA of the `Review fix:` commit applied on top).
+  SHA of the implementer's commit. At `level=step` with
+  `mode=INITIAL`/`WITH_GUIDANCE` it is the step's primary commit; at
+  `level=step` with `mode=FIX_REVIEW_FINDINGS` and at `level=track`
+  it is the SHA of the `Review fix:` commit applied on top.
 - `FILES_TOUCHED` lists every path in the diff with a `(new)` or
   `(modified)` annotation. On `FAILED`, list paths the implementer
   attempted to modify even though they are now reverted.
@@ -529,19 +645,28 @@ FAILURE:                          # only if RESULT == FAILED
   `line_coverage_changed` and `branch_coverage_changed` to
   `n/a (test-additive)` and keep `passed` / `module` /
   `spotless_applied` populated normally.
-- `EPISODE_DRAFT` is populated on `SUCCESS` only. The orchestrator
-  finalises it (merging in cross-track-impact-check observations from
-  sub-step 5) before writing the episode to the step file. On
-  `FAILED`, the orchestrator uses `FAILURE` instead of
-  `EPISODE_DRAFT`. On `DESIGN_DECISION_NEEDED` and
-  `RISK_UPGRADE_REQUESTED`, omit `EPISODE_DRAFT` — the eventual
-  respawn produces the authoritative draft once the step actually
-  completes.
-- `CROSS_TRACK_HINTS` is a free-form note for the orchestrator's
-  cross-track impact check (sub-step 5). Anything that might affect
-  upcoming tracks goes here — invariant weakened, new dependency
-  surfaced, API shape clarified differently than expected. Empty is
-  fine; the orchestrator does not require a hint per step.
+- `EPISODE_DRAFT` is populated on `SUCCESS` only and only at
+  `level=step`. The Phase B orchestrator finalises it (merging in
+  cross-track-impact-check observations from sub-step 5) before
+  writing the episode to the step file. On `FAILED`, the
+  orchestrator uses `FAILURE` instead of `EPISODE_DRAFT`. On
+  `DESIGN_DECISION_NEEDED` and `RISK_UPGRADE_REQUESTED`, omit
+  `EPISODE_DRAFT` — the eventual respawn produces the authoritative
+  draft once the step actually completes. **Omit at `level=track`** —
+  use `FIX_NOTES` instead.
+- `FIX_NOTES` is populated on `SUCCESS` only and only at
+  `level=track`. The Phase C orchestrator folds it into the eventual
+  track episode (compiled at track completion). On `FAILED`, the
+  orchestrator uses `FAILURE` instead. **Omit at `level=step`** —
+  use `EPISODE_DRAFT` instead.
+- `CROSS_TRACK_HINTS` is a free-form note for the orchestrator. At
+  `level=step` the Phase B orchestrator consumes it in sub-step 5
+  (cross-track impact check). At `level=track` the Phase C
+  orchestrator folds it into the track episode and any plan
+  corrections. Anything that might affect upcoming tracks goes here —
+  invariant weakened, new dependency surfaced, API shape clarified
+  differently than expected. Empty is fine; the orchestrator does
+  not require a hint per spawn.
 
 ---
 

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -490,11 +490,21 @@ Run the snapshot-and-diff revert sequence at the top of this section
 (snapshot pre-existing untracked files first, then `git reset --hard
 HEAD`, then `comm -13` against a post-snapshot to surgically remove
 only files this spawn created), then return `RESULT: FAILED` with `FAILURE` populated: `what_was_attempted`, `why_it_failed`,
-`impact_on_remaining_steps`, and `recommended_action` (`retry` |
-`split` | `escalate`).
+`impact_on_remaining_steps`, and `recommended_action`. Allowed values
+for `recommended_action` are level-conditional:
+
+- At `level=step`: `retry` | `split` | `escalate`.
+- At `level=track`: `retry` | `escalate` only. **`split` is
+  forbidden** — step-splitting is a Phase B planning operation
+  against per-step risk tags and has no analogue at Phase C, where
+  the failure is against the cumulative track diff. Returning
+  `recommended_action: split` from a `level=track` spawn is a
+  contract violation; the orchestrator surfaces the return to the
+  user instead of dispatching.
 
 The orchestrator writes the failed episode to the step file, inserts
-retry/split rows, and runs the two-failure detection on its side.
+retry/split rows, and runs the two-failure detection on its side
+(`level=step` only — Phase C does not insert retry/split rows).
 
 ### Mode-specific scope of the local revert
 
@@ -635,6 +645,12 @@ FAILURE:                          # only if RESULT == FAILED
                                   # "impact on remaining findings /
                                   # remaining iterations"
   recommended_action: retry | split | escalate
+                                  # split is forbidden at level=track
+                                  # — step-splitting does not apply to
+                                  # the cumulative track diff (see
+                                  # §Fundamental failure above).
+                                  # Allowed values at level=track:
+                                  # retry | escalate.
 ```
 
 ### Field rules
@@ -682,6 +698,12 @@ FAILURE:                          # only if RESULT == FAILED
   invariant weakened, new dependency surfaced, API shape clarified
   differently than expected. Empty is fine; the orchestrator does
   not require a hint per spawn.
+- `FAILURE.recommended_action` is level-conditional. At `level=step`
+  it is one of `retry | split | escalate`. At `level=track` it is
+  one of `retry | escalate` — **`split` is forbidden** (see
+  §"Fundamental failure" above). Returning `split` from a
+  `level=track` spawn is a contract violation; the orchestrator
+  surfaces the return to the user instead of dispatching.
 
 ---
 

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -275,7 +275,14 @@ profile build, integration tests:
   production lines. Run the targeted tests in foreground, confirm
   Spotless, and commit — record the gate as `n/a (test-additive)`
   in the `TEST_SUMMARY` and let the track's final-verification step
-  pick up per-package totals from a single full coverage run.
+  pick up per-package totals from a single full coverage run. Note
+  that the check is against `origin/develop`, i.e. the **cumulative**
+  branch diff. At `level=track` this shortcut therefore only fires
+  for test-only tracks (where Phase B itself touched no production
+  source); for any track whose Phase B steps added production code,
+  the cumulative diff is non-empty and the implementer must run the
+  full coverage profile build even when the iteration's own diff is
+  test-only.
 
 If even a staged sequence cannot fit the foreground budget (rare —
 only large `-P ci-integration-tests` runs or full multi-module
@@ -516,9 +523,17 @@ what gets reverted differs:
   step_base_commit` or `git revert` to undo prior commits; that
   would silently destroy work the orchestrator may need.
 - **`level=track`, `mode=FIX_REVIEW_FINDINGS`** or **`mode=WITH_GUIDANCE`**:
-  `HEAD` is the most recent commit on the track — typically the
-  last episode commit from Phase B, or a prior iteration's
-  `Review fix:` commit if this is iteration 2 or 3. The implementer's
+  `HEAD` is the most recent commit on the track. At iteration 1 this
+  is the last episode commit from Phase B (or, if findings were
+  deferred, the `Apply plan corrections` Workflow update commit
+  sitting on top of it). At iterations 2 and 3 it is the prior
+  iteration's `Record Phase C iteration N` Workflow update commit,
+  which itself sits on top of that iteration's `Review fix:` commit
+  (the orchestrator records Progress as a Workflow update commit
+  immediately after each successful fix iteration; see
+  [`track-code-review.md`](track-code-review.md) §Review loop). The
+  implementer commits on top of HEAD whatever it is and does not
+  need to inspect the prior commit's subject. The implementer's
   reset clears only its in-progress fix attempt; nothing else is
   rolled back. Phase C does **not** roll back prior iterations'
   successful `Review fix:` commits on a `FAILED` return — the

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -34,6 +34,22 @@ architecture notes.
 - Removed tracks that are no longer needed
 - Clear rationale for each change
 
+**Tooling — PSI for code references in the revised plan.** Replans
+routinely add new claims about the codebase (a Component Map entry
+names a class, a Decision Record cites a method, an Invariant points
+at an enforcement site, an Integration Point names callers). Those
+are reference-accuracy facts and must be verified through mcp-steroid
+PSI find-usages / find-implementations / type-hierarchy via
+`steroid_execute_code`, not grep, when the mcp-steroid MCP server is
+reachable per the SessionStart hook — same rule as Phase 1 planning
+(see [`planning.md`](planning.md) §"Tooling — PSI-backed Component
+Map and integration points" and [`conventions.md`](conventions.md)
+§1.4 *Tooling discipline*). Run `steroid_list_projects` once before
+the first symbol audit; do not re-probe. Fall back to grep with an
+explicit reference-accuracy caveat in any plan claim that depends on
+a symbol search only when mcp-steroid is unreachable. Silent grep
+misses become Phase A surprises in the revised tracks.
+
 Decision Record revisions follow this format:
 ```markdown
 #### D3: <Decision title> (revised after Track N)

--- a/.claude/workflow/step-implementation-recovery.md
+++ b/.claude/workflow/step-implementation-recovery.md
@@ -200,10 +200,31 @@ prefixes):
    touching only `_workflow/tracks/track-<N>.md`) — mark the
    boundary between completed and in-progress steps. The most
    recent episode commit is the last fully-finished step.
-3. **`Review fix:` commits** — indicate the dim-review loop already
-   ran for the step they belong to. When an orphan `Review fix:`
-   commit appears after the last episode commit, resume from
-   episode production.
+3. **`Review fix:` commits** — indicate that a review-fix
+   implementer applied changes. The same prefix is used at both
+   levels (`level=step` in Phase B and `level=track` in Phase C); the
+   discriminator is **position**:
+   - **Phase B (`level=step`) `Review fix:` commits** appear
+     interleaved with episode commits (one episode commit follows
+     each completed step's implementer + Review-fix commits). They
+     belong to the step whose implementer commit immediately
+     precedes them.
+   - **Phase C (`level=track`) `Review fix:` commits** appear
+     strictly **after the last episode commit** — Phase B is fully
+     done before Phase C runs (the `Step implementation` row in the
+     Progress section is `[x]` before any Phase C spawn). They do
+     not belong to any step; they are track-level fix commits.
+
+   When an orphan Phase B `Review fix:` commit appears after the
+   last episode commit during Phase B Resume, resume from episode
+   production. Phase B Resume **never** encounters Phase C-fix
+   `Review fix:` commits because Phase B Resume only runs while a
+   `[ ]` step exists, and Phase C cannot have started yet. Phase C
+   resume is owned by [`track-code-review.md`](track-code-review.md);
+   it reads the Progress section's iteration count, treats the
+   current HEAD as the gate-check target, and does not need to
+   classify orphan commits since the orchestrator never edits
+   source files itself.
 4. **Implementer code commits** — touch code (paths outside
    `_workflow/`); subject is the imperative summary of the step's
    change. When an orphan implementer commit appears after the
@@ -212,17 +233,23 @@ prefixes):
 5. **Other Workflow update commits** — touch only `_workflow/`
    but are not episode commits (Phase 1 init, Phase A
    decomposition, Phase B base-commit recording, plan-corrections
-   application, track-completion mark, inline-replanning update).
-   They are scaffolding and **not** orphans regardless of
-   position.
+   application, track-completion mark, inline-replanning update,
+   Phase C iteration-count Progress updates, Phase C iteration-
+   failure Progress updates with the `FAILURE` fields embedded in
+   the commit message body). They are scaffolding and **not**
+   orphans regardless of position.
 
 The step file on disk is the source of truth for which steps are
-complete (have episodes). Any implementer or `Review fix:` code
-commits beyond the last episode commit are orphans for the next
-`[ ]` step. A `Revert step:` commit cancels the implementer +
-`Review fix:` commits it reverts — together they form a
-self-contained "attempted and rolled back" group that does not count
-toward any `[x]` step's expected commits.
+complete (have episodes). During Phase B Resume specifically, any
+implementer or Phase B `Review fix:` code commits beyond the last
+episode commit are orphans for the next `[ ]` step. A `Revert step:`
+commit cancels the implementer + Phase B `Review fix:` commits it
+reverts — together they form a self-contained "attempted and rolled
+back" group that does not count toward any `[x]` step's expected
+commits. This orphan-classification rule does not extend to Phase C
+resume — Phase C-fix `Review fix:` commits are valid track-level
+fix commits, not orphans, and Phase C resume relies on the Progress
+section's iteration count rather than orphan detection.
 
 ---
 

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -189,8 +189,14 @@ the next respawn from Sonnet to Opus, and `WITH_GUIDANCE` /
 model the tag selects. Downgrades mid-Phase B are not permitted (see
 `risk-tagging.md`), so the model never demotes once a step has run.
 
+The same template is used by Phase C with `level=track` (see
+[`track-code-review.md`](track-code-review.md) §Implementer Spawns
+for the Phase C model selection — `model: "opus"` always, since
+Phase C fixes operate on the cumulative track diff and there is no
+per-step risk tag to consult).
+
 The prompt body has a **stable static prefix** followed by the
-**per-step variable inputs**. The static block goes first for
+**per-spawn variable inputs**. The static block goes first for
 predictability and to keep the variable section easy to spot in
 transcripts; whether the platform's prompt cache hits across
 sub-agent spawns depends on Claude Code's `cache_control` placement
@@ -200,10 +206,10 @@ so do not rely on caching as a load-bearing optimisation here.
 ```
 ## Workflow Context (static — same on every spawn this session)
 
-You are the **per-step implementer** in Phase B of a structured
-development workflow. You implement one step (sub-steps 1–3:
-implement, test, commit) and return a structured handoff to the
-orchestrator. Read the rulebook before starting any work:
+You are the **implementer** in a structured development workflow.
+You apply a code change (sub-steps 1–3: implement/fix, test, commit)
+and return a structured handoff to the orchestrator. Read the
+rulebook before starting any work:
 
   Rulebook: .claude/workflow/implementer-rules.md
 
@@ -219,15 +225,19 @@ plan_slim_path: /tmp/claude-code-plan-slim-{PPID}.md
 step_file_path: docs/adr/{dir-name}/_workflow/tracks/track-{N}.md
 design_path: docs/adr/{dir-name}/_workflow/design.md
 
-## Per-step variable inputs
+## Per-spawn variable inputs
+
+level: {step | track}
+base_commit: {base_commit}
+mode: {INITIAL | WITH_GUIDANCE | FIX_REVIEW_FINDINGS}
+
+# Level-conditional fields — only populated when level == step.
 
 step_index: {step_index}
 step_description: {step_description}
 risk_tag: {risk_tag}
-base_commit: {base_commit}
-mode: {INITIAL | WITH_GUIDANCE | FIX_REVIEW_FINDINGS}
 
-# Mode-conditional fields below — only populated when relevant.
+# Mode-conditional fields — only populated when relevant.
 
 Guidance: {populated only when mode == WITH_GUIDANCE}
 exploration_notes_echo: {populated only when mode == WITH_GUIDANCE}
@@ -236,13 +246,20 @@ findings: {populated only when mode == FIX_REVIEW_FINDINGS}
 ## Instructions
 
 Read the rulebook at the path above, then perform sub-steps 1–3 for
-the step at step_index. Return the structured block defined in the
-rulebook's §Return contract. Do not return free-form prose after the
-block — the orchestrator parses only the block.
+the spawn (the step at step_index when level=step; the cumulative
+track diff base_commit..HEAD when level=track). Return the
+structured block defined in the rulebook's §Return contract. Do not
+return free-form prose after the block — the orchestrator parses
+only the block.
 ```
 
 The orchestrator substitutes `{repo_root}`, `{PPID}`, `{dir-name}`,
-`{N}`, and the per-step variable values when composing each prompt.
+`{N}`, and the per-spawn variable values when composing each prompt.
+Phase B always passes `level: step` and populates `step_index`,
+`step_description`, and `risk_tag`; Phase C always passes
+`level: track` and leaves the three step-conditional fields out
+(see the validity matrix in
+[`implementer-rules.md`](implementer-rules.md) §Inputs).
 
 **Why the rulebook is referenced by path, not inlined.** Inlining the
 rulebook on every spawn would re-embed it in the orchestrator's

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -285,8 +285,8 @@ orchestrator never edits source files itself in Phase C.
          FAILED                   -> handle_iteration_failure(result)
      ```
 
-     The four handlers are spelled out in §Phase C Implementer
-     Handlers below.
+     The three normal handlers and the contract-violation path are
+     spelled out in §Phase C Implementer Handlers below.
    - On `SUCCESS`: the implementer has already pushed a `Review fix:`
      commit and run tests + Spotless + coverage gate. The orchestrator
      does **not** re-run tests or re-stage files; it proceeds to the
@@ -371,12 +371,15 @@ or body when it makes the log easier to follow.
 
 ## Phase C Implementer Handlers
 
-The implementer's structured return drives one of four
-orchestrator-side handlers. None of them roll back prior `Review fix:`
-commits — see [`implementer-rules.md`](implementer-rules.md)
-§"Mode-specific scope of the local revert" `level=track` row for the
-rationale (prior iterations' fixes have already passed their gate
-check; a failed iteration does not invalidate them).
+The implementer's structured return drives one of three
+orchestrator-side handlers (success / escalate / failure), plus a
+fourth `RISK_UPGRADE_REQUESTED` contract-violation path that aborts
+to the user rather than running a handler. None of the three
+handlers roll back prior `Review fix:` commits — see
+[`implementer-rules.md`](implementer-rules.md) §"Mode-specific scope
+of the local revert" `level=track` row for the rationale (prior
+iterations' fixes have already passed their gate check; a failed
+iteration does not invalidate them).
 
 ### `on_iteration_success(result)`
 
@@ -409,6 +412,16 @@ user instead of proceeding.
      additional direction
    - `exploration_notes_echo` set to
      `result.DESIGN_DECISION.exploration_notes`
+
+   The original `findings:` list is **intentionally not** carried
+   into the `WITH_GUIDANCE` respawn — `findings:` is populated only
+   in `mode=FIX_REVIEW_FINDINGS` per the matrix in
+   [`implementer-rules.md`](implementer-rules.md) §Inputs. The
+   user's `Guidance:` is decisive about what to do with the
+   surfaced design question; the implementer does not need the
+   raw findings list to apply the chosen alternative. If the
+   guidance leaves part of the original findings unaddressed, the
+   gate-check fan-out re-surfaces them in the next iteration.
 3. The respawn's result re-enters the dispatch above. No iteration
    count increment for the escalation respawn — the user-decided
    alternative continues the same iteration.

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -458,10 +458,15 @@ user instead of proceeding.
    "If blockers persist after 3 iterations, note them" branch).
 3. If `recommended_action: escalate`, present the situation to the
    user and consider entering ESCALATE per
-   [`inline-replanning.md`](inline-replanning.md). For `retry` /
-   `split`, both reduce to "no further automatic attempts at this
+   [`inline-replanning.md`](inline-replanning.md). For `retry`, the
+   recommendation reduces to "no further automatic attempts at this
    set of findings"; the user decides whether to re-spawn with
    guidance or accept the unfixed state at track completion.
+   `recommended_action: split` is **forbidden at `level=track`** per
+   [`implementer-rules.md`](implementer-rules.md) §Fundamental
+   failure — if surfaced, treat as a contract violation: present the
+   return block verbatim to the user (do not respawn) alongside the
+   same options ESCALATE / accept-as-unfixed.
 
 ### `RISK_UPGRADE_REQUESTED` (contract violation)
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -1,9 +1,33 @@
 # Track Execution — Phase C: Code Review + Track Completion
 
+Phase C is a **two-actor phase**, mirroring Phase B's split:
+
+- The **orchestrator** (this document) drives the per-iteration loop:
+  spawn the review fan-out sub-agents, synthesise findings, classify
+  in-scope vs deferred, spawn the per-iteration **implementer** to
+  apply in-scope fixes, dispatch on its return, run the gate-check
+  fan-out, manage iteration counts, run the context check, apply
+  plan corrections, compile the track episode, present results to
+  the user, mark the track `[x]` upon approval.
+- The **implementer** (a fresh sub-agent spawned per iteration that
+  has fixes to apply, see [`implementer-rules.md`](implementer-rules.md))
+  performs sub-steps 1–3 of fix application — read the cumulative
+  track diff and the synthesised findings, apply the fixes, run
+  tests + Spotless + the coverage gate, stage and commit a
+  `Review fix:` commit. The implementer's output is the same
+  structured handoff used at `level=step`, with `level=track`
+  selecting the variant defined in
+  [`implementer-rules.md`](implementer-rules.md) §Inputs and
+  §Return contract.
+
 After all steps are committed, review the full track diff using sub-agents.
 These are deliberately sub-agents — fresh eyes catch systematic issues that
 the main agent, having read every step episode and skimmed the cumulative
-diff, can normalise away.
+diff, can normalise away. Delegating fix application to a per-iteration
+implementer keeps the cumulative review sub-agent fan-out, source-file
+reads, Spotless and Maven traffic out of the orchestrator's tool-call
+history — exactly the rationale that justified the Phase B split (PR
+#1021); the same shape applies here.
 
 ## Tooling — PSI for cross-step reference accuracy
 
@@ -233,28 +257,53 @@ Present the synthesized findings list to proceed to the review loop.
 
 ## Review loop
 
-Iterate on the synthesized findings:
+Iterate on the synthesized findings. Each iteration that has fixes to
+apply spawns a **fresh per-iteration implementer** (`level=track`,
+`mode=FIX_REVIEW_FINDINGS`) per §Implementer Spawns below; the
+orchestrator never edits source files itself in Phase C.
 
-1. If any findings need fixes:
-   - Apply fixes as **additional commits** (never amend prior commits).
-     The Ephemeral identifier rule (full rule in
-     [`ephemeral-identifier-rule.md`](ephemeral-identifier-rule.md);
-     stub recap in `conventions-execution.md` §2.3) applies to
-     durable content — no `Track N`, `Step N`, finding IDs, or
-     review iteration counters in source code, tests, or code
-     comments. Branch-only commit messages are exempt and may
-     cite finding IDs when it makes the log easier to follow (per
-     [`commit-conventions.md`](commit-conventions.md) "Branch-only
-     commit messages may cite workflow-internal identifiers").
-     Push each commit immediately per the per-commit push rule.
-   - Run tests to verify fixes don't break anything
+1. **Classify findings.** From the synthesised list, separate
+   in-scope findings (to apply now) from deferred findings (to push
+   to other tracks via plan corrections — see §Plan Corrections from
+   Deferred Findings below). The implementer receives only the
+   in-scope subset.
+2. **If any in-scope findings need fixes:**
+   - **Spawn the per-iteration implementer** with `level=track`,
+     `mode=FIX_REVIEW_FINDINGS`, `base_commit` (read from the step
+     file's `## Base commit`), and the iteration's in-scope findings
+     as `findings`. Use the prompt template in
+     [`step-implementation.md`](step-implementation.md) §Implementer
+     Prompt Template — the same template both phases share. See
+     §Implementer Spawns below for the per-iteration variable inputs.
+   - **Dispatch on the structured return:**
+
+     ```
+     match result.RESULT:
+         SUCCESS                  -> on_iteration_success(result)
+         DESIGN_DECISION_NEEDED   -> escalate_to_user_then_respawn(result)
+         RISK_UPGRADE_REQUESTED   -> contract violation — surface to user
+         FAILED                   -> handle_iteration_failure(result)
+     ```
+
+     The four handlers are spelled out in §Phase C Implementer
+     Handlers below.
+   - On `SUCCESS`: the implementer has already pushed a `Review fix:`
+     commit and run tests + Spotless + coverage gate. The orchestrator
+     does **not** re-run tests or re-stage files; it proceeds to the
+     gate check.
    - **Update the Progress section** on disk to record the completed
      iteration (e.g., `- [ ] Track-level code review (1/3 iterations)`).
+     Commit and push the Progress update as a Workflow update commit
+     (per [`commit-conventions.md`](commit-conventions.md) § Commit
+     type prefixes — "Workflow update" row).
    - Spawn **fresh sub-agents** to verify (gate check) — only re-run the
      review dimension(s) that had open findings. For example, if only
      crash-safety code findings and test-completeness findings remain,
      spawn only `review-crash-safety` and `review-test-completeness`.
      If findings span all dimensions, re-run all originally selected agents.
+     The gate-check sub-agents review the new HEAD (after the
+     `Review fix:` commit), which they reach via the same
+     `git diff {base_commit}..HEAD` instruction.
    - **Context consumption check** (mandatory after each iteration,
      except the last): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
@@ -265,14 +314,152 @@ Iterate on the synthesized findings:
      `safe`/`info`, continue to the next iteration. If the file does
      not exist or the command fails, this is **not an error** — treat
      as `safe` and continue.
-2. Max 3 iterations **total across sessions** — on resume, read the
+3. Max 3 iterations **total across sessions** — on resume, read the
    iteration count from the Progress section to determine how many remain.
    The iteration count is shared across all review dimensions (not
    independent counters).
-3. If blockers persist after 3 iterations, note them — they'll be presented
-   to the user during track completion (below).
-4. When all reviews pass (or max iterations reached), mark
+4. If blockers persist after 3 iterations, or if any iteration ended
+   in a non-`SUCCESS` return that exited the loop, note the unfixed
+   findings — they'll be presented to the user during track completion
+   (below).
+5. When all reviews pass (or max iterations reached), mark
    `Track-level code review` as `[x]` in the step file's Progress section.
+
+---
+
+## Implementer Spawns
+
+Each Phase C implementer spawn uses `subagent_type: "general-purpose"`
+and `model: "opus"`. (Track-level fix application operates on the
+cumulative track diff and may surface cross-step interactions; the
+risk tag, which would otherwise gate the model choice in Phase B, is
+locked per-step at end-of-Phase-B and does not inform the
+track-level model. Always spawn Opus.)
+
+Use the **shared Implementer Prompt Template** in
+[`step-implementation.md`](step-implementation.md) §Implementer Prompt
+Template — the static prefix is identical across both levels. Phase C
+populates the variable section as follows:
+
+| Field | Value |
+|---|---|
+| `level` | `track` |
+| `base_commit` | SHA from the step file's `## Base commit` section. |
+| `mode` | `FIX_REVIEW_FINDINGS` (or `WITH_GUIDANCE` after a design-decision escalation per §Phase C Implementer Handlers below). |
+| `step_index` / `step_description` / `risk_tag` | **Omit** — the level-conditional fields are not populated at `level=track`. |
+| `findings` | The iteration's in-scope synthesised findings (only when `mode=FIX_REVIEW_FINDINGS`). |
+| `Guidance` / `exploration_notes_echo` | The user's chosen alternative + the prior `exploration_notes` (only when `mode=WITH_GUIDANCE`). |
+
+The implementer's contract — what it reads, what it commits, when it
+must early-return, and what fields its return block carries — is the
+same rulebook used at `level=step`. The contract differences for
+track-level work (cumulative diff target, no `RISK_UPGRADE_REQUESTED`,
+`FIX_NOTES` instead of `EPISODE_DRAFT`, no orchestrator-side
+rollback on `FAILED`) are documented inline in
+[`implementer-rules.md`](implementer-rules.md). The orchestrator does
+not need to load that file; the implementer reads it on every spawn.
+
+Each implementer's `Review fix:` commit is pushed by the implementer
+itself (per the per-commit push rule in
+[`commit-conventions.md`](commit-conventions.md) § Push every commit).
+The Ephemeral identifier rule applies to durable content (source code,
+tests, comments) but not to branch-only commit messages — the
+implementer may cite finding IDs in its `Review fix:` commit subject
+or body when it makes the log easier to follow.
+
+---
+
+## Phase C Implementer Handlers
+
+The implementer's structured return drives one of four
+orchestrator-side handlers. None of them roll back prior `Review fix:`
+commits — see [`implementer-rules.md`](implementer-rules.md)
+§"Mode-specific scope of the local revert" `level=track` row for the
+rationale (prior iterations' fixes have already passed their gate
+check; a failed iteration does not invalidate them).
+
+### `on_iteration_success(result)`
+
+The implementer's `Review fix:` commit is on disk and pushed;
+`result.COMMIT` is its SHA. `result.FIX_NOTES` carries the
+implementer's per-iteration notes (which findings were addressed,
+which were skipped, what was discovered). Stash `FIX_NOTES` and
+`CROSS_TRACK_HINTS` for inclusion in the eventual track episode (see
+§Track Completion below). Proceed to the Progress update + gate-check
+fan-out per the review loop above.
+
+### `escalate_to_user_then_respawn(result)`
+
+Triggered when `result.RESULT == DESIGN_DECISION_NEEDED`. The
+implementer has run the snapshot-and-diff revert sequence per
+[`implementer-rules.md`](implementer-rules.md) §Detection rules, so
+the working tree is clean at HEAD (no commit was produced).
+`result.DESIGN_DECISION` is populated.
+
+Verify `git status` is clean before continuing — a dirty tree at
+this point is a contract violation; surface the discrepancy to the
+user instead of proceeding.
+
+1. Present `result.DESIGN_DECISION` to the user via
+   [`design-decision-escalation.md`](design-decision-escalation.md).
+2. On user response, respawn the implementer with:
+   - `level=track`
+   - `mode=WITH_GUIDANCE`
+   - `Guidance:` set to the user's chosen alternative + any
+     additional direction
+   - `exploration_notes_echo` set to
+     `result.DESIGN_DECISION.exploration_notes`
+3. The respawn's result re-enters the dispatch above. No iteration
+   count increment for the escalation respawn — the user-decided
+   alternative continues the same iteration.
+
+### `handle_iteration_failure(result)`
+
+Triggered when `result.RESULT == FAILED`. The implementer has run
+the snapshot-and-diff revert sequence per
+[`implementer-rules.md`](implementer-rules.md) §Detection rules, so
+the working tree is clean at HEAD; no `Review fix:` commit was
+produced this iteration. `result.FAILURE` carries
+`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`
+(at `level=track` this is "impact on remaining findings"), and
+`recommended_action`.
+
+Verify `git status` is clean before continuing — a dirty tree at
+this point is a contract violation; surface the discrepancy to the
+user instead of proceeding.
+
+1. **Record the failure** — update the step file's Progress section
+   to mark the track-level code review entry with the failure (e.g.,
+   `- [ ] Track-level code review (FAILED at iteration N/3)`) and
+   commit the Progress update as a Workflow update commit. Embed the
+   `FAILURE` fields (`what_was_attempted`, `why_it_failed`,
+   `impact_on_remaining_findings`, `recommended_action`) verbatim in
+   the commit message body so the git history preserves the failure
+   context for the draft PR — review findings are not persisted to a
+   separate file (per [`track-review.md`](track-review.md) §Phase A,
+   the durable trace is step-file edits plus the workflow-update
+   commit).
+2. **Exit the iteration loop.** Do not respawn the implementer for
+   the same findings. The remaining findings are now "unfixed" and
+   are presented to the user during track completion (the existing
+   "If blockers persist after 3 iterations, note them" branch).
+3. If `recommended_action: escalate`, present the situation to the
+   user and consider entering ESCALATE per
+   [`inline-replanning.md`](inline-replanning.md). For `retry` /
+   `split`, both reduce to "no further automatic attempts at this
+   set of findings"; the user decides whether to re-spawn with
+   guidance or accept the unfixed state at track completion.
+
+### `RISK_UPGRADE_REQUESTED` (contract violation)
+
+`RESULT: RISK_UPGRADE_REQUESTED` is **forbidden at `level=track`**
+per [`implementer-rules.md`](implementer-rules.md) §"Risk upgrade
+required (level=step only)". If a Phase C implementer returns this
+value, treat it as a contract violation: surface the return block
+verbatim to the user, do not respawn automatically, and let the
+user decide whether to enter ESCALATE
+([`inline-replanning.md`](inline-replanning.md)) or to proceed to
+track completion with the iteration's findings unfixed.
 
 ---
 
@@ -324,11 +511,19 @@ If no findings were deferred, skip this section.
 After the review loop completes and any plan corrections are committed,
 proceed directly to track completion **in the same session**.
 
-1. **Compile the track episode** from all step episodes in the step file.
-   The track episode is a strategic summary — what was built, key
-   discoveries, plan deviations with cross-track impact. If findings were
-   deferred to other tracks, mention the plan corrections and which
-   tracks were affected.
+1. **Compile the track episode** from all step episodes in the step
+   file plus any per-iteration `FIX_NOTES` and `CROSS_TRACK_HINTS`
+   stashed by the review loop's `on_iteration_success` handler. The
+   track episode is a strategic summary — what was built, key
+   discoveries (including any surfaced during the review-fix
+   iterations), plan deviations with cross-track impact, and which
+   review-fix iterations applied non-trivial changes (cite the
+   `Review fix:` commit subjects when they aid the strategic
+   narrative; do not embed finding IDs in the durable text per the
+   Ephemeral identifier rule). If findings were deferred to other
+   tracks, mention the plan corrections and which tracks were
+   affected. If any iteration ended in a non-`SUCCESS` return, name
+   the unfixed findings and why they were not addressed.
 
 2. **Present track results to the user** (do NOT write to plan file yet):
    - Track episode (compiled but not yet persisted)
@@ -344,10 +539,18 @@ proceed directly to track completion **in the same session**.
 
 3. **Wait for user response:**
    - **Approved** — proceed to step 4.
-   - **Fixes needed** — apply the user's specific fixes as additional
-     commits. Re-run track-level code review if fixes are substantial.
-     Re-compile the track episode if fixes changed outcomes.
-     Present updated results and wait again.
+   - **Fixes needed** — package the user's specific fixes as a
+     synthesised findings list (each item: location, issue, proposed
+     fix) and **spawn a fresh implementer** with `level=track`,
+     `mode=FIX_REVIEW_FINDINGS`, and the user-provided findings.
+     Use the same prompt template, validity matrix, and handler
+     dispatch as §Implementer Spawns and §Phase C Implementer
+     Handlers above. The implementer's `Review fix:` commit lands
+     on top of HEAD; the orchestrator does not touch source files
+     itself. Re-run track-level code review if the user's fixes are
+     substantial enough that a gate-check run alone won't catch
+     potential regressions. Re-compile the track episode if fixes
+     changed outcomes. Present updated results and wait again.
    - **Fundamental rework** — trigger ESCALATE (see workflow.md
      §Inline Replanning).
 

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -7,9 +7,22 @@ that reads the plan, determines where execution left off, and either performs
 a strategy refresh or begins/resumes track execution.
 
 There are no agent teams or sub-teams. You execute tracks directly. Sub-agents
-are used only for self-contained review tasks (technical/risk/adversarial
-reviews, code review, track-level code review) where fresh perspective or
-parallel execution is valuable.
+are used for two distinct purposes:
+
+1. **Self-contained review tasks** (technical/risk/adversarial
+   reviews, step-level dim review, track-level code review) where
+   fresh perspective or parallel execution is valuable.
+2. **Code-touching implementation work** delegated to the
+   **implementer** sub-agent. The implementer runs at two levels:
+   `level=step` for Phase B per-step implementation
+   (`step-implementation.md`) and `level=track` for Phase C
+   per-iteration review-fix application
+   (`track-code-review.md`). Both share the same rulebook
+   ([`implementer-rules.md`](implementer-rules.md)) and prompt
+   template; the level switch is a single variable input. The
+   orchestrator never edits source files itself in either Phase B
+   or Phase C — Maven, Spotless, source-file reads, and IDE traffic
+   are absorbed by the implementer's context.
 
 ### Terminology: Phases 0/1/2/3/4 vs Phases A/B/C
 


### PR DESCRIPTION
## Motivation

Phase C track-level review fixes were the one major remaining orchestrator-applied code-edit site after the Phase B split (PR #1021). The same arguments apply: each iteration's fix application reads source, runs Spotless, runs Maven tests, and with up to 3 iterations per track the Maven/IDE/source-read traffic dominates the Phase C orchestrator's tool-call history. The expected effect is a similar context-consumption reduction in Phase C as #1021 delivered for Phase B.

This change extends the implementer rulebook with a single new variable input — `level: step | track` — instead of authoring a parallel rulebook. Phase B keeps `level=step` verbatim; Phase C now spawns a fresh per-iteration implementer at `level=track, mode=FIX_REVIEW_FINDINGS` for both review-loop fixes and user-requested fixes during track completion. The orchestrator no longer edits source files in Phase C; Maven, Spotless, source reads, PSI audits, and cumulative-diff inspection are absorbed by the implementer's context.

### Contract differences from `level=step`

Documented inline in `implementer-rules.md` rather than split into a parallel rulebook (the rest of the rulebook — PSI/grep, IDE refactor vs Edit, Maven routing, foreground-only Maven, snapshot-and-diff revert, coverage gate, ephemeral identifier rule — is fungible across both levels):

- **Diff target.** At `level=track` the implementer reads `base_commit..HEAD` (the cumulative track diff) instead of the prior step's commit. `step_index`, `step_description`, and `risk_tag` are step-conditional and unset at `level=track`.
- **No `RISK_UPGRADE_REQUESTED`.** Risk tags are locked at end-of-Phase-B; there is no per-step tag to upgrade at Phase C. The return is forbidden at `level=track` and treated as a contract violation if it ever surfaces. If a Phase C fix genuinely demands re-running an earlier step under heavier review, the implementer returns `FAILED` with `recommended_action: escalate` and the orchestrator triggers inline replanning.
- **No orchestrator-side rollback on `FAILED`.** Phase B's post-commit rollback (`git revert -n` + `Revert step:` commit) exists because each step is one commit and a failed fix-respawn invalidates the step's premise. Phase C iterations are independent — prior iterations' `Review fix:` commits already passed their gate check and remain valid. A failed iteration exits the loop with the unfixed findings surfaced to the user at track completion.

### Return contract

The return contract gains a thinner `FIX_NOTES` field at `level=track` (parallel to `EPISODE_DRAFT` at `level=step`) so the Phase C orchestrator can fold per-iteration notes — which findings were addressed, which were skipped, what was discovered — into the eventual track episode. `CROSS_TRACK_HINTS` stays at both levels.

### Resume / commit-pattern impact

The same `Review fix:` prefix is used at both levels; the discriminator is **position**:

- Phase B `Review fix:` commits appear interleaved with episode commits (one episode commit follows each completed step's implementer + Review-fix commits).
- Phase C `Review fix:` commits appear strictly **after the last episode commit** — Phase B is fully done before Phase C runs (the `Step implementation` row in the Progress section is `[x]` before any Phase C spawn).

Phase B Resume already operates only while a `[ ]` step exists (i.e., before Phase C can have started), so it never encounters Phase C-fix `Review fix:` commits. The commit-pattern reference in `step-implementation-recovery.md` gains a clarifying note for readers; no new resume slug or commit prefix is needed. Phase C resume relies on the Progress section's iteration count rather than orphan detection.

### Sites NOT delegated, deliberately

- **Phase A pre-execution review fixes** — workflow-file edits only (step decomposition, risk tags). No Maven/IDE/source-read traffic.
- **Phase 2 consistency / structural review fixes** — plan / backlog / design via `edit-design`.
- **Inline replanning revisions** — same.
- **Plan corrections from deferred Phase C findings** — workflow-file edits to plan and backlog.

These sites have nothing to absorb; the implementer's value proposition (context absorption + fresh eyes for code) does not apply.

## Summary of file changes

- `implementer-rules.md` — add `level: step | track` input; describe the three Phase C contract deltas inline; add `FIX_NOTES` to the return contract; mode/level validity matrix; clarify the snapshot-and-diff revert's per-level scope.
- `step-implementation.md` §Implementer Prompt Template — variable section now starts with `level`; step-conditional fields documented as such; cross-link to Phase C model selection.
- `track-code-review.md` — replace the inline "Apply fixes as additional commits" with a per-iteration implementer spawn (`level=track, mode=FIX_REVIEW_FINDINGS`); new §Implementer Spawns and §Phase C Implementer Handlers sections; Track Completion's "Fixes needed" branch routes through the same delegation; track episode now folds in per-iteration `FIX_NOTES` and `CROSS_TRACK_HINTS`.
- `step-implementation-recovery.md` §Resume-side commit-pattern reference — clarify the `Review fix:` position discriminator; scope the orphan-classification rule to Phase B Resume; explicitly note Phase C-fix `Review fix:` commits are not orphans.
- `commit-conventions.md` — update the Review fix table row with the position discriminator; clarify Phase C never produces `Revert step:` commits.
- `code-review-protocol.md` — one sentence noting fixes are delegated at both levels.
- `workflow.md` Overview — implementer described at both levels; orchestrator never edits source files in either Phase B or Phase C.

## Test plan

- [ ] Workflow-doc-only change — no source-code or test-suite impact; CI test gate not load-bearing here
- [ ] Reviewer confirms cross-references resolve (`level=track` mentions, `FIX_NOTES` mentions, "shared Implementer Prompt Template" reference from `track-code-review.md`)
- [ ] Reviewer confirms the validity matrix in `implementer-rules.md` §Inputs is consistent with the dispatch in `track-code-review.md` §Phase C Implementer Handlers
- [ ] Reviewer confirms the Phase C handler set (`on_iteration_success`, `escalate_to_user_then_respawn`, `handle_iteration_failure`, `RISK_UPGRADE_REQUESTED` contract violation) is internally consistent with the no-rollback rule in `implementer-rules.md` §"Mode-specific scope of the local revert"
- [ ] Reviewer confirms the on-demand-load split is preserved: a Phase C session does not need to load `step-implementation-recovery.md` (Phase B Resume) just to spawn track-level implementers
- [ ] First real Phase C run on a future feature branch validates the orchestrator/implementer hand-off end-to-end at `level=track`