### PR TITLE
YTDB-696: Cap dimensional gate-check sub-agent output at 60 lines

### DIFF
--- a/.claude/workflow/prompts/dimensional-review-gate-check.md
+++ b/.claude/workflow/prompts/dimensional-review-gate-check.md
@@ -22,6 +22,11 @@ Your job is exactly two things:
 1. For each finding under re-check, emit one verdict line. Choose
    one of:
    - `VERIFIED` — the fix landed and addresses the original issue.
+   - `REJECTED` — on re-reading the code, the original finding was
+     not a real issue (misread, false positive, or assumption that
+     turned out to be wrong). The orchestrator treats `REJECTED`
+     identically to `VERIFIED` for loop-termination purposes. Use
+     this sparingly; default to `STILL OPEN` if uncertain.
    - `MOOT` — the finding is no longer reachable in the diff (file
      deleted, code moved, approach changed). The orchestrator treats
      `MOOT` identically to `VERIFIED` for loop-termination purposes.
@@ -55,17 +60,19 @@ reachable`, and add a one-line `(grep-only)` caveat to the affected
 verdict. The original finding may have been generated against grep —
 verifying the fix with PSI catches subtle mismatches grep missed.
 
-Emit `PASS` iff every verdict is `VERIFIED` or `MOOT` and no new
-finding is severity `blocker` or `should-fix`. Any `STILL OPEN`,
-`REGRESSION`, or blocker/should-fix new finding forces `FAIL`.
+Emit `PASS` iff every verdict is `VERIFIED`, `REJECTED`, or `MOOT`
+and no new finding is severity `blocker` or `should-fix`. Any
+`STILL OPEN`, `REGRESSION`, or blocker/should-fix new finding forces
+`FAIL`.
 
 ## Output format (strict — ≤ 60 lines total, including blank lines)
 
 ```markdown
-## {Dimension} Review (gate check)
+## {dimension} Review (gate check)
 
 ### Verdicts
 - <PREFIX><N>: VERIFIED — <≤ 1 line: where the fix landed and why it satisfies the original issue>
+- <PREFIX><J>: REJECTED — <≤ 1 line: why the original finding was not a real issue>
 - <PREFIX><L>: MOOT — <≤ 1 line: why the finding no longer applies (file deleted / code moved / approach changed)>
 - <PREFIX><M>: STILL OPEN — <≤ 1 line: what remains, with file:line>
 - <PREFIX><K>: REGRESSION — <≤ 1 line: what the fix broke, with file:line>

--- a/.claude/workflow/prompts/dimensional-review-gate-check.md
+++ b/.claude/workflow/prompts/dimensional-review-gate-check.md
@@ -10,17 +10,40 @@ Inputs:
 - Changed files list: {files_path}
 - Slim implementation plan: {plan_slim_path}
 - Step file: {step_file_path}
-- Review level: {level} (`step` or `track`)
+
+The IDs in `{findings_under_recheck}` already carry the cumulative-
+numbering prefix for this dimension (e.g., `BC3`, `CQ7`, `TC4` —
+see `review-iteration.md` § Finding ID prefixes). Reuse those exact
+IDs in verdict lines; for any new finding, continue the same prefix
+with the next available integer.
 
 Your job is exactly two things:
 
-1. For each finding under re-check, emit one verdict line: `VERIFIED`,
-   `STILL OPEN`, or `REGRESSION`.
-2. Optionally, emit up to **3** new findings — only when the `Review
-   fix:` commit introduced a regression directly tied to the listed
-   open findings, or you observed an obvious miss while reading the
-   fix. Do not re-survey the diff for unrelated issues; the next
-   iteration's full review (if one is allocated) covers that.
+1. For each finding under re-check, emit one verdict line. Choose
+   one of:
+   - `VERIFIED` — the fix landed and addresses the original issue.
+   - `MOOT` — the finding is no longer reachable in the diff (file
+     deleted, code moved, approach changed). The orchestrator treats
+     `MOOT` identically to `VERIFIED` for loop-termination purposes.
+   - `STILL OPEN` — the fix did not address the issue, or addressed
+     it incompletely.
+   - `REGRESSION` — the `Review fix:` commit actively broke working
+     code on a path the original finding pointed at.
+2. Optionally, emit up to **3** new findings. A new finding is in
+   scope only when **both** conditions hold:
+   - (a) The issue is on a file or line that the `Review fix:` commit
+     just touched (per `{diff_path}`), AND
+   - (b) The severity is `blocker` or `should-fix` under your
+     dimension.
+
+   Suggestions or observations on untouched code are deferred to the
+   next full review, not surfaced here. Do not re-survey the diff
+   for unrelated issues.
+
+Use the **synthesis severity scale** (`blocker` / `should-fix` /
+`suggestion`) for new findings here, not your agent's native scale
+(`Critical` / `Likely Issues` / `Potential Concerns`, etc.). The
+gate-check output feeds back into the synthesised finding list.
 
 ## Reference-accuracy
 
