### PR TITLE
Harden orchestrator recovery for budget-pressure implementer exits

### DIFF
--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -271,6 +271,16 @@ sessions repeatedly stranded on this exact pattern.
 - MUST NOT start Maven invocations with Bash `run_in_background: true`.
 - MUST NOT chain `sleep` / monitor poll loops waiting for a
   background task to finish.
+- MUST NOT use **self-referential `pgrep -f` poll loops**. A pattern
+  like `until ! pgrep -f "surefire"; do sleep 5; done` matches its
+  own shell because the shell's argv contains the literal
+  `surefire`, so the loop never terminates and runs forever after
+  the implementer exits — exactly the runaway poll observed in the
+  Track-18 incident (2026-05-07). If a poll loop is genuinely
+  unavoidable, exclude the shell's own pid (`pgrep -f surefire |
+  grep -v $$`) or prefer `tail --pid=N` / `wait`. The cleanest
+  path is to not use a poll loop at all — foreground Bash already
+  blocks until the test run finishes, which is the rule above.
 
 Pacing is the orchestrator's job, not the implementer's. The
 implementer runs straight through sub-steps 1–3 and emits exactly
@@ -308,6 +318,32 @@ profile build, integration tests:
   the cumulative diff is non-empty and the implementer must run the
   full coverage profile build even when the iteration's own diff is
   test-only.
+- **Prefer targeted `-Dtest=…` re-runs during fix iteration.** When
+  applying review findings (`mode=FIX_REVIEW_FINDINGS` at either
+  level), re-run only the test classes the fix actually touched —
+  `./mvnw -pl <module> test -Dtest='Foo,Bar,Baz'` rather than the
+  full module suite. Targeted re-runs finish in seconds, fit
+  comfortably inside the foreground Bash budget, and keep the
+  implementer's context lean: a 1500-test module re-run on a
+  failing assertion can dump tens of thousands of tokens of stack
+  traces into the conversation, and the Track-18 implementer
+  exhausted its message budget on exactly this pattern
+  (2026-05-07). Reserve the full module suite for one final
+  pre-commit verification, and only when the cumulative diff
+  genuinely justifies it; routine fix iterations do not.
+- **Route targeted re-runs through `steroid_execute_code` when
+  mcp-steroid is reachable.** Per the project's `CLAUDE.md` § MCP
+  Steroid → "Maven — when to route through mcp-steroid",
+  single-test re-runs and short targeted lists belong on the IDE
+  route. The `test/failure-details` and `test/statistics` recipes
+  (catalogued in `conventions.md` §1.4 *Recipes*) return structured
+  per-test outcomes from `RunContentManager` rather than streaming
+  surefire stdout into the conversation — typically a 10–25× context
+  saving on a failing run, which is the lever that prevents the
+  message-budget exhaustion mode the targeted-rerun rule above is
+  also targeting. Full-module verification, coverage-profile builds,
+  and integration tests stay on Bash per the project rule, even
+  when the IDE is reachable.
 
 If even a staged sequence cannot fit the foreground budget (rare —
 only large `-P ci-integration-tests` runs or full multi-module
@@ -591,6 +627,46 @@ the prior step commits; Phase C never rolls back across spawns.
 The implementer's return is a **single structured block**. The
 orchestrator parses it; everything else in the implementer's output is
 informational and ignored.
+
+**Silent exit is forbidden.** The implementer MUST emit a `RESULT:`
+block before exiting for **any** reason — successful completion,
+detection-rule early return (design decision, risk upgrade,
+fundamental failure), context-window exhaustion, message-budget
+pressure, tool-call-budget pressure, or unrecoverable runtime error
+in any tool call. A return whose text contains no parsable `RESULT:`
+block (or a block truncated mid-field) is a contract violation: the
+orchestrator cannot dispatch on missing data, the implementer's last
+actions are by definition uncommitted, and recovery requires manual
+inspection of the working tree (see
+[`track-code-review.md`](track-code-review.md) §Phase C Implementer
+Handlers → `RESULT_MISSING` for the orchestrator-side handler).
+
+When an exit is forced before sub-steps 1–3 complete, the priority
+order is: **(1) emit `RESULT: FAILED` first**, with the cause stated
+honestly in `FAILURE.why_it_failed` (e.g., "ran out of message
+budget after applying 7 of 22 findings; tests not yet re-run; tree
+dirty"), `FAILURE.what_was_attempted` populated, and
+`FAILURE.recommended_action: retry`. List every path the
+implementer touched in `FILES_TOUCHED` even when not yet reverted —
+the orchestrator uses `FILES_TOUCHED` to decide between
+commit-as-is, re-spawn, and discard. **(2) Then run the revert
+sequence** per §"Detection rules — return early without committing"
+if time and budget still permit. If the revert cannot complete,
+leaving a dirty tree at HEAD on a `FAILED` return is itself a
+contract violation that the orchestrator's
+`handle_iteration_failure` path surfaces to the user (see
+[`track-code-review.md`](track-code-review.md) §Phase C Implementer
+Handlers → `handle_iteration_failure` "Verify `git status` is clean
+before continuing"); the user then chooses among the same
+commit-as-is / re-spawn / discard options as the `RESULT_MISSING`
+path. Both paths converge on the same recovery flow, so an honest
+partial-progress `FAILED` (even with a dirty tree) is strictly
+better than a silent exit. The §"Detection rules" section still
+governs **deliberate** early-returns (design decision, risk upgrade,
+fundamental failure under normal budget) — those have time to
+revert and must do so; this clause governs the **unplanned-exit**
+case where the priority is preserving the RESULT contract over the
+cleanup contract.
 
 ```
 RESULT: SUCCESS | DESIGN_DECISION_NEEDED | RISK_UPGRADE_REQUESTED | FAILED

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -336,7 +336,8 @@ profile build, integration tests:
   Steroid → "Maven — when to route through mcp-steroid",
   single-test re-runs and short targeted lists belong on the IDE
   route. The `test/failure-details` and `test/statistics` recipes
