### PR TITLE
Make plan review the autonomous first phase of /execute-tracks

### DIFF
--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -184,6 +184,9 @@ shape, lifecycle).
   > **Scope:** ~N steps covering A, B
   > **Depends on:** Track 1
 
+## Plan Review
+- [ ] Plan review (consistency + structural) — autonomous; runs as the first phase of `/execute-tracks`
+
 ## Final Artifacts
 - [ ] Phase 4: Final artifacts (`design-final.md`, `adr.md`)
 ```
@@ -295,5 +298,8 @@ rest of the workflow carry no CI cost. The user manually flips the
 PR from draft to "ready for review" at the end of Phase 4 — Claude
 never runs `gh pr ready` automatically.
 
-When I'm satisfied, I'll run `/review-plan` to review the plan, then
-`/execute-tracks` to execute track by track.
+When I'm satisfied, I'll run `/execute-tracks` to start track execution.
+The autonomous plan review (Phase 2 — consistency + structural) runs as
+its first phase and ends the session before track work begins. I can
+also run `/review-plan` manually at any time to re-validate the plan
+(useful after inline replanning produces a revised plan).

--- a/.claude/skills/execute-tracks/SKILL.md
+++ b/.claude/skills/execute-tracks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execute-tracks
-description: "Execute implementation plan tracks phase by phase (review, implement, code review). Use after /create-plan and /review-plan to implement the planned work."
+description: "Execute the implementation plan: autonomous plan review (Phase 2) on first invocation, then track-by-track execution (Phase A review + decomposition, Phase B implementation, Phase C code review). Use after /create-plan to implement the planned work."
 argument-hint: "[plan-directory-name]"
 user-invocable: true
 ---
@@ -19,6 +19,7 @@ Read these workflow documents in order before starting:
    (ESCALATE), track completion protocol
 
 After determining which phase to execute, load the phase-specific document:
+- State 0 (autonomous plan review): `.claude/workflow/implementation-review.md`
 - Phase A: `.claude/workflow/track-review.md`
 - Phase B: `.claude/workflow/step-implementation.md`
 - Phase C: `.claude/workflow/track-code-review.md`
@@ -29,6 +30,8 @@ Do NOT load phase documents you won't use this session. Prompt files
 (in `.claude/workflow/prompts/`) are read only when spawning the specific
 sub-agent that needs them — `create-final-design.md` is the one exception
 because Phase 4 is main-agent work rather than a sub-agent spawn.
+`implementation-review.md` is loaded only when State 0 fires; non-
+State-0 sessions never read it.
 
 On-demand reference documents (load only when the situation arises):
 - `strategy-refresh.md` — load when entering State A (strategy refresh)
@@ -57,6 +60,10 @@ Follow the startup protocol in `workflow.md`:
 2. Identify all tracks and their status (`[ ]` not started, `[x]` completed,
    `[~]` skipped).
 3. Determine session state and auto-resume:
+   - **State 0** (`## Plan Review` is `[ ]` or section missing): load
+     `implementation-review.md` on-demand and run the autonomous plan
+     review (consistency + structural). End session after the audit
+     summary lands.
    - **State A** (track just completed, needs strategy refresh): perform
      strategy refresh, then proceed to Phase A of the next track.
    - **State B** (fresh start): identify first uncompleted track, begin
@@ -74,13 +81,17 @@ Follow the startup protocol in `workflow.md`:
      `adr.md`. Mark the Phase 4 checklist entry `[>]` when starting and
      `[x]` when the commit lands. See workflow.md §Startup Protocol for
      the `[ ]` / `[>]` resume-action table.
+
+   State 0 is checked **before** State A/B/C — plan review must
+   complete before any track-level work begins.
 4. Inform the user of the auto-resume decision. The user can override, but
    by default proceed without waiting for confirmation.
 5. Load the phase-specific workflow document and execute that phase only.
 6. After the phase completes, end the session. Instruct the user to clear
    context and re-run `/execute-tracks` for the next phase.
 
-Each session handles exactly ONE PHASE of one track (or Phase 4):
+Each session handles exactly ONE PHASE of one track (or Phase 4 / State 0):
+- State 0 (autonomous plan review) → end session after `## Plan Review` is `[x]`
 - Phase A → end session
 - Phase B → end session (or mid-phase checkpoint if 5+ steps done)
 - Phase C → end session
@@ -89,6 +100,7 @@ Each session handles exactly ONE PHASE of one track (or Phase 4):
 
 User interaction happens at specific points:
 - Session start: auto-resume decision (confirm or override)
+- State 0 design-decision findings: resolve each escalated finding (only design-decision; mechanical fixes apply autonomously)
 - Strategy refresh: accept recommendation or override
 - Phase complete: user clears session, re-runs `/execute-tracks`
 - Cross-track impact detected: continue, pause, or escalate

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -51,10 +51,11 @@ to verify pending-track descriptions; pass its absolute path as the
 
 1. Run the clean-tree precondition from
    [`implementation-review.md`](../../workflow/implementation-review.md)
-   § How to run > Precondition — path-scoped to the three workflow
-   files (plan, backlog, design). Halt and ask the user to commit or
-   stash if any of the three are dirty. Other dirty paths in the
-   working tree are safe to ignore.
+   § How to run > Precondition — path-scoped to the workflow files
+   the audit-trail commit will touch (plan, backlog, design,
+   design-mechanics, design-mutations). Halt and ask the user to
+   commit or stash if any of those are dirty. Other dirty paths in
+   the working tree are safe to ignore.
 2. Load `.claude/workflow/implementation-review.md` and follow its
    §"Step 1: Consistency Review" → §"Step 2: Structural Review" → §
    "Completion" sections in order. The orchestration is identical to

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -49,10 +49,12 @@ to verify pending-track descriptions; pass its absolute path as the
 
 ## What this skill does
 
-1. Confirm via `git status --porcelain` that the working tree is clean
-   (the autonomous flow commits the resulting plan/backlog/design
-   updates as a single workflow-update commit; a dirty tree confuses
-   the audit-trail commit).
+1. Run the clean-tree precondition from
+   [`implementation-review.md`](../../workflow/implementation-review.md)
+   § How to run > Precondition — path-scoped to the three workflow
+   files (plan, backlog, design). Halt and ask the user to commit or
+   stash if any of the three are dirty. Other dirty paths in the
+   working tree are safe to ignore.
 2. Load `.claude/workflow/implementation-review.md` and follow its
    §"Step 1: Consistency Review" → §"Step 2: Structural Review" → §
    "Completion" sections in order. The orchestration is identical to

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -1,35 +1,42 @@
 ---
 name: review-plan
-description: "Review an implementation plan for consistency and structural quality before execution. Use after /create-plan and before /execute-tracks."
+description: "Manually re-run the autonomous plan review (Phase 2 — consistency + structural). The same review runs automatically as the first phase of /execute-tracks; this command is for re-runs after inline replanning or whenever the plan needs explicit re-validation."
 argument-hint: "[plan-directory-name]"
 user-invocable: true
 ---
 
 Read and follow the workflow for Phase 2 (Implementation Review).
 
+> **Manual override.** Phase 2 normally runs autonomously as the first
+> phase of `/execute-tracks` when the startup protocol detects State 0
+> (`## Plan Review` is `[ ]`). This skill is a manual entry point for
+> re-running the same review — useful after inline replanning has
+> produced a revised plan, or when you want to explicitly re-validate
+> the plan against current code without going through `/execute-tracks`.
+
 Read these workflow documents in order before starting:
-1. `.claude/workflow/conventions.md` — shared formats,
-   glossary, plan file structure, scope indicators, review iteration protocol
+1. `.claude/workflow/conventions.md` — shared formats, glossary, plan
+   file structure, scope indicators, review iteration protocol
 2. `.claude/workflow/implementation-review.md` — Phase 2 orchestration:
-   two-step review (consistency review then automatic structural review)
+   autonomous classifier flow (mechanical findings auto-fixed,
+   design-decision findings escalated to user), audit trail, mutation
+   discipline for `design.md` fixes
 
 You are the Implementation Review Orchestrator. Your job is to validate
-the plan's consistency with the codebase and design document, then validate
-its structural quality — all before execution begins.
+the plan's consistency with the codebase and design document, then
+validate its structural quality — applying mechanical fixes
+autonomously and escalating only design-level decisions to the user.
+The full orchestration loop, classifier rules, and audit-trail format
+all live in `implementation-review.md`; this skill exists only to
+provide a manual entry point.
 
-Plan directory name: if "$ARGUMENTS" is non-empty, use it as the directory
-name. Otherwise, default to the current git branch name
+Plan directory name: if "$ARGUMENTS" is non-empty, use it as the
+directory name. Otherwise, default to the current git branch name
 (`git branch --show-current`).
 
-Plan file: docs/adr/<dir-name>/_workflow/implementation-plan.md
-Backlog file: docs/adr/<dir-name>/_workflow/implementation-backlog.md
-Design document: docs/adr/<dir-name>/_workflow/design.md
-
-Phase 2 reviews are not persisted to disk. Findings ride in the
-conversation context during the iteration loop, accepted fixes are
-applied to the plan/backlog/design document via `Edit`, and the
-durable trace is the resulting plan/design state plus the workflow-update
-commit that lands once the gates pass.
+Plan file: `docs/adr/<dir-name>/_workflow/implementation-plan.md`
+Backlog file: `docs/adr/<dir-name>/_workflow/implementation-backlog.md`
+Design document: `docs/adr/<dir-name>/_workflow/design.md`
 
 The backlog file holds pending-track
 `**What/How/Constraints/Interactions**` detail and any track-level