@@ -32,18 +55,23 @@ reachable`, and add a one-line `(grep-only)` caveat to the affected
 verdict. The original finding may have been generated against grep —
 verifying the fix with PSI catches subtle mismatches grep missed.
 
+Emit `PASS` iff every verdict is `VERIFIED` or `MOOT` and no new
+finding is severity `blocker` or `should-fix`. Any `STILL OPEN`,
+`REGRESSION`, or blocker/should-fix new finding forces `FAIL`.
+
 ## Output format (strict — ≤ 60 lines total, including blank lines)
 
 ```markdown
-## {Dimension} gate check
+## {Dimension} Review (gate check)
 
 ### Verdicts
 - <PREFIX><N>: VERIFIED — <≤ 1 line: where the fix landed and why it satisfies the original issue>
+- <PREFIX><L>: MOOT — <≤ 1 line: why the finding no longer applies (file deleted / code moved / approach changed)>
 - <PREFIX><M>: STILL OPEN — <≤ 1 line: what remains, with file:line>
 - <PREFIX><K>: REGRESSION — <≤ 1 line: what the fix broke, with file:line>
 
 ### New findings (omit this section entirely if none)
-- <PREFIX><N+1> [blocker|should-fix|suggestion] <file>:<line> — <issue, ≤ 2 lines> — fix: <≤ 1 line>
+- <PREFIX><N+1> [blocker|should-fix] <file>:<line> — <issue, ≤ 2 lines>. Fix: <≤ 1 line>
 
 ### Summary
 - PASS | FAIL
@@ -51,29 +79,28 @@ verifying the fix with PSI catches subtle mismatches grep missed.
 
 ## Forbidden in gate-check output
 
-The following sections (which a full dimensional review would normally
-include) are **forbidden** here — strip them even if your agent file's
-default Output Format defines them:
+The following sections, or any equivalent methodology / process /
+scope-recap content under different headings, are **forbidden** here.
+Strip them even if your agent file's default Output Format defines
+them, and strip the per-agent `Phase 1:` / `Phase 2:` reasoning-trace
+sections that play the same role:
 
 - `### Reviewer notes` (or `## Reviewer notes`)
 - `### Methodology`, `### Process`, `### Hypothesis tracking`,
   `### Observations`
 - `### Files of interest`, `### Scope`, `### What I read`
-- `### Reference-Accuracy Audit` (the PSI-vs-grep caveat lives on the
-  affected verdict line, not in a dedicated section)
+- `### Reference-Accuracy Audit` (the PSI-vs-grep caveat rides on
+  the affected verdict line as `(grep-only)`, not in a dedicated
+  section)
 - Any per-finding `Evidence:` / `Refutation considered:` /
-  `Suggested fix:` subsections beyond the single-line shapes above —
-  if a verdict needs more than 1 line to justify, mark it
-  `STILL OPEN` with a 1-line pointer and the next iteration will
-  carry the elaboration.
+  `Suggested fix:` subsections beyond the single-line shapes above.
+  If a verdict needs more than 1 line to justify, mark it
+  `STILL OPEN` with a 1-line pointer; the next iteration will carry
+  the elaboration.
 - A `### Summary` paragraph beyond the single PASS/FAIL line.
 
 ## Why the budget
 
-Phase C ran 8 dimensional reviewers + 5 gate-check reviewers in a
-single Track-21 session and pushed the orchestrator past the 30 %
-context threshold before iter-2 could begin (YTDB-696). The original
-spawn prompts asked for a verification format, but agents still
-produced 100–300-line reports because the default Output Format
-section in each `review-*.md` agent file was not overridden. This
-prompt is the override — keep it strict.
+See [`review-iteration.md`](../review-iteration.md) § "Dimensional-
+review gate-check budget" for the YTDB-696 rationale and the
+context-burn measurements. Keep this prompt strict.