-  (catalogued in `conventions.md` §1.4 *Recipes*) return structured
+  (catalogued in `conventions.md` §1.4 → "Recipes" subsection)
+  return structured
   per-test outcomes from `RunContentManager` rather than streaming
   surefire stdout into the conversation — typically a 10–25× context
   saving on a failing run, which is the lever that prevents the

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -251,6 +251,20 @@ track diff base_commit..HEAD when level=track). Return the
 structured block defined in the rulebook's §Return contract. Do not
 return free-form prose after the block — the orchestrator parses
 only the block.
+
+**Mandatory RESULT block on every exit.** Emit the structured
+RESULT block before exiting for any reason — successful completion,
+detection-rule early return, fundamental failure, context-window
+exhaustion, message-budget pressure, tool-call-budget pressure, or
+runtime error in any tool call. A return with no parsable RESULT
+block (or a truncated one) is a contract violation that prevents
+the orchestrator from recovering. When an exit is forced before
+sub-steps 1–3 complete, emit RESULT: FAILED with the cause stated
+in FAILURE.why_it_failed, every touched path listed in
+FILES_TOUCHED (even if not yet reverted), and recommended_action:
+retry. The orchestrator can recover from honest partial-failure but
+not from silence. See the rulebook's §Return contract for the full
+clause.
 ```
 
 The orchestrator substitutes `{repo_root}`, `{PPID}`, `{dir-name}`,

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -578,8 +578,9 @@ manual and requires user approval — do not auto-respawn.
      | grep -v ' grep '
    ```
 
-   and terminate orphaned PIDs with `kill -TERM <pid>` (then
-   `kill -KILL <pid>` if they survive). Two patterns are
+   and terminate orphaned PIDs with `kill -TERM <pid>`. Wait a few
+   seconds for graceful cleanup (releasing file locks, flushing logs),
+   then escalate to `kill -KILL <pid>` only if they survive. Two patterns are
    particularly common after a `RESULT_MISSING` exit:
    - a defunct `[java]` zombie from an interrupted Maven fork
      (still listed but consuming no CPU; reaped by killing its

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -363,8 +363,16 @@ orchestrator never edits source files itself in Phase C.
    independent counters). Iterations short-circuited via the
    pre-spawn budget split in step 2 each consume one counter — a
    24-finding set split into a 12+12 sequence consumes 2 of 3
