### PR TITLE
YTDB-680: Require Phase A orchestrator to PSI-verify class names before writing step file

### DIFF
--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -95,22 +95,6 @@ authoritative source for edge cases.
 
 Review against these criteria:
 
-NAMED REFERENCES IN STEP FILE
-- For every production class, package, or SPI service named in the step
-  file's `## Description` (`**What/How/Constraints/Interactions**` blocks)
-  and `## Steps` bodies, verify the name resolves via PSI find-class
-  (`steroid_execute_code` with `JavaPsiFacade.findClass` or the shortname
-  recipe). Pattern-inducing class names from precedent (V1 → V2/V3) is a
-  known trap — generic-extraction refactors often collapse version-
-  suffixed classes into a single generic class (e.g., the v3 single-/
-  multi-value B-tree engines share one generic
-  `internal.core.storage.index.sbtree.singlevalue.v3.BTree` rather than
-  separate `CellBTreeSingleValueV3` / `CellBTreeMultiValueV2` classes).
-  Any name that does NOT resolve is a `blocker` finding so the
-  orchestrator corrects it before Phase B. If mcp-steroid is unreachable,
-  fall back to `find . -name '<ClassName>.java'` and downgrade severity
-  only when the find result is unambiguous.
-
 CRITICAL PATH EXPOSURE
 - Which steps in this track touch critical system paths (storage, WAL,
   transactions, indexes, cache)?

--- a/.claude/workflow/prompts/risk-review.md
+++ b/.claude/workflow/prompts/risk-review.md
@@ -95,6 +95,22 @@ authoritative source for edge cases.
 
 Review against these criteria:
 
+NAMED REFERENCES IN STEP FILE
+- For every production class, package, or SPI service named in the step
+  file's `## Description` (`**What/How/Constraints/Interactions**` blocks)
+  and `## Steps` bodies, verify the name resolves via PSI find-class
+  (`steroid_execute_code` with `JavaPsiFacade.findClass` or the shortname
+  recipe). Pattern-inducing class names from precedent (V1 → V2/V3) is a
+  known trap — generic-extraction refactors often collapse version-
+  suffixed classes into a single generic class (e.g., the v3 single-/
+  multi-value B-tree engines share one generic
+  `internal.core.storage.index.sbtree.singlevalue.v3.BTree` rather than
+  separate `CellBTreeSingleValueV3` / `CellBTreeMultiValueV2` classes).
+  Any name that does NOT resolve is a `blocker` finding so the
+  orchestrator corrects it before Phase B. If mcp-steroid is unreachable,
+  fall back to `find . -name '<ClassName>.java'` and downgrade severity
+  only when the find result is unambiguous.
+
 CRITICAL PATH EXPOSURE
 - Which steps in this track touch critical system paths (storage, WAL,
   transactions, indexes, cache)?

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -127,9 +127,14 @@ NAMED REFERENCES IN STEP FILE
   before flagging — references to existing code and references to
   code this track creates look identical at the name level.
 - If mcp-steroid is unreachable, fall back to
-  `find . -name '<ClassName>.java'` and downgrade severity only when
-  the find result is unambiguous; record the fallback in the
-  Premise's `Search performed` field.
+  `find . -name '<ClassName>.java'`. If the result is unambiguous
+  (single match whose package matches the reconstructed FQN), the
+  Premise's `Verdict` is CONFIRMED — record the fallback tool in
+  `Search performed` and add a reference-accuracy caveat to `Detail`.
+  If the result is ambiguous (zero matches, multiple matches across
+  different packages, or a package mismatch), the Premise's `Verdict`
+  is NOT FOUND and the finding stays a `blocker` under the
+  planned-class rule above.
 
 DESIGN FEASIBILITY
 - Does the described approach work given the current code structure?

--- a/.claude/workflow/prompts/technical-review.md
+++ b/.claude/workflow/prompts/technical-review.md
@@ -106,6 +106,31 @@ COMPONENT MAP ACCURACY (for this track)
 - Are the relationships (calls, depends-on, extends) accurate?
 - Are there components this track misses that will be affected?
 
