### PR TITLE
YTDB-807: Add mid-phase handoff protocol for context pauses

### DIFF
--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -27,7 +27,7 @@ it. Otherwise, default to `$(git branch --show-current)`.
 **Step 1a — Handoff check (mandatory, before any other on-disk work).**
 Run:
 ```bash
-ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
+ls -t docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
 ```
 If any files exist, load
 [`.claude/workflow/mid-phase-handoff.md`](../../workflow/mid-phase-handoff.md)

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -19,16 +19,22 @@ Do **NOT** read `.claude/workflow/planning.md` or
 `.claude/workflow/design-document-rules.md` yet — they are only needed when
 the user asks to create the plan (Step 4). Load them on demand at that point.
 
-**Handoff check (mandatory, before anything else).** Run:
+**Resolve `<dir-name>`.** All subsequent steps reference
+`docs/adr/<dir-name>/_workflow/`; resolve the placeholder once before
+running any command that uses it. If `"$ARGUMENTS"` is non-empty, use
+it. Otherwise, default to `$(git branch --show-current)`.
+
+**Step 1a — Handoff check (mandatory, before any other on-disk work).**
+Run:
 ```bash
 ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
 ```
 If any files exist, load
 [`.claude/workflow/mid-phase-handoff.md`](../../workflow/mid-phase-handoff.md)
-and follow its §Resume protocol BEFORE Step 2. A previous `/create-plan`
-session paused mid-research or mid-planning and left a handoff to be
-re-presented. Do NOT ask for the aim, start fresh research, or write
-plan files until the handoff is resolved.
+and follow its §Resume protocol BEFORE Step 1b. A previous
+`/create-plan` session paused mid-research or mid-planning and left a
+handoff to be re-presented. Do NOT ask for the aim, start fresh
+research, or write plan files until the handoff is resolved.
 
 **Step 1b — Create the workflow directory.**
 