-   iterations on the in-scope findings alone, leaving exactly one
-   iteration for any gate-check carry-over.
+   iterations on the in-scope findings alone, leaving only one
+   iteration for any gate-check carry-over from **either** chunk.
+   This is tight: if iteration 1's gate-check surfaces new fixable
+   findings and iteration 2 is already full at 12 carry-overs, the
+   single remaining iteration must absorb gate-check carry from
+   both prior iterations and may exhaust the budget. When the
+   pre-spawn finding-set is large enough that a 2-chunk split is
+   forced, expect blockers-persist exit at the end and surface the
+   residual findings at track completion rather than treating the
+   third iteration as a guaranteed cleanup slot.
 5. If blockers persist after 3 iterations, or if any iteration ended
    in a non-`SUCCESS` return that exited the loop, note the unfixed
    findings — they'll be presented to the user during track completion
@@ -623,9 +631,30 @@ manual and requires user approval — do not auto-respawn.
      + the coverage gate, commits as `Review fix: <subject>` per
      [`commit-conventions.md`](commit-conventions.md), and
      proceeds to the gate-check fan-out as if the iteration had
-     returned `SUCCESS`. **This is the only Phase C case where the
-     orchestrator commits source-file changes directly** — note
-     the deviation in the eventual track episode so the audit
+     returned `SUCCESS`. **Apply the test-additive carve-out** from
+     [`implementer-rules.md`](implementer-rules.md) §Pacing
+     long-running tasks → "Test-additive spawns skip the
+     coverage-profile build entirely": when
+     `git diff origin/develop -- '**/src/main/**'` is empty for the
+     cumulative branch diff, record the gate as `n/a (test-additive)`
+     and skip the coverage profile build — running it on a test-only
+     iteration is wasted budget. **If we reached this handler via
+     the dirty-tree-at-FAILED redirect from `handle_iteration_failure`
+     above** (i.e., `result.RESULT == FAILED` with a populated
+     `result.FAILURE` block, not a true `RESULT_MISSING` where no
+     RESULT block was parsed), fold the implementer's
+     `FAILURE.what_was_attempted` / `FAILURE.why_it_failed` /
+     `FAILURE.recommended_action` fields into the `Review fix:`
+     commit message body verbatim so the git history preserves the
+     budget-pressure context — the implementer's own pre-exit
+     diagnosis is the most authoritative record of what happened
+     and must not be discarded just because the iteration was
+     finalised by the orchestrator. For a true `RESULT_MISSING`
+     entry the FAILURE block doesn't exist; record what was visible
+     (the implementer's last visible message excerpt from step 3)
+     in the commit message body instead. **This is the only Phase C case
+     where the orchestrator commits source-file changes directly** —
+     note the deviation in the eventual track episode so the audit
      trail is preserved.
    - **Discard.** Run the snapshot-and-diff revert on the
      implementer's behalf and treat the iteration as `FAILED`

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -282,7 +282,28 @@ orchestrator never edits source files itself in Phase C.
    to other tracks via plan corrections — see §Plan Corrections from
    Deferred Findings below). The implementer receives only the
    in-scope subset.
