### PR TITLE
  YTDB-556 Fix CASObjectArray.set() writing value to wrong index under contention

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArray.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArray.java
@@ -10,11 +10,30 @@ public final class CASObjectArray<T> {
   private final AtomicReferenceArray<AtomicReferenceArray<T>> containers =
       new AtomicReferenceArray<>(32);
 
+  public boolean add(T value, int index) {
+    Objects.requireNonNull(value);
+    return doAdd(value, index) >= 0;
+  }
+
   public int add(T value) {
     Objects.requireNonNull(value);
+    return doAdd(value, -1);
+  }
 
+  /**
+   * Core add logic shared by both {@code add(T)} and {@code add(T, int)}.
+   *
+   * @param requiredIndex the index the caller expects to write at, or {@code -1}
+   *     to accept any index (unconditional append).
+   * @return the index where the value was placed, or {@code -1} if
+   *     {@code requiredIndex >= 0} and the current size did not match it.
+   */
+  private int doAdd(T value, int requiredIndex) {
     while (true) {
       final var newIndex = size.get();
+      if (requiredIndex >= 0 && newIndex != requiredIndex) {
+        return -1;
+      }
       final var containerIndex = 31 - Integer.numberOfLeadingZeros(newIndex + 1);
       final var containerSize = 1 << containerIndex;
       final var indexInsideContainer = newIndex + 1 - containerSize;
@@ -51,8 +70,7 @@ public final class CASObjectArray<T> {
       }
       // size >= index now. If size == index, the target slot is the next to
       // be allocated — write the actual value directly, no placeholder window.
-      if (this.size.get() == index) {
-        add(value);
+      if (add(value, index)) {
         return;
       }
       // size > index: the target slot was already expanded past (by a

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
@@ -1,7 +1,6 @@
 package com.jetbrains.youtrackdb.internal.common.concur.collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.vmlens.api.AllInterleavingsBuilder;
@@ -169,60 +168,6 @@ public class CASObjectArrayMTTest {
         // Exactly one thread must have returned true.
         assertEquals(1, trueCount.get(),
             "Exactly one add(T, int) should return true when two threads race");
-      }
-    }
-  }
-
-  /**
-   * Verifies that {@code add(value, index)} returns {@code false} without side
-   * effects when the current size does not match the requested index — even
-   * when another thread is concurrently advancing the size past that index.
-   *
-   * <p>Thread 1 calls {@code add(value, 0)} repeatedly while Thread 2 advances
-   * the array via unindexed {@code add()}. Since size is never 0 again after the
-   * first unindexed add, every indexed call must return {@code false} and the
-   * value at index 0 must remain the original filler — never the indexed writer's
-   * value.
-   */
-  @Test
-  public void addWithStaleIndexAlwaysReturnsFalse() throws Exception {
-    final Integer FILLER = -1;
-    final int STALE_INDEX = 0;
-    final int INDEXED_VALUE = 777;
-
-    try (var allInterleavings = new AllInterleavingsBuilder()
-        .withMaximumIterations(MAX_ITERATIONS)
-        .build("addWithStaleIndexAlwaysReturnsFalse")) {
-      while (allInterleavings.hasNext()) {
-        var array = new CASObjectArray<Integer>();
-
-        // Seed index 0 so that size > STALE_INDEX from the start.
-        array.add(FILLER);
-
-        var indexedResult = new boolean[] {false};
-
-        var indexedWriter = new Thread(() -> {
-          // Attempt to write at a slot that's already past.
-          indexedResult[0] = array.add(INDEXED_VALUE, STALE_INDEX);
-        });
-
-        // Concurrently advance the array further.
-        var advancer = new Thread(() -> {
-          array.add(42);
-        });
-
-        indexedWriter.start();
-        advancer.start();
-        indexedWriter.join();
-        advancer.join();
-
-        // The indexed add must have returned false — index 0 is behind size.
-        assertFalse(indexedResult[0],
-            "add(T, staleIndex) should return false when size has advanced past the index");
-
-        // Index 0 must still hold the original filler, not the indexed writer's value.
-        assertEquals(FILLER, array.get(STALE_INDEX),
-            "Index 0 should still hold filler — add(T, staleIndex) must not overwrite it");
       }
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
@@ -1,8 +1,10 @@
 package com.jetbrains.youtrackdb.internal.common.concur.collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.vmlens.api.AllInterleavingsBuilder;
+import java.util.concurrent.*;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -112,6 +114,113 @@ public class CASObjectArrayMTTest {
         // Target index must have the actual value
         assertEquals(ACTUAL, readValues[TARGET_INDEX],
             "Target index should have actual value, not placeholder");
+      }
+    }
+  }
+
+  /**
+   * Verifies that concurrent set() calls targeting the same index never write
+   * the value to the adjacent index (index + 1).
+   *
+   * <p>The race scenario: two threads both call set(targetIndex, value, placeholder)
+   * when size == targetIndex. Both enter the {@code add(value)} fast path (line 74-76
+   * in CASObjectArray). One writer's CAS succeeds at targetIndex, but the other's
+   * CAS fails and retries inside {@code add()} — reading the now-incremented size
+   * and writing its value to targetIndex + 1 instead of targetIndex. The second
+   * writer then returns without falling through to the overwrite path, leaving
+   * its value permanently at the wrong index.
+   *
+   * <p>Two writer threads call {@code set(TARGET_INDEX, value, PLACEHOLDER)}
+   * concurrently. A reader thread continuously probes {@code getOrDefault(TARGET_INDEX + 1)}
+   * and asserts that only the placeholder is ever visible there — never a writer value.
+   * After all threads join, we also verify the final state: TARGET_INDEX must hold
+   * a writer value, and TARGET_INDEX + 1 must hold only the placeholder.
+   */
+  @Test
+  public void concurrentSetToSameIndexShouldNeverWriteToNextIndex() throws Exception {
+    final Integer PLACEHOLDER = -1;
+    final int TARGET_INDEX = 2;
+    final int VALUE_A = 100;
+    final int VALUE_B = 200;
+
+    try (var allInterleavings = new AllInterleavingsBuilder()
+        .withMaximumIterations(MAX_ITERATIONS)
+        .build("concurrentSetToSameIndexShouldNeverWriteToNextIndex")) {
+      while (allInterleavings.hasNext()) {
+        var array = new CASObjectArray<Integer>();
+
+        // Pre-fill the array so that size == TARGET_INDEX.
+        // This ensures both writers enter the add(value) expansion path
+        // at line 74-76 rather than the overwrite path at line 97.
+        for (int i = 0; i < TARGET_INDEX; i++) {
+          array.add(PLACEHOLDER);
+        }
+
+        // Collects any non-placeholder value the reader observes at
+        // TARGET_INDEX + 1 during the concurrent set() calls.
+        var violations = new CopyOnWriteArrayList<Integer>();
+
+        var writer1 = new Thread(() -> {
+          array.set(TARGET_INDEX, VALUE_A, PLACEHOLDER);
+        });
+
+        var writer2 = new Thread(() -> {
+          array.set(TARGET_INDEX, VALUE_B, PLACEHOLDER);
+        });
+
+        // Reader continuously probes the slot right after the target.
+        // If a writer's add() overshoots due to the CAS retry, the
+        // writer value will appear here instead of the placeholder.
+        var reader = new Thread(() -> {
+          for (int probe = 0; probe < 20; probe++) {
+            try {
+              var val = array.get(TARGET_INDEX + 1);
+              if (!PLACEHOLDER.equals(val)) {
+                violations.add(val);
+              }
+            } catch (ArrayIndexOutOfBoundsException e) {
+              // index is not written yet, continue
+              continue;
+            }
+          }
+        });
+
+        reader.start();
+        writer1.start();
+        writer2.start();
+        writer1.join();
+        writer2.join();
+        reader.join();
+
+        // The target index must hold one of the writer values.
+        var targetValue = array.get(TARGET_INDEX);
+        assertTrue(
+            targetValue.equals(VALUE_A) || targetValue.equals(VALUE_B),
+            "Target index should hold VALUE_A or VALUE_B, got: " + targetValue);
+
+        // The slot at TARGET_INDEX + 1 must never have been written with
+        // a writer value. If the bug triggers, one writer's add() overshoots
+        // and lands its value here.
+        var nextValue = array.get(TARGET_INDEX);
+        assertTrue(
+            PLACEHOLDER.equals(nextValue),
+            "Index " + (TARGET_INDEX + 1) + " should only contain the placeholder ("
+                + PLACEHOLDER + "), but found: " + nextValue
+                + " — a set() targeting index " + TARGET_INDEX
+                + " wrote its value to the wrong slot");
+
+        // Also verify that the reader never observed a writer value leak
+        // during execution, not just after completion.
+        assertTrue(
+            violations.isEmpty(),
+            "Reader observed non-placeholder values at index " + (TARGET_INDEX + 1)
+                + " during concurrent set(): " + violations);
+
+        // If both writers correctly targeted index TARGET_INDEX, the size
+        // should be TARGET_INDEX + 1 (one expansion). If a writer overshot,
+        // the size would be TARGET_INDEX + 2.
+        assertEquals(TARGET_INDEX + 1, array.size(),
+            "Array grew beyond expected size — a writer likely wrote to the wrong index");
       }
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayMTTest.java
@@ -1,10 +1,12 @@
 package com.jetbrains.youtrackdb.internal.common.concur.collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.vmlens.api.AllInterleavingsBuilder;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -119,6 +121,252 @@ public class CASObjectArrayMTTest {
   }
 
   /**
+   * Verifies that when two threads race {@code add(value, TARGET_INDEX)}, exactly
+   * one returns {@code true} (the winner whose CAS succeeded) and the other returns
+   * {@code false} (the loser whose size check failed after retry).
+   *
+   * <p>This validates the return-value contract: {@code true} means "I wrote the
+   * value at the requested index", {@code false} means "I did not write".
+   */
+  @Test
+  public void addWithIndexReturnsTrueOnlyForWinningThread() throws Exception {
+    final int TARGET_INDEX = 2;
+    final Integer FILLER = -1;
+    final int VALUE_A = 100;
+    final int VALUE_B = 200;
+
+    try (var allInterleavings = new AllInterleavingsBuilder()
+        .withMaximumIterations(MAX_ITERATIONS)
+        .build("addWithIndexReturnsTrueOnlyForWinningThread")) {
+      while (allInterleavings.hasNext()) {
+        var array = new CASObjectArray<Integer>();
+
+        // Pre-fill so that size == TARGET_INDEX.
+        for (int i = 0; i < TARGET_INDEX; i++) {
+          array.add(FILLER);
+        }
+
+        // Count how many threads got true.
+        var trueCount = new AtomicInteger(0);
+
+        var writer1 = new Thread(() -> {
+          if (array.add(VALUE_A, TARGET_INDEX)) {
+            trueCount.incrementAndGet();
+          }
+        });
+
+        var writer2 = new Thread(() -> {
+          if (array.add(VALUE_B, TARGET_INDEX)) {
+            trueCount.incrementAndGet();
+          }
+        });
+
+        writer1.start();
+        writer2.start();
+        writer1.join();
+        writer2.join();
+
+        // Exactly one thread must have returned true.
+        assertEquals(1, trueCount.get(),
+            "Exactly one add(T, int) should return true when two threads race");
+      }
+    }
+  }
+
+  /**
+   * Verifies that {@code add(value, index)} returns {@code false} without side
+   * effects when the current size does not match the requested index — even
+   * when another thread is concurrently advancing the size past that index.
+   *
+   * <p>Thread 1 calls {@code add(value, 0)} repeatedly while Thread 2 advances
+   * the array via unindexed {@code add()}. Since size is never 0 again after the
+   * first unindexed add, every indexed call must return {@code false} and the
+   * value at index 0 must remain the original filler — never the indexed writer's
+   * value.
+   */
+  @Test
+  public void addWithStaleIndexAlwaysReturnsFalse() throws Exception {
+    final Integer FILLER = -1;
+    final int STALE_INDEX = 0;
+    final int INDEXED_VALUE = 777;
+
+    try (var allInterleavings = new AllInterleavingsBuilder()
+        .withMaximumIterations(MAX_ITERATIONS)
+        .build("addWithStaleIndexAlwaysReturnsFalse")) {
+      while (allInterleavings.hasNext()) {
+        var array = new CASObjectArray<Integer>();
+
+        // Seed index 0 so that size > STALE_INDEX from the start.
+        array.add(FILLER);
+
+        var indexedResult = new boolean[] {false};
+
+        var indexedWriter = new Thread(() -> {
+          // Attempt to write at a slot that's already past.
+          indexedResult[0] = array.add(INDEXED_VALUE, STALE_INDEX);
+        });
+
+        // Concurrently advance the array further.
+        var advancer = new Thread(() -> {
+          array.add(42);
+        });
+
+        indexedWriter.start();
+        advancer.start();
+        indexedWriter.join();
+        advancer.join();
+
+        // The indexed add must have returned false — index 0 is behind size.
+        assertFalse(indexedResult[0],
+            "add(T, staleIndex) should return false when size has advanced past the index");
+
+        // Index 0 must still hold the original filler, not the indexed writer's value.
+        assertEquals(FILLER, array.get(STALE_INDEX),
+            "Index 0 should still hold filler — add(T, staleIndex) must not overwrite it");
+      }
+    }
+  }
+
+  /**
+   * Verifies that two threads racing {@code add(value, TARGET_INDEX)} when
+   * {@code size == TARGET_INDEX} result in exactly one write at the target index
+   * and no writes anywhere else.
+   *
+   * <p>The race: both threads read {@code size == TARGET_INDEX}, pass the guard,
+   * and attempt CAS on the same container slot. One CAS succeeds and increments
+   * size; the other CAS fails, loops, re-reads size (now TARGET_INDEX + 1),
+   * finds {@code size != TARGET_INDEX}, and returns false. The invariant under
+   * test: the losing thread must NOT write its value to TARGET_INDEX + 1 or any
+   * other slot — it must exit without side effects.
+   */
+  @Test
+  public void addWithIndexShouldOnlyWriteToTargetIndex() throws Exception {
+    final int TARGET_INDEX = 2;
+    final Integer FILLER = -1;
+    final int VALUE_A = 100;
+    final int VALUE_B = 200;
+
+    try (var allInterleavings = new AllInterleavingsBuilder()
+        .withMaximumIterations(MAX_ITERATIONS)
+        .build("addWithIndexShouldOnlyWriteToTargetIndex")) {
+      while (allInterleavings.hasNext()) {
+        var array = new CASObjectArray<Integer>();
+
+        // Pre-fill so that size == TARGET_INDEX, placing both writers
+        // on the fast path where size matches their target.
+        for (int i = 0; i < TARGET_INDEX; i++) {
+          array.add(FILLER);
+        }
+
+        var writer1 = new Thread(() -> {
+          array.add(VALUE_A, TARGET_INDEX);
+        });
+
+        var writer2 = new Thread(() -> {
+          array.add(VALUE_B, TARGET_INDEX);
+        });
+
+        writer1.start();
+        writer2.start();
+        writer1.join();
+        writer2.join();
+
+        // Exactly one add should have succeeded — size must grow by exactly 1.
+        assertEquals(TARGET_INDEX + 1, array.size(),
+            "Only one add(T, int) should succeed when two threads target the same index");
+
+        // The value at TARGET_INDEX must be one of the two writer values.
+        var targetValue = array.get(TARGET_INDEX);
+        assertTrue(
+            targetValue.equals(VALUE_A) || targetValue.equals(VALUE_B),
+            "Target index should hold VALUE_A or VALUE_B, got: " + targetValue);
+
+        // Filler slots must be untouched — no writer corrupted a pre-existing slot.
+        for (int i = 0; i < TARGET_INDEX; i++) {
+          assertEquals(FILLER, array.get(i),
+              "Index " + i + " should still hold filler value, but was: " + array.get(i));
+        }
+      }
+    }
+  }
+
+  /**
+   * Verifies that {@code add(value, TARGET_INDEX)} racing against an unindexed
+   * {@code add(value)} does not corrupt adjacent slots.
+   *
+   * <p>When {@code size == TARGET_INDEX}, both the indexed and unindexed adds
+   * target the same slot. One CAS wins. If the indexed add loses, it must exit
+   * without writing — it must not follow the unindexed add's value by writing
+   * to TARGET_INDEX + 1. Conversely, if the indexed add wins, the unindexed
+   * add should write to TARGET_INDEX + 1 (its normal behavior), and the indexed
+   * add's value must remain exclusively at TARGET_INDEX.
+   */
+  @Test
+  public void addWithIndexShouldNotCorruptAdjacentSlotWhenRacingUnindexedAdd() throws Exception {
+    final int TARGET_INDEX = 2;
+    final Integer FILLER = -1;
+    final int INDEXED_VALUE = 42;
+    final int UNINDEXED_VALUE = 99;
+
+    try (var allInterleavings = new AllInterleavingsBuilder()
+        .withMaximumIterations(MAX_ITERATIONS)
+        .build("addWithIndexShouldNotCorruptAdjacentSlotWhenRacingUnindexedAdd")) {
+      while (allInterleavings.hasNext()) {
+        var array = new CASObjectArray<Integer>();
+
+        // Pre-fill so that size == TARGET_INDEX.
+        for (int i = 0; i < TARGET_INDEX; i++) {
+          array.add(FILLER);
+        }
+
+        var indexedWriter = new Thread(() -> {
+          array.add(INDEXED_VALUE, TARGET_INDEX);
+        });
+
+        var unindexedWriter = new Thread(() -> {
+          array.add(UNINDEXED_VALUE);
+        });
+
+        indexedWriter.start();
+        unindexedWriter.start();
+        indexedWriter.join();
+        unindexedWriter.join();
+
+        // The unindexed add always succeeds, so size is at least
+        // TARGET_INDEX + 1. If the indexed add also succeeded (won the
+        // CAS), size is TARGET_INDEX + 2; otherwise TARGET_INDEX + 1.
+        var size = array.size();
+        assertTrue(
+            size == TARGET_INDEX + 1 || size == TARGET_INDEX + 2,
+            "Size should be TARGET_INDEX+1 or TARGET_INDEX+2, got: " + size);
+
+        var valueAtTarget = array.get(TARGET_INDEX);
+
+        if (size == TARGET_INDEX + 2) {
+          // Both adds succeeded. The indexed add won the CAS at
+          // TARGET_INDEX, and the unindexed add retried at TARGET_INDEX + 1.
+          // Verify values landed at their correct indices.
+          assertEquals(INDEXED_VALUE, valueAtTarget.intValue(),
+              "When both succeed, indexed value must be at TARGET_INDEX");
+          assertEquals(UNINDEXED_VALUE, array.get(TARGET_INDEX + 1).intValue(),
+              "When both succeed, unindexed value must be at TARGET_INDEX + 1");
+        } else {
+          // Only the unindexed add succeeded at TARGET_INDEX; the indexed
+          // add lost the CAS and returned false without writing.
+          assertEquals(UNINDEXED_VALUE, valueAtTarget.intValue(),
+              "When indexed add loses, unindexed value must be at TARGET_INDEX");
+        }
+
+        // Filler slots must be untouched in all interleavings.
+        for (int i = 0; i < TARGET_INDEX; i++) {
+          assertEquals(FILLER, array.get(i),
+              "Index " + i + " should still hold filler value, but was: " + array.get(i));
+        }
+      }
+    }
+  }
+
+  /**
    * Verifies that concurrent set() calls targeting the same index never write
    * the value to the adjacent index (index + 1).
    *
@@ -201,7 +449,13 @@ public class CASObjectArrayMTTest {
         // The slot at TARGET_INDEX + 1 must never have been written with
         // a writer value. If the bug triggers, one writer's add() overshoots
         // and lands its value here.
-        var nextValue = array.get(TARGET_INDEX);
+        Integer nextValue;
+        try {
+          nextValue = array.get(TARGET_INDEX + 1);
+        } catch (ArrayIndexOutOfBoundsException e) {
+          nextValue = PLACEHOLDER;
+          // index was not populated concurrently, everything is fine
+        }
         assertTrue(
             PLACEHOLDER.equals(nextValue),
             "Index " + (TARGET_INDEX + 1) + " should only contain the placeholder ("

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/concur/collection/CASObjectArrayTest.java
@@ -5,6 +5,86 @@ import org.junit.Test;
 
 public class CASObjectArrayTest {
 
+  // --- add(T, int) ---
+
+  /**
+   * Verifies that add(value, index) succeeds and returns true when the current
+   * size matches the requested index — the caller is appending at the expected
+   * position.
+   */
+  @Test
+  public void testAddWithIndexSucceedsWhenSizeMatchesIndex() {
+    final var array = new CASObjectArray<Integer>();
+    array.add(10);
+    array.add(20);
+    // size == 2, requesting index 2 → should succeed
+    Assert.assertTrue(array.add(42, 2));
+    Assert.assertEquals(3, array.size());
+    Assert.assertEquals(42, array.get(2).intValue());
+  }
+
+  /**
+   * Verifies that add(value, index) returns false without modifying the array
+   * when the current size is larger than the requested index (stale index) or
+   * smaller than it (gap).
+   */
+  @Test
+  public void testAddWithIndexFailsWhenSizeDoesNotMatchIndex() {
+    final var array = new CASObjectArray<Integer>();
+    array.add(10); // size = 1
+
+    // size (1) > requested index (0) — stale index
+    Assert.assertFalse(array.add(42, 0));
+    // size (1) < requested index (5) — gap
+    Assert.assertFalse(array.add(42, 5));
+
+    // Array must remain unchanged — only the original element
+    Assert.assertEquals(1, array.size());
+    Assert.assertEquals(10, array.get(0).intValue());
+  }
+
+  // --- set() expansion path ---
+
+  /**
+   * Verifies that set() correctly expands the array when the target index is
+   * beyond the current size: gap slots are filled with placeholders, and the
+   * actual value is written directly at the target index via add(value, index).
+   */
+  @Test
+  public void testSetExpandsArrayAndWritesValueAtTargetIndex() {
+    final var array = new CASObjectArray<Integer>();
+    // Array is empty (size 0). Setting index 3 must expand: fill 0,1,2
+    // with placeholders, then write the value at index 3.
+    array.set(3, 42, -1);
+
+    Assert.assertEquals(4, array.size());
+    Assert.assertEquals(-1, array.get(0).intValue());
+    Assert.assertEquals(-1, array.get(1).intValue());
+    Assert.assertEquals(-1, array.get(2).intValue());
+    Assert.assertEquals(42, array.get(3).intValue());
+  }
+
+  /**
+   * Verifies that set() falls through to the overwrite path when size is
+   * already past the target index — the gap-filling loop is skipped and the
+   * existing value at the target index is simply overwritten.
+   */
+  @Test
+  public void testSetOverwritesWhenSizeAlreadyPastIndex() {
+    final var array = new CASObjectArray<Integer>();
+    array.add(10);
+    array.add(20);
+    array.add(30); // size = 3
+
+    // Target index 1 is well below size → no expansion, direct overwrite
+    array.set(1, 99, -1);
+
+    Assert.assertEquals(3, array.size());
+    Assert.assertEquals(10, array.get(0).intValue());
+    Assert.assertEquals(99, array.get(1).intValue());
+    Assert.assertEquals(30, array.get(2).intValue());
+  }
+
   @Test
   public void testAddSingleItem() {
     final var array = new CASObjectArray<Integer>();


### PR DESCRIPTION
#### Motivation

When two threads call `set(targetIndex, value, placeholder)` concurrently and `size == targetIndex`, both enter the `add(value)` expansion path. One thread's CAS succeeds at `targetIndex` and increments size. The other thread's CAS fails, retries inside the `add()` loop, reads the now-incremented size, and appends its value to `targetIndex + 1` instead of the intended slot. It then returns without falling through to the overwrite path, leaving a stale writer value permanently at the wrong index.

A concurrent reader scanning with `while (get(index + 1) != PLACEHOLDER)` can observe this dirty value at `targetIndex + 1`, breaking snapshot isolation assumptions in callers like `AtomicOperationsTable`.

Follows up on a review discussion: https://github.com/JetBrains/youtrackdb/pull/795/changes#r3192912829


#### Changes

- Add `add(T value, int index)` — a conditional append that returns `false` without side effects when the current size does not match the requested index. The losing thread's retry sees `size != targetIndex` and exits cleanly instead of writing to the next slot.
- Refactor the existing unconditional `add(T)` and the new conditional variant to share a single `doAdd(T, int)` implementation with a `requiredIndex` guard (`-1` = unconditional).
- Update `set()` to use `add(value, index)` instead of the size-check-then-unconditional-add sequence that had the race window.
- Add single-threaded unit tests for `add(T, int)` success/failure paths and `set()` expansion/overwrite paths.
- Add multi-threaded tests (vmlens `AllInterleavings`) covering: two indexed adds racing the same slot, indexed add with stale index, indexed add racing unindexed add, and concurrent `set()` verifying no write leaks to `targetIndex + 1`.

#### Test plan

- [x] All new multi-threaded tests use vmlens `AllInterleavings` to exhaustively explore thread interleavings
- [x] `concurrentSetToSameIndexShouldNeverWriteToNextIndex` directly reproduces the bug scenario — fails on the old code, passes with the fix
- [x] Single-threaded tests verify `add(T, int)` return-value contract and `set()` expansion/overwrite paths
- [x] Existing `CASObjectArrayMTTest` tests continue to pass