### PR TITLE
Route all workflow implementers to Opus

### DIFF
--- a/.claude/workflow/risk-tagging.md
+++ b/.claude/workflow/risk-tagging.md
@@ -36,21 +36,29 @@ justified.
 |---|---|---|---|
 | `high` | `opus` | Full dimensional review (4 baseline + conditional, up to 3 iterations) | Focal point |
 | `medium` | `opus` | None | Focal point |
-| `low` | `sonnet` | None | Default coverage |
+| `low` | `opus` | None | Default coverage |
+
+**All implementer spawns use `opus` regardless of risk tag.** Sonnet's
+reliability on multi-step implementation work is below the threshold
+required for this workflow — even at `risk: low`, Sonnet implementers
+intermittently execute steps with errors (skipped sub-steps, incorrect
+test invocations, malformed return blocks) that Opus does not. The
+implementer model is therefore not allocated by risk tag; only the
+step-level dimensional review (sub-step 4) and the focal-point
+treatment in track-level review remain risk-tag-driven.
 
 The implementer-model column is read by the Phase B orchestrator when
 spawning the per-step implementer (see
 [`step-implementation.md`](step-implementation.md) §Implementer Prompt
-Template). The model is locked at spawn time and re-evaluated against
-the current risk tag on every respawn, so a `low → high` upgrade (see
-§"Phase B upgrade" below) automatically promotes the respawn from
-Sonnet to Opus. Downgrades mid-Phase B are not permitted, so the
-model never demotes once a step has run.
+Template). Because every row resolves to `opus`, the `low → high`
+upgrade path (see §"Phase B upgrade" below) does not change the model
+— it only enables sub-step 4's dimensional review and promotes the
+step to a focal point in track-level review.
 
 Phase A reviews, the dimensional-review fan-out agents (which fire only
 on `risk: high` steps), the Phase C track-level review, and the Phase
-B/C orchestrators themselves remain on Opus regardless of step risk —
-review and orchestration capacity is not allocated by step tag.
+B/C orchestrators themselves also run on Opus — review and
+orchestration capacity is not allocated by step tag.
 
 ## HIGH-risk triggers
 

--- a/.claude/workflow/risk-tagging.md
+++ b/.claude/workflow/risk-tagging.md
@@ -47,13 +47,16 @@ implementer model is therefore not allocated by risk tag; only the
 step-level dimensional review (sub-step 4) and the focal-point
 treatment in track-level review remain risk-tag-driven.
 
-The implementer-model column is read by the Phase B orchestrator when
-spawning the per-step implementer (see
-[`step-implementation.md`](step-implementation.md) §Implementer Prompt
-Template). Because every row resolves to `opus`, the `low → high`
-upgrade path (see §"Phase B upgrade" below) does not change the model
-— it only enables sub-step 4's dimensional review and promotes the
-step to a focal point in track-level review.
+The implementer-model column is informational — it documents the
+model used by the Phase B orchestrator's spawn template. The operative
+source is [`step-implementation.md`](step-implementation.md)
+§Implementer Prompt Template, which hard-codes `model: "opus"`
+regardless of the step's risk tag (the orchestrator does not look the
+model up from this column at spawn time). Because every row resolves
+to `opus`, the `low → high` upgrade path (see §"Phase B upgrade"
+below) does not change the model — it only enables sub-step 4's
+dimensional review and promotes the step to a focal point in
+track-level review.
 
 Phase A reviews, the dimensional-review fan-out agents (which fire only
 on `risk: high` steps), the Phase C track-level review, and the Phase

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -179,24 +179,26 @@ of those branches. The implementer prompt template is in
 
 ## Implementer Prompt Template
 
-Each spawn uses `subagent_type: "general-purpose"`. Pick `model` from
-the step's risk tag at spawn time: `risk: low` spawns with
-`model: "sonnet"`; `risk: medium` and `risk: high` spawn with
-`model: "opus"`. See [`risk-tagging.md`](risk-tagging.md) §"Risk
-levels — quick reference" for the full allocation table.
+Each spawn uses `subagent_type: "general-purpose"` and
+`model: "opus"` regardless of the step's risk tag. Sonnet's
+reliability on multi-step implementation work is below the threshold
+required for this workflow — implementer steps that complete cleanly
+on Opus surface intermittent execution errors on Sonnet even at
+`risk: low` (skipped sub-steps, incorrect test invocations, malformed
+return blocks). See [`risk-tagging.md`](risk-tagging.md) §"Risk
+levels — quick reference" for the rationale and for the risk-tag
+effects that DO still apply (sub-step 4 dimensional review, track-level
+focal-point treatment).
 
