### PR TITLE
YTDB-675: Make implementer push obligation explicit and harden recovery

### DIFF
--- a/.claude/workflow/defensive-push-check.md
+++ b/.claude/workflow/defensive-push-check.md
@@ -1,0 +1,76 @@
+# Defensive push check
+
+Loaded by Phase B `on_success` ([`step-implementation.md`](step-implementation.md))
+and Phase C `on_iteration_success`
+([`track-code-review.md`](track-code-review.md)) immediately after
+the implementer returns `RESULT: SUCCESS`. The implementer contract
+([`implementer-rules.md`](implementer-rules.md) §Return contract)
+already requires that `SUCCESS` implies `result.COMMIT` has been
+pushed to `origin`; this check is the orchestrator-side assertion of
+that invariant.
+
+## Why it exists
+
+A clean-context sub-agent can drop a step (run the commit, forget the
+push) without intending to violate the contract. Pushing the orphan
+locally is a side-effect, not a content decision, so auto-recovery
+here is safe — the commit's content has already passed the
+implementer's tests and (for fix commits) the dimensional review.
+Surfacing every orphan to the user instead would block on a
+correctable mechanical slip.
+
+## Procedure
+
+The orchestrator inserts `result.COMMIT` from the implementer's
+return block where the recipe says `$COMMIT`. The current branch
+must have an upstream — Phase B and Phase C always run after the
+branch's first `git push -u`, but the probe below guards against
+edge cases (fresh worktree, detached HEAD recovery).
+
+```bash
+# 1. Probe upstream. If unset, the implementer's own push would have
+#    surfaced the problem; nothing for the orchestrator to verify.
+git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1 \
+  || { echo "no upstream — skipping defensive push check"; exit 0; }
+
+# 2. Assert result.COMMIT is reachable from origin.
+if git merge-base --is-ancestor "$COMMIT" '@{u}'; then
+  : # invariant holds
+else
+  # Contract violation: implementer returned SUCCESS but the commit
+  # is not on origin. Push the orphan and continue.
+  git push
+fi
+```
+
+The check uses `merge-base --is-ancestor` rather than asking whether
+`@{u}..HEAD` is empty: the ancestor form directly asserts the
+contract ("`result.COMMIT` is on `origin`") instead of the weaker
+"no local commits are ahead of `origin`," which can be spuriously
+true when `HEAD` happens to match `origin` at a different SHA.
+
+## Recovery push failure
+
+If the orchestrator's recovery `git push` fails, route per
+[`commit-conventions.md`](commit-conventions.md) § Push failure
+handling: `non-fast-forward` → load
+[`branch-divergence-check.md`](branch-divergence-check.md) (gated
+to the first per-session rejection, as already specified in
+`step-implementation.md`'s established push-failure block); other
+shapes (network, auth, pre-receive hook, large-file rejection) →
+record the failure in the session log and continue with the next
+phase action per the conventions doc's record-and-continue rule.
+Do not silently continue with an unpushed commit beyond the
+record-and-continue allowance defined there.
+
+## Caller framing
+
+Callers vary the surrounding prose to name the commit class:
+
+- `step-implementation.md` § `on_success` — the implementer's primary
+  step commit.
+- `track-code-review.md` § `on_iteration_success` — the `Review fix:`
+  commit applied on top of the track diff.
+
+Otherwise the recipe is identical at both sites. Update this file,
+not the call sites, when the procedure changes.

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -211,8 +211,8 @@ also defines the test-additive shortcut that skips the
 coverage-profile build when the step adds no production-source
 changes.
 
-**Sub-step 3 — Stage explicit paths and commit** in one commit. No
-`git add -A`. No `--amend`. Apply the project's commit-message
+**Sub-step 3 — Stage explicit paths, commit, and push** in one commit.
+No `git add -A`. No `--amend`. Apply the project's commit-message
 convention from `CLAUDE.md` (imperative summary under 50 chars, blank
 line, detailed why). The Ephemeral identifier rule
 ([`conventions-execution.md`](conventions-execution.md) §2.3) covers
@@ -234,6 +234,20 @@ episode commit, since Phase B is fully done before Phase C runs);
 see [`commit-conventions.md`](commit-conventions.md) and
 [`step-implementation-recovery.md`](step-implementation-recovery.md)
 §Resume-side commit-pattern reference.
