### PR TITLE
YTDB-684: Verify ## Base commit is HEAD-ancestor before Phase B/C reads

### DIFF
--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -139,6 +139,20 @@ Phase B, before the first implementation commit. Phase B writes this once
 at session start. Phase C reads it to compute `git diff {base_commit}..HEAD`
 for the track-level code review.
 
+**Readers must verify the recorded SHA is a HEAD-ancestor before using
+it.** A rebase between recording and reading rewrites every on-branch
+commit; the recorded SHA still resolves (kept in the reflog) but is no
+longer an ancestor of HEAD, and any `git diff` / `git log` computed
+against it returns commits from earlier tracks. The canonical preflight
++ recompute procedure lives at the two reader sites:
+[`step-implementation.md`](step-implementation.md) §Phase B Startup
+step 1 (resume case) and
+[`track-code-review.md`](track-code-review.md) §Phase C Startup
+step 2. On stale, both sites recompute the actual on-branch parent
+from the `Record Phase B base commit for` commit and append a
+discrepancy note to this section — they never overwrite the original
+SHA, so the audit trail records both values.
+
 The **Reviews completed** section records which pre-execution reviews
 finished. If a session is interrupted during Phase A, the next session
 can skip completed reviews and only re-run missing ones.

--- a/.claude/workflow/conventions-execution.md
+++ b/.claude/workflow/conventions-execution.md
@@ -143,8 +143,8 @@ for the track-level code review.
 it.** A rebase between recording and reading rewrites every on-branch
 commit; the recorded SHA still resolves (kept in the reflog) but is no
 longer an ancestor of HEAD, and any `git diff` / `git log` computed
-against it returns commits from earlier tracks. The canonical preflight
-+ recompute procedure lives at the two reader sites:
+against it returns commits from earlier tracks. The canonical
+preflight-and-recompute procedure lives at the two reader sites:
 [`step-implementation.md`](step-implementation.md) §Phase B Startup
 step 1 (resume case) and
 [`track-code-review.md`](track-code-review.md) §Phase C Startup

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -82,19 +82,20 @@ Before spawning the first implementer:
    the orphans for this track.
 
    ```bash
-   if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+   ACTUAL_BASE="$BASE_SHA"
+   if ! git merge-base --is-ancestor "$ACTUAL_BASE" HEAD; then
        # Stale — typically a post-Phase-B rebase.
        RECORDING=$(git log -F \
            --grep="Record Phase B base commit for <track>" \
-           --format=%H HEAD | head -1)
+           --format=%H HEAD | head -n 1)
        if [ -z "$RECORDING" ]; then
            # No recording commit on HEAD's path — surface to user;
            # do not invent a base.
            exit 1
        fi
        ACTUAL_BASE=$(git log -1 --format=%P "$RECORDING")
-       # Use $ACTUAL_BASE as {base_commit} for the rest of Phase B.
    fi
+   # Use $ACTUAL_BASE as {base_commit} for the rest of Phase B.
    ```
 
    Scope `git log` to `HEAD` (not `--all`) and match the track title

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -84,18 +84,25 @@ Before spawning the first implementer:
    ```bash
    if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
        # Stale — typically a post-Phase-B rebase.
-       RECORDING=$(git log --grep="^Record Phase B base commit for <track>" \
+       RECORDING=$(git log -F \
+           --grep="Record Phase B base commit for <track>" \
            --format=%H HEAD | head -1)
+       if [ -z "$RECORDING" ]; then
+           # No recording commit on HEAD's path — surface to user;
+           # do not invent a base.
+           exit 1
+       fi
        ACTUAL_BASE=$(git log -1 --format=%P "$RECORDING")
        # Use $ACTUAL_BASE as {base_commit} for the rest of Phase B.
    fi
    ```
 