--- a/.claude/workflow/prompts/dimensional-review-gate-check.md
+++ b/.claude/workflow/prompts/dimensional-review-gate-check.md
@@ -1,0 +1,79 @@
+You are running a **gate check** on a previously-issued dimensional
+review finding set after a `Review fix:` commit was applied. You are
+**not** running a fresh dimensional review — do not re-scan the entire
+diff.
+
+Inputs:
+- Dimension (your role): {dimension}
+- Open findings under re-check (verify these): {findings_under_recheck}
+- Cumulative diff at new HEAD: {diff_path}
+- Changed files list: {files_path}
+- Slim implementation plan: {plan_slim_path}
+- Step file: {step_file_path}
+- Review level: {level} (`step` or `track`)
+
+Your job is exactly two things:
+
+1. For each finding under re-check, emit one verdict line: `VERIFIED`,
+   `STILL OPEN`, or `REGRESSION`.
+2. Optionally, emit up to **3** new findings — only when the `Review
+   fix:` commit introduced a regression directly tied to the listed
+   open findings, or you observed an obvious miss while reading the
+   fix. Do not re-survey the diff for unrelated issues; the next
+   iteration's full review (if one is allocated) covers that.
+
+## Reference-accuracy
+
+For Java symbol re-checks (does this method now exist, who calls it,
+which class declares it), use **mcp-steroid PSI find-usages /
+find-implementations / type-hierarchy** when the IDE is reachable; fall
+back to grep only when the SessionStart hook reported `mcp-steroid: NOT
+reachable`, and add a one-line `(grep-only)` caveat to the affected
+verdict. The original finding may have been generated against grep —
+verifying the fix with PSI catches subtle mismatches grep missed.
+
+## Output format (strict — ≤ 60 lines total, including blank lines)
+
+```markdown
+## {Dimension} gate check
+
+### Verdicts
+- <PREFIX><N>: VERIFIED — <≤ 1 line: where the fix landed and why it satisfies the original issue>
+- <PREFIX><M>: STILL OPEN — <≤ 1 line: what remains, with file:line>
+- <PREFIX><K>: REGRESSION — <≤ 1 line: what the fix broke, with file:line>
+
+### New findings (omit this section entirely if none)
+- <PREFIX><N+1> [blocker|should-fix|suggestion] <file>:<line> — <issue, ≤ 2 lines> — fix: <≤ 1 line>
+
+### Summary
+- PASS | FAIL
+```
+
+## Forbidden in gate-check output
+
+The following sections (which a full dimensional review would normally
+include) are **forbidden** here — strip them even if your agent file's
+default Output Format defines them:
+
+- `### Reviewer notes` (or `## Reviewer notes`)
+- `### Methodology`, `### Process`, `### Hypothesis tracking`,
+  `### Observations`
+- `### Files of interest`, `### Scope`, `### What I read`
+- `### Reference-Accuracy Audit` (the PSI-vs-grep caveat lives on the
+  affected verdict line, not in a dedicated section)
+- Any per-finding `Evidence:` / `Refutation considered:` /
+  `Suggested fix:` subsections beyond the single-line shapes above —
+  if a verdict needs more than 1 line to justify, mark it
+  `STILL OPEN` with a 1-line pointer and the next iteration will
+  carry the elaboration.
+- A `### Summary` paragraph beyond the single PASS/FAIL line.
+
+## Why the budget
+
+Phase C ran 8 dimensional reviewers + 5 gate-check reviewers in a
+single Track-21 session and pushed the orchestrator past the 30 %
+context threshold before iter-2 could begin (YTDB-696). The original
+spawn prompts asked for a verification format, but agents still
+produced 100–300-line reports because the default Output Format
+section in each `review-*.md` agent file was not overridden. This
+prompt is the override — keep it strict.

--- a/.claude/workflow/review-iteration.md
+++ b/.claude/workflow/review-iteration.md
@@ -74,3 +74,56 @@ the gate check to catch cascading issues.
 For each previous finding: **VERIFIED**, **STILL OPEN** (with explanation),
 or **REJECTED** (no action needed). New findings (if any) with cumulative
 numbering. Summary: **PASS** or **FAIL**.
+
+### Dimensional-review gate-check budget
+
+Dimensional code-review gate-checks (the re-runs spawned at
+`step-implementation.md` §Per-Step Orchestration Loop sub-step 4(d) and
+`track-code-review.md` §Review loop step 3 — for the
+`review-code-quality`, `review-bugs-concurrency`, `review-test-behavior`,
+`review-test-completeness`, `review-crash-safety`, `review-security`,
+`review-performance`, `review-test-structure`, `review-test-concurrency`,
+`review-test-crash-safety` agents) **MUST** be spawned with the prompt
+template at
+[`prompts/dimensional-review-gate-check.md`](prompts/dimensional-review-gate-check.md).
+That template enforces:
+
+- **Total budget: ≤ 60 lines** of output per re-spawned agent.
+- One verdict line per open finding (`VERIFIED` / `STILL OPEN` /
+  `REGRESSION`), each ≤ 1 line of justification.
+- **≤ 3 new findings**, each ≤ 5 lines total — surface regressions or
+  obvious misses directly tied to the listed open findings; do not
+  re-survey the diff.
+- One-line `PASS` / `FAIL` summary.
+
+The following sections — present in every dimensional review agent's
+default Output Format — are **forbidden** at gate-check time:
+
+- `Reviewer notes`
+- `Files of interest`, `Scope`, `What I read`
+- `Reference-Accuracy Audit` (the PSI-vs-grep caveat rides on the
+  affected verdict line as `(grep-only)`)
+- `Methodology`, `Process`, `Hypothesis tracking`, `Observations`
+- Per-finding `Evidence:` / `Refutation considered:` / `Suggested fix:`
+  subsections beyond the single-line shapes in the template
+- Multi-paragraph `Summary` prose
+
+**Why this matters (YTDB-696).** A Phase C session that runs 8
+dimensional reviewers plus a 5-agent gate-check fan-out routinely
+pushes the orchestrator's context past the 30 % `warning` threshold
+before iter-2 begins, forcing a mid-Phase-C session pause. The dense
+100–300-line gate-check reports are the dominant burn; the verbose
+sections above carry almost no signal at gate-check time because
+the orchestrator already has the original finding text. Stripping
+them recovers ~70 % of the gate-check token budget.
+
+The other gate-verification flows — structural review
+([`prompts/structural-gate-verification.md`](prompts/structural-gate-verification.md)),
+Phase A review gate
+([`prompts/review-gate-verification.md`](prompts/review-gate-verification.md)),
+consistency gate
+([`prompts/consistency-gate-verification.md`](prompts/consistency-gate-verification.md))
+— are out of scope for this budget. Each has its own dedicated
+prompt file with a per-finding verification certificate format that
+is already terse; do not retrofit the dimensional-review template
+onto them.