@@ -40,90 +47,27 @@ to verify pending-track descriptions; pass its absolute path as the
 
 ---
 
-## Step 1: Consistency Review (interactive)
+## What this skill does
 
-1. Read the plan file, the backlog file, the design document, and the
-   workflow documents. Also consult `planning.md` §Architecture Notes
-   format and `design-document-rules.md` for the rules the review
-   validates against.
-2. Spawn the consistency review sub-agent with the prompt from
-   `.claude/workflow/prompts/consistency-review.md`. Pass the plan file,
-   backlog file, and design document path as the prompt's named inputs.
-   The sub-agent reads the codebase directly via Grep/Glob/Read (cwd is
-   the repo root), so no separate codebase path input is required.
-3. Receive the findings report.
-4. Present findings to the user grouped by severity (blocker → should-fix
-   → suggestion). For each finding, show:
-   - The issue and evidence from the code
-   - The proposed fix
-   - Your recommendation (accept/modify/reject) with reasoning
-5. Wait for the user's decision on each finding.
-6. Apply accepted fixes to the plan file and/or design document.
-7. Spawn the consistency gate verification sub-agent with:
-   - The updated plan file
-   - The backlog file
-   - The updated design document
-   - Previous findings (context only, finalized in earlier iterations) —
-     passed as the `previous_findings` argument
-   - Findings under re-check (verify these) — passed as the `findings`
-     argument
-   - Instructions to verify fixes and flag regressions
-8. If the gate finds new blockers, present them and loop (max 3 iterations).
-   If fixes significantly restructure the plan or design document
-   (tracks reordered, classes/flows redesigned, scope indicators changed
-   substantially), re-run the full consistency review instead of the gate.
-9. When the gate is clean, summarise the consistency-review outcome in
-   the conversation (findings count, accepted/rejected, gate verdict)
-   and proceed to Step 2.
+1. Confirm via `git status --porcelain` that the working tree is clean
+   (the autonomous flow commits the resulting plan/backlog/design
+   updates as a single workflow-update commit; a dirty tree confuses
+   the audit-trail commit).
+2. Load `.claude/workflow/implementation-review.md` and follow its
+   §"Step 1: Consistency Review" → §"Step 2: Structural Review" → §
+   "Completion" sections in order. The orchestration is identical to
+   the autonomous State 0 path inside `/execute-tracks`.
+3. Apply mechanical fixes via `Edit` (plan/backlog) or the
+   `edit-design` skill (design.md — mutation discipline).
+4. Batch-escalate any `design-decision` findings to the user once per
+   step. Apply user-resolved fixes the same way.
+5. After both reviews pass, overwrite the plan file's `## Plan Review`
+   section with the audit summary (`[x]` + auto-fixed/escalated
+   listings) per `implementation-review.md` § Audit trail.
+6. Commit the plan/backlog/design updates with the message
+   `Plan review autonomous fixes for <plan-name>` and push.
+7. End the session.
 
-Finding IDs are cumulative across iterations (CR1, CR2, ... CR6, CR7).
-
----
-
-## Step 2: Structural Review (automatic)
-
-After consistency review passes, proceed **automatically** to structural
-review without waiting for user confirmation.
-
-10. Spawn the structural review sub-agent with the prompt from
-    `.claude/workflow/prompts/structural-review.md`. Pass:
-    - The plan file
-    - The backlog file
-    - The design document path
-    - The workflow directory path
-11. Receive the findings report.
-12. **If no blockers**: summarise the structural-review outcome in the
-    conversation (no findings) and proceed to completion.
-13. **If blockers found**: present findings to the user grouped by severity.
-    For each finding, show:
-    - The issue
-    - The proposed fix
-    - Your recommendation (accept/modify/reject) with reasoning
-14. Wait for the user's decision on each finding.
-15. Apply accepted fixes.
-16. Spawn the structural gate verification sub-agent with:
-    - The updated plan file
-    - The backlog file
-    - The design document
-    - Previous findings (context only, finalized in earlier iterations) —
-      passed as the `previous_findings` argument
-    - Findings under re-check (verify these) — passed as the `findings`
-      argument
-17. If the gate finds new blockers, present them and loop (max 3 iterations).
-    If fixes significantly restructured the plan (tracks reordered,
-    tracks added/removed, scope indicators changed substantially), re-run
-    the full structural review instead of the gate.
-18. When the gate is clean, summarise the structural-review outcome
-    in the conversation (findings count, accepted/rejected, gate verdict).
-
-Finding IDs are cumulative across iterations (S1, S2, ... S6, S7).
-
----
-
-## Completion
-
-When both reviews pass:
-19. Summarize all changes made to the plan and design document.
-20. Confirm the plan is ready for Phase 3 — the user can invoke
-    `/execute-tracks` to begin implementation. Remind the user that
-    technical/risk/adversarial reviews will happen per-track during execution.
+The behavior is identical to the autonomous State 0 path — both share
+the same orchestration in `implementation-review.md`. The only thing
+this skill adds is the entry point.

--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -163,7 +163,7 @@ paragraph + `**Skipped:**` + `**Strategy refresh:**`; never collapsed).
 | Phase | Authoritative location | Writer | Reader(s) |
 |---|---|---|---|
 | Pre-Phase-1 | (none) | — | — |
-| Phase 1 write | `implementation-backlog.md` | Phase 1 agent (via `create-plan/SKILL.md`) | Phase 2 consistency + structural reviews |
+| Phase 1 write | `implementation-backlog.md` | Phase 1 agent (via `create-plan/SKILL.md`) | Phase 2 autonomous plan review (consistency + structural sub-agents) |
 | Phase A start — before step-file write | `implementation-backlog.md` | (inherited from Phase 1) | Phase A orchestration (reads the track's backlog section) |
 | Phase A mid — step file has `## Description`, backlog entry still present | **step file** (Phase A writes the step file first, then removes the backlog entry — the step file takes authority the moment it is written, so an interrupted session always resumes against a single source) | Phase A orchestration (wrote the step file) | Phase A resume logic (idempotent re-entry); Phase A review sub-agents |
 | Phase A end | step file | Phase A orchestration (backlog section already removed) | Phase A review sub-agents (Track 3 prompts) |

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -122,9 +122,24 @@ durable artifacts survive the squash-merge into `develop`. See
   > **Scope:** ~N steps covering X, Y, Z
   > **Depends on:** Track 1 (when applicable)
 
+## Plan Review
+- [ ] Plan review (consistency + structural) — autonomous; runs as the first phase of `/execute-tracks`
+
 ## Final Artifacts
 - [ ] Phase 4: Final artifacts (`design-final.md`, `adr.md`)
 ```
+
+The `## Plan Review` section is the State 0 marker the
+`/execute-tracks` startup protocol reads (see
+[`workflow.md`](workflow.md) §Startup Protocol). When the entry is
+`[ ]` (or the section is missing entirely on a pre-existing plan),
+`/execute-tracks` loads `implementation-review.md` and runs the
+autonomous plan review before any track work begins. After the
+review passes, the section is overwritten with the audit summary
+(see [`implementation-review.md`](implementation-review.md) §Audit
+trail for the format) and the entry becomes `[x]`. A user may
+manually re-set the entry to `[ ]` (or invoke `/review-plan`) after
+inline replanning to force a re-validation.
 
 **Planning rule:** If a track would need more than ~5-7 steps or internal
 phasing, split it into separate dependent tracks. Track sequencing and

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -102,6 +102,25 @@ the orchestrator does after the flow completes:
 - Manual re-entry: marks `## Plan Review` as `[x]` (re-stamping with the
   fresh iteration count), commits, ends the session.
 
+### Precondition (both entry points)
+
+Before starting the flow, check that the three plan-review files have
+no uncommitted changes:
+
+```bash
+git status --porcelain \
+  docs/adr/<dir-name>/_workflow/implementation-plan.md \
+  docs/adr/<dir-name>/_workflow/implementation-backlog.md \
+  docs/adr/<dir-name>/_workflow/design.md
+```
+
+If the output is non-empty, halt and ask the user to commit (or stash)
+those edits first — uncommitted changes to these files would otherwise
+be bundled into the audit-trail commit alongside the auto-fixes,
+muddling the trace. Other dirty paths in the working tree are safe to
+ignore (the audit-trail `git add` is path-scoped to the three files
+above).
+
 ---
 
 ## Step 1: Consistency Review
@@ -463,10 +482,13 @@ When both reviews pass:
    Escalated: <IDs, or 'none'>"
    git push
    ```
-3. Inform the user that Phase 2 passed and the next `/execute-tracks`
-   session will enter State B (Phase A of Track 1). Remind them that
-   technical/risk/adversarial reviews will happen per-track during
-   execution.
+3. Inform the user that Phase 2 passed. The next `/execute-tracks`
+   session will resume per the startup protocol — typically State B
+   (Phase A of Track 1) for a fresh plan, or whichever state was
+   active before the manual re-validation (e.g., State A if a track
+   was just completed but not yet strategy-refreshed). Remind them
+   that technical/risk/adversarial reviews will happen per-track
+   during execution.
 4. **End the session.** Do not proceed to Phase A of Track 1 in the
    same session — the session boundary is mandatory (see
    `workflow.md` §Session Boundary Rules).

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -1,18 +1,35 @@
 # Implementation Review (Phase 2)
 
+> **Loaded on-demand.** This document is read only when the
+> `/execute-tracks` startup protocol detects **State 0** (the plan
+> file's `## Plan Review` checklist entry is `[ ]`), or when the user
+> manually invokes `/review-plan` to re-validate after inline
+> replanning. Non-State-0 sessions never load this file, so its
+> length carries no per-session cost.
+
 ## Overview
 
-Phase 2 validates the plan before execution begins. It runs two steps
-in sequence:
+Phase 2 validates the plan before track execution begins. It runs **autonomously** —
+the orchestrator applies mechanical fixes itself and escalates only **design-level**
+decisions to the user (missing Decision Records, track contradictions, target-state
+vs. current-state ambiguity, ASPIRATIONAL/VIOLATED invariants). Two steps run in
+sequence:
 
 1. **Consistency Review** — reads the design document, implementation plan,
    backlog, and actual codebase to find gaps and inconsistencies between
-   them. Findings are presented to the user for feedback. Iterates until
-   clean.
+   them. Each finding carries a `Classification: mechanical | design-decision`
+   tag emitted by the sub-agent. Mechanical fixes apply automatically; design
+   decisions are batched and escalated to the user once at the end of the step.
 2. **Structural Review** — validates plan-internal structure (dependency
-   ordering, track sizing, scope indicators, architecture notes). Runs
-   **automatically** after consistency review passes — no user interaction
-   unless blockers are found.
+   ordering, track sizing, scope indicators, architecture notes, bloat).
+   All bloat findings are classified `mechanical` by construction; ordering
+   and contradiction findings classify as `design-decision`. Same
+   autonomous flow.
+
+After both steps pass, the orchestrator marks `## Plan Review` as `[x]` in the
+plan file (with a brief audit summary), commits the workflow update, and ends
+the session. The next `/execute-tracks` invocation enters State B (Phase A of
+Track 1).
 
 **Division of labor with the design mutation discipline.** Phase 2
 does **not** separately review the narrative quality of `design.md`