@@ -46,10 +52,6 @@ commit removes it before merge (see
 **Step 2 — Ask the user for the aim.**
 
 After you have finished reading the workflow documents, ask the user to describe the aim and goal for this session. Do NOT proceed until the user provides the aim. Wait for the user's response before starting any research or planning work.
-
-Plan directory name: if "$ARGUMENTS" is non-empty, use it as the directory
-name. Otherwise, default to the current git branch name
-(`git branch --show-current`).
 
 The plan will be saved to:
 `docs/adr/<dir-name>/_workflow/implementation-plan.md`

--- a/.claude/skills/create-plan/SKILL.md
+++ b/.claude/skills/create-plan/SKILL.md
@@ -19,6 +19,30 @@ Do **NOT** read `.claude/workflow/planning.md` or
 `.claude/workflow/design-document-rules.md` yet — they are only needed when
 the user asks to create the plan (Step 4). Load them on demand at that point.
 
+**Handoff check (mandatory, before anything else).** Run:
+```bash
+ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
+```
+If any files exist, load
+[`.claude/workflow/mid-phase-handoff.md`](../../workflow/mid-phase-handoff.md)
+and follow its §Resume protocol BEFORE Step 2. A previous `/create-plan`
+session paused mid-research or mid-planning and left a handoff to be
+re-presented. Do NOT ask for the aim, start fresh research, or write
+plan files until the handoff is resolved.
+
+**Step 1b — Create the workflow directory.**
+
+As the first durable action of `/create-plan`, ensure the workflow
+directory exists so research handoff files have a home if context
+fills up before Step 4:
+```bash
+mkdir -p docs/adr/<dir-name>/_workflow/tracks
+```
+This is idempotent — safe to re-run on resume. The directory carries
+the plan, design, step files, and handoff files; the Phase 4 cleanup
+commit removes it before merge (see
+`.claude/workflow/conventions.md` §1.2).
+
 **Step 2 — Ask the user for the aim.**
 
 After you have finished reading the workflow documents, ask the user to describe the aim and goal for this session. Do NOT proceed until the user provides the aim. Wait for the user's response before starting any research or planning work.

--- a/.claude/skills/execute-tracks/SKILL.md
+++ b/.claude/skills/execute-tracks/SKILL.md
@@ -59,13 +59,17 @@ Follow the startup protocol in `workflow.md`:
    `docs/adr/<dir-name>/_workflow/implementation-plan.md`.
 2. Identify all tracks and their status (`[ ]` not started, `[x]` completed,
    `[~]` skipped).
-3. **Check for active handoffs first.** Run
+3. **Run the Branch Divergence Check** per
+   `.claude/workflow/branch-divergence-check.md`. This must complete
+   before any commit / push work in this session — including a
+   handoff resolution commit in step 4.
+4. **Check for active handoffs.** Run
    `ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null`. If any
    files exist, load `.claude/workflow/mid-phase-handoff.md` and follow
    its §Resume protocol before any state evaluation below. Do NOT spawn
    sub-agents, recompile episodes, or re-run gate-checks while a handoff
    is unresolved.
-4. Determine session state and auto-resume:
+5. Determine session state and auto-resume:
    - **State 0** (`## Plan Review` is `[ ]` or section missing): load
      `implementation-review.md` on-demand and run the autonomous plan
      review (consistency + structural). End session after the audit
@@ -92,10 +96,10 @@ Follow the startup protocol in `workflow.md`:
 
    State 0 is checked **before** State A/C/D — plan review must
    complete before any track-level work begins.
-4. Inform the user of the auto-resume decision. The user can override, but
+6. Inform the user of the auto-resume decision. The user can override, but
    by default proceed without waiting for confirmation.
-5. Load the phase-specific workflow document and execute that phase only.
-6. After the phase completes, end the session. Instruct the user to clear
+7. Load the phase-specific workflow document and execute that phase only.
+8. After the phase completes, end the session. Instruct the user to clear
    context and re-run `/execute-tracks` for the next phase.
 
 Each session handles exactly ONE PHASE of one track (or Phase 4 / State 0):

--- a/.claude/skills/execute-tracks/SKILL.md
+++ b/.claude/skills/execute-tracks/SKILL.md
@@ -64,7 +64,7 @@ Follow the startup protocol in `workflow.md`:
    before any commit / push work in this session — including a
    handoff resolution commit in step 4.
 4. **Check for active handoffs.** Run
-   `ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null`. If any
+   `ls -t docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null`. If any
    files exist, load `.claude/workflow/mid-phase-handoff.md` and follow
    its §Resume protocol before any state evaluation below. Do NOT spawn
    sub-agents, recompile episodes, or re-run gate-checks while a handoff

--- a/.claude/skills/execute-tracks/SKILL.md
+++ b/.claude/skills/execute-tracks/SKILL.md
@@ -59,7 +59,13 @@ Follow the startup protocol in `workflow.md`:
    `docs/adr/<dir-name>/_workflow/implementation-plan.md`.
 2. Identify all tracks and their status (`[ ]` not started, `[x]` completed,
    `[~]` skipped).
-3. Determine session state and auto-resume:
+3. **Check for active handoffs first.** Run
+   `ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null`. If any
+   files exist, load `.claude/workflow/mid-phase-handoff.md` and follow
+   its §Resume protocol before any state evaluation below. Do NOT spawn
+   sub-agents, recompile episodes, or re-run gate-checks while a handoff
+   is unresolved.
+4. Determine session state and auto-resume:
    - **State 0** (`## Plan Review` is `[ ]` or section missing): load
      `implementation-review.md` on-demand and run the autonomous plan
      review (consistency + structural). End session after the audit

--- a/.claude/workflow/conventions.md
+++ b/.claude/workflow/conventions.md
@@ -24,6 +24,7 @@ during Phase 3 execution.
 | **Orchestrator** | The session-level agent driving `/execute-tracks`. In Phase B owns sub-steps 4–7 of step implementation and all session-level decisions (cross-track impact, escalation, episode synthesis, context-level session-end gate). Distinct from the implementer. |
 | **Implementer** | A fresh sub-agent spawned per step in Phase B that performs sub-steps 1–3 of step implementation (implement, test, commit) and returns a structured handoff to the orchestrator. See [`implementer-rules.md`](implementer-rules.md). |
 | **Step file** | `tracks/track-N.md` — the per-track working file. Created during Phase 1 alongside `implementation-plan.md` with `## Description` already populated (intro paragraph + `**What/How/Constraints/Interactions**` + any track-level Mermaid diagram); other sections (`## Progress`, `## Reviews completed`, `## Steps`, `## Base commit`) start as `[ ]` placeholders and are filled by Phase A → C. Lives under `_workflow/tracks/` (tracked on the branch for backup and team visibility, removed in Phase 4 cleanup before merge). |
+| **Mid-phase handoff** | An on-disk file `_workflow/handoff-*.md` written when a session pauses with un-derivable mid-phase state (research notes, verbatim re-present text, partial reviews). Distinct from the implementer-return "handoff" — see [`mid-phase-handoff.md`](mid-phase-handoff.md) for the protocol. Resolved and deleted on resume; otherwise removed by the Phase 4 cleanup commit. |
 
 ---
 
@@ -76,6 +77,12 @@ docs/adr/<dir-name>/
                                      step episodes
       track-2.md
       ...
+    handoff-*.md                  <- (optional, transient) mid-phase handoff
+                                     written when a session pauses with un-
+                                     derivable in-flight state; deleted on
+                                     resume, otherwise removed in the Phase 4
+                                     cleanup commit. See
+                                     `mid-phase-handoff.md` for the protocol.
 
   ## Final artifacts (committed in Phase 4 — the only files that survive
   ## merge into develop)

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -106,8 +106,16 @@ the orchestrator does after the flow completes:
 
 ### Precondition (both entry points)
 
-Before starting the flow, check that the plan-review files have no
-uncommitted changes:
+**Resolve active handoffs first.** If
+`docs/adr/<dir-name>/_workflow/handoff-state0.md` exists, complete
+[`mid-phase-handoff.md`](mid-phase-handoff.md) §Resume protocol
+(including the resolution commit) BEFORE running the clean-tree check
+below. The resolution commit deletes the handoff file and the PAUSED
+marker line in `implementation-plan.md`, so leaving it for after the
+check would dirty the very file the check is gating on.
+
+Once any handoff is resolved (or there was none), check that the
+plan-review files have no uncommitted changes:
 
 ```bash
 git status --porcelain \
@@ -218,10 +226,10 @@ gate-PASS commit): run `cat /tmp/claude-code-context-usage-$PPID.txt`.
 If the level is `warning` (≥30%) or `critical` (≥40%), do NOT start
 the next review or iteration. Save all work and ask the user for a
 session refresh (see `workflow.md` §Context Consumption Check). If the
-pause leaves State 0 mid-flight — for example, consistency review
+pause leaves State 0 mid-flight (for example, consistency review
 passed but structural review has not run, or an iteration's
 mechanical fixes are applied but the gate sub-agent has not yet been
-spawned — write a handoff file at
+spawned), write a handoff file at
 `docs/adr/<dir-name>/_workflow/handoff-state0.md` per
 [`mid-phase-handoff.md`](mid-phase-handoff.md). Capture the iteration
 count, which classifier passes are done, and the verbatim list of

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -212,6 +212,21 @@ If blockers persist after 3 iterations, escalate to the user with the
 remaining open findings and recommend returning to Phase 1 (Planning) to
 rework the plan/design before re-entering.
 
+**Context consumption check** (mandatory between consistency review,
+structural review, and any iteration boundary, except after the final
+gate-PASS commit): run `cat /tmp/claude-code-context-usage-$PPID.txt`.
+If the level is `warning` (≥30%) or `critical` (≥40%), do NOT start
+the next review or iteration. Save all work and ask the user for a
+session refresh (see `workflow.md` §Context Consumption Check). If the
+pause leaves State 0 mid-flight — for example, consistency review
+passed but structural review has not run, or an iteration's
+mechanical fixes are applied but the gate sub-agent has not yet been
+spawned — write a handoff file at
+`docs/adr/<dir-name>/_workflow/handoff-state0.md` per
+[`mid-phase-handoff.md`](mid-phase-handoff.md). Capture the iteration
+count, which classifier passes are done, and the verbatim list of
+mechanical fixes that landed so the next session does not re-run them.
+
 ### Review output
 
 Findings ride in the orchestrator's conversation context for the

--- a/.claude/workflow/mid-phase-handoff.md
+++ b/.claude/workflow/mid-phase-handoff.md
@@ -1,0 +1,301 @@
+# Mid-Phase Handoff Protocol
+
+When the active context window is too full to safely continue, the
+current phase must end without losing the work-in-progress that has
+not yet landed in the durable plan / step / design files. This
+document defines the canonical bridge between such a paused session
+and its successor.
+
+Loaded on-demand by:
+- the context-consumption gate in `workflow.md` and the inline gates
+  in `track-review.md`, `track-code-review.md`, `step-implementation.md`,
+  `implementation-review.md`, and `prompts/create-final-design.md`, when
+  the gate decides a pause is required and the next session would
+  otherwise re-derive work already done;
+- the startup protocols in `/execute-tracks` and `/create-plan`, when
+  one or more `handoff-*.md` files are detected in `_workflow/`.
+
+## When this protocol fires
+
+Trigger: a context-consumption check returns `warning` (≥30%) or
+`critical` (≥40%) **and** either
+
+- the user asks to pause, or
+- the current phase boundary has not yet landed in the durable
+  plan / step / design files, so re-entering the phase from scratch
+  on the next session would re-run sub-agents, gate-checks,
+  reviewer iterations, or research already on disk.
+
+If both conditions miss — the gate is fired and the next session can
+re-derive everything from the plan / step file Progress section alone
+— no handoff file is needed. The Progress section update plus the
+end-of-session push are sufficient. Examples of the "no handoff
+needed" case: a Phase B pause right after committing a step
+(the next session resumes from the next `[ ]` step naturally); a
+Phase A pause after `Review + decomposition` was marked `[x]`.
+
+Examples that **do** need a handoff: a Phase C pause between
+iteration 3 gate-checks PASSing and user track-completion approval; a
+Phase 0 pause mid-investigation with promising leads but no findings
+captured yet; a Phase 1 pause mid-plan-drafting with a half-written
+Decision Record in a scratch buffer; a Phase 4 pause with `design-final.md`
+half-written.
+
+## File location
+
+```
+docs/adr/<dir-name>/_workflow/handoff-<phase-slug>[-<discriminator>].md
+```
+
+Naming convention:
+
+| Phase | Filename |
+|---|---|
+| 0 — research (`/create-plan`) | `handoff-research.md` |
+| 1 — planning (`/create-plan`) | `handoff-planning.md` |
+| 2 — plan review (State 0 in `/execute-tracks`) | `handoff-state0.md` |
+| A — track review | `handoff-track-N-phaseA.md` |
+| B — step implementation | `handoff-track-N-phaseB.md` |
+| C — track code review | `handoff-track-N-phaseC.md` |
+| 4 — final artifacts (State D) | `handoff-phase4.md` |
+| Ad-hoc research interlude | `handoff-research-<slug>.md` |
+
+Multiple concurrent pauses are allowed (e.g., a paused track plus an
+ad-hoc research interlude). The resume protocol processes them
+most-recent-first by file mtime.
+
+The handoff file lives under `_workflow/` for three reasons:
+1. it survives `/clear` (it is on disk);
+2. it survives local-disk loss because the end-of-session
+   `git push` carries it into the draft PR;
+3. it is removed automatically in the Phase 4 cleanup commit
+   alongside the rest of `_workflow/`, so finished branches do not
+   carry stale handoffs into the merged tree.
+
+If `_workflow/` does not exist yet (very early in `/create-plan`),
+create it before writing the handoff. `/create-plan` is already
+required to create `_workflow/` as its first durable action, so this
+case is rare.
+
+## Detection at session start
+
+Both `/create-plan` and `/execute-tracks` MUST run this check at the
+top of their startup protocol, BEFORE any state evaluation:
+
+```bash
+ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
+```
+
+If any files exist, load this document and follow §Resume protocol
+below INSTEAD of the normal state-evaluation path. The file's
+existence is the **authoritative pause signal** — the secondary
+PAUSED line inside the step / plan file exists only as a visual cue
+for humans reading those files directly, and is kept in sync with
+the handoff file by the author and resume protocols below.
+
+## Secondary marker (defense-in-depth)
+
+In addition to writing the handoff file, leave a single line marker
+inside the natural progress-tracking file for the phase:
+
+| Phase | Marker location |
+|---|---|
+| 0 / 1 | top of `implementation-plan.md` under a `## Status` line (create the section if missing) |
+| 2 (State 0) | beneath `## Plan Review` heading in `implementation-plan.md` |
+| A / B / C | step file Progress section (`tracks/track-N.md`) |
+| 4 | beneath `## Final Artifacts` heading in `implementation-plan.md` |
+| Ad-hoc research | none — the handoff file is the sole signal |
+
+Marker format:
+
+```
+**PAUSED <YYYY-MM-DD> at <phase-state> pending <decision-or-action>**
+- Handoff: <relative-path-to-handoff-file>
+```
+
+The literal `**PAUSED ` prefix is greppable; if a regression in
+the resume protocol misses the `ls handoff-*.md` check, a follow-up
+`grep -rn '^\*\*PAUSED ' docs/adr/<dir>/_workflow/` recovers the
+pointer.
+
+## MEMORY.md cross-reference
+
+After writing the handoff file, add or update a MEMORY.md entry under
+the current branch. The entry has two bullets:
+
+```markdown
+## Branch: <branch-name> — <phase> paused
+- [<short-slug>](<path-to-handoff-file>) — one-line hook
+- **RESUME PROTOCOL (must read on /execute-tracks resume):** handoff
+  file at `docs/adr/<dir>/_workflow/handoff-<phase>.md` carries the
+  re-present text. Do not re-spawn reviewers / gate-checks before
+  reading it.
+```
+
+The MEMORY.md entry is supplemental: the authoritative signal is the
+handoff file under `_workflow/`. The cross-reference exists because
+MEMORY.md is auto-loaded on every session start and gives the
+orchestrator a second chance to notice a pause if the
+`ls handoff-*.md` check is accidentally skipped.
+
+## Templates
+
+Both templates share a common header. Pick the body that matches the
+phase: research-shaped for Phase 0 / 1 and ad-hoc interludes;
+decision-shaped for State 0 / A / B / C / 4.
+
+### Header (both templates)
+
+```markdown
+# Handoff: <phase> — <short scope>
+
+**Paused:** <YYYY-MM-DD>
+**Phase:** <0 / 1 / 2 (State 0) / A / B / C / 4 / ad-hoc>
+**Context level at pause:** warning | critical
+**Branch:** <branch-name>
+**HEAD:** <sha> "<commit subject>"
+**Unpushed:** <N> commits
+```
+
+### Research-shaped body (Phase 0 / 1, ad-hoc interludes)
+
+```markdown
+## What I was investigating
+<1-2 sentences>
+
+## Already ruled out
+- <claim> — <evidence: path:line or short reason>
+
+## Most promising lead
+<1-2 sentences, with path:line anchors>
+
+## Open questions
+- <question>
+
+## Raw notes / partial findings
+<in-flight context that would otherwise be lost on /clear — paste
+file excerpts, intermediate conclusions, half-formed designs>
+
+## Resume protocol
+- Do NOT re-explore: <topics / files already covered>
+- Next action on resume: <specific>
+```
+
+### Decision-shaped body (State 0, Phase A / B / C / 4)
+
+```markdown
+## Durable artifacts on disk
+- <path> — <one-line description>
+
+## Pending decision
+<what was being asked of the user; the options on the table>
+
+## Verbatim re-present text
+<exact text / episode to paste back to the user on resume so the
+reasoning chain is not re-derived under high context pressure>
+
+## Resume protocol
+- Do NOT redo: <per-phase list — see §Phase-specific "do NOT redo"
+  defaults below; add case-specific items as needed>
+- On user approval: <next action>
+- On fixes requested: <fallback path>
+```
+
+## Phase-specific "do NOT redo" defaults
+
+Use these as the starting point for the `Do NOT redo` line. Add
+case-specific items as needed.
+
+| Phase | Do NOT redo |
+|---|---|
+| 0 / 1 | research paths in "Already ruled out"; sections already drafted in `design.md` or `implementation-plan.md` |
+| 2 (State 0) | classifier passes whose findings already landed in the plan file |
+| A | reviews already marked `[x]` in the step file's **Reviews completed** section |
+| B | committed steps (Phase B orphan-commit recovery handles uncommitted ones; see `step-implementation-recovery.md`) |
+| C | iteration count already in **Progress**; gate-checks already PASSed; plan corrections already committed |
+| 4 | sections of `design-final.md` / `adr.md` already on disk |
+
+## Author protocol — writing the handoff at pause time
+
+When the context-consumption check returns `warning` or `critical` and
+the trigger conditions in §When this protocol fires are met:
+
+1. **Pick the filename** from the table in §File location.
+2. **Write the handoff file** using the matching template. Be
+   explicit about the verbatim re-present text and the durable-
+   artifact list — re-deriving them in the next session burns
+   context and may drift.
+3. **Add the secondary PAUSED marker** to the natural progress-
+   tracking file (see §Secondary marker table).
+4. **Add or update the MEMORY.md cross-reference** for this branch.
+5. **Commit all three changes together** with a message in the form
+   `Workflow update: pause <phase> for context refresh`.
+6. **Push** (`git push`) so the draft PR carries the handoff.
+7. **Tell the user**: context is at `<level>`, work is paused, next
+   session should resume via `/execute-tracks` (or `/create-plan`
+   for Phase 0 / 1) — the handoff file will drive the resume.
+
+## Resume protocol
+
+When startup detects one or more `handoff-*.md` files, the
+orchestrator MUST:
+
+1. **Stop** — do NOT match the normal state-evaluation table yet, and
+   do NOT spawn any sub-agents.
+2. **Sort the handoffs** most-recent-first by mtime.
+3. **For each handoff:**
+   - Verify the durable artifacts listed in the file actually exist
+     (commits in `git log`, files on disk). If anything is missing,
+     flag it to the user before resuming — the handoff may be stale.
+   - Present the body verbatim to the user (the research findings or
+     the pending decision plus the verbatim re-present text).
+   - Wait for the user's response (approval / fixes / redirect).
+4. **After resolution** (per file):
+   - Delete the handoff file.
+   - Remove the matching PAUSED marker line from the step / plan
+     file.
+   - Remove the MEMORY.md cross-reference line(s) for this handoff.
+   - Commit all three deletions with a message recording the
+     resolution outcome (e.g., `Workflow update: resume Phase C and
+     approve Track 4 completion`).
+5. **After all handoffs are resolved**, run the normal startup
+   state-evaluation table (the State 0 / A / C / D resume) and
+   continue.
+
+The orchestrator MUST NOT, while a handoff is unresolved:
+
+- Re-spawn sub-agents (reviewers, implementer, gate-checks) before
+  reading the handoff.
+- Re-run the context-consumption check as a way to skip the handoff.
+- Treat the in-file PAUSED marker as authoritative if it disagrees
+  with the handoff file — the file always wins. If the marker is
+  missing but a handoff file exists, the handoff file is still
+  authoritative; the missing marker is a defense-in-depth gap, not a
+  reason to ignore the handoff.
+
+## Symmetry table — where each phase typically pauses
+
+| Phase | Session command | Likely pause points |
+|---|---|---|
+| 0 | `/create-plan` | mid-research, after a deep dive that consumed context but before findings are captured |
+| 1 | `/create-plan` | mid-plan-drafting, after sections of `implementation-plan.md` / `design.md` are partly written |
+| 2 (State 0) | `/execute-tracks` | between consistency and structural reviews, or mid-classifier escalation |
+| A | `/execute-tracks` | between sequential reviews (technical / risk / adversarial); after decomposition but before risk-tagging |
+| B | `/execute-tracks` | after a committed step, before the next one starts (rare — usually no handoff needed) |
+| C | `/execute-tracks` | between iterations, between gate checks, before track-completion approval |
+| 4 | `/execute-tracks` (State D) | between sections of `design-final.md`, or between `design-final.md` and `adr.md` |
+| Ad-hoc | any | open-ended research interlude inside an otherwise-active phase |
+
+## See also
+
+- `workflow.md` § Startup Protocol (Auto-Resume) — runs the
+  `ls handoff-*.md` check before state evaluation
+- `workflow.md` § Context Consumption Check — defines `warning` /
+  `critical` thresholds and invokes this protocol
+- `track-review.md`, `track-code-review.md`, `step-implementation.md`,
+  `implementation-review.md`, `prompts/create-final-design.md` —
+  inline gates that hand off to this document
+- `.claude/skills/create-plan/SKILL.md` — creates `_workflow/` as
+  its first durable action and runs the same startup check
+- `commit-conventions.md` § Commit type prefixes — `Workflow update:`
+  prefix for handoff write and handoff resolution commits

--- a/.claude/workflow/mid-phase-handoff.md
+++ b/.claude/workflow/mid-phase-handoff.md
@@ -94,8 +94,11 @@ top of their startup protocol, after the Branch Divergence Check
 (workflow.md startup step 5) but BEFORE any state evaluation:
 
 ```bash
-ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
+ls -t docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
 ```
+
+`-t` sorts most-recent-first by mtime, matching the resume
+protocol's processing order.
 
 If any files exist, load this document and follow §Resume protocol
 below INSTEAD of the normal state-evaluation path. The file's
@@ -317,7 +320,8 @@ orchestrator MUST:
 
 1. **Stop** — do NOT match the normal state-evaluation table yet, and
    do NOT spawn any sub-agents.
-2. **Sort the handoffs** most-recent-first by mtime. On mtime tie,
+2. **Sort the handoffs** most-recent-first by mtime (e.g., using
+   `ls -t`, which matches the detection command above). On mtime tie,
    fall back to filename sort order.
 3. **For each handoff** (one at a time — present, wait, resolve,
    then move to the next):

--- a/.claude/workflow/mid-phase-handoff.md
+++ b/.claude/workflow/mid-phase-handoff.md
@@ -1,10 +1,10 @@
 # Mid-Phase Handoff Protocol
 
-When the active context window is too full to safely continue, the
-current phase must end without losing the work-in-progress that has
-not yet landed in the durable plan / step / design files. This
-document defines the canonical bridge between such a paused session
-and its successor.
+A handoff file bridges a paused workflow session and its successor
+when the current phase has work-in-progress that has not yet landed
+in the durable plan / step / design files. Without it, the next
+session re-runs sub-agents, gate-checks, reviewer iterations, or
+research already on disk.
 
 Loaded on-demand by:
 - the context-consumption gate in `workflow.md` and the inline gates
@@ -26,20 +26,23 @@ Trigger: a context-consumption check returns `warning` (≥30%) or
   on the next session would re-run sub-agents, gate-checks,
   reviewer iterations, or research already on disk.
 
-If both conditions miss — the gate is fired and the next session can
-re-derive everything from the plan / step file Progress section alone
-— no handoff file is needed. The Progress section update plus the
-end-of-session push are sufficient. Examples of the "no handoff
-needed" case: a Phase B pause right after committing a step
-(the next session resumes from the next `[ ]` step naturally); a
-Phase A pause after `Review + decomposition` was marked `[x]`.
+If both conditions miss, no handoff file is needed: the gate is
+fired and the next session can re-derive everything from the plan /
+step file Progress section alone. The Progress section update plus
+the end-of-session push are sufficient. Examples of the "no handoff
+needed" case:
+- a Phase B pause right after committing a step (the next session
+  resumes from the next `[ ]` step naturally);
+- a Phase A pause after `Review + decomposition` was marked `[x]`.
 
-Examples that **do** need a handoff: a Phase C pause between
-iteration 3 gate-checks PASSing and user track-completion approval; a
-Phase 0 pause mid-investigation with promising leads but no findings
-captured yet; a Phase 1 pause mid-plan-drafting with a half-written
-Decision Record in a scratch buffer; a Phase 4 pause with `design-final.md`
-half-written.
+Examples that **do** need a handoff:
+- a Phase C pause between iteration 3 gate-checks PASSing and user
+  track-completion approval;
+- a Phase 0 pause mid-investigation with promising leads but no
+  findings captured yet;
+- a Phase 1 pause mid-plan-drafting with a half-written Decision
+  Record in a scratch buffer;
+- a Phase 4 pause with `design-final.md` half-written.
 
 ## File location
 
@@ -64,6 +67,14 @@ Multiple concurrent pauses are allowed (e.g., a paused track plus an
 ad-hoc research interlude). The resume protocol processes them
 most-recent-first by file mtime.
 
+**Filename collisions.** If a handoff with the chosen filename
+already exists (re-pausing the same phase before resolving the prior
+handoff, or two ad-hoc interludes sharing a slug), append `-2`, `-3`,
+… to the discriminator (e.g., `handoff-track-3-phaseC-2.md`). The
+resume protocol's mtime-first sort processes the newest first; the
+older handoff resolves on its own turn. Do NOT overwrite an existing
+handoff.
+
 The handoff file lives under `_workflow/` for three reasons:
 1. it survives `/clear` (it is on disk);
 2. it survives local-disk loss because the end-of-session
@@ -72,15 +83,15 @@ The handoff file lives under `_workflow/` for three reasons:
    alongside the rest of `_workflow/`, so finished branches do not
    carry stale handoffs into the merged tree.
 
-If `_workflow/` does not exist yet (very early in `/create-plan`),
-create it before writing the handoff. `/create-plan` is already
-required to create `_workflow/` as its first durable action, so this
-case is rare.
+The author protocol below has an unconditional Step 0 that creates
+`_workflow/` if missing, so writing a handoff is safe even on a
+mid-Phase-0 pause before `/create-plan`'s own Step 1b has run.
 
 ## Detection at session start
 
 Both `/create-plan` and `/execute-tracks` MUST run this check at the
-top of their startup protocol, BEFORE any state evaluation:
+top of their startup protocol, after the Branch Divergence Check
+(workflow.md startup step 5) but BEFORE any state evaluation:
 
 ```bash
 ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
@@ -93,6 +104,12 @@ PAUSED line inside the step / plan file exists only as a visual cue
 for humans reading those files directly, and is kept in sync with
 the handoff file by the author and resume protocols below.
 
+`/review-plan` is not a typical resume entry — users normally resume
+through `/execute-tracks` after a `/clear`. A State 0 handoff written
+during a manual `/review-plan` session MUST still be resolvable on
+the next `/execute-tracks` invocation; `/review-plan` itself does not
+need a handoff-detection step at the top of its skill instructions.
+
 ## Secondary marker (defense-in-depth)
 
 In addition to writing the handoff file, leave a single line marker
@@ -100,7 +117,7 @@ inside the natural progress-tracking file for the phase:
 
 | Phase | Marker location |
 |---|---|
-| 0 / 1 | top of `implementation-plan.md` under a `## Status` line (create the section if missing) |
+| 0 / 1 | none — `implementation-plan.md` may not exist yet during early Phase 0, and the handoff file + MEMORY.md cross-reference are sufficient signals |
 | 2 (State 0) | beneath `## Plan Review` heading in `implementation-plan.md` |
 | A / B / C | step file Progress section (`tracks/track-N.md`) |
 | 4 | beneath `## Final Artifacts` heading in `implementation-plan.md` |
@@ -115,34 +132,54 @@ Marker format:
 
 The literal `**PAUSED ` prefix is greppable; if a regression in
 the resume protocol misses the `ls handoff-*.md` check, a follow-up
-`grep -rn '^\*\*PAUSED ' docs/adr/<dir>/_workflow/` recovers the
+`grep -rn '^\*\*PAUSED ' docs/adr/<dir-name>/_workflow/` recovers the
 pointer.
 
 ## MEMORY.md cross-reference
 
 After writing the handoff file, add or update a MEMORY.md entry under
-the current branch. The entry has two bullets:
+the current branch. MEMORY.md is user-global, not project-local — it
+lives at `~/.claude/projects/<project>/memory/MEMORY.md` and is
+auto-loaded on every session start.
+
+**Single-handoff case** — create a new `## Branch:` section:
 
 ```markdown
 ## Branch: <branch-name> — <phase> paused
 - [<short-slug>](<path-to-handoff-file>) — one-line hook
 - **RESUME PROTOCOL (must read on /execute-tracks resume):** handoff
-  file at `docs/adr/<dir>/_workflow/handoff-<phase>.md` carries the
-  re-present text. Do not re-spawn reviewers / gate-checks before
-  reading it.
+  file at `docs/adr/<dir-name>/_workflow/handoff-<phase>.md` carries
+  the re-present text. Do not re-spawn reviewers / gate-checks before
+  reading it. (handoff: `<handoff-filename>`)
 ```
+
+**Multiple handoffs on the same branch** — if a `## Branch:
+<branch-name>` heading already exists in MEMORY.md, append the two
+bullets under the existing heading rather than creating a duplicate.
+Every bullet pair carries its handoff filename in a parenthetical so
+the resume protocol can remove only the bullets belonging to the
+resolved handoff. Do NOT create a second `## Branch:` heading for the
+same branch.
 
 The MEMORY.md entry is supplemental: the authoritative signal is the
 handoff file under `_workflow/`. The cross-reference exists because
-MEMORY.md is auto-loaded on every session start and gives the
-orchestrator a second chance to notice a pause if the
-`ls handoff-*.md` check is accidentally skipped.
+MEMORY.md is auto-loaded on every session start, so the orchestrator
+still notices the pause if the `ls handoff-*.md` check is
+accidentally skipped.
 
 ## Templates
 
 Both templates share a common header. Pick the body that matches the
-phase: research-shaped for Phase 0 / 1 and ad-hoc interludes;
-decision-shaped for State 0 / A / B / C / 4.
+pause's shape, not just its phase:
+
+- **Research-shaped** — Phase 0 / 1, ad-hoc interludes, OR any pause
+  that captures exploratory findings without a clear pending
+  decision (regardless of phase). Example: a Phase B pause that
+  noticed a cross-track impact but has no committed step yet and no
+  decision waiting on the user.
+- **Decision-shaped** — State 0 / A / B / C / 4 pauses where a
+  specific decision is waiting on the user (approval / fixes /
+  redirect) and the verbatim re-present text must survive `/clear`.
 
 ### Header (both templates)
 
@@ -156,6 +193,10 @@ decision-shaped for State 0 / A / B / C / 4.
 **HEAD:** <sha> "<commit subject>"
 **Unpushed:** <N> commits
 ```
+
+If `git rev-list --count @{u}..HEAD` fails (no upstream set, or
+detached HEAD), write `<no upstream — see workflow.md §What to do
+before ending a session>` on the **Unpushed:** line.
 
 ### Research-shaped body (Phase 0 / 1, ad-hoc interludes)
 
@@ -176,7 +217,7 @@ decision-shaped for State 0 / A / B / C / 4.
 <in-flight context that would otherwise be lost on /clear — paste
 file excerpts, intermediate conclusions, half-formed designs>
 
-## Resume protocol
+## Resume notes
 - Do NOT re-explore: <topics / files already covered>
 - Next action on resume: <specific>
 ```
@@ -194,7 +235,7 @@ file excerpts, intermediate conclusions, half-formed designs>
 <exact text / episode to paste back to the user on resume so the
 reasoning chain is not re-derived under high context pressure>
 
-## Resume protocol
+## Resume notes
 - Do NOT redo: <per-phase list — see §Phase-specific "do NOT redo"
   defaults below; add case-specific items as needed>
 - On user approval: <next action>
@@ -220,47 +261,119 @@ case-specific items as needed.
 When the context-consumption check returns `warning` or `critical` and
 the trigger conditions in §When this protocol fires are met:
 
-1. **Pick the filename** from the table in §File location.
+0. **Ensure `_workflow/` exists.** Run
+   `mkdir -p docs/adr/<dir-name>/_workflow` (idempotent — safe to
+   re-run). This is unconditional so a mid-Phase-0 pause that fires
+   before `/create-plan` Step 1b still has a place to write the
+   handoff.
+1. **Pick the filename** from the table in §File location. If the
+   chosen filename collides with an existing handoff, append `-2`,
+   `-3`, … to the discriminator per §File location → "Filename
+   collisions".
 2. **Write the handoff file** using the matching template. Be
    explicit about the verbatim re-present text and the durable-
    artifact list — re-deriving them in the next session burns
    context and may drift.
 3. **Add the secondary PAUSED marker** to the natural progress-
-   tracking file (see §Secondary marker table).
-4. **Add or update the MEMORY.md cross-reference** for this branch.
-5. **Commit all three changes together** with a message in the form
-   `Workflow update: pause <phase> for context refresh`.
+   tracking file (see §Secondary marker table). Skip this step for
+   Phase 0 / 1 and ad-hoc interludes — those rows have no marker.
+4. **Add or update the MEMORY.md cross-reference** for this branch
+   per §MEMORY.md cross-reference (append under existing branch
+   heading if one is already present).
+5. **Commit all changes together** with a bare imperative message,
+   e.g. `Pause Phase C for context refresh — write handoff`. Stage
+   explicit paths only (the handoff file, the marker host file if
+   applicable, and the MEMORY.md update); never `git add -A`.
+5a. **If the commit fails** (pre-commit hook rejection, dirty
+    unrelated paths picked up by the hook): fix the underlying
+    issue, re-stage, and create a **new** commit. Do NOT `--amend`
+    and do NOT bypass hooks (no `--no-verify`). Repeat until the
+    commit lands. See `commit-conventions.md` § Push failure
+    handling for the analogous push case.
 6. **Push** (`git push`) so the draft PR carries the handoff.
-7. **Tell the user**: context is at `<level>`, work is paused, next
+6a. **If the push fails non-fast-forward**, route through
+    `branch-divergence-check.md` — do NOT force-push, and do NOT
+    rebase before resolving with the user. For any other push
+    failure, warn the user that the handoff is committed locally
+    but not yet on the PR, then ask whether to retry now or accept
+    the degraded-durability state.
+7. **Run self-improvement reflection** per
+   `self-improvement-reflection.md` **when the context level is
+   `warning`**. The friction that triggered the pause is the
+   highest-value reflection input. **Skip reflection at `critical`
+   level**: context is too tight to safely run the reflection itself,
+   and the durable trail (handoff file + commit + push) already
+   captures what the next session needs.
+8. **Tell the user**: context is at `<level>`, work is paused, next
    session should resume via `/execute-tracks` (or `/create-plan`
    for Phase 0 / 1) — the handoff file will drive the resume.
 
 ## Resume protocol
+
+### Per-handoff loop
 
 When startup detects one or more `handoff-*.md` files, the
 orchestrator MUST:
 
 1. **Stop** — do NOT match the normal state-evaluation table yet, and
    do NOT spawn any sub-agents.
-2. **Sort the handoffs** most-recent-first by mtime.
-3. **For each handoff:**
-   - Verify the durable artifacts listed in the file actually exist
-     (commits in `git log`, files on disk). If anything is missing,
-     flag it to the user before resuming — the handoff may be stale.
-   - Present the body verbatim to the user (the research findings or
-     the pending decision plus the verbatim re-present text).
-   - Wait for the user's response (approval / fixes / redirect).
+2. **Sort the handoffs** most-recent-first by mtime. On mtime tie,
+   fall back to filename sort order.
+3. **For each handoff** (one at a time — present, wait, resolve,
+   then move to the next):
+   - **Verify durable artifacts.** Confirm every commit / file
+     listed in the handoff's "Durable artifacts on disk" (decision-
+     shaped) or "Already ruled out" / "Most promising lead" path
+     references (research-shaped) actually exist. If anything is
+     missing, present the missing items to the user and the
+     three-option resolution table below.
+   - **Present the body** based on the template shape:
+     - **Decision-shaped body**: present the *Pending decision* and
+       the *Verbatim re-present text* exactly as written, then wait
+       for one of `approve` / `request fixes` / `redirect`.
+     - **Research-shaped body**: present *What I was investigating*,
+       *Already ruled out*, *Most promising lead*, *Raw notes*, and
+       *Resume notes → Next action on resume*; then ask the user to
+       choose `proceed with Next action on resume` / `redirect` /
+       `pause again` (the research has no pending decision, so the
+       agent needs explicit guidance on how to proceed).
 4. **After resolution** (per file):
    - Delete the handoff file.
    - Remove the matching PAUSED marker line from the step / plan