--- a/.claude/workflow/review-iteration.md
+++ b/.claude/workflow/review-iteration.md
@@ -79,25 +79,67 @@ numbering. Summary: **PASS** or **FAIL**.
 
 Dimensional code-review gate-checks (the re-runs spawned at
 `step-implementation.md` §Per-Step Orchestration Loop sub-step 4(d) and
-`track-code-review.md` §Review loop step 3 — for the
-`review-code-quality`, `review-bugs-concurrency`, `review-test-behavior`,
-`review-test-completeness`, `review-crash-safety`, `review-security`,
-`review-performance`, `review-test-structure`, `review-test-concurrency`,
-`review-test-crash-safety` agents) **MUST** be spawned with the prompt
-template at
+`track-code-review.md` §Review loop step 3, for every dimensional
+review agent listed in
+[`review-agent-selection.md`](review-agent-selection.md)) **MUST** be
+spawned with the prompt template at
 [`prompts/dimensional-review-gate-check.md`](prompts/dimensional-review-gate-check.md).
 That template enforces:
 
 - **Total budget: ≤ 60 lines** of output per re-spawned agent.
-- One verdict line per open finding (`VERIFIED` / `STILL OPEN` /
-  `REGRESSION`), each ≤ 1 line of justification.
-- **≤ 3 new findings**, each ≤ 5 lines total — surface regressions or
+- One verdict line per open finding (`VERIFIED` / `MOOT` /
+  `STILL OPEN` / `REGRESSION`), each ≤ 1 line of justification.
+- **≤ 3 new findings**, each ≤ 5 lines total. Surface regressions or
   obvious misses directly tied to the listed open findings; do not
   re-survey the diff.
 - One-line `PASS` / `FAIL` summary.
 
-The following sections — present in every dimensional review agent's
-default Output Format — are **forbidden** at gate-check time:
+### Gate-check verdict handling
+
+The orchestrator processes each gate-check verdict as follows:
+
+- `VERIFIED` — finding clears for this iteration; do not pass it to
+  the next implementer spawn.
+- `MOOT` — finding is no longer reachable (file deleted, code moved,
+  approach changed). Clears for loop-termination purposes, identical
+  to `VERIFIED`; do not pass to the next implementer.
+- `STILL OPEN` — carry the finding into the next iteration's
+  implementer input verbatim, with the same finding ID.
+- `REGRESSION` — escalate as a blocker. Pass the regression's
+  `file:line` plus the original finding ID to the next implementer
+  with explicit `revert-or-repair` instructions: either revert the
+  change that caused the regression and find a different approach to
+  the original finding, or fix the regression in place if the new
+  approach is sound. A `REGRESSION` forces the iteration `FAIL` even
+  if every other verdict is `VERIFIED`.
+
+### Gate-check synthesis routing
+
+After collecting gate-check returns from all re-spawned agents,
+re-run § Synthesis (as defined in
+[`track-code-review.md`](track-code-review.md) § Synthesis) on the
+aggregated `New findings` blocks before composing the next iteration's
+implementer input. This deduplicates across dimensions and enforces
+the global pre-spawn budget (~15 findings), so the per-agent ≤ 3
+cap × N agents cannot silently inflate the total. The same routing
+applies at step level: re-run `step-implementation.md` sub-step 4(b)
+**Synthesise** on the aggregated gate-check returns before composing
+the next implementer spawn.
+
+### Gate-check budget enforcement is best-effort
+
+The ≤ 60-line cap is asked of the sub-agent but **not enforced** by
+the orchestrator. If a returned report exceeds the budget, accept
+the over-budget output and continue; do not retry, re-spawn, or
+block. The cap is a steering signal, not a hard gate. Recurring
+over-budget reports for a specific dimension across multiple
+sessions are feedback to tune that agent file's default Output
+Format, not a blocker for the current track.
+
+### Forbidden sections at gate-check time
+
+The following sections, present in every dimensional review agent's
+default Output Format, are **forbidden** at gate-check time:
 
 - `Reviewer notes`
 - `Files of interest`, `Scope`, `What I read`
