### PR TITLE
Drop implementation-backlog.md from the planning workflow

### DIFF
--- a/.claude/scripts/design-mechanical-checks.py
+++ b/.claude/scripts/design-mechanical-checks.py
@@ -11,7 +11,7 @@ Usage:
         --design-path docs/adr/<dir>/_workflow/design.md \
         [--design-mechanics-path docs/adr/<dir>/_workflow/design-mechanics.md] \
         [--plan-path docs/adr/<dir>/_workflow/implementation-plan.md] \
-        [--backlog-path docs/adr/<dir>/_workflow/implementation-backlog.md] \
+        [--tracks-dir docs/adr/<dir>/_workflow/tracks/] \
         [--changed-section "Section Title"] \
         [--target design|mechanics|both] \
         [--scope bounded|whole-doc]
@@ -1087,21 +1087,21 @@ def check_full_design_link_resolution(
     design_lines: List[str],
     plan_path: Optional[str],
     plan_lines: Optional[List[str]],
-    backlog_path: Optional[str],
-    backlog_lines: Optional[List[str]],
+    track_files: Optional[List[Tuple[str, List[str]]]],
     design_mechanics_path: Optional[str],
     design_mechanics_lines: Optional[List[str]],
 ) -> List[Dict]:
-    """Every `**Full design**: <design-basename> §"<name>"` in plan and
-    backlog must resolve to a heading in design.md (and any chained
-    `<mechanics-basename> §"<name>"` must resolve in mechanics).
+    """Every `**Full design**: <design-basename> §"<name>"` in the plan and
+    in any step file (`tracks/track-N.md`) must resolve to a heading in
+    design.md (and any chained `<mechanics-basename> §"<name>"` must
+    resolve in mechanics).
 
     Basenames are derived from `--design-path` / `--design-mechanics-path` so
     the check works whether the supplied paths point at the original `design.md`
     pair or at the Phase 4 `*-final.md` variants.
     """
     findings: List[Dict] = []
-    if plan_lines is None and backlog_lines is None:
+    if plan_lines is None and not track_files:
         return findings
 
     design_basename = os.path.basename(design_path)
@@ -1132,7 +1132,7 @@ def check_full_design_link_resolution(
                 target_table = mech_norm
                 target_label = mech_basename
             elif fname in {"design-mechanics.md", "design-mechanics-final.md"}:
-                # Plan/backlog refs to a mechanics file but no mechanics path supplied.
+                # Plan / step-file refs to a mechanics file but no mechanics path supplied.
                 out.append(make_finding(
                     "blocker",
                     "full-design-link-resolution",
@@ -1163,8 +1163,9 @@ def check_full_design_link_resolution(
 
     if plan_lines is not None and plan_path is not None:
         findings.extend(check_file(plan_path, plan_lines))
-    if backlog_lines is not None and backlog_path is not None:
-        findings.extend(check_file(backlog_path, backlog_lines))
+    if track_files:
+        for track_path, track_lines in track_files:
+            findings.extend(check_file(track_path, track_lines))
     return findings
 
 
@@ -1178,7 +1179,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--design-path", required=True, help="Absolute path to design.md")
     p.add_argument("--design-mechanics-path", help="Absolute path to design-mechanics.md (optional)")
     p.add_argument("--plan-path", help="Absolute path to implementation-plan.md (optional)")
-    p.add_argument("--backlog-path", help="Absolute path to implementation-backlog.md (optional)")
+    p.add_argument("--tracks-dir", help="Absolute path to the tracks/ directory containing tracks/track-N.md step files (optional). Every *.md file in this directory is scanned for `**Full design**` refs.")
     p.add_argument("--changed-section", help="Title of the section that changed (for bounded scope)")
     p.add_argument("--scope", choices=("bounded", "whole-doc"), default="whole-doc",
                    help=("Scope of the section-bounded checks (default: whole-doc). When "
@@ -1202,7 +1203,7 @@ def parse_args() -> argparse.Namespace:
                          "use for phase1-creation, design-sync, length-trigger-crossing, and "
                          "phase4-creation mutations that touch both files. (For phase4-creation, "
                          "the --design-path and --design-mechanics-path point at the *-final.md "
-                         "variants; omit --plan-path and --backlog-path so the cross-file ref "
+                         "variants; omit --plan-path and --tracks-dir so the cross-file ref "
                          "check is naturally skipped — Phase 4 produces a new artifact, not a "
                          "modification of the original design.md.)"))
     args = p.parse_args()
@@ -1278,19 +1279,24 @@ def main() -> int:
                 "Pass an existing path or omit the flag.",
             ))
 
-    backlog_lines: Optional[List[str]] = None
-    if args.backlog_path:
-        if os.path.exists(args.backlog_path):
-            backlog_lines = read_lines(args.backlog_path)
+    track_files: Optional[List[Tuple[str, List[str]]]] = None
+    if args.tracks_dir:
+        if os.path.isdir(args.tracks_dir):
+            track_paths = sorted(
+                os.path.join(args.tracks_dir, name)
+                for name in os.listdir(args.tracks_dir)
+                if name.endswith(".md")
+            )
+            track_files = [(p, read_lines(p)) for p in track_paths]
         else:
             findings.append(make_finding(
                 "blocker",
                 "companion-path-missing",
-                args.backlog_path,
-                (f"--backlog-path was supplied but the file does not exist at "
-                 f"{args.backlog_path}. `**Full design**` ref resolution against the "
-                 "backlog would be silently skipped, masking any broken refs."),
-                "Pass an existing path or omit the flag.",
+                args.tracks_dir,
+                (f"--tracks-dir was supplied but the directory does not exist at "
+                 f"{args.tracks_dir}. `**Full design**` ref resolution against the "
+                 "step files would be silently skipped, masking any broken refs."),
+                "Pass an existing directory or omit the flag.",
             ))
 
     # design.md shape checks fire only when the mutation actually touched
@@ -1333,7 +1339,7 @@ def main() -> int:
     findings.extend(check_full_design_link_resolution(
         args.design_path, design_lines,
         args.plan_path, plan_lines,
-        args.backlog_path, backlog_lines,
+        track_files,
         args.design_mechanics_path, design_mechanics_lines))
 
     # Reverse-direction ref check: per design-document-rules.md § Length-

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -30,7 +30,7 @@ name. Otherwise, default to the current git branch name
 The plan will be saved to:
 `docs/adr/<dir-name>/_workflow/implementation-plan.md`
 (the `_workflow/` subdir holds every ephemeral working file — plan,
-backlog, design, step files, reviews — and is removed in the Phase 4
+design, step files, reviews — and is removed in the Phase 4
 cleanup commit before merge; see `conventions.md` §1.2 and
 `workflow.md` § Final Artifacts).
 The codebase is at the current working directory.
@@ -87,15 +87,16 @@ Help the user develop the plan:
    workflow rules:
    - Every track gets an **intro paragraph** in the plan checklist
      entry (a short paragraph of high-level context) and a matching
-     `## Track N: <title>` section in `implementation-backlog.md`
-     carrying the detailed `**What**:` / `**How**:` /
-     `**Constraints**:` / `**Interactions**:` subsections (no length
-     cap on the detail). See `planning.md` §Track descriptions for
-     what each subsection should cover.
-   - Include a track-level Mermaid component diagram in the backlog
-     (immediately after the `**Interactions**:` blockquote) when the
-     track has 3+ internal components with non-trivial interactions.
-     Track-level diagrams are **never rendered in the plan file**.
+     `tracks/track-N.md` step file whose `## Description` section
+     carries the same intro paragraph followed by detailed `**What**:`
+     / `**How**:` / `**Constraints**:` / `**Interactions**:`
+     subsections (no length cap on the detail). See `planning.md`
+     §Track descriptions for what each subsection should cover.
+   - Include a track-level Mermaid component diagram in the step
+     file's `## Description` (immediately after the
+     `**Interactions**:` blockquote) when the track has 3+ internal
+     components with non-trivial interactions. Track-level diagrams
+     are **never rendered in the plan file**.
    - Track sizing rule: if a track would need more than ~5-7 steps, split
      it into separate dependent tracks. The execution agent handles
      sequencing and episode propagation between dependent tracks.
@@ -127,18 +128,19 @@ Help the user develop the plan:
 
 Do NOT implement anything. Only research and plan.
 
-Write both the implementation plan to
-`docs/adr/<dir-name>/_workflow/implementation-plan.md` AND the
-track-details backlog to
-`docs/adr/<dir-name>/_workflow/implementation-backlog.md` using the
-two structures below. The plan carries strategic context (Goals,
+Write the implementation plan to
+`docs/adr/<dir-name>/_workflow/implementation-plan.md` AND one step
+file per planned track at
+`docs/adr/<dir-name>/_workflow/tracks/track-N.md` using the two
+structures below. The plan carries strategic context (Goals,
 Constraints, Architecture Notes, Decision Records) plus a thin
-checklist; the backlog carries each track's detailed
+checklist; each step file carries that track's detailed
 `**What/How/Constraints/Interactions**` subsections and any
-track-level Mermaid diagrams. Splitting keeps `/execute-tracks`
-startup context small — see `.claude/workflow/conventions.md` §1.2 for
-the full rules (directory layout under `_workflow/`, backlog file
-shape, lifecycle).
+track-level Mermaid diagram in its `## Description` section. Keeping
+per-track detail out of the plan keeps `/execute-tracks` startup
+context small — see `.claude/workflow/conventions.md` §1.2 (directory
+layout under `_workflow/`) and `conventions-execution.md` §2.1
+(step-file shape and description lifecycle).
 
 ```
 # <Feature Name>
@@ -176,11 +178,11 @@ shape, lifecycle).
 
 ## Checklist
 - [ ] Track 1: <title>
-  > <intro paragraph — high-level context; detailed description in implementation-backlog.md>
+  > <intro paragraph — high-level context; detailed description in tracks/track-1.md>
   > **Scope:** ~N steps covering X, Y, Z
 
 - [ ] Track 2: <title>
-  > <intro paragraph — high-level context; detailed description in implementation-backlog.md>
+  > <intro paragraph — high-level context; detailed description in tracks/track-2.md>
   > **Scope:** ~N steps covering A, B
   > **Depends on:** Track 1
 
@@ -191,10 +193,17 @@ shape, lifecycle).
 - [ ] Phase 4: Final artifacts (`design-final.md`, `adr.md`)
 ```
 
-````markdown
-# <Feature Name> — Track Details
+Each step file (`tracks/track-N.md`) is created with `## Description`
+fully populated and the remaining sections as `[ ]` placeholders that
+Phase A → C will fill:
 
-## Track 1: <title>
+````markdown
+# Track N: <title>
+
+## Description
+<intro paragraph — same as the plan checklist entry's intro, so the
+step file is self-sufficient context for Phase B/C sub-agents that
+don't read the plan>
 
 > **What**:
 > - <bullet list of concrete deliverables>
@@ -212,17 +221,19 @@ shape, lifecycle).
 <optional track-level component diagram (≤10 nodes); see planning.md>
 ```
 
-## Track 2: <title>
+## Progress
+- [ ] Review + decomposition
+- [ ] Step implementation
+- [ ] Track-level code review
 
-> **What**: …
-> **How**: …
-> **Constraints**: …
-> **Interactions**: …
+## Reviews completed
 
-<!-- The Track 2 above uses a condensed one-line-per-label style as a
-layout exemplar; expand each track section to carry the full
-description content per planning.md §Track descriptions. -->
+## Steps
 ````
+
+The `## Base commit` section is added by Phase B at session start and
+is omitted from the Phase 1 skeleton. The full step-file shape across
+phases is documented in `conventions-execution.md` §2.1.
 
 Write the design document to
 `docs/adr/<dir-name>/_workflow/design.md` using this structure:

--- a/.claude/skills/edit-design/SKILL.md
+++ b/.claude/skills/edit-design/SKILL.md
@@ -36,7 +36,7 @@ the plan lifecycle:
 Use the `phase4-creation` kind — structurally similar to
 `phase1-creation` (one-shot creation, full discipline; one or both
 files depending on whether a mechanics companion is needed) but
-targeting the `*-final.md` paths and skipping plan/backlog ref
+targeting the `*-final.md` paths and skipping plan / step-file ref
 propagation (those refs point at the original `design.md`, not at the
 new final artifact). No follow-up `mechanics-edit` / `design-sync` cycle:
 Phase 4 is committed once.
@@ -53,7 +53,7 @@ The invoking agent supplies these when calling the skill:
 | `design_path` | Absolute path to `design.md` (or `design-final.md` in Phase 4). |
 | `design_mechanics_path` | Absolute path to `design-mechanics.md` (or `null` if no companion). |
 | `plan_path` | Absolute path to `implementation-plan.md` (for `**Full design**` link resolution). |
-| `backlog_path` | Absolute path to `implementation-backlog.md` (same purpose). |
+| `tracks_dir` | Absolute path to the `tracks/` directory containing every `tracks/track-N.md` step file (same purpose — each step file's `## Description` may carry `**Full design**` references that the cross-file ref check has to resolve). |
 | `target` | `design`, `mechanics`, or `both` — the file(s) the edit touches. Threaded through to the script's `--target` flag verbatim. (No `.md` suffix — the script's argparse choices are `design`/`mechanics`/`both`.) |
 | `intended_edit` | Either `(old_string, new_string)` for a focused edit, or full new content for a section-add / section-rewrite / file creation. |
 | `mutation_kind` | One of the values listed in the mode table above. |
@@ -80,12 +80,12 @@ mechanics companion) or `both` if the mutation also propagates into
 | `design-sync` | both files (re-distill design.md from updated mechanics) | `both` | `whole-doc` on design.md, plus mechanics-link-resolution sweep |
 | `content-edit` | design.md | `design` | `bounded` — changed section + 1-2 surrounding sections + Overview + (when present) Core Concepts |
 | `section-add` | design.md | `design` | `bounded` — new section + Overview + (when present) Core Concepts + structure roadmap |
-| `section-remove` | design.md (+ plan/backlog ref cleanup — `**Full design**` lines pointing at the removed section must be updated in the same mutation, otherwise `**Full design**` link resolution fails) | `design` | `whole-doc` |
-| `section-rename` | design.md + (when mechanics exists) the matching section in `design-mechanics.md` + plan/backlog ref propagation | `design \| both` | `whole-doc` |
+| `section-remove` | design.md (+ plan / step-file ref cleanup — `**Full design**` lines pointing at the removed section must be updated in the same mutation, otherwise `**Full design**` link resolution fails) | `design` | `whole-doc` |
+| `section-rename` | design.md + (when mechanics exists) the matching section in `design-mechanics.md` + plan / step-file ref propagation | `design \| both` | `whole-doc` |
 | `section-move` | design.md | `design` | `whole-doc` |
 | `structural-rewrite` | design.md + (when mechanics exists and any rename or split propagates) the matching sections in `design-mechanics.md` | `design \| both` | `whole-doc` |
 | `length-trigger-crossing` | both files (split into design-mechanics) | `both` | `whole-doc` |
-| `phase4-creation` | `design-final.md` + (optional) `design-mechanics-final.md` | `both` if mechanics-final exists, else `design` | `whole-doc` on `design-final.md` (mechanics-final is exempt — agent-targeted long-form). Skip plan/backlog ref propagation: omit `--plan-path` / `--backlog-path` so the cross-file ref check is naturally skipped. |
+| `phase4-creation` | `design-final.md` + (optional) `design-mechanics-final.md` | `both` if mechanics-final exists, else `design` | `whole-doc` on `design-final.md` (mechanics-final is exempt — agent-targeted long-form). Skip plan / step-file ref propagation: omit `--plan-path` / `--tracks-dir` so the cross-file ref check is naturally skipped. |
 
 **Periodic whole-doc check.** Independent of mode: every Nth design-touching
 mutation (default `N=5`, counted from the review log) escalates the cold-read
@@ -139,7 +139,7 @@ content reflects what was *actually built* — not the planned design. The
 caller (`prompts/create-final-design.md`) is expected to have run the
 PSI-backed verification tables before invoking the skill, so each diagram
 element traces to a real code location. Do **not** pass `--plan-path` /
-`--backlog-path` (the cross-file ref check is naturally skipped — see the
+`--tracks-dir` (the cross-file ref check is naturally skipped — see the
 table above).
 
 For `design-sync`: see Step 1.5 below — sync has a distillation sub-step
@@ -170,8 +170,10 @@ Sync re-distills `design.md` from the current state of
 5. For sections **removed** in mechanics: remove from `design.md` (or, if
    the section was renamed, propagate the rename and update the
    `Mechanics:` link).
-6. **Update plan/backlog `**Full design**` refs** for any section that was
-   added/removed/renamed in this sync.
+6. **Update plan / step-file `**Full design**` refs** for any section
+   that was added/removed/renamed in this sync — the plan-file checklist
+   entries' Decision Records and every step file's `## Description` may
+   carry references to the affected section.
 
 Apply the distilled `design.md` to disk via `Edit`/`Write`.
 
@@ -192,7 +194,7 @@ python3 .claude/scripts/design-mechanical-checks.py \
     --design-path <design_path> \
     --design-mechanics-path <design_mechanics_path or omit> \
     --plan-path <plan_path or omit> \
-    --backlog-path <backlog_path or omit> \
+    --tracks-dir <tracks_dir or omit> \
     --changed-section "<title>" \
     --target <design|mechanics|both> \
     --scope <bounded|whole-doc>
@@ -257,7 +259,7 @@ sub-agent via the `Agent` tool:
 - bounded_scope: <changed_section name + surrounding section names, when bounded>
 - mutation_kind: <kind>
 - plan_path: <abs path or "(none)">
-- backlog_path: <abs path or "(none)">
+- tracks_dir: <abs path or "(none)">
 ```
 
 For `design-sync`, also include in the prompt body: *"This sync re-distills
@@ -444,11 +446,12 @@ the meaning of the request.
 
 ## When NOT to use this skill
 
-- Edits to `implementation-plan.md`, `implementation-backlog.md`, or any
-  other workflow file. Those have their own gates (Phase 2 structural
-  review). The `**Full design**` ref-propagation that lands in plan and
-  backlog during a `section-rename` or `design-sync` is part of this
-  skill's scope, but isolated plan-only edits are not.
+- Edits to `implementation-plan.md`, the per-track step files under
+  `tracks/`, or any other workflow file. Those have their own gates
+  (Phase 2 structural review). The `**Full design**` ref-propagation
+  that lands in the plan and the step files during a `section-rename`
+  or `design-sync` is part of this skill's scope, but isolated plan-only
+  or step-file-only edits are not.
 - Edits to source code, tests, or docs outside `docs/adr/<plan-dir>/`.
 - Pre-Phase-1 scratch notes that haven't been promoted to `design.md`
   yet — only the canonical paths above trigger the discipline.
@@ -484,8 +487,8 @@ design.md". The skill:
 2. Reads `design-mechanics.md` to see the current state.
 3. Distills `design.md` — updates each affected section's TL;DR +
    overview + edge cases + references to match current mechanics.
-4. Updates plan/backlog `**Full design**` refs for any renamed/added/
-   removed sections.
+4. Updates plan / step-file `**Full design**` refs for any renamed /
+   added / removed sections.
 5. Runs mechanical checks with `--target=both`.
 6. Spawns cold-read with `whole-doc` scope, including the sync-specific
    "verify design.md reflects current mechanics" instruction.
@@ -506,8 +509,8 @@ companion, so the rename has to propagate. The skill:
    `design-document-rules.md` § Length-triggered split into
    `design-mechanics.md`.
 3. Updates every `**Full design**: design.md §"DPB (D33)"` line in
-   `implementation-plan.md` and `implementation-backlog.md` to use the
-   new name.
+   `implementation-plan.md` and in every `tracks/track-N.md` step file
+   to use the new name.
 4. Runs mechanical checks with `--target=both`, `--scope=whole-doc` —
    confirms zero broken refs. (`both` because mechanics was touched;
    the cold-read scope table resolves `design \| both` to `both` for
@@ -517,7 +520,7 @@ companion, so the rename has to propagate. The skill:
 
 If the design has **no** `design-mechanics.md` companion, step 2 is
 skipped and step 4 runs with `--target=design`. Step 3 still runs —
-plan/backlog ref propagation is independent of whether mechanics
+plan / step-file ref propagation is independent of whether mechanics
 exists.
 
 ## Reference

--- a/.claude/skills/execute-tracks/SKILL.md
+++ b/.claude/skills/execute-tracks/SKILL.md
@@ -103,7 +103,7 @@ Each session handles exactly ONE PHASE of one track (or Phase 4 / State 0):
 User interaction happens at specific points:
 - Session start: auto-resume decision (confirm or override)
 - State 0 design-decision findings: resolve each escalated finding (only design-decision; mechanical fixes apply autonomously)
-- Track Pre-Flight (State A — pre-Phase-A): two-panel gate. Panel 1 (strategy assessment, look-back) is shown when an earlier track has just completed/skipped — accept the CONTINUE/ADJUST recommendation or override; an ESCALATE recommendation routes to inline replanning. Panel 2 (upcoming track summary, look-forward) always renders. Options on the combined gate: Proceed; Adjust (light edits to any remaining track including reorder); Clarify (notes for the upcoming track's step-file Description); ESCALATE → inline replanning. Skipped on State C resume.
+- Track Pre-Flight (State A — pre-Phase-A): two-panel gate. Panel 1 (strategy assessment, look-back) is shown when an earlier track has just completed/skipped — accept the CONTINUE/ADJUST recommendation or override; an ESCALATE recommendation routes to inline replanning. Panel 2 (upcoming track summary, look-forward) always renders. Options on the combined gate: Proceed; Adjust (light edits to any remaining track's plan / step file including reorder); Clarify (notes written into the upcoming track's step-file Description as a `### Clarifications` subsection on Proceed); ESCALATE → inline replanning. Skipped on State C resume.
 - Phase complete: user clears session, re-runs `/execute-tracks`
 - Cross-track impact detected: continue, pause, or escalate
 - Track complete: approve, request fixes, or request rework

--- a/.claude/skills/review-plan/SKILL.md
+++ b/.claude/skills/review-plan/SKILL.md
@@ -35,15 +35,16 @@ directory name. Otherwise, default to the current git branch name
 (`git branch --show-current`).
 
 Plan file: `docs/adr/<dir-name>/_workflow/implementation-plan.md`
-Backlog file: `docs/adr/<dir-name>/_workflow/implementation-backlog.md`
+Step files directory: `docs/adr/<dir-name>/_workflow/tracks/`
 Design document: `docs/adr/<dir-name>/_workflow/design.md`
 
-The backlog file holds pending-track
-`**What/How/Constraints/Interactions**` detail and any track-level
-Mermaid diagrams (see `conventions-execution.md` §2.1 for the
-Description lifecycle). Phase 2 sub-agents read it alongside the plan
-to verify pending-track descriptions; pass its absolute path as the
-`backlog_path` argument on each sub-agent spawn.
+Each `tracks/track-N.md` step file's `## Description` section holds
+that pending track's `**What/How/Constraints/Interactions**` detail and
+any track-level Mermaid diagram (see `conventions-execution.md` §2.1
+for the Description lifecycle). Phase 2 sub-agents read every pending
+track's step file alongside the plan to verify pending-track
+descriptions; pass the absolute step-files directory path as the
+`tracks_dir` argument on each sub-agent spawn.
 
 ---
 
@@ -52,22 +53,22 @@ to verify pending-track descriptions; pass its absolute path as the
 1. Run the clean-tree precondition from
    [`implementation-review.md`](../../workflow/implementation-review.md)
    § How to run > Precondition — path-scoped to the workflow files
-   the audit-trail commit will touch (plan, backlog, design,
-   design-mechanics, design-mutations). Halt and ask the user to
-   commit or stash if any of those are dirty. Other dirty paths in
-   the working tree are safe to ignore.
+   the audit-trail commit will touch (plan, every step file under
+   `tracks/`, design, design-mechanics, design-mutations). Halt and ask
+   the user to commit or stash if any of those are dirty. Other dirty
+   paths in the working tree are safe to ignore.
 2. Load `.claude/workflow/implementation-review.md` and follow its
    §"Step 1: Consistency Review" → §"Step 2: Structural Review" → §
    "Completion" sections in order. The orchestration is identical to
    the autonomous State 0 path inside `/execute-tracks`.
-3. Apply mechanical fixes via `Edit` (plan/backlog) or the
+3. Apply mechanical fixes via `Edit` (plan / step files) or the
    `edit-design` skill (design.md — mutation discipline).
 4. Batch-escalate any `design-decision` findings to the user once per
    step. Apply user-resolved fixes the same way.
 5. After both reviews pass, overwrite the plan file's `## Plan Review`
    section with the audit summary (`[x]` + auto-fixed/escalated
    listings) per `implementation-review.md` § Audit trail.
-6. Commit the plan/backlog/design updates with the message
+6. Commit the plan / step-file / design updates with the message
    `Plan review autonomous fixes for <plan-name>` and push.
 7. End the session.
 

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -5,7 +5,7 @@ Conventions). These conventions apply during Phase 3 execution and enable
 reliable session resume by making commit types identifiable in `git log`.
 
 During execution both **code changes** and **workflow-file changes**
-under `docs/adr/<dir-name>/_workflow/` (the plan, backlog, design,
+under `docs/adr/<dir-name>/_workflow/` (the plan, design,
 step files, design-mutations log) are committed. Workflow files are
 tracked under `_workflow/` for the branch lifetime and are removed in
 the Phase 4 cleanup commit before the PR is merged. See

--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -36,11 +36,13 @@ detection is used.
 # Track N: <title>
 
 ## Description
-<assembled at Phase A start — intro paragraph from the plan entry plus
-`**What/How/Constraints/Interactions**` + optional diagram from the
-backlog, optionally followed by a `### Clarifications` subsection
-populated from the Track Pre-Flight gate (omitted when the gate
-captured no clarifications). See the "Description lifecycle"
+<written at Phase 1 by `create-plan` — intro paragraph from the plan
+entry plus `**What**:` / `**How**:` / `**Constraints**:` /
+`**Interactions**:` subsections plus any optional track-level Mermaid
+diagram. The Track Pre-Flight gate (see
+[`track-review.md`](track-review.md) §Track Pre-Flight) may amend this
+section and/or append a `### Clarifications` subsection (omitted when
+the gate captured no clarifications). See the "Description lifecycle"
 subsection at the end of §2.1 for authoritative-location rules across
 phases.>
 
@@ -81,20 +83,20 @@ phases.>
 ````
 
 The **Description** section carries the track's full description —
-intro paragraph (sourced from the plan-file entry), `**What**:` /
+intro paragraph (mirroring the plan-file entry's intro), `**What**:` /
 `**How**:` / `**Constraints**:` / `**Interactions**:` subsections, and
-any track-level Mermaid diagram (both sourced from
-`implementation-backlog.md`), optionally followed by a
-`### Clarifications` subsection populated from the Track Pre-Flight
-gate (see [`track-review.md`](track-review.md) §Track Pre-Flight).
-Phase A orchestration writes the section once at the start of the
-track, concatenating the plan-entry intro with the backlog-section
-body and the (possibly empty) clarifications buffer; it is re-written
-only if [`inline-replanning.md`](inline-replanning.md) updates a
-mid-execution track's description. Phase B and Phase C sub-agents that already read
-the step file see the description here automatically — see the
-Description lifecycle subsection below for the authoritative-location
-rules across phases.
+any track-level Mermaid diagram. Phase 1 writes this section directly
+when it creates the step file, so by the time `/execute-tracks` enters
+Phase A the description is already on disk. The Track Pre-Flight gate
+(see [`track-review.md`](track-review.md) §Track Pre-Flight) may amend
+the section in place and/or append a `### Clarifications` subsection
+populated from the gate's clarifications buffer (omitted when the buffer
+is empty). Inline replanning (see
+[`inline-replanning.md`](inline-replanning.md)) is the only other writer
+mid-execution. Phase B and Phase C sub-agents that already read the step
+file see the description here automatically — see the Description
+lifecycle subsection below for the authoritative-location rules across
+phases.
 
 The **Progress** section tracks which phase the track is in. The execution
 agent updates it at each phase transition:
@@ -158,8 +160,8 @@ require escalation.
 
 A track's detailed description (the `**What/How/Constraints/Interactions**`
 subsections plus any track-level Mermaid diagram, plus any
-`### Clarifications` captured by the Track Pre-Flight gate) travels
-between files as the track moves through the workflow. The table below is the
+`### Clarifications` captured by the Track Pre-Flight gate) lives in the
+step file from the moment Phase 1 creates it. The table below is the
 canonical reference for where that content lives at each phase for
 pending, active, and completed tracks. Phase A resume logic (see
 [`track-review.md`](track-review.md)) and inline replanning (see
@@ -174,55 +176,24 @@ gate per the rule above.
 | Phase | Authoritative location | Writer | Reader(s) |
 |---|---|---|---|
 | Pre-Phase-1 | (none) | — | — |
-| Phase 1 write | `implementation-backlog.md` | Phase 1 agent (via `create-plan/SKILL.md`) | Phase 2 autonomous plan review (consistency + structural sub-agents) |
-| Phase A start — before step-file write | `implementation-backlog.md` | (inherited from Phase 1) | Phase A orchestration (reads the track's backlog section) |
-| Phase A mid — step file has `## Description`, backlog entry still present | **step file** (Phase A writes the step file first, then removes the backlog entry — the step file takes authority the moment it is written, so an interrupted session always resumes against a single source) | Phase A orchestration (wrote the step file) | Phase A resume logic (idempotent re-entry); Phase A review sub-agents |
-| Phase A end | step file | Phase A orchestration (backlog section already removed) | Phase A review sub-agents (Track 3 prompts) |
+| Phase 1 write | step file (`tracks/track-N.md`) | Phase 1 agent (via `create-plan/SKILL.md`) | Phase 2 autonomous plan review (consistency + structural sub-agents) |
+| Phase A | step file | (stable; Track Pre-Flight may amend `## Description` and/or append `### Clarifications`) | Phase A orchestration; Phase A review sub-agents |
 | Phase B / Phase C | step file | (stable — only inline replan rewrites) | Phase B implementer + Phase B/C code-review sub-agents |
-| Phase C after collapse | step file + plan intro paragraph | Phase C collapse (writes intro + episode) | future-track sessions (as strategic context) |
-| Skipped at or before Phase A | plan file entry (retained under `[~]`) + (backlog entry removed; step file never created) | `track-skip` | next session's Track Pre-Flight Panel 1 / future sessions |
-| Skipped after Phase A (rare) | plan file entry (retained under `[~]`) + step file (retained so the skip is traceable) | `track-skip` | next session's Track Pre-Flight Panel 1 / future sessions |
+| Phase C after collapse | plan intro paragraph + plan-resident track episode (the step file remains on disk until Phase 4 cleanup but is no longer load-bearing strategic context) | Phase C collapse (writes intro + episode) | future-track sessions (as strategic context) |
+| Skipped | plan file entry (retained under `[~]`) + step file deleted | `track-skip` | next session's Track Pre-Flight Panel 1 / future sessions |
 | Inline replan | per authoritative-location rule in [`inline-replanning.md`](inline-replanning.md) | inline-replanning orchestration | — |
 
-Track-level Mermaid diagrams follow the same trajectory as the
-description (backlog → step file at Phase A; never rendered in the
-plan file). The writer and readers at each phase are the same as the
+Track-level Mermaid diagrams live inside the step file's `## Description`
+under the `**Interactions**:` blockquote (never rendered in the plan
+file). The writer and readers at each phase are the same as the
 corresponding description row above.
 
-**Monotonic shrinkage:** The backlog grows only during Phase 1 or inline
-replanning, and shrinks as tracks enter Phase A or are skipped. Normal
-Phase A / B / C execution never adds entries. The file lives under
-`docs/adr/<dir-name>/_workflow/` — tracked in git during the branch
-lifetime so changes are pushed to the draft PR for team visibility and
-disk-loss backup, and removed in the Phase 4 cleanup commit before
-merge (see `conventions.md` §1.2 for the full lifecycle and
-`workflow.md` § Final Artifacts for the cleanup procedure).
-
-### Backlog section body extraction rule
-
-Track N's section body in `implementation-backlog.md` is everything
-between the `## Track N: <title>` header line and the next
-`## Track M: <title>` header line (or EOF, if Track N is the last
-section), excluding the `## Track N:` header line itself. Optional
-trailing blank lines between Track N's content and the next
-`## Track M:` header are stripped from the extracted body so repeated
-extract-then-insert cycles do not accumulate whitespace.
-
-Do **NOT** use line-count deletion to implement the removal — that
-approach breaks when track-level `mermaid` diagrams or
-multi-paragraph blockquotes change a section's line count between
-when the agent originally read it and when the removal runs. Always
-search for the header boundary at removal time.
-
-This is the single authoritative definition used wherever the workflow
-reads or removes a track's backlog section: Phase A description-move
-(see [`track-review.md`](track-review.md) §What You Do item 2,
-sub-step (d)), `track-skip` backlog cleanup (see
-[`track-skip.md`](track-skip.md)), and inline-replanning updates (see
-[`inline-replanning.md`](inline-replanning.md)). All three entry points
-apply the rule verbatim — keeping the extraction logic identical
-across them avoids accidental divergence when section bodies contain
-track-level `mermaid` diagrams or multi-paragraph blockquotes.
+**Step files live under `docs/adr/<dir-name>/_workflow/tracks/`** —
+tracked in git during the branch lifetime so changes are pushed to the
+draft PR for team visibility and disk-loss backup, and removed alongside
+the rest of `_workflow/` in the Phase 4 cleanup commit before merge
+(see `conventions.md` §1.2 for the full lifecycle and `workflow.md`
+§ Final Artifacts for the cleanup procedure).
 
 ---
 

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -23,7 +23,7 @@ during Phase 3 execution.
 | **Sub-agent** | A spawned agent for self-contained tasks — review (technical/risk/adversarial, dimensional code review, test quality review) where fresh perspective matters, or implementation (Phase B per-step implementer) where context absorption matters. The orchestrator retains session-level state. |
 | **Orchestrator** | The session-level agent driving `/execute-tracks`. In Phase B owns sub-steps 4–7 of step implementation and all session-level decisions (cross-track impact, escalation, episode synthesis, context-level session-end gate). Distinct from the implementer. |
 | **Implementer** | A fresh sub-agent spawned per step in Phase B that performs sub-steps 1–3 of step implementation (implement, test, commit) and returns a structured handoff to the orchestrator. See [`implementer-rules.md`](implementer-rules.md). |
-| **Backlog** | `implementation-backlog.md` — the companion file to `implementation-plan.md` that holds the detailed `**What/How/Constraints/Interactions**` subsections and any track-level Mermaid diagrams for pending tracks. Written during Phase 1 alongside the plan (and extended by inline replanning); shrinks monotonically as tracks enter Phase A or are skipped. Lives under `_workflow/` (tracked on the branch for backup and team visibility, removed in Phase 4 cleanup before merge). |
+| **Step file** | `tracks/track-N.md` — the per-track working file. Created during Phase 1 alongside `implementation-plan.md` with `## Description` already populated (intro paragraph + `**What/How/Constraints/Interactions**` + any track-level Mermaid diagram); other sections (`## Progress`, `## Reviews completed`, `## Steps`, `## Base commit`) start as `[ ]` placeholders and are filled by Phase A → C. Lives under `_workflow/tracks/` (tracked on the branch for backup and team visibility, removed in Phase 4 cleanup before merge). |
 
 ---
 
@@ -40,12 +40,8 @@ docs/adr/<dir-name>/
   _workflow/
     implementation-plan.md        <- strategic: goals, architecture, tracks,
                                      track-level episodic summaries (thin
-                                     checklist — description detail lives in
-                                     implementation-backlog.md)
-    implementation-backlog.md     <- pending-track details (what/how/
-                                     constraints/interactions + any
-                                     track-level diagrams); shrinks
-                                     monotonically
+                                     checklist — per-track detailed
+                                     description lives in tracks/track-N.md)
     design.md                     <- narrative: concept-first Overview
                                      (first content), Core Concepts vocabulary
                                      primer (when doc has Parts or ≥3 new
@@ -72,7 +68,12 @@ docs/adr/<dir-name>/
                                      `design-sync` step to find the last
                                      sync point.
     tracks/
-      track-1.md                  <- tactical: decomposed steps, step episodes
+      track-1.md                  <- per-track working file: ## Description
+                                     (intro paragraph + What/How/Constraints/
+                                     Interactions + any track-level Mermaid
+                                     diagram, written at Phase 1), Progress,
+                                     Reviews completed, Base commit, Steps,
+                                     step episodes
       track-2.md
       ...
 
@@ -115,10 +116,10 @@ durable artifacts survive the squash-merge into `develop`. See
 
 ## Checklist
 - [ ] Track 1: <title>
-  > <intro paragraph — high-level context; detailed description in implementation-backlog.md>
+  > <intro paragraph — high-level context; detailed description in tracks/track-1.md>
   > **Scope:** ~N steps covering X, Y, Z
 - [ ] Track 2: <title>
-  > <intro paragraph — high-level context; detailed description in implementation-backlog.md>
+  > <intro paragraph — high-level context; detailed description in tracks/track-2.md>
   > **Scope:** ~N steps covering X, Y, Z
   > **Depends on:** Track 1 (when applicable)
 
@@ -158,58 +159,18 @@ per-section budgets and rationale, and
 [`structural-review.md`](structural-review.md) § Bloat checks for how
 the structural review enforces them.
 
-### Backlog file content (`implementation-backlog.md`)
+### Step file content (`tracks/track-N.md`)
 
-Companion file to `implementation-plan.md`. It holds the detailed
-`**What/How/Constraints/Interactions**` subsections and any track-level
-Mermaid diagrams for **pending** tracks. Keeping this detail out of the
-plan keeps `implementation-plan.md` thin so `/execute-tracks` sessions
-read only strategic context at startup; the backlog is read only in
-Phase A of one track per session.
+Created during Phase 1 alongside `implementation-plan.md` — one file per
+planned track. The full file shape (every section, including
+`## Description`'s `**What/How/Constraints/Interactions**` subsections
+and any optional track-level Mermaid diagram) is defined in
+`conventions-execution.md` §2.1 *Step file content*. That doc is also
+where Phase A → C subsequent population is documented.
 
-````markdown
-# <Feature Name> — Track Details
-
-## Track 1: <title>
-
-> **What**:
-> - <bullet list of concrete deliverables>
->
-> **How**:
-> - <approach notes, ordering constraints, invariants to preserve>
->
-> **Constraints**:
-> - <in-scope/out-of-scope files, compatibility requirements>
->
-> **Interactions**:
-> - <how this track depends on or enables other tracks>
-
-```mermaid
-<optional track-level component diagram (≤10 nodes); see planning.md>
-```
-
-## Track 2: <title>
-
-> **What**: …
-> **How**: …
-> **Constraints**: …
-> **Interactions**: …
-
-…
-````
-
-**File shape requirements:**
-- `# <Feature Name> — Track Details` — required canonical header.
-- One `## Track N: <title>` section per pending track, with bold-label
-  blockquote subsections and an optional fenced `mermaid` block for any
-  track-level diagram.
-
-**Lifecycle (overview):** Sections are removed from the backlog as their
-tracks enter Phase A or are skipped, so the backlog shrinks monotonically
-during normal execution. Entries are added only during Phase 1 or inline
-replanning. Full per-phase detail (writers, readers, authoritative
-location) lives in the description-lifecycle table in
-`conventions-execution.md` §2.1.
+`/execute-tracks` startup loads only `implementation-plan.md` — step
+files are read on demand: by Phase 2 reviews (which read the step files
+for pending tracks) and by Phase A/B/C of the active track.
 
 ### Status markers
 

--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -34,15 +34,15 @@ design document.
 | `implementation-plan.md` | Goals, constraints, the **decisions themselves** (alternatives / rationale / risks / where-implemented / link-to-design), the Component Map (topology + short intent bullets), short invariant statements, short integration-point bullets, the track checklist. **Strategic, scannable, loaded every session.** |
 | `design.md` | Concept-first Overview; Core Concepts (when applicable); class diagrams; sequence/flow diagrams; **TL;DR-shaped** entries for every complex topic; condensed mechanism overview; edge-case bullets; references footer. **Loaded only when referenced; serves both human reviewers and execution agents.** |
 | `design-mechanics.md` (optional, length-triggered) | Long-form derivations, file:line citations, edit-list subsections, full state-machine tables, exhaustive worked examples that don't fit in design.md's mechanism overview. **Created only when design.md exceeds the length trigger; cross-referenced from design.md's References footer.** |
-| `implementation-backlog.md` | Per-track concrete deliverables — files, classes, methods, edit lists, ordering constraints, track-level diagrams. **Per-track edit detail, loaded only in Phase A of one track per session.** |
+| `tracks/track-N.md` `## Description` | Per-track concrete deliverables — files, classes, methods, edit lists, ordering constraints, track-level diagrams. **Per-track edit detail; written by `create-plan` at Phase 1; loaded only in Phase A of one track per session (and by Phase 2 reviews of pending tracks).** |
 
 > **The rule, succinctly:** if you find yourself writing a worked
 > example, a multi-paragraph derivation, a code-change inventory, or
 > a "here is how all the pieces fit together" walk-through inside a
 > decision record, an invariant, or an integration-point bullet,
 > **stop and move it to `design.md`** (or, if it is per-track edit
-> detail, to `implementation-backlog.md`). Replace the original
-> location with a one-line link.
+> detail, to that track's `tracks/track-N.md` `## Description`).
+> Replace the original location with a one-line link.
 
 The reciprocal pointer is the `**Full design**: design.md §<section>`
 line in the Decision Record template (see `planning.md` § Decision
@@ -171,12 +171,12 @@ time.
 | `design-sync` (re-distill design.md from current mechanics) | both files | `both` | **Whole-doc** on `design.md`, plus mechanics-link sweep |
 | `content-edit` within an existing section | `design.md` | `design` | **Bounded** — changed section + 1-2 surrounding sections + Overview + (when present) Core Concepts |
 | `section-add` | `design.md` | `design` | **Bounded** — new section + Overview + (when present) Core Concepts + structure roadmap (for placement check) |
-| `section-remove` | `design.md` (+ plan/backlog ref cleanup) | `design` | **Whole-doc** — verify no broken references and no orphaned forward-pointers |
-| `section-rename` | `design.md` + (when mechanics exists) the matching section in `design-mechanics.md` + plan/backlog ref propagation | `design \| both` | **Whole-doc** — every cross-reference to the renamed section must be updated, including the matching mechanics heading and every `**Full design**` ref in plan and backlog |
+| `section-remove` | `design.md` (+ plan / step-file ref cleanup) | `design` | **Whole-doc** — verify no broken references and no orphaned forward-pointers |
+| `section-rename` | `design.md` + (when mechanics exists) the matching section in `design-mechanics.md` + plan / step-file ref propagation | `design \| both` | **Whole-doc** — every cross-reference to the renamed section must be updated, including the matching mechanics heading and every `**Full design**` ref in the plan and in every step file |
 | `section-move` | `design.md` | `design` | **Whole-doc** — verify the new placement makes sense in the reader journey |
 | `structural-rewrite` (multiple section adds/moves/renames) | `design.md` + (when mechanics exists and any rename or split propagates) the matching sections in `design-mechanics.md` | `design \| both` | **Whole-doc** |
 | `length-trigger-crossing` (file crosses the 2,000-line / 50,000-token trigger) | both files | `both` | **Whole-doc** — verify split into `design-mechanics.md` is correctly applied |
-| `phase4-creation` (Phase 4 production of `design-final.md` ± `design-mechanics-final.md`) | `design-final.md` + (optional) `design-mechanics-final.md` | `both` if mechanics-final exists, else `design` | **Whole-doc** on `design-final.md`. Plan/backlog ref propagation is **N/A** — Phase 4 produces a *new* committed artifact whose section structure may differ from the original `design.md`; the plan/backlog `**Full design**` refs continue to point at the original (frozen) `design.md`, not at the final variant. The skill omits `--plan-path` / `--backlog-path` so the cross-file ref check is naturally skipped. |
+| `phase4-creation` (Phase 4 production of `design-final.md` ± `design-mechanics-final.md`) | `design-final.md` + (optional) `design-mechanics-final.md` | `both` if mechanics-final exists, else `design` | **Whole-doc** on `design-final.md`. Plan / step-file ref propagation is **N/A** — Phase 4 produces a *new* committed artifact whose section structure may differ from the original `design.md`; the plan and step files' `**Full design**` refs continue to point at the original (frozen) `design.md`, not at the final variant. The skill omits `--plan-path` / `--tracks-dir` so the cross-file ref check is naturally skipped. |
 
 **Periodic whole-doc check.** Every Nth design-touching mutation
 (default N=5, counted from the review log) triggers a whole-doc
@@ -210,7 +210,7 @@ context to disambiguate.
 | Length trigger compliance | If file > 2,000 lines and `design-mechanics.md` doesn't exist, blocker |
 | Same-shape sibling detection | Cluster of 3+ sibling `## ` sections with ≥80% Jaccard overlap on custom sub-headings → flag for consolidation. Pairs above the threshold are merged via union-find so a near-duplicate cluster (e.g. 5 sections sharing `### Inputs / ### Algorithm / ### Outputs` plus one with an extra `### Edge Cases`) flags as a single same-shape group. |
 | `Mechanics:` / mechanics-link resolution | Every `design-mechanics.md §"<name>"` reference appearing in `design.md` resolves to a real heading in `design-mechanics.md`. The check is applied to all such references — the canonical home for these is the per-section `Mechanics:` line in the References footer, but the script flags any unresolved reference regardless of how the line is prefixed. |
-| `**Full design**` link resolution | Every `**Full design**: design.md §"<name>"` in `implementation-plan.md` and `implementation-backlog.md` resolves to a real section in `design.md` (and any chained `design-mechanics.md §"<name>"` resolves in mechanics). This is also the check that catches stale references after a rename — when a `section-rename` (or rename inside `structural-rewrite`) has not propagated, the un-updated `**Full design**` and `Mechanics:` lines simply fail to resolve here, blocking the mutation. |
+| `**Full design**` link resolution | Every `**Full design**: design.md §"<name>"` in `implementation-plan.md` and in every step file under `tracks/` resolves to a real section in `design.md` (and any chained `design-mechanics.md §"<name>"` resolves in mechanics). This is also the check that catches stale references after a rename — when a `section-rename` (or rename inside `structural-rewrite`) has not propagated, the un-updated `**Full design**` and `Mechanics:` lines simply fail to resolve here, blocking the mutation. |
 
 ### Findings and severities
 
@@ -353,8 +353,8 @@ current state of `design-mechanics.md`:
   in `design.md`.
 - Sections **removed** in mechanics are removed from `design.md`.
 - Sections **renamed** in mechanics propagate the rename to
-  `design.md` and to every `**Full design**` ref in plan and
-  backlog.
+  `design.md` and to every `**Full design**` ref in the plan and
+  in every step file under `tracks/`.
 
 The sync's cold-read sub-agent gets an extended instruction:
 *"Verify that every TL;DR and mechanism overview in design.md
@@ -649,8 +649,8 @@ name the D-codes because they are the subject. Use sparingly.
 Renames and consolidations break references. When `design.md` or
 `design-mechanics.md` is restructured, every `**Full design**:
 design.md §"<section name>"` line in `implementation-plan.md`
-and `implementation-backlog.md` that references the old name
-**MUST be updated in the same commit** that renames the section.
+and in every `tracks/track-N.md` step file that references the old
+name **MUST be updated in the same commit** that renames the section.
 Same rule for any file that cross-links to the design document.
 
 The structural review's design-doc bloat checks include a "Full
@@ -792,8 +792,8 @@ that warrant dedicated sections:
     `design-mechanics.md`. Section names match between files.
 12. **D/S codes follow the discipline** — no parenthetical
     asides; allowed when subject; collected in References footer.
-13. **Section renames update all `**Full design**` refs in plan
-    and backlog same commit.**
+13. **Section renames update all `**Full design**` refs in the plan
+    and in every step file under `tracks/` in the same commit.**
 14. **Complex parts are mandatory** — if any part of the design involves concurrency,
     crash recovery, performance-critical paths, or non-obvious invariants, it MUST
     have a dedicated section. Omitting these is a structural review finding.

--- a/.claude/workflow/ephemeral-identifier-rule.md
+++ b/.claude/workflow/ephemeral-identifier-rule.md
@@ -4,8 +4,8 @@
 rule; every phase-specific prompt that touches durable content points
 here.
 
-`implementation-plan.md`, `implementation-backlog.md`,
-`tracks/track-N.md`, and `design-mutations.md` live under
+`implementation-plan.md`, `tracks/track-N.md`, `design.md`,
+`design-mechanics.md`, and `design-mutations.md` live under
 `docs/adr/<dir-name>/_workflow/`. They are tracked on the branch during
 development, but the entire `_workflow/` directory is removed in the
 Phase 4 cleanup commit before the PR is merged — so any identifier
@@ -56,13 +56,13 @@ present in the branch tree at the time those commits are made. The
 forbidden list above is what lives durably on `develop`.
 
 It does **not** apply to the working files themselves: step files
-(`tracks/track-N.md`), the plan, and the backlog all cite tracks,
-steps, findings, and iterations freely — that's exactly what those
-identifiers are for inside the workflow. Review findings themselves
-no longer have a separate on-disk home (they ride in the orchestrator's
-conversation context for the iteration loop), so the rule against
-citing finding IDs in durable content remains, just without a working
-file to cite from.
+(`tracks/track-N.md`) and the plan all cite tracks, steps, findings,
+and iterations freely — that's exactly what those identifiers are
+for inside the workflow. Review findings themselves no longer have a
+separate on-disk home (they ride in the orchestrator's conversation
+context for the iteration loop), so the rule against citing finding
+IDs in durable content remains, just without a working file to cite
+from.
 
 ## Forbidden
 
@@ -103,8 +103,8 @@ implemented it.
 Examples:
 
 - ❌ `// added during Track 2 Step 1 to unblock Phase A resume`
-- ✅ `// part of the atomic step-file-write + backlog-section-remove
-      ordering that keeps Phase A resume idempotent`
+- ✅ `// part of the description-amendment + clarifications-append
+      ordering that keeps Phase A pre-flight resume idempotent`
 
 - ❌ `Review fix: address CQ72 (anchor drift in slim rendering)`
 - ✅ `Review fix: restore byte-identical phrasing at the two

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -16,10 +16,11 @@ vs. current-state ambiguity, ASPIRATIONAL/VIOLATED invariants). Two steps run in
 sequence:
 
 1. **Consistency Review** — reads the design document, implementation plan,
-   backlog, and actual codebase to find gaps and inconsistencies between
-   them. Each finding carries a `Classification: mechanical | design-decision`
-   tag emitted by the sub-agent. Mechanical fixes apply automatically; design
-   decisions are batched and escalated to the user once at the end of the step.
+   step files (one per pending track), and actual codebase to find gaps and
+   inconsistencies between them. Each finding carries a
+   `Classification: mechanical | design-decision` tag emitted by the
+   sub-agent. Mechanical fixes apply automatically; design decisions are
+   batched and escalated to the user once at the end of the step.
 2. **Structural Review** — validates plan-internal structure (dependency
    ordering, track sizing, scope indicators, architecture notes, bloat).
    All bloat findings are classified `mechanical` by construction; ordering
@@ -111,7 +112,7 @@ uncommitted changes:
 ```bash
 git status --porcelain \
   docs/adr/<dir-name>/_workflow/implementation-plan.md \
-  docs/adr/<dir-name>/_workflow/implementation-backlog.md \
+  docs/adr/<dir-name>/_workflow/tracks/ \
   docs/adr/<dir-name>/_workflow/design.md \
   docs/adr/<dir-name>/_workflow/design-mechanics.md \
   docs/adr/<dir-name>/_workflow/design-mutations.md
@@ -162,9 +163,9 @@ findings.
 
 Each pending track's detailed description
 (`**What/How/Constraints/Interactions**` subsections and any track-level
-Mermaid diagram) lives in `implementation-backlog.md` rather than
-inline in the plan file; the consistency review reads the backlog
-alongside the plan.
+Mermaid diagram) lives in that track's step file (`tracks/track-N.md`,
+written by `create-plan` at Phase 1) rather than inline in the plan
+file; the consistency review reads the step files alongside the plan.
 
 ### Sub-agent prompt
 
@@ -184,10 +185,10 @@ field, not on severity.
 
 ```
 Iteration 1 (full review):
-  1. Spawn the consistency sub-agent with plan, backlog, design, codebase.
+  1. Spawn the consistency sub-agent with plan, step files, design, codebase.
   2. Receive findings, each tagged Classification: mechanical | design-decision.
   3. Apply ALL mechanical fixes immediately:
-     - Plan/backlog edits: native Edit.
+     - Plan / step-file edits: native Edit.
      - design.md edits: route through the edit-design skill (mutation
        discipline — see §Mutation discipline for design.md fixes below).
   4. If any design-decision findings remain: batch-present to the user
@@ -215,10 +216,10 @@ rework the plan/design before re-entering.
 
 Findings ride in the orchestrator's conversation context for the
 iteration loop; plan and design fixes are applied via Edit / edit-design
-to `implementation-plan.md`, `implementation-backlog.md`, and the
-design document. The review itself is not persisted to a separate file —
-once the gate passes, the conversation is the only in-flight record,
-and the durable trace is:
+to `implementation-plan.md`, the affected `tracks/track-N.md` files, and
+the design document. The review itself is not persisted to a separate
+file — once the gate passes, the conversation is the only in-flight
+record, and the durable trace is:
 
 - The resulting plan/design state.
 - The gate-PASS commit.
@@ -240,9 +241,10 @@ consistency, and plan-file bloat.
 
 Each pending track's detailed description (the subject of TRACK
 DESCRIPTIONS checks, plus several cross-file bullets in TRACK SIZING,
-SCOPE INDICATORS, and CONSISTENCY) lives in `implementation-backlog.md`
-rather than inline in the plan file; the structural review reads the
-backlog alongside the plan.
+SCOPE INDICATORS, and CONSISTENCY) lives in that track's step file
+(`tracks/track-N.md`, written by `create-plan` at Phase 1) rather than
+inline in the plan file; the structural review reads the step files
+alongside the plan.
 
 **Full details:** [`structural-review.md`](structural-review.md)
 
@@ -260,13 +262,13 @@ Same shape as the consistency review:
 
 ```
 Iteration 1 (full review):
-  1. Spawn the structural sub-agent with plan, backlog, design.
+  1. Spawn the structural sub-agent with plan, step files, design.
   2. Receive findings, each tagged Classification: mechanical | design-decision.
      Per-prompt rule: ALL bloat findings classify as mechanical; track-ordering
      and contradiction findings classify as design-decision (see §Mechanical
      vs. design-decision classifier below).
-  3. Apply mechanical fixes immediately (Edit for plan/backlog, edit-design
-     for design.md).
+  3. Apply mechanical fixes immediately (Edit for plan / step files,
+     edit-design for design.md).
   4. Batch-escalate any design-decision findings to the user once. Apply
      user-approved fixes.
   5. Spawn the gate verification sub-agent with the updated artifacts and
@@ -358,11 +360,11 @@ plan/design claim along the **intent axis**:
   classes, Architecture Notes referencing today's SPI). Discrepancies
   here become findings.
 - **Target-state claim** — the plan/design says something about code
-  a `[ ]` track will create (`**What**:` bullets in the backlog,
-  forward-looking Decision Records, design.md sections describing
-  the post-implementation state). The current code naturally won't
-  match — this is **not a finding** unless the target is unreachable
-  from the current code (in which case the finding is
+  a `[ ]` track will create (`**What**:` bullets in the track's step
+  file, forward-looking Decision Records, design.md sections
+  describing the post-implementation state). The current code
+  naturally won't match — this is **not a finding** unless the target
+  is unreachable from the current code (in which case the finding is
   `design-decision`).
 
 The same rule already applies to invariants via the
@@ -409,7 +411,7 @@ end. Pre-existing plans don't break.
 
 ### 2. The workflow-update commit
 
-After Phase 2 passes, the orchestrator stages the plan, backlog, and
+After Phase 2 passes, the orchestrator stages the plan, step files, and
 design files, and commits with the message:
 
 ```
@@ -437,7 +439,7 @@ for narrative breakage. If the cold-read rejects the mutation, the
 orchestrator escalates that specific fix to the user (effectively
 re-classifying it from `mechanical` to `design-decision`).
 
-Plan-file and backlog edits use `Edit` directly — no mutation
+Plan-file and step-file edits use `Edit` directly — no mutation
 discipline applies to those files.
 
 ---
@@ -478,15 +480,19 @@ broken that incremental revision cannot fix it.
 When both reviews pass:
 
 1. Update `## Plan Review` with the audit summary (see §Audit trail).
-2. Stage and commit the plan/backlog/design changes. The
-   `design*.md` glob picks up `design.md` plus
-   `design-mechanics.md` and `design-mutations.md` when
-   `edit-design` touched them during the review (`design.md`
-   always exists post-Phase-1, so the glob always matches at least
-   one path):
+2. Stage and commit the plan / step-file / design changes. Stage every
+   step file the review actually touched (use `git status --porcelain
+   docs/adr/<dir-name>/_workflow/tracks/` to find them; pass each
+   modified path explicitly rather than the whole `tracks/` directory
+   so unrelated files don't sneak in). The `design*.md` glob picks up
+   `design.md` plus `design-mechanics.md` and `design-mutations.md`
+   when `edit-design` touched them during the review (`design.md`
+   always exists post-Phase-1, so the glob always matches at least one
+   path):
    ```bash
    git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
-           docs/adr/<dir-name>/_workflow/implementation-backlog.md \
+           docs/adr/<dir-name>/_workflow/tracks/track-<N>.md \
+           ... (one path per modified step file) \
            docs/adr/<dir-name>/_workflow/design*.md
    git commit -m "Plan review autonomous fixes for <plan-name>
 

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -239,13 +239,14 @@ see [`commit-conventions.md`](commit-conventions.md) and
 below). The orchestrator parses the block; everything else in the
 implementer's output is ignored.
 
-The implementer **MUST NOT** modify the step file, the plan file, or
-the backlog. At `level=step` all step-file
+The implementer **MUST NOT** modify the step file or the plan file.
+At `level=step` all step-file
 mutations — episode write, risk-line rewrite, `[x]` mark, Progress
 count update, retry/split row inserts — are the Phase B
-orchestrator's responsibility. At `level=track` all plan/backlog
+orchestrator's responsibility. At `level=track` all plan and step-file
 mutations — Progress section iteration count, plan corrections from
-deferred findings, track episode, `[x]` mark on the plan track entry —
+deferred findings (which may add a new step file or update an
+existing one), track episode, `[x]` mark on the plan track entry —
 are the Phase C orchestrator's responsibility.
 
 ### Pacing long-running tasks — foreground only
@@ -390,9 +391,9 @@ preserve any untracked files that pre-existed the spawn (test
 fixtures, scratch logs, anything outside the workflow's tracked
 state).
 
-The orchestrator's working state — step file, review reports,
-design document, implementation backlog, baselines — is **tracked
-under `docs/adr/<dir>/_workflow/`** and committed by the orchestrator
+The orchestrator's working state — step files, review reports,
+design document, baselines — is **tracked under
+`docs/adr/<dir>/_workflow/`** and committed by the orchestrator
 on the appropriate cadence (see `commit-conventions.md` § Push every
 commit). The orchestrator commits any pending workflow-file changes
 **before** spawning the implementer, so `HEAD` at spawn time

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -79,8 +79,8 @@ Decision Record revisions follow this format:
 
 **File-location mechanics.** Each proposed track revision lands in a
 specific file on disk depending on the track's current status. See
-[§Updating plan and backlog](#updating-plan-and-backlog) below for the
-authoritative rule per case.
+[§Updating plan and step files](#updating-plan-and-step-files) below
+for the authoritative rule per case.
 
 **Design coherence.** When the revision invalidates a Decision
 Record's `**Full design**` link, adds a new design section, or
@@ -133,11 +133,11 @@ together (see [`implementation-review.md`](implementation-review.md)
 § Replanning). The preview exists so you don't end the session and
 clear context only to learn on the next invocation that the revision
 was structurally broken. The invocation passes `plan_path` +
-`backlog_path` per the path-passing rule in
+`tracks_dir` per the path-passing rule in
 `.claude/skills/review-plan/SKILL.md`. The sub-agent receives the
 full plan file including both completed track episodes and the
-proposed revisions, plus the backlog so pending-track details split
-into `implementation-backlog.md` are reachable.
+proposed revisions, plus the step-file directory so pending-track
+details (each track's `## Description`) are reachable.
 
 **5. Iterate** — if the preview finds structural blockers, revise and
 re-preview. Maximum 3 iterations. Consistency findings (phantom
@@ -160,14 +160,14 @@ preview — they will appear in the next-session State 0 re-run.
 
   ```bash
   git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
-          docs/adr/<dir-name>/_workflow/implementation-backlog.md \
           docs/adr/<dir-name>/_workflow/tracks/track-*.md
   git commit -m "Inline replan after Track <N>"
   git push
   ```
 
   Stage only the paths that the revision actually touched (the
-  enumeration in [§Updating plan and backlog](#updating-plan-and-backlog)
+  enumeration in
+  [§Updating plan and step files](#updating-plan-and-step-files)
   tells you which files apply per case). Any `design.md` /
   `design-mechanics.md` changes from step 3 land via the
   `edit-design` skill, which writes a separate
@@ -187,39 +187,43 @@ preview — they will appear in the next-session State 0 re-run.
 
 ---
 
-## Updating plan and backlog
+## Updating plan and step files
 
 When a revision drafted during step 3 of [§Process](#process) lands —
 whether during the propose step itself or after review passes — each
-affected track must be written to its authoritative file location. The "Description
-lifecycle" table in `conventions-execution.md` §2.1 is the authority for
-non-inline-replan phases (Phase A start, Phase A mid, Phase C after
-collapse, Skipped at or before Phase A); this section is the authority
-for inline-replan revisions. If the two ever diverge, a future plan
-correction must resync them.
+affected track must be written to its authoritative file location. The
+"Description lifecycle" table in `conventions-execution.md` §2.1 is the
+authority for non-inline-replan phases (Phase 1 write, Phase A,
+Phase C after collapse, Skipped at or before Phase A); this section is
+the authority for inline-replan revisions. If the two ever diverge, a
+future plan correction must resync them.
 
 Enumerate by case — each case names the plan status at the moment of
 revision and the file(s) that carry the new description:
 
 1. **New track.** Add a thin checklist entry (title + intro paragraph +
    `**Scope:**` + optional `**Depends on:**`) to
-   `implementation-plan.md`, and add the full
-   `**What/How/Constraints/Interactions**` subsections (plus any
-   track-level Mermaid diagram) to `implementation-backlog.md`.
+   `implementation-plan.md`, and create a new
+   `tracks/track-N.md` step file whose `## Description` carries the
+   intro paragraph + the full `**What/How/Constraints/Interactions**`
+   subsections + any track-level Mermaid diagram. Use the same
+   step-file shape `create-plan` produces at Phase 1 (see
+   [`conventions-execution.md`](conventions-execution.md) §2.1
+   *Step file content* for the template) — `## Progress`,
+   `## Reviews completed`, and `## Steps` start as `[ ]` placeholders.
 
-2. **Revising a not-yet-started track** (status `[ ]`, no step file yet).
-   Update that track's section in `implementation-backlog.md`. The
-   plan-file checklist entry keeps its intro paragraph + `**Scope:**` +
-   `**Depends on:**` unchanged unless the intro itself is being revised.
+2. **Revising a not-yet-started track** (status `[ ]`, no Phase A
+   reviews recorded yet). Update the step file's `## Description`
+   section. The plan-file checklist entry keeps its intro paragraph
+   + `**Scope:**` + `**Depends on:**` unchanged unless the intro
+   itself is being revised.
 
-3. **Revising a mid-execution track** (status `[ ]` with a step file on
-   disk — the execution workflow never sets `[>]` on a track). Update
-   the step file's `## Description` section. The backlog entry was
-   already removed at Phase A start (see `track-review.md` sub-step (d)),
-   so the step file is now the single authoritative location for this
-   track's description — do NOT add a new backlog entry. If the
-   revision changes the intro paragraph, update the plan-file checklist
-   entry's intro paragraph to match.
+3. **Revising a mid-execution track** (status `[ ]` with Phase A
+   reviews recorded and/or steps decomposed in the step file — the
+   execution workflow never sets `[>]` on a track). Update the step
+   file's `## Description` section. If the revision changes the intro
+   paragraph, update the plan-file checklist entry's intro paragraph
+   to match.
 
 4. **Revising a completed track** (status `[x]`). This is rare — code
    for `[x]` tracks is already merged, so a revision typically means
@@ -230,18 +234,19 @@ revision and the file(s) that carry the new description:
    scope becomes a new track (case 1).
 
 5. **Revising a skipped track** (status `[~]`). Update the plan entry.
-   Skipped tracks never retain a backlog entry after the skip (see
+   Skipped tracks never retain a step file after the skip (see
    `track-skip.md` step 3), so the plan entry is always an
    authoritative location. If the track was skipped **after** Phase A
    began — the "Skipped after Phase A" sub-case in the Description
    lifecycle table in `conventions-execution.md` §2.1, where the step
    file is retained so the skip is traceable — also update the step
-   file's `## Description`. Per `track-skip.md`'s "Backlog deletion is
-   terminal" warning, a reader un-skipping a `[~]` track must re-author
-   the description from scratch — the backlog is not a recovery source
-   after skip, and the revision here is the re-authoring.
+   file's `## Description`. Per `track-skip.md`'s "Step-file deletion
+   is terminal" warning, a reader un-skipping a `[~]` track must
+   re-author the description from scratch — the deleted step file is
+   not a recovery source after skip, and the revision here is the
+   re-authoring.
 
-6. **Removing a track.** Remove the plan entry. If the backlog section
-   still exists (the track had not yet entered Phase A and was not yet
-   skipped), remove it too using the "Backlog section body extraction
-   rule" in `conventions-execution.md` §2.1.
+6. **Removing a track.** Remove the plan entry and delete the step
+   file at `tracks/track-N.md` if it still exists. (If the track had
+   already been skipped, its step file was deleted then; case 6
+   becomes a no-op for the step file.)

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -235,12 +235,8 @@ revision and the file(s) that carry the new description:
 
 5. **Revising a skipped track** (status `[~]`). Update the plan entry.
    Skipped tracks never retain a step file after the skip (see
-   `track-skip.md` step 3), so the plan entry is always an
-   authoritative location. If the track was skipped **after** Phase A
-   began — the "Skipped after Phase A" sub-case in the Description
-   lifecycle table in `conventions-execution.md` §2.1, where the step
-   file is retained so the skip is traceable — also update the step
-   file's `## Description`. Per `track-skip.md`'s "Step-file deletion
+   `track-skip.md` step 3), so the plan entry is the only
+   authoritative location. Per `track-skip.md`'s "Step-file deletion
    is terminal" warning, a reader un-skipping a `[~]` track must
    re-author the description from scratch — the deleted step file is
    not a recovery source after skip, and the revision here is the

--- a/.claude/workflow/plan-slim-rendering.md
+++ b/.claude/workflow/plan-slim-rendering.md
@@ -65,8 +65,8 @@ on stderr — surface that to the user rather than continuing with a
 half-rendered snapshot.
 
 Pending-track entries (`[ ]`) are already thin on disk (their detail
-lives in `implementation-backlog.md`), so the transform for that row
-is a no-op — the script passes them through verbatim.
+lives in `tracks/track-N.md` `## Description`), so the transform for
+that row is a no-op — the script passes them through verbatim.
 
 ### How sub-agents use it
 
@@ -111,7 +111,7 @@ Sub-agents run in separate processes and don't inherit the main agent's
 
    | Status | Keep | Drop |
    |---|---|---|
-   | `[ ]` (not started or in-progress current track) | Everything in the entry verbatim — title line, intro paragraph, `**Scope:**`, optional `**Depends on:**`. The detailed `**What/How/Constraints/Interactions**` content lives in `implementation-backlog.md`, not in the plan-file entry; the transform is a no-op. | Nothing |
+   | `[ ]` (not started or in-progress current track) | Everything in the entry verbatim — title line, intro paragraph, `**Scope:**`, optional `**Depends on:**`. The detailed `**What/How/Constraints/Interactions**` content lives in `tracks/track-N.md` `## Description`, not in the plan-file entry; the transform is a no-op. | Nothing |
    | `[x]` (completed) | Title line, **intro paragraph** (the first quoted block before any `**Keyword**:` subsection), **Track episode**, **Strategy refresh** line (if present) | **Scope** line, **Depends on** line, **Step file** pointer line |
    | `[~]` (skipped) | Title line, **intro paragraph**, **Skipped:** reason, **Strategy refresh** line (if present) | **Scope** line, **Depends on** line |
 

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -115,7 +115,7 @@ only track-level or decision-level changes require escalation.
 Architecture notes document the structural context and design decisions for the plan.
 They live in the `## High-level plan > ### Architecture Notes` section of the plan file.
 
-### Boundary with `design.md` and `implementation-backlog.md`
+### Boundary with `design.md` and step files
 
 Architecture Notes carry the **strategic** shape of the design — what
 components are touched, what decisions were made, what must remain true,
@@ -123,9 +123,9 @@ where new code plugs in. Long-form material — worked examples, layered
 design diagrams, audit findings, edit-by-edit walk-throughs, crash
 scenarios, multi-paragraph rationale derivations — **does not belong
 here**. It belongs in `design.md` (long-form architectural and
-behavioral design) or `implementation-backlog.md` (per-track edit
-detail). Architecture Notes link to those longer documents rather than
-duplicating them.
+behavioral design) or `tracks/track-N.md` `## Description` (per-track
+edit detail). Architecture Notes link to those longer documents rather
+than duplicating them.
 
 The plan file is loaded at every `/execute-tracks` session startup, so
 bloat in Architecture Notes is paid by every Phase A/B/C session for
@@ -138,8 +138,8 @@ alongside its format rules.
 > multi-paragraph derivation, a code-change inventory, or a "here is
 > how all the pieces fit together" walk-through inside a decision
 > record, an invariant, or an integration-point bullet, **stop and
-> move it to `design.md`** (or, if it is per-track edit detail, to
-> `implementation-backlog.md`). Replace the original location with a
+> move it to `design.md`** (or, if it is per-track edit detail, to the
+> step file's `## Description`). Replace the original location with a
 > one-line link.
 
 ### Per-section budget at a glance
@@ -164,9 +164,9 @@ Each section below restates its own budget alongside its format rules.
 Where a plan would exceed a budget, the long-form material almost
 always belongs in `design.md` (worked examples, layered diagrams,
 complex-topic walk-throughs, multi-paragraph rationale) or
-`implementation-backlog.md` (per-track edit detail — files, classes,
-methods, edit ordering). The structural review (Phase 2) enforces the
-budgets as first-class findings — see
+`tracks/track-N.md` `## Description` (per-track edit detail — files,
+classes, methods, edit ordering). The structural review (Phase 2)
+enforces the budgets as first-class findings — see
 [`structural-review.md`](structural-review.md) § Bloat checks.
 
 ### Required sections
@@ -214,8 +214,8 @@ Every plan must include these two sections:
   to its long-form design*. Worked examples, audit findings, edit-by-
   edit guidance, layered designs, and crash-scenario walk-throughs
   **do not belong here** — they belong in `design.md` (long-form
-  design) or `implementation-backlog.md` (per-track edit detail). The
-  DR links to those rather than absorbing them.
+  design) or the step file's `## Description` (per-track edit detail).
+  The DR links to those rather than absorbing them.
 - **Superseded DRs are deleted, not retained.** When a decision is
   replaced (e.g., DN supersedes DM), remove DM from the plan entirely
   and document the supersession in DN's rationale ("This replaces an
@@ -249,8 +249,8 @@ result tables, edit-list bullets, crash-scenario walk-throughs. The
 fix is mechanical: **trim back to the four-bullet form** and move the
 long-form material to a new (or existing) `design.md` section, linked
 from `Full design`. If the displaced material is per-track edit detail
-(files to touch, methods to add), move it to the track section in
-`implementation-backlog.md` instead.
+(files to touch, methods to add), move it to that track's step file
+`## Description` instead.
 
 ### Optional sections (include when applicable)
 
@@ -319,7 +319,7 @@ scope creep during execution.
    *Per-section budget at a glance* table above and each section's own
    rules for the rationale). Exceeding a budget is the signal that
    long-form material has leaked into the plan and should move to
-   `design.md` or `implementation-backlog.md`.
+   `design.md` or the relevant track's step file `## Description`.
 9. **No plan/design duplication.** If a decision record, invariant, or
    integration-point bullet starts to repeat prose that already exists
    in `design.md`, replace the duplicated body with a one-line link to
@@ -337,17 +337,17 @@ Each **track** in the checklist is described across two files:
   line and, when applicable, the `**Depends on:**` line. This is the
   content every `/execute-tracks` session loads at startup, so keep it
   compact.
-- **`implementation-backlog.md` (detailed description):** a `## Track N:
-  <title>` section with bold-label blockquote subsections covering the
-  full detail. The intro paragraph lives in the plan entry only — the
-  backlog section carries only the `**What/How/Constraints/Interactions**`
-  subsections and any optional track-level diagram. Phase A assembles
-  the step file's `## Description` section from both sources (intro
-  from the plan; detail from the backlog). This content is read only
-  in Phase A of one track per session; there is no length cap — make
-  it as long as the execution agent needs.
+- **`tracks/track-N.md` (detailed description):** the step file's
+  `## Description` section, written by `create-plan` at Phase 1. It
+  carries the same intro paragraph (so the step file is self-sufficient
+  context for Phase B/C sub-agents that don't read the plan) followed by
+  the `**What/How/Constraints/Interactions**` subsections and any
+  optional track-level Mermaid diagram. This content is read on demand
+  — by Phase 2 reviews for pending tracks and by Phase A/B/C of the
+  active track — so there is no length cap; make it as long as the
+  execution agent needs.
 
-The detailed description in the backlog should cover:
+The detailed description in the step file should cover:
 - **What** the track achieves (concrete deliverables — files to touch,
   APIs to add, behaviors to change)
 - **How** (high-level approach — sequencing, invariants to preserve,
@@ -358,9 +358,10 @@ The detailed description in the backlog should cover:
   ordering, hand-off artifacts)
 
 The file format and template for both files are defined in
-`conventions.md` §1.2; the authoritative location of the detailed
-description over time (Phase 1 → Phase A → Phase B/C) is given by the
-description-lifecycle table in `conventions-execution.md` §2.1.
+`conventions.md` §1.2 and the step-file template in
+`conventions-execution.md` §2.1; the authoritative location of the
+detailed description over time (Phase 1 → Phase A → Phase B/C) is given
+by the description-lifecycle table in `conventions-execution.md` §2.1.
 
 **Track sizing rule:** If a track would need more than ~5-7 steps, split it
 into separate dependent tracks during planning. The execution agent
@@ -375,18 +376,14 @@ Optional Mermaid diagrams that belong with a track's **detailed
 description**, for when the track has 3+ internal components with
 non-trivial interactions and the flow isn't obvious from the prose alone.
 
-Location lifecycle:
-- **Phase 1 (planning):** the diagram is written inside the track's
-  section of `implementation-backlog.md` as a separate fenced `mermaid`
-  block immediately after the `**Interactions**:` blockquote (outside
-  the blockquote — see the template in `conventions.md` §1.2). It is
-  **never rendered in `implementation-plan.md`** — plan readers who
-  want visual reasoning about a specific track open the backlog (or,
-  after Phase A, the step file).
-- **Phase A (start of track execution):** the diagram moves with the
-  rest of the description into the step file's `## Description`
-  section. See the lifecycle row for track-level diagrams in
-  `conventions-execution.md` §2.1.
+Location: the diagram is written inside the step file's `## Description`
+as a separate fenced `mermaid` block immediately after the
+`**Interactions**:` blockquote (outside the blockquote — see the
+step-file template in `conventions-execution.md` §2.1). It is **never
+rendered in `implementation-plan.md`** — plan readers who want visual
+reasoning about a specific track open `tracks/track-N.md`. Phase 1
+writes the diagram alongside the rest of the description; Track
+Pre-Flight may amend it; inline replanning may rewrite it.
 
 Rules:
 - Scoped to the track — don't repeat the top-level Component Map. If a

--- a/.claude/workflow/prompts/consistency-gate-verification.md
+++ b/.claude/workflow/prompts/consistency-gate-verification.md
@@ -3,7 +3,11 @@ based on your previous consistency review findings.
 
 Inputs:
 - Updated plan file: {plan_path}
-- Backlog file: {backlog_path}
+- Step files directory: {tracks_dir} — every `tracks/track-N.md` whose
+  matching plan-file entry is `[ ]` (pending). Read each pending
+  track's `## Description` for that track's
+  `**What/How/Constraints/Interactions**` detail and any track-level
+  Mermaid diagram.
 - Updated design document: {design_path}
 - Previous findings (context only, finalized in earlier iterations):
   {previous_findings}
@@ -27,7 +31,7 @@ the design document but not updating the corresponding sequence diagram).
 Before verifying any finding whose fix touched a pending track's
 description, re-read that track's description (the
 `**What/How/Constraints/Interactions**` subsections and any track-level
-Mermaid diagram) from the backlog's `## Track N: <title>` section. For
+Mermaid diagram) from `tracks/track-N.md` `## Description`. For
 **completed** (`[x]`) and **skipped** (`[~]`) tracks, read from the
 plan-file entry (intro paragraph + track episode for completed; intro +
 `**Skipped:**` reason for skipped). Read Architecture Notes, Decision
@@ -62,7 +66,7 @@ edge cases.
 ```markdown
 #### Verify CR<N>: <finding title>
 - **Original issue**: <what was wrong — from the finding>
-- **Fix applied**: <what changed in the plan, backlog, or design text>
+- **Fix applied**: <what changed in the plan, step file, or design text>
 - **Re-check**:
   - Search/trace performed: <PSI find-usages / find-implementations
     query when the IDE is reachable; Grep/Glob query or flow trace

--- a/.claude/workflow/prompts/consistency-review.md
+++ b/.claude/workflow/prompts/consistency-review.md
@@ -4,9 +4,10 @@ checks plan-internal quality without reading code), this review reads the
 code to find gaps and inconsistencies between the four artifacts:
 
 1. **Implementation plan** (`implementation-plan.md`)
-2. **Backlog** (`implementation-backlog.md`) — companion file to the plan.
-   Holds the `**What/How/Constraints/Interactions**` detail and any
-   track-level Mermaid diagrams for pending tracks.
+2. **Step files** (`tracks/track-N.md`, one per pending track) — each
+   step file's `## Description` section holds that track's
+   `**What/How/Constraints/Interactions**` detail and any track-level
+   Mermaid diagram. Written by `create-plan` at Phase 1.
 3. **Design document** (`design.md`)
 4. **Actual codebase**
 
@@ -59,7 +60,12 @@ incorrect code.
 
 Inputs:
 - Plan file: {plan_path}
-- Backlog file: {backlog_path}
+- Step files directory: {tracks_dir} — every `tracks/track-N.md` whose
+  matching plan-file entry is `[ ]` (pending). Read each pending track's
+  step file `## Description` for that track's
+  `**What/How/Constraints/Interactions**` detail and any track-level
+  Mermaid diagram. Skip step files for `[x]`/`[~]` tracks — those
+  tracks' final descriptions live in the plan-file entry instead.
 - Design document: {design_path}
 - Previous findings: {previous_findings or "None — this is the first pass"}
 
@@ -85,21 +91,23 @@ design claim along the **intent axis**:
   invariant tagged `ENFORCED`). Discrepancies with these become
   findings — emit normally.
 - **Target-state claim** — the plan/design says something about code a
-  `[ ]` track will create (`**What**:` bullets in the backlog,
-  forward-looking Decision Records describing the post-implementation
-  shape, design.md sections describing the post-implementation state,
-  invariants tagged `ASPIRATIONAL`). The current code naturally won't
-  match — **do NOT emit a finding** unless the target is unreachable
-  from the current code (in which case emit a `design-decision`
-  finding so the user can resolve the gap).
+  `[ ]` track will create (`**What**:` bullets in the step file
+  `## Description`, forward-looking Decision Records describing the
+  post-implementation shape, design.md sections describing the
+  post-implementation state, invariants tagged `ASPIRATIONAL`). The
+  current code naturally won't match — **do NOT emit a finding**
+  unless the target is unreachable from the current code (in which
+  case emit a `design-decision` finding so the user can resolve the
+  gap).
 
 The same rule already applies to invariants via the
 `ENFORCED / ASPIRATIONAL / VIOLATED` tagging. The pre-screen extends
 it to all design.md / Component Map / track-description claims.
 
 **How to determine intent for each claim:**
-- If the claim is inside a backlog `**What/How/Constraints/Interactions**`
-  subsection for a `[ ]` track → target-state.
+- If the claim is inside a step-file `## Description`
+  `**What/How/Constraints/Interactions**` subsection for a `[ ]`
+  track → target-state.
 - If the claim is in a Decision Record's "Implemented in: Track N" line
   for a `[ ]` track → target-state.
 - If the claim is in design.md and a `[ ]` track's description names
@@ -140,11 +148,11 @@ finding and the classification rules below will route it correctly.
   (e.g., if the plan says "Query optimizer reads histograms via
   `IndexStatistics.getHistogram()`", does that method exist?)
 - Do track descriptions reference code constructs (classes, methods, SPIs)
-  that actually exist? Flag phantom references. *(Applies to the backlog
-  for pending tracks; to the plan-file entry for completed/skipped tracks.
-  Architecture Notes, Component Map, Decision Records, Invariants, and
-  Integration Points bullets in this section remain plan-only per
-  `conventions.md` §1.2.)*
+  that actually exist? Flag phantom references. *(Applies to the step
+  file `## Description` for pending tracks; to the plan-file entry for
+  completed/skipped tracks. Architecture Notes, Component Map, Decision
+  Records, Invariants, and Integration Points bullets in this section
+  remain plan-only per `conventions.md` §1.2.)*
 - Are Invariants listed in the plan consistent with the current code
   behavior? (e.g., if the plan says "histogram updates occur inside WAL
   atomic operations", is that how the current code works, or is that an
@@ -157,10 +165,10 @@ finding and the classification rules below will route it correctly.
 - Do the workflow diagrams align with the track descriptions? (e.g., if a
   track says "add snapshot reads for histograms", is there a corresponding
   flow in the design document?) *(For pending tracks, read track
-  descriptions from the backlog; for completed/skipped tracks, read from
-  the plan-file entry. The Component Map/Decision Records bullet above
-  and the Decision Records and scope-indicators bullets below remain
-  plan-only.)*
+  descriptions from the step file `## Description`; for
+  completed/skipped tracks, read from the plan-file entry. The Component
+  Map/Decision Records bullet above and the Decision Records and
+  scope-indicators bullets below remain plan-only.)*
 - Do Decision Records in the plan correspond to design choices visible in
   the design document? Are there design choices in the diagrams that lack
   a Decision Record?
@@ -173,9 +181,10 @@ finding and the classification rules below will route it correctly.
 - Are there parts of the implementation plan that have no corresponding
   design coverage? (e.g., a track describes complex concurrency behavior
   but the design document has no concurrency section) *(For pending
-  tracks, the "track describes …" text lives in the backlog; for
-  completed/skipped tracks, in the plan-file entry. The orphan-scope
-  and orphan-codebase-construct bullets below remain plan-only.)*
+  tracks, the "track describes …" text lives in the step file
+  `## Description`; for completed/skipped tracks, in the plan-file
+  entry. The orphan-scope and orphan-codebase-construct bullets below
+  remain plan-only.)*
 - Are there parts of the design document that no track covers? (e.g., the
   design shows a class that isn't mentioned in any track's scope)
 - Are there codebase constructs (existing classes, interfaces, SPIs) that
@@ -212,22 +221,24 @@ real mismatch hidden)? When in doubt, route through PSI.
 - Run PSI queries (find-usages, find-implementations, type-hierarchy) via `steroid_execute_code`, which evaluates a Kotlin snippet against the PSI tree — there is no dedicated `find_usages` tool.
 - For Kotlin recipes, fetch the `coding-with-intellij-psi` skill via `steroid_fetch_resource`.
 
-1. **Read the plan, backlog, and design document** thoroughly.
-2. **Identify all code references** — every class, interface, method, SPI,
-   configuration parameter, or file path mentioned in the plan, backlog,
-   or design document.
+1. **Read the plan, every pending track's step file, and the design
+   document** thoroughly.
+2. **Identify all code references** — every class, interface, method,
+   SPI, configuration parameter, or file path mentioned in the plan,
+   the step files, or the design document.
 
    **Where track-description code references live:** For each
-   **pending** track, read the track's detailed description
+   **pending** track (`[ ]`), read the track's detailed description
    (`**What/How/Constraints/Interactions**` subsections and any
-   track-level Mermaid diagram) from the backlog's `## Track N:
-   <title>` section. For **completed** tracks (`[x]`) and **skipped**
-   tracks (`[~]`), the plan-file entry already holds the track's final
-   form (intro paragraph + track episode for completed; intro +
-   `**Skipped:**` reason for skipped) — there is no backlog section to
+   track-level Mermaid diagram) from `tracks/track-N.md` `## Description`.
+   For **completed** tracks (`[x]`) and **skipped** tracks (`[~]`),
+   the plan-file entry already holds the track's final form (intro
+   paragraph + track episode for completed; intro + `**Skipped:**`
+   reason for skipped) — there is no live step-file description to
    consult, so read code references directly from the plan-file entry.
-   Phantom references in a backlog section have the same severity as
-   phantom references in the plan file (see the severity guide below).
+   Phantom references in a step file's description have the same
+   severity as phantom references in the plan file (see the severity
+   guide below).
 3. **Verify each reference** against the actual codebase. For Java
    symbols, prefer mcp-steroid PSI find-usages / find-implementations /
    type-hierarchy when the IDE is reachable; use Grep/Glob/Read for

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -22,12 +22,11 @@ Read:
 - `docs/adr/<dir-name>/_workflow/design.md` — original design document (do NOT modify)
 - `docs/adr/<dir-name>/_workflow/tracks/track-*.md` — all step files with step
   episodes. Each step file begins with a `## Description` section
-  carrying the track's original description (copied there at Phase A
-  start from the backlog), so "what each track was supposed to do"
-  lives in the step file rather than in `implementation-backlog.md`.
-  By Phase 4 the backlog is header-only: every track has either
-  completed or been skipped, and both paths removed their backlog
-  entries.
+  carrying the track's original description (written there by
+  `create-plan` at Phase 1), so "what each track was supposed to do"
+  lives in the step file. Skipped tracks may have had their step
+  files deleted by `track-skip` — for those tracks read the
+  `[~] Track N`'s `**Skipped:**` line in the plan file instead.
 
 Using the plan's Architecture Notes and track episodes as a guide, read the
 actual implemented code: all classes, interfaces, and components mentioned
@@ -65,8 +64,8 @@ authoritative source for edge cases.
 
 `design-final.md` and `adr.md` are the **only** workflow files that
 survive merge into `develop`. Every other workflow file —
-`implementation-plan.md`, `implementation-backlog.md`,
-`tracks/track-N.md`, `design-mutations.md` — lives under
+`implementation-plan.md`, `tracks/track-N.md`, `design.md`,
+`design-mechanics.md`, `design-mutations.md` — lives under
 `docs/adr/<dir-name>/_workflow/` and is removed in the cleanup commit
 at the end of Phase 4 (Step 5 below) before the PR is merged. Anything
 these final artifacts say must survive that deletion.
@@ -152,11 +151,11 @@ with:
 - `target`: `both` when a mechanics-final companion exists, else
   `design` (no `.md` suffix — these values pass through to the
   script's `--target` flag verbatim)
-- `plan_path` / `backlog_path`: **omit**. Phase 4 produces a new
+- `plan_path` / `tracks_dir`: **omit**. Phase 4 produces a new
   committed artifact whose section structure may differ from the
-  original `design.md`; the plan/backlog `**Full design**` refs continue
-  to point at the (frozen) original. The cross-file ref check is
-  naturally skipped when these paths are absent.
+  original `design.md`; the plan and step-file `**Full design**` refs
+  continue to point at the (frozen) original. The cross-file ref check
+  is naturally skipped when these paths are absent.
 - `intended_edit`: full file content for both files. Section names match
   between `design-final.md` and `design-mechanics-final.md` from the
   start (same rule as Phase 1).
@@ -281,8 +280,8 @@ git commit -m "Remove workflow scaffolding"
 git push
 ```
 
-This deletes plan, backlog, design.md, design-mechanics.md, every
-step file under `tracks/`, and the design-mutations log in one commit.
+This deletes the plan, design.md, design-mechanics.md, every step
+file under `tracks/`, and the design-mutations log in one commit.
 The squash-merge folds this deletion together with the rest of the
 branch's history; on `develop`, the final state is the two (or three)
 durable artifacts plus the implemented code.

--- a/.claude/workflow/prompts/design-review.md
+++ b/.claude/workflow/prompts/design-review.md
@@ -30,8 +30,10 @@ warning, or pass.
 - `plan_path` (optional) — absolute path to
   `implementation-plan.md`. Read **only** to verify
   `**Full design**` link resolution, never for context.
-- `backlog_path` (optional) — same: read only for link
-  resolution.
+- `tracks_dir` (optional) — same: a directory of
+  `tracks/track-N.md` step files, each potentially carrying
+  `**Full design**` references inside its `## Description`.
+  Read **only** for link resolution, never for context.
 
 ### Mutation-kind specific instructions
 
@@ -61,8 +63,8 @@ warning, or pass.
   **Phase 4 is committed to git** and read by humans (PR
   reviewers, future re-readers, decision auditors), so the bar
   is higher than Phase 1: the artifact must stand on its own as
-  documentation — no reliance on working files (plan, backlog,
-  tracks), since those live under `_workflow/` and are removed
+  documentation — no reliance on working files (plan, step
+  files), since those live under `_workflow/` and are removed
   by the Phase 4 cleanup commit before merge.
 
   **In addition to the standard whole-doc cold-read AND the
@@ -190,9 +192,9 @@ absent audience framing is.
 - **Whole-doc scope**: read the entire `design.md`. Read
   `design-mechanics.md` only when verifying that a
   `Mechanics: design-mechanics.md §"…"` link resolves.
-- **Plan / backlog reads** are restricted to grepping for
+- **Plan / step-file reads** are restricted to grepping for
   `**Full design**` lines and verifying the targets exist.
-  Do not read plan or backlog content for context.
+  Do not read plan or step-file content for context.
 
 ## Comprehension questions
 
@@ -249,7 +251,7 @@ enough to answer, that itself is a finding.
   appears in Core Concepts; each entry has a `→ Part X §"…"`
   pointer; no concept entries name removed Parts.
 - (**Whole-doc scope only**) **`**Full design**` refs in plan
-  and backlog all resolve** to real `design.md` sections.
+  and step files all resolve** to real `design.md` sections.
 
 ## Output format
 

--- a/.claude/workflow/prompts/structural-gate-verification.md
+++ b/.claude/workflow/prompts/structural-gate-verification.md
@@ -3,7 +3,11 @@ structural review findings.
 
 Inputs:
 - Updated plan file: {plan_path}
-- Backlog file: {backlog_path}
+- Step files directory: {tracks_dir} — every `tracks/track-N.md` whose
+  matching plan-file entry is `[ ]` (pending). Read each pending
+  track's `## Description` for that track's
+  `**What/How/Constraints/Interactions**` detail and any track-level
+  Mermaid diagram.
 - Design document: {design_path}
 - Previous findings (context only, finalized in earlier iterations):
   {previous_findings}
@@ -24,7 +28,7 @@ fixes sometimes shift problems rather than solving them.
 Before verifying any finding whose fix touched a pending track's
 description, re-read that track's description (the
 `**What/How/Constraints/Interactions**` subsections and any track-level
-Mermaid diagram) from the backlog's `## Track N: <title>` section. For
+Mermaid diagram) from `tracks/track-N.md` `## Description`. For
 **completed** (`[x]`) and **skipped** (`[~]`) tracks, read from the
 plan-file entry (intro paragraph + track episode for completed; intro +
 `**Skipped:**` reason for skipped). Read Architecture Notes, Decision
@@ -36,9 +40,9 @@ certificate** that re-checks the specific plan location:
 ```markdown
 #### Verify S<N>: <finding title>
 - **Original issue**: <what was wrong — from the finding>
-- **Fix applied**: <what changed in the plan, backlog, or design text>
+- **Fix applied**: <what changed in the plan, step file, or design text>
 - **Re-check**:
-  - Plan/backlog/design location: <section and line where the fix was applied>
+  - Plan / step file / design location: <section and line where the fix was applied>
   - Current state: <what the document now says>
   - Criteria met: <which structural criteria from the review checklist
     are now satisfied>

--- a/.claude/workflow/prompts/structural-review.md
+++ b/.claude/workflow/prompts/structural-review.md
@@ -1,13 +1,14 @@
 You are reviewing an implementation plan for structural correctness.
-The plan lives in three documents under review: the **plan file**
-(`implementation-plan.md`, strategic context + thin checklist + episodes),
-the **backlog** (`implementation-backlog.md`, pending-track
-`**What/How/Constraints/Interactions**` detail and any track-level
-Mermaid diagrams), and the **design document** (`design.md`,
-class/workflow diagrams and dedicated sections for complex parts). The
-workflow rules file listed in `Inputs:` is procedural input (reviewer
-guidance), not a review target. You do NOT need to read the codebase —
-this review is about plan quality, not technical accuracy.
+The plan lives in three sets of documents under review: the **plan
+file** (`implementation-plan.md`, strategic context + thin checklist +
+episodes), the **step files** (`tracks/track-N.md`, one per pending
+track — each holds its track's `**What/How/Constraints/Interactions**`
+detail and any track-level Mermaid diagram in its `## Description`
+section), and the **design document** (`design.md`, class/workflow
+diagrams and dedicated sections for complex parts). The workflow rules
+file listed in `Inputs:` is procedural input (reviewer guidance), not
+a review target. You do NOT need to read the codebase — this review is
+about plan quality, not technical accuracy.
 
 ## Workflow Context
 
@@ -59,23 +60,29 @@ descriptions, oversized tracks, contradictions — directly impair execution.
 
 Inputs:
 - Plan file: {plan_path}
-- Backlog file: {backlog_path}
+- Step files directory: {tracks_dir} — every `tracks/track-N.md` whose
+  matching plan-file entry is `[ ]` (pending). Each pending track's
+  step file `## Description` carries that track's
+  `**What/How/Constraints/Interactions**` detail and any track-level
+  Mermaid diagram. Skip step files for `[x]`/`[~]` tracks — those
+  tracks' final descriptions live in the plan-file entry instead.
 - Design document: {design_path}
 - Workflow rules: {workflow_path}
 - Previous findings: {previous_findings or "None — this is the first pass"}
 
-**Where track descriptions live:** For each **pending** track, read the
-track's detailed description (`**What/How/Constraints/Interactions**`
-subsections and any track-level Mermaid diagram) from the backlog's
-`## Track N: <title>` section. For **completed** tracks (`[x]`) and
-**skipped** tracks (`[~]`), the plan-file entry already holds the
-track's final form (intro paragraph + track episode for completed;
-intro + `**Skipped:**` reason for skipped) — read directly from the
-plan-file entry. Phantom references or structural defects in a backlog
-section have the same severity as defects in the plan file. Per-entry
-annotations on individual criterion bullets below (tagged `*(cross-file:
-…)*` or `*(backlog for pending, plan-file for completed/skipped)*`)
-route each check to the right source.
+**Where track descriptions live:** For each **pending** track (`[ ]`),
+read the track's detailed description
+(`**What/How/Constraints/Interactions**` subsections and any
+track-level Mermaid diagram) from `tracks/track-N.md` `## Description`.
+For **completed** tracks (`[x]`) and **skipped** tracks (`[~]`), the
+plan-file entry already holds the track's final form (intro paragraph
++ track episode for completed; intro + `**Skipped:**` reason for
+skipped) — read directly from the plan-file entry. Phantom references
+or structural defects in a step file's description have the same
+severity as defects in the plan file. Per-entry annotations on
+individual criterion bullets below (tagged `*(cross-file: …)*` or
+`*(step file for pending, plan-file for completed/skipped)*`) route
+each check to the right source.
 
 Review the plan against these criteria:
 
@@ -86,8 +93,9 @@ SCOPE INDICATORS
 - Are scope indicators plausible given the track description? (e.g., a
   track describing 8 distinct changes but claiming ~2 steps is suspect)
   *(cross-file: the scope indicator is in the plan-file entry; the track
-  description is in the backlog for pending tracks, in the plan-file
-  entry for completed/skipped tracks. Compare both halves.)*
+  description is in the step file `## Description` for pending tracks,
+  in the plan-file entry for completed/skipped tracks. Compare both
+  halves.)*
 - Are there any full `- [ ] Step:` items or *(provisional)* markers?
   These should NOT be present — step decomposition is deferred to
   execution. *(plan-file only)*
@@ -100,7 +108,7 @@ annotations, and track ordering all live in the plan checklist)*
 - Are cross-cutting concerns ordered before the tracks that depend on them?
 - Are dependent tracks properly annotated with `**Depends on:** Track N`?
 
-TRACK DESCRIPTIONS *(backlog for pending, plan-file for completed/skipped)*
+TRACK DESCRIPTIONS *(step file `## Description` for pending, plan-file for completed/skipped)*
 - Does every track have a description covering what/how/constraints/interactions?
 - Are track-level component diagrams present where needed (3+ internal
   components with non-trivial interactions)?
@@ -110,7 +118,7 @@ TRACK DESCRIPTIONS *(backlog for pending, plan-file for completed/skipped)*
   sentences (the prose paragraph that precedes `**Scope:**` and, if
   present, `**Depends on:**`)? An intro that runs 4+ sentences or
   spans multiple paragraphs has expanded into territory that belongs
-  in the backlog's W/H/C/I subsections or in `design.md`; the plan
+  in the step file's W/H/C/I subsections or in `design.md`; the plan
   checklist is loaded at every `/execute-tracks` session startup, so
   every extra intro sentence is paid by every Phase A/B/C session for
   the rest of the plan's life. *(plan-file only — the intro paragraph
@@ -123,9 +131,9 @@ TRACK SIZING
 - Does any track's description cover work that would naturally split into
   distinct phases with internal sequencing? If so, splitting into
   dependent tracks would give better just-in-time decomposition.
-  *(cross-file: Scope line in plan, description in backlog for pending
-  tracks / plan-file entry for completed/skipped tracks — read both
-  halves before concluding.)*
+  *(cross-file: Scope line in plan, description in the step file
+  `## Description` for pending tracks / plan-file entry for
+  completed/skipped tracks — read both halves before concluding.)*
 
 ARCHITECTURE NOTES *(plan-file only — Component Map, Decision Records,
 Invariants, Integration Points, and Non-Goals all live in the plan per
@@ -142,8 +150,9 @@ Invariants, Integration Points, and Non-Goals all live in the plan per
 
 DESIGN DOCUMENT *(design-file for diagram/prose checks; plan-file for
 the Architecture-Notes/Decision-Records cross-reference. The final
-bullet's "track descriptions" half is sourced backlog-for-pending,
-plan-file-for-completed/skipped.)*
+bullet's "track descriptions" half is sourced from the step file
+`## Description` for pending tracks, from the plan-file entry for
+completed/skipped tracks.)*
 - Does the design document exist at `docs/adr/<dir-name>/_workflow/design.md`?
 - Does it include an Overview section summarizing the design approach?
 - Does it include class diagrams (Mermaid `classDiagram`) when the plan
@@ -171,13 +180,14 @@ track references live in the plan's Architecture Notes)*
 CONSISTENCY
 - Do track descriptions, decision records, component maps, and scope
   indicators tell the same story? *(cross-file: track descriptions are
-  sourced backlog-for-pending, plan-file-for-completed/skipped. Decision
-  records, component maps, and scope indicators are plan-file only.
-  Verify the story is coherent across all sources.)*
+  sourced from the step file `## Description` for pending tracks, from
+  the plan-file entry for completed/skipped tracks. Decision records,
+  component maps, and scope indicators are plan-file only. Verify the
+  story is coherent across all sources.)*
 - Are there contradictions between tracks (e.g., Track 1 says X, Track 3
   assumes not-X)? *(cross-file: read each track's description from its
-  current authoritative location — backlog for pending, plan-file for
-  completed/skipped.)*
+  current authoritative location — step file `## Description` for
+  pending, plan-file for completed/skipped.)*
 
 BLOAT *(plan-file only for the per-section checks; plan/design
 duplication is cross-file between the plan and `design.md`)* — these

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -220,8 +220,8 @@ rulebook before starting any work:
 
 The rulebook defines what you do, the three early-return cases
 (design decision, risk upgrade, failure), and the return contract
-your output must end with. Do not modify the step file, the plan,
-or the backlog — those are the orchestrator's responsibility.
+your output must end with. Do not modify the step file or the plan —
+those are the orchestrator's responsibility.
 
 ## Stable inputs (static)
 

--- a/.claude/workflow/structural-review.md
+++ b/.claude/workflow/structural-review.md
@@ -3,11 +3,12 @@
 ## Goal
 
 Validate the plan's internal structure and completeness across the plan
-file and backlog. This is a lightweight check that does NOT read the
-codebase — it catches plan-level defects (dependency cycles, missing
+file and the step files. This is a lightweight check that does NOT read
+the codebase — it catches plan-level defects (dependency cycles, missing
 descriptions, contradictions, **bloat**) cheaply. Pending-track
-`**What/How/Constraints/Interactions**` detail lives in
-`implementation-backlog.md`; the review reads both files.
+`**What/How/Constraints/Interactions**` detail lives in each track's
+`tracks/track-N.md` `## Description`; the review reads the plan file
+plus every pending track's step file.
 
 The review also enforces the per-section budgets defined in
 `planning.md` § Architecture Notes format. Plan-file bloat is paid by
@@ -111,12 +112,12 @@ issues.
 ## Review output
 
 The structural review is not persisted to disk. Mechanical fixes are
-applied autonomously to `implementation-plan.md` (and
-`implementation-backlog.md` when relevant); design-decision findings
-ride in the orchestrator's conversation context until escalated and
-resolved. The durable trace is the gate-PASS state, the resulting
-commit, and the audit-summary entry in the plan file's `## Plan
-Review` section (see
+applied autonomously to `implementation-plan.md` (and the relevant
+`tracks/track-N.md` files when track descriptions need updates);
+design-decision findings ride in the orchestrator's conversation
+context until escalated and resolved. The durable trace is the
+gate-PASS state, the resulting commit, and the audit-summary entry in
+the plan file's `## Plan Review` section (see
 [`implementation-review.md`](implementation-review.md) §Audit trail).
 A typical iteration looks like:
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -697,11 +697,11 @@ implementation plan:
      indicator, and dependency notation (typically depends on the current
      track). Follow the same format as other tracks in the plan.
 
-2. **Save plan changes** — update `implementation-plan.md` (and
-   `implementation-backlog.md` if a new track's
+2. **Save plan changes** — update `implementation-plan.md` and, if a
+   new track was added or an existing track's
    `**What/How/Constraints/Interactions**` subsections need
-   somewhere to live) on disk. Note the finding IDs that motivated
-   each plan correction.
+   somewhere to live, the corresponding `tracks/track-<M>.md` step
+   file. Note the finding IDs that motivated each plan correction.
 
 3. **Commit and push the plan corrections** as a separate Workflow
    update commit (per `commit-conventions.md` § Commit type
@@ -710,13 +710,14 @@ implementation plan:
 
    ```bash
    git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
-           docs/adr/<dir-name>/_workflow/implementation-backlog.md
+           docs/adr/<dir-name>/_workflow/tracks/track-<M>.md \
+           ... (one path per modified or newly created step file)
    git commit -m "Apply plan corrections from <track> review"
    git push
    ```
 
-   Stage explicit paths only. Drop `implementation-backlog.md` from
-   the `git add` if no new track was added.
+   Stage explicit paths only. Drop step-file paths from the `git add`
+   if no step file was modified or created.
 
 If no findings were deferred, skip this section.
 
@@ -795,9 +796,10 @@ proceed directly to track completion **in the same session**.
    during Phase 1, so there are no
    `**What**: / **How**: / **Constraints**: / **Interactions**:`
    subsections present in the plan-file entry to drop — the detailed
-   description was removed from the backlog at Phase A start and
-   already lives in the step file's `## Description` section. Phase C
-   does not touch the backlog.
+   description has lived in the step file's `## Description` section
+   from Phase 1 onward. Phase C does not touch the step file's
+   description either; it only writes the track episode + collapse
+   into the plan-file entry.
 
    **Track episode fields:**
    - Strategic summary covering: what was built, key discoveries, plan

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -67,11 +67,13 @@ tracks, attach clarifications to the upcoming track, or escalate to
 inline replanning before sub-agents start reading the plan.
 
 The gate fires once per fresh Phase A entry. State C resume (the
-step file already has a populated `## Description`) **skips** the
-gate; the user saw it in the original session and the description
-is already authoritative. The gate is also re-runnable on session
-resume (step file still missing) — the resume idempotency rule at
-the end of this section governs that case.
+step file's `## Description` already carries the agreed-upon track
+plan, including any prior clarifications) **skips** the gate; the
+user saw it in the original session and the description is already
+authoritative. The gate is also re-runnable on session resume (no
+review has yet been recorded in `## Reviews completed` — see
+§Phase A Resume) — the resume idempotency rule at the end of this
+section governs that case.
 
 **1. Build Panel 1 — strategy assessment (look-back).**
 
@@ -107,12 +109,13 @@ on-disk strategy-refresh line.
 **2. Build Panel 2 — track summary (look-forward).**
 
 Read the plan-file Track N entry (title, intro paragraph, scope
-indicators, any inline notes) and the backlog's `## Track N:`
-section (`**What/How/Constraints/Interactions**` plus any `mermaid`
-diagram, per the "Backlog section body extraction rule" in
-[`conventions-execution.md`](conventions-execution.md) §2.1).
-Render the summary inline. The step file is created in §What You
-Do sub-step 2c after this gate clears — do not write it yet.
+indicators, any inline notes) and the upcoming track's step file
+`## Description` section
+(`**What/How/Constraints/Interactions**` plus any `mermaid`
+diagram, written by `create-plan` at Phase 1 and possibly amended
+by prior Pre-Flight rounds or inline replanning, including any
+`### Clarifications` subsection from a prior gate session).
+Render the summary inline.
 
 **3. Ask the user.** This step runs only if step 1 did not exit
 the gate — i.e., Panel 1 was skipped (no anchor track), Panel 1's
@@ -127,26 +130,28 @@ Render Panel 1 (if active) followed by Panel 2, and use
 - **Proceed** — accept the assessment (CONTINUE) and start Phase A
   with the upcoming track as summarised.
 - **Adjust** — modify any remaining track's plan-file entry and/or
-  backlog section. Light edits only (see step 4 below for the
-  boundary). Reordering remaining `[ ]` tracks is a light edit; if
-  the reorder changes which track is "next", re-render Panel 2
-  with the new upcoming track's summary before re-asking.
+  step file's `## Description`. Light edits only (see step 4 below
+  for the boundary). Reordering remaining `[ ]` tracks is a light
+  edit; if the reorder changes which track is "next", re-render
+  Panel 2 with the new upcoming track's summary before re-asking.
 - **Clarify** — attach guidance, must-/must-not- considerations,
   or open questions to be carried into Phase A. Clarifications
   target the **upcoming track only**; they do not modify the plan
-  or backlog and are appended to the step file's `## Description`
-  as a `### Clarifications` subsection in sub-step 2c.
+  or other tracks' step files and are written into the upcoming
+  track's step file's `## Description` as a `### Clarifications`
+  subsection on Proceed (see step 6 below).
 - **ESCALATE** — request "fundamental rework" → route to inline
   replanning.
 
 `AskUserQuestion` captures one option per round, so a user who
 wants to combine **Adjust** and **Clarify** spans multiple rounds.
 Each round: the user picks one option; the orchestrator applies it
-(edit the plan/backlog for **Adjust**, append to the clarifications
-buffer for **Clarify**); then re-render Panel 1 (re-running the
-strategy assessment if Panel 1 is active and the adjustment touched
-a remaining track) and Panel 2 from the (now-updated) files; re-ask.
-Loop until the user picks **Proceed** or **ESCALATE**.
+(edit the plan/step file for **Adjust**, append to the
+clarifications buffer for **Clarify**); then re-render Panel 1
+(re-running the strategy assessment if Panel 1 is active and the
+adjustment touched a remaining track) and Panel 2 from the
+(now-updated) files; re-ask. Loop until the user picks **Proceed**
+or **ESCALATE**.
 
 **4. Apply amendments — light vs deep boundary.**
 
@@ -158,8 +163,9 @@ native `Edit` for single-site changes here):
 
 - Track title, intro paragraph
 - Scope indicators in the plan-file checklist entries
-- `**What/How/Constraints/Interactions**` subsections in the backlog
-- Track-level `mermaid` diagrams in the backlog
+- `**What/How/Constraints/Interactions**` subsections in the step
+  file's `## Description`
+- Track-level `mermaid` diagrams in the step file's `## Description`
 - Reordering of remaining `[ ]` tracks within the plan checklist
   (only if dependencies still hold; re-render Panel 2 if the
   reorder changes the upcoming track)
@@ -187,9 +193,9 @@ notes plus any orchestrator-stated interpretations the user
 confirmed. The buffer is non-empty only if the user picked
 **Clarify** at least once during the loop. When the user picks
 **Proceed**, the buffer flows verbatim into the step file's
-`## Description` in sub-step 2c (see §What You Do).
+`## Description` in step 6 below.
 
-**6. Persist amendments + strategy-refresh line.**
+**6. Persist amendments + clarifications + strategy-refresh line.**
 
 After the user picks **Proceed**, write the on-disk artifacts of
 this round:
@@ -228,51 +234,73 @@ this round:
   track — there is no anchor block) or when the gate ESCALATEd
   (inline replanning restructures the plan directly).
 
-- **Plan/backlog amendments** (any `Adjust` rounds in the loop):
+- **Clarifications subsection** (buffer non-empty): write the
+  buffer as a `### Clarifications` subsection at the end of the
+  upcoming track's step file's `## Description`. **If a
+  `### Clarifications` subsection already exists** (e.g., a prior
+  gate session committed clarifications and was interrupted before
+  any review ran, then re-fired on resume per §Phase A Resume),
+  **delete the existing subsection first and replace it with the
+  new buffer** — the gate's output reflects this session's
+  decision, not a layered history. Panel 2 already surfaced any
+  prior on-disk clarifications in the summary, so anything still
+  relevant can be re-stated by the user during the loop. If the
+  buffer is empty, skip this edit. An existing
+  `### Clarifications` subsection on disk from a prior session is
+  preserved as-is in this case (the user neither re-clarified nor
+  asked for it to be removed).
+
+- **Plan/step-file amendments** (any `Adjust` rounds in the loop):
   the edits already landed in the working tree during step 4. They
-  are committed alongside the strategy-refresh line below.
+  are committed alongside the strategy-refresh line and any
+  clarifications below.
 
 After all artifacts are in place, run a single Workflow update
 commit:
 
 ```bash
 git add docs/adr/<dir-name>/_workflow/implementation-plan.md \
-        docs/adr/<dir-name>/_workflow/implementation-backlog.md
+        docs/adr/<dir-name>/_workflow/tracks/track-<N>.md
 git commit -m "Apply pre-flight amendments before Track <N>"
 git push
 ```
 
 Stage only the files actually edited — drop the path that wasn't
-touched. If the round produced no amendments and no strategy-refresh
-line (the user only clarified, and Panel 1 was skipped or its
-outcome already on disk from a prior interrupted session — see
-resume idempotency below), skip this commit entirely.
+touched. If the round produced no amendments, no clarifications,
+and no strategy-refresh line (the gate was a pure no-op — only
+possible when Panel 1 was skipped or its outcome was already on
+disk from a prior interrupted session, and the user picked
+Proceed without Adjust/Clarify rounds), skip this commit
+entirely.
 
 **7. Resume idempotency.** If the merged gate is re-entered on a
-session resume (step file still missing — see the resume table at
-the end of this section), the gate checks for a `**Strategy
-refresh:**` line under the just-completed/skipped track's block
-before running Panel 1. If the line exists, Panel 1 is **skipped**
-on resume — the earlier session's assessment is the historical
-record and is preserved. The Pre-Flight loop runs on Panel 2 only.
-Plan/backlog edits committed in the previous session persist;
-clarifications captured in the previous session lived only in
-conversation context and are lost — the user must re-enter them
-if still relevant.
+session resume (no review has been recorded in `## Reviews
+completed` yet — see §Phase A Resume), the gate checks for a
+`**Strategy refresh:**` line under the just-completed/skipped
+track's block before running Panel 1. If the line exists, Panel 1
+is **skipped** on resume — the earlier session's assessment is the
+historical record and is preserved. The Pre-Flight loop runs on
+Panel 2 only. Plan/step-file edits committed in the previous
+session persist; clarifications captured in the previous session
+lived only in conversation context and are lost — the user must
+re-enter them if still relevant. (An on-disk `### Clarifications`
+subsection committed by the prior session does persist; step 6's
+replace-then-write rule governs how it interacts with this
+session's buffer.)
 
 **Partial-commit asymmetry.** A prior session may have committed
-step 4 plan/backlog edits but died before step 6 wrote the
+step 4 plan/step-file edits but died before step 6 wrote the
 strategy-refresh line. On resume the line is missing, so the gate
 re-runs Panel 1; the committed edits are the new baseline (they
 do not appear as a diff against the original plan).
 
 To surface any such prior amendments, the orchestrator MUST run
-the following before Panel 1 starts on a resume entry (step file
-missing):
+the following before Panel 1 starts on a resume entry (no review
+recorded yet):
 
 ```bash
 git log --oneline -10 -- docs/adr/<dir-name>/_workflow/implementation-plan.md \
-                          docs/adr/<dir-name>/_workflow/implementation-backlog.md
+                          docs/adr/<dir-name>/_workflow/tracks/track-<N>.md
 ```
 
 If the output contains a recent `Apply pre-flight amendments
@@ -288,68 +316,24 @@ output so the user does not re-issue them in this round's
 ### What You Do
 
 > The Track Pre-Flight gate above must clear before sub-step 1 starts.
-> On State C resume the gate is skipped (see §Phase A Resume —
-> Description-move recovery).
+> On State C resume the gate is skipped (see §Phase A Resume).
 
-1. **Assess track complexity** to determine which reviews to run (see
+1. **Read the plan file** for strategic context (Goals, Architecture
+   Notes, Decision Records, Component Map) and the **step file**
+   (`docs/adr/<dir-name>/_workflow/tracks/track-N.md`) for the track's
+   detailed description. The step file already exists from Phase 1
+   and may carry pre-flight amendments and a `### Clarifications`
+   subsection committed by the gate above; both phases of consumption
+   route through the same file.
+
+2. **Assess track complexity** to determine which reviews to run (see
    §Complexity Assessment below).
-
-2. **Move the track description into the step file** (Phase A's first
-   on-disk write — this extends today's "create the step file early"
-   pattern so reviews can update the Reviews section and Phase B/C
-   sub-agents find the description in the file they already read).
-
-   a. **Read the plan file** for strategic context (Goals, Architecture
-      Notes, Decision Records, Component Map) and the current track's
-      intro paragraph.
-
-   b. **Read Track N's section from the backlog**
-      (`docs/adr/<dir-name>/_workflow/implementation-backlog.md`). Read the
-      track's intro paragraph from the plan-file entry and the
-      `**What/How/Constraints/Interactions**` subsections + any
-      track-level `mermaid` block from the backlog's `## Track N:
-      <title>` section. The section body is defined by the "Backlog
-      section body extraction rule" in `conventions-execution.md`
-      §2.1.
-
-   c. **Create the step file atomically** at
-      `docs/adr/<dir-name>/_workflow/tracks/track-N.md` in a single Write call
-      that contains: `## Description` (populated with the copied intro
-      + `**What/How/Constraints/Interactions**` subsections + any
-      track-level diagram from sub-step (b), **followed by a
-      `### Clarifications` subsection containing the verbatim
-      clarifications buffer captured by the Track Pre-Flight gate when
-      that buffer is non-empty; omit the subsection entirely when the
-      buffer is empty**), `## Progress` (with all three entries as
-      `[ ]`: `Review + decomposition`, `Step implementation`,
-      `Track-level code review`), an empty
-      `## Reviews completed`, and an empty `## Steps` placeholder.
-      Items 4–5 below populate `## Steps`; Phase B writes
-      `## Base commit` at its session start. Do NOT create an empty
-      shell and append the description in a second Write — the single
-      atomic Write closes the window in which the description has been
-      pulled out of its source but has not yet landed on disk.
-      Subsequent phases may Edit the file normally; only the initial
-      creation must be atomic.
-
-   d. **Remove Track N's section from the backlog.** Delete per the
-      "Backlog section body extraction rule" in
-      `conventions-execution.md` §2.1 — that rule states the
-      header-boundary algorithm and the line-count-deletion
-      prohibition once as the single authoritative source. Preserve
-      the backlog's opening `# <Feature> — Track Details` header.
-
-      When the last remaining `## Track M:` section is removed, leave
-      the backlog file on disk with only its header. The whole
-      `_workflow/` directory (including the empty backlog) is deleted
-      by the Phase 4 cleanup commit; no per-track removal is needed.
 
 3. **Run track-scoped reviews** as sub-agents (technical, risk, adversarial
    as warranted). After each review completes:
-   - Update the **Reviews completed** section in the step file
-     (created atomically in sub-step 2c) with a one-line summary —
-     review type, iteration count at PASS, and a brief tally of
-     findings that drove plan/step edits (e.g.,
+   - Update the **Reviews completed** section in the step file with a
+     one-line summary — review type, iteration count at PASS, and a
+     brief tally of findings that drove plan/step edits (e.g.,
      `- [x] Technical: PASS at iteration 2 (3 findings, 2 accepted, 1 rejected)`).
    - The findings themselves are not persisted to a separate file —
      they ride in the orchestrator's conversation context for the
@@ -378,16 +362,15 @@ output so the user does not re-issue them in this round's
    blockquote. Mark `Review + decomposition` as `[x]` in the Progress
    section.
 
-6. **Commit and push the Phase A workflow updates.** All of Phase A's
-   on-disk writes — the step file (created in 2c, populated in step 5)
-   and the backlog edit (the Track N section removal in 2d) — must be
-   committed before Phase B spawns the first implementer for this
-   track. The implementer's revert path uses `git reset --hard HEAD`,
-   which would otherwise discard the uncommitted decomposition.
+6. **Commit and push the Phase A workflow updates.** Phase A's on-disk
+   writes — the populated `## Steps` section and the `[x]` mark in
+   `## Progress` — must be committed before Phase B spawns the first
+   implementer for this track. The implementer's revert path uses
+   `git reset --hard HEAD`, which would otherwise discard the
+   uncommitted decomposition.
 
    ```bash
-   git add docs/adr/<dir-name>/_workflow/tracks/track-<N>.md \
-           docs/adr/<dir-name>/_workflow/implementation-backlog.md
+   git add docs/adr/<dir-name>/_workflow/tracks/track-<N>.md
    git commit -m "Phase A review and decomposition for <track>"
    git push
    ```
@@ -396,10 +379,7 @@ output so the user does not re-issue them in this round's
    `commit-conventions.md` § Commit type prefixes. Stage explicit
    paths only — never `git add -A` — so unrelated files in the
    working tree (e.g., scratch logs from prior debugging) don't get
-   pulled in. If a particular file does not exist (e.g., the backlog
-   had no Track N section to begin with), drop that path from the
-   `git add` command rather than letting the missing-path error stop
-   the commit.
+   pulled in.
 
 ### Complexity Assessment and Which Reviews to Run
 
@@ -575,55 +555,54 @@ The scope indicators serve as a starting point, not a binding contract. You
 may produce more or fewer steps than the indicator suggested, or cover
 different aspects, based on what is actually needed.
 
-### Phase A Resume — Description-move recovery
+### Phase A Resume
 
-The description-move in §What You Do sub-steps (b)-(d) performs two
-on-disk mutations: the atomic step-file write in (c) and the
-backlog-section removal in (d). Either operation may be interrupted by
-a session termination. When `/execute-tracks` auto-resumes into Phase A
+The step file already exists from Phase 1 with `## Description`
+populated, so Phase A resume's only concerns are (1) what state the
+Track Pre-Flight gate left behind and (2) which Phase A activities
+have completed. When `/execute-tracks` auto-resumes into Phase A
 (the Startup Protocol's State C `Review + decomposition is [ ]` row
-routes here), the main agent observes two states — the step file's
-`## Description` section and the backlog's `## Track N:` section — and
-picks the resume action from the decision table below.
+routes here), the main agent applies the rules below.
 
-The **Track Pre-Flight gate** does not re-fire on resume once the
-step file exists. The gate runs once per fresh Phase A entry and
-persists its outcome through the step file's `## Description`
-(which holds any `### Clarifications` captured during the gate),
-through any plan/backlog edits already committed in the original
-session, and (when Panel 1 was active) through the
-`**Strategy refresh:**` line on the just-completed/skipped track's
-block. The first row below — step file missing — is the only row
-that re-runs the gate, because the original session was interrupted
-before sub-step 2c wrote the step file. The re-fired gate honours
-the resume idempotency rule in §Track Pre-Flight step 7: if the
-strategy-refresh line is already on disk, Panel 1 is skipped and
-only Panel 2 is presented. Clarifications captured in that prior
-session lived only in the orchestrator's conversation context and
-are lost; the re-fired gate sees the post-amendment plan/backlog
-(any committed amendments persist) but the user must re-enter any
+**Track Pre-Flight gate.** The gate re-fires on resume only when no
+review has been recorded in the step file's `## Reviews completed`
+section yet. Once any review has been recorded, the gate's outcome
+(amendments + clarifications) is baked into the step file the
+reviews ran against — re-firing would invalidate that work. The
+re-fired gate honours the resume idempotency rule in §Track
+Pre-Flight step 7: if a `**Strategy refresh:**` line is already on
+disk under the just-completed/skipped track's block, Panel 1 is
+skipped and only Panel 2 is presented. Clarifications captured in
+the prior session lived only in the orchestrator's conversation
+context and are lost; the re-fired gate sees committed amendments
+on disk (an on-disk `### Clarifications` subsection persists and
+interacts with this round's buffer per §Track Pre-Flight step 6's
+replace-then-write rule), but the user must re-enter any
 clarifications they had given previously.
 
-The table is **idempotent**: running the indicated action produces the
-steady-state even if the table is re-entered multiple times. The
-**non-re-copy rule** (never overwrite a non-empty `## Description`
-from the plan + backlog) is what protects any post-Phase-A edits to
-the step file's description — e.g., a later inline-replan that
-revises a mid-execution track — from being silently undone if Phase A
-is re-entered later (most commonly because an earlier Phase A session
-was interrupted and State C resumed here).
+**Uncommitted gate state.** Before re-firing the gate, run
+`git status --porcelain docs/adr/<dir-name>/_workflow/implementation-plan.md
+docs/adr/<dir-name>/_workflow/tracks/track-<N>.md`. If either path is
+dirty, the previous session was interrupted between applying
+amendments and committing them. Surface the diff to the user and ask
+whether to keep or revert the uncommitted changes before continuing —
+silently committing them would smuggle un-reviewed edits into the
+gate's audit trail, and silently reverting them would lose user-
+approved amendments.
 
-| Step file state | Backlog state | Resume action |
+**Resume actions** (after the gate has cleared, or skipped because
+reviews are already in progress):
+
+| `## Reviews completed` state | `## Steps` state | Action |
 |---|---|---|
-| Missing | `## Track N:` section present | Fresh Phase A: run the Track Pre-Flight gate, then §What You Do sub-steps (a)-(d) from the top. Sub-step (c)'s single-Write rule rules out an on-disk step file with an empty `## Description`, so this row cannot represent a partial (c); it only represents an interruption at or before (b). Pre-flight amendments committed by an earlier interrupted session are already on disk; the re-fired gate sees the post-amendment state in the plan/backlog. |
-| Present, `## Description` populated | `## Track N:` section still present | Partial interruption after (c), before (d) completed. Run sub-step (d) **verbatim** and remove the backlog section using the "Backlog section body extraction rule" in `conventions-execution.md` §2.1. Do NOT re-copy into the step file's `## Description`. |
-| Present, `## Description` populated | No `## Track N:` section | Steady state. No description mutation needed. Resume from the next incomplete Phase A activity (reviews not yet run, decomposition not yet written). |
+| Empty | Empty | Re-fire the gate (per the rules above), then run §What You Do sub-steps 1-6 from the top. |
+| One or more reviews recorded as `[x]` | Empty | Skip the gate. Resume reviews from the next missing review type (§What You Do sub-step 3 onward). |
+| All planned reviews recorded | Non-empty `[ ]` items | Skip the gate. Decomposition has run; resume from sub-step 6 (commit) if not yet committed, otherwise the step file is already in steady state and `/execute-tracks` should route to Phase B on the next invocation. |
 
-After the resume action completes, Phase A continues normally — the
-§Complexity Assessment, review loop, and §Step Decomposition proceed
-exactly as on a fresh start (skipping any reviews already recorded in
-the step file's `## Reviews completed` section, and reusing already-
-decomposed steps if the `## Steps` section is non-empty).
+The non-re-copy rule (no operation re-derives `## Description` from
+external sources during Phase A) protects any amendments / inline-
+replan rewrites the step file may have accumulated since Phase 1 from
+being silently overwritten on resume.
 
 ---
 

--- a/.claude/workflow/track-skip.md
+++ b/.claude/workflow/track-skip.md
@@ -43,39 +43,30 @@ A track can be skipped (`[~]`) in two situations:
 
    The plan entry holds only the intro paragraph; the
    `**What/How/Constraints/Interactions**` subsections and any
-   track-level diagram lived in `implementation-backlog.md` and are
-   removed in step 3 below.
+   track-level diagram live in the step file (`tracks/track-N.md`)
+   and are removed in step 3 below.
 
    The authoritative retention rule for `[~]` entries lives in
-   step 5 below — this process step must not diverge from that rule.
+   step 4 below — this process step must not diverge from that rule.
 
    The skip record replaces both the track episode and step file
    reference. It must include enough context for the next session's
    Track Pre-Flight Panel 1 (strategy assessment) to assess
    downstream impact.
 
-3. **Remove Track N's section from `implementation-backlog.md`**.
-   Delete per the "Backlog section body extraction rule" in
-   `conventions-execution.md` §2.1 — that rule states the
-   header-boundary algorithm (and the line-count-deletion
-   prohibition) once as the single authoritative source. Preserve
-   the backlog's opening `# <Feature> — Track Details` header.
-   No-op if the section is already gone.
+3. **Delete the step file** (`tracks/track-N.md`) from disk if one
+   exists. The step file was created at Phase 1 with `## Description`
+   populated, so it is the only on-disk artifact carrying the
+   per-track detail; the delete drops both the description and any
+   reviews / decomposition / step episodes that may have accumulated
+   during Phase A or B.
 
-   When the last remaining `## Track M:` section is removed, leave
-   the backlog file on disk with only its header — same empty-backlog
-   final-state rule that Phase A follows. The whole `_workflow/`
-   directory is removed by the Phase 4 cleanup commit before merge.
-
-   **Backlog deletion is terminal.** Un-skipping a track via inline
-   replanning requires re-authoring the plan entry's description
-   from scratch; once a track has been skipped, the backlog is no
+   **Step-file deletion is terminal.** Un-skipping a track via inline
+   replanning requires re-authoring the step file's `## Description`
+   from scratch; once a track has been skipped, the step file is no
    longer a recovery source for it.
 
-4. **Delete the step file** (`tracks/track-N.md`) from disk if one
-   exists (e.g., Phase A created it before the skip was decided).
-
-5. **Track Pre-Flight (Panel 1 strategy assessment)** treats `[~]`
+4. **Track Pre-Flight (Panel 1 strategy assessment)** treats `[~]`
    tracks the same as `[x]` tracks. A skipped track's `**Skipped:**`
    line serves as its episode — the next session's Pre-Flight gate
    reads it as the just-skipped-track signal in Panel 1 to assess
@@ -93,9 +84,9 @@ A track can be skipped (`[~]`) in two situations:
    [`track-code-review.md`](track-code-review.md) § Track Completion
    step 4); skipped tracks bypass that pass entirely. The
    `**What/How/Constraints/Interactions**` subsections and any
-   track-level diagram lived in `implementation-backlog.md` and were
-   removed in step 3 above; they are not recoverable from the plan
-   entry once a track has been skipped.
+   track-level diagram lived in the step file's `## Description` and
+   were removed in step 3 above; they are not recoverable from the
+   plan entry once a track has been skipped.
 
 ---
 
@@ -105,9 +96,9 @@ If the skip is decided during Phase A (review sub-agent recommends it and
 user confirms):
 
 - Write the `[~]` marker and skip record to the plan file on disk
-- Remove Track N's section from `implementation-backlog.md` (no-op
-  if the section is already gone)
-- Delete any partially-created step file from disk
+- Delete `tracks/track-N.md` from disk (no-op if it has already been
+  removed; for tracks reaching this point the step file always exists
+  because Phase 1 created it)
 - The session continues: if Panel 1 of the Track Pre-Flight gate was
   already cleared in this session, proceed to the next `[ ]` track's
   Phase A. If the skip changed which track is "next", re-render
@@ -121,7 +112,6 @@ user confirms):
 If the user says "skip Track N" at session start:
 
 - Write the `[~]` marker and skip record on disk (user provides the reason)
-- Remove Track N's section from `implementation-backlog.md` (no-op
-  if the section is already gone)
-- Delete any step file for that track from disk
+- Delete `tracks/track-N.md` from disk (no-op if it has already been
+  removed)
 - Continue with normal startup protocol for the next track

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -122,9 +122,9 @@ cross-track impact.
 ## Startup Protocol (Auto-Resume)
 
 1. **Read the plan file** at `docs/adr/<dir-name>/_workflow/implementation-plan.md`
-   (not the backlog — startup reads only the plan;
-   `implementation-backlog.md` is loaded later, when a track enters Phase A
-   or is skipped).
+   (startup reads only the plan; per-track step files at
+   `tracks/track-N.md` are loaded later, when a track enters Phase A
+   or its description is being amended).
 
 2. **Identify all tracks** and their status:
    - `[ ]` — not started
@@ -159,7 +159,7 @@ cross-track impact.
 
    | Progress section | Resume action |
    |---|---|
-   | `Review + decomposition` is `[ ]` | Enter `track-review.md` §Phase A Resume — Description-move recovery (often a no-op), then re-run only missing reviews and decompose. |
+   | `Review + decomposition` is `[ ]` | Enter `track-review.md` §Phase A Resume (often a no-op since the step file already has its description from Phase 1), then re-run only missing reviews and decompose. |
    | `Review + decomposition` is `[x]`, steps partially complete | Resume from next `[ ]` step (see step-implementation-recovery.md §Phase B Resume for orphan commit recovery) |
    | Steps contain `[!]` (failed) entries | Check if a retry `[ ]` step follows — if yes, resume from retry. If no retry step, present failed episode to user |
    | All steps `[x]`, code review `[ ]` or partial | Run Phase C from current iteration (single-step tracks skip code review but still run track completion — see track-code-review.md; includes track completion after review) |
@@ -234,9 +234,9 @@ Phase boundaries are **mandatory** session boundaries. Each session handles
 exactly one phase:
 
 - **After State 0 (autonomous plan review)** — both consistency and
-  structural reviews have passed, the plan/backlog/design have been
-  fixed (mechanical fixes auto-applied; design decisions resolved by
-  the user), `## Plan Review` is marked `[x]` with the audit summary,
+  structural reviews have passed, the plan / step files / design have
+  been fixed (mechanical fixes auto-applied; design decisions resolved
+  by the user), `## Plan Review` is marked `[x]` with the audit summary,
   and the workflow-update commit has been pushed. Session ends. Next
   session starts Phase A of Track 1.
 
@@ -345,7 +345,7 @@ User interaction points:
 |---|---|---|
 | **Session start** | Auto-resume decision (which track, which phase, or State 0 plan review) | Confirm or override |
 | **State 0 design-decision findings** | Batched list of CR/S findings the consistency and/or structural sub-agents classified as `design-decision`, with proposed alternatives and recommendation | Resolve each finding (choose alternative, provide guidance, defer) |
-| **Track pre-flight (State A — pre-Phase-A)** | Two-panel summary: Panel 1 — strategy assessment (look-back: CONTINUE / ADJUST / ESCALATE) when an earlier track has just completed/skipped; Panel 2 — upcoming track summary built from the plan-file entry + backlog Track N section (intro, **What/How/Constraints/Interactions**, scope indicators, optional diagram). Panel 1 is skipped on the very first Phase A entry (no anchor track) and on resume when the strategy-refresh line is already on disk. | Proceed; adjust (light edits to any remaining track's plan/backlog including reorder, applied directly); clarify (notes captured for inclusion in the upcoming track's step-file `## Description`, written at Phase A sub-step 2c); or ESCALATE (Panel 1 ESCALATE accepted, or deep amendment requested) → inline replanning. Skipped on State C resume. |
+| **Track pre-flight (State A — pre-Phase-A)** | Two-panel summary: Panel 1 — strategy assessment (look-back: CONTINUE / ADJUST / ESCALATE) when an earlier track has just completed/skipped; Panel 2 — upcoming track summary built from the plan-file entry + the step file's `## Description` (intro, **What/How/Constraints/Interactions**, scope indicators, optional diagram). Panel 1 is skipped on the very first Phase A entry (no anchor track) and on resume when the strategy-refresh line is already on disk. | Proceed; adjust (light edits to any remaining track's plan / step file including reorder, applied directly); clarify (notes written into the upcoming track's step-file `## Description` as a `### Clarifications` subsection on Proceed); or ESCALATE (Panel 1 ESCALATE accepted, or deep amendment requested) → inline replanning. Skipped on State C resume. |
 | **Phase A/B complete (and State 0 complete)** | Phase summary, what was done, next phase | User clears session, re-runs `/execute-tracks` |
 | **Cross-track impact** | Which tracks affected, what broke, recommendation | Continue, pause, or escalate |
 | **Track complete (end of Phase C)** | Track episode, step episodes, git log of commits, plan corrections | Approve, request fixes, or rework |
@@ -414,7 +414,7 @@ branch:
    § Step 4; push.
 2. **Cleanup commit.** Run `git rm -r docs/adr/<dir-name>/_workflow/`
    to remove every working file under the `_workflow/` subtree
-   (plan, backlog, design.md, design-mechanics.md, step files,
+   (plan, design.md, design-mechanics.md, step files,
    design-mutations log). Commit with a message such
    as `Remove workflow scaffolding`. Push.
 


### PR DESCRIPTION
## Motivation

The planning workflow staged per-track What/How/Constraints/Interactions content in `implementation-backlog.md` during Phase 1, then moved it into `tracks/track-N.md` during Phase A. The backlog was a transit file with one real consumer (the step file's `## Description`), but it carried its own lifecycle: monotonic shrinkage rule, header-boundary extraction rule, a description-move sub-step in Phase A, plus cleanup branches in `track-skip` and `inline-replanning`. All of that machinery existed to manage a duplicate of content with one destination.

This branch removes the staging file and writes track content directly to `tracks/track-N.md ## Description` from Phase 1 onward. The second commit cleans up contradictions that the rename surfaced — three references disagreed on what happens to a track's step file when it gets skipped, because the original docs distinguished a backlog entry from a step file (two files) and the first commit collapsed them into one.

Phase 4's wholesale `_workflow/` removal still runs, so the durable artifacts merged into `develop` are unchanged.

## What ships

**Commit 1 — Drop implementation-backlog.md:**
- `create-plan` writes one `tracks/track-N.md` per planned track at Phase 1 with `## Description` fully populated; other sections start as `[ ]` placeholders.
- Phase 2 reviews (consistency + structural, plus their gate prompts) take a `tracks_dir` input instead of `backlog_path`; each prompt reads every pending track's step file alongside the plan.
- Phase A track-review drops the description-move sub-steps. Track Pre-Flight amends the step file's Description in place and appends `### Clarifications` on Proceed; Phase A Resume reduces to uncommitted-state detection plus review/decomposition resume.
- `track-skip` deletes the step file (no parallel backlog cleanup); `inline-replanning` revises the step file's Description directly.
- `design-mechanical-checks.py` swaps `--backlog-path` for `--tracks-dir` and scans every `*.md` in that directory for `**Full design**` refs; `edit-design` and `review-plan` skills pass `tracks_dir` through.
- `conventions-execution.md` description-lifecycle table collapses from 9 rows to 7; the "Backlog section body extraction rule" subsection is removed.

**Commit 2 — Resolve step-file-on-skip contradictions:**
- `conventions-execution.md`: collapse the two skip rows in the Description-lifecycle table into one (`Skipped → step file deleted`). The "(rare) step file retained" state was unreachable given the actual delete paths.
- `inline-replanning.md`: drop case 5's contradictory "after Phase A → retained → also update" branch. Skipped tracks have only the plan entry as an authoritative location.
- `track-skip.md`: remove step 3's "for tracks skipped at or before Phase A" qualifier; the delete uniformly drops any accumulated Phase A/B work.
- `track-review.md`: specify replace-then-write semantics for the Track Pre-Flight gate's Clarifications append when a prior interrupted session left a Clarifications subsection on disk. Empty-buffer case explicitly preserves any prior on-disk subsection so a no-op resume is truly a no-op.

## Trade-offs

- Workflow-only change. No source code, build, or test artifacts are touched.
- Existing in-flight branches that started before this lands will still have `implementation-backlog.md` on disk; the next `create-plan` invocation on those branches will not regenerate it. The cleanup commit at Phase 4 still wipes `_workflow/` wholesale, so nothing leaks into `develop`.
- The collapsed lifecycle table is shorter and easier to read, at the cost of removing the "rare retained step file after Phase A skip" row that documented an unreachable state.

## Test plan

- [ ] Mechanical: `python3 .claude/scripts/design-mechanical-checks.py --tracks-dir <some>/tracks/` runs without referencing the old `--backlog-path` flag.
- [ ] Visual: skim `conventions-execution.md` Description-lifecycle table — 7 rows, no contradictory skip semantics.
- [ ] Visual: `track-skip.md` step 3 reads as a single unconditional delete; `inline-replanning.md` case 5 has no contradictory branch; `track-review.md` Track Pre-Flight describes replace-then-write for Clarifications.