### PR TITLE
Pause page flusher during test storage copy

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/WriteCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/WriteCache.java
@@ -261,5 +261,39 @@ public interface WriteCache {
     return new IntOpenHashSet();
   }
 
+  /**
+   * Pauses the background <i>periodic</i> page-flush task and drains any
+   * in-flight page write started by it. After this returns: every async
+   * page write started by the previous periodic-flush invocation has been
+   * awaited, no scheduled periodic flush will fire until
+   * {@link #resumeBackgroundFlush()} is called, and direct calls to
+   * {@link #flush()} from any thread are still allowed (so the storage's
+   * freeze / checkpoint paths keep working).
+   *
+   * <p>Note: only the periodic flush task is gated. Foreground flush paths
+   * (explicit {@link #flush()}, {@link #flushTillSegment(long)},
+   * {@code checkCacheOverflow}) and on-demand tasks (file creation,
+   * page allocation) are <i>not</i> gated. Callers must therefore avoid
+   * triggering writes from other threads while paused, otherwise pages
+   * may still be written to disk during the pause window.
+   *
+   * <p>Intended for tests that need to read raw storage files without racing
+   * with the periodic flusher (torn-page hazard). Not part of any
+   * production-runtime contract. The default is a no-op for in-memory and
+   * mock implementations that have no background flusher.
+   */
+  default void pauseBackgroundFlush() {
+  }
+
+  /**
+   * Re-enables background flushing previously paused via
+   * {@link #pauseBackgroundFlush()}. Calling without a prior pause is a no-op,
+   * so it is safe to call unconditionally in a {@code finally} block on the
+   * same thread that called pause. The default is a no-op for in-memory and
+   * mock implementations.
+   */
+  default void resumeBackgroundFlush() {
+  }
+
   String getStorageName();
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -455,6 +455,16 @@ public final class WOWCache extends AbstractWriteCache
   private volatile boolean stopFlush;
   private volatile Future<?> flushFuture;
 
+  /**
+   * When {@code true}, the periodic flush task exits early at its entry guard
+   * and does not re-arm itself in the finally block; foreground {@link #flush()}
+   * is unaffected so production checkpoint paths keep working. Toggled only by
+   * {@link #pauseBackgroundFlush()} / {@link #resumeBackgroundFlush()} —
+   * intended for tests that need to read raw storage files without racing the
+   * flusher (torn-page hazard).
+   */
+  private volatile boolean backgroundFlushPaused;
+
   private final ConcurrentHashMap<ExclusiveFlushTask, CountDownLatch> triggeredTasks =
       new ConcurrentHashMap<>();
 
@@ -1390,6 +1400,71 @@ public final class WOWCache extends AbstractWriteCache
       throw BaseException.wrapException(
           new WriteCacheException(storageName, "File flush was abnormally terminated"), e,
           storageName);
+    }
+  }
+
+  @Override
+  public void pauseBackgroundFlush() {
+    // Setting the flag first ensures any periodic flush that fires after this
+    // point sees backgroundFlushPaused == true at the entry guard in
+    // executePeriodicFlush and exits without doing any I/O or re-arming.
+    backgroundFlushPaused = true;
+
+    // Submit a no-op task to the single-threaded commitExecutor and wait for
+    // it. Because the executor is single-threaded, by the time our barrier
+    // task returns, any periodic flush that was already running has fully
+    // returned, including waiting on every in-flight AsynchronousFileChannel
+    // write: partitionAndFlushChunks calls IOResult.await() on every queued
+    // write before returning, so no async page write is outstanding once
+    // executePeriodicFlush has returned. Periodic tasks that were merely
+    // scheduled (not yet running) will see the flag at the entry guard and
+    // exit without doing work, so no work is queued behind the barrier
+    // either.
+    final var barrier = commitExecutor().submit(() -> null);
+    try {
+      barrier.get();
+    } catch (final java.lang.InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw BaseException.wrapException(
+          new ThreadInterruptedException("Pausing background flush was interrupted"),
+          e, storageName);
+    } catch (final Exception e) {
+      throw BaseException.wrapException(
+          new WriteCacheException(storageName, "Pause barrier failed"), e, storageName);
+    }
+
+    // Cancel any periodic future that the just-finished invocation re-armed
+    // before its finally observed the flag write, OR that an even earlier
+    // periodic invocation scheduled and we never had a chance to gate. We
+    // can safely cancel(false) here: on a queued-but-not-started task it
+    // removes the task from the executor's delay queue; on the currently
+    // running task it only sets the cancelled bit (the task continues, but
+    // its entry guard and finally re-arm both see the flag and skip work).
+    // Without this, a fast action.run() could return before the queued task
+    // fired, leaving an orphan chain in the queue that resumeBackgroundFlush
+    // would then duplicate.
+    final var pending = flushFuture;
+    if (pending != null) {
+      pending.cancel(false);
+    }
+  }
+
+  @Override
+  public void resumeBackgroundFlush() {
+    if (!backgroundFlushPaused) {
+      return;
+    }
+    backgroundFlushPaused = false;
+
+    // The periodic task that ran during the pause window saw the flag in its
+    // finally block and skipped its re-schedule. Restart it explicitly so
+    // background flushing resumes. If pagesFlushInterval == 0 or the cache
+    // has been closed (stopFlush == true), stay idle — matching the
+    // constructor's gating at construction time.
+    if (pagesFlushInterval > 0 && !stopFlush) {
+      flushFuture =
+          commitExecutor().schedule(
+              new PeriodicFlushTask(this), pagesFlushInterval, TimeUnit.MILLISECONDS);
     }
   }
 