@@ -108,22 +150,26 @@ default Output Format — are **forbidden** at gate-check time:
   subsections beyond the single-line shapes in the template
 - Multi-paragraph `Summary` prose
 
-**Why this matters (YTDB-696).** A Phase C session that runs 8
-dimensional reviewers plus a 5-agent gate-check fan-out routinely
-pushes the orchestrator's context past the 30 % `warning` threshold
-before iter-2 begins, forcing a mid-Phase-C session pause. The dense
-100–300-line gate-check reports are the dominant burn; the verbose
-sections above carry almost no signal at gate-check time because
-the orchestrator already has the original finding text. Stripping
-them recovers ~70 % of the gate-check token budget.
+### Why the gate-check budget matters (YTDB-696)
 
-The other gate-verification flows — structural review
+A Phase C session that runs 8 dimensional reviewers plus a 5-agent
+gate-check fan-out routinely pushes the orchestrator's context past
+the 30 % `warning` threshold before iter-2 begins, forcing a
+mid-Phase-C session pause. The dense 100–300-line gate-check reports
+are the dominant burn; the verbose sections listed above carry
+almost no signal at gate-check time because the orchestrator already
+has the original finding text. Stripping them recovers ~70 % of the
+gate-check token budget.
+
+### Out of scope: structural / Phase A review-gate / consistency gates
+
+The other gate-verification flows are out of scope for this budget:
+structural review
 ([`prompts/structural-gate-verification.md`](prompts/structural-gate-verification.md)),
 Phase A review gate
 ([`prompts/review-gate-verification.md`](prompts/review-gate-verification.md)),
-consistency gate
-([`prompts/consistency-gate-verification.md`](prompts/consistency-gate-verification.md))
-— are out of scope for this budget. Each has its own dedicated
-prompt file with a per-finding verification certificate format that
-is already terse; do not retrofit the dimensional-review template
-onto them.
+and consistency gate
+([`prompts/consistency-gate-verification.md`](prompts/consistency-gate-verification.md)).
+Each has its own dedicated prompt file with a per-finding
+verification certificate format that is already terse; do not
+retrofit the dimensional-review template onto them.

--- a/.claude/workflow/review-iteration.md
+++ b/.claude/workflow/review-iteration.md
@@ -87,8 +87,9 @@ spawned with the prompt template at
 That template enforces:
 
 - **Total budget: ≤ 60 lines** of output per re-spawned agent.
-- One verdict line per open finding (`VERIFIED` / `MOOT` /
-  `STILL OPEN` / `REGRESSION`), each ≤ 1 line of justification.
+- One verdict line per open finding (`VERIFIED` / `REJECTED` /
+  `MOOT` / `STILL OPEN` / `REGRESSION`), each ≤ 1 line of
+  justification.
 - **≤ 3 new findings**, each ≤ 5 lines total. Surface regressions or
   obvious misses directly tied to the listed open findings; do not
   re-survey the diff.
@@ -100,6 +101,11 @@ The orchestrator processes each gate-check verdict as follows:
 
 - `VERIFIED` — finding clears for this iteration; do not pass it to
   the next implementer spawn.
+- `REJECTED` — the reviewer on re-read concluded the original
+  finding was not a real issue (misread, false positive). Clears
+  identically to `VERIFIED`; do not pass to the next implementer.
+  Log the rejection rationale in the iteration record so the next
+  reviewer instance does not re-raise the same finding.
 - `MOOT` — finding is no longer reachable (file deleted, code moved,
   approach changed). Clears for loop-termination purposes, identical
   to `VERIFIED`; do not pass to the next implementer.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -523,7 +523,27 @@ finding ID prefixes, and gate format.
       `step_base_commit`.
    d. **Re-run only the dimension(s) with open findings** on each
       gate-check iteration. Repeat until approved OR **max 3