-   Scope `git log` to `HEAD` (not `--all`) and grep on the track
-   title so the lookup ignores reflog orphans and other tracks'
-   recording commits. If `git log --grep` returns nothing, surface
-   the discrepancy to the user before proceeding; do not invent a
-   base.
+   Scope `git log` to `HEAD` (not `--all`) and match the track title
+   literally with `-F` (fixed-strings) so titles containing regex
+   metacharacters (`.`, `(`, `[`, `*`, …) cannot mis-match and so
+   reflog orphans and other tracks' recording commits are ignored.
+   If `git log --grep` returns nothing, surface the discrepancy to
+   the user before proceeding; do not invent a base.
 
    On stale, **append** a discrepancy note to the step file's
    `## Base commit` section (do not overwrite the original SHA —

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -71,6 +71,51 @@ Before spawning the first implementer:
 
    Skip the commit on resume (when `## Base commit` already had a
    SHA and no write happened).
+
+   **On resume, verify the recorded base is reachable from HEAD
+   before using it for orphan detection (step 3 below) or any other
+   downstream computation.** A rebase between the prior session and
+   this resume rewrites every on-branch commit; the recorded SHA
+   still resolves (the old object stays in the reflog) but is no
+   longer an ancestor of HEAD, and `git log {base_commit}..HEAD`
+   would then enumerate commits from earlier tracks instead of just
+   the orphans for this track.
+
+   ```bash
+   if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+       # Stale — typically a post-Phase-B rebase.
+       RECORDING=$(git log --grep="^Record Phase B base commit for <track>" \
+           --format=%H HEAD | head -1)
+       ACTUAL_BASE=$(git log -1 --format=%P "$RECORDING")
+       # Use $ACTUAL_BASE as {base_commit} for the rest of Phase B.
+   fi
+   ```
+
+   Scope `git log` to `HEAD` (not `--all`) and grep on the track
+   title so the lookup ignores reflog orphans and other tracks'
+   recording commits. If `git log --grep` returns nothing, surface
+   the discrepancy to the user before proceeding; do not invent a
+   base.
+
+   On stale, **append** a discrepancy note to the step file's
+   `## Base commit` section (do not overwrite the original SHA —
+   keep both for the audit trail):
+
+   ```
+   Note: recorded base <stale-sha> was stale (likely from a
+   rebase since Phase B); using actual on-branch parent <actual-sha>
+   for resume.
+   ```
+
+   Commit the step-file edit as a Workflow update commit before
+   spawning the first implementer (per
+   [`commit-conventions.md`](commit-conventions.md) § Commit type
+   prefixes — "Workflow update" row) so the draft PR records the
+   recompute. Use `$ACTUAL_BASE` as `{base_commit}` for the orphan
+   detection in step 3 and every subsequent reference in Phase B
+   (the implementer's `base_commit` field in §Implementer Prompt
+   Template, the recovery file's `git log {base_commit}..HEAD`
+   patterns).
 2. **Generate the slim plan snapshot** at
    `/tmp/claude-code-plan-slim-$PPID.md` by running:
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -120,19 +120,20 @@ of the changes.
    parent from the `Record Phase B base commit for` commit:
 
    ```bash
-   if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+   ACTUAL_BASE="$BASE_SHA"
+   if ! git merge-base --is-ancestor "$ACTUAL_BASE" HEAD; then
        # Stale — typically a post-Phase-B rebase.
        RECORDING=$(git log -F \
-           --grep="Record Phase B base commit for <track-title>" \
-           --format=%H HEAD | head -1)
+           --grep="Record Phase B base commit for <track>" \
+           --format=%H HEAD | head -n 1)
        if [ -z "$RECORDING" ]; then
            # No recording commit on HEAD's path — surface to user;
            # do not invent a base.
            exit 1
        fi
        ACTUAL_BASE=$(git log -1 --format=%P "$RECORDING")
-       # Use $ACTUAL_BASE as {base_commit} for the rest of Phase C.
    fi
+   # Use $ACTUAL_BASE as {base_commit} for the rest of Phase C.
    ```
 
    Scope `git log` to `HEAD` (not `--all`) and match the track title

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -122,18 +122,26 @@ of the changes.
    ```bash
    if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
        # Stale — typically a post-Phase-B rebase.
-       RECORDING=$(git log --grep="^Record Phase B base commit for <track-title>" \
+       RECORDING=$(git log -F \
+           --grep="Record Phase B base commit for <track-title>" \
            --format=%H HEAD | head -1)
+       if [ -z "$RECORDING" ]; then
+           # No recording commit on HEAD's path — surface to user;
+           # do not invent a base.
+           exit 1
+       fi
        ACTUAL_BASE=$(git log -1 --format=%P "$RECORDING")
        # Use $ACTUAL_BASE as {base_commit} for the rest of Phase C.
    fi
    ```
 
-   Scope `git log` to `HEAD` (not `--all`) and grep on the track title
-   so the lookup ignores reflog orphans and any other tracks' recording
-   commits. If `git log --grep` returns nothing (no recording commit on
-   HEAD's path for this track), the base SHA was never written through
-   the workflow path — surface the discrepancy to the user before
+   Scope `git log` to `HEAD` (not `--all`) and match the track title
+   literally with `-F` (fixed-strings) so titles containing regex
+   metacharacters (`.`, `(`, `[`, `*`, …) cannot mis-match and so
+   reflog orphans and any other tracks' recording commits are ignored.
+   If `git log --grep` returns nothing (no recording commit on HEAD's
+   path for this track), the base SHA was never written through the
+   workflow path — surface the discrepancy to the user before
    proceeding; do not invent a base.
 
    On stale, **append** a discrepancy note to the step file's `## Base

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -108,12 +108,58 @@ of the changes.
 
 1. Read the step file's `## Base commit` section to get the SHA recorded
    at the start of Phase B.
-2. Read the **implementation plan** (`docs/adr/<dir-name>/_workflow/implementation-plan.md`)
+2. **Verify the recorded base is reachable from HEAD.** A rebase
+   between Phase B and Phase C rewrites every on-branch commit, so the
+   SHA recorded at Phase B startup still resolves (the old object stays
+   in the reflog) but is no longer an ancestor of HEAD. `git diff
+   <stale-base>..HEAD` then returns commits from earlier tracks —
+   either inflating the review diff by orders of magnitude or, after a
+   subtle rebase, silently shifting it by a handful of files.
+
+   Run the ancestor check, and on stale, recompute the actual on-branch
+   parent from the `Record Phase B base commit for` commit:
+
+   ```bash
+   if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+       # Stale — typically a post-Phase-B rebase.
+       RECORDING=$(git log --grep="^Record Phase B base commit for <track-title>" \
+           --format=%H HEAD | head -1)
+       ACTUAL_BASE=$(git log -1 --format=%P "$RECORDING")
+       # Use $ACTUAL_BASE as {base_commit} for the rest of Phase C.
+   fi
+   ```
+
+   Scope `git log` to `HEAD` (not `--all`) and grep on the track title
+   so the lookup ignores reflog orphans and any other tracks' recording
+   commits. If `git log --grep` returns nothing (no recording commit on
+   HEAD's path for this track), the base SHA was never written through
+   the workflow path — surface the discrepancy to the user before
+   proceeding; do not invent a base.
+
+   On stale, **append** a discrepancy note to the step file's `## Base
+   commit` section (do not overwrite the original SHA — keep both for
+   the audit trail):
+
+   ```
+   Note: recorded base <stale-sha> was stale (likely from a
+   post-Phase-B rebase); using actual on-branch parent <actual-sha>
+   for this Phase C.
+   ```
+
+   Commit the step-file edit as a Workflow update commit before
+   continuing (per
+   [`commit-conventions.md`](commit-conventions.md) § Commit type
+   prefixes — "Workflow update" row) so the draft PR records the
+   recompute. Use `$ACTUAL_BASE` as `{base_commit}` for every
+   subsequent step in Phase C (review sub-agent spawns, the diff
+   measurement at step 7, the implementer's `base_commit` field in
+   §Implementer Spawns).
+3. Read the **implementation plan** (`docs/adr/<dir-name>/_workflow/implementation-plan.md`)
    — this provides strategic context (goals, architecture notes, decision
    records, track episodes from completed tracks).
-3. Read the **step file** (`docs/adr/<dir-name>/_workflow/tracks/track-N.md`) — this
+4. Read the **step file** (`docs/adr/<dir-name>/_workflow/tracks/track-N.md`) — this
    provides the step descriptions and episodes.
-4. **Generate the slim plan snapshot** at
+5. **Generate the slim plan snapshot** at
    `/tmp/claude-code-plan-slim-$PPID.md` by running:
 
    ```bash
@@ -134,9 +180,9 @@ of the changes.
    agent's tool-call history from accumulating a plan copy per
    sub-agent spawn. Regenerate the snapshot if plan corrections are
    applied during the review loop (before the next spawn batch).
-5. Use `{base_commit}` when spawning all review sub-agents.
+6. Use `{base_commit}` when spawning all review sub-agents.
    All sub-agents review `git diff {base_commit}..HEAD`.
-6. **Measure the cumulative diff and pre-stage if it exceeds the
+7. **Measure the cumulative diff and pre-stage if it exceeds the
    threshold.** Run:
 
    ```bash
@@ -228,7 +274,7 @@ this review carries more of the load there).
 {Below the size threshold (~3K diff lines / ~25 files): paste output
 of `git diff {base_commit}..HEAD --name-only` inline. Above the
 threshold: reference the pre-staged file written at Phase C Startup
-step 6 —
+step 7 —
   pre_staged_files_path: /tmp/claude-code-track-{N}-files-{PPID}.txt
 The sub-agent reads it via Bash / Read.}
 
@@ -256,7 +302,7 @@ that depends on a symbol search.
 `git diff {base_commit}..HEAD` inline (the diff is the review target
 and at small sizes the orchestrator tool-call cost is negligible).
 Above the threshold: reference the pre-staged file written at
-Phase C Startup step 6 —
+Phase C Startup step 7 —
   pre_staged_diff_path: /tmp/claude-code-track-{N}-diff-{PPID}.patch
 The sub-agent reads it via Bash / Read. See § "Pre-stage above
 threshold" below for staging mechanics and regeneration rules.}
@@ -265,7 +311,7 @@ threshold" below for staging mechanics and regeneration rules.}
 ### Pre-stage above threshold
 
 For cumulative track diffs exceeding ~3K lines or ~25 files, the diff
-and the changed-files list are pre-staged at Phase C Startup step 6
+and the changed-files list are pre-staged at Phase C Startup step 7
 and the canonical context block references the staged paths instead
 of inlining content.
 
@@ -303,7 +349,7 @@ The unique-suffix requirement from project-level `CLAUDE.md`
 commit.** Each iteration's `Review fix:` commit grows the cumulative
 diff, so any previously staged files go stale and a previously
 sub-threshold diff may now exceed the threshold. Re-run the full
-measurement + staging logic from Phase C Startup step 6 before
+measurement + staging logic from Phase C Startup step 7 before
 composing the next fan-out's sub-agent prompts — this covers both
 the in-loop gate-check fan-out (§ Iteration loop) and the post-approval
 re-review fan-out triggered by user-requested fixes during
@@ -448,7 +494,7 @@ orchestrator never edits source files itself in Phase C.
      The gate-check sub-agents review the new HEAD (after the
      `Review fix:` commit), which they reach via the same
      `git diff {base_commit}..HEAD` instruction. **Re-run the
-     measurement + staging logic from Phase C Startup step 6 before
+     measurement + staging logic from Phase C Startup step 7 before
      composing the gate-check prompts** — the new `Review fix:` commit
      grew the cumulative diff, which may now exceed the threshold (and
      need fresh staging) or, if already staged, leave the staged copies


### PR DESCRIPTION
#### Motivation:

The Phase B `git rev-parse HEAD` SHA written to `## Base commit` survives a subsequent rebase as an unreachable object in the reflog, but it stops being a HEAD-ancestor. Phase C's `git diff {base_commit}..HEAD` then silently scopes to the wrong commit range — in the unit-test-coverage / Track 19 incident the recorded base returned 305 commits / 39 files / 5,836 insertions where the correct on-branch parent gave 28 / 5,169. Detection there required spotting a `CommitDate` divergence in a duplicate-named commit, which is not a signal the orchestrator can always rely on.

#### Summary

- Add an explicit HEAD-ancestor preflight at every `## Base commit` reader: Phase C Startup (`track-code-review.md` step 2) and Phase B Resume (`step-implementation.md` step 1). On stale, recompute the actual on-branch parent from the `Record Phase B base commit for <track>` commit, append a discrepancy note to `## Base commit` (never overwrite the original SHA — keep both for audit), and commit the note as a Workflow update before continuing.
- Scope the recompute's `git log --grep` to `HEAD` (not `--all`) so reflog orphans and other tracks' recording commits can't match. Pass `-F` (fixed-strings) so track titles containing regex metacharacters (`.`, `(`, `[`, `*`, …) match literally, eliminating both false positives and false negatives.
- Explicit empty-result guard: if no recording commit is found on HEAD's path, exit with a discrepancy surfaced to the user instead of silently falling back to `git log -1 HEAD` (which would have returned HEAD's parent and masked the missing-recording case).
- `conventions-execution.md`'s `## Base commit` schema description now points at both reader sites so a grep for the section name reaches the canonical preflight-and-recompute procedure.

#### Test plan

- [ ] Manual: simulate a Phase B → rebase → Phase C resume locally; confirm the preflight detects the stale SHA, the recompute recovers the correct base, and a discrepancy note is appended to `## Base commit`.
- [ ] Manual: confirm a track title containing regex metacharacters (e.g., `Refactor X.foo()`) is matched literally by the `-F` grep.
- [ ] Manual: confirm the empty-result guard fires when no recording commit exists on HEAD's path (e.g., after a workflow-skipping squash).