+
+**After the commit lands, run `git push` immediately** per
+[`commit-conventions.md`](commit-conventions.md) § Push every commit.
+The implementer is responsible for the push; the orchestrator does
+not push on the implementer's behalf. Inspect the `git push` exit
+code: a successful push is a precondition for emitting
+`RESULT: SUCCESS` (see §Return contract `COMMIT` field rule below).
+On push failure (`non-fast-forward` from concurrent activity, network
+blip, auth, pre-receive hook), do **not** emit `SUCCESS` — surface
+the situation via `RESULT: FAILED` with
+`FAILURE.recommended_action: retry` and `FAILURE.why_it_failed`
+naming the push failure shape, so the Phase B / Phase C orchestrator
+can reconcile (e.g., run the branch-divergence gate before
+respawning).
 
 **Return.** Emit the structured result block (see §Return contract
 below). The orchestrator parses the block; everything else in the
@@ -766,6 +780,15 @@ FAILURE:                          # only if RESULT == FAILED
   `mode=INITIAL`/`WITH_GUIDANCE` it is the step's primary commit; at
   `level=step` with `mode=FIX_REVIEW_FINDINGS` and at `level=track`
   it is the SHA of the `Review fix:` commit applied on top.
+  **`RESULT: SUCCESS` implies the commit at `COMMIT` has been pushed
+  to `origin`.** Sub-step 3 above mandates `git push` immediately
+  after the commit lands. If the push failed (e.g.,
+  `non-fast-forward` from concurrent activity, network blip, auth,
+  pre-receive hook), do not emit `SUCCESS` — emit `RESULT: FAILED`
+  with `FAILURE.recommended_action: retry` and a
+  `FAILURE.why_it_failed` that names the push failure shape, so the
+  orchestrator can reconcile (e.g., run the branch-divergence gate
+  before respawning).
 - `FILES_TOUCHED` lists every path in the diff with a `(new)` or
   `(modified)` annotation. On `FAILED`, list paths the implementer
   attempted to modify even though they are now reverted.

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -241,13 +241,18 @@ The implementer is responsible for the push; the orchestrator does
 not push on the implementer's behalf. Inspect the `git push` exit
 code: a successful push is a precondition for emitting
 `RESULT: SUCCESS` (see §Return contract `COMMIT` field rule below).
-On push failure (`non-fast-forward` from concurrent activity, network
-blip, auth, pre-receive hook), do **not** emit `SUCCESS` — surface
-the situation via `RESULT: FAILED` with
-`FAILURE.recommended_action: retry` and `FAILURE.why_it_failed`
-naming the push failure shape, so the Phase B / Phase C orchestrator
-can reconcile (e.g., run the branch-divergence gate before
-respawning).
+On push failure (the shapes enumerated in
+[`commit-conventions.md`](commit-conventions.md) § Push failure
+handling), do **not** emit `SUCCESS`. Surface the situation via
+`RESULT: FAILED` with `FAILURE.recommended_action: retry`,
+`FAILURE.failure_class: push_only`, and `FAILURE.why_it_failed`
+naming the push failure shape. The `failure_class: push_only` flag
+tells the orchestrator that the commit content is fine and only the
+push relationship to `origin` failed — at `mode=FIX_REVIEW_FINDINGS`
+the orchestrator skips the rollback that would otherwise revert the
+implementer's good commit (see
+[`step-implementation-recovery.md`](step-implementation-recovery.md)
+§`rollback_and_handle_failure`).
 
 **Return.** Emit the structured result block (see §Return contract
 below). The orchestrator parses the block; everything else in the
@@ -768,6 +773,13 @@ FAILURE:                          # only if RESULT == FAILED
                                   # §Fundamental failure above).
                                   # Allowed values at level=track:
                                   # retry | escalate.