-2. **If any in-scope findings need fixes:**
+2. **Pre-spawn budget check.** If the in-scope subset has ≥ ~15
+   findings or spans ≥ ~10 distinct source files, split the work
+   across multiple iterations rather than one mega-iteration. Pick
+   the highest-severity subset that fits the budget (typical safe
+   shape: 8–12 findings touching ≤ 6–8 files, leaving room for
+   targeted re-runs of the touched test classes per
+   [`implementer-rules.md`](implementer-rules.md) §Pacing
+   long-running tasks → "Prefer targeted `-Dtest=…` re-runs"). The
+   remaining findings re-surface in iteration 2's gate-check
+   fan-out and consume an iteration counter normally — they are not
+   lost. This is a soft-pacing rule, not a hard split: when the
+   findings are genuinely independent and the diff is small (e.g.,
+   20 identical-pattern Javadoc fixes touching 10 files), one large
+   iteration is still fine. The Track-18 incident (2026-05-07) — a
+   22-finding × 14-file spawn that ran an Opus implementer out of
+   message budget mid-iteration — motivated this rule. **The
+   thresholds (~15 findings / ~10 files) are heuristics, not
+   contract gates** — when the finding-set is borderline, prefer
+   splitting; when an iteration count is already tight (2 of 3 used)
+   and the remaining findings genuinely cohere, accept the larger
+   spawn and document the choice.
+3. **If any in-scope findings need fixes:**
    - **Spawn the per-iteration implementer** with `level=track`,
      `mode=FIX_REVIEW_FINDINGS`, `base_commit` (read from the step
      file's `## Base commit`), and the iteration's in-scope findings
@@ -293,15 +314,22 @@ orchestrator never edits source files itself in Phase C.
    - **Dispatch on the structured return:**
 
      ```
-     match result.RESULT:
-         SUCCESS                  -> on_iteration_success(result)
-         DESIGN_DECISION_NEEDED   -> escalate_to_user_then_respawn(result)
-         RISK_UPGRADE_REQUESTED   -> contract violation — surface to user
-         FAILED                   -> handle_iteration_failure(result)
+     match result:
+         result.RESULT == SUCCESS                  -> on_iteration_success(result)
+         result.RESULT == DESIGN_DECISION_NEEDED   -> escalate_to_user_then_respawn(result)
+         result.RESULT == RISK_UPGRADE_REQUESTED   -> contract violation — surface to user
+         result.RESULT == FAILED                   -> handle_iteration_failure(result)
+         <no parsable RESULT block>                -> handle_result_missing(result_text)
      ```
 
-     The three normal handlers and the contract-violation path are
-     spelled out in §Phase C Implementer Handlers below.
+     The three normal handlers and the two contract-violation paths
+     are spelled out in §Phase C Implementer Handlers below. The
+     `RESULT_MISSING` path covers implementers that exited mid-flight
+     without emitting the contract block — typically due to
+     message-budget exhaustion or a tool-call crash; per
+     [`implementer-rules.md`](implementer-rules.md) §Return contract,
+     silent exit is forbidden, but the orchestrator must still be
+     able to recover when it happens.
    - On `SUCCESS`: the implementer has already pushed a `Review fix:`
      commit and run tests + Spotless + coverage gate. The orchestrator
      does **not** re-run tests or re-stage files; it proceeds to the
@@ -329,15 +357,19 @@ orchestrator never edits source files itself in Phase C.
      `safe`/`info`, continue to the next iteration. If the file does
      not exist or the command fails, this is **not an error** — treat
      as `safe` and continue.
-3. Max 3 iterations **total across sessions** — on resume, read the
+4. Max 3 iterations **total across sessions** — on resume, read the
    iteration count from the Progress section to determine how many remain.
    The iteration count is shared across all review dimensions (not
-   independent counters).
-4. If blockers persist after 3 iterations, or if any iteration ended
+   independent counters). Iterations short-circuited via the
+   pre-spawn budget split in step 2 each consume one counter — a
+   24-finding set split into a 12+12 sequence consumes 2 of 3
+   iterations on the in-scope findings alone, leaving exactly one
+   iteration for any gate-check carry-over.
+5. If blockers persist after 3 iterations, or if any iteration ended
    in a non-`SUCCESS` return that exited the loop, note the unfixed
    findings — they'll be presented to the user during track completion
    (below).
-5. When all reviews pass (or max iterations reached), mark
+6. When all reviews pass (or max iterations reached), mark
    `Track-level code review` as `[x]` in the step file's Progress section.
 
 ---
@@ -389,8 +421,10 @@ or body when it makes the log easier to follow.
 The implementer's structured return drives one of three
 orchestrator-side handlers (success / escalate / failure), plus a
 fourth `RISK_UPGRADE_REQUESTED` contract-violation path that aborts
-to the user rather than running a handler. None of the three
-handlers roll back prior `Review fix:` commits — see
+to the user rather than running a handler, plus a fifth
+`RESULT_MISSING` recovery path for the case where the implementer
+exited mid-flight without emitting the contract block at all. None
+of the five paths roll back prior `Review fix:` commits — see
 [`implementer-rules.md`](implementer-rules.md) §"Mode-specific scope
 of the local revert" `level=track` row for the rationale (prior
 iterations' fixes have already passed their gate check; a failed