+NAMED REFERENCES IN STEP FILE
+- For every production class named in the step file's `## Description`
+  (`**What/How/Constraints/Interactions**` blocks), verify the name
+  resolves via PSI find-class (`steroid_execute_code` with
+  `JavaPsiFacade.findClass(fqn, GlobalSearchScope.allScope(project))`).
+  Pattern-inducing class names from precedent (V1 → V2/V3) is a known
+  trap: generic-extraction refactors often collapse version-suffixed
+  classes into a single generic class. The v3 single- and multi-value
+  B-tree engines, for instance, share one generic
+  `com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3.BTree`
+  rather than separate `CellBTreeSingleValueV3` / `CellBTreeMultiValueV2`
+  classes.
+- Each verified name produces a Premise certificate (see §Certificate
+  requirements). A name that does NOT resolve is a `blocker` finding
+  UNLESS the track's `## Description` explicitly marks it as a class
+  this track creates (e.g., "we will introduce `Foo`"). In the
+  planned-class case, log the Premise with verdict CONFIRMED and note
+  "planned by this track" in `Detail`. Read the description carefully
+  before flagging — references to existing code and references to
+  code this track creates look identical at the name level.
+- If mcp-steroid is unreachable, fall back to
+  `find . -name '<ClassName>.java'` and downgrade severity only when
+  the find result is unambiguous; record the fallback in the
+  Premise's `Search performed` field.
+
 DESIGN FEASIBILITY
 - Does the described approach work given the current code structure?
 - Are there APIs, interfaces, or contracts the track assumes but that don't
@@ -145,10 +170,12 @@ interface probably has that method" and catches subtle mismatches.
 ```markdown
 #### Premise: <what the track assumes>
 - **Track claim**: <quote or paraphrase from the track description>
-- **Search performed**: <PSI find-usages / find-implementations /
-  type-hierarchy query when the IDE is reachable; Grep/Glob query
-  otherwise. Record which tool was used so the certificate's
-  reference-accuracy is auditable.>
+- **Search performed**: <PSI find-class / find-usages /
+  find-implementations / type-hierarchy query when the IDE is
+  reachable; Grep/Glob query otherwise. Record which tool was used so
+  the certificate's reference-accuracy is auditable. For NAMED
+  REFERENCES IN STEP FILE premises, this is `findClass` against the
+  reconstructed FQN.>
 - **Code location**: <file:line, or "NOT FOUND">
 - **Actual behavior**: <what the code actually shows — copy relevant
   declaration, method signature, or excerpt>
@@ -188,10 +215,13 @@ interface probably has that method" and catches subtle mismatches.
 ### Rules for certificates
 
 - **Every premise requires a search.** Do not confirm an API exists
-  because its name is plausible. Search and read the actual code. For
-  Java symbols, use mcp-steroid PSI find-usages / find-implementations
-  when the IDE is reachable; only fall back to grep for filename globs,
-  unique string literals, or when mcp-steroid is unreachable.
+  because its name is plausible — and do not confirm a class exists
+  because its name follows a sibling-version pattern (the V1 → V2/V3
+  trap). Search and read the actual code. For Java symbols, use
+  mcp-steroid PSI find-class (for NAMED REFERENCES existence checks),
+  find-usages, or find-implementations when the IDE is reachable;
+  only fall back to grep for filename globs, unique string literals,
+  or when mcp-steroid is unreachable.
 - **Follow calls interprocedurally.** When checking feasibility of an
   approach, trace the actual call chain. A method may delegate, throw,
   or behave differently than its name suggests.

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -56,6 +56,60 @@ all default to grep unless their prompts explicitly route them to
 PSI. The canonical prompts under `prompts/` already include this
 instruction — keep it intact when customising.
 
+### Pre-write rule — PSI-verify class names
+
+Before any write that names a production class in the step file's
+`## Description` (`**What/How/Constraints/Interactions**` blocks,
+including light amendments committed via the Track Pre-Flight gate's
+step 4) or in decomposed step bodies under `## Steps`, the orchestrator
+MUST PSI-verify every named class via `mcp-steroid` find-class. Use
+`steroid_execute_code` with
+`JavaPsiFacade.findClass(fqn, GlobalSearchScope.allScope(project))`.
+If the orchestrator only has a short name (e.g., `BTree`), construct
+the FQN from package context first — `findClass` returns null on bare
+short names.
+
+Pattern-inducing class names from precedent is a known trap: the
+V1 → V2/V3 naming pattern often does NOT survive a generic-extraction
+refactor. For example, the live v3 single- and multi-value B-tree
+lifecycle classes are NOT `CellBTreeSingleValueV3` /
+`CellBTreeMultiValueV2` / `SBTreeV2` — they collapsed into a single
+generic
+`com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3.BTree`
+that is wrapped twice from
+`core/.../index/engine/v1/BTreeMultiValueIndexEngine.java:77,81`.
+When the orchestrator infers a class name from sibling-version
+conventions, generated-code conventions, or package-naming precedent
+rather than reading existing tests or production callers, it MUST
+verify the name via PSI before committing it to the step file.
+
+**mcp-steroid state handling.** The session-start hook surfaces one
+of three states per [`conventions.md`](conventions.md) §1.4:
+
+- **Reachable + cwd matches** → run PSI find-class as above.
+- **Reachable + cwd mismatch** (`steroid_list_projects` reports a
+  different project from the working tree) → pause and ask the user
+  via `AskUserQuestion` to switch the open project before proceeding.
+  Do NOT silently fall back to `find` — a PSI query against the wrong
+  project produces false negatives that look identical to a true
+  hallucination.
+- **Unreachable** → fall back to `find . -name '<ClassName>.java'`
+  and add a reference-accuracy caveat to the step file's
+  `### Clarifications` subsection.
+
+**Failure path.** If PSI-verify reports a name does not resolve and
+the track's `## Description` does not explicitly mark it as a class
+this track creates: try once — read the production code or existing
+tests for the named target, derive the canonical name, and re-verify.
+If after one retry the name still does not resolve, do NOT write or
+commit the step file. Surface the conflict via `AskUserQuestion` with
+three options: **Use the verified alternative** (orchestrator proposes
+the closest matching name), **Drop the mention** (remove the reference
+from the step body), **Escalate to inline replanning**.
+
+This rule is the orchestrator-side complement to the sub-agent-side
+PSI rule in §Tooling above.
+
 ### Track Pre-Flight — Strategy Assessment + Track Summary
 
 Before Phase A's reviews and decomposition begin, the orchestrator