@@ -30,35 +47,60 @@ mutation action's responsibility.
 
 ```mermaid
 flowchart TD
-    START["/review-plan"]
+    START["/execute-tracks State 0\n(or /review-plan manual)"]
     CR["Step 1: Consistency Review\n(reads code + design + plan)"]
-    CR_FIND["Present findings to user"]
-    CR_FIX["Apply accepted fixes"]
-    CR_GATE["Gate verification"]
-    SR["Step 2: Structural Review\n(plan-internal quality)\nRuns automatically"]
-    SR_BLOCKER["Present blockers to user"]
-    SR_FIX["Apply fixes"]
+    CR_CLASSIFY["Classify findings:\nmechanical | design-decision"]
+    CR_AUTO["Auto-apply mechanical fixes\n(Edit / edit-design)"]
+    CR_ESC{"Any design-decision\nfindings?"}
+    CR_USER["Batch-escalate to user\n(present alternatives,\napply user resolutions)"]
+    CR_GATE["Gate verification\n(verify fixes,\ncatch regressions)"]
+    SR["Step 2: Structural Review\n(plan-internal quality)"]
+    SR_CLASSIFY["Classify findings:\nmechanical | design-decision"]
+    SR_AUTO["Auto-apply mechanical fixes"]
+    SR_ESC{"Any design-decision\nfindings?"}
+    SR_USER["Batch-escalate to user"]
     SR_GATE["Gate verification"]
-    DONE["Phase 2 PASS\nReady for /execute-tracks"]
+    AUDIT["Write audit summary\nto ## Plan Review"]
+    DONE["Phase 2 PASS\nCommit + push\nEnd session"]
 
     START --> CR
-    CR --> CR_FIND
-    CR_FIND -->|"Fixes needed"| CR_FIX --> CR_GATE
-    CR_FIND -->|"All clean"| SR
+    CR --> CR_CLASSIFY
+    CR_CLASSIFY --> CR_AUTO
+    CR_AUTO --> CR_ESC
+    CR_ESC -->|No| CR_GATE
+    CR_ESC -->|Yes| CR_USER --> CR_GATE
     CR_GATE -->|"PASS"| SR
-    CR_GATE -->|"FAIL (max 3 iter)"| CR_FIND
-    SR -->|"No blockers"| DONE
-    SR -->|"Blockers found"| SR_BLOCKER
-    SR_BLOCKER --> SR_FIX --> SR_GATE
-    SR_GATE -->|"PASS"| DONE
-    SR_GATE -->|"FAIL (max 3 iter)"| SR_BLOCKER
+    CR_GATE -->|"FAIL (max 3 iter)"| CR_CLASSIFY
+    SR --> SR_CLASSIFY
+    SR_CLASSIFY --> SR_AUTO
+    SR_AUTO --> SR_ESC
+    SR_ESC -->|No| SR_GATE
+    SR_ESC -->|Yes| SR_USER --> SR_GATE
+    SR_GATE -->|"PASS"| AUDIT
+    SR_GATE -->|"FAIL (max 3 iter)"| SR_CLASSIFY
+    AUDIT --> DONE
 ```
 
 ## How to run
 
-Start a new Claude Code session and run `/review-plan` (optionally pass a
-directory name; if omitted, the current git branch is used). The slash
-command is implemented by the skill at `.claude/skills/review-plan/SKILL.md`.
+Phase 2 has two entry points:
+
+1. **Autonomous (default).** Triggered by `/execute-tracks` when the startup
+   protocol detects State 0 (plan file's `## Plan Review` entry is `[ ]` or
+   missing). The orchestrator loads this document on-demand and runs the flow
+   below.
+2. **Manual re-run.** The user runs `/review-plan` to re-validate the plan
+   after inline replanning produced a revised plan, or to audit the plan
+   independently. The skill at `.claude/skills/review-plan/SKILL.md` loads
+   this document and runs the same flow regardless of the current `## Plan
+   Review` checkbox state.
+
+Both entry points share the same orchestration. The only difference is what
+the orchestrator does after the flow completes:
+- Autonomous entry: marks `## Plan Review` as `[x]`, commits, ends the
+  session so the next `/execute-tracks` enters Phase A of Track 1.
+- Manual re-entry: marks `## Plan Review` as `[x]` (re-stamping with the
+  fresh iteration count), commits, ends the session.
 
 ---
 
@@ -102,38 +144,60 @@ alongside the plan.
 
 **Prompt file:** [`prompts/consistency-review.md`](prompts/consistency-review.md)
 
+The prompt embeds the **intent-axis pre-screen** (current-state vs.
+target-state) and the **classification rules** (see §Mechanical vs.
+design-decision classifier below). Each finding the sub-agent emits
+carries a `Classification` field — the orchestrator routes on that
+field, not on severity.
+
 ### Gate verification
 
 **Prompt file:** [`prompts/consistency-gate-verification.md`](prompts/consistency-gate-verification.md)
 
-### Review iteration
-
-The consistency review iterates with user feedback:
+### Autonomous orchestration loop
 
 ```
-Iteration 1: Full review → findings → present to user → user decisions → apply fixes
-Iteration 2: Gate check → verify fixes + catch regressions → if blockers, present to user
-Iteration 3: Gate check → if still blockers, escalate to user
+Iteration 1 (full review):
+  1. Spawn the consistency sub-agent with plan, backlog, design, codebase.
+  2. Receive findings, each tagged Classification: mechanical | design-decision.
+  3. Apply ALL mechanical fixes immediately:
+     - Plan/backlog edits: native Edit.
+     - design.md edits: route through the edit-design skill (mutation
+       discipline — see §Mutation discipline for design.md fixes below).
+  4. If any design-decision findings remain: batch-present to the user
+     once (single message listing all open design questions with proposed
+     alternatives). Wait for user resolutions. Apply user-approved fixes
+     using the same plan-vs-design routing.
+  5. Spawn the gate verification sub-agent with the updated artifacts and
+     the iteration's findings.
+
+Iteration 2-3 (gate, then full re-review if structure changed):
+  - If the gate finds new findings, classify and re-route as in iteration 1.
+  - If iteration 1 fixes significantly restructured the plan or design
+    (tracks reordered, classes/flows redesigned, scope indicators changed
+    substantially), re-run the FULL consistency review instead of the gate
+    to catch cascading inconsistencies.
+
+Cap: 3 iterations. Findings IDs cumulative (CR1, CR2, ... CR6, CR7).
 ```
 
-Max 3 iterations. Finding IDs: `CR1, CR2, ...` (cumulative).
-
-If consistency fixes significantly restructure the plan or design document
-(tracks reordered, classes/flows redesigned, scope indicators changed
-substantially), re-run the full consistency review instead of the gate
-check to catch cascading inconsistencies.
-
-If blockers persist after 3 iterations, escalate to the user and return to
-Phase 1 (Planning) to rework the plan/design before re-entering.
+If blockers persist after 3 iterations, escalate to the user with the
+remaining open findings and recommend returning to Phase 1 (Planning) to
+rework the plan/design before re-entering.
 
 ### Review output
 