@@ -452,9 +486,18 @@ produced this iteration. `result.FAILURE` carries
 (at `level=track` this is "impact on remaining findings"), and
 `recommended_action`.
 
-Verify `git status` is clean before continuing — a dirty tree at
-this point is a contract violation; surface the discrepancy to the
-user instead of proceeding.
+Verify `git status` is clean before continuing. A dirty tree at this
+point is a contract violation, but per
+[`implementer-rules.md`](implementer-rules.md) §Return contract this
+violation is **expected** when the implementer hit a budget-pressure
+exit and prioritised emitting `RESULT: FAILED` over completing the
+revert sequence. **Route a dirty tree at FAILED through the same
+recovery flow as `RESULT_MISSING`**: kill background tasks, inspect
+the tree, and present the user with commit-as-is / re-spawn /
+discard (see §`handle_result_missing` below for the full procedure).
+The implementer's `FILES_TOUCHED` and `FAILURE.why_it_failed` are
+authoritative inputs to the user's choice — do not discard them. If
+`git status` is clean, proceed with the steps below.
 
 1. **Record the failure** — update the step file's Progress section
    to mark the track-level code review entry with the failure (e.g.,
@@ -493,6 +536,112 @@ verbatim to the user, do not respawn automatically, and let the
 user decide whether to enter ESCALATE
 ([`inline-replanning.md`](inline-replanning.md)) or to proceed to
 track completion with the iteration's findings unfixed.
+
+### `handle_result_missing(result_text)` (contract violation, recovery required)
+
+The implementer's return text contains **no parsable `RESULT:` block**
+(or the block is truncated mid-field). This is a contract violation
+per [`implementer-rules.md`](implementer-rules.md) §Return contract —
+the implementer is required to emit a RESULT block before any exit,
+including context/budget exhaustion. The most common causes are:
+
+- the implementer ran out of message budget mid-iteration (the
+  Track-18 incident, 2026-05-07: ~213k cache_read peak from
+  foreground Maven runs dumping stack traces, implementer truncated
+  while applying the 22nd of 22 findings and never reached its own
+  return block);
+- a runtime crash or timeout in a tool call (Bash 600 s timeout
+  fired in foreground, Agent runtime dropped a wake-up
+  notification, MCP server became unresponsive mid-call);
+- the implementer left a runaway poll loop or background task alive
+  that the system terminated externally.
+
+The orchestrator cannot dispatch on missing data and the
+implementer's last actions are by definition uncommitted (a
+successful commit always emits `RESULT: SUCCESS`). Recovery is
+manual and requires user approval — do not auto-respawn.
+
+1. **Kill any background tasks the implementer may have left
+   alive.** Run
+
+   ```bash
+   ps -o pid,ppid,cmd -e \
+     | grep -E 'mvnw|surefire|java.*test|pgrep -f' \
+     | grep -v ' grep '
+   ```
+
+   and terminate orphaned PIDs with `kill -TERM <pid>` (then
+   `kill -KILL <pid>` if they survive). Two patterns are
+   particularly common after a `RESULT_MISSING` exit:
+   - a defunct `[java]` zombie from an interrupted Maven fork
+     (still listed but consuming no CPU; reaped by killing its
+     parent);
+   - a runaway `pgrep -f "surefire"` poll loop whose own shell
+     command line matches the search pattern, so the loop never
+     exits — see [`implementer-rules.md`](implementer-rules.md)
+     §Pacing long-running tasks → forbidden self-referential
+     pgrep. Untouched, this loop runs forever and consumes a CPU.
+
+2. **Inspect the tree.** Run `git status --short` and
+   `git diff --stat`. Three states are possible:
+
+   - **Clean tree** — implementer reverted before exiting (or
+     never began applying fixes). Skip to step 3 with the **discard**
+     option pre-selected; the iteration is effectively a no-op.
+   - **Dirty tree, edits look correct on inspection** — the
+     implementer applied fixes but never committed (the most
+     common Track-18 shape). The **commit-as-is** option is
+     viable if the orchestrator can verify the edits independently.
+   - **Dirty tree, edits look incomplete or wrong** — the
+     implementer was mid-edit when its budget ran out. Recovery
+     is most likely **re-spawn from a clean state**.
+
+3. **Present the situation to the user with three options.**
+   Include the inspection output (a `git status --short` excerpt
+   and the implementer's last visible message, truncated to a few
+   hundred characters) so the user can choose informedly.
+
+   - **Re-spawn finalizer.** Clean the tree on the implementer's
+     behalf (run the snapshot-and-diff revert sequence per
+     [`implementer-rules.md`](implementer-rules.md) §Detection
+     rules — the implementer never reached its own revert path,
+     so the orchestrator owns the cleanup this once), then
+     re-spawn a fresh implementer with the original findings. **If
+     the original findings list was large** (≥ ~15 items or ≥ ~10
+     files, the same heuristic as §Review loop step 2's pre-spawn
+     budget check), halve the in-scope subset on the respawn so
+     the new spawn doesn't repeat the budget exhaustion. The
+     halved-off findings re-surface in the next iteration's
+     gate-check fan-out.
+   - **Commit-as-is.** Only when the dirty tree's edits look
+     complete and correct on inspection, and when the orchestrator
+     is in a position to verify them itself. The orchestrator
+     stages explicit paths (no `git add -A`), runs Spotless +
+     targeted tests of the touched test classes (per
+     [`implementer-rules.md`](implementer-rules.md) §Pacing
+     long-running tasks → "Prefer targeted `-Dtest=…` re-runs")
+     + the coverage gate, commits as `Review fix: <subject>` per
+     [`commit-conventions.md`](commit-conventions.md), and
+     proceeds to the gate-check fan-out as if the iteration had
+     returned `SUCCESS`. **This is the only Phase C case where the
+     orchestrator commits source-file changes directly** — note
+     the deviation in the eventual track episode so the audit
+     trail is preserved.
+   - **Discard.** Run the snapshot-and-diff revert on the
+     implementer's behalf and treat the iteration as `FAILED`
+     with `recommended_action: escalate`. The remaining findings
+     are surfaced at track completion via the existing "blockers
+     persist after N iterations" branch.
+
+4. **Iteration counter accounting.** A `RESULT_MISSING` recovery
+   consumes one iteration counter regardless of which option the
+   user picks — the implementer was spawned, ran, and produced a
+   commit's worth of state on disk; that has the same impact on
+   the budget as a `FAILED` return. Update the Progress section
+   with the new counter and a note (e.g.,
+   `- [ ] Track-level code review (1/3 iterations, iteration 1
+   recovered from RESULT_MISSING via commit-as-is)`) and commit it
+   as a Workflow update commit before the next action.
 
 ---
 


