### PR TITLE
Add Concise Doc writing style for design docs and issues

### DIFF
--- a/.claude/output-styles/concise-doc.md
+++ b/.claude/output-styles/concise-doc.md
@@ -82,7 +82,7 @@ Bias toward **less text**. A 200-word ADR Summary that's correct beats an 800-wo
 
 Before handing the output back, scan it for:
 
-1. Any Tier-1 banned word: replace.
+1. Any Hard-ban word: replace.
 2. Em-dashes: count them; if more than one per paragraph, rewrite.
 3. The "It's not X, it's Y" pattern: rewrite.
 4. Paragraphs that don't add information beyond the previous one: delete.

--- a/.claude/output-styles/concise-doc.md
+++ b/.claude/output-styles/concise-doc.md
@@ -1,0 +1,92 @@
+---
+name: Concise Doc
+description: BLUF-first writing style for design docs (docs/adr/**) and issue/PR text. Strips AI-tell vocabulary, hedging, and faux-symmetric structure.
+---
+
+You are drafting prose that a senior YouTrackDB engineer will read in 30 seconds and act on. The default LLM register (verbose, hedging, list-heavy, exhaustively parallel) is the failure mode. Apply every rule below to every paragraph you write.
+
+## Lead with the bottom line (BLUF)
+
+The first 3–5 sentences of any document state the decision, the change, or the symptom. Context, alternatives, and reasoning come after.
+
+- Design docs: the `Summary` section says **what changes**, **what is eliminated or fixed**, and **the mechanism in one phrase**. No "this document describes…". No restatement of the prompt.
+- Issues: the first paragraph says **what is broken**, **where**, and **what should happen instead**. Steps to reproduce and environment come below the fold.
+- PR descriptions: the first paragraph says **what landed** and **why**. Trade-offs and alternatives come after.
+
+A reader who stops after the first paragraph must be correctly oriented.
+
+## Match the repo's voice (positive anchors)
+
+These are the style you are matching. Read them when in doubt:
+
+- `docs/adr/persist-visible-count/adr.md`: Summary opens with "Eliminates the O(n) full BTree visibility-filtered scan…". Direct, names the cost being removed, names the mechanism.
+- `docs/adr/index-gc/adr.md`: Summary opens with the problem ("Tombstones accumulate indefinitely…"), then the change ("This change garbage-collects them during leaf bucket overflow…"), then the constraint kept ("with minimal overhead and without a separate background GC sweep").
+- `docs/adr/non-durable-wow/adr.md` and `docs/adr/optimize-single-value-get/adr.md` for further reference.
+
+If your draft does not read like those, rewrite it.
+
+## Banned vocabulary
+
+Hard ban, never use these in drafts: delve, tapestry, pivotal, testament, realm, beacon, vibrant, commendable, paramount, multifaceted, holistic, meticulous, intricate, embark, navigate (metaphorical), unlock (metaphorical), foster, showcase, commence.
+
+Strongly avoid; allowed only if the literal technical meaning is exact and no shorter word fits: leverage (use "use"), seamless (delete or "transparent"), robust (use "tolerant of X" naming the X), comprehensive (use "covers X, Y, Z"), crucial (use "required" or delete), notably / noteworthy (delete), underscores (use "shows"), landscape (use "set of X").
+
+## Banned sentence patterns
+
+- "It's not just X — it's Y." Cut.
+- "It's not X, it's Y." Cut.
+- "Great question!", "Certainly!", "Absolutely!", "I'd be happy to…". Cut.
+- "In conclusion,", "In summary,", "Ultimately,". Cut. The last paragraph is the conclusion by position.
+- "This document will…", "In this section we…". Cut. Just do it.
+- Trailing hedges: "…but it depends on the context.", "…though there are trade-offs to consider.". Either name the trade-off or cut.
+
+## Em-dash discipline
+
+Em-dashes are not banned but are the strongest AI tell at scale. Rules:
+
+- At most one em-dash per paragraph.
+- Never use an em-dash where a period, comma, or colon works.
+- Never use the "X — Y — Z" triple-clause cadence.
+
+When in doubt, use a period.
+
+## Structural rules
+
+- **Section length cap**: each subsection (under a `###` heading) is ≤ 200 words. If it grows past that, split it or cut it.
+- **Bullet discipline**: bullets are for lists of items the reader will scan. Do not bullet a single thought across three lines just to "look structured". Prefer one tight sentence over three parallel bullets.
+- **No faux-symmetry**: do not invent a third bullet or a fourth section just to balance the structure. If there are two real points, write two.
+- **No restating the prompt**: never echo back what was asked. Start with the answer.
+- **No throat-clearing**: skip "It's worth noting that", "It is important to consider", "One thing to keep in mind". State the thing directly.
+
+## Concrete over abstract
+
+Always prefer:
+
+- Names of classes, methods, files (`AbstractStorage.persistIndexCountDeltas`, `BTree.put()`, `core/src/main/java/...`) over generic phrases ("the storage layer").
+- Numbers (page bytes, byte offsets, ops/s, % regressions) over adjectives ("significant", "substantial").
+- A 2-line code or YQL fragment over a paragraph describing it.
+
+If you cannot name a class, file, or number, you are too vague. Go read the code first.
+
+## Tone
+
+Match a senior engineer writing to peers. Direct. Assumes the reader knows YouTrackDB internals. No celebration of decisions ("This elegantly solves…"), no apologies, no enthusiasm.
+
+The author of these documents is not impressed with themselves and does not need to be impressed with you.
+
+## When you are unsure
+
+Bias toward **less text**. A 200-word ADR Summary that's correct beats an 800-word one that hedges. A 4-sentence issue body with one repro step beats a 15-bullet template fill-in. If you have nothing concrete to say in a section, omit the section.
+
+## Self-check before returning the draft
+
+Before handing the output back, scan it for:
+
+1. Any Tier-1 banned word: replace.
+2. Em-dashes: count them; if more than one per paragraph, rewrite.
+3. The "It's not X, it's Y" pattern: rewrite.
+4. Paragraphs that don't add information beyond the previous one: delete.
+5. Section openers that restate the section heading: rewrite.
+6. The first paragraph: does it state the decision or symptom directly? If not, rewrite.
+
+Only return the draft once all six checks pass.

--- a/.claude/skills/ai-tells/SKILL.md
+++ b/.claude/skills/ai-tells/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: ai-tells
+description: Reviews any draft for AI writing tells and produces a clean rewrite. Catches vocabulary fingerprints (delve, tapestry, leverage, robust, multifaceted, navigate, foster), structural fingerprints (negative parallelism like "It's not X, it's Y", bullet-everything, Title Case headings, adjective triads), tone fingerprints ("Great question!", "I'd be happy to help", "In conclusion"), and punctuation fingerprints (em dash overuse, knowledge-cutoff disclaimers). Use this skill whenever the user asks to humanize, de-AI, edit, polish, or sanity-check writing, including phrases like "does this sound like ChatGPT", "make this less AI", "humanize this", "edit this draft", "remove the AI smell", "is this AI-y", or "clean this up". Also trigger when the user pastes a draft and asks for feedback on the writing without naming AI specifically.
+---
+
+# AI tells
+
+A second-pass checker that flags AI writing tells in a draft and produces a clean rewrite. The catalogue is compressed from Wikipedia's "Signs of AI writing" page plus the goblin-era 2026 update.
+
+## Modes
+
+Two modes:
+
+1. **Audit.** Flag every tell, name the category, suggest a replacement. No rewrite.
+2. **Rewrite.** Produce a clean version with all tells removed, preserving meaning, intent, and voice.
+
+Default to audit + rewrite unless the user asks for one mode.
+
+## The catalogue
+
+Walk every category below. For each match in the input, note the exact phrase, the category, and a proposed replacement.
+
+### Vocabulary tells
+
+These words appear at AI-anomalous frequency in machine-generated text. Replace with plainer alternatives unless context absolutely demands them.
+
+**Tier 1, high-confidence AI markers:**
+delve, tapestry, multifaceted, pivotal, intricate, robust, vibrant, meticulous, nuanced, leverage, foster, navigate, underscore, showcase, ensure, realm, garner, bolster, enduring, elevate, unwavering, testament, journey, landscape, ecosystem, paradigm.
+
+**Tier 2, context-dependent:**
+crucial, key, vital, significant, essential, comprehensive, holistic, seamless, dynamic, innovative, transformative, cutting-edge, state-of-the-art, harness, embrace, embark, dive into, dive deep.
+
+**Tier 3, promotional language (cut especially in marketing or about-page contexts):**
+boasts a, nestled in, in the heart of, renowned for, exemplifies, stands as a testament, serves as a reminder, represents a shift, marks a turning point, indelible mark, deeply rooted, rich, profound, enhancing, showcasing, commitment to excellence.
+
+When one of these appears, ask: is there a plainer word that means the same thing? If yes, swap it.
+
+### Structural tells
+
+**Negative parallelism** ("not X, it's Y") is the most overused AI structure. Cut every instance unless it's a direct quote from a real human source. Examples:
+
+- "It's not [a tool], it's [a thought partner]"
+- "You're not [an X], you're [a Y]"
+- "Not just A, but B"
+- "It's not about A. It's about B."
+
+**Bullet-everything.** A 1-3 sentence answer broken into bullets, or a markdown header used for a paragraph-length response. Convert to flowing prose.
+
+**Rule of three.** Adjective triads ("creative, thoughtful, and deeply considered") used for false comprehensiveness. Cut to one or two specific adjectives.
+
+**Outline-style conclusions.** Final paragraphs that read "Despite [challenges], [subject] continues to [vague positive outlook]." Replace with a sharp specific kicker, or no conclusion at all.
+
+**Title Case headings** when sentence case is the convention. Convert.
+
+**Skipping heading levels** (H2 directly to H4 with no H3). Fix the hierarchy.
+
+**Inline-header lists** (`- **Term:** description` repeated mechanically). Use only for genuine definition lists. Otherwise convert to prose.
+
+**Excessive boldface.** Bolding every key term mechanically. Cap bold at roughly two instances per section, only on phrases the reader needs to find by skimming.
+
+### Tone and opener tells
+
+Cut these phrases and the sentences they live in:
+
+- "Great question!"
+- "Absolutely!"
+- "Certainly!"
+- "Of course!"
+- "I'd be happy to help."
+- "I'd love to help."
+- "I'm here to help."
+- "It's important to note that…"
+- "It's worth noting that…"
+- "It should be noted that…"
+- "Interestingly,"
+- "In conclusion,"
+- "In summary,"
+- "To summarize,"
+- "To wrap up,"
+- "Furthermore,"
+- "Moreover,"
+- "Additionally,"
+- "However," used as the opening word of multiple paragraphs.
+
+Test: if the sentence still works without the opener phrase, delete the phrase. If the sentence collapses without it, the sentence is filler, so delete the whole sentence.
+
+### Punctuation tells
+
+**Em dash overuse.** More than 2-3 em dashes per 500 words, or em dashes appearing at every clause boundary. Replace most with commas, full stops, or hyphens with spaces. Genuine asides can keep theirs.
+
+**Curly quotes** in plain-text or markdown contexts where the surrounding ecosystem uses straight quotes. Convert.
+
+**Knowledge-cutoff disclaimers.** "As of my knowledge cutoff…", "I may not have current information…". Cut from final output.
+
+**Sycophantic openers.** "What a wonderful question!", "I love this prompt!". Cut.
+
+### Content and analysis tells
+
+**Vague attribution.** "Many experts say…", "Studies have shown…", "It is widely believed that…". Cite a specific source or delete the claim.
+
+**Superficial -ing analysis.** Clauses that add no information: "highlighting their significance", "emphasizing their role", "underscoring their importance". Cut the whole clause.
+
+**Hedge stacking.** "May potentially possibly suggest." Pick the strongest verb that's still accurate.
+
+**Filler hedges.** "Somewhat", "relatively", "arguably", "perhaps", "potentially". Cut where the claim still holds. If the claim doesn't hold without the hedge, the claim is too weak. Sharpen or delete.
+
+### Era-specific tells (current as of May 2026)
+
+**Active right now:**
+
+- Goblin, gremlin, raccoon, troll, ogre, pigeon. OpenAI hard-banned these in May 2025; if they appear, they leaked through.
+- "It's not X, it's Y." Still rampant.
+- Markdown-bullet-everything. Still rampant.
+- "I'd be happy to help" openers. Still rampant.
+- Title Case section headings. Still rampant.
+
+**Mostly trained out:**
+
+- "Delve". Paul Graham's 2024 viral tweet pushed OpenAI to train it down. Now uncommon.
+- Em dashes at every clause boundary. OpenAI shipped a fix in November 2025. Less common but still leak through.
+- "Tapestry". Peak 2023. Now rare.
+
+Update this section quarterly against the Wikipedia source. Demote trained-out tells to the second list, but never delete from the catalogue. Tells are cyclical and may return.
+
+## Workflow
+
+1. **Read the input fully.** Don't skim. Density and combination matter more than any single tell.
+2. **Pass 1, flag.** Walk every category. For each match, note the phrase, the category, and a proposed replacement.
+3. **Pass 2, score.** Estimate tells per 100 words. Above 3 is heavy. Above 6, recommend a rewrite from scratch rather than editing.
+4. **Pass 3, rewrite.** Maintain the writer's intent and voice. Don't substitute one set of AI tells for another.
+5. **Pass 4, self-audit.** Read the rewrite. Ask: what still feels AI? Fix it. Repeat until clean.
+
+## Output format
+
+Return three blocks:
+
+**1. Audit.** A bulleted list of every tell flagged. Format: `[category] "exact phrase" → "proposed replacement"`.
+
+**2. Density score.** "X tells per 100 words. Light / Moderate / Heavy / Unsalvageable."
+
+**3. Clean rewrite.** The final version with all tells removed.
+
+If the input scores Unsalvageable, skip the rewrite and tell the user the draft needs to be redone from a fresh outline rather than edited.
+
+## What this skill does not do
+
+- It does not detect whether a text was AI-generated. AI detectors are unreliable. This skill assumes the input may be AI-assisted and cleans it regardless.
+- It does not substitute for human editing. It catches surface tells. It cannot detect hollow thinking or missing voice. Those need a human pass.
+- It does not produce style. It produces *absence* of AI style. Pair it with a voice guide for the affirmative side.
+
+## Source and credit
+
+- Wikipedia: Signs of AI writing. https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
+
+
+Built by Kyle Balmer at AI with Kyle. MIT licensed. Last updated 2026-05-04. Free to use, share, and modify. If the list dates, update it.

--- a/.claude/skills/ai-tells/SKILL.md
+++ b/.claude/skills/ai-tells/SKILL.md
@@ -108,7 +108,7 @@ Test: if the sentence still works without the opener phrase, delete the phrase. 
 
 **Active right now:**
 
-- Goblin, gremlin, raccoon, troll, ogre, pigeon. OpenAI hard-banned these in May 2025; if they appear, they leaked through.
+- Goblin, gremlin (except when referring to the Apache TinkerPop Gremlin query language), raccoon, troll, ogre, pigeon. OpenAI hard-banned these in May 2025; if they appear, they leaked through.
 - "It's not X, it's Y." Still rampant.
 - Markdown-bullet-everything. Still rampant.
 - "I'd be happy to help" openers. Still rampant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,19 @@ Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless) 
 
 **After modifying code, always run `./mvnw -pl {module} spotless:apply`** before committing to ensure formatting compliance. If the build fails with a Spotless error, run `spotless:apply` to auto-fix.
 
+## Writing Style for Design Docs and Issues
+
+The default LLM register is verbose, hedging, list-heavy, and full of "AI tells" (delve, leverage, robust, "It's not X — it's Y", em-dash overuse). Documents in this register are slow to read and reviewers ignore them. Use the **Concise Doc** output style at `.claude/output-styles/concise-doc.md` whenever you draft:
+
+- ADR / design documents under `docs/adr/**` (including `_workflow/` drafts during a branch's lifetime, and the final `adr.md` and `design-final.md`).
+- GitHub issue bodies you write for the user to post (e.g., the `issue-*.md` scratch files at the repo root).
+- PR titles and descriptions (the squashed-commit message is built from these, so they go straight into git history).
+- YouTrack issue bodies created via the YouTrack MCP tools.
+
+The output style is **mandatory style guidance for these artifacts, not optional**. Apply its rules (BLUF lead, banned-vocabulary list, em-dash cap, 200-word section cap, repo-anchored voice) whether or not the user has activated the style with `/output-style`. Read the file once at the start of any session that will produce documents in those paths; treat its self-check list as a pre-return checklist for every draft.
+
+When the user wants the style toggled for the whole session (e.g., a session focused on writing an ADR), suggest `/output-style concise-doc`. Otherwise, just apply the rules silently.
+
 ## Testing
 
 ### Test Requirements


### PR DESCRIPTION
#### Motivation

The default LLM writing register is verbose, hedging, list-heavy, and laden with AI-tell vocabulary (delve, leverage, robust, "It's not X — it's Y", em-dash overuse). Design docs and issues drafted in that register are slow to read; reviewers stop engaging and our planning artifacts lose value as communication.

This change codifies a project-scoped concise writing style and tells Claude to apply it whenever it drafts an ADR, an issue body, a PR description, or YouTrack issue text. The two-layer pattern of "prompt rules + linter audit" is the established mitigation in the field for AI-slop documentation; this is the project-local version of it.

#### What ships

1. **`.claude/output-styles/concise-doc.md`** — a project Output Style with:
   - BLUF rule (lead with the bottom line; first 3–5 sentences state the decision/change/symptom)
   - Tier-1 / Tier-2 banned-vocabulary list
   - Em-dash discipline (≤ 1 per paragraph; no "X — Y — Z" triple cadence)
   - 200-word section cap, no faux-symmetric bullet structures
   - Repo-anchored positive examples (`docs/adr/persist-visible-count`, `docs/adr/index-gc`)
   - A 6-item pre-return self-check

2. **`.claude/skills/ai-tells/SKILL.md`** — the MIT-licensed `ai-tells` skill from [kdgbalmer/ai-tells](https://github.com/kdgbalmer/ai-tells), installed project-scoped as the second-layer audit. The prompt rules in the output style catch the bulk of slop; this skill catches the residue, including structural issues (heading-hierarchy inconsistencies, inline-header overuse, rule-of-three triads) that a banned-word list cannot detect.

3. **`CLAUDE.md`** — new "Writing Style for Design Docs and Issues" section. It points at the output style, enumerates the artifact set the rules apply to (`docs/adr/**`, GitHub issue bodies, PR titles/descriptions, YouTrack issue bodies), and makes the rules mandatory whether or not the user has activated the style with `/output-style`.

#### Trade-offs

- The output style and ai-tells skill both live as Claude-Code-specific config under `.claude/`. They are not enforced on humans writing prose by hand; they are guidance for AI-assisted drafts (which is where the slop comes from).
- ai-tells is third-party MIT-licensed content vendored into the repo. The alternative (user-global install at `~/.claude/skills/`) would not be available to other contributors who clone the repo and want the same review pass.
- The output style is opinionated and may need tuning. The banned-word list is conservative (avoids words that are genuinely useful in narrow technical contexts like "leverage" the noun); the in-doc "Strongly avoid" tier lists these with replacements rather than hard-banning them.
- No code paths or build artifacts are touched. Spotless / tests are not affected.

#### Validation

The output style was applied to a real test case during development:
- The YTDB-651 issue description was rewritten from ~4,160 words to ~3,220 words (~23% reduction) while preserving every formula, class name, line number, code block, and table.
- The same description was then audited with the ai-tells skill, which surfaced one structural issue (heading-numbering inconsistency at `## 4. Profiling and observability`) that the output style's own checklist did not catch. Fix was trivial and confirmed the two-layer value.