-Every spawn re-reads the current risk tag, so a `low → high` upgrade
-per [`risk-tagging.md`](risk-tagging.md) §"Phase B upgrade" promotes
-the next respawn from Sonnet to Opus, and `WITH_GUIDANCE` /
-`FIX_REVIEW_FINDINGS` respawns at the same tag stay on whichever
-model the tag selects. Downgrades mid-Phase B are not permitted (see
-`risk-tagging.md`), so the model never demotes once a step has run.
+Because the model is the same across all risk tags, `INITIAL`,
+`WITH_GUIDANCE`, and `FIX_REVIEW_FINDINGS` respawns all use Opus, and
+a `low → high` upgrade per
+[`risk-tagging.md`](risk-tagging.md) §"Phase B upgrade" does not
+change the model — it only changes what review pressure runs after
+the implementer returns.
 
 The same template is used by Phase C with `level=track` (see
-[`track-code-review.md`](track-code-review.md) §Implementer Spawns
-for the Phase C model selection — `model: "opus"` always, since
-Phase C fixes operate on the cumulative track diff and there is no
-per-step risk tag to consult).
+[`track-code-review.md`](track-code-review.md) §Implementer Spawns).
 
 The prompt body has a **stable static prefix** followed by the
 **per-spawn variable inputs**. The static block goes first for

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -389,11 +389,11 @@ orchestrator never edits source files itself in Phase C.
 ## Implementer Spawns
 
 Each Phase C implementer spawn uses `subagent_type: "general-purpose"`
-and `model: "opus"`. (Track-level fix application operates on the
-cumulative track diff and may surface cross-step interactions; the
-risk tag, which would otherwise gate the model choice in Phase B, is
-locked per-step at end-of-Phase-B and does not inform the
-track-level model. Always spawn Opus.)
+and `model: "opus"` — the same as every Phase B implementer spawn (see
+[`risk-tagging.md`](risk-tagging.md) §"Risk levels — quick reference"
+for the rationale: Sonnet's reliability on multi-step implementation
+work is below the threshold this workflow requires, and the model is
+not allocated by risk tag).
 
 Use the **shared Implementer Prompt Template** in
 [`step-implementation.md`](step-implementation.md) §Implementer Prompt


### PR DESCRIPTION
#### Motivation

Sonnet's reliability on multi-step implementation work is below the threshold this workflow requires. Even on `risk: low` steps, Sonnet implementer spawns intermittently execute with errors that Opus does not — skipped sub-steps, malformed return blocks, and incorrect test invocations. The model-by-risk-tag allocation was meant to save tokens on low-risk steps, but the recovery cost from a misbehaving Sonnet run (orphan-commit cleanup, respawns, manual intervention) exceeds those savings in practice.

This PR drops Sonnet from the implementer-spawn rotation entirely. The `Implementer model` column in the risk-levels table now shows `opus` for all three rows (low / medium / high). Phase B and Phase C implementer spawns route to Opus uniformly, and `INITIAL` / `WITH_GUIDANCE` / `FIX_REVIEW_FINDINGS` respawns no longer differ by tag.

The risk tag still drives:
- Sub-step 4 dimensional review (fires only on `risk: high`).
- Focal-point treatment in Phase C track-level review (`medium` and `high` ranges).

The `low → high` Phase B upgrade no longer changes the model — it only enables the dim-review pressure and focal-point treatment above. Downgrades remain disallowed.

#### Files changed

- `.claude/workflow/risk-tagging.md` — table updated; new explanatory paragraph; Phase B upgrade prose adjusted; column clarified as informational with `step-implementation.md` as the operative source.
- `.claude/workflow/step-implementation.md` — Implementer Prompt Template hard-codes `model: "opus"`.
- `.claude/workflow/track-code-review.md` — Phase C Implementer Spawns cross-references the unified rule rather than rationalising track-level Opus separately.

Documentation-only; no source code or test changes.

#### Test plan

- [ ] No tests required — workflow documentation change only.
- [ ] Verify no stale `model: "sonnet"` directives remain anywhere in `.claude/workflow/` or `.claude/agents/` (confirmed locally).