-     file.
-   - Remove the MEMORY.md cross-reference line(s) for this handoff.
-   - Commit all three deletions with a message recording the
-     resolution outcome (e.g., `Workflow update: resume Phase C and
-     approve Track 4 completion`).
+     file (skip if the marker row was "none" for this phase).
+   - Remove the MEMORY.md cross-reference bullets that carry this
+     handoff's filename in their parenthetical. If they were the
+     last bullets under the `## Branch:` heading, remove the
+     heading too.
+   - Commit the deletions together with a bare imperative message
+     describing the resolution outcome, e.g.
+     `Resume Phase C and approve Track 4 completion`.
+   - **Phase 4 cleanup exception**: when the resolved handoff is
+     `handoff-phase4.md` AND `adr.md` is already committed, do NOT
+     produce a separate resolution commit. The Phase 4 cleanup
+     commit (Step 5 of `create-final-design.md`) `git rm -r`s
+     `_workflow/` and removes the handoff file, PAUSED marker host
+     (the plan file), and MEMORY.md entry in the same commit.
 5. **After all handoffs are resolved**, run the normal startup
    state-evaluation table (the State 0 / A / C / D resume) and
    continue.
+
+### Stale-handoff resolution
+
+If durable-artifact verification fails on a handoff, present the
+missing items and ask the user to pick one of:
+
+| Option | What it means | When to pick it |
+|---|---|---|
+| **Discard handoff** | Delete the file + marker + MEMORY.md bullets without resolving the underlying work. Move on to the next handoff in the mtime-sorted list. | The handoff is stale and the missing artifact is irrelevant — e.g., the work was redone differently and the in-flight notes are obsolete. |
+| **Proceed anyway** | Keep the handoff authoritative; the missing artifact is the next-session work the handoff is supposed to drive. Continue with §Per-handoff loop step 3. | The missing artifact is exactly what the handoff says is left to do (e.g., a not-yet-written commit named in "Next action on resume"). |
+| **Abort** *(default)* | End the session without resolving any handoffs. The user investigates manually and re-runs the session. | The missing artifact is unexpected and not covered by either of the above. |
+
+Default is **Abort** — silent fall-through would mask a real
+problem. On Discard, the next handoff in the list is processed; on
+Abort, the session ends and no further handoffs are touched.
+
+### Forbidden actions while unresolved
 
 The orchestrator MUST NOT, while a handoff is unresolved:
 