-Findings are presented to the user inline during the iteration loop;
-plan and design fixes are applied via `Edit` to
-`implementation-plan.md`, `implementation-backlog.md`, and the design
-document. The review itself is not persisted to disk — once the gate
-passes, the conversation is the only record, and the durable trace is
-the resulting plan/design state plus the gate-PASS commit.
+Findings ride in the orchestrator's conversation context for the
+iteration loop; plan and design fixes are applied via Edit / edit-design
+to `implementation-plan.md`, `implementation-backlog.md`, and the
+design document. The review itself is not persisted to a separate file —
+once the gate passes, the conversation is the only in-flight record,
+and the durable trace is:
+
+- The resulting plan/design state.
+- The gate-PASS commit.
+- The audit summary written into the plan file's `## Plan Review`
+  section (see §Audit trail below).
 
 ---
 
@@ -142,14 +206,11 @@ the resulting plan/design state plus the gate-PASS commit.
 Runs **automatically** after the consistency review passes. Validates
 plan-internal structure without reading the codebase.
 
-If the structural review finds no blockers, it completes silently and
-Phase 2 passes. If blockers are found, they are presented to the user.
-
 ### What it checks
 
 Dependency ordering, track sizing, scope indicators, architecture notes
 completeness, design document structure, decision traceability, internal
-consistency.
+consistency, and plan-file bloat.
 
 Each pending track's detailed description (the subject of TRACK
 DESCRIPTIONS checks, plus several cross-file bullets in TRACK SIZING,
@@ -167,30 +228,245 @@ backlog alongside the plan.
 
 **Prompt file:** [`prompts/structural-gate-verification.md`](prompts/structural-gate-verification.md)
 
-### Review iteration
+### Autonomous orchestration loop
+
+Same shape as the consistency review:
 
 ```
-Iteration 1: Full review → if no blockers, PASS. If blockers → present to user → fixes
-Iteration 2: Gate check → if PASS, done. If blockers → present to user → fixes
-Iteration 3: Gate check → if still blockers, escalate
-```
+Iteration 1 (full review):
+  1. Spawn the structural sub-agent with plan, backlog, design.
+  2. Receive findings, each tagged Classification: mechanical | design-decision.
+     Per-prompt rule: ALL bloat findings classify as mechanical; track-ordering
+     and contradiction findings classify as design-decision (see §Mechanical
+     vs. design-decision classifier below).
+  3. Apply mechanical fixes immediately (Edit for plan/backlog, edit-design
+     for design.md).
+  4. Batch-escalate any design-decision findings to the user once. Apply
+     user-approved fixes.
+  5. Spawn the gate verification sub-agent with the updated artifacts and
+     the iteration's findings.
 
