### PR TITLE
YTDB-679: Detect branch divergence at session start

### DIFF
--- a/.claude/workflow/branch-divergence-check.md
+++ b/.claude/workflow/branch-divergence-check.md
@@ -18,26 +18,33 @@ resolution applies for the remainder of the session.
 
 ## Detection
 
-Run:
+Run, in order:
 
 ```bash
-git fetch origin
-git status -sb | grep -q 'diverged' && \
-    git rev-list --left-right --count HEAD...@{u}
+git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1 || exit
+git fetch || exit
+git rev-list --left-right --count HEAD...'@{u}'
 ```
 
-If `git status -sb` does not contain `diverged`, continue normally.
-Otherwise surface the ahead/behind counts from `git rev-list` to
-the user and ask which of three resolutions to apply. Do **not**
-pick a default — force-pushing or resetting without explicit
-consent violates the harness git-safety protocol (see user-global
-`~/.claude/CLAUDE.md`).
+The upstream check runs first so a branch with no upstream skips
+cleanly without attempting the fetch. `git fetch` (no argument)
+targets the upstream's remote, which is not always `origin`. The
+final command prints `<ahead>\t<behind>` (tab-separated). The
+branch has diverged iff **both** counts are non-zero — `git status
+-sb` does not emit the literal word `diverged`, so do not grep for
+it.
+
+If both counts are non-zero, surface them to the user and ask
+which of three resolutions to apply. Do **not** pick a default —
+force-pushing or resetting without explicit consent violates the
+harness git-safety protocol (see user-global `~/.claude/CLAUDE.md`).
 
 **Skip the check** when `git fetch` fails (offline, no remote
-configured) or the branch has no upstream (`@{u}` does not resolve).
-The first per-commit push will surface any later issue, and the
-session-end unpushed-commit report (see `workflow.md` § What to do
-before ending a session) still covers the silent-failure case.
+configured) or the branch has no upstream (`@{u}` does not resolve)
+— both `exit` paths above. The first per-commit push will surface
+any later issue, and the session-end unpushed-commit report (see
+`workflow.md` § What to do before ending a session) still covers
+the silent-failure case.
 
 ---
 

--- a/.claude/workflow/branch-divergence-check.md
+++ b/.claude/workflow/branch-divergence-check.md
@@ -1,0 +1,106 @@
+# Branch Divergence Check
+
+Runs in turn 1 of every `/execute-tracks` session, immediately
+after the auto-resume decision and before any phase work begins.
+A diverged branch left undetected makes every per-commit push fail
+non-fast-forward, and the workflow's "push every commit" safety net
+silently lapses — the draft PR drifts behind local, and a
+mid-session crash destroys work that was supposed to be backed up.
+
+Re-entered mid-session when a per-commit `git push` is rejected
+`non-fast-forward` for the first time in the session (routed from
+`step-implementation.md` sub-step 8 and the central rule in
+`commit-conventions.md` § Push failure handling). Subsequent
+rejections in the same session do not re-route; the user's chosen
+resolution applies for the remainder of the session.
+
+---
+
+## Detection
+
+Run:
+
+```bash
+git fetch origin
+git status -sb | grep -q 'diverged' && \
+    git rev-list --left-right --count HEAD...@{u}
+```
+
+If `git status -sb` does not contain `diverged`, continue normally.
+Otherwise surface the ahead/behind counts from `git rev-list` to
+the user and ask which of three resolutions to apply. Do **not**
+pick a default — force-pushing or resetting without explicit
+consent violates the harness git-safety protocol (see user-global
+`~/.claude/CLAUDE.md`).
+
+**Skip the check** when `git fetch` fails (offline, no remote
+configured) or the branch has no upstream (`@{u}` does not resolve).
+The first per-commit push will surface any later issue, and the
+session-end unpushed-commit report (see `workflow.md` § What to do
+before ending a session) still covers the silent-failure case.
+
+---
+
+## Resolutions
+
+Present all three options to the user, with the ahead/behind counts
+already on screen, and wait for an explicit choice.
+
+### Local-authoritative
+
+The local rewrite (rebase, squash, amend) is intended and the
+remote is stale. Run once at startup:
+
+```bash
+git push --force-with-lease
+```
+
+Per-commit push operates normally for the rest of the session.
+
+Never use plain `--force`. If `--force-with-lease` itself rejects
+(the remote moved after the local fetch), re-route to this gate
+rather than retry blindly — the new remote state may invalidate
+the user's earlier choice.
+
+### Remote-authoritative
+
+Discard the local rewrites in favour of `origin`. After explicit
+confirmation that local-only commits are unrecoverable:
+
+```bash
+git reset --hard origin/<branch>
+```
+
+Workflow files (`docs/adr/<dir-name>/_workflow/`) are restored from
+the most recent reachable remote commit; any uncommitted local
+changes are lost. Warn the user before running, and surface
+`git log @{u}..HEAD --oneline` so they can confirm which local
+commits will be discarded.
+
+After the reset, the auto-resume decision computed earlier in the
+Startup Protocol may no longer match the new HEAD. Re-run the
+Startup Protocol's state-determination step (workflow.md
+§ Startup Protocol step 3) before proceeding.
+
+### Defer
+
+The user wants to resolve the divergence manually after the
+session. Per-commit pushes will continue to fail throughout the
+session but do not block phase progress.
+
+Acknowledge the choice, then proceed. The session-end summary
+reports the unpushed-commit count per `workflow.md` § What to do
+before ending a session, so the residue is visible at session end
+even though it accumulated silently across the session.
+
+---
+
+## After the choice
+
+The user's choice applies for the remainder of the session; no
+re-check is required. Mid-session non-fast-forward rejections under
+the **Defer** resolution are expected and are not re-routed here.
+
+Local-authoritative and Remote-authoritative resolutions both
+return to the Startup Protocol; the orchestrator then continues to
+the phase-specific work for the auto-resume state.

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -38,13 +38,15 @@ After every per-commit `git push`, inspect the exit code and stderr.
 Distinguish two failure shapes; do not silently treat them the same.
 
 - **Non-fast-forward rejection** (`! [rejected] ... (non-fast-forward)`).