@@ -4324,7 +4399,11 @@ public final class WOWCache extends AbstractWriteCache
   }
 
   public void executePeriodicFlush(PeriodicFlushTask task) {
-    if (stopFlush) {
+    // backgroundFlushPaused is the test-only gate that lets WalTestUtils
+    // freeze background page flushes while a raw-file copy runs; the entry
+    // check here is what makes the barrier-submit in pauseBackgroundFlush
+    // safe (no work happens after pause returns until resume is called).
+    if (stopFlush || backgroundFlushPaused) {
       return;
     }
 
@@ -4356,9 +4435,10 @@ public final class WOWCache extends AbstractWriteCache
           }
         }
 
-        // Check stopFlush between flush phases so the flush aborts quickly
-        // when the cache is being shut down.
-        if (stopFlush) {
+        // Check stopFlush / backgroundFlushPaused between flush phases so
+        // the flush aborts quickly when the cache is being shut down or a
+        // test has paused background flushing.
+        if (stopFlush || backgroundFlushPaused) {
           return;
         }
 
@@ -4388,7 +4468,9 @@ public final class WOWCache extends AbstractWriteCache
         flushError = t;
       }
     } finally {
-      if (flushInterval > 0 && !stopFlush) {
+      if (flushInterval > 0 && !stopFlush && !backgroundFlushPaused) {
+        // Skip the re-arm while paused; resumeBackgroundFlush() restarts
+        // the periodic task explicitly when the pause is lifted.
         flushFuture = commitExecutor().schedule(task, flushInterval, TimeUnit.MILLISECONDS);
       }
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -1420,7 +1420,7 @@ public final class WOWCache extends AbstractWriteCache
     // scheduled (not yet running) will see the flag at the entry guard and
     // exit without doing work, so no work is queued behind the barrier
     // either.
-    final var barrier = commitExecutor().submit(() -> null);
+    final var barrier = submitPauseBarrier();
     try {
       barrier.get();
     } catch (final java.lang.InterruptedException e) {
@@ -1440,9 +1440,9 @@ public final class WOWCache extends AbstractWriteCache
     // removes the task from the executor's delay queue; on the currently
     // running task it only sets the cancelled bit (the task continues, but
     // its entry guard and finally re-arm both see the flag and skip work).
-    // Without this, a fast action.run() could return before the queued task
-    // fired, leaving an orphan chain in the queue that resumeBackgroundFlush
-    // would then duplicate.
+    // Without this, a fast PeriodicFlushTask.run() could return before the
+    // queued task fired, leaving an orphan chain in the queue that
+    // resumeBackgroundFlush would then duplicate.
     final var pending = flushFuture;
     if (pending != null) {
       pending.cancel(false);
@@ -1462,10 +1462,27 @@ public final class WOWCache extends AbstractWriteCache
     // has been closed (stopFlush == true), stay idle — matching the
     // constructor's gating at construction time.
     if (pagesFlushInterval > 0 && !stopFlush) {
-      flushFuture =
-          commitExecutor().schedule(
-              new PeriodicFlushTask(this), pagesFlushInterval, TimeUnit.MILLISECONDS);
+      flushFuture = scheduleResumeFlush();
     }
+  }
+
+  // Package-private test seam: submit the barrier no-op task used by
+  // pauseBackgroundFlush(). Extracted so unit tests can stub the executor
+  // interaction (the real commitExecutor() is a global singleton fetched
+  // via YouTrackDBEnginesManager and cannot be mocked). Production
+  // behavior is identical to inlining commitExecutor().submit(() -> null).
+  Future<?> submitPauseBarrier() {
+    return commitExecutor().submit(() -> null);
+  }
+
+  // Package-private test seam: schedule the periodic flush task used by
+  // resumeBackgroundFlush(). Extracted so unit tests can verify that the
+  // schedule branch is taken without depending on the real executor.
+  // Production behavior is identical to inlining the
+  // commitExecutor().schedule(...) call.
+  Future<?> scheduleResumeFlush() {
+    return commitExecutor().schedule(
+        new PeriodicFlushTask(this), pagesFlushInterval, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -1428,7 +1428,7 @@ public final class WOWCache extends AbstractWriteCache
       throw BaseException.wrapException(
           new ThreadInterruptedException("Pausing background flush was interrupted"),
           e, storageName);
-    } catch (final Exception e) {
+    } catch (final ExecutionException e) {
       throw BaseException.wrapException(
           new WriteCacheException(storageName, "Pause barrier failed"), e, storageName);
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCachePauseResumeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCachePauseResumeTest.java
@@ -1,0 +1,221 @@
+package com.jetbrains.youtrackdb.internal.core.storage.cache.local;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests the pause / resume background-flush primitive added to
+ * {@link WOWCache#pauseBackgroundFlush()} and {@link WOWCache#resumeBackgroundFlush()}.
+ *
+ * <p>These tests pin the contract advertised by {@link WriteCache#pauseBackgroundFlush()}
+ * and {@link WriteCache#resumeBackgroundFlush()}: the periodic-flush entry guard at the
+ * top of {@link WOWCache#executePeriodicFlush} exits early when the pause flag is set,
+ * the resume early-return contract holds when no prior pause was issued, and resume
+ * respects the same scheduling guards the constructor uses ({@code pagesFlushInterval > 0
+ * && !stopFlush}).
+ *
+ * <p>The end-to-end IT {@code LocalPaginatedStorageRestoreFromWALIT.testSimpleRestore}
+ * exercises the full barrier-submit + IOResult.await drain, but it runs only in the
+ * nightly {@code -P ci-integration-tests} profile and, on the platforms where it runs in
+ * PR pipelines, the workload settles before pause is called. A regression that breaks one
+ * of the entry-guard / resume-scheduling invariants would not necessarily fail that IT,
+ * so these focused unit tests pin the smaller invariants on every PR run.
+ *
+ * <p>Uses Mockito's {@code CALLS_REAL_METHODS} pattern with reflection-set private fields,
+ * mirroring {@link WOWCacheFlushErrorTest}; the indirection is unavoidable because
+ * {@code WOWCache} has no test-friendly constructor.
+ */
+public class WOWCachePauseResumeTest {
+
+  /**
+   * Verifies that {@link WOWCache#executePeriodicFlush} returns immediately when the
+   * pause flag is set. This is the entry-guard half of the pause contract: a periodic
+   * task that fires after pause must observe the flag at its first line and exit without
+   * touching the write cache or scheduling further work.
+   */
+  @Test
+  public void testExecutePeriodicFlushReturnsWhenBackgroundFlushPaused() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", true);
+
+    // Passing null PeriodicFlushTask would NPE if the method body executes;
+    // the entry guard must return before reaching the re-arm in the finally.
+    cache.executePeriodicFlush(null);
+  }
+
+  /**
+   * Verifies that {@link WOWCache#resumeBackgroundFlush()} is a no-op when called
+   * without a prior pause. The {@code flushFuture} reference must stay untouched —
+   * scheduling a duplicate periodic task on every {@code finally} block would leak
+   * scheduled work into the shared {@code commitExecutor()} queue.
+   *
+   * <p>This is the contract that makes the {@code WalTestUtils.withWalProtection}
+   * {@code finally} block safe even if {@code pauseBackgroundFlush()} threw before
+   * setting the flag.
+   */
+  @Test
+  public void testResumeWithoutPauseIsNoOp() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", false);
+
+    // sentinelFuture stands in for whatever the constructor would have scheduled
+    // (or null if pagesFlushInterval == 0); resume must not replace it.
+    var sentinelFuture = new CompletableFuture<Void>();
+    setField(cache, "flushFuture", sentinelFuture);
+
+    cache.resumeBackgroundFlush();
+
+    assertFalse(
+        "resume without pause must leave backgroundFlushPaused at its prior value",
+        getBackgroundFlushPaused(cache));
+    assertSame(
+        "resume without pause must not schedule a new periodic task",
+        sentinelFuture, getFlushFuture(cache));
+  }
+
+  /**
+   * Verifies that {@link WOWCache#resumeBackgroundFlush()} clears the pause flag but
+   * does NOT schedule a new periodic task when {@code pagesFlushInterval == 0}. The
+   * constructor's gating at the equivalent code site uses the same condition, so resume
+   * must mirror it — otherwise a cache built with periodic flush disabled would suddenly
+   * start firing periodic flushes after the first pause / resume cycle.
+   */
+  @Test
+  public void testResumeWhenPagesFlushIntervalZeroDoesNotSchedule() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", true);
+    setField(cache, "pagesFlushInterval", 0L);
+    setField(cache, "stopFlush", false);
+    setField(cache, "storageName", "test");
+
+    var sentinelFuture = new CompletableFuture<Void>();
+    setField(cache, "flushFuture", sentinelFuture);
+
+    cache.resumeBackgroundFlush();
+
+    assertFalse(
+        "resume must clear the pause flag",
+        getBackgroundFlushPaused(cache));
+    assertSame(
+        "resume with pagesFlushInterval == 0 must not schedule a new periodic task",
+        sentinelFuture, getFlushFuture(cache));
+  }
+
+  /**
+   * Verifies that {@link WOWCache#resumeBackgroundFlush()} clears the pause flag but
+   * does NOT schedule a new periodic task when {@code stopFlush == true} (the cache
+   * is being shut down). A re-scheduled task after close would either run uselessly
+   * or, worse, race with shutdown bookkeeping in {@code stopFlush()}.
+   */
+  @Test
+  public void testResumeWhenStopFlushTrueDoesNotSchedule() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", true);
+    setField(cache, "pagesFlushInterval", 25L);
+    setField(cache, "stopFlush", true);
+    setField(cache, "storageName", "test");
+
+    var sentinelFuture = new CompletableFuture<Void>();
+    setField(cache, "flushFuture", sentinelFuture);
+
+    cache.resumeBackgroundFlush();
+
+    assertFalse(
+        "resume must clear the pause flag",
+        getBackgroundFlushPaused(cache));
+    assertSame(
+        "resume with stopFlush == true must not schedule a new periodic task",
+        sentinelFuture, getFlushFuture(cache));
+  }
+
+  /**
+   * Verifies that double-resume is idempotent: the second call's early-return branch
+   * is reached when the flag is already false from the first call. Without the guard,
+   * resume would schedule a duplicate periodic task on every spurious finally call
+   * (e.g., nested {@code WalTestUtils.withWalProtection} usage in future tests).
+   */
+  @Test
+  public void testDoubleResumeDoesNotDoubleSchedule() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", false);
+    setField(cache, "pagesFlushInterval", 25L);
+    setField(cache, "stopFlush", false);
+    setField(cache, "storageName", "test");
+
+    var sentinelFuture = new CompletableFuture<Void>();
+    setField(cache, "flushFuture", sentinelFuture);
+
+    // First resume hits the early-return because the flag was never set.
+    cache.resumeBackgroundFlush();
+    // Second resume hits the same early-return.
+    cache.resumeBackgroundFlush();
+
+    assertSame(
+        "double resume without pause must leave flushFuture untouched",
+        sentinelFuture, getFlushFuture(cache));
+  }
+
+  /**
+   * Verifies that the default no-op {@link WriteCache#pauseBackgroundFlush()} /
+   * {@link WriteCache#resumeBackgroundFlush()} methods on the interface do not throw
+   * for implementations that do not override them (e.g.,
+   * {@code DirectMemoryOnlyDiskCache} and the test mocks in {@code chm/*}). This pins
+   * the "safe to call unconditionally" contract that
+   * {@code WalTestUtils.withWalProtection} relies on.
+   */
+  @Test
+  public void testInterfaceDefaultsAreNoOps() {
+    // CALLS_REAL_METHODS routes calls through the default interface methods so
+    // we exercise the actual default no-op bodies, not Mockito's auto-stubs.
+    WriteCache stub = Mockito.mock(WriteCache.class, Mockito.CALLS_REAL_METHODS);
+
+    stub.pauseBackgroundFlush();
+    stub.resumeBackgroundFlush();
+    stub.resumeBackgroundFlush(); // idempotent on default path too
+    assertTrue("default pause / resume completed without throwing", true);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helper methods (reflection access to private fields — mirrors the pattern
+  // used by WOWCacheFlushErrorTest in this same package).
+  // ---------------------------------------------------------------------------
+
+  private static boolean getBackgroundFlushPaused(WOWCache cache) throws Exception {
+    Field field = findField(cache.getClass(), "backgroundFlushPaused");
+    field.setAccessible(true);
+    return (boolean) field.get(cache);
+  }
+
+  private static Future<?> getFlushFuture(WOWCache cache) throws Exception {
+    Field field = findField(cache.getClass(), "flushFuture");
+    field.setAccessible(true);
+    return (Future<?>) field.get(cache);
+  }
+
+  private static void setField(Object target, String fieldName, Object value)
+      throws Exception {
+    Field field = findField(target.getClass(), fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Field findField(Class<?> clazz, String fieldName)
+      throws NoSuchFieldException {
+    while (clazz != null) {
+      try {
+        return clazz.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException ignored) {
+        clazz = clazz.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCachePauseResumeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCachePauseResumeTest.java
@@ -1,13 +1,21 @@
 package com.jetbrains.youtrackdb.internal.core.storage.cache.local;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import com.jetbrains.youtrackdb.internal.common.concur.lock.ThreadInterruptedException;
+import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
+import com.jetbrains.youtrackdb.internal.core.exception.WriteCacheException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
 import java.lang.reflect.Field;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -34,6 +42,19 @@ import org.mockito.Mockito;
  * {@code WOWCache} has no test-friendly constructor.
  */
 public class WOWCachePauseResumeTest {
+
+  /**
+   * Clears the per-thread interrupt flag after every test. Surefire is configured with
+   * {@code parallel=classes}, so all @Test methods in this class run sequentially on a
+   * single reused thread. If a test left the interrupt flag set (e.g., a regression in
+   * {@link WOWCache#pauseBackgroundFlush()} that throws something other than
+   * {@link BaseException} on the interrupt path), the leak would pollute whichever test
+   * runs next on that thread. Calling {@link Thread#interrupted()} both reads and clears.
+   */
+  @After
+  public void clearInterruptFlag() {
+    Thread.interrupted();
+  }
 
   /**
    * Verifies that {@link WOWCache#executePeriodicFlush} returns immediately when the
@@ -79,6 +100,7 @@ public class WOWCachePauseResumeTest {
     assertSame(
         "resume without pause must not schedule a new periodic task",
         sentinelFuture, getFlushFuture(cache));
+    Mockito.verify(cache, Mockito.never()).scheduleResumeFlush();
   }
 
   /**
@@ -107,6 +129,7 @@ public class WOWCachePauseResumeTest {
     assertSame(
         "resume with pagesFlushInterval == 0 must not schedule a new periodic task",
         sentinelFuture, getFlushFuture(cache));
+    Mockito.verify(cache, Mockito.never()).scheduleResumeFlush();
   }
 
   /**
@@ -134,6 +157,7 @@ public class WOWCachePauseResumeTest {
     assertSame(
         "resume with stopFlush == true must not schedule a new periodic task",
         sentinelFuture, getFlushFuture(cache));
+    Mockito.verify(cache, Mockito.never()).scheduleResumeFlush();
   }
 
   /**
@@ -161,6 +185,7 @@ public class WOWCachePauseResumeTest {
     assertSame(
         "double resume without pause must leave flushFuture untouched",
         sentinelFuture, getFlushFuture(cache));
+    Mockito.verify(cache, Mockito.never()).scheduleResumeFlush();
   }
 
   /**
@@ -181,6 +206,244 @@ public class WOWCachePauseResumeTest {
     stub.resumeBackgroundFlush();
     stub.resumeBackgroundFlush(); // idempotent on default path too
     assertTrue("default pause / resume completed without throwing", true);
+  }
+
+  /**
+   * Verifies the happy path of {@link WOWCache#pauseBackgroundFlush()}: the pause flag is
+   * set, the barrier task is awaited, and the currently-scheduled {@code flushFuture} is
+   * cancelled with {@code cancel(false)} (NOT {@code cancel(true)} — interrupting a
+   * running flusher mid-write is exactly the hazard pause is meant to avoid).
+   *
+   * <p>The barrier executor seam ({@code submitPauseBarrier()}) is stubbed so the test
+   * does not depend on the real global commit executor; what we are pinning here is the
+   * method's own flow control — set flag, wait for barrier, cancel pending without
+   * interrupt. The full barrier semantics (drains every in-flight
+   * {@code AsynchronousFileChannel.write} via {@code IOResult.await()}) are covered by
+   * the integration test {@code LocalPaginatedStorageRestoreFromWALIT.testSimpleRestore},
+   * which runs in the nightly {@code -P ci-integration-tests} profile.
+   */
+  @SuppressWarnings("unchecked") // unchecked: generic Future<Object> mock
+  @Test
+  public void testPauseSetsFlagAndCancelsPendingFuture() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", false);
+
+    // Use a Mockito-mocked Future so we can verify the EXACT cancel argument.
+    // A real CompletableFuture would not let us distinguish cancel(false) from
+    // cancel(true) because CompletableFuture#cancel ignores mayInterruptIfRunning
+    // per the JDK contract — making the cancel(true) regression invisible.
+    var pending = Mockito.mock(Future.class);
+    setField(cache, "flushFuture", pending);
+
+    // Stub the barrier so we don't touch the singleton executor. doReturn form
+    // is required because submitPauseBarrier() is dispatched via CALLS_REAL_METHODS.
+    var completedBarrier = CompletableFuture.<Object>completedFuture(null);
+    Mockito.doReturn(completedBarrier).when(cache).submitPauseBarrier();
+
+    cache.pauseBackgroundFlush();
+
+    assertTrue(
+        "pause must set the backgroundFlushPaused flag",
+        getBackgroundFlushPaused(cache));
+    Mockito.verify(cache).submitPauseBarrier();
+    Mockito.verify(pending).cancel(false);
+    Mockito.verify(pending, Mockito.never()).cancel(true);
+  }
+
+  /**
+   * Verifies that {@link WOWCache#pauseBackgroundFlush()} skips the cancel call when
+   * {@code flushFuture} is null. The null check is what makes pause safe to call before
+   * any periodic task has been scheduled (e.g., when the constructor was given
+   * {@code pagesFlushInterval == 0}).
+   */
+  @Test
+  public void testPauseSkipsCancelWhenFlushFutureNull() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", false);
+    setField(cache, "flushFuture", null);
+
+    var completedBarrier = CompletableFuture.<Object>completedFuture(null);
+    Mockito.doReturn(completedBarrier).when(cache).submitPauseBarrier();
+
+    // Must not NPE despite flushFuture being null.
+    cache.pauseBackgroundFlush();
+
+    assertTrue(
+        "pause must set the backgroundFlushPaused flag even when flushFuture is null",
+        getBackgroundFlushPaused(cache));
+    assertNull(
+        "pause must not write a new future into flushFuture when it started as null",
+        getFlushFuture(cache));
+    Mockito.verify(cache).submitPauseBarrier();
+  }
+
+  /**
+   * Verifies that {@link WOWCache#pauseBackgroundFlush()} restores the interrupt flag and
+   * throws a {@link ThreadInterruptedException} wrapping the original
+   * {@link InterruptedException} when the barrier {@code get()} is interrupted. Pins the
+   * exact wrapper subtype and cause chain so a regression that swaps the wrapper for a
+   * different {@link BaseException} subclass, or drops the {@code initCause} call, fails
+   * loudly. Callers must be able to detect the interruption via {@link Thread#interrupted()}
+   * for downstream shutdown handling.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testPauseInterruptedRestoresInterruptFlagAndThrowsBaseException()
+      throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", false);
+    setField(cache, "flushFuture", null);
+    setField(cache, "storageName", "test");
+
+    // Mock Future whose get() throws InterruptedException. We can't use a real
+    // CompletableFuture for this because there is no way to make its get()
+    // throw InterruptedException without interrupting the calling thread first
+    // (which would race against the actual barrier path under test).
+    var barrier = Mockito.mock(Future.class);
+    Mockito.when(barrier.get()).thenThrow(new InterruptedException("simulated"));
+    Mockito.doReturn(barrier).when(cache).submitPauseBarrier();
+
+    // Clear any stale interrupt flag from prior tests so we can assert on the
+    // restoration below.
+    Thread.interrupted();
+
+    try {
+      cache.pauseBackgroundFlush();
+      fail("expected ThreadInterruptedException wrapping the InterruptedException");
+    } catch (ThreadInterruptedException e) {
+      // Thread.interrupted() both reads and clears; the @After also clears, but the
+      // assertion here pins that the catch block restored the flag at the moment of throw.
+      assertTrue(
+          "interrupt flag must be restored by the catch block before throwing",
+          Thread.interrupted());
+      assertTrue(
+          "cause must be the original InterruptedException so operators can diagnose",
+          e.getCause() instanceof InterruptedException);
+      assertEquals(
+          "original interrupt message must be preserved in the cause chain",
+          "simulated", e.getCause().getMessage());
+      assertTrue(
+          "flag must be set before the barrier wait, so the pause flag remains true "
+              + "even on a failed pause",
+          getBackgroundFlushPaused(cache));
+    }
+  }
+
+  /**
+   * Verifies that {@link WOWCache#pauseBackgroundFlush()} does NOT cancel the
+   * pending {@code flushFuture} when the barrier {@code get()} throws — the re-throw
+   * exits the method before reaching the cancel block. Pins the semantic so a future
+   * refactor that hoists the cancel into the catch handler is caught: hoisting would
+   * interrupt a flusher that the failed pause did not actually drain, breaking the
+   * very invariant pause was added to protect.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testPauseInterruptedDoesNotCancelPendingFlushFuture() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", false);
+    setField(cache, "storageName", "test");
+
+    // Non-null pending future; the catch path must NOT cancel it. Mockito-mocked
+    // so we can verify cancel was never invoked on either argument value.
+    var pending = Mockito.mock(Future.class);
+    setField(cache, "flushFuture", pending);
+
+    var barrier = Mockito.mock(Future.class);
+    Mockito.when(barrier.get()).thenThrow(new InterruptedException("simulated"));
+    Mockito.doReturn(barrier).when(cache).submitPauseBarrier();
+
+    Thread.interrupted();
+
+    try {
+      cache.pauseBackgroundFlush();
+      fail("expected ThreadInterruptedException");
+    } catch (ThreadInterruptedException e) {
+      Mockito.verify(pending, Mockito.never()).cancel(Mockito.anyBoolean());
+    }
+  }
+
+  /**
+   * Verifies that {@link WOWCache#pauseBackgroundFlush()} wraps a barrier
+   * {@link ExecutionException} as a {@link WriteCacheException} and preserves the full
+   * cause chain ({@code WriteCacheException → ExecutionException → original cause}) so
+   * operators can diagnose the underlying executor failure. Also pins that this path
+   * does NOT touch the thread interrupt flag (only the InterruptedException path does)
+   * and that the pause flag remains set after the throw (mirroring the interrupted-path
+   * invariant — both failure paths leave the caller responsible for clearing state).
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testPauseExecutionExceptionWrapsAsBaseException() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", false);
+    setField(cache, "flushFuture", null);
+    setField(cache, "storageName", "test");
+
+    var barrier = Mockito.mock(Future.class);
+    Mockito.when(barrier.get())
+        .thenThrow(new ExecutionException(new RuntimeException("executor down")));
+    Mockito.doReturn(barrier).when(cache).submitPauseBarrier();
+
+    // Pre-clear the interrupt flag so the post-condition assertion is meaningful.
+    Thread.interrupted();
+
+    try {
+      cache.pauseBackgroundFlush();
+      fail("expected WriteCacheException wrapping the ExecutionException");
+    } catch (WriteCacheException e) {
+      assertTrue(
+          "wrapped cause must be the ExecutionException raised by the barrier",
+          e.getCause() instanceof ExecutionException);
+      assertTrue(
+          "ExecutionException must preserve the underlying root cause for operator diagnosis",
+          e.getCause().getCause() instanceof RuntimeException);
+      assertEquals(
+          "root-cause message must survive the wrap",
+          "executor down", e.getCause().getCause().getMessage());
+      assertFalse(
+          "ExecutionException path must NOT set the interrupt flag (only the "
+              + "InterruptedException path restores it)",
+          Thread.interrupted());
+      assertTrue(
+          "flag must be set before the barrier wait, so the pause flag remains true "
+              + "even on a failed pause",
+          getBackgroundFlushPaused(cache));
+    }
+  }
+
+  /**
+   * Verifies the happy path of {@link WOWCache#resumeBackgroundFlush()}: when the pause
+   * flag is set, {@code pagesFlushInterval > 0}, and {@code stopFlush == false}, resume
+   * clears the flag and writes the newly-scheduled future into {@code flushFuture}. The
+   * schedule seam ({@code scheduleResumeFlush()}) is stubbed so we verify the wiring
+   * without depending on the real executor or instantiating a PeriodicFlushTask against
+   * a partly-built mock.
+   */
+  @Test
+  public void testResumeSchedulesNewPeriodicTaskWhenIntervalPositive() throws Exception {
+    var cache = Mockito.mock(WOWCache.class, Mockito.CALLS_REAL_METHODS);
+    setField(cache, "backgroundFlushPaused", true);
+    setField(cache, "pagesFlushInterval", 25L);
+    setField(cache, "stopFlush", false);
+
+    // Pre-existing flushFuture (e.g., a cancelled one left by pause) must be
+    // replaced by the freshly-scheduled future.
+    var previousFuture = new CompletableFuture<Void>();
+    setField(cache, "flushFuture", previousFuture);
+
+    var newScheduledFuture = new CompletableFuture<Void>();
+    Mockito.doReturn(newScheduledFuture).when(cache).scheduleResumeFlush();
+
+    cache.resumeBackgroundFlush();
+
+    assertFalse(
+        "resume must clear the pause flag",
+        getBackgroundFlushPaused(cache));
+    assertSame(
+        "resume must write the freshly-scheduled future into flushFuture",
+        newScheduledFuture, getFlushFuture(cache));
+    Mockito.verify(cache).scheduleResumeFlush();
   }
 
   // ---------------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/WalTestUtils.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/WalTestUtils.java
@@ -14,21 +14,55 @@ final class WalTestUtils {
   }
 
   /**
-   * Prevents WAL segment truncation during the execution of the given action.
-   * This is needed when copying storage files while the database is still open,
-   * to avoid {@code FileNotFoundException} due to WAL segment rotation.
+   * Prepares the storage for a user-space copy of its raw files while the
+   * database is still open, then runs {@code action}.
+   *
+   * <p>Two hazards have to be neutralized for the copy to produce a recoverable
+   * snapshot:
+   *
+   * <ol>
+   *   <li><b>WAL segment rotation.</b> A background fuzzy checkpoint can
+   *       delete WAL segments mid-copy and cause {@code FileNotFoundException}
+   *       on the reader side. Flushing the WAL and pinning the current
+   *       {@code begin} LSN via {@code addCutTillLimit} prevents segment
+   *       rotation for the duration of {@code action}.
+   *   <li><b>Torn page reads.</b> The background page flusher uses
+   *       {@code AsynchronousFileChannel.write} to write 4 KB pages into the
+   *       data files. A user-space byte-stream copy can otherwise observe a
+   *       half-written page, which then fails magic / checksum verification
+   *       during WAL replay and aborts recovery — losing every operation
+   *       buffered after the torn page in the WAL. Pausing the background
+   *       flusher and draining its in-flight writes before the copy starts
+   *       eliminates this race.
+   * </ol>
+   *
+   * <p>Pausing the flusher does <i>not</i> advance on-disk page LSNs, so the
+   * subsequent WAL replay on the copy still has real work to do — page-level
+   * {@code redo()} dispatch, LSN comparison logic, and recovery dispatch —
+   * exactly as the calling test was written to exercise.
    */
   static void withWalProtection(
       DatabaseSessionEmbedded session, ThrowingRunnable action) throws Exception {
     var storage = (DiskStorage) session.getStorage();
     var wal = storage.getWALInstance();
+    var writeCache = storage.getWriteCache();
+
     wal.flush();
 
     var walBegin = wal.begin();
     wal.addCutTillLimit(walBegin);
     try {
-      action.run();
+      writeCache.pauseBackgroundFlush();
+      try {
+        action.run();
+      } finally {
+        writeCache.resumeBackgroundFlush();
+      }
     } finally {
+      // Outer finally guarantees the WAL cut-till limit is always released,
+      // even if resumeBackgroundFlush() itself throws (e.g., a shutdown race
+      // makes commitExecutor() reject the re-schedule). A leaked cut-till
+      // limit would pin every subsequent test's WAL segments.
       wal.removeCutTillLimit(walBegin);
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/WalTestUtils.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/WalTestUtils.java
@@ -52,8 +52,20 @@ final class WalTestUtils {
     var walBegin = wal.begin();
     wal.addCutTillLimit(walBegin);
     try {
-      writeCache.pauseBackgroundFlush();
+      // Inner try-finally covers BOTH pause and action so that a pause that
+      // throws after setting backgroundFlushPaused = true (e.g., barrier
+      // wait was interrupted, executor rejected the no-op task) still falls
+      // through to resumeBackgroundFlush() and clears the flag. Without
+      // this nesting, a failed pause would leave the cache paused for the
+      // rest of its lifetime — every subsequent periodic flush would exit
+      // at the entry guard and the cache would silently stop writing.
+      // resumeBackgroundFlush() is a documented safe no-op when no prior
+      // pause set the flag (pinned by
+      // WOWCachePauseResumeTest#testResumeWithoutPauseIsNoOp), so it is
+      // safe to call even if pauseBackgroundFlush() threw before reaching
+      // the volatile-flag write.
       try {
+        writeCache.pauseBackgroundFlush();
         action.run();
       } finally {
         writeCache.resumeBackgroundFlush();


### PR DESCRIPTION
#### Motivation:

`LocalPaginatedStorageRestoreFromWALIT.testSimpleRestore` is flaky on macOS-arm + JDK 25 temurin (~12 failed develop runs since 2026-04-17). The test's user-space `copyFile()` (1 KB buffered byte loop) races with the background page flusher's `AsynchronousFileChannel.write` calls. `FileInputStream.read` on this platform does not serialize against in-flight async writes, so the copy observes torn pages. WAL replay on the copy fails magic/checksum verification, `AbstractStorage.restoreFrom` catches the exception, and the rest of the WAL is silently dropped — turning a single torn page into multi-million-record data loss and making the `databaseCompare` assertion fail.

A previous attempt to fix this by calling `writeCache.flush()` inside `WalTestUtils.withWalProtection` was rejected by reviewers: it advanced every on-disk page LSN to match the WAL, so WAL replay had no `redo()` work to do and the test no longer exercised the page-level recovery path it was written to cover. This PR pauses the periodic flusher and drains its in-flight async writes instead. Pages stay at their pre-pause LSNs, so WAL replay on the copy still has real `redo()` work to do (28.6 M operations in the local Linux-x86 verification run).

##### What changed

- New `WriteCache#pauseBackgroundFlush` / `resumeBackgroundFlush` methods (default no-op on the interface; real impl on `WOWCache`).
- `pauseBackgroundFlush` sets a volatile flag, submits a barrier task to the single-threaded `commitExecutor()`, and after the barrier returns calls `cancel(false)` on the latest `flushFuture`. The barrier guarantees that any in-flight `executePeriodicFlush` has fully returned and that `IOResult.await()` has drained every queued `AsynchronousFileChannel.write`. The trailing cancel closes the orphan race where the in-flight task's finally re-arms before observing the flag.
- Two package-private test seams `submitPauseBarrier()` / `scheduleResumeFlush()` are extracted from `pauseBackgroundFlush` / `resumeBackgroundFlush` so unit tests can stub the executor interaction via `Mockito.doReturn`. Production behavior is identical to inlining; the seams exist only because `commitExecutor()` is a `YouTrackDBEnginesManager` global singleton that cannot be mocked.
- `WalTestUtils.withWalProtection` nests pause/resume inside the WAL cut-till-limit pin so `removeCutTillLimit` always runs, even if `resume` throws. The inner try-finally also wraps the `pauseBackgroundFlush()` call itself: if pause throws after setting the flag (interrupt / executor rejection), the finally still calls `resumeBackgroundFlush()` and clears the flag. Without this, a failed pause would leave the cache silently paused for the rest of its lifetime.
- Foreground `flush()` is intentionally NOT gated, so production freeze / checkpoint paths keep working under the pause.

##### Verification

- `LocalPaginatedStorageRestoreFromWALIT.testSimpleRestore` passes locally (326 s, BUILD SUCCESS). Recovery log shows 28.6 M operations replayed and `Storage data recover was completed` with no `Magic number` / `StorageException` / `Data restore was paused` markers.
- 12 focused unit tests in `WOWCachePauseResumeTest` pin the entry-guard, resume-scheduling, idempotency, interface-default, pause happy-path (with `cancel(false)` verified specifically — `CompletableFuture#cancel` ignores the flag, so a regression to `cancel(true)` would otherwise slip past), pause + Interrupted (with cause-chain assertions plus a companion test that the catch path does NOT cancel a non-null pending future), pause + ExecutionException (with two-level cause-chain assertion), and resume schedule contracts. The four no-schedule resume tests verify `scheduleResumeFlush()` was never invoked at the seam, not only the post-state field. Total `WOWCache*Test` count: 76 / 76 pass.
- Coverage Gate locally: line 92.3% (24/26), branch 90.9% (20/22), both pass.
- `spotless:check` clean.
- 9-dimensional review run (code-quality, bugs-concurrency, crash-safety, performance + 5 test-quality reviewers) returned zero correctness blockers; all recommended fixes are folded into this PR. The follow-up CI Coverage Gate fix went through a second 7-dimensional pass with iteration-2 confirmation that all should-fix findings were resolved.

##### Out-of-scope follow-ups, filed separately

- [YTDB-797](https://youtrack.jetbrains.com/issue/YTDB-797): `restoreFrom` catches `RuntimeException` and drops rest of the WAL on first bad page.
- [YTDB-798](https://youtrack.jetbrains.com/issue/YTDB-798): `PageOperation` replay branch missing `initialLsn` check that `UpdatePageRecord` retains.
- [YTDB-799](https://youtrack.jetbrains.com/issue/YTDB-799): TOCTOU between `wal.begin()` and `addCutTillLimit` in `WalTestUtils.withWalProtection`.
- [YTDB-800](https://youtrack.jetbrains.com/issue/YTDB-800): Re-enable or delete `@Ignore`d WAL-restore sibling tests (share the same helper).
- [YTDB-801](https://youtrack.jetbrains.com/issue/YTDB-801): Remove the now-redundant `Thread.sleep(1500)` at `LocalPaginatedStorageRestoreFromWALIT.java:130`.