### PR DESCRIPTION
#### Motivation

The Track-18 incident (Phase C, 22-finding × 14-file fix iteration on 2026-05-07) showed an Opus implementer applying review fixes correctly, then exiting silently mid-flight: no `RESULT:` block, dirty tree, defunct `[java]` zombie from an interrupted Maven fork, and a runaway self-referential `pgrep -f surefire` poll loop that survived the implementer's own exit and burned a CPU until killed manually.

The orchestrator had no defined recovery path for this shape of exit:
- `handle_iteration_failure` assumed a clean tree post-revert and treated a dirty tree as a contract violation to surface — leaving the user with no procedure.
- The `match result.RESULT` dispatch in §Review loop had no case for "no parsable RESULT block at all," so the orchestrator's behavior on this input was undefined.
- No rule discouraged spawning 22-finding mega-iterations in the first place, so the same exhaustion mode would recur.

This PR is procedural across three workflow docs — no source-code change. It closes the silent-exit hole and adds the budget-pressure preventatives that would have averted the incident.

#### What changes

**`implementer-rules.md`**
- Bans **self-referential `pgrep -f` poll loops**. The Track-18 loop matched its own shell's argv (containing the literal `surefire`) and never terminated. The rule prescribes excluding `$$` or — better — using foreground Bash with no poll loop, which is already the rule for Maven.
- Adds **targeted `-Dtest=…` re-runs** as the default during fix iterations. A 1500-test module re-run on a failing assertion can dump tens of thousands of stack-trace tokens into the conversation; the Track-18 implementer exhausted its message budget on exactly this pattern. Full module suite is reserved for one final pre-commit verification.
- Routes those targeted re-runs through `steroid_execute_code` when MCP Steroid is reachable, so structured `test/failure-details` and `test/statistics` results from `RunContentManager` replace surefire stdout (a 10–25× context saving on a failing run).
- Makes **silent exit explicitly a contract violation** and prescribes the priority order on a forced exit: emit `RESULT: FAILED` first (with `FAILURE.why_it_failed` populated honestly and every touched path listed in `FILES_TOUCHED`), then run the revert sequence if budget permits. Honest partial-progress `FAILED` is strictly better than silence.