@@ -280,11 +393,17 @@ The orchestrator MUST NOT, while a handoff is unresolved:
 | 0 | `/create-plan` | mid-research, after a deep dive that consumed context but before findings are captured |
 | 1 | `/create-plan` | mid-plan-drafting, after sections of `implementation-plan.md` / `design.md` are partly written |
 | 2 (State 0) | `/execute-tracks` | between consistency and structural reviews, or mid-classifier escalation |
-| A | `/execute-tracks` | between sequential reviews (technical / risk / adversarial); after decomposition but before risk-tagging |
+| A | `/execute-tracks` | between sequential reviews (technical / risk / adversarial); after decomposition but before the atomic step-file write |
 | B | `/execute-tracks` | after a committed step, before the next one starts (rare — usually no handoff needed) |
 | C | `/execute-tracks` | between iterations, between gate checks, before track-completion approval |
 | 4 | `/execute-tracks` (State D) | between sections of `design-final.md`, or between `design-final.md` and `adr.md` |
 | Ad-hoc | any | open-ended research interlude inside an otherwise-active phase |
+
+State A (Track Pre-Flight gate, between Panel 1 and Panel 2) is out
+of scope — the gate is short enough that mid-panel pauses are not
+supported. Finish both panels before any pause; if context fills up
+between completing State A and starting Phase A, the pause lands as
+a Phase A pause and uses the Phase A row above.
 
 ## See also
 