@@ -160,10 +214,11 @@ when more than two sites are touched — these are markdown edits, no
 IntelliJ PSI/VFS refresh concern applies, so the project CLAUDE.md
 "always route file edits through MCP Steroid" rule is satisfied with
 native `Edit` for single-site changes here). Amendments that name
-production classes, packages, or SPI services in the
-`**What/How/Constraints/Interactions**` blocks are bound by the §What You
-Do pre-write rule — PSI-verify every named target via `mcp-steroid` find-
-class before committing the amendment:
+production classes in the `**What/How/Constraints/Interactions**`
+blocks are bound by the §Pre-write rule above — PSI-verify every
+named class via `mcp-steroid` find-class **before applying the Edit**
+inside the Adjust round, so the user can correct a pattern-induced
+name in the same `AskUserQuestion` round rather than after commit:
 
 - Track title, intro paragraph
 - Scope indicators in the plan-file checklist entries
@@ -322,32 +377,8 @@ output so the user does not re-issue them in this round's
 > The Track Pre-Flight gate above must clear before sub-step 1 starts.
 > On State C resume the gate is skipped (see §Phase A Resume).
 
-**Pre-write rule — PSI-verify class names before authoring the step file.**
-Before any write that names a production class, package, or SPI service in
-the step file's `## Description` (`**What/How/Constraints/Interactions**`
-blocks, including light amendments committed via the Track Pre-Flight gate's
-step 4) or in decomposed step bodies under `## Steps`, the orchestrator MUST
-PSI-verify every named target via `mcp-steroid` find-class (use
-`steroid_execute_code` with `JavaPsiFacade.findClass(fqn,
-GlobalSearchScope.allScope(project))` or the shortname recipe in
-[`conventions.md`](conventions.md) §1.4). Pattern-inducing class names from
-precedent is a known trap: the V1 → V2/V3 naming pattern often does NOT
-survive a generic-extraction refactor. For example, the live v3 single- and
-multi-value B-tree lifecycle classes are NOT `CellBTreeSingleValueV3` /
-`CellBTreeMultiValueV2` / `SBTreeV2` — they collapsed into a single generic
-`com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3.BTree`
-that is wrapped twice from
-`core/.../index/engine/v1/BTreeMultiValueIndexEngine.java:77,81`. When the
-orchestrator infers a class name from sibling-version conventions, generated-
-code conventions, or package-naming precedent rather than reading existing
-tests or production callers, it MUST verify the name via PSI before
-committing it to the step file. If `mcp-steroid` is unreachable, fall back to
-`find . -name '<ClassName>.java'` and add a reference-accuracy caveat to the
-step file's `### Clarifications` subsection (or, when reconstructing a
-missing description, to the Reconstruction note). This is the orchestrator-
-side complement to the sub-agent-side PSI rule in §Tooling — PSI is required
-for symbol audits in Phase A (lines 27-58); the sub-agent-side rule binds
-the spawned reviewers, this rule binds the orchestrator's own writes.
+> The §Pre-write rule above governs every write below that names a
+> production class — apply it before the atomic write in sub-step 5.
 
 1. **Read the plan file** for strategic context (Goals, Architecture
    Notes, Decision Records, Component Map) and the **step file**