-Max 3 iterations. Finding IDs: `S1, S2, ...` (cumulative).
+Iteration 2-3: gate or full re-review (re-run full review if fixes
+significantly restructured the plan).
+
+Cap: 3 iterations. Findings IDs cumulative (S1, S2, ... S6, S7).
+```
 
 If structural fixes significantly restructure the plan (tracks reordered,
 tracks added/removed, scope indicators changed substantially), re-run
-the full structural review instead of the gate check.
+the full structural review instead of the gate check to catch cascading
+issues.
 
 ### Review output
 
-Same as the consistency review above — findings ride in the conversation
-during the loop; the durable trace is the plan-file edits and the
-gate-PASS state, not a saved review document.
+Same as the consistency review — findings ride in the conversation
+during the loop; the durable trace is the plan-file edits, the gate-PASS
+commit, and the audit-summary entry in `## Plan Review`.
+
+---
+
+## Mechanical vs. design-decision classifier
+
+The classifier lives in the review prompts so the sub-agent emits the
+classification alongside each finding. The orchestrator trusts the
+sub-agent's tag and routes on it.
+
+### `mechanical` — orchestrator applies the fix without asking
+
+ALL of these must hold for a consistency finding to classify as
+`mechanical`:
+
+1. The plan/design claim is about **current state** — code that should
+   already exist at the time of writing, not code a track will create.
+   (Aspirational claims about target state are pre-filtered; see
+   §Intent-axis pre-screen below.)
+2. There is exactly one unambiguous correct rendering — rename to the
+   actual class, update to the real signature, fix the participant
+   name in a sequenceDiagram, drop a phantom reference, etc.
+3. Applying the fix doesn't change what the plan is trying to achieve.
+   Only the description is updated; the plan's goals, scope, and
+   architecture are unchanged.
+
+For structural findings, **all bloat findings** are mechanical by
+construction (DR length, intro length, component-intent length,
+integration-point length, plan/design duplication, superseded DR
+retained, plan-file budget, missing track-reference annotation,
+scope-indicator format). The fix follows the rule mechanically —
+trim back to the four-bullet form, move long-form material to
+`design.md`, replace duplicated body with a one-line link, delete the
+superseded DR, etc.
+
+### `design-decision` — orchestrator escalates to the user
+
+ANY of these triggers `design-decision`:
+
+- The discrepancy reveals a **missing Decision Record** for a non-obvious
+  choice. The user has the rationale; the orchestrator does not.
+- The discrepancy is a **contradiction between two tracks** (Track 1
+  assumes X, Track 3 assumes not-X). Which one is right is a design
+  call.
+- An **ASPIRATIONAL invariant has no implementing track**. Do we add a
+  track or change the invariant? Both are plausible.
+- A **VIOLATED invariant** exists. Do we fix the code (track scope
+  expansion) or restate the invariant (design retreat)?
+- **Design ↔ code mismatch where the plan describes a target state**
+  (a `[ ]` track is meant to create what the design claims) and the
+  divergence is whether to keep the target shape or change it. The
+  pre-screening rule (§Intent-axis pre-screen) catches the
+  no-divergence case; what reaches this rule is genuine design choice.
+- **Track ordering** issues where reordering changes the contract
+  (e.g., Track B's scope mentions wiring X, but X is introduced in
+  Track C — does B move after C, or does X move into B?).
+
+The classifier rules belong in the prompt files — the orchestrator
+does not re-classify; it acts on the tag.
+
+### Intent-axis pre-screen (consistency review only)
+
+Before emitting any finding, the consistency sub-agent classifies each
+plan/design claim along the **intent axis**:
+
+- **Current-state claim** — the plan/design says something about code
+  that should already exist (Component Map describing a current
+  module's role, design.md class diagram describing pre-existing
+  classes, Architecture Notes referencing today's SPI). Discrepancies
+  here become findings.
+- **Target-state claim** — the plan/design says something about code
+  a `[ ]` track will create (`**What**:` bullets in the backlog,
+  forward-looking Decision Records, design.md sections describing
+  the post-implementation state). The current code naturally won't
+  match — this is **not a finding** unless the target is unreachable
+  from the current code (in which case the finding is
+  `design-decision`).
+
+The same rule already applies to invariants via the
+`ENFORCED / ASPIRATIONAL / VIOLATED` tagging. The pre-screen extends
+the same idea to all claims: a divergence with target-state code is
+expected and silenced; a divergence with current-state code is a
+finding.
+
+---
+
+## Audit trail
+
+Two durable traces survive the autonomous flow:
+
+### 1. The `## Plan Review` section in the plan file
+
+Before Phase 2 runs (or after `/create-plan` produced the initial
+plan), the section reads:
+
+```markdown
+## Plan Review
+- [ ] Plan review (consistency + structural) — autonomous; runs as the first phase of `/execute-tracks`
+```
+
+After Phase 2 passes, the orchestrator overwrites the section with:
+
+```markdown
+## Plan Review
+- [x] Plan review (consistency + structural) — passed at iteration <N>
+
+**Auto-fixed (mechanical)**: <CR/S finding IDs with one-line summaries>.
+
+**Escalated (design decisions)**: <CR/S finding IDs with one-line user resolutions, or "none">.
+```
+
+If the user re-runs `/review-plan` later, the orchestrator overwrites
+this section again with the new iteration's audit. The `[x]` checkbox
+is what the startup protocol's State 0 detection reads.
+
+If the section is missing entirely (a pre-existing plan from before
+this convention), the orchestrator treats it as `[ ]` and runs the
+autonomous flow, then writes the section for the first time at the
+end. Pre-existing plans don't break.
+
+### 2. The workflow-update commit
+
+After Phase 2 passes, the orchestrator stages the plan, backlog, and
+design files, and commits with the message:
+
+```
+Plan review autonomous fixes for <plan-name>
+
+Auto-fixed: <CR/S IDs>
+Escalated: <CR/S IDs, or "none">
+```
+
+This is a single Workflow update commit per the table in
+`commit-conventions.md` § Commit type prefixes. Push after commit.
+
+---
+
+## Mutation discipline for design.md fixes
+
+Every fix that touches `design.md` (or `design-mechanics.md`) routes
+through the `edit-design` skill — see [`design-document-rules.md`](design-document-rules.md)
+§ Mutation discipline. The skill applies the mechanical checks +
+cold-read sub-agent gate before the change stands.
+
+The autonomous flow handles this by invoking `edit-design` for each
+design.md mechanical fix; the cold-read sub-agent is the safety net
+for narrative breakage. If the cold-read rejects the mutation, the
+orchestrator escalates that specific fix to the user (effectively
+re-classifying it from `mechanical` to `design-decision`).
+
+Plan-file and backlog edits use `Edit` directly — no mutation
+discipline applies to those files.
+
+---
+
+## Replanning
+
+**Not a separate phase.** Replanning is handled within Phase 3
+by the execution agent's ESCALATE flow (see "Inline Replanning
+(ESCALATE)" in `workflow.md`).
+
+**Why:** The execution agent reads all track episodes from the plan file
+and can read/write it directly. It has the context to revise the plan
+within the session. A separate phase would add unnecessary context loss.
+
+**What happens on ESCALATE:**
+1. Execution agent stops starting new steps.
+2. Presents full situation to user (all episodes, what broke, what
+   assumptions failed).
+3. Proposes revised plan (new/modified tracks, reordering, removed
+   tracks).
+4. Spawns a structural review sub-agent to validate the revised plan
+   (uses the same prompt as Phase 2 Step 2; classifier still applies).
+5. On review PASS — updates the plan file with the revised plan and
+   ends the session. Sets `## Plan Review` back to `[ ]` so the next
+   `/execute-tracks` re-runs the full Phase 2 flow against the revised
+   plan, picking up any new consistency issues introduced by the
+   replan.
+6. On review FAIL with persistent blockers — advises user to restart
+   from Phase 1 (`/create-plan`) with accumulated episodes as input.
+
+The only case that exits to Phase 1 is when the plan is so fundamentally
+broken that incremental revision cannot fix it.
 
 ---
 
 ## Completion
 
-When both reviews pass, Phase 2 is complete. Proceed to Phase 3 execution
-(`/execute-tracks`). Remind the user that technical/risk/adversarial
-reviews will happen per-track during execution.
+When both reviews pass:
+
+1. Update `## Plan Review` with the audit summary (see §Audit trail).
+2. Stage and commit the plan/backlog/design changes:
+   ```bash
+   git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
+           docs/adr/<dir-name>/_workflow/implementation-backlog.md \
+           docs/adr/<dir-name>/_workflow/design.md
+   git commit -m "Plan review autonomous fixes for <plan-name>
+
+   Auto-fixed: <IDs>
+   Escalated: <IDs, or 'none'>"
+   git push
+   ```
+3. Inform the user that Phase 2 passed and the next `/execute-tracks`
+   session will enter State B (Phase A of Track 1). Remind them that
+   technical/risk/adversarial reviews will happen per-track during
+   execution.
+4. **End the session.** Do not proceed to Phase A of Track 1 in the
+   same session — the session boundary is mandatory (see
+   `workflow.md` §Session Boundary Rules).

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -104,22 +104,28 @@ the orchestrator does after the flow completes:
 
 ### Precondition (both entry points)
 
-Before starting the flow, check that the three plan-review files have
-no uncommitted changes:
+Before starting the flow, check that the plan-review files have no
+uncommitted changes:
 
 ```bash
 git status --porcelain \
   docs/adr/<dir-name>/_workflow/implementation-plan.md \
   docs/adr/<dir-name>/_workflow/implementation-backlog.md \
-  docs/adr/<dir-name>/_workflow/design.md
+  docs/adr/<dir-name>/_workflow/design.md \
+  docs/adr/<dir-name>/_workflow/design-mechanics.md \
+  docs/adr/<dir-name>/_workflow/design-mutations.md
 ```
+
+The last two paths are checked when present — `design-mechanics.md`
+exists only when the length trigger has fired, and `design-mutations.md`
+is created on the first `edit-design` run. Non-existent paths produce
+no output, so listing them is safe.
 
 If the output is non-empty, halt and ask the user to commit (or stash)
 those edits first — uncommitted changes to these files would otherwise
 be bundled into the audit-trail commit alongside the auto-fixes,
 muddling the trace. Other dirty paths in the working tree are safe to
-ignore (the audit-trail `git add` is path-scoped to the three files
-above).
+ignore (the audit-trail `git add` is path-scoped to the files above).
 
 ---
 
@@ -471,11 +477,16 @@ broken that incremental revision cannot fix it.
 When both reviews pass:
 
 1. Update `## Plan Review` with the audit summary (see §Audit trail).
-2. Stage and commit the plan/backlog/design changes:
+2. Stage and commit the plan/backlog/design changes. The
+   `design*.md` glob picks up `design.md` plus
+   `design-mechanics.md` and `design-mutations.md` when
+   `edit-design` touched them during the review (`design.md`
+   always exists post-Phase-1, so the glob always matches at least
+   one path):
    ```bash
    git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
            docs/adr/<dir-name>/_workflow/implementation-backlog.md \
-           docs/adr/<dir-name>/_workflow/design.md
+           docs/adr/<dir-name>/_workflow/design*.md
    git commit -m "Plan review autonomous fixes for <plan-name>
 
    Auto-fixed: <IDs>

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -118,22 +118,39 @@ on the size of the inline-replanning revision (see
 ([`.claude/skills/edit-design/SKILL.md`](../skills/edit-design/SKILL.md)),
 not direct `Edit` / `Write` calls.
 
-**4. Review** — spawn a sub-agent to validate the revised plan using the
-structural review protocol from Phase 2 (see `structural-review.md`).
-The invocation passes `plan_path` + `backlog_path` per the path-passing
-rule in `.claude/skills/review-plan/SKILL.md`. The sub-agent receives
-the full plan file including both completed track episodes and the
+**4. Review (advisory preview)** — spawn a sub-agent to run the
+structural review protocol from Phase 2 (see `structural-review.md`)
+on the revised plan. This is a fail-fast preview, **not the gate** —
+the definitive gate is the State 0 re-run on the next
+`/execute-tracks` session, which runs consistency + structural
+together (see [`implementation-review.md`](implementation-review.md)
+§ Replanning). The preview exists so you don't end the session and
+clear context only to learn on the next invocation that the revision
+was structurally broken. The invocation passes `plan_path` +
+`backlog_path` per the path-passing rule in
+`.claude/skills/review-plan/SKILL.md`. The sub-agent receives the
+full plan file including both completed track episodes and the
 proposed revisions, plus the backlog so pending-track details split
 into `implementation-backlog.md` are reachable.
 
-**5. Iterate** — if the review finds blockers, revise and re-review. Maximum
-3 iterations.
+**5. Iterate** — if the preview finds structural blockers, revise and
+re-preview. Maximum 3 iterations. Consistency findings (phantom
+references, flow-trace mismatches) are **not** surfaced by this
+preview — they will appear in the next-session State 0 re-run.
 
 **6. Resume or exit:**
 
-- **Review PASS** — update the plan file with the revised plan, then
-  commit and push the workflow changes immediately so the next
-  implementer spawn doesn't lose them via `git reset --hard HEAD`:
+- **Review PASS** — update the plan file with the revised plan **and
+  reset the `## Plan Review` section** to
+  `- [ ] Plan review (consistency + structural) — autonomous; runs as
+  the first phase of /execute-tracks`. The reset routes the next
+  `/execute-tracks` session through State 0, which re-runs Phase 2
+  against the revised plan and catches any consistency drift the
+  replan introduced (see
+  [`implementation-review.md`](implementation-review.md) § Replanning
+  for the contract). Then commit and push the workflow changes
+  immediately so the next implementer spawn doesn't lose them via
+  `git reset --hard HEAD`:
 
   ```bash
   git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
@@ -155,7 +172,8 @@ into `implementation-backlog.md` are reachable.
   the table in `commit-conventions.md` § Commit type prefixes).
   Resume orphan-detection treats it as scaffolding and does not
   count it toward any `[x]` step. End the session after the push;
-  the next session picks up the revised plan and continues.
+  the next `/execute-tracks` session enters State 0, re-runs Phase 2
+  against the revised plan, then resumes track execution.
 
 - **Blockers persist after 3 iterations** — the plan is fundamentally broken
   at a level that incremental revision cannot fix. Advise the user to restart

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -14,8 +14,11 @@ session. Phase 1 is preceded by Phase 0 (Research) in the same session.
 - **Phase 1 (Planning):** Develop a plan informed by Phase 0 findings.
   Produce tracks with architecture notes, scope indicators, and design document.
 - **Phase 2 (Implementation Review):** See
-  [`implementation-review.md`](implementation-review.md) — two-step review:
-  (1) consistency review (design doc ↔ code ↔ plan), (2) structural review.
+  [`implementation-review.md`](implementation-review.md) — autonomous
+  two-step review run as the first phase of `/execute-tracks` (State 0):
+  (1) consistency review (design doc ↔ code ↔ plan), (2) structural
+  review. Mechanical findings auto-fixed; only design-decision findings
+  escalated to the user. Optionally re-invoked via `/review-plan`.
 - **Phase 3 (Execution):** See [`workflow.md`](workflow.md).
 - **Phase 4 (Final Artifacts):** See [`workflow.md`](workflow.md)
   §Final Artifacts.
@@ -24,8 +27,8 @@ session. Phase 1 is preceded by Phase 0 (Research) in the same session.
 flowchart TD
     P0["/create-plan\nPhase 0: Research\nInteractive exploration\n+ code & internet research"]
     P1["Phase 1: Planning\nTracks + architecture notes\n+ design document"]
-    P2["/review-plan\nPhase 2: Implementation Review\n1. Consistency review (interactive)\n2. Structural review (automatic)"]
-    P3["/execute-tracks\nPhase 3: Execution\n(see workflow.md)\nIncludes replanning via ESCALATE"]
+    P2["/execute-tracks State 0\n(or /review-plan)\nPhase 2: Implementation Review\n1. Consistency review (autonomous)\n2. Structural review (autonomous)\nDesign decisions → user escalation"]
+    P3["/execute-tracks State A/B/C\nPhase 3: Execution\n(see workflow.md)\nIncludes replanning via ESCALATE"]
     P4["Phase 4: Final Artifacts\ndesign-final.md + adr.md\n(only files that survive merge)"]
     DONE((Done))
 

--- a/.claude/workflow/prompts/consistency-gate-verification.md
+++ b/.claude/workflow/prompts/consistency-gate-verification.md
@@ -88,7 +88,11 @@ For REJECTED findings, verify the rejection reason with a lighter check:
 
 Output:
 - For each finding under re-check: the verification certificate above
-- New findings (if any) in the same format with cumulative numbering
-  (continue from the highest CR number)
+- New findings (if any) in the same format as the consistency review's
+  finding template — including `**Classification**: mechanical |
+  design-decision` and `**Justification**:` fields per the rules in
+  `prompts/consistency-review.md` § Classification rules. Apply the
+  intent-axis pre-screen before emitting any new finding. Cumulative
+  numbering (continue from the highest CR number).
 - Summary: PASS (all verified/rejected, no new blockers) or FAIL (with
   list of remaining blockers)

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -65,6 +65,56 @@ Inputs:
 
 ---
 
+## Intent-axis pre-screen (run BEFORE generating findings)
+
+Phase 2 runs autonomously: the orchestrator applies your `mechanical`
+findings without asking the user, and only escalates `design-decision`
+findings. A finding fired against a target-state claim (a `[ ]` track is
+meant to create what the design claims; the current code naturally
+won't match yet) would either be auto-fixed wrong (silently rewriting
+the plan toward current code) or escalated as a non-issue. Both are
+broken outcomes — the pre-screen is what prevents them.
+
+**Pre-screen rule.** Before emitting any finding, classify each plan or
+design claim along the **intent axis**:
+
+- **Current-state claim** — the plan/design says something about code
+  that should already exist at the time of writing (Component Map
+  describing a current module's role, design.md class diagram showing
+  pre-existing classes, Architecture Notes referencing today's SPI, an
+  invariant tagged `ENFORCED`). Discrepancies with these become
+  findings — emit normally.
+- **Target-state claim** — the plan/design says something about code a
+  `[ ]` track will create (`**What**:` bullets in the backlog,
+  forward-looking Decision Records describing the post-implementation
+  shape, design.md sections describing the post-implementation state,
+  invariants tagged `ASPIRATIONAL`). The current code naturally won't
+  match — **do NOT emit a finding** unless the target is unreachable
+  from the current code (in which case emit a `design-decision`
+  finding so the user can resolve the gap).
+
+The same rule already applies to invariants via the
+`ENFORCED / ASPIRATIONAL / VIOLATED` tagging. The pre-screen extends
+it to all design.md / Component Map / track-description claims.
+
+**How to determine intent for each claim:**
+- If the claim is inside a backlog `**What/How/Constraints/Interactions**`
+  subsection for a `[ ]` track → target-state.
+- If the claim is in a Decision Record's "Implemented in: Track N" line
+  for a `[ ]` track → target-state.
+- If the claim is in design.md and a `[ ]` track's description names
+  the same component, class, or flow as something to be created or
+  modified → target-state for that aspect; current-state for any
+  pre-existing surrounding context.
+- Otherwise (Component Map of pre-existing modules, references to
+  today's SPI, infrastructure mentioned without a track creating it) →
+  current-state.
+
+When in doubt, treat as current-state — the orchestrator will see the
+finding and the classification rules below will route it correctly.
+
+---
+
 ## Review Criteria
 
 ### DESIGN ↔ CODE CONSISTENCY
@@ -289,6 +339,10 @@ For each issue found, produce a finding:
 **Evidence**: <what you found in the code vs. what the document says —
   summarize from the certificate>
 **Proposed fix**: <concrete change to the plan/design text>
+**Classification**: mechanical | design-decision
+**Justification**: <one-line citation of the rule from §Classification rules
+  below — e.g., "current-state claim, single unambiguous correct rendering"
+  or "missing DR for non-obvious choice; user has the rationale">
 
 Severity guide:
 - **blocker**: A factual error that would cause the execution agent to make
@@ -298,3 +352,66 @@ Severity guide:
   block execution (slightly outdated method signature, missing cross-reference)
 - **suggestion**: An improvement that would strengthen the documents
   (additional diagram, clarifying note about existing code behavior)
+
+---
+
+## Classification rules
+
+Severity (`blocker | should-fix | suggestion`) tells the user how
+urgent the finding is. **Classification** (`mechanical |
+design-decision`) tells the orchestrator who decides — itself or the
+user. The two axes are orthogonal: a blocker can be mechanical
+(phantom reference) and a suggestion can be design-decision (consider
+extracting a separate track).
+
+### `mechanical` — orchestrator applies the fix without asking
+
+ALL of these must hold:
+
+1. The plan/design claim is about **current state** (the intent-axis
+   pre-screen passed it through as a current-state claim, not a
+   target-state claim).
+2. There is exactly **one unambiguous correct rendering** of the truth —
+   rename to the actual class, update to the real signature, fix the
+   participant name in a sequenceDiagram, drop a phantom reference,
+   replace a renamed identifier with its current name.
+3. Applying the fix **doesn't change what the plan is trying to
+   achieve**. Only the description is updated; the plan's goals,
+   scope, and architecture are unchanged.
+
+Typical mechanical cases:
+- Phantom reference to a class/method/field that should already exist —
+  fix by updating to the actual identifier or dropping the reference.
+- Outdated method signature on existing code — fix by matching the
+  current signature.
+- Workflow diagram showing an existing call flow with a renamed
+  participant — fix by renaming the participant in the diagram.
+- Component Map listing a module that's been split or merged — fix by
+  matching the actual module structure.
+
+### `design-decision` — orchestrator escalates to the user
+
+ANY of these triggers `design-decision`:
+
+- The discrepancy reveals a **missing Decision Record** for a
+  non-obvious choice. The user has the rationale, alternatives, and
+  trade-offs; the orchestrator does not.
+- The discrepancy is a **contradiction between two tracks** (Track 1
+  assumes X, Track 3 assumes not-X). Which one is right is a design
+  call.
+- An **`ASPIRATIONAL` invariant has no implementing track**. Do we add
+  a track or change the invariant? Both are plausible.
+- A **`VIOLATED` invariant** exists. Do we fix the code (track scope
+  expansion) or restate the invariant (design retreat)?
+- **Design ↔ code mismatch where the plan describes a target state**
+  AND the target is unreachable from the current code (the
+  intent-axis pre-screen surfaced it as needing escalation). The
+  user must pick: keep the target shape, change it, or restructure
+  the track that delivers it.
+- **Multiple plausible fix renderings** exist. Even if the claim is
+  about current state, if the orchestrator can't pick a single
+  correct fix without making a design choice, escalate.
+
+When in doubt between the two classifications, choose
+`design-decision` — over-escalating costs one user round-trip, under-
+escalating risks silently rewriting the plan.

--- a/.claude/workflow/prompts/structural-gate-verification.md
+++ b/.claude/workflow/prompts/structural-gate-verification.md
@@ -62,7 +62,12 @@ For REJECTED findings:
 
 Output:
 - For each finding under re-check: the verification certificate above
-- New findings (if any) in the same format, with cumulative numbering
-  (continue from the highest finding number)
+- New findings (if any) in the same format as the structural review's
+  finding template — including `**Classification**: mechanical |
+  design-decision` and `**Justification**:` fields per the rules in
+  `prompts/structural-review.md` § Classification rules. Bloat
+  findings are always `mechanical`; ordering, sizing, and
+  contradiction findings are `design-decision`. Cumulative numbering
+  (continue from the highest finding number).
 - Summary: PASS (all verified/rejected, no new blockers) or FAIL (with
   list of remaining blockers)

--- a/.claude/workflow/prompts/structural-review.md
+++ b/.claude/workflow/prompts/structural-review.md
@@ -242,6 +242,9 @@ For each issue found, produce a finding in this format:
 **Location**: <where in the plan>
 **Issue**: <what's wrong>
 **Proposed fix**: <concrete change to the plan text>
+**Classification**: mechanical | design-decision
+**Justification**: <one-line citation of the rule from §Classification
+  rules below>
 
 Severity guide:
 - blocker: Plan cannot be executed correctly (dependency cycle, missing track
@@ -253,3 +256,69 @@ Severity guide:
   exceeds the overall budget**)
 - suggestion: Improvement that isn't strictly necessary (better wording,
   optional diagram that would help)
+
+---
+
+## Classification rules
+
+Severity (`blocker | should-fix | suggestion`) tells the user how
+urgent the finding is. **Classification** (`mechanical |
+design-decision`) tells the orchestrator who decides — itself or the
+user. The two axes are orthogonal.
+
+### `mechanical` — orchestrator applies the fix without asking
+
+**All BLOAT findings are `mechanical` by construction.** The fix
+follows the rule mechanically — trim back to the four-bullet form,
+move long-form material to `design.md`, replace duplicated body with
+a one-line link, delete the superseded DR, etc.
+
+Specifically:
+- DR length, invariant length, integration-point length,
+  component-intent length — `mechanical`.
+- Plan/design duplication — `mechanical` (replace with link).
+- Superseded DR retained — `mechanical` (delete).
+- Plan-file budget exceeded — `mechanical` (apply per-section trims).
+- Missing track-reference annotation on a Decision Record where the
+  matching track is obvious from the DR's topic — `mechanical`.
+- Scope-indicator format issues (missing `**Scope:**` line, missing
+  `**Depends on:**` annotation when a dependency is implied by the
+  description) — `mechanical`.
+
+Other findings classify as `mechanical` only when the fix is a single
+unambiguous edit that doesn't change plan intent — e.g., an obvious
+typo in a track number reference, a missing required heading.
+
+### `design-decision` — orchestrator escalates to the user
+
+ANY of these triggers `design-decision`:
+
+- **Track ordering** issues where reordering changes the contract.
+  E.g., Track B's scope mentions wiring X, but X is introduced in
+  Track C — does B move after C, or does X move into B? The user
+  picks.
+- **Track sizing** — a track that exceeds ~5-7 steps and needs to be
+  split. Where the split goes is a design call.
+- **Track contradictions** — Track 1 assumes X, Track 3 assumes
+  not-X. Which is right is a design call.
+- **Missing Decision Record** for a non-obvious choice. The user has
+  the rationale.
+- **Implausible scope indicator** — the description implies more work
+  than the scope claims. Either the description scopes down or the
+  indicator scopes up; the user decides which.
+- **Architecture Notes gaps** — missing Component Map, missing
+  Invariants, missing Integration Points, missing Non-Goals where
+  the scope boundary is ambiguous. Filling these requires the user's
+  rationale.
+- **Design document gaps** — missing Overview, missing class diagram
+  when 2+ new classes are introduced, missing workflow diagram when
+  a new flow is introduced, missing dedicated section for
+  concurrency / crash recovery / performance. The content of those
+  sections is a design call.
+- **Decision-traceability gaps** — a track implements a non-obvious
+  choice but no DR exists. The user must articulate the alternatives
+  and rationale.
+
+When in doubt between the two classifications, choose
+`design-decision` — over-escalating costs one user round-trip, under-
+escalating risks silently rewriting the plan.

--- a/.claude/workflow/structural-review.md
+++ b/.claude/workflow/structural-review.md
@@ -35,6 +35,17 @@ table-form summary and the per-section rationale). Detection is
 mechanical — line-count and pattern-match on the plan file, no
 codebase read required — and the findings carry the severities below.
 
+**All bloat findings are classified `mechanical`** by the autonomous
+Phase 2 orchestrator (see
+[`prompts/structural-review.md`](prompts/structural-review.md) §
+Classification rules). The fix follows the rule mechanically — trim
+to the four-bullet form, move long-form material to `design.md`,
+replace the duplicated body with a one-line link, delete the
+superseded DR — and the orchestrator applies it without asking the
+user. Findings escalate as `design-decision` only when the structural
+issue is ordering / sizing / contradiction / decision-traceability,
+not bloat.
+
 | Category | Severity | Trigger | Fix |
 |---|---|---|---|
 | **DR-length** | should-fix | Decision Record body exceeds ~30 lines | Trim DR back to the four-bullet form; move long-form material to a `design.md` section and link from `**Full design**`. |
@@ -66,15 +77,28 @@ After fixes are applied, the structural review re-runs to verify.
 
 ## Review iteration
 
-The structural review iterates until clean:
+The structural review iterates until clean. Each finding carries a
+`Classification` field (`mechanical | design-decision`) emitted by the
+sub-agent — the orchestrator auto-applies `mechanical` fixes and
+batches `design-decision` findings for a single user-resolution pass
+per iteration:
 
 ```
-Iteration 1: Full review → findings → user decisions → apply fixes
-Iteration 2: Gate check → verify fixes + catch regressions → if blockers, loop
+Iteration 1: Full review → classify findings →
+             auto-apply mechanical fixes (Edit / edit-design) →
+             escalate design-decision findings to user once →
+             apply user resolutions
+Iteration 2: Gate check → verify fixes + catch regressions →
+             if new findings, classify and re-route as in iteration 1
 Iteration 3: Gate check → if still blockers, escalate to user
 ```
 
 Max 3 iterations. Finding IDs are cumulative (S1, S2, ... S6, S7).
+Classification rules live in
+[`prompts/structural-review.md`](prompts/structural-review.md)
+§ Classification rules (bloat findings → `mechanical` by construction;
+ordering, sizing, contradiction, decision-traceability findings →
+`design-decision`).
 
 If blockers persist after 3 iterations, escalate to the user and return to
 Phase 1 (Planning) to rework the plan before re-entering structural review.
@@ -86,20 +110,26 @@ issues.
 
 ## Review output
 
-The structural review is not persisted to disk. Findings are presented
-inline during the iteration loop, accepted fixes are applied directly
-to `implementation-plan.md` (and `implementation-backlog.md` when
-relevant), and the gate-PASS state plus the resulting commit are the
-durable trace. A typical iteration looks like:
+The structural review is not persisted to disk. Mechanical fixes are
+applied autonomously to `implementation-plan.md` (and
+`implementation-backlog.md` when relevant); design-decision findings
+ride in the orchestrator's conversation context until escalated and
+resolved. The durable trace is the gate-PASS state, the resulting
+commit, and the audit-summary entry in the plan file's `## Plan
+Review` section (see
+[`implementation-review.md`](implementation-review.md) §Audit trail).
+A typical iteration looks like:
 
 ```
 Iteration 1
-  Finding S1 [blocker]  → ACCEPTED → reorder Track 3 before Track 2
-  Finding S2 [should-fix] → REJECTED — Tracks 1 and 3 are independent
+  Finding S1 [blocker, mechanical]      → AUTO-FIX → delete superseded DR D2 (replaced by D5)
+  Finding S2 [should-fix, mechanical]   → AUTO-FIX → trim D3 from 42 lines to 18; move worked example to design.md §Histogram Build
+  Finding S3 [should-fix, design-decision] → ESCALATE → user resolves Track 2 vs. Track 4 contradiction by reordering
 
 Iteration 2 (Gate Verification)
   S1: VERIFIED
-  S2: REJECTED (no action needed)
+  S2: VERIFIED
+  S3: VERIFIED
   No new findings → PASS
 ```
 

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -29,9 +29,15 @@ are used for two distinct purposes:
 The overall workflow has five phases:
 - **Phase 0 (Research)**: `/create-plan` — interactive research and exploration (same session as Phase 1)
 - **Phase 1 (Planning)**: `/create-plan` — develop the implementation plan and design document, informed by Phase 0 findings
-- **Phase 2 (Implementation Review)**: `/review-plan` — two-step review:
-  (1) consistency review (design doc ↔ code ↔ plan, interactive),
-  (2) structural review (plan-internal quality, automatic)
+- **Phase 2 (Implementation Review)**: runs **autonomously** as the first
+  phase of `/execute-tracks` when the startup protocol detects State 0
+  (plan file's `## Plan Review` checklist entry is `[ ]`). Two-step review:
+  (1) consistency review (design doc ↔ code ↔ plan, autonomous classifier
+  with user escalation only for design decisions),
+  (2) structural review (plan-internal quality, autonomous classifier).
+  Optionally re-invoked via `/review-plan` for manual re-runs after inline
+  replanning. Full orchestration in `implementation-review.md` (loaded
+  on-demand only when State 0 is active).
 - **Phase 3 (Execution)**: `/execute-tracks` — implement and review tracks
 - **Phase 4 (Final Artifacts)**: `/execute-tracks` (State D) — produce `design-final.md` and `adr.md` (follows `prompts/create-final-design.md`)
 
@@ -67,12 +73,14 @@ flowchart TD
 
     START --> READ
 
+    READ -->|"Plan review not yet done\n(## Plan Review is [ ])"| P2["State 0: Autonomous Plan Review\n(implementation-review.md)"]
     READ -->|"Track just completed\n(no strategy refresh yet)"| SR["Strategy Refresh\n(CONTINUE / ADJUST / ESCALATE)"]
     READ -->|"Fresh start"| PA["Phase A: Review +\nDecomposition"]
     READ -->|"Phase A done,\nsteps incomplete"| PB["Phase B: Step\nImplementation"]
     READ -->|"All steps done,\ncode review incomplete\nor track not marked [x]"| PC["Phase C: Code Review\n+ Track Completion"]
     READ -->|"All tracks done,\nPhase 4 not complete"| P4["Phase 4: Final\nArtifacts"]
 
+    P2 --> END_P2["Session ends\n(plan review complete)"]
     SR -->|CONTINUE / ADJUST| PA
     SR -->|ESCALATE| REPLAN["Inline Replanning"]
 
@@ -90,6 +98,7 @@ flowchart TD
 
     P4 --> END_P4["Session ends\n(Phase 4 complete)"]
 
+    END_P2 -->|"Next session"| START
     END_A -->|"Next session"| START
     END_B -->|"Next session"| START
     END_TRACK -->|"Next session"| START
@@ -124,11 +133,17 @@ perspective on cross-track impact.
 
    | Plan file state | Step file state | Session state |
    |---|---|---|
-   | Last completed/skipped track (`[x]` or `[~]`) has no `**Strategy refresh:**` line | — | **State A**: strategy refresh first |
-   | All `[x]`/`[~]` tracks have `**Strategy refresh:**`; next track is `[ ]` | No step file | **State B**: fresh start (Phase A) |
-   | A track is `[ ]` | Step file exists | **State C**: mid-track resume |
+   | `## Plan Review` checklist entry is `[ ]` (or section missing entirely) | — | **State 0**: autonomous plan review (load `implementation-review.md` and follow it) |
+   | `## Plan Review` is `[x]`; last completed/skipped track has no `**Strategy refresh:**` line | — | **State A**: strategy refresh first |
+   | `## Plan Review` is `[x]`; all `[x]`/`[~]` tracks have `**Strategy refresh:**`; next track is `[ ]` | No step file | **State B**: fresh start (Phase A) |
+   | `## Plan Review` is `[x]`; a track is `[ ]` | Step file exists | **State C**: mid-track resume |
    | All tracks `[x]` or `[~]`; Phase 4 is `[ ]` or `[>]` | — | **State D**: Phase 4 (final artifacts) |
    | All tracks `[x]` or `[~]`; Phase 4 is `[x]` | — | **Done** |
+
+   State 0 is checked **first** — plan review must complete before any
+   track-level work begins. After State 0 passes, the session ends and
+   the next `/execute-tracks` invocation re-evaluates the table starting
+   from State A.
 
    **State C sub-states** (from step file Progress section):
 
@@ -149,12 +164,21 @@ perspective on cross-track impact.
    | `[ ]` | Start Phase 4: mark `[>]`, follow `prompts/create-final-design.md` |
    | `[>]` | Resume Phase 4: check which artifacts exist. If both exist, review and complete. Otherwise, restart from Step 3 of `create-final-design.md` |
 
+   **State 0** (autonomous plan review): load `implementation-review.md`
+   on-demand and follow the autonomous orchestration loop there
+   (consistency review → structural review, classifier-driven
+   auto-fix vs. user escalation). End the session after the gate
+   passes.
+
 4. **Inform the user** of the auto-resume decision:
-   - Which track you're working on and why
+   - Which track you're working on and why (or that plan review is
+     pending if State 0)
    - If resuming mid-track: which steps are done, which is next
    - If strategy refresh is needed: do it and present results before
      proceeding
    - If Phase 4: whether starting fresh or resuming an interrupted session