@@ -297,5 +416,7 @@ The orchestrator MUST NOT, while a handoff is unresolved:
   inline gates that hand off to this document
 - `.claude/skills/create-plan/SKILL.md` — creates `_workflow/` as
   its first durable action and runs the same startup check
-- `commit-conventions.md` § Commit type prefixes — `Workflow update:`
-  prefix for handoff write and handoff resolution commits
+- `step-implementation-recovery.md` — Phase B orphan-commit recovery
+  referenced from the §Phase-specific "do NOT redo" table
+- `commit-conventions.md` § Commit type prefixes — commit category
+  used for handoff write and handoff resolution commits

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -178,6 +178,20 @@ Rules (these are enforced by the discipline; listed here for orientation):
 - Do **NOT** modify the original `design.md` (and `design-mechanics.md`
   if present) — those are frozen after Phase 1.
 
+**Context consumption check between artifacts.** After
+`design-final.md` is written and committed, run
+`cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
+`warning` (≥30%) or `critical` (≥40%), do NOT start `adr.md`. Save
+all work and ask the user for a session refresh (see
+`workflow.md` §Context Consumption Check). Because `design-final.md`
+is already on disk but `adr.md` is not, write a handoff file at
+`docs/adr/<dir-name>/_workflow/handoff-phase4.md` per
+[`mid-phase-handoff.md`](../mid-phase-handoff.md) so the next session
+resumes at the ADR step without re-reading every episode or
+re-writing the final-design content. The same applies to mid-`adr.md`
+pauses — capture which sections of `adr.md` are already drafted in
+the handoff.
+
 ### Artifact 2: ADR (`adr.md`)
 
 Write `docs/adr/<dir-name>/adr.md` — a post-implementation Architecture

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -183,14 +183,15 @@ Rules (these are enforced by the discipline; listed here for orientation):
 `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
 `warning` (≥30%) or `critical` (≥40%), do NOT start `adr.md`. Save
 all work and ask the user for a session refresh (see
-`workflow.md` §Context Consumption Check). Because `design-final.md`
-is already on disk but `adr.md` is not, write a handoff file at
+`workflow.md` §Context Consumption Check). Write a handoff file at
 `docs/adr/<dir-name>/_workflow/handoff-phase4.md` per