@@ -391,11 +422,14 @@ the spawned reviewers, this rule binds the orchestrator's own writes.
 5. **Write decomposed steps** to the step file's `## Steps` section as
    `[ ]` items, each with its `**Risk:**` line in the description
    blockquote. Mark `Review + decomposition` as `[x]` in the Progress
-   section. Before this atomic write, apply the §What You Do pre-write
-   rule above to every production class, package, or SPI service named in
-   a step body — PSI-verify each via `mcp-steroid` find-class so a
-   pattern-induced name (V1 → V2/V3 trap, generated-code package drift)
-   does not slip into the step file and force an iter-2 fix round.
+   section. Before this atomic write, apply the §Pre-write rule above
+   to every production class named in a step body — PSI-verify each
+   via `mcp-steroid` find-class so a pattern-induced name (V1 → V2/V3
+   trap, generated-code package drift) does not slip into the step
+   file and force an iter-2 fix round. On unresolved-name failure,
+   follow the **Failure path** in §Pre-write rule (one retry, then
+   `AskUserQuestion`) — do NOT write the step file with an unresolved
+   reference.
 
 6. **Commit and push the Phase A workflow updates.** Phase A's on-disk
    writes — the populated `## Steps` section and the `[x]` mark in

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -159,7 +159,11 @@ Light amendments (apply directly via `Edit`, or `steroid_apply_patch`
 when more than two sites are touched — these are markdown edits, no
 IntelliJ PSI/VFS refresh concern applies, so the project CLAUDE.md
 "always route file edits through MCP Steroid" rule is satisfied with
-native `Edit` for single-site changes here):
+native `Edit` for single-site changes here). Amendments that name
+production classes, packages, or SPI services in the
+`**What/How/Constraints/Interactions**` blocks are bound by the §What You
+Do pre-write rule — PSI-verify every named target via `mcp-steroid` find-
+class before committing the amendment:
 
 - Track title, intro paragraph
 - Scope indicators in the plan-file checklist entries
@@ -318,6 +322,33 @@ output so the user does not re-issue them in this round's
 > The Track Pre-Flight gate above must clear before sub-step 1 starts.
 > On State C resume the gate is skipped (see §Phase A Resume).
 