-  The branch has diverged from `origin`. This is the case that
-  motivated the §Branch Divergence Check in `workflow.md`. On the
-  first occurrence in the session, route once to that check and
-  apply the user's chosen resolution; do not silently retry across
-  subsequent commits. The harness git-safety protocol forbids
-  unauthorised `--force-with-lease`, so the resolution must come
-  from the user.
+  The branch has diverged from `origin`. On the first occurrence
+  in the session, load
+  [`branch-divergence-check.md`](branch-divergence-check.md) and
+  follow it; apply the user's chosen resolution and do not silently
+  retry across subsequent commits. The harness git-safety protocol
+  forbids unauthorised `--force-with-lease`, so the resolution must
+  come from the user. If the session has already routed through the
+  gate once (e.g., the user chose **Defer**), subsequent rejections
+  are expected — record and continue.
 - **Any other push failure** (network, auth, pre-receive hook,
   large-file rejection). Record the failure and continue with the
   next phase action; do not block phase progress on a transient

--- a/.claude/workflow/commit-conventions.md
+++ b/.claude/workflow/commit-conventions.md
@@ -32,6 +32,30 @@ amend has rewritten history that was already pushed — never plain
 `--force`. CI does not run on draft PRs, so the push frequency
 carries no CI cost.
 
+### Push failure handling
+
+After every per-commit `git push`, inspect the exit code and stderr.
+Distinguish two failure shapes; do not silently treat them the same.
+
+- **Non-fast-forward rejection** (`! [rejected] ... (non-fast-forward)`).
+  The branch has diverged from `origin`. This is the case that
+  motivated the §Branch Divergence Check in `workflow.md`. On the
+  first occurrence in the session, route once to that check and
+  apply the user's chosen resolution; do not silently retry across
+  subsequent commits. The harness git-safety protocol forbids
+  unauthorised `--force-with-lease`, so the resolution must come
+  from the user.
+- **Any other push failure** (network, auth, pre-receive hook,
+  large-file rejection). Record the failure and continue with the
+  next phase action; do not block phase progress on a transient
+  push error. The session-end summary's unpushed-commit report
+  (see `workflow.md` § What to do before ending a session) makes
+  the residue visible.
+
+A silent `git push` failure that goes unreported defeats all three
+guarantees above — team visibility, disk-loss backup, and the
+safety-net intent.
+
 ---
 
 ## Commit type prefixes

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -494,12 +494,13 @@ See `commit-conventions.md` § Push every commit, and the
 message form.
 
 **Push failure handling.** Inspect the `git push` exit code and