-[`mid-phase-handoff.md`](../mid-phase-handoff.md) so the next session
-resumes at the ADR step without re-reading every episode or
-re-writing the final-design content. The same applies to mid-`adr.md`
-pauses — capture which sections of `adr.md` are already drafted in
-the handoff.
+[`mid-phase-handoff.md`](../mid-phase-handoff.md): `design-final.md`
+is on disk but `adr.md` is not, so the next session resumes at the
+ADR step without re-reading every episode or re-writing the
+final-design content. The same applies to mid-`adr.md` pauses;
+capture which sections of `adr.md` are already drafted in the
+handoff. If the file does not exist or the command fails, this is
+**not an error** — treat as `safe` and continue.
 
 ### Artifact 2: ADR (`adr.md`)
 

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -609,7 +609,14 @@ reports the unpushed-commit count. The full rule lives in
 **Session-end gate.** After committing the episode: if the context
 level was `warning` or `critical`, do NOT spawn the implementer for
 the next step. Save all work and ask the user for a session refresh
-(see workflow.md §Context Consumption Check).
+(see workflow.md §Context Consumption Check). The default Phase B
+case (just finished a step, next session resumes from the next `[ ]`
+step) does **not** require a handoff file — the step file's Progress
+section is sufficient. Write a handoff per
+[`mid-phase-handoff.md`](mid-phase-handoff.md) only if the pause
+captures state the next session cannot re-derive from the step file
+(for example, a partial cross-track-impact finding that needs to be
+re-presented before the next step starts).
 
 **→ GATE: Step is now complete.** Do not spawn the next implementer
 until sub-steps 1–8 above are done.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -618,6 +618,16 @@ captures state the next session cannot re-derive from the step file
 (for example, a partial cross-track-impact finding that needs to be
 re-presented before the next step starts).
 