+   - If State 0: that the autonomous plan review is about to run and
+     only design-decision findings will be surfaced
 
    The user can override: reorder tracks, skip a track, or choose a different
    resume point. But by default, you proceed without waiting for confirmation.
@@ -188,6 +212,13 @@ not at startup.
 
 Phase boundaries are **mandatory** session boundaries. Each session handles
 exactly one phase:
+
+- **After State 0 (autonomous plan review)** — both consistency and
+  structural reviews have passed, the plan/backlog/design have been
+  fixed (mechanical fixes auto-applied; design decisions resolved by
+  the user), `## Plan Review` is marked `[x]` with the audit summary,
+  and the workflow-update commit has been pushed. Session ends. Next
+  session starts Phase A of Track 1.
 
 - **After Phase A (review + decomposition)** — step file is written to disk
   with all steps as `[ ]` and `Review + decomposition` marked `[x]`. Session
@@ -285,9 +316,10 @@ User interaction points:
 
 | When | What you present | What the user decides |
 |---|---|---|
-| **Session start** | Auto-resume decision (which track, which phase) | Confirm or override |
+| **Session start** | Auto-resume decision (which track, which phase, or State 0 plan review) | Confirm or override |
+| **State 0 design-decision findings** | Batched list of CR/S findings the consistency and/or structural sub-agents classified as `design-decision`, with proposed alternatives and recommendation | Resolve each finding (choose alternative, provide guidance, defer) |
 | **Strategy refresh** | Assessment report (CONTINUE / ADJUST / ESCALATE) | Accept or override |