+**Pre-write rule — PSI-verify class names before authoring the step file.**
+Before any write that names a production class, package, or SPI service in
+the step file's `## Description` (`**What/How/Constraints/Interactions**`
+blocks, including light amendments committed via the Track Pre-Flight gate's
+step 4) or in decomposed step bodies under `## Steps`, the orchestrator MUST
+PSI-verify every named target via `mcp-steroid` find-class (use
+`steroid_execute_code` with `JavaPsiFacade.findClass(fqn,
+GlobalSearchScope.allScope(project))` or the shortname recipe in
+[`conventions.md`](conventions.md) §1.4). Pattern-inducing class names from
+precedent is a known trap: the V1 → V2/V3 naming pattern often does NOT
+survive a generic-extraction refactor. For example, the live v3 single- and
+multi-value B-tree lifecycle classes are NOT `CellBTreeSingleValueV3` /
+`CellBTreeMultiValueV2` / `SBTreeV2` — they collapsed into a single generic
+`com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3.BTree`
+that is wrapped twice from
+`core/.../index/engine/v1/BTreeMultiValueIndexEngine.java:77,81`. When the
+orchestrator infers a class name from sibling-version conventions, generated-
+code conventions, or package-naming precedent rather than reading existing
+tests or production callers, it MUST verify the name via PSI before
+committing it to the step file. If `mcp-steroid` is unreachable, fall back to
+`find . -name '<ClassName>.java'` and add a reference-accuracy caveat to the
+step file's `### Clarifications` subsection (or, when reconstructing a
+missing description, to the Reconstruction note). This is the orchestrator-
+side complement to the sub-agent-side PSI rule in §Tooling — PSI is required
+for symbol audits in Phase A (lines 27-58); the sub-agent-side rule binds
+the spawned reviewers, this rule binds the orchestrator's own writes.
+
 1. **Read the plan file** for strategic context (Goals, Architecture
    Notes, Decision Records, Component Map) and the **step file**
    (`docs/adr/<dir-name>/_workflow/tracks/track-N.md`) for the track's
@@ -360,7 +391,11 @@ output so the user does not re-issue them in this round's
 5. **Write decomposed steps** to the step file's `## Steps` section as
    `[ ]` items, each with its `**Risk:**` line in the description
    blockquote. Mark `Review + decomposition` as `[x]` in the Progress
-   section.
+   section. Before this atomic write, apply the §What You Do pre-write
+   rule above to every production class, package, or SPI service named in
+   a step body — PSI-verify each via `mcp-steroid` find-class so a
+   pattern-induced name (V1 → V2/V3 trap, generated-code package drift)
+   does not slip into the step file and force an iter-2 fix round.
 
 6. **Commit and push the Phase A workflow updates.** Phase A's on-disk
    writes — the populated `## Steps` section and the `[x]` mark in


### PR DESCRIPTION
## Motivation

Phase A iter-1 step files have been shipping production class names
that look right (sibling-version conventions, generated-code package
precedent) but do not resolve — the V1 → V2/V3 trap is the recurring
example, where `CellBTreeSingleValueV3` / `CellBTreeMultiValueV2` /
`SBTreeV2` are inferred from precedent but the live code is a single
generic
`com.jetbrains.youtrackdb.internal.core.storage.index.sbtree.singlevalue.v3.BTree`.
The hallucinated names then survive into iter-2 fix rounds (or worse,
into implementation) because the technical-review and orchestrator
pre-write paths both treat name-existence as implicit.

This change closes the gap on both sides: the technical reviewer is
now required to certify every named class via PSI find-class, and the
orchestrator is required to PSI-verify the same names before the
atomic write in sub-step 5 (and before applying any light amendment
that mentions a production class). State handling for the three
mcp-steroid session states (reachable+match, reachable+mismatch,
unreachable) is spelled out so the orchestrator does not silently
fall back to a stale-cwd PSI query or to grep without a recorded
caveat.

## Summary

- Add NAMED REFERENCES IN STEP FILE block to
  `.claude/workflow/prompts/technical-review.md`, with the V1 → V2/V3
  trap as the worked precedent and a planned-class carve-out so
  classes the track explicitly creates do not produce false blockers.
- Update the Premise certificate schema to record `findClass` as a
  valid `Search performed` tool, and amend the certificate rules to
  call out the sibling-version-pattern hallucination explicitly.
- Add a Pre-write rule to `.claude/workflow/track-review.md` that
  the orchestrator MUST apply before writing the step file in
  sub-step 5 and before applying light amendments under the
  Track Pre-Flight gate, with the three mcp-steroid state branches
  and a one-retry-then-AskUserQuestion failure path.

## Test plan

- [ ] Drop a step-file draft naming a hallucinated class
      (`CellBTreeSingleValueV3`) into a scratch track; confirm the
      orchestrator's pre-write rule flags it and surfaces the
      AskUserQuestion round instead of writing.
- [ ] Drop a step-file draft naming a class the track explicitly
      creates; confirm the technical-review block records it as
      CONFIRMED with `planned by this track` rather than a blocker.
- [ ] Force the cwd-mismatch state (open a different project in the
      IDE while running the workflow); confirm the orchestrator
      pauses and asks the user to switch instead of falling back.