### PR TITLE
Require --out on render-slim-plan and document canonical $PPID path

### DIFF
--- a/.claude/scripts/render-slim-plan.py
+++ b/.claude/scripts/render-slim-plan.py
@@ -10,13 +10,15 @@ detail.
 Usage:
     python3 .claude/scripts/render-slim-plan.py \\
         --plan-path docs/adr/<dir>/_workflow/implementation-plan.md \\
-        [--out /tmp/claude-code-plan-slim-$PPID.md] \\
+        --out /tmp/claude-code-plan-slim-$PPID.md \\
         [--quiet]
 
-If --out is omitted the script writes to
-`/tmp/claude-code-plan-slim-<ppid>.md` where `<ppid>` is this process's
-parent PID — matching the convention in plan-slim-rendering.md so
-concurrent sessions do not collide.
+`--out` is required. Callers must pass the orchestrator-scoped path
+`/tmp/claude-code-plan-slim-$PPID.md` so the snapshot lands where
+sub-agents look for it (per the convention in plan-slim-rendering.md).
+The script does not infer the orchestrator PID — when invoked through
+the Bash tool, this process's parent is the bash shell, not the
+orchestrator, so any auto-derived path would silently drift.
 
 Output:
     Stdout: one-line summary of tracks rendered (suppressed by --quiet).