-| **Phase A/B complete** | Phase summary, what was done, next phase | User clears session, re-runs `/execute-tracks` |
+| **Phase A/B complete (and State 0 complete)** | Phase summary, what was done, next phase | User clears session, re-runs `/execute-tracks` |
 | **Cross-track impact** | Which tracks affected, what broke, recommendation | Continue, pause, or escalate |
 | **Track complete (end of Phase C)** | Track episode, step episodes, git log of commits, plan corrections | Approve, request fixes, or rework |
 | **Step failure (2nd attempt)** | What failed twice, what was tried, options | Retry differently, adjust, or escalate |
@@ -381,7 +413,7 @@ For other workflow components, see:
 - **`track-code-review.md`** — Phase C: code review + track completion
 - **`research.md`** — Phase 0 (research: interactive exploration before planning)
 - **`planning.md`** — Phase 1 (planning)
-- **`implementation-review.md`** — Phase 2 (implementation review: consistency + structural)
+- **`implementation-review.md`** — Phase 2 (autonomous implementation review: consistency + structural). **Loaded on-demand only when State 0 is active** (the startup protocol routes there when `## Plan Review` is `[ ]`); also loaded on manual `/review-plan` invocation. Non-State-0 sessions never read this file.
 - **`prompts/create-final-design.md`** — Phase 4 (final artifacts: `design-final.md`, `adr.md`)
 
 On-demand reference documents (loaded only when their specific situation arises):