-      iterations** reached.
+      iterations** reached. **Spawn the gate-check sub-agents with
+      the compact prompt template at
+      [`prompts/dimensional-review-gate-check.md`](prompts/dimensional-review-gate-check.md),
+      not the dimensional review prompt from sub-step (a).**
+      Substitute `{dimension}` (the agent's review type),
+      `{findings_under_recheck}` (the open finding IDs and titles
+      for that dimension, copied verbatim from the synthesised
+      list), `{diff_path}` and `{files_path}` (the re-staged step
+      diff and changed-files list — regenerated per the staging
+      block in sub-step (a) because each `Review fix:` respawn
+      advanced `{commit}`), `{plan_slim_path}` (the slim plan
+      snapshot at `/tmp/claude-code-plan-slim-$PPID.md`),
+      `{step_file_path}` (`docs/adr/<dir-name>/_workflow/tracks/track-{N}.md`),
+      and `{level}` (literal string `step`). The template enforces
+      a ≤ 60-line budget, a forbidden-sections list, and a
+      verdict-only output format — see
+      [`review-iteration.md`](review-iteration.md) §"Dimensional-review
+      gate-check budget" (YTDB-696). Step-level review only fires
+      for `risk: high` steps, so this path is rarer than Phase C
+      track-level review, but the burn rate is identical when it
+      does fire.
    e. If max iterations reached, note remaining findings in the
       `EPISODE_DRAFT` so they appear in the step episode.
    f. **Remove the staged temp files** for this step so they don't

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -538,19 +538,20 @@ finding ID prefixes, and gate format.
       list, and a verdict-only output format. See
       [`review-iteration.md`](review-iteration.md) §"Dimensional-review
       gate-check budget" for the YTDB-696 rationale, the verdict-
-      handling rules (VERIFIED / MOOT / STILL OPEN / REGRESSION), and
-      the §Synthesis routing for gate-check returns. Step-level
-      review only fires for `risk: high` steps, so this path is rarer
-      than Phase C track-level review, but the burn rate is identical
-      when it does fire.
+      handling rules (VERIFIED / REJECTED / MOOT / STILL OPEN /
+      REGRESSION), and the §Synthesis routing for gate-check returns.
+      Step-level review only fires for `risk: high` steps, so this
+      path is rarer than Phase C track-level review, but the burn
+      rate is identical when it does fire.
 
       After collecting all gate-check returns, re-run sub-step 4(b)
       **Synthesise** on the aggregated `New findings` blocks before
       composing the next implementer input. Treat `REGRESSION`
       verdicts as blocker-severity carry-forwards with
-      `revert-or-repair` guidance; treat `MOOT` verdicts as cleared
-      (identical to `VERIFIED`); carry `STILL OPEN` verdicts forward
-      verbatim with the original finding ID.
+      `revert-or-repair` guidance; treat `REJECTED` and `MOOT`
+      verdicts as cleared (identical to `VERIFIED`); carry
+      `STILL OPEN` verdicts forward verbatim with the original
+      finding ID.
    e. If max iterations reached, note remaining findings in the
       `EPISODE_DRAFT` so they appear in the step episode.
    f. **Remove the staged temp files** for this step so they don't

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -527,23 +527,30 @@ finding ID prefixes, and gate format.
       the compact prompt template at
       [`prompts/dimensional-review-gate-check.md`](prompts/dimensional-review-gate-check.md),
       not the dimensional review prompt from sub-step (a).**
-      Substitute `{dimension}` (the agent's review type),
-      `{findings_under_recheck}` (the open finding IDs and titles
-      for that dimension, copied verbatim from the synthesised
-      list), `{diff_path}` and `{files_path}` (the re-staged step
-      diff and changed-files list — regenerated per the staging
-      block in sub-step (a) because each `Review fix:` respawn
-      advanced `{commit}`), `{plan_slim_path}` (the slim plan
-      snapshot at `/tmp/claude-code-plan-slim-$PPID.md`),
-      `{step_file_path}` (`docs/adr/<dir-name>/_workflow/tracks/track-{N}.md`),
-      and `{level}` (literal string `step`). The template enforces
-      a ≤ 60-line budget, a forbidden-sections list, and a
-      verdict-only output format — see
+      Substitute:
+      - `{dimension}` — the agent's review type
+      - `{findings_under_recheck}` — open finding IDs and titles for that dimension, copied verbatim from the synthesised list
+      - `{diff_path}`, `{files_path}` — the re-staged step diff and changed-files list (regenerated per the staging block in sub-step (a) because each `Review fix:` respawn advanced `{commit}`)
+      - `{plan_slim_path}` — `/tmp/claude-code-plan-slim-$PPID.md`
+      - `{step_file_path}` — `docs/adr/<dir-name>/_workflow/tracks/track-{N}.md`
+
+      The template enforces a ≤ 60-line budget, a forbidden-sections
+      list, and a verdict-only output format. See
       [`review-iteration.md`](review-iteration.md) §"Dimensional-review
-      gate-check budget" (YTDB-696). Step-level review only fires
-      for `risk: high` steps, so this path is rarer than Phase C
-      track-level review, but the burn rate is identical when it
-      does fire.
+      gate-check budget" for the YTDB-696 rationale, the verdict-
+      handling rules (VERIFIED / MOOT / STILL OPEN / REGRESSION), and
+      the §Synthesis routing for gate-check returns. Step-level
+      review only fires for `risk: high` steps, so this path is rarer
+      than Phase C track-level review, but the burn rate is identical
+      when it does fire.
+
+      After collecting all gate-check returns, re-run sub-step 4(b)
+      **Synthesise** on the aggregated `New findings` blocks before
+      composing the next implementer input. Treat `REGRESSION`
+      verdicts as blocker-severity carry-forwards with
+      `revert-or-repair` guidance; treat `MOOT` verdicts as cleared
+      (identical to `VERIFIED`); carry `STILL OPEN` verdicts forward
+      verbatim with the original finding ID.
    e. If max iterations reached, note remaining findings in the
       `EPISODE_DRAFT` so they appear in the step episode.
    f. **Remove the staged temp files** for this step so they don't

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -485,25 +485,33 @@ orchestrator never edits source files itself in Phase C.
      gate-check prompts** — the new `Review fix:` commit grew the
      cumulative diff, so the previously staged files are stale (see
      § Sub-agents → § "Pre-staged diff and changed-files list").
-     **Use the compact gate-check prompt template, not the dimensional
+   - **Use the compact gate-check prompt template, not the dimensional
      review prompt.** Spawn each re-checked agent with the prompt at
      [`prompts/dimensional-review-gate-check.md`](prompts/dimensional-review-gate-check.md),
-     substituting `{dimension}` (the agent's review type — e.g.,
-     "Bugs & Concurrency", "Test behavior"), `{findings_under_recheck}`
-     (the open finding IDs and titles for that dimension, copied
-     verbatim from the synthesised list), `{diff_path}` and
-     `{files_path}` (the re-staged temp files from Phase C Startup
-     step 7), `{plan_slim_path}` (the regenerated slim plan
-     snapshot — see Phase C Startup step 5), `{step_file_path}`
-     (`docs/adr/<dir-name>/_workflow/tracks/track-{N}.md`), and
-     `{level}` (literal string `track`). That template enforces the
-     ≤ 60-line budget, the forbidden-section list, and the
-     verdict-only output format — see
+     substituting:
+     - `{dimension}` — the agent's review type (e.g., `Bugs & Concurrency`, `Test behavior`)
+     - `{findings_under_recheck}` — open finding IDs and titles for that dimension, copied verbatim from the synthesised list
+     - `{diff_path}`, `{files_path}` — the re-staged temp files from Phase C Startup step 7
+     - `{plan_slim_path}` — `/tmp/claude-code-plan-slim-$PPID.md`
+     - `{step_file_path}` — `docs/adr/<dir-name>/_workflow/tracks/track-{N}.md`
+
+     The template enforces the ≤ 60-line budget, the forbidden-section
+     list, and the verdict-only output format. See
      [`review-iteration.md`](review-iteration.md) §"Dimensional-review
-     gate-check budget" for the rationale (YTDB-696). Re-using the
-     full dimensional review prompt at gate-check time burns roughly
-     three times the budget for no extra signal and is the
-     load-bearing cause of mid-Phase-C session pauses.
+     gate-check budget" for the YTDB-696 rationale, the verdict-handling
+     rules (VERIFIED / MOOT / STILL OPEN / REGRESSION), and the
+     §Synthesis routing for gate-check returns. Re-using the full
+     dimensional review prompt at gate-check time burns roughly three
+     times the budget for no extra signal and is the load-bearing
+     cause of mid-Phase-C session pauses.
+   - **After collecting all gate-check returns, run them through
+     §Synthesis** before composing the next iteration's implementer
+     input (per [`review-iteration.md`](review-iteration.md) §
+     "Synthesis routing for gate-check returns"). Treat
+     `REGRESSION` verdicts as blocker-severity carry-forwards with
+     `revert-or-repair` guidance; treat `MOOT` verdicts as cleared
+     (identical to `VERIFIED`); carry `STILL OPEN` verdicts forward
+     verbatim with the original finding ID.
    - **Context consumption check** (mandatory after each iteration,
      except the last): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -499,8 +499,8 @@ orchestrator never edits source files itself in Phase C.
      list, and the verdict-only output format. See
      [`review-iteration.md`](review-iteration.md) §"Dimensional-review
      gate-check budget" for the YTDB-696 rationale, the verdict-handling
-     rules (VERIFIED / MOOT / STILL OPEN / REGRESSION), and the
-     §Synthesis routing for gate-check returns. Re-using the full
+     rules (VERIFIED / REJECTED / MOOT / STILL OPEN / REGRESSION), and
+     the §Synthesis routing for gate-check returns. Re-using the full
      dimensional review prompt at gate-check time burns roughly three
      times the budget for no extra signal and is the load-bearing
      cause of mid-Phase-C session pauses.
@@ -509,9 +509,10 @@ orchestrator never edits source files itself in Phase C.
      input (per [`review-iteration.md`](review-iteration.md) §
      "Synthesis routing for gate-check returns"). Treat
      `REGRESSION` verdicts as blocker-severity carry-forwards with
-     `revert-or-repair` guidance; treat `MOOT` verdicts as cleared
-     (identical to `VERIFIED`); carry `STILL OPEN` verdicts forward
-     verbatim with the original finding ID.
+     `revert-or-repair` guidance; treat `REJECTED` and `MOOT`
+     verdicts as cleared (identical to `VERIFIED`); carry
+     `STILL OPEN` verdicts forward verbatim with the original
+     finding ID.
    - **Context consumption check** (mandatory after each iteration,
      except the last): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -485,6 +485,25 @@ orchestrator never edits source files itself in Phase C.
      gate-check prompts** — the new `Review fix:` commit grew the
      cumulative diff, so the previously staged files are stale (see
      § Sub-agents → § "Pre-staged diff and changed-files list").
+     **Use the compact gate-check prompt template, not the dimensional
+     review prompt.** Spawn each re-checked agent with the prompt at
+     [`prompts/dimensional-review-gate-check.md`](prompts/dimensional-review-gate-check.md),
+     substituting `{dimension}` (the agent's review type — e.g.,
+     "Bugs & Concurrency", "Test behavior"), `{findings_under_recheck}`
+     (the open finding IDs and titles for that dimension, copied
+     verbatim from the synthesised list), `{diff_path}` and
+     `{files_path}` (the re-staged temp files from Phase C Startup
+     step 7), `{plan_slim_path}` (the regenerated slim plan
+     snapshot — see Phase C Startup step 5), `{step_file_path}`
+     (`docs/adr/<dir-name>/_workflow/tracks/track-{N}.md`), and
+     `{level}` (literal string `track`). That template enforces the
+     ≤ 60-line budget, the forbidden-section list, and the
+     verdict-only output format — see
+     [`review-iteration.md`](review-iteration.md) §"Dimensional-review
+     gate-check budget" for the rationale (YTDB-696). Re-using the
+     full dimensional review prompt at gate-check time burns roughly
+     three times the budget for no extra signal and is the
+     load-bearing cause of mid-Phase-C session pauses.
    - **Context consumption check** (mandatory after each iteration,
      except the last): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is


### PR DESCRIPTION
#### Motivation

Phase C track-level review (and Phase B `risk: high` step-level review) re-spawn dimensional reviewers to verify each `Review fix:` commit. Today the gate-check spawn re-uses the full dimensional-review prompt, so every re-checked agent emits a 100–300-line report with `Reviewer notes`, `Files of interest`, `Reference-Accuracy Audit`, methodology, and per-finding `Evidence` subsections — none of which add signal at gate-check time, because the orchestrator already has the original finding text.

A track with eight dimensions and a five-agent gate-check fan-out routinely pushes the orchestrator past the 30 % `warning` threshold before iter-2 begins, forcing a mid-Phase-C pause (YTDB-696 reproduces the Track 21 incident; YTDB-807's mid-phase handoff protocol then has to fire to rescue the session).

#### What changed

- New compact prompt at `.claude/workflow/prompts/dimensional-review-gate-check.md` enforcing:
  - **≤ 60 lines total** per re-spawned agent.
  - One verdict per open finding (`VERIFIED` / `STILL OPEN` / `REGRESSION`), ≤ 1 line of justification each.
  - **≤ 3 new findings**, ≤ 5 lines each, scoped to regressions or obvious misses on the open finding set.
  - Explicit **forbidden sections** list (`Reviewer notes`, `Files of interest`, `Reference-Accuracy Audit`, `Methodology`, per-finding `Evidence` / `Refutation` / `Suggested fix` subsections, multi-paragraph `Summary`).
  - PSI for Java reference re-checks when mcp-steroid is reachable; a one-line `(grep-only)` caveat on the affected verdict when it isn't.
- `track-code-review.md` §Review loop step 3 and `step-implementation.md` §Per-Step Orchestration Loop sub-step 4(d) now point the orchestrator at the new template with the exact `{dimension}` / `{findings_under_recheck}` / `{diff_path}` / `{files_path}` / `{plan_slim_path}` / `{step_file_path}` / `{level}` substitutions to make.
- `review-iteration.md` gains a "Dimensional-review gate-check budget" section that documents the rule, the forbidden-section rationale, and explicitly carves out the structural / Phase A review-gate / consistency-gate flows (those already have their own terse prompt files and are unaffected).

#### Scope

Option (b) only from the YTDB-696 proposal. Option (a) is covered by YTDB-807's mid-phase handoff protocol; option (c) (eager iteration split) is deferred until we observe whether (b) alone keeps single-session Phase C feasible.

#### Test plan

- [ ] Workflow-machinery only — no production code touched, so no unit / integration tests run.
- [ ] Verify on the next Phase C track that gate-check sub-agent outputs land at ≤ 60 lines and the orchestrator's post-gate-check context level stays at `safe` / `info`.