@@ -29,7 +31,6 @@ Exit codes:
 """
 
 import argparse
-import os
 import re
 import sys
 from typing import List, Optional, Set, Tuple
@@ -376,11 +377,15 @@ def main() -> int:
     )
     parser.add_argument(
         "--out",
-        default=None,
+        required=True,
         help=(
-            "Path to write the slim snapshot. Default: "
-            "/tmp/claude-code-plan-slim-<ppid>.md (uses this process's "
-            "parent PID)."
+            "Path to write the slim snapshot. Required — pass "
+            "/tmp/claude-code-plan-slim-$PPID.md from the orchestrator's "
+            "shell so the snapshot lands at the path sub-agents read. "
+            "The script does not infer this path: when invoked via the "
+            "Bash tool, getppid() returns the bash shell, not the "
+            "orchestrator, so any auto-derived default would silently "
+            "drift."
         ),
     )
     parser.add_argument(
@@ -391,8 +396,6 @@ def main() -> int:
     args = parser.parse_args()
 
     out_path = args.out
-    if out_path is None:
-        out_path = f"/tmp/claude-code-plan-slim-{os.getppid()}.md"
 
     try:
         with open(args.plan_path, "r", encoding="utf-8") as f:

--- a/.claude/workflow/plan-slim-rendering.md
+++ b/.claude/workflow/plan-slim-rendering.md
@@ -45,14 +45,21 @@ Run the pre-built renderer:
 
 ```bash
 python3 .claude/scripts/render-slim-plan.py \
-    --plan-path docs/adr/<dir-name>/_workflow/implementation-plan.md
+    --plan-path docs/adr/<dir-name>/_workflow/implementation-plan.md \
+    --out /tmp/claude-code-plan-slim-$PPID.md
 ```
 
-With no `--out`, the script writes
-`/tmp/claude-code-plan-slim-<ppid>.md` using its parent PID — i.e.,
-the orchestrator's PID — matching the snapshot path convention above.
-The script implements the rendering rule below; do **not** re-derive
-the transform inline (that's the whole reason this script exists). On
+`--out` is required and must be the orchestrator-scoped path
+`/tmp/claude-code-plan-slim-$PPID.md`. The shell variable `$PPID`
+resolves to the orchestrator process ID inside the Bash invocation,
+matching the snapshot path convention above. The script does **not**
+auto-derive this path: when invoked through the Bash tool, the
+script's parent process is the bash shell that launched it, not the
+orchestrator, so any default based on `getppid()` would silently drift
+to the wrong PID and every downstream sub-agent would see a missing
+snapshot. Pass `--out` explicitly on every invocation. The script
+implements the rendering rule below; do **not** re-derive the
+transform inline (that's the whole reason this script exists). On
 malformed input the script exits non-zero with a line-numbered error
 on stderr — surface that to the user rather than continuing with a
 half-rendered snapshot.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -76,20 +76,23 @@ Before spawning the first implementer:
 
    ```bash
    python3 .claude/scripts/render-slim-plan.py \
-       --plan-path docs/adr/<dir-name>/_workflow/implementation-plan.md
+       --plan-path docs/adr/<dir-name>/_workflow/implementation-plan.md \
+       --out /tmp/claude-code-plan-slim-$PPID.md
    ```
 
    The script implements the rule from
    [`plan-slim-rendering.md`](plan-slim-rendering.md); do not re-derive
-   the transform inline. With no `--out` it writes
-   `/tmp/claude-code-plan-slim-<ppid>.md` using its parent (the
-   orchestrator) PID, matching the snapshot path convention. Both the
-   implementer and any dimensional review sub-agents read this
-   snapshot by path — it keeps the orchestrator's tool-call history
-   from accumulating a plan copy per spawn. Regenerate the snapshot
-   only if inline replanning (ESCALATE) modifies the plan mid-session.
-   The snapshot lives in `/tmp` (not under `_workflow/`) and is not
-   committed.
+   the transform inline. **Always pass `--out` explicitly** with
+   `$PPID` — the orchestrator's PID inside its bash shell. The script
+   does not auto-derive this path because, when invoked via the Bash
+   tool, the script's parent is the bash shell, not the orchestrator,
+   so any default would silently drift to the wrong PID and sub-agents
+   would see a missing snapshot. Both the implementer and any
+   dimensional review sub-agents read this snapshot by path — it keeps
+   the orchestrator's tool-call history from accumulating a plan copy
+   per spawn. Regenerate the snapshot only if inline replanning
+   (ESCALATE) modifies the plan mid-session. The snapshot lives in
+   `/tmp` (not under `_workflow/`) and is not committed.
 3. **Detect orphan commits.** Run `git log --oneline
    {base_commit}..HEAD` and inspect the result. If it shows orphan
    implementer commits, orphan `Review fix:` commits, or a

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -118,19 +118,22 @@ of the changes.
 
    ```bash
    python3 .claude/scripts/render-slim-plan.py \
-       --plan-path docs/adr/<dir-name>/_workflow/implementation-plan.md
+       --plan-path docs/adr/<dir-name>/_workflow/implementation-plan.md \
+       --out /tmp/claude-code-plan-slim-$PPID.md
    ```
 
    The script implements the rule from
    [`plan-slim-rendering.md`](plan-slim-rendering.md); do not re-derive
-   the transform inline. With no `--out` it writes
-   `/tmp/claude-code-plan-slim-<ppid>.md` using its parent (the
-   orchestrator) PID, matching the snapshot path convention.
-   Sub-agents spawned for track-level review will read this snapshot
-   by path — this keeps the main agent's tool-call history from
-   accumulating a plan copy per sub-agent spawn. Regenerate the
-   snapshot if plan corrections are applied during the review loop
-   (before the next spawn batch).
+   the transform inline. **Always pass `--out` explicitly** with
+   `$PPID` — the orchestrator's PID inside its bash shell. The script
+   does not auto-derive this path because, when invoked via the Bash
+   tool, the script's parent is the bash shell, not the orchestrator,
+   so any default would silently drift to the wrong PID and sub-agents
+   would see a missing snapshot. Sub-agents spawned for track-level
+   review will read this snapshot by path — this keeps the main
+   agent's tool-call history from accumulating a plan copy per
+   sub-agent spawn. Regenerate the snapshot if plan corrections are
+   applied during the review loop (before the next spawn batch).
 5. Use `{base_commit}` when spawning all review sub-agents.
    All sub-agents review `git diff {base_commit}..HEAD`.
 


### PR DESCRIPTION
#### Motivation:

When the orchestrator invokes `render-slim-plan.py` through the Bash tool, `os.getppid()` resolves to the bash shell's PID rather than the orchestrator's, so the snapshot landed at the wrong path and every downstream sub-agent silently saw a missing slim plan. The mismatch went unnoticed because the script reported success on stdout, forcing each Phase B / Phase C session to recover with a manual `cp` before spawning sub-agents.

This PR makes `--out` required (and removes the broken default) so the silent drift is impossible. Keeping a "smart" default would just trade one silent failure mode for another — the script genuinely cannot infer the orchestrator PID from inside the Bash-tool invocation, so the safe move is to force the caller to pass it.

The three workflow docs that invoke the script (`plan-slim-rendering.md`, `step-implementation.md`, `track-code-review.md`) are updated to pass `/tmp/claude-code-plan-slim-\$PPID.md` explicitly, with an in-place explanation of why the script can't infer the path itself. The rationale is duplicated across the docs intentionally — each is read independently by orchestrators, and `plan-slim-rendering.md` remains the canonical home if the explanation ever needs to be updated.

#### Scope:

- `.claude/scripts/render-slim-plan.py` — drop unused `import os`, make `--out` required, remove the `getppid()`-based fallback.
- `.claude/workflow/plan-slim-rendering.md`, `step-implementation.md`, `track-code-review.md` — pass `--out` explicitly and document why.

No production code or test changes.