+  failure_class: push_only | content
+                                  # default: content. Set to push_only
+                                  # when the commit landed locally but
+                                  # `git push` failed (see Sub-step 3
+                                  # above). Routes the orchestrator
+                                  # past the rollback handler — the
+                                  # commit content is fine.
 ```
 
 ### Field rules
@@ -782,13 +794,12 @@ FAILURE:                          # only if RESULT == FAILED
   it is the SHA of the `Review fix:` commit applied on top.
   **`RESULT: SUCCESS` implies the commit at `COMMIT` has been pushed
   to `origin`.** Sub-step 3 above mandates `git push` immediately
-  after the commit lands. If the push failed (e.g.,
-  `non-fast-forward` from concurrent activity, network blip, auth,
-  pre-receive hook), do not emit `SUCCESS` — emit `RESULT: FAILED`
-  with `FAILURE.recommended_action: retry` and a
-  `FAILURE.why_it_failed` that names the push failure shape, so the
-  orchestrator can reconcile (e.g., run the branch-divergence gate
-  before respawning).
+  after the commit lands. If the push failed (see Sub-step 3 above
+  for the failure-shape reference), do not emit `SUCCESS`. Emit
+  `RESULT: FAILED` with `FAILURE.recommended_action: retry`,
+  `FAILURE.failure_class: push_only`, and a `FAILURE.why_it_failed`
+  that names the push failure shape so the orchestrator can
+  reconcile without rolling back the commit.
 - `FILES_TOUCHED` lists every path in the diff with a `(new)` or
   `(modified)` annotation. On `FAILED`, list paths the implementer
   attempted to modify even though they are now reverted.
@@ -830,6 +841,17 @@ FAILURE:                          # only if RESULT == FAILED
   §"Fundamental failure" above). Returning `split` from a
   `level=track` spawn is a contract violation; the orchestrator
   surfaces the return to the user instead of dispatching.
+- `FAILURE.failure_class` discriminates content failures (`content`,
+  the default) from push-only failures (`push_only`). Set `push_only`
+  only when Sub-step 1's content work succeeded, Sub-step 3's commit
+  landed locally, and only `git push` failed. The orchestrator uses
+  this flag at `mode=FIX_REVIEW_FINDINGS` to skip the rollback path
+  in `rollback_and_handle_failure` — see
+  [`step-implementation-recovery.md`](step-implementation-recovery.md).
+  Omit or set to `content` for every other failure (work didn't
+  start, tests failed, spotless failed, commit refused, etc.).
+  Mis-tagging a content failure as `push_only` leaves a broken
+  commit at HEAD and is a contract violation.
 
 ---
 

--- a/.claude/workflow/step-implementation-recovery.md
+++ b/.claude/workflow/step-implementation-recovery.md
@@ -339,12 +339,45 @@ Triggered when `result.RESULT == FAILED` from `mode=INITIAL` or
 `mode=FIX_REVIEW_FINDINGS`, the dim-review loop dispatches to
 `rollback_and_handle_failure` instead — see §Post-Commit Handlers.
 
-The implementer has already reverted any uncommitted changes and
-removed any untracked artefacts
-(the snapshot-and-diff revert sequence) before returning, so the
-working tree is clean at `step_base_commit`. `result.FAILURE` carries
-`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
-and `recommended_action`.
+`result.FAILURE` carries `what_was_attempted`, `why_it_failed`,
+`impact_on_remaining_steps`, `recommended_action`, and
+`failure_class`.
+
+**Pre-step: push-only short-circuit.** If
+`result.FAILURE.failure_class == push_only`, the step's content is
+fine — Sub-steps 1–2 succeeded, the commit landed at HEAD, and only
+`git push` failed (see
+[`implementer-rules.md`](implementer-rules.md) §Return contract).
+The working tree is **not** clean at `step_base_commit` in this case
+(the implementer's commit is at HEAD by design); the snapshot-and-diff
+revert assumption documented below does **not** apply.
+
+Skip the `[!]` write and retry/split inserts entirely. Instead:
+
+1. Route the push failure per
+   [`commit-conventions.md`](commit-conventions.md) § Push failure
+   handling — `non-fast-forward` triggers
+   [`branch-divergence-check.md`](branch-divergence-check.md) (gated
+   to first per-session rejection); other shapes record-and-continue.
+2. After the gate (or record-and-continue), run `git push` from the
+   orchestrator to publish the implementer's commit.
+3. If the orchestrator's push succeeds, `result.COMMIT` is now on
+   `origin`. Synthesise the success path: treat the return as if the
+   implementer had emitted `SUCCESS`, then run `on_success(step,
+   result)` ([`step-implementation.md`](step-implementation.md))
+   from the top so the dimensional review loop, gate checks, and
+   episode write all happen on the now-pushed commit.
+4. If the orchestrator's push still fails after the gate, escalate
+   to the user with the step commit SHA and the `git push` stderr —
+   the situation is no longer mechanically recoverable. Do **not**
+   fall through to the numbered steps below; the commit at HEAD is
+   good work that should not be marked `[!]` for content reasons.
+
+The numbered steps below apply only to the default
+`failure_class: content` path. In that path the implementer has
+already reverted any uncommitted changes and removed any untracked
+artefacts (the snapshot-and-diff revert sequence) before returning,
+so the working tree is clean at `step_base_commit`.
 
 1. **Write the failed episode** to the step file from
    `result.FAILURE` (mark the step `[!]`).
@@ -442,7 +475,38 @@ Triggered when a `FIX_REVIEW_FINDINGS` respawn returns
 typically because the findings reveal a deeper issue than a
 mechanical fix can address. `fix_result.FAILURE` carries
 `what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`,
-and `recommended_action`.
+`recommended_action`, and `failure_class`.
+
+**Pre-step: push-only short-circuit.** If
+`fix_result.FAILURE.failure_class == push_only`, the `Review fix:`
+commit content is fine — Sub-step 1's work succeeded, the commit
+landed locally, and only `git push` failed (see
+[`implementer-rules.md`](implementer-rules.md) §Return contract).
+Skip the rollback entirely. Instead:
+
+1. Route the push failure per
+   [`commit-conventions.md`](commit-conventions.md) § Push failure
+   handling — `non-fast-forward` triggers
+   [`branch-divergence-check.md`](branch-divergence-check.md) (gated
+   to first per-session rejection); other shapes record-and-continue.
+2. After the divergence gate completes (or record-and-continue), run
+   `git push` from the orchestrator to publish the existing
+   `Review fix:` commit.
+3. If the orchestrator's push succeeds, treat the iteration as
+   successful — `result.COMMIT` is now on `origin`. Proceed with the
+   rest of `on_iteration_success`
+   ([`track-code-review.md`](track-code-review.md)) as if the
+   implementer had completed the push itself: stash `FIX_NOTES`,
+   continue with the gate-check fan-out. Do not run the rollback
+   steps below.
+4. If the orchestrator's push still fails after the gate, escalate
+   to the user with the `Review fix:` SHA and the `git push` stderr —
+   the situation is no longer mechanically recoverable.
+
+The numbered rollback steps below apply only to the default
+`failure_class: content` path. Reverting a good commit because
+its push collided with concurrent activity would destroy work the
+implementer already finished and validated.
 
 1. **Run the rollback** (revert + `Revert step:` commit) per the
    common procedure above. The revert lands **before** any step-file
@@ -551,16 +615,25 @@ trying to patch it — is the wrong tradeoff.
 
 ## Step Failure
 
-If the implementer returns `RESULT: FAILED`, the implementer has
-already reverted uncommitted changes and removed any untracked
-artefacts (the snapshot-and-diff revert sequence). For
-pre-commit failures (`mode=INITIAL` / `mode=WITH_GUIDANCE`) the
-working tree is now clean at `step_base_commit` and the orchestrator
-proceeds directly with the steps below. For post-commit failures
+If the implementer returns `RESULT: FAILED` with the default
+`failure_class: content`, the implementer has already reverted
+uncommitted changes and removed any untracked artefacts (the
+snapshot-and-diff revert sequence). For pre-commit failures
+(`mode=INITIAL` / `mode=WITH_GUIDANCE`) the working tree is now
+clean at `step_base_commit` and the orchestrator proceeds directly
+with the steps below. For post-commit failures
 (`mode=FIX_REVIEW_FINDINGS`) the orchestrator first runs the
 rollback per §Post-Commit Handlers, then proceeds with the steps
-below; the retry/split rows below apply to both. The orchestrator
-handles the rest:
+below; the retry/split rows below apply to both.
+
+`failure_class: push_only` short-circuits this entire flow — the
+commit at HEAD is good content that only failed to push. The
+relevant handler (`handle_failure` or `rollback_and_handle_failure`)
+runs its push-only pre-step instead of the rollback / step-file
+write, and on success routes back through `on_success` rather than
+the retry/split protocol below. See those handlers for the detail.
+
+For the `content` path the orchestrator handles the rest:
 
 1. **Write a failed episode** to the step file from
    `result.FAILURE` (see

--- a/.claude/workflow/step-implementation-recovery.md
+++ b/.claude/workflow/step-implementation-recovery.md
@@ -493,12 +493,13 @@ Skip the rollback entirely. Instead:
    `git push` from the orchestrator to publish the existing
    `Review fix:` commit.
 3. If the orchestrator's push succeeds, treat the iteration as
-   successful — `result.COMMIT` is now on `origin`. Proceed with the
-   rest of `on_iteration_success`
-   ([`track-code-review.md`](track-code-review.md)) as if the
-   implementer had completed the push itself: stash `FIX_NOTES`,
-   continue with the gate-check fan-out. Do not run the rollback
-   steps below.
+   successful — `result.COMMIT` is now on `origin`. Resume the
+   dimensional review loop in
+   [`step-implementation.md`](step-implementation.md) §Sub-step 4 as
+   if the implementer had returned `SUCCESS`: the new `Review fix:`
+   commit becomes the diff target for the next gate-check iteration
+   (re-run only the dimension(s) with open findings, max 3 iterations
+   total per the protocol). Do not run the rollback steps below.
 4. If the orchestrator's push still fails after the gate, escalate
    to the user with the `Review fix:` SHA and the `git push` stderr —
    the situation is no longer mechanically recoverable.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -349,27 +349,12 @@ The implementer's commit is now on disk; `result.COMMIT` is its SHA.
 Per [`implementer-rules.md`](implementer-rules.md) §Return contract,
 `RESULT: SUCCESS` implies the commit has been pushed to `origin`.
 
-**Defensive push check.** Before running sub-steps 4–7, verify the
-commit is actually on `origin`:
-
-```bash
-git log @{u}..HEAD --format=%H
-```
-
-Expected output: empty (no local-only commits). If the output names
-any commit — including `result.COMMIT` itself — the implementer
-emitted `SUCCESS` without pushing, which is a contract violation.
-Recover by pushing the orphan(s) immediately:
-
-```bash
-git push
-```
-
-Then proceed with sub-steps 4–7. If the push fails (e.g.,
-`non-fast-forward`), route through
-[`branch-divergence-check.md`](branch-divergence-check.md) per
-`commit-conventions.md` § Push failure handling — do not silently
-continue with an unpushed implementer commit.
+**Defensive push check.** Before running sub-steps 4–7, assert that
+the implementer's step commit (`result.COMMIT`) is on `origin` per
+[`defensive-push-check.md`](defensive-push-check.md). The check
+short-circuits when no upstream is set, asserts ancestry against
+`@{u}`, and auto-recovers via `git push` if the implementer skipped
+the push.
 
 Run sub-steps 4–7 in order.
 

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -346,6 +346,31 @@ sub-agent context.
 ### `on_success(step, result)` — sub-steps 4–7
 
 The implementer's commit is now on disk; `result.COMMIT` is its SHA.
+Per [`implementer-rules.md`](implementer-rules.md) §Return contract,
+`RESULT: SUCCESS` implies the commit has been pushed to `origin`.
+
+**Defensive push check.** Before running sub-steps 4–7, verify the
+commit is actually on `origin`:
+
+```bash
+git log @{u}..HEAD --format=%H
+```
+
+Expected output: empty (no local-only commits). If the output names
+any commit — including `result.COMMIT` itself — the implementer
+emitted `SUCCESS` without pushing, which is a contract violation.
+Recover by pushing the orphan(s) immediately:
+
+```bash
+git push
+```
+
+Then proceed with sub-steps 4–7. If the push fails (e.g.,
+`non-fast-forward`), route through
+[`branch-divergence-check.md`](branch-divergence-check.md) per
+`commit-conventions.md` § Push failure handling — do not silently
+continue with an unpushed implementer commit.
+
 Run sub-steps 4–7 in order.
 
 **Sub-step 4 — Dimensional review loop (only when `step.risk_tag ==

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -578,31 +578,18 @@ iteration does not invalidate them).
 
 ### `on_iteration_success(result)`
 
-The implementer's `Review fix:` commit is on disk and — per
-[`implementer-rules.md`](implementer-rules.md) §Return contract —
-pushed to `origin`; `result.COMMIT` is its SHA. `result.FIX_NOTES`
-carries the implementer's per-iteration notes (which findings were
-addressed, which were skipped, what was discovered).
+The implementer's `Review fix:` commit is on disk and pushed to
+`origin` per [`implementer-rules.md`](implementer-rules.md) §Return
+contract; `result.COMMIT` is its SHA. `result.FIX_NOTES` carries the
+implementer's per-iteration notes (which findings were addressed,
+which were skipped, what was discovered).
 
 **Defensive push check.** Before stashing notes and proceeding,
-verify the `Review fix:` commit is actually on `origin`:
-
-```bash
-git log @{u}..HEAD --format=%H
-```
-
-Expected output: empty. If the output names any commit, the
-implementer emitted `SUCCESS` without pushing, which is a contract
-violation. Recover by pushing the orphan(s) immediately:
-
-```bash
-git push
-```
-
-If the push fails (e.g., `non-fast-forward`), route through
-[`branch-divergence-check.md`](branch-divergence-check.md) per
-`commit-conventions.md` § Push failure handling — do not silently
-continue with an unpushed `Review fix:` commit.
+assert that the `Review fix:` commit (`result.COMMIT`) is on
+`origin` per [`defensive-push-check.md`](defensive-push-check.md).
+The check short-circuits when no upstream is set, asserts ancestry
+against `@{u}`, and auto-recovers via `git push` if the implementer
+skipped the push.
 
 Stash `FIX_NOTES` and `CROSS_TRACK_HINTS` for inclusion in the
 eventual track episode (see §Track Completion below). Proceed to the
@@ -645,14 +632,44 @@ user instead of proceeding.
 
 ### `handle_iteration_failure(result)`
 
-Triggered when `result.RESULT == FAILED`. The implementer has run
+Triggered when `result.RESULT == FAILED`. `result.FAILURE` carries
+`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`
+(at `level=track` this is "impact on remaining findings"),
+`recommended_action`, and `failure_class`.
+
+**Pre-step: push-only short-circuit.** If
+`result.FAILURE.failure_class == push_only`, the `Review fix:`
+commit content is fine — content work succeeded, the commit landed
+at HEAD, and only `git push` failed (see
+[`implementer-rules.md`](implementer-rules.md) §Return contract).
+The clean-tree-at-HEAD assumption below does **not** apply; the
+`Review fix:` commit is at HEAD by design.
+
+Skip the failure-recording flow entirely. Instead:
+
+1. Route the push failure per
+   [`commit-conventions.md`](commit-conventions.md) § Push failure
+   handling — `non-fast-forward` triggers
+   [`branch-divergence-check.md`](branch-divergence-check.md) (gated
+   to first per-session rejection); other shapes record-and-continue.
+2. After the gate (or record-and-continue), run `git push` from the
+   orchestrator to publish the existing `Review fix:` commit.
+3. If the orchestrator's push succeeds, `result.COMMIT` is now on
+   `origin`. Synthesise the success path: route to
+   `on_iteration_success(result)` above so notes are stashed and the
+   gate-check fan-out runs on the now-pushed commit.
+4. If the orchestrator's push still fails after the gate, escalate
+   to the user with the `Review fix:` SHA and the `git push` stderr.
+   Do **not** fall through to the numbered steps below; the
+   `Review fix:` commit at HEAD is good work that should not be
+   recorded as a content failure.
+
+The numbered steps below apply only to the default
+`failure_class: content` path. In that path the implementer has run
 the snapshot-and-diff revert sequence per
 [`implementer-rules.md`](implementer-rules.md) §Detection rules, so
-the working tree is clean at HEAD; no `Review fix:` commit was
-produced this iteration. `result.FAILURE` carries
-`what_was_attempted`, `why_it_failed`, `impact_on_remaining_steps`
-(at `level=track` this is "impact on remaining findings"), and
-`recommended_action`.
+the working tree is clean at HEAD and no `Review fix:` commit was
+produced this iteration.
 
 Verify `git status` is clean before continuing. A dirty tree at this
 point is a contract violation, but per

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -578,13 +578,35 @@ iteration does not invalidate them).
 
 ### `on_iteration_success(result)`
 
-The implementer's `Review fix:` commit is on disk and pushed;
-`result.COMMIT` is its SHA. `result.FIX_NOTES` carries the
-implementer's per-iteration notes (which findings were addressed,
-which were skipped, what was discovered). Stash `FIX_NOTES` and
-`CROSS_TRACK_HINTS` for inclusion in the eventual track episode (see
-§Track Completion below). Proceed to the Progress update + gate-check
-fan-out per the review loop above.
+The implementer's `Review fix:` commit is on disk and — per
+[`implementer-rules.md`](implementer-rules.md) §Return contract —
+pushed to `origin`; `result.COMMIT` is its SHA. `result.FIX_NOTES`
+carries the implementer's per-iteration notes (which findings were
+addressed, which were skipped, what was discovered).
+
+**Defensive push check.** Before stashing notes and proceeding,
+verify the `Review fix:` commit is actually on `origin`:
+
+```bash
+git log @{u}..HEAD --format=%H
+```
+
+Expected output: empty. If the output names any commit, the
+implementer emitted `SUCCESS` without pushing, which is a contract
+violation. Recover by pushing the orphan(s) immediately:
+
+```bash
+git push
+```
+
+If the push fails (e.g., `non-fast-forward`), route through
+[`branch-divergence-check.md`](branch-divergence-check.md) per
+`commit-conventions.md` § Push failure handling — do not silently
+continue with an unpushed `Review fix:` commit.
+
+Stash `FIX_NOTES` and `CROSS_TRACK_HINTS` for inclusion in the
+eventual track episode (see §Track Completion below). Proceed to the
+Progress update + gate-check fan-out per the review loop above.
 
 ### `escalate_to_user_then_respawn(result)`
 


### PR DESCRIPTION
#### Motivation

In Track 18 Phase C iter-2 (2026-05-07) an implementer returned `RESULT: SUCCESS` with an unpushed commit. The implementer rulebook only mentioned the push obligation indirectly inside an orchestrator-cadence paragraph, sub-step 3 (commit) and the §Return contract said nothing about pushing, and the orchestrator had no defensive check — so the slip was silent until the next dispatch.

Follow-up review of the first fix exposed more sharp edges in the orchestrator-side defence:

- `git log @{u}..HEAD` crashed without an upstream and could spuriously pass when HEAD matched origin at a different SHA.
- A push-only failure inside `mode=FIX_REVIEW_FINDINGS` tripped `rollback_and_handle_failure` and reverted a good commit because a benign concurrent push collision was treated as a content failure.
- Two near-identical defensive blocks lived in `step-implementation.md` and `track-code-review.md`, prone to drift.

Gemini's PR review then caught that the Phase B push-only short-circuit copied Phase C symbols (`on_iteration_success`, `FIX_NOTES`, `track-code-review.md`) when it should resume the dim-review loop's gate check on the new commit.

#### What changed

**Implementer contract**
- `implementer-rules.md` sub-step 3 renamed to "commit and push"; mandates `git push` immediately after commit; on push failure return `RESULT: FAILED` with `recommended_action: retry` (not `SUCCESS`).
- §Return contract `COMMIT` field rule: `RESULT: SUCCESS` now explicitly implies the commit is on origin.
- New `FAILURE.failure_class: push_only | content` field. Push-after-commit failures must tag the return as `push_only` so the orchestrator can distinguish them from content failures. Mis-tagging is called out as a contract violation.

**Shared recovery snippet**
- Extracted the defensive push check into `defensive-push-check.md`. The recipe uses `git merge-base --is-ancestor "\$COMMIT" '@{u}'` against the actual commit SHA (not `@{u}..HEAD` emptiness), guards for missing upstream, and documents the silent-recovery policy.

**Orchestrator wiring**
- `handle_failure` (pre-commit FAILED in INITIAL / WITH_GUIDANCE), `rollback_and_handle_failure` (FIX_REVIEW_FINDINGS FAILED at level=step), and `handle_iteration_failure` (level=track FAILED) each short-circuit on `push_only`: route through the divergence gate, run the orchestrator-side push, and synthesise the success path so the good commit is never reverted. Persistent push failure escalates to the user.
- The `rollback_and_handle_failure` success path resumes the dim-review loop's gate check on the new commit (Phase B), not Phase C's `on_iteration_success`/`FIX_NOTES`.
- `step-implementation.md` `on_success` and `track-code-review.md` `on_iteration_success` now reference the shared snippet so the recipe lives in one place.

**Style**
- Trimmed em-dash overuse and redundant enumerations of push-failure shapes in the prose.

#### Test plan

- [ ] Workflow docs only — no code changes, no test gate impact (affected files are under `.claude/workflow/`).
- [ ] Manual: run a dispatch where the implementer commits but its `git push` is rejected (e.g., concurrent commit on remote). Verify the orchestrator's `push_only` short-circuit re-pushes the existing commit instead of reverting it.
- [ ] Manual: run a dispatch where the implementer returns `SUCCESS` with an unpushed commit. Verify the defensive `merge-base --is-ancestor` check in `on_success` triggers a recovery push.
- [ ] Manual: in a `FIX_REVIEW_FINDINGS` respawn with `failure_class: push_only`, confirm the orchestrator resumes the dim-review loop's gate check on the new commit instead of stashing FIX_NOTES.