+**Phase B can only pause at the episode-commit gate.** Mid-step
+pauses are not supported: the orchestrator MUST NOT pause while the
+implementer sub-agent is running, and MUST NOT pause between
+sub-steps 4–7 of step implementation. If a context-pressure signal
+arrives mid-step, wait for the implementer to return and complete
+sub-steps 4–8, then handle the pause here. The implementer's
+revert-on-failure logic and the orphan-commit recovery in
+`step-implementation-recovery.md` assume an episode boundary; pausing
+inside the step would leave both invariants undefined.
+
 **→ GATE: Step is now complete.** Do not spawn the next implementer
 until sub-steps 1–8 above are done.
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -492,10 +492,10 @@ orchestrator never edits source files itself in Phase C.
      iteration. Save all work (update Progress section with current
      iteration count, commit) and ask the user for a session refresh
      (see workflow.md §Context Consumption Check). If the pause leaves
-     Phase C mid-flight — e.g., gate-checks already PASSed but
+     Phase C mid-flight (for example, gate-checks already PASSed but
      track-completion approval is still pending, or iteration N has
      committed `Review fix:` but iteration N+1's gate-check sub-agents
-     have not run — write a handoff file per
+     have not run), write a handoff file per
      [`mid-phase-handoff.md`](mid-phase-handoff.md). The handoff
      captures the iteration count, the gate-check outcomes, and the
      verbatim track-completion summary to re-present, so the next

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -491,10 +491,19 @@ orchestrator never edits source files itself in Phase C.
      `warning` (≥30%) or `critical` (≥40%), do NOT start the next
      iteration. Save all work (update Progress section with current
      iteration count, commit) and ask the user for a session refresh
-     (see workflow.md §Context Consumption Check). If the level is
-     `safe`/`info`, continue to the next iteration. If the file does
-     not exist or the command fails, this is **not an error** — treat
-     as `safe` and continue.
+     (see workflow.md §Context Consumption Check). If the pause leaves
+     Phase C mid-flight — e.g., gate-checks already PASSed but
+     track-completion approval is still pending, or iteration N has
+     committed `Review fix:` but iteration N+1's gate-check sub-agents
+     have not run — write a handoff file per
+     [`mid-phase-handoff.md`](mid-phase-handoff.md). The handoff
+     captures the iteration count, the gate-check outcomes, and the
+     verbatim track-completion summary to re-present, so the next
+     session does not re-spawn reviewer / gate-check sub-agents whose
+     output is already on disk. If the level is `safe`/`info`,
+     continue to the next iteration. If the file does not exist or
+     the command fails, this is **not an error** — treat as `safe`
+     and continue.
 4. Max 3 iterations **total across sessions** — on resume, read the
    iteration count from the Progress section to determine how many remain.
    The iteration count is shared across all review dimensions (not

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -410,10 +410,16 @@ output so the user does not re-issue them in this round's
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
      `warning` (≥30%) or `critical` (≥40%), do NOT start the next review
      or decomposition. Save all work and ask the user for a session
-     refresh (see workflow.md §Context Consumption Check). If the level
-     is `safe`/`info`, continue. If the file does not exist or the
-     command fails, this is **not an error** — treat as `safe` and
-     continue.
+     refresh (see workflow.md §Context Consumption Check). If the pause
+     leaves Phase A mid-flight — for example, technical review PASSed
+     but risk / adversarial reviews are still unrun, or all reviews
+     PASSed but decomposition has not yet been written — write a
+     handoff file per
+     [`mid-phase-handoff.md`](mid-phase-handoff.md) so the next session
+     does not re-spawn reviewers whose results already landed in the
+     **Reviews completed** section. If the level is `safe`/`info`,
+     continue. If the file does not exist or the command fails, this
+     is **not an error** — treat as `safe` and continue.
 4. **Decompose scope indicators** into concrete steps. For each step,
    assign a **risk tag** (`low` / `medium` / `high`) per the criteria
    in [`risk-tagging.md`](risk-tagging.md) — load that file at the

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -411,9 +411,9 @@ output so the user does not re-issue them in this round's
      `warning` (≥30%) or `critical` (≥40%), do NOT start the next review
      or decomposition. Save all work and ask the user for a session
      refresh (see workflow.md §Context Consumption Check). If the pause
-     leaves Phase A mid-flight — for example, technical review PASSed
+     leaves Phase A mid-flight (for example, technical review PASSed
      but risk / adversarial reviews are still unrun, or all reviews
-     PASSed but decomposition has not yet been written — write a
+     PASSed but decomposition has not yet been written), write a
      handoff file per
      [`mid-phase-handoff.md`](mid-phase-handoff.md) so the next session
      does not re-spawn reviewers whose results already landed in the

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -144,8 +144,10 @@ cross-track impact.
 
 4. **Check for active handoffs.** Run:
    ```bash
-   ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
+   ls -t docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
    ```
+   `-t` sorts most-recent-first by mtime so the resume protocol
+   processes handoffs in the correct order.
    If any files exist, load
    [`mid-phase-handoff.md`](mid-phase-handoff.md) and follow its
    §Resume protocol. That protocol re-presents the pending decision

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -131,7 +131,22 @@ cross-track impact.
    - `[x]` — completed
    - `[~]` — skipped
 
-3. **Determine session state** from the plan file and step files:
+3. **Determine session state** from the plan file and step files.
+
+   **First, check for active handoffs.** Before consulting the state
+   table below, run:
+   ```bash
+   ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
+   ```
+   If any files exist, load
+   [`mid-phase-handoff.md`](mid-phase-handoff.md) and follow its
+   §Resume protocol. That protocol re-presents the pending decision
+   (or research findings) to the user, deletes resolved handoff files
+   and their secondary PAUSED markers, and only then returns control
+   to this state table. While a handoff is unresolved, the
+   orchestrator MUST NOT spawn sub-agents, re-run gate-checks, or
+   recompile episodes. See `mid-phase-handoff.md` for the full
+   resume contract.
 
    | Plan file state | Step file state | Session state |
    |---|---|---|
@@ -313,6 +328,20 @@ yet.
    - Ensure all code changes are committed
    - Ensure all progress is written to the step file on disk
    - Update the **Progress** section in the step file on disk
+   - **If the pause leaves mid-phase state that the next session
+     cannot re-derive from the plan / step files alone, write a
+     handoff file per
+     [`mid-phase-handoff.md`](mid-phase-handoff.md).** This is
+     mandatory for: between-iteration pauses in Phase C, post-
+     decomposition / between-review pauses in Phase A, mid-research
+     pauses in Phase 0 / 1, mid-section pauses in Phase 4, and any
+     pause where verbatim re-present text or partial research notes
+     would otherwise be lost. The handoff file goes under
+     `docs/adr/<dir-name>/_workflow/handoff-<phase>.md`, with a
+     matching `**PAUSED ...**` marker in the natural progress-
+     tracking file and a cross-reference in MEMORY.md — all three
+     channels are written in a single `Workflow update: pause
+     <phase> for context refresh` commit.
 3. **Ask the user for a session refresh:**
    - Inform them of current progress and what remains
    - Instruct: "Context window is running low. Please clear the session

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -131,10 +131,18 @@ cross-track impact.
    - `[x]` — completed
    - `[~]` — skipped
 
-3. **Determine session state** from the plan file and step files.
+3. **Run the Branch Divergence Check.** Load
+   [`branch-divergence-check.md`](branch-divergence-check.md) and
+   follow it. This must happen in turn 1, before any per-commit push
+   work — including handoff-resolution commits in the next step. A
+   diverged branch left undetected makes every `git push` across the
+   session reject silently and defeats the "push every commit"
+   safety net (see `commit-conventions.md` § Push every commit). The
+   protocol detects divergence and asks the user to pick one of three
+   resolutions (local-authoritative, remote-authoritative, defer);
+   no default is picked.
 
-   **First, check for active handoffs.** Before consulting the state
-   table below, run:
+4. **Check for active handoffs.** Run:
    ```bash
    ls docs/adr/<dir-name>/_workflow/handoff-*.md 2>/dev/null
    ```
@@ -143,10 +151,11 @@ cross-track impact.
    §Resume protocol. That protocol re-presents the pending decision
    (or research findings) to the user, deletes resolved handoff files
    and their secondary PAUSED markers, and only then returns control
-   to this state table. While a handoff is unresolved, the
-   orchestrator MUST NOT spawn sub-agents, re-run gate-checks, or
-   recompile episodes. See `mid-phase-handoff.md` for the full
-   resume contract.
+   to step 5 below. While a handoff is unresolved, the orchestrator
+   MUST NOT spawn sub-agents, re-run gate-checks, or recompile
+   episodes. See `mid-phase-handoff.md` for the full resume contract.
+
+5. **Determine session state** from the plan file and step files.
 
    | Plan file state | Step file state | Session state |
    |---|---|---|
@@ -195,7 +204,7 @@ cross-track impact.
    auto-fix vs. user escalation). End the session after the gate
    passes.
 