-stderr. If the rejection is `non-fast-forward` (branch divergence),
-route once to `workflow.md` § Branch Divergence Check and apply the
-user's chosen resolution; do not silently keep pushing per-step.
-For any other push failure (network, auth, pre-receive hook),
-record the failure and continue — the session-end summary reports
-the unpushed-commit count. The full rule lives in
+stderr. If the rejection is `non-fast-forward` (branch divergence)
+and this is the first such rejection in the session, load
+[`branch-divergence-check.md`](branch-divergence-check.md) and
+apply the user's chosen resolution; do not silently keep pushing
+per-step. For any other push failure (network, auth, pre-receive
+hook), record the failure and continue — the session-end summary
+reports the unpushed-commit count. The full rule lives in
 `commit-conventions.md` § Push failure handling.
 
 **Session-end gate.** After committing the episode: if the context

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -493,6 +493,15 @@ See `commit-conventions.md` § Push every commit, and the
 "Workflow update" row in § Commit type prefixes for the standard
 message form.
 
+**Push failure handling.** Inspect the `git push` exit code and
+stderr. If the rejection is `non-fast-forward` (branch divergence),
+route once to `workflow.md` § Branch Divergence Check and apply the
+user's chosen resolution; do not silently keep pushing per-step.
+For any other push failure (network, auth, pre-receive hook),
+record the failure and continue — the session-end summary reports
+the unpushed-commit count. The full rule lives in
+`commit-conventions.md` § Push failure handling.
+
 **Session-end gate.** After committing the episode: if the context
 level was `warning` or `critical`, do NOT spawn the implementer for
 the next step. Save all work and ask the user for a session refresh

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -198,6 +198,63 @@ cross-track impact.
    The user can override: reorder tracks, skip a track, or choose a different
    resume point. But by default, you proceed without waiting for confirmation.
 
+5. **Run the Branch Divergence Check** (see §Branch Divergence Check
+   below). This must happen in turn 1, before any per-commit push
+   work. A diverged branch left undetected makes every `git push`
+   across the session reject silently and defeats the "push every
+   commit" safety net (see `commit-conventions.md` § Push every
+   commit).
+
+---
+
+## Branch Divergence Check
+
+Runs in turn 1 of every session, immediately after the auto-resume
+decision and before any phase work begins. A diverged branch left
+undetected makes every per-commit push fail non-fast-forward, and
+the workflow's "push every commit" safety net silently lapses — the
+draft PR drifts behind local, and a mid-session crash destroys work
+that was supposed to be backed up.
+
+**Check.** Run:
+
+```bash
+git fetch origin
+git status -sb | grep -q 'diverged' && \
+    git rev-list --left-right --count HEAD...@{u}
+```
+
+If `git status -sb` does not contain `diverged`, continue normally.
+Otherwise surface the ahead/behind counts from `git rev-list` to the
+user and ask which of three resolutions to apply. Do **not** pick a
+default — force-pushing or resetting without explicit consent
+violates the harness git-safety protocol (see user-global
+`~/.claude/CLAUDE.md`).
+
+**Resolution options.**
+
+- **Local-authoritative.** The local rewrite (rebase, squash, amend)
+  is intended and the remote is stale. Run
+  `git push --force-with-lease` once. Per-commit push operates
+  normally for the rest of the session.
+- **Remote-authoritative.** Discard the local rewrites. Run
+  `git reset --hard origin/<branch>` after explicit confirmation.
+  Local-only commits are unrecoverable; warn the user before
+  running.
+- **Defer.** Resolve manually after the session. Per-commit pushes
+  will continue to fail throughout the session but do not block
+  phase progress. The session-end summary reports the unpushed-commit
+  count (see §What to do before ending a session below).
+
+The user's choice applies for the remainder of the session; no
+re-check is required after the chosen action.
+
+**Skip the check** when `git fetch` fails (offline, no remote
+configured) or the branch has no upstream (`@{u}` does not resolve).
+The first per-commit push will surface any later issue, and the
+session-end unpushed-commit report still covers the silent-failure
+case.
+
 ---
 
 ## Track Pre-Flight (Strategy Assessment + Track Summary)
