### PR TITLE
Colour the statusline context bar by threshold level

### DIFF
--- a/.claude/scripts/statusline-command.sh
+++ b/.claude/scripts/statusline-command.sh
@@ -32,10 +32,29 @@ build_bar() {
   printf "%s" "$bar"
 }
 
+# Determine threshold level and ANSI colour for the progress bar.
+# Colour scheme: green for safe/info, yellow for warning, red for critical.
+# Threshold table: see CLAUDE.md § Context Window Monitor.
+pct_int=""
+level=""
 if [ -n "$used_pct" ]; then
   pct_int=$(printf "%.0f" "$used_pct")
+  if [ "$pct_int" -ge 40 ]; then
+    level="critical"
+    ctx_color=$'\033[31m'  # red
+  elif [ "$pct_int" -ge 30 ]; then
+    level="warning"
+    ctx_color=$'\033[33m'  # yellow
+  elif [ "$pct_int" -ge 20 ]; then
+    level="info"
+    ctx_color=$'\033[32m'  # green
+  else
+    level="safe"
+    ctx_color=$'\033[32m'  # green
+  fi
+  ctx_reset=$'\033[0m'
   bar=$(build_bar "$pct_int")
-  ctx_str="[${bar}] ${pct_int}%"
+  ctx_str="${ctx_color}[${bar}] ${pct_int}%${ctx_reset}"
 else
   ctx_str="[----------] --%"
 fi
@@ -58,14 +77,6 @@ if [ -n "$used_pct" ]; then
     pid=$ppid
   done
   if [ -n "$claude_pid" ]; then
-    level="safe"
-    if [ "$pct_int" -ge 40 ]; then
-      level="critical"
-    elif [ "$pct_int" -ge 30 ]; then
-      level="warning"
-    elif [ "$pct_int" -ge 20 ]; then
-      level="info"
-    fi
     printf "ctx: %s%% level=%s" "$pct_int" "$level" \
       > "/tmp/claude-code-context-usage-${claude_pid}.txt"
   fi

--- a/.claude/scripts/statusline-command.sh
+++ b/.claude/scripts/statusline-command.sh
@@ -32,28 +32,31 @@ build_bar() {
   printf "%s" "$bar"
 }
 
-# Determine threshold level and ANSI colour for the progress bar.
-# Colour scheme: green for safe, dim-green for info, yellow for warning, red for critical.
+# Determine threshold level. Also used for the on-disk usage file below.
 if [ -n "$used_pct" ]; then
   pct_int=$(printf "%.0f" "$used_pct")
   if [ "$pct_int" -ge 40 ]; then
     level="critical"
-    ctx_color=$'\033[31m'    # red
   elif [ "$pct_int" -ge 30 ]; then
     level="warning"
-    ctx_color=$'\033[33m'    # yellow
   elif [ "$pct_int" -ge 20 ]; then
     level="info"
-    ctx_color=$'\033[2;32m'  # dim green
   else
     level="safe"
-    ctx_color=$'\033[32m'    # green
   fi
-  ctx_reset=$'\033[0m'
-  # Honour NO_COLOR for non-TTY consumers (log capture, snapshot tests).
-  if [ -n "$NO_COLOR" ]; then
-    ctx_color=""
-    ctx_reset=""
+
+  # Map level → ANSI colour for the progress bar, honouring NO_COLOR
+  # (non-TTY consumers like log capture and snapshot tests).
+  ctx_color=""
+  ctx_reset=""
+  if [ -z "$NO_COLOR" ]; then
+    case "$level" in
+      critical) ctx_color=$'\033[31m' ;;   # red
+      warning)  ctx_color=$'\033[33m' ;;   # yellow
+      info)     ctx_color=$'\033[2;32m' ;; # dim green
+      safe)     ctx_color=$'\033[32m' ;;   # green
+    esac
+    ctx_reset=$'\033[0m'
   fi
   bar=$(build_bar "$pct_int")
   ctx_str="${ctx_color}[${bar}] ${pct_int}%${ctx_reset}"

--- a/.claude/scripts/statusline-command.sh
+++ b/.claude/scripts/statusline-command.sh
@@ -33,26 +33,28 @@ build_bar() {
 }
 
 # Determine threshold level and ANSI colour for the progress bar.
-# Colour scheme: green for safe/info, yellow for warning, red for critical.
-# Threshold table: see CLAUDE.md § Context Window Monitor.
-pct_int=""
-level=""
+# Colour scheme: green for safe, dim-green for info, yellow for warning, red for critical.
 if [ -n "$used_pct" ]; then
   pct_int=$(printf "%.0f" "$used_pct")
   if [ "$pct_int" -ge 40 ]; then
     level="critical"
-    ctx_color=$'\033[31m'  # red
+    ctx_color=$'\033[31m'    # red
   elif [ "$pct_int" -ge 30 ]; then
     level="warning"
-    ctx_color=$'\033[33m'  # yellow
+    ctx_color=$'\033[33m'    # yellow
   elif [ "$pct_int" -ge 20 ]; then
     level="info"
-    ctx_color=$'\033[32m'  # green
+    ctx_color=$'\033[2;32m'  # dim green
   else
     level="safe"
-    ctx_color=$'\033[32m'  # green
+    ctx_color=$'\033[32m'    # green
   fi
   ctx_reset=$'\033[0m'
+  # Honour NO_COLOR for non-TTY consumers (log capture, snapshot tests).
+  if [ -n "$NO_COLOR" ]; then
+    ctx_color=""
+    ctx_reset=""
+  fi
   bar=$(build_bar "$pct_int")
   ctx_str="${ctx_color}[${bar}] ${pct_int}%${ctx_reset}"
 else


### PR DESCRIPTION
#### Motivation

The statusline already classified context usage into `safe` / `info` / `warning` / `critical` buckets and wrote them to the on-disk usage file, but the rendered progress bar itself was uncoloured. With Opus 4.7 / 1M context, sessions routinely sit at single-digit percentages for a long time and then cross into the degradation zone in one or two large reads — and without a visual signal it was easy to miss the transition until quality already started slipping.

Colouring the bar by level makes the threshold immediately legible without having to read the percentage:

- `safe` (<20%) — green
- `info` (≥20%) — dim green (distinct from safe, but not alarming)
- `warning` (≥30%) — yellow
- `critical` (≥40%) — red

Also consolidates the level computation that was previously duplicated between the bar-rendering and the file-write blocks, and honours `NO_COLOR` for non-TTY consumers (log capture, snapshot tests).

The thresholds match the table documented in `CLAUDE.md` § Context Window Monitor and the on-disk usage file (`/tmp/claude-code-context-usage-<pid>.txt`), so they remain in sync.

## Test plan
- [ ] Open a fresh session and confirm the bar renders green at low context usage.
- [ ] Force usage past 20% / 30% / 40% and confirm the bar transitions to dim-green / yellow / red respectively, and the on-disk usage file reports the matching level.
- [ ] Run with `NO_COLOR=1` and confirm the bar renders without ANSI escapes.