### PR DESCRIPTION
## Motivation

The `/review-plan` command is fragile as a separate user-invoked step — easy to skip, and its per-finding interactive triage forces the user to decide on every mechanical fix (phantom reference, bloat trim, superseded DR) when only design-level decisions actually need their input. Phase 3's Phase A already runs review sub-agents autonomously at track scope; the same shape extends naturally to plan scope.

## Summary

- **Plan review becomes State 0 of `/execute-tracks`.** Consistency review and structural review both spawn sub-agents that emit a Classification (mechanical | design-decision) per finding. The orchestrator auto-applies mechanical fixes (current-state phantom references, all bloat findings, missing track-references on DRs) and batches design-decision findings (missing DR for non-obvious choice, track contradictions, ASPIRATIONAL/VIOLATED invariants, target-state gaps) for a single user-escalation pass per iteration.
- **Intent-axis pre-screen** distinguishes current-state vs. target-state claims so target-state divergences toward current code aren't silently auto-fixed.
- **State lives in the plan's new `## Plan Review` checklist entry**, which the startup protocol checks before State A. After the review passes, the orchestrator overwrites the section with an audit summary (auto-fixed + escalated finding IDs) so auto-fixes are recoverable via `git log`. design.md fixes route through `edit-design` to preserve mutation discipline.
- **Orchestration content lives in `implementation-review.md`** (loaded on-demand only when State 0 fires); `workflow.md` gains only a state-table row and a flowchart node — keeping per-session context cost zero for non-Phase-2 sessions.
- `/review-plan` is kept as a thin manual override invoking the same orchestration, useful after inline replanning produces a revised plan.

### Follow-up fixes (commit `bddedd6`)

1. **ESCALATE replan now flips `## Plan Review` back to `[ ]`** so the next `/execute-tracks` re-runs Phase 2 against the revised plan and catches consistency drift the replan introduced.
2. **Clean-tree precondition** lifted into `implementation-review.md` § How to run > Precondition and narrowed to the three plan-review files (the audit-trail `git add` is path-scoped, so the broad `git status --porcelain` check was over-restrictive). Both `/execute-tracks` State 0 and `/review-plan` point at the canonical version.
3. **Structural review inside ESCALATE retitled to "advisory preview"** — State 0's autonomous re-run on the next session is the real validation gate; ESCALATE's spawn is just fail-fast feedback. Iteration cap scopes blockers to structural-only; consistency findings surface in State 0.

### Gemini review fixes (commit `54a3762`)

Gemini code review flagged that the precondition check and audit-trail commit listed only plan/backlog/design.md, but `edit-design` — which the autonomous flow invokes for every design.md mechanical fix — also writes `design-mechanics.md` (when the design crossed the length trigger) and appends to `design-mutations.md` (the mutation log, created lazily on first call). Three changes:

- **Precondition extended** to five paths (`git status --porcelain` lists all; non-existent paths produce no output, so listing optional files is harmless).
- **Audit-trail `git add` switched to a `design*.md` glob** — `design.md` always exists post-Phase-1 so the glob always matches at minimum, and the mechanics + mutations files are picked up automatically when present.
- **Prose updated** in `review-plan/SKILL.md` to drop the "three workflow files" wording and list all five so the description matches what the canonical precondition actually checks.

## Test plan

- [ ] Manual: run `/execute-tracks <plan-dir>` on a plan with a fresh `## Plan Review [ ]` entry — verify State 0 fires, auto-fixes apply, audit summary is written, and State A starts only after the section flips to `[x]`
- [ ] Manual: trigger an ESCALATE replan in a track and confirm the `## Plan Review` section flips back to `[ ]` and the next `/execute-tracks` re-enters State 0
- [ ] Manual: dirty the working tree with an unrelated file and run `/execute-tracks` — State 0 should proceed (precondition only blocks edits to the five plan-review files)
- [ ] Manual: dirty `design-mutations.md` from a prior `edit-design` run and run `/execute-tracks` — precondition halts and asks the user to commit or stash
- [ ] Manual: run `/review-plan` standalone after inline replanning and confirm it resumes via the same orchestration