@@ -327,6 +384,16 @@ work when context consumption is at `warning` level or above.
 - Run `git push` so the branch's draft PR reflects the final state
   of the session (every commit is pushed; this is the safety net
   for unexpected session-end interruptions)
+- **Report unpushed commits.** Run
+  `git rev-list --count @{u}..HEAD` to count commits not yet pushed
+  to the tracked remote. If the count is non-zero, the session-end
+  summary MUST list both the count and the commits
+  (`git log --oneline @{u}..HEAD`) so the user can act before the
+  next session. A silent unpushed list defeats the "push every
+  commit" safety net (see `commit-conventions.md` § Push every
+  commit). If the branch has no upstream, substitute
+  `origin/<branch>` and warn the user that upstream tracking is not
+  configured.
 - Inform the user of the session state so the next `/execute-tracks`
   auto-resumes correctly
 

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -336,7 +336,11 @@ work when context consumption is at `warning` level or above.
   step before "End the session".
 - Run `git push` so the branch's draft PR reflects the final state
   of the session (every commit is pushed; this is the safety net
-  for unexpected session-end interruptions)
+  for unexpected session-end interruptions). If this push is
+  rejected, follow `commit-conventions.md` § Push failure handling
+  — a non-fast-forward rejection at session-end is the same
+  divergence case as during phase work and routes to
+  `branch-divergence-check.md` on first occurrence.
 - **Report unpushed commits.** Run
   `git rev-list --count @{u}..HEAD` to count commits not yet pushed
   to the tracked remote. If the count is non-zero, the session-end

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -198,62 +198,15 @@ cross-track impact.
    The user can override: reorder tracks, skip a track, or choose a different
    resume point. But by default, you proceed without waiting for confirmation.
 
-5. **Run the Branch Divergence Check** (see §Branch Divergence Check
-   below). This must happen in turn 1, before any per-commit push
-   work. A diverged branch left undetected makes every `git push`
-   across the session reject silently and defeats the "push every
-   commit" safety net (see `commit-conventions.md` § Push every
-   commit).
-
----
-
-## Branch Divergence Check
-
-Runs in turn 1 of every session, immediately after the auto-resume
-decision and before any phase work begins. A diverged branch left
-undetected makes every per-commit push fail non-fast-forward, and
-the workflow's "push every commit" safety net silently lapses — the
-draft PR drifts behind local, and a mid-session crash destroys work
-that was supposed to be backed up.
-
-**Check.** Run:
-
-```bash
-git fetch origin
-git status -sb | grep -q 'diverged' && \
-    git rev-list --left-right --count HEAD...@{u}
-```
-
-If `git status -sb` does not contain `diverged`, continue normally.
-Otherwise surface the ahead/behind counts from `git rev-list` to the
-user and ask which of three resolutions to apply. Do **not** pick a
-default — force-pushing or resetting without explicit consent
-violates the harness git-safety protocol (see user-global
-`~/.claude/CLAUDE.md`).
-
-**Resolution options.**
-
-- **Local-authoritative.** The local rewrite (rebase, squash, amend)
-  is intended and the remote is stale. Run
-  `git push --force-with-lease` once. Per-commit push operates
-  normally for the rest of the session.
-- **Remote-authoritative.** Discard the local rewrites. Run
-  `git reset --hard origin/<branch>` after explicit confirmation.
-  Local-only commits are unrecoverable; warn the user before
-  running.
-- **Defer.** Resolve manually after the session. Per-commit pushes
-  will continue to fail throughout the session but do not block
-  phase progress. The session-end summary reports the unpushed-commit
-  count (see §What to do before ending a session below).
-
-The user's choice applies for the remainder of the session; no
-re-check is required after the chosen action.
-
-**Skip the check** when `git fetch` fails (offline, no remote
-configured) or the branch has no upstream (`@{u}` does not resolve).
-The first per-commit push will surface any later issue, and the
-session-end unpushed-commit report still covers the silent-failure
-case.
+5. **Run the Branch Divergence Check.** Load
+   [`branch-divergence-check.md`](branch-divergence-check.md) and
+   follow it. This must happen in turn 1, before any per-commit
+   push work. A diverged branch left undetected makes every
+   `git push` across the session reject silently and defeats the
+   "push every commit" safety net (see `commit-conventions.md`
+   § Push every commit). The protocol detects divergence and asks
+   the user to pick one of three resolutions (local-authoritative,
+   remote-authoritative, defer); no default is picked.
 
 ---
 