**`step-implementation.md`**
- Short reinforcement of the mandatory-`RESULT`-block rule in the Implementer Prompt Template's `Instructions` block, so every spawn carries the contract clause directly in its prompt.

**`track-code-review.md`**
- **Pre-spawn budget check** (§Review loop step 2). When the in-scope finding-set is ≥ ~15 findings or spans ≥ ~10 files, split across iterations rather than one mega-iteration. Soft-pacing rule (with explicit "borderline-set" carve-outs), motivated by the Track-18 exhaustion shape.
- **`<no parsable RESULT block>`** added as a fifth dispatch case alongside `SUCCESS` / `DESIGN_DECISION_NEEDED` / `RISK_UPGRADE_REQUESTED` / `FAILED`.
- **New `handle_result_missing` handler** (§Phase C Implementer Handlers): kill stragglers (the `[java]` zombie and the runaway pgrep loop both have explicit recipes), inspect the tree, and present the user with three options — **commit-as-is** (when the dirty edits look complete; orchestrator stages explicit paths, runs Spotless + targeted tests + coverage gate, commits as `Review fix:`), **re-spawn finalizer** (revert on the implementer's behalf and re-spawn with the finding-set halved if the original was over the budget heuristic), or **discard** (revert and treat as `FAILED` with `recommended_action: escalate`). Iteration counter consumed regardless of choice.
- **Routes a dirty tree at `FAILED` through the same `handle_result_missing` recovery flow.** Per the new implementer-rules contract, a budget-pressure exit may legitimately leave a dirty tree (the implementer prioritised RESULT over revert). The user gets one consistent commit-as-is / re-spawn / discard menu either way.
- **Test-additive carve-out and FAILURE-fields preservation** on the commit-as-is path: the orchestrator skips the coverage profile build for test-only iterations and folds the implementer's `FAILURE` block verbatim into the `Review fix:` commit body so the budget-pressure diagnosis survives in git history.
- Counter accounting note honestly flags the squeeze: forcing a 2-chunk split leaves only one iteration for gate-check carry from **either** chunk, so blockers-persist exit at track completion is the expected outcome on large finding-sets, not a failure mode to engineer around.

#### Compatibility

- The historical "no `run_in_background` for Maven" rule (PR #1029) is preserved verbatim — these changes attack the message-budget exhaustion that caused Track 18, not the dropped-wake-up failure mode that motivated the foreground-only rule.
- `level=step` flow is unchanged. Phase B implementer-rules additions are scoped to fix-iteration behavior (`mode=FIX_REVIEW_FINDINGS`) and the return-contract clarification, both of which are strict additions.
- No source code, no tests, no public API.

#### Test plan

- [x] Cross-references resolved: every `§<Section>` and file pointer in the new content was grepped against its target file and lands on a real heading.
- [x] Five-path dispatch verified: all five handler labels (`on_iteration_success`, `escalate_to_user_then_respawn`, `RISK_UPGRADE_REQUESTED`, `handle_iteration_failure`, `handle_result_missing`) have matching `### <handler>` definitions in `track-code-review.md`.
- [x] No production source changed; coverage gate and test count gate are not applicable. (If CI flags the test-count gate, the PR title can be amended with `[no-test-number-check]` per the project rule.)