-4. **Inform the user** of the auto-resume decision:
+6. **Inform the user** of the auto-resume decision:
    - Which track you're working on and why (or that plan review is
      pending if State 0)
    - If resuming mid-track: which steps are done, which is next
@@ -212,16 +221,6 @@ cross-track impact.
 
    The user can override: reorder tracks, skip a track, or choose a different
    resume point. But by default, you proceed without waiting for confirmation.
-
-5. **Run the Branch Divergence Check.** Load
-   [`branch-divergence-check.md`](branch-divergence-check.md) and
-   follow it. This must happen in turn 1, before any per-commit
-   push work. A diverged branch left undetected makes every
-   `git push` across the session reject silently and defeats the
-   "push every commit" safety net (see `commit-conventions.md`
-   § Push every commit). The protocol detects divergence and asks
-   the user to pick one of three resolutions (local-authoritative,
-   remote-authoritative, defer); no default is picked.
 
 ---
 
@@ -328,20 +327,25 @@ yet.
    - Ensure all code changes are committed
    - Ensure all progress is written to the step file on disk
    - Update the **Progress** section in the step file on disk
-   - **If the pause leaves mid-phase state that the next session
-     cannot re-derive from the plan / step files alone, write a
-     handoff file per
-     [`mid-phase-handoff.md`](mid-phase-handoff.md).** This is
-     mandatory for: between-iteration pauses in Phase C, post-
-     decomposition / between-review pauses in Phase A, mid-research
-     pauses in Phase 0 / 1, mid-section pauses in Phase 4, and any
-     pause where verbatim re-present text or partial research notes
-     would otherwise be lost. The handoff file goes under
-     `docs/adr/<dir-name>/_workflow/handoff-<phase>.md`, with a
-     matching `**PAUSED ...**` marker in the natural progress-
-     tracking file and a cross-reference in MEMORY.md — all three
-     channels are written in a single `Workflow update: pause
-     <phase> for context refresh` commit.
+   - **Write a handoff file** per
+     [`mid-phase-handoff.md`](mid-phase-handoff.md) if the pause
+     leaves mid-phase state the next session cannot re-derive from
+     the plan / step files alone. Mandatory for:
+     - between-iteration pauses in Phase C;
+     - post-decomposition / between-review pauses in Phase A;
+     - mid-research pauses in Phase 0 / 1;
+     - mid-section pauses in Phase 4;
+     - any pause where verbatim re-present text or partial research
+       notes would otherwise be lost.
+
+     The handoff file goes under
+     `docs/adr/<dir-name>/_workflow/handoff-<phase>.md`, paired with
+     a `**PAUSED ...**` marker in the natural progress-tracking file
+     (skipped for Phase 0 / 1 — see `mid-phase-handoff.md`
+     §Secondary marker) and a cross-reference in MEMORY.md. All
+     channels are written in a single commit with a bare imperative
+     message such as `Pause <phase> for context refresh — write
+     handoff`.
 3. **Ask the user for a session refresh:**
    - Inform them of current progress and what remains
    - Instruct: "Context window is running low. Please clear the session
@@ -521,7 +525,7 @@ On-demand reference documents (loaded only when their specific situation arises)
 - **`design-decision-escalation.md`** — when/how to escalate design decisions to the user
 - **`structural-review.md`** — structural review details (loaded by implementation-review.md)
 - **`track-skip.md`** — full track skip protocol (when `[~]` is triggered)
-- **`branch-divergence-check.md`** — turn-1 divergence detection and three-resolution gate (loaded by the Startup Protocol step 5; also re-routed to from `commit-conventions.md` § Push failure handling on the first non-fast-forward rejection in the session)
+- **`branch-divergence-check.md`** — turn-1 divergence detection and three-resolution gate (loaded by the Startup Protocol step 3; also re-routed to from `commit-conventions.md` § Push failure handling on the first non-fast-forward rejection in the session)
 - **`review-agent-selection.md`** — characteristic-based review agent selection (loaded by step-implementation.md and track-code-review.md)
 - **`risk-tagging.md`** — per-step risk criteria and lifecycle (loaded by `track-review.md` during Phase A decomposition; loaded by `step-implementation-recovery.md` only on the rare Phase B upgrade path; **not** loaded by Phase B normal execution or by Phase C — those phases consume the per-step `**Risk:**` tag from the step file directly)
 - **`implementer-rules.md`** — Phase B per-step implementer sub-agent rulebook (loaded only by the implementer; orchestrators do not load it)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,10 @@ The thresholds in this section MUST stay in sync with:
 - `.claude/scripts/statusline-command.sh` — the line that writes `level=...`
 - `.claude/workflow/workflow.md` — § Context Consumption Check (the level table)
 - `.claude/workflow/track-review.md` and `.claude/workflow/track-code-review.md` — the inline "warning (≥30%) or critical (≥40%)" gates
+- `.claude/workflow/implementation-review.md` — the State 0 inline gate
+- `.claude/workflow/step-implementation.md` — the Phase B inline gate
+- `.claude/workflow/prompts/create-final-design.md` — the Phase 4 inline gate
+- `.claude/workflow/mid-phase-handoff.md` — § When this protocol fires (defines the trigger thresholds)
 
 If you change a threshold here, grep for the others and update them in the same commit.
 


### PR DESCRIPTION
#### Motivation

When the context-consumption check forces a session refresh mid-phase, work not yet in the durable plan / step files would otherwise be lost or re-derived under context pressure on resume. The orchestrator was improvising across three channels (memory, step file, plan) with no documented canonical path, and discoverability on resume relied on noticing a single MEMORY.md line.

This PR introduces a canonical handoff file under `docs/adr/<dir>/_workflow/handoff-<phase>.md` as the authoritative pause signal, detected by both `/create-plan` and `/execute-tracks` at startup before any state evaluation. Secondary PAUSED markers in the step/plan file and a MEMORY.md cross-reference provide defense in depth. Two template shapes — research and decision — cover Phase 0 / 1, State 0, Phase A / B / C, and Phase 4. Per-phase "do NOT redo" defaults prevent re-spawning reviewers or gate-checks whose output is already on disk.

Resolves YTDB-807.

#### Summary

- Add `.claude/workflow/mid-phase-handoff.md` defining the protocol, author and resume procedures, two template shapes, and per-phase scope rules.
- Wire detection into `/create-plan` and `/execute-tracks` startup (before state evaluation and the clean-tree check). Make `/create-plan` create `_workflow/` as its first durable action so handoff files always have a home.
- Add inline gate references in `workflow.md`, `track-review.md`, `track-code-review.md`, `implementation-review.md`, `step-implementation.md`, and `prompts/create-final-design.md`.
- Extend `CLAUDE.md` threshold-sync list to cover the new gate sites; add handoff-*.md to `conventions.md` directory layout and a glossary entry.

The second commit applies fixes from the workflow review: BLUF rewrite, decision/research shape split for the resume loop, stale-handoff decision table, Phase 4 cleanup exception, filename-collision rule, mtime tie-breaker, Unpushed-line fallback, MEMORY.md multi-handoff rule, commit-retry and push-failure recovery, Step 0 mkdir guarantee, and self-improvement reflection step gated at the warning level.

#### Test plan

- [ ] No code changes — workflow machinery only. Verify by reading the resume flow end-to-end on the next mid-phase pause.
- [ ] Confirm `/create-plan` and `/execute-tracks` skill files detect a planted `handoff-*.md` before any state evaluation.
- [ ] Confirm threshold-sync list in CLAUDE.md matches gate sites in the changed workflow files.