@@ -535,6 +488,7 @@ On-demand reference documents (loaded only when their specific situation arises)
 - **`design-decision-escalation.md`** — when/how to escalate design decisions to the user
 - **`structural-review.md`** — structural review details (loaded by implementation-review.md)
 - **`track-skip.md`** — full track skip protocol (when `[~]` is triggered)
+- **`branch-divergence-check.md`** — turn-1 divergence detection and three-resolution gate (loaded by the Startup Protocol step 5; also re-routed to from `commit-conventions.md` § Push failure handling on the first non-fast-forward rejection in the session)
 - **`review-agent-selection.md`** — characteristic-based review agent selection (loaded by step-implementation.md and track-code-review.md)
 - **`risk-tagging.md`** — per-step risk criteria and lifecycle (loaded by `track-review.md` during Phase A decomposition; loaded by `step-implementation-recovery.md` only on the rare Phase B upgrade path; **not** loaded by Phase B normal execution or by Phase C — those phases consume the per-step `**Risk:**` tag from the step file directly)
 - **`implementer-rules.md`** — Phase B per-step implementer sub-agent rulebook (loaded only by the implementer; orchestrators do not load it)


### PR DESCRIPTION
#### Motivation:

The `/execute-tracks` Startup Protocol had no answer for the case where local rewrote history that origin still holds (rebase, squash, amend without force-push). When that condition was present at session start, every per-step `git push` rejected non-fast-forward, the orchestrator silently skipped the push (the harness git-safety protocol correctly forbids unauthorised `--force-with-lease`), the draft PR drifted behind local, and the "push every commit" disk-loss safety net silently lapsed. The user only saw the failure at session end, after multiple unpushed commits had accumulated. This is YTDB-679.

#### What changed:

- **`branch-divergence-check.md`** (new on-demand doc). Detects divergence via `git fetch origin && git status -sb | grep -q 'diverged'`, surfaces the ahead/behind counts, and asks the user to pick one of three resolutions (force-with-lease, hard-reset to origin, or defer manual resolution). No default is picked — explicit consent is required by the harness git-safety protocol. Loading discipline matches `track-skip.md` and other on-demand procedure docs.
- **`workflow.md` § Startup Protocol step 5** (new). Names the divergence check and loads `branch-divergence-check.md` in turn 1. Also adds the new file to the on-demand reference list at the bottom of `workflow.md`.
- **`workflow.md` § What to do before ending a session** (extended). Now requires reporting unpushed-commit count via `git rev-list --count @{u}..HEAD` plus the commit list when non-zero, so a silent push failure becomes loud at session end.
- **`commit-conventions.md` § Push failure handling** (new subsection under § Push every commit). Centralises the rule: distinguish non-fast-forward rejection from other failures; route the first divergence rejection in the session to `branch-divergence-check.md`; record other failures and rely on the session-end report.
- **`step-implementation.md` sub-step 8** (extended). References the centralised push-failure rule and routes per-step pushes through `branch-divergence-check.md` on the first non-fast-forward rejection.

#### Acceptance criteria covered:

- ✅ Workflow docs name the divergence case explicitly and route to one of three resolutions.
- ✅ A diverged-branch session produces a user prompt within turn 1, not at session end.
- ✅ `step-implementation.md` sub-step 8 distinguishes divergence from other push failures.
- ✅ Session-end summary requires reporting non-zero unpushed-commit count.

#### Notes:

- No code or tests changed — workflow-doc-only PR.
- The `.claude/workflow/*.md` files only affect `/execute-tracks` sessions, so there is nothing to verify against unit tests or CI beyond the spotless / line-length checks that run on every PR.