### PR TITLE
Add review-mode loop to gate approval panels

### DIFF
--- a/.claude/skills/execute-tracks/SKILL.md
+++ b/.claude/skills/execute-tracks/SKILL.md
@@ -113,10 +113,10 @@ Each session handles exactly ONE PHASE of one track (or Phase 4 / State 0):
 User interaction happens at specific points:
 - Session start: auto-resume decision (confirm or override)
 - State 0 design-decision findings: resolve each escalated finding (only design-decision; mechanical fixes apply autonomously)
-- Track Pre-Flight (State A — pre-Phase-A): two-panel gate. Panel 1 (strategy assessment, look-back) is shown when an earlier track has just completed/skipped — accept the CONTINUE/ADJUST recommendation or override; an ESCALATE recommendation routes to inline replanning. Panel 2 (upcoming track summary, look-forward) always renders. Options on the combined gate: Proceed; Adjust (light edits to any remaining track's plan / step file including reorder); Clarify (notes written into the upcoming track's step-file Description as a `### Clarifications` subsection on Proceed); ESCALATE → inline replanning. Skipped on State C resume.
+- Track Pre-Flight (State A — pre-Phase-A): two-panel gate. Panel 1 (strategy assessment, look-back) is shown when an earlier track has just completed/skipped — accept the CONTINUE/ADJUST recommendation or override; an ESCALATE recommendation routes to inline replanning. Panel 2 (upcoming track summary, look-forward) always renders. Three one-step options per `.claude/workflow/review-mode.md` § Approval-panel contract: **Approve** (accept and start Phase A with whatever review-mode-accumulated amendments and clarifications have landed); **Review mode** (free-form refinement loop — translator produces a typed action set the user confirms before Apply; on Apply executes `EDIT_PLAN` / `EDIT_STEP_DESC` / `SKIP_TRACK`, buffers `CLARIFY`, answers `QUESTION` inline; panels re-render); **ESCALATE** → inline replanning. Skipped on State C resume.
 - Phase complete: user clears session, re-runs `/execute-tracks`
 - Cross-track impact detected: continue, pause, or escalate
-- Track complete: approve, request fixes, or request rework
+- Track complete: three one-step options per `.claude/workflow/review-mode.md` § Approval-panel contract — **Approve** (write track episode + collapse + `[x]`); **Review mode** (free-form refinement; on Apply, `FIX_FINDING` items spawn a fresh implementer with `mode=FIX_REVIEW_FINDINGS`; `QUESTION` items are answered inline); **ESCALATE** → inline replanning
 - Step failure (2nd attempt): retry, adjust, or escalate
 
 Everything within a phase executes autonomously: Phase A runs reviews

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -10,11 +10,14 @@ notes.
 - Track Pre-Flight Panel 1 (strategy assessment) returns ESCALATE
   and the user accepts (see [`track-review.md`](track-review.md)
   § Track Pre-Flight step 1)
-- Track Pre-Flight `Adjust` would touch a deep amendment category
-  — Decision Records, Architecture Notes, Goals, Constraints,
-  adding/removing tracks, cross-track interaction surfaces, or
-  user-requested "fundamental rework" (see `track-review.md`
-  § Track Pre-Flight step 4)
+- Track Pre-Flight review mode produces an `ESCALATE` action item,
+  or the user picks **Escalate now** on the Mixed-set policy panel
+  (see [`review-mode.md`](review-mode.md) § ESCALATE detection and
+  § Mixed-set policy) — i.e., the requested change touches Decision
+  Records, Architecture Notes, Goals, Constraints, adds or removes
+  tracks, crosses cross-track interaction surfaces, or the user
+  describes it as "fundamental rework" (deep-amendment list in
+  `track-review.md` § Track Pre-Flight step 4)
 - Cross-track impact monitoring detects a fundamental assumption failure
 - A step failure affects the track's approach at a level additional commits
   cannot fix

--- a/.claude/workflow/inline-replanning.md
+++ b/.claude/workflow/inline-replanning.md
@@ -14,10 +14,12 @@ notes.
   or the user picks **Escalate now** on the Mixed-set policy panel
   (see [`review-mode.md`](review-mode.md) § ESCALATE detection and
   § Mixed-set policy) — i.e., the requested change touches Decision
-  Records, Architecture Notes, Goals, Constraints, adds or removes
-  tracks, crosses cross-track interaction surfaces, or the user
+  Records, Architecture Notes, Goals, Constraints, **adds** a new
+  track, crosses cross-track interaction surfaces, or the user
   describes it as "fundamental rework" (deep-amendment list in
-  `track-review.md` § Track Pre-Flight step 4)
+  `track-review.md` § Track Pre-Flight step 4). **Removing** a
+  remaining track is light (`SKIP_TRACK`) and does not trigger
+  inline replanning.
 - Cross-track impact monitoring detects a fundamental assumption failure
 - A step failure affects the track's approach at a level additional commits
   cannot fix
@@ -33,6 +35,14 @@ notes.
 - What assumptions broke and why
 - Which remaining tracks are affected and how
 - What Decision Records are weakened or invalidated
+
+If `pending_escalate_description` is set in conversation context
+when inline-replanning fires from a Track Pre-Flight or Track
+Completion gate (captured by a Strip-and-apply earlier in the same
+session per [`review-mode.md`](review-mode.md) § Mixed-set policy),
+read the stashed text as the user-supplied deep-change description
+for this Assess. Do not prompt the user to re-state it. Clear the
+slot after consumption.
 
 **3. Propose** — draft a revised plan:
 

--- a/.claude/workflow/planning.md
+++ b/.claude/workflow/planning.md
@@ -309,7 +309,8 @@ scope creep during execution.
    find any specific decision in under 10 seconds.
 6. **Update diagrams with steps** — when a step modifies component interactions,
    updating the Component Map diagram is part of the episode capture or the
-   Track Pre-Flight gate's `Adjust` action (Panel 1 strategy assessment).
+   Track Pre-Flight gate's review-mode loop (an `EDIT_PLAN` item per
+   [`review-mode.md`](review-mode.md) § Loop step 2).
 7. **Mermaid diagrams** — required when there are 3+ components with
    non-trivial relationships; omit for simpler cases where a bullet list
    alone is clearer.

--- a/.claude/workflow/review-mode.md
+++ b/.claude/workflow/review-mode.md
@@ -17,9 +17,9 @@ PSI-verifies any named production classes, and asks the user to
 confirm the set before applying. After Apply, the gate's original
 approval panel re-renders.
 
-The point is to let the user combine concerns in one round —
+The point is to let the user combine concerns in one round, e.g.
 "why was X done this way, also rename the variable to Y, and add
-a clarification that the implementer must preserve Z" — instead of
+a clarification that the implementer must preserve Z", instead of
 picking categorical buckets across multiple rounds.
 
 ## Approval-panel contract
@@ -47,11 +47,14 @@ single one-step decision.
 
 ### 1. Free-form input
 
-Single open prompt via `AskUserQuestion` with one option labelled
-"Submit" and a free-form text capture (or the user's normal reply
-to the orchestrator's prompt). User describes: observations,
-requested edits, missing context, open questions, or anything else
-relevant to the gate's decision. No template, no fields.
+Use `AskUserQuestion` with one labelled option (`Submit`) so the
+user's input arrives via the tool's free-text override field —
+the same idiom every multi-option panel exposes for off-list
+answers. (Alternatively, skip the tool call entirely and accept
+the user's next chat reply as the free-form input — see §Off-panel
+responses for how routine panels consume chat replies.) The user
+describes: observations, requested edits, missing context, or open
+questions. No template, no fields.
 
 ### 2. Translate to a typed action set
 
@@ -61,7 +64,8 @@ order the user mentioned them. Each item has a type and a payload:
 | Type | Payload | Side effect on Apply | Available in |
 |---|---|---|---|
 | `QUESTION` | Question text + orchestrator's answer (resolved during translation by reading conversation context, git log, step / track episodes, plan file, and source code as needed) | None — already answered at render time | Both gates |
-| `EDIT_PLAN` | Path + anchor + new text. Light edits to a remaining track's plan-file entry: title, intro paragraph, scope indicators, or reorder of remaining `[ ]` tracks | Apply via `Edit` (single site) or `steroid_apply_patch` (>2 sites) per `track-review.md` § Track Pre-Flight step 4 | Pre-Flight only |
+| `EDIT_PLAN` | Path + anchor + new text. Light edits to a remaining track's plan-file entry: title, intro paragraph, scope indicators, or reorder of remaining `[ ]` tracks | Apply via `Edit` for single-site text changes (title, intro, scope) or via `steroid_apply_patch` for >2 sites **and for any reorder** (a move is a remove + insert pair and must land atomically — two chained `Edit` calls are not atomic). See `track-review.md` § Track Pre-Flight step 4 | Pre-Flight only |
+| `SKIP_TRACK` | `{track_index, reason}`. `reason` is required and must be non-empty — Panel 1 reads it as the next session's just-skipped signal. If the user did not supply a reason, the translator prompts for one inline before the item enters the proposal panel | Run the full [`track-skip.md`](track-skip.md) § Process for `track_index`: mark `[~]`, write `**Skipped:** <reason>` line in the plan entry, delete `tracks/track-<index>.md` (terminal per `track-skip.md` step 3). Re-render rules in step 6 below | Pre-Flight only |
 | `EDIT_STEP_DESC` | Path + anchor + new text. Light edits to the upcoming track's step file `## Description` (`**What/How/Constraints/Interactions**` blocks, `mermaid` diagram) | Apply via `Edit` / `steroid_apply_patch` as above | Pre-Flight only |
 | `CLARIFY` | Note text targeting the upcoming track | Appended to the in-conversation clarifications buffer; persisted to the step file's `### Clarifications` subsection on the gate's final Approve per `track-review.md` § Track Pre-Flight step 6 | Pre-Flight only |
 | `FIX_FINDING` | `{location, issue, proposed fix}` triple | Collected into a synthesised findings list; on Apply completion, a fresh implementer is spawned with `level=track`, `mode=FIX_REVIEW_FINDINGS` per `track-code-review.md` § Track Completion step 3 | Completion only |
@@ -71,59 +75,231 @@ Each item also carries a one-line summary of the user's intent,
 paraphrased from the input, so the proposal panel can show what
 the orchestrator believes the user meant.
 
-### 3. PSI-verify named classes
+### 3. Validate action-set semantics
 
-Before rendering the proposal, find-class every production-class
-name appearing in any `EDIT_PLAN`, `EDIT_STEP_DESC`, or
-`FIX_FINDING` payload via mcp-steroid — same rule as the pre-write
-verification in [`track-review.md`](track-review.md) § Pre-write
-rule. Use `steroid_execute_code` with
+Two checks run before the proposal renders. Both attach warnings
+to items that fail; the warnings flow through step 4's
+`⚠`-headers so the user sees them before clicking Apply.
+
+#### 3a. PSI-verify named classes
+
+Find-class every production-class name appearing in any
+`EDIT_PLAN`, `EDIT_STEP_DESC`, or `FIX_FINDING` payload via
+mcp-steroid. Use `steroid_execute_code` with
 `JavaPsiFacade.findClass(fqn, GlobalSearchScope.allScope(project))`;
 construct the FQN from package context when the user supplied only
-a short name. Names that do not resolve attach a
-`⚠ unverified: <name>` warning to the item in step 4's render —
-the user can correct via Refine.
+a short name — `findClass` returns null on bare short names.
 
-When mcp-steroid is unreachable per the SessionStart hook, fall
-back to `find . -name '<ClassName>.java'` and mark the item with a
-`(grep-fallback)` caveat. The translator does NOT silently drop
-unresolved names; the user must see them.
+The verification mechanism is the orchestrator-side complement to
+the pre-write rule in [`track-review.md`](track-review.md)
+§ Pre-write rule. Review mode is the **interactive** counterpart —
+warnings render in the action-set confirmation panel (step 4)
+where the user accepts or refines, instead of an autonomous
+hard-stop. The two paths share the verify mechanism and the
+one-retry rule below, and diverge only on the final consent step.
+
+**mcp-steroid state handling** (matches `track-review.md`
+§ Pre-write rule):
+
+- **Reachable + cwd matches** → run PSI find-class as above.
+- **Reachable + cwd mismatch** (`steroid_list_projects` reports a
+  different project from the working tree) → pause and ask the
+  user via `AskUserQuestion` to switch the open project before
+  proceeding. Do NOT silently fall back to `find` — a PSI query
+  against the wrong project produces false negatives identical to
+  hallucinations. The pause fires at most once per session
+  (mcp-steroid state is session-wide); after the user switches,
+  re-run translation step 2 to retry verification before reaching
+  step 4.
+- **Unreachable** → fall back to `find . -name '<ClassName>.java'`
+  and tag the item with a `(grep-fallback)` caveat in step 4's
+  render.
+
+**Failure path** (matches `track-review.md` § Pre-write rule with
+one interactive divergence at the end):
+
+If PSI-verify reports a name does not resolve and the proposed
+payload does not explicitly mark it as a class the action creates:
+**try once** — read the production code or existing tests for the
+named target (e.g., grep the cited package, read the surrounding
+classes), derive the canonical name, and re-verify. If the retry
+resolves, replace the name in the payload silently and proceed to
+step 4.
+
+If after one retry the name still does not resolve, attach a
+`⚠ Unverified production class name: <name>` warning to the item.
+The user's recourse in step 4's confirmation panel covers every
+option the non-interactive Pre-write hard-stop offers:
+
+| Pre-write hard-stop option | Review-mode equivalent in step 4 |
+|---|---|
+| Use the verified alternative | **Refine** with the corrected name |
+| Drop the mention | **Refine** with the name removed |
+| Escalate to inline replanning | **Cancel** back to the gate's approval panel, then pick **ESCALATE** |
+| *(none — Pre-write is non-interactive)* | **Apply** — user explicitly accepts the unverified name |
+
+The Apply-with-warnings option exists only because the user is
+already in the loop; the Pre-write rule has no equivalent because
+it fires inside autonomous orchestrator steps. The translator does
+NOT silently drop unresolved names; warnings must reach step 4's
+render so the user makes the call.
+
+#### 3b. Dependency validity for `EDIT_PLAN` reorders
+
+For any `EDIT_PLAN` item whose payload reorders the plan
+checklist (changes the position of one or more remaining `[ ]`
+tracks relative to each other), parse the `**Depends on:**` lines
+on every remaining `[ ]` track in the proposed order and verify
+each dependency target appears earlier in the new sequence.
+
+If a violation exists (Track N's `**Depends on:**` lists Track M
+but the proposed order places Track M at or after Track N), attach
+a `⚠ Reorder breaks dependencies: Track <N> requires Track <M>
+earlier` warning to the item. Multiple violations in one reorder
+produce multiple lines under the same header.
+
+User recourse in step 4 matches §3a: Refine to adjust the order,
+Cancel back to the approval panel, or Apply to accept the new
+dependency shape (e.g., the user knows the `**Depends on:**` is
+stale and plans to amend it in a follow-up round). Apply with a
+dependency warning is the explicit consent that this reorder
+intentionally restructures dependencies.
+
+Non-reorder `EDIT_PLAN` items (title edit, intro paragraph edit,
+scope indicator edit) skip this check — they do not change the
+order of remaining tracks.
+
+#### 3c. Anchor-section gate for `EDIT_PLAN` / `EDIT_STEP_DESC`
+
+The translator's keyword-based ESCALATE detection (§ESCALATE
+detection) catches deep amendments by what the user said. The
+anchor-section gate catches deep amendments by where the edit
+lands. The two are complementary; either is sufficient to promote
+an item to `ESCALATE`.
+
+For each `EDIT_PLAN` / `EDIT_STEP_DESC` item, find the enclosing
+section heading (H2 or H3) of the anchor in the target file.
+Protected sections per file:
+
+- **Plan file (`implementation-plan.md`)**:
+  - `## Goals`
+  - `## Constraints`
+  - `## Architecture Notes` (entire section, including the
+    `### Component Map` / `### Decision Records` /
+    `### Invariants` / `### Integration Points` subsections)
+- **Step file (`tracks/track-<N>.md`)**:
+  - Anything outside `## Description` — `## Progress`,
+    `## Reviews completed`, `## Steps`, `### Clarifications`.
+    `## Description` is the only light-amendment zone for review
+    mode; `## Steps` in particular is Phase A decomposition's
+    territory.
+
+If the anchor falls inside a protected section, **promote the
+item to `ESCALATE`** at translation time. The promotion replaces
+the original item; do not keep both. The replacement payload
+carries:
+
+- The user's original input as the deep-change description
+- A note: `auto-promoted from anchor-section gate (anchor in
+  <section name>)`
+
+The user sees the promotion in step 4's confirmation panel with
+the same render rules as keyword-detected ESCALATE items. From
+there: **Apply** routes to inline replanning, **Refine** lets
+the user rephrase if they meant to land outside the protected
+zone, **Cancel** returns to the gate's approval panel.
+
+Mixed-set policy (§Mixed-set policy) then applies normally — if
+the action set already had light items alongside the promoted
+ESCALATE, the user gets Strip-and-apply / Escalate-now in place
+of Apply.
 
 ### 4. Confirm the action set
 
 Render the typed list. Each item is shown with:
 
-- Type label (`QUESTION` / `EDIT_PLAN` / `EDIT_STEP_DESC` /
-  `CLARIFY` / `FIX_FINDING` / `ESCALATE`)
+- **Validation-warning header** (when present from step 3) —
+  rendered first, above the type label, so the user cannot miss
+  it. One line per warning kind:
+  - `⚠ Unverified production class name(s): <name1>, <name2>, …`
+    from step 3a (PSI-verify), including any `(grep-fallback)`
+    caveat appended when the Unreachable state forced a `find`
+    fallback.
+  - `⚠ Reorder breaks dependencies: Track <N> requires Track <M>
+    earlier` from step 3b (dependency validity), one line per
+    violation.
+- Type label (`QUESTION` / `EDIT_PLAN` / `SKIP_TRACK` /
+  `EDIT_STEP_DESC` / `CLARIFY` / `FIX_FINDING` / `ESCALATE`)
 - One-line intent summary
-- Full payload — the proposed text for `EDIT_*`, the question +
+- Full payload — the proposed text for `EDIT_*`, the
+  `{track_index, reason}` pair for `SKIP_TRACK`, the question +
   orchestrator's answer for `QUESTION`, the finding triple for
   `FIX_FINDING`, the deep-change description for `ESCALATE`
-- Any unverified-class warning from step 3
 
 Present `AskUserQuestion` with three one-step options:
 
 - **Apply** — execute every side-effecting item in order (see
   §Execution below). `QUESTION` items are no-ops (already answered).
   When the proposal contains only `QUESTION` items, the option
-  label is **Done** instead — there is nothing to execute, but the
+  label is **Done** instead. There is nothing to execute, but the
   user has read the answers.
 - **Refine** — discard the proposed set, return to step 1 with the
-  user's prior input shown as a verbatim quote for context. Each
-  round is otherwise atomic — the translator does not carry state
-  across rounds.
+  user's prior input quoted in the new step-1 prompt body (above
+  the `Submit` option), introduced as `Your prior input was: …`,
+  so the user can edit or replace it rather than re-typing from
+  scratch. Each round is otherwise atomic; the translator does not
+  carry state across rounds.
 - **Cancel** — discard the proposed set, return to the gate's
   approval panel as if review mode had never been entered.
 
 Whole-set only. There is no per-item accept/reject — the user
 either approves the proposal as a unit, refines it, or cancels.
 
+Off-panel chat replies on this panel route to implicit Refine —
+see §Off-panel responses below.
+
 ### 5. Execute (only on Apply)
 
-For each side-effecting item, in declaration order:
+**Apply preflight (dry-run every item before any side effect).**
+Before running the first side-effecting item, validate each item
+against the current working tree. Catch failures here so the user
+sees them in the next confirmation panel rather than as a mid-Apply
+interruption:
+
+- `EDIT_PLAN` / `EDIT_STEP_DESC` (`Edit` mode): resolve the target
+  file; locate `old_string` exactly once in the file (zero or
+  multiple matches both fail). For multi-site `steroid_apply_patch`,
+  parse and validate the patch against the current file contents.
+- `SKIP_TRACK`: resolve `tracks/track-<index>.md` on disk and
+  confirm the plan-file entry for that track exists in
+  `implementation-plan.md` with status `[ ]`.
+- `FIX_FINDING`: re-resolve any production-class FQNs in the
+  finding payload via PSI (the verification from step 3 may have
+  gone stale if a long Refine→Apply cycle let HEAD drift). Skip if
+  no class names are named.
+- `CLARIFY` / `QUESTION` / `ESCALATE`: no preflight (no real side
+  effect, or the side effect is buffer-only / routing-only).
+
+If any preflight check fails, abort Apply with zero side effects.
+Return to step 1 (Refine), prepending one
+`⚠ Apply preflight: <item> — <reason>` line per failed item to the
+free-form prompt so the user can correct via the next round.
+
+If all preflights pass, capture
+`pre_apply_sha = git rev-parse HEAD` in conversation context — used
+by `FIX_FINDING`'s `RESULT_MISSING` discard branch
+(`track-code-review.md` § Track Completion step 3) and as a safety
+net for rare real-write failures (disk full, file lock).
+
+**Execute side-effecting items in declaration order:**
 
 - `EDIT_PLAN` / `EDIT_STEP_DESC`: apply via `Edit` (single site)
   or `steroid_apply_patch` (>2 sites).
+- `SKIP_TRACK`: run the full [`track-skip.md`](track-skip.md)
+  § Process for `track_index` — write the `[~]` marker plus
+  `**Skipped:** <reason>` line in the plan entry, then delete
+  `tracks/track-<index>.md`. Step-file deletion is terminal per
+  `track-skip.md` step 3.
 - `CLARIFY`: append to the in-conversation clarifications buffer.
   The buffer flows to the step file's `### Clarifications`
   subsection on the gate's final Approve, per
@@ -131,10 +307,15 @@ For each side-effecting item, in declaration order:
 - `FIX_FINDING`: collect into the synthesised findings list.
   After all other items have run, spawn a fresh implementer with
   `level=track`, `mode=FIX_REVIEW_FINDINGS` per
-  `track-code-review.md` § Track Completion step 3 and route its
-  return through the same handlers (`handle_iteration_success` /
-  `handle_iteration_failure` / `handle_result_missing`).
-- `ESCALATE`: see §Mixed-set policy below — a sole `ESCALATE` item
+  `track-code-review.md` § Track Completion step 3, which also
+  defines the Completion-specific outcome mapping for the four
+  implementer return statuses (`SUCCESS` / `FAILED` /
+  `DESIGN_DECISION` / `RESULT_MISSING`). Completion FIX_FINDING
+  does **not** reuse the §Phase C Implementer Handlers (those carry
+  per-iteration bookkeeping for the pre-Completion review loop,
+  which has already exited); the spec lives at the Completion
+  callsite.
+- `ESCALATE`: see §Mixed-set policy below. A sole `ESCALATE` item
   routes to `inline-replanning.md` immediately; mixed sets are
   refused before they reach this step.
 
@@ -144,17 +325,22 @@ For each side-effecting item, in declaration order:
 
 After Apply completes, the gate rebuilds its presentation from the
 now-updated files and re-renders the three-option approval panel
-(Approve / Review mode / ESCALATE). The user can approve, re-enter
-review mode for more refinement, or escalate.
+(Approve / Review mode / ESCALATE).
 
 Per-gate re-render rules:
 
 - **Pre-Flight.** Rebuild Panel 2 from disk (plan-file entry + step
   file `## Description`). If any `EDIT_PLAN` item touched a
   remaining track, re-run Panel 1's strategy assessment before
-  re-rendering — the touched track may have changed the look-back
-  picture. If an `EDIT_PLAN` reorder changed which track is "next",
-  Panel 2 is rebuilt against the new upcoming track per
+  re-rendering, since the touched track may have changed the
+  look-back picture. If an `EDIT_PLAN` reorder changed which track
+  is "next", Panel 2 is rebuilt against the new upcoming track per
+  `track-skip.md` step 2's panel-rendering contract. If any
+  `SKIP_TRACK` item ran, re-run Panel 1's strategy assessment with
+  the just-skipped track as the new look-back anchor (its
+  `**Skipped:** <reason>` line serves as the just-skipped-track
+  signal); if the skipped track was the upcoming track summarised in
+  Panel 2, Panel 2 is rebuilt against the new upcoming track per
   `track-skip.md` step 2's panel-rendering contract.
 - **Completion.** Rebuild the track-results presentation. If
   `FIX_FINDING` items spawned an implementer that produced a
@@ -162,19 +348,40 @@ Per-gate re-render rules:
   (`git diff {base_commit}..HEAD`) and re-compile the track
   episode before re-rendering.
 
+**Pending-escalation block** (both gates). If
+`pending_escalate_description` is set in conversation context
+when re-rendering (captured by a prior Strip-and-apply per
+§Mixed-set policy), include a `**Pending escalation:**` block in
+the panel surface — below Panel 2's upcoming-track summary for
+Pre-Flight, or in the track-results presentation for Completion.
+The block leads with one line "From an earlier review-mode round
+in this session, deferred by Strip-and-apply." followed by the
+stashed description verbatim. The block stays visible across
+subsequent re-renders until the slot clears.
+
 ## Mixed-set policy
 
 If the proposed action set contains an `ESCALATE` item alongside
-any other items (any `QUESTION` / `EDIT_*` / `CLARIFY` /
-`FIX_FINDING`), the confirmation panel **refuses Apply** and offers
-two one-step options in its place:
+any other items (any `QUESTION` / `EDIT_*` / `SKIP_TRACK` /
+`CLARIFY` / `FIX_FINDING`), the confirmation panel **refuses Apply**
+and offers two one-step options in its place:
 
 - **Strip and apply light items** — drop the `ESCALATE` item,
   apply the rest, return to the gate's approval panel. The user
   can pick ESCALATE there afterwards if the deep change is still
-  needed.
+  needed. **Carry the dropped `ESCALATE` description forward** —
+  capture it into a `pending_escalate_description` slot in the
+  orchestrator's conversation context (single-slot, latest-wins).
+  The next gate re-render surfaces it as a `**Pending escalation:**`
+  block per step 6 below, and if the user later picks ESCALATE,
+  inline-replanning step 2 reads it as the deep-change description
+  instead of prompting cold. The slot clears on the gate's Approve
+  (user moved on), on consumption by inline-replanning, or on
+  session restart (conversation context loss — accepted).
 - **Escalate now** — discard the light items, route to
-  `inline-replanning.md` immediately.
+  `inline-replanning.md` immediately. No stash needed; the
+  description is fresh in conversation context and inline-replanning
+  step 2 reads it directly.
 
 The **Refine** and **Cancel** options remain available.
 
@@ -190,18 +397,32 @@ input names any of the deep-amendment categories from
 
 - Decision Records, Architecture Notes, Goals, or Constraints in
   the plan file
-- Adding or removing tracks
+- **Adding** a new track (requires authoring a fresh step file
+  `## Description`, dependency analysis, and design decisions —
+  none of which review mode can do in a single round). **Removing**
+  a remaining track is `SKIP_TRACK`, not ESCALATE — see §2's
+  action-type table; it is a single user-initiated action with a
+  reason, terminal step-file delete, no design work.
 - Cross-track interaction surfaces beyond pure reordering of
   remaining `[ ]` tracks
 - Explicit "fundamental rework" / "redesign" / "rethink" / "this
   is wrong at the architectural level" language
 
-Detection is best-effort — the orchestrator does not need to be
-perfect at classification because the action-set confirmation
-panel (step 4) is the safety net. The user can Refine if the
-translator over- or under-classified, and the Mixed-set policy
-above prevents a mis-classified item from being smuggled into a
-light Apply.
+Detection is best-effort. The action-set confirmation panel in
+step 4 is the safety net, so the orchestrator does not need to
+classify perfectly. The user can Refine if the translator over-
+or under-classified, and the Mixed-set policy above prevents a
+mis-classified item from being smuggled into a light Apply.
+
+Two complementary detections feed `ESCALATE` classification —
+keyword-based on user input (this section, by *what the user
+said*) and the **anchor-section gate** at translation time (see
+§ Loop step 3c, by *where the edit would land*). The two run in
+parallel; either is sufficient to promote an item. Keyword
+detection catches "this is fundamental rework"-shaped phrasing
+that doesn't yet have an anchor; the anchor gate catches edits
+whose anchor falls inside a protected section regardless of how
+the user phrased the request.
 
 ## Empty / no-op input
 
@@ -232,25 +453,99 @@ translator splits user input by intent:
 The proposal panel renders the split so the user can correct via
 Refine if the translator misjudged.
 
-On Completion, `CLARIFY` is not available — Completion has no
+On Completion, `CLARIFY` is not available: Completion has no
 upcoming-track step file to write into. Forward-looking notes on
-Completion are typically expressed as `FIX_FINDING` items
-("change X to handle the case I just noticed") rather than
-clarifications.
+Completion are typically `FIX_FINDING` items ("change X to handle
+the case I just noticed").
 
 ## State and resume
 
 Review mode runs entirely in-conversation until **Apply**.
-Crashes mid-loop lose the proposed action set but no on-disk
-state. On resume the gate re-fires per the caller's resume rules
-(`track-review.md` § Track Pre-Flight step 7 for Pre-Flight;
-`track-code-review.md` State C row "All steps `[x]`, code review
-`[x]`, track still `[ ]` in plan" for Completion). The user
+Crashes during steps 1-4 (input, translate, PSI-verify, confirm)
+lose the proposed action set but no on-disk state. On resume the
+gate re-fires per the caller's resume rules (`track-review.md`
+§ Track Pre-Flight step 7 for Pre-Flight; `workflow.md`
+§ Startup Protocol State C sub-states row "All steps `[x]`, code
+review `[x]`, track still `[ ]` in plan" for Completion). The user
 re-enters review mode if needed.
 
-Once **Apply** executes, the existing on-disk artifacts carry
-the state forward per the caller's existing persistence rules.
-Review mode itself does not own any durable state — it is a
-translator + executor that produces the same kinds of edits and
-commits the prior multi-option panels did, only with a different
-UI on top.
+**Crashes during step 5 (Execute).** Apply preflight catches almost
+all failures before any side effect runs (zero on-disk state to
+recover from). The remaining real-write failures and crashes split
+by gate:
+
+- **Pre-Flight.** Successful Apply items land as uncommitted
+  working-tree edits — the durable commit happens only at
+  `track-review.md` § Track Pre-Flight step 6 after the user picks
+  **Approve**. A mid-round crash therefore leaves a partially
+  edited working tree with no on-disk marker for which items ran.
+  This is intentional: the gate re-reads files from disk on
+  resume and surfaces them as the current state. The user reviews
+  the partial-round content in Panel 2 of the next re-render, the
+  same way they review any other in-loop edit, and can refine,
+  approve, or escalate from there. The `### Clarifications`
+  in-conversation buffer is lost on crash; the user re-enters any
+  still-relevant clarifications via a new review-mode round.
+
+- **Completion.** A `FIX_FINDING` Apply may land `Review fix:`
+  commit(s) on HEAD via a spawned implementer that exits or
+  crashes before the orchestrator re-compiles the track episode.
+  On State C re-entry (the gate's resume row), the Completion
+  re-render **always** re-reads `git diff {base_commit}..HEAD`
+  and re-compiles the track episode against the current HEAD
+  before presenting the three-option panel — see
+  [`track-code-review.md`](track-code-review.md) § Track Completion
+  step 3 for the rule and its single code path shared between
+  initial render, post-Apply re-render, and resume. This subsumes
+  the prior-session-orphan-commit case.
+
+Once **Apply** completes cleanly, the existing on-disk artifacts
+carry the state forward per the caller's existing persistence
+rules. Review mode owns no durable state of its own.
+
+## Off-panel responses
+
+`AskUserQuestion` panels can be dismissed without picking an
+option — the user types a chat reply instead. For routine
+action-set panels in this protocol, the chat text replaces the
+prior round's free-form input and feeds step 1's translator
+directly, as if the user had clicked **Refine** and re-submitted.
+
+This rule applies to:
+
+- **Step 4 action-set confirmation panel** (Apply / Refine /
+  Cancel, or Done / Refine / Cancel for question-only proposals).
+- **Empty/no-op input recovery panel** (Approve / Refine / Cancel
+  per §Empty / no-op input).
+- **Mixed-set policy panel** (Strip-and-apply / Escalate-now,
+  plus Refine and Cancel per §Mixed-set policy).
+
+The fall-through is well-behaved for approval-shaped chat: the
+translator extracts zero items from text like "looks fine, ship
+it", which lands in the §Empty / no-op input recovery and
+prompts the user to pick **Approve** explicitly. One extra round;
+no lost state.
+
+Step 1's input panel itself does not need this rule — it already
+accepts chat replies directly by design.
+
+**Carve-outs.** Two panels in review mode do not follow the
+implicit-Refine rule because chat content on them is most likely
+an answer to the specific prompt rather than a refinement of an
+action set:
+
+- **cwd-mismatch pause** (step 3a): asks the user to switch the
+  IDE's open project. Off-panel chat such as "I switched it"
+  triggers a re-run of PSI-verify against the now-correct project,
+  not a re-translation. Re-render the panel after the chat reply
+  finishes its side effect.
+- **`FIX_FINDING RESULT_MISSING` recovery** (per
+  `track-code-review.md` § Track Completion step 3): chat reply
+  on the commit-as-is / re-spawn / discard sub-panel is not a
+  refinement of an action set — one of the options performs
+  `git reset --hard`. Re-render the panel and require an explicit
+  pick.
+
+The gate's own approval panel (Approve / Review mode / ESCALATE)
+is owned by `track-review.md` / `track-code-review.md`, not by
+this protocol — off-panel behaviour there is up to those files.

--- a/.claude/workflow/review-mode.md
+++ b/.claude/workflow/review-mode.md
@@ -150,13 +150,18 @@ For any `EDIT_PLAN` item whose payload reorders the plan
 checklist (changes the position of one or more remaining `[ ]`
 tracks relative to each other), parse the `**Depends on:**` lines
 on every remaining `[ ]` track in the proposed order and verify
-each dependency target appears earlier in the new sequence.
+each dependency target **that is itself a remaining `[ ]` track**
+appears earlier in the new sequence. Dependency targets pointing
+at completed (`[x]`) or skipped (`[~]`) tracks are already
+satisfied and impose no ordering constraint on the remaining
+sequence — skip them.
 
-If a violation exists (Track N's `**Depends on:**` lists Track M
-but the proposed order places Track M at or after Track N), attach
-a `⚠ Reorder breaks dependencies: Track <N> requires Track <M>
-earlier` warning to the item. Multiple violations in one reorder
-produce multiple lines under the same header.
+If a violation exists (Track N's `**Depends on:**` lists Track M,
+Track M is still `[ ]`, but the proposed order places Track M at
+or after Track N), attach a `⚠ Reorder breaks dependencies: Track
+<N> requires Track <M> earlier` warning to the item. Multiple
+violations in one reorder produce multiple lines under the same
+header.
 
 User recourse in step 4 matches §3a: Refine to adjust the order,
 Cancel back to the approval panel, or Apply to accept the new
@@ -189,10 +194,17 @@ Protected sections per file:
     `### Invariants` / `### Integration Points` subsections)
 - **Step file (`tracks/track-<N>.md`)**:
   - Anything outside `## Description` — `## Progress`,
-    `## Reviews completed`, `## Steps`, `### Clarifications`.
-    `## Description` is the only light-amendment zone for review
-    mode; `## Steps` in particular is Phase A decomposition's
-    territory.
+    `## Reviews completed`, `## Steps`.
+  - The `### Clarifications` subsection inside `## Description`
+    (see `track-review.md` § Track Pre-Flight step 6 for the
+    write rule that places it there). It is the only `## Description`
+    subsection that is protected; the surrounding free-form
+    prose (intro, **What/How/Constraints/Interactions**, optional
+    `mermaid` diagram) remains the light-amendment zone.
+
+  `## Description` (minus the `### Clarifications` exception above)
+  is the only light-amendment zone for review mode; `## Steps` in
+  particular is Phase A decomposition's territory.
 
 If the anchor falls inside a protected section, **promote the
 item to `ESCALATE`** at translation time. The promotion replaces

--- a/.claude/workflow/review-mode.md
+++ b/.claude/workflow/review-mode.md
@@ -307,14 +307,11 @@ net for rare real-write failures (disk full, file lock).
 - `FIX_FINDING`: collect into the synthesised findings list.
   After all other items have run, spawn a fresh implementer with
   `level=track`, `mode=FIX_REVIEW_FINDINGS` per
-  `track-code-review.md` § Track Completion step 3, which also
-  defines the Completion-specific outcome mapping for the four
+  `track-code-review.md` § Track Completion step 3. See
+  § Completion FIX_FINDING outcome mapping below for the four
   implementer return statuses (`SUCCESS` / `FAILED` /
-  `DESIGN_DECISION` / `RESULT_MISSING`). Completion FIX_FINDING
-  does **not** reuse the §Phase C Implementer Handlers (those carry
-  per-iteration bookkeeping for the pre-Completion review loop,
-  which has already exited); the spec lives at the Completion
-  callsite.
+  `DESIGN_DECISION` / `RESULT_MISSING`) and what each means for
+  the re-render.
 - `ESCALATE`: see §Mixed-set policy below. A sole `ESCALATE` item
   routes to `inline-replanning.md` immediately; mixed sets are
   refused before they reach this step.
@@ -457,6 +454,67 @@ On Completion, `CLARIFY` is not available: Completion has no
 upcoming-track step file to write into. Forward-looking notes on
 Completion are typically `FIX_FINDING` items ("change X to handle
 the case I just noticed").
+
+## Completion FIX_FINDING outcome mapping
+
+Completion `FIX_FINDING` Apply spawns an implementer with
+`level=track`, `mode=FIX_REVIEW_FINDINGS` per
+[`track-code-review.md`](track-code-review.md) § Track Completion
+step 3. This section defines what each of the four implementer
+return statuses means for review-mode's three-option re-render at
+Completion.
+
+Completion FIX_FINDING does **not** reuse the §Phase C Implementer
+Handlers from `track-code-review.md` — those handlers carry
+per-iteration bookkeeping (3-iteration counter, Progress row,
+gate-check fan-out) tied to the pre-Completion review loop, which
+has already exited by the time Completion's three-option panel
+renders. The `Track-level code review` Progress row is already
+`[x]` and stays that way; there is no iteration counter at
+Completion (user-initiated, not budget-driven; see
+`track-code-review.md` § Track Completion step 5 for the matching
+re-open rule).
+
+The four implementer outcomes feed Completion's re-render
+directly:
+
+- **`SUCCESS`** (implementer committed a `Review fix:` on top of
+  HEAD). Re-read the cumulative track diff (`git diff
+  {base_commit}..HEAD`) and re-compile the track episode against
+  the new HEAD per `track-code-review.md` § Track Completion
+  step 1 (the single re-compile entry point). If the user's fixes
+  were substantial enough that a gate-check run alone won't catch
+  potential regressions, also re-run track-level code review
+  against the new HEAD (this is a separate per-substance decision;
+  not automatic). Present updated results and re-render the
+  three-option panel.
+- **`FAILED`** (implementer returned `level=track, status=FAILED`
+  after exhausting its own internal retries). Do not write any
+  Progress row. Re-read the diff and re-compile the track episode
+  (the working tree may still have partial progress on HEAD).
+  Surface the unfixed findings to the user in the re-render with
+  a `**Review-mode fix attempt failed:**` line listing the items
+  that did not land. The user picks Review mode again to refine,
+  Approve to accept the track as-is despite the failure, or
+  ESCALATE.
+- **`DESIGN_DECISION`** (implementer returned a deferred design
+  decision rather than a fix). Invoke
+  [`design-decision-escalation.md`](design-decision-escalation.md)
+  to walk the user through the alternatives. Treat the chosen
+  alternative as a new `FIX_FINDING` and re-enter the Review-mode
+  loop with that item pre-seeded — the user confirms it via the
+  action-set confirmation panel before another implementer spawns.
+- **`RESULT_MISSING`** (implementer exited without producing the
+  expected output — e.g., context exhaustion or crash). Present
+  three sub-options via `AskUserQuestion`: **commit-as-is**
+  (the implementer made partial progress on HEAD; treat it as
+  `SUCCESS` and re-compile the episode), **re-spawn** (one more
+  try with the same findings), **discard** (revert HEAD to
+  pre-Apply via `git reset --hard {pre_apply_sha}` and re-render
+  the panel as if Apply had not run). `pre_apply_sha` is captured
+  by step 5's Apply preflight before any side effect runs. Off-
+  panel chat replies on this sub-panel re-render the panel rather
+  than routing as implicit Refine — see §Off-panel responses.
 
 ## State and resume
 

--- a/.claude/workflow/review-mode.md
+++ b/.claude/workflow/review-mode.md
@@ -1,0 +1,256 @@
+# Review Mode
+
+Shared protocol for refining a gate decision in free form. Both
+Track Pre-Flight (see [`track-review.md`](track-review.md) § Track
+Pre-Flight) and Track Completion (see
+[`track-code-review.md`](track-code-review.md) § Track Completion)
+load this when the user picks **Review mode** on the gate's
+approval panel.
+
+## What review mode does
+
+Replaces the previous multi-option panels (Adjust / Clarify on
+Pre-Flight; Fixes needed on Completion) with a free-form input
+loop. The user types observations, questions, or requested edits.
+The orchestrator translates the input into a typed action set,
+PSI-verifies any named production classes, and asks the user to
+confirm the set before applying. After Apply, the gate's original
+approval panel re-renders.
+
+The point is to let the user combine concerns in one round —
+"why was X done this way, also rename the variable to Y, and add
+a clarification that the implementer must preserve Z" — instead of
+picking categorical buckets across multiple rounds.
+
+## Approval-panel contract
+
+Both gates render their approval with the same three one-step
+options. This is the only `AskUserQuestion` call the gate itself
+makes for routine acceptance — review mode runs its own confirmation
+panel (step 4 below) when entered.
+
+- **Approve** — terminal accept. The gate runs its own post-approve
+  writes (Pre-Flight: strategy-refresh line + `### Clarifications`
+  subsection + amendments commit per `track-review.md` § Track
+  Pre-Flight step 6; Completion: track episode + collapse + `[x]`
+  per `track-code-review.md` § Track Completion step 4).
+- **Review mode** — enter the loop below.
+- **ESCALATE** — route to
+  [`inline-replanning.md`](inline-replanning.md).
+
+Pre-Flight's Panel 1 ESCALATE sub-panel (Accept escalation /
+Override, see `track-review.md` § Track Pre-Flight step 1) is
+independent of this contract and unchanged — it is already a
+single one-step decision.
+
+## Loop
+
+### 1. Free-form input
+
+Single open prompt via `AskUserQuestion` with one option labelled
+"Submit" and a free-form text capture (or the user's normal reply
+to the orchestrator's prompt). User describes: observations,
+requested edits, missing context, open questions, or anything else
+relevant to the gate's decision. No template, no fields.
+
+### 2. Translate to a typed action set
+
+Parse the input into an ordered list of items, preserving the
+order the user mentioned them. Each item has a type and a payload:
+
+| Type | Payload | Side effect on Apply | Available in |
+|---|---|---|---|
+| `QUESTION` | Question text + orchestrator's answer (resolved during translation by reading conversation context, git log, step / track episodes, plan file, and source code as needed) | None — already answered at render time | Both gates |
+| `EDIT_PLAN` | Path + anchor + new text. Light edits to a remaining track's plan-file entry: title, intro paragraph, scope indicators, or reorder of remaining `[ ]` tracks | Apply via `Edit` (single site) or `steroid_apply_patch` (>2 sites) per `track-review.md` § Track Pre-Flight step 4 | Pre-Flight only |
+| `EDIT_STEP_DESC` | Path + anchor + new text. Light edits to the upcoming track's step file `## Description` (`**What/How/Constraints/Interactions**` blocks, `mermaid` diagram) | Apply via `Edit` / `steroid_apply_patch` as above | Pre-Flight only |
+| `CLARIFY` | Note text targeting the upcoming track | Appended to the in-conversation clarifications buffer; persisted to the step file's `### Clarifications` subsection on the gate's final Approve per `track-review.md` § Track Pre-Flight step 6 | Pre-Flight only |
+| `FIX_FINDING` | `{location, issue, proposed fix}` triple | Collected into a synthesised findings list; on Apply completion, a fresh implementer is spawned with `level=track`, `mode=FIX_REVIEW_FINDINGS` per `track-code-review.md` § Track Completion step 3 | Completion only |
+| `ESCALATE` | Deep-change description | Routes to `inline-replanning.md`; see §Mixed-set policy below | Both gates |
+
+Each item also carries a one-line summary of the user's intent,
+paraphrased from the input, so the proposal panel can show what
+the orchestrator believes the user meant.
+
+### 3. PSI-verify named classes
+
+Before rendering the proposal, find-class every production-class
+name appearing in any `EDIT_PLAN`, `EDIT_STEP_DESC`, or
+`FIX_FINDING` payload via mcp-steroid — same rule as the pre-write
+verification in [`track-review.md`](track-review.md) § Pre-write
+rule. Use `steroid_execute_code` with
+`JavaPsiFacade.findClass(fqn, GlobalSearchScope.allScope(project))`;
+construct the FQN from package context when the user supplied only
+a short name. Names that do not resolve attach a
+`⚠ unverified: <name>` warning to the item in step 4's render —
+the user can correct via Refine.
+
+When mcp-steroid is unreachable per the SessionStart hook, fall
+back to `find . -name '<ClassName>.java'` and mark the item with a
+`(grep-fallback)` caveat. The translator does NOT silently drop
+unresolved names; the user must see them.
+
+### 4. Confirm the action set
+
+Render the typed list. Each item is shown with:
+
+- Type label (`QUESTION` / `EDIT_PLAN` / `EDIT_STEP_DESC` /
+  `CLARIFY` / `FIX_FINDING` / `ESCALATE`)
+- One-line intent summary
+- Full payload — the proposed text for `EDIT_*`, the question +
+  orchestrator's answer for `QUESTION`, the finding triple for
+  `FIX_FINDING`, the deep-change description for `ESCALATE`
+- Any unverified-class warning from step 3
+
+Present `AskUserQuestion` with three one-step options:
+
+- **Apply** — execute every side-effecting item in order (see
+  §Execution below). `QUESTION` items are no-ops (already answered).
+  When the proposal contains only `QUESTION` items, the option
+  label is **Done** instead — there is nothing to execute, but the
+  user has read the answers.
+- **Refine** — discard the proposed set, return to step 1 with the
+  user's prior input shown as a verbatim quote for context. Each
+  round is otherwise atomic — the translator does not carry state
+  across rounds.
+- **Cancel** — discard the proposed set, return to the gate's
+  approval panel as if review mode had never been entered.
+
+Whole-set only. There is no per-item accept/reject — the user
+either approves the proposal as a unit, refines it, or cancels.
+
+### 5. Execute (only on Apply)
+
+For each side-effecting item, in declaration order:
+
+- `EDIT_PLAN` / `EDIT_STEP_DESC`: apply via `Edit` (single site)
+  or `steroid_apply_patch` (>2 sites).
+- `CLARIFY`: append to the in-conversation clarifications buffer.
+  The buffer flows to the step file's `### Clarifications`
+  subsection on the gate's final Approve, per
+  `track-review.md` § Track Pre-Flight step 6.
+- `FIX_FINDING`: collect into the synthesised findings list.
+  After all other items have run, spawn a fresh implementer with
+  `level=track`, `mode=FIX_REVIEW_FINDINGS` per
+  `track-code-review.md` § Track Completion step 3 and route its
+  return through the same handlers (`handle_iteration_success` /
+  `handle_iteration_failure` / `handle_result_missing`).
+- `ESCALATE`: see §Mixed-set policy below — a sole `ESCALATE` item
+  routes to `inline-replanning.md` immediately; mixed sets are
+  refused before they reach this step.
+
+`QUESTION` items have no execution side effect.
+
+### 6. Re-render the gate's approval panel
+
+After Apply completes, the gate rebuilds its presentation from the
+now-updated files and re-renders the three-option approval panel
+(Approve / Review mode / ESCALATE). The user can approve, re-enter
+review mode for more refinement, or escalate.
+
+Per-gate re-render rules:
+
+- **Pre-Flight.** Rebuild Panel 2 from disk (plan-file entry + step
+  file `## Description`). If any `EDIT_PLAN` item touched a
+  remaining track, re-run Panel 1's strategy assessment before
+  re-rendering — the touched track may have changed the look-back
+  picture. If an `EDIT_PLAN` reorder changed which track is "next",
+  Panel 2 is rebuilt against the new upcoming track per
+  `track-skip.md` step 2's panel-rendering contract.
+- **Completion.** Rebuild the track-results presentation. If
+  `FIX_FINDING` items spawned an implementer that produced a
+  `Review fix:` commit, re-read the cumulative track diff
+  (`git diff {base_commit}..HEAD`) and re-compile the track
+  episode before re-rendering.
+
+## Mixed-set policy
+
+If the proposed action set contains an `ESCALATE` item alongside
+any other items (any `QUESTION` / `EDIT_*` / `CLARIFY` /
+`FIX_FINDING`), the confirmation panel **refuses Apply** and offers
+two one-step options in its place:
+
+- **Strip and apply light items** — drop the `ESCALATE` item,
+  apply the rest, return to the gate's approval panel. The user
+  can pick ESCALATE there afterwards if the deep change is still
+  needed.
+- **Escalate now** — discard the light items, route to
+  `inline-replanning.md` immediately.
+
+The **Refine** and **Cancel** options remain available.
+
+Rationale: a mixed Apply would commit light edits and then route
+mid-flight to inline replanning, leaving a partial state that is
+hard to interpret on resume.
+
+## ESCALATE detection
+
+The translator classifies an item as `ESCALATE` when the user's
+input names any of the deep-amendment categories from
+`track-review.md` § Track Pre-Flight step 4:
+
+- Decision Records, Architecture Notes, Goals, or Constraints in
+  the plan file
+- Adding or removing tracks
+- Cross-track interaction surfaces beyond pure reordering of
+  remaining `[ ]` tracks
+- Explicit "fundamental rework" / "redesign" / "rethink" / "this
+  is wrong at the architectural level" language
+
+Detection is best-effort — the orchestrator does not need to be
+perfect at classification because the action-set confirmation
+panel (step 4) is the safety net. The user can Refine if the
+translator over- or under-classified, and the Mixed-set policy
+above prevents a mis-classified item from being smuggled into a
+light Apply.
+
+## Empty / no-op input
+
+- **Zero items extracted** (e.g., user typed "looks fine"): prompt
+  *"No actions extracted — did you mean to Approve?"* with options
+  **Approve / Refine / Cancel**. **Approve** here is a shortcut
+  back to the gate's approval panel pre-selected to Approve.
+- **Question-only input**: produces a `QUESTION`-only proposal.
+  Step 4's confirmation panel uses the **Done / Refine / Cancel**
+  label set — no Apply, since there is nothing to execute.
+
+## Question / CLARIFY distinction (Pre-Flight only)
+
+`QUESTION` and `CLARIFY` are easy to confuse on Pre-Flight. The
+translator splits user input by intent:
+
+- *Read-only / retrospective* — "what does X do?", "why was this
+  decided?", "did Y get covered in the prior track?" → `QUESTION`.
+  Answered inline at proposal time. No side effect.
+- *Forward-looking note* — "make sure the implementer considers
+  X", "don't break Y", "the new code must preserve Z" →
+  `CLARIFY`. Persists to the step file's `### Clarifications`
+  subsection on the gate's final Approve.
+- *Mixed in one sentence* — "what does X do, and make sure we
+  don't break it" → both items, in declaration order: `QUESTION`
+  first (with answer), then `CLARIFY`.
+
+The proposal panel renders the split so the user can correct via
+Refine if the translator misjudged.
+
+On Completion, `CLARIFY` is not available — Completion has no
+upcoming-track step file to write into. Forward-looking notes on
+Completion are typically expressed as `FIX_FINDING` items
+("change X to handle the case I just noticed") rather than
+clarifications.
+
+## State and resume
+
+Review mode runs entirely in-conversation until **Apply**.
+Crashes mid-loop lose the proposed action set but no on-disk
+state. On resume the gate re-fires per the caller's resume rules
+(`track-review.md` § Track Pre-Flight step 7 for Pre-Flight;
+`track-code-review.md` State C row "All steps `[x]`, code review
+`[x]`, track still `[ ]` in plan" for Completion). The user
+re-enters review mode if needed.
+
+Once **Apply** executes, the existing on-disk artifacts carry
+the state forward per the caller's existing persistence rules.
+Review mode itself does not own any durable state — it is a
+translator + executor that produces the same kinds of edits and
+commits the prior multi-option panels did, only with a different
+UI on top.

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -964,22 +964,39 @@ proceed directly to track completion **in the same session**.
      subsections are now superseded by the committed code and step
      episodes
 
-3. **Wait for user response:**
-   - **Approved** — proceed to step 4.
-   - **Fixes needed** — package the user's specific fixes as a
-     synthesised findings list (each item: location, issue, proposed
-     fix) and **spawn a fresh implementer** with `level=track`,
-     `mode=FIX_REVIEW_FINDINGS`, and the user-provided findings.
-     Use the same prompt template, validity matrix, and handler
-     dispatch as §Implementer Spawns and §Phase C Implementer
-     Handlers above. The implementer's `Review fix:` commit lands
-     on top of HEAD; the orchestrator does not touch source files
-     itself. Re-run track-level code review if the user's fixes are
-     substantial enough that a gate-check run alone won't catch
-     potential regressions. Re-compile the track episode if fixes
-     changed outcomes. Present updated results and wait again.
-   - **Fundamental rework** — trigger ESCALATE (see workflow.md
-     §Inline Replanning).
+3. **Wait for user response.** Use `AskUserQuestion` with three
+   one-step options per the approval-panel contract in
+   [`review-mode.md`](review-mode.md) § Approval-panel contract:
+
+   - **Approve** — proceed to step 4 with whatever fix-finding
+     work the review-mode loop has accumulated (none on the first
+     render, or one or more `Review fix:` commits on HEAD if
+     earlier rounds applied `FIX_FINDING` items).
+   - **Review mode** — enter the free-form refinement loop per
+     [`review-mode.md`](review-mode.md) § Loop. The loop produces
+     a typed action set the user confirms before Apply. On Apply,
+     `FIX_FINDING` items are collected into a synthesised findings
+     list (each item: location, issue, proposed fix) and a fresh
+     implementer is spawned with `level=track`,
+     `mode=FIX_REVIEW_FINDINGS`, using the same prompt template,
+     validity matrix, and handler dispatch as §Implementer Spawns
+     and §Phase C Implementer Handlers above. The implementer's
+     `Review fix:` commit lands on top of HEAD; the orchestrator
+     does not touch source files itself. `QUESTION` items are
+     answered inline at proposal time and have no side effect.
+     `EDIT_PLAN` / `EDIT_STEP_DESC` / `CLARIFY` are not available
+     on Completion (see [`review-mode.md`](review-mode.md) § Loop
+     step 2). After Apply, re-read the cumulative track diff
+     (`git diff {base_commit}..HEAD`) and re-compile the track
+     episode; if the user's fixes were substantial enough that a
+     gate-check run alone won't catch potential regressions, also
+     re-run track-level code review. Present updated results and
+     re-render this three-option panel.
+   - **ESCALATE** — trigger inline replanning per
+     [`inline-replanning.md`](inline-replanning.md).
+
+   The three-option panel re-renders after every review-mode Apply
+   until the user picks **Approve** or **ESCALATE**.
 
 4. **Write the track episode, collapse the description, and mark `[x]`**
    in the plan file on disk (only after user approval).

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -1001,49 +1001,18 @@ proceed directly to track completion **in the same session**.
    are not available on Completion (see
    [`review-mode.md`](review-mode.md) § Loop step 2).
 
-   **Completion outcome mapping.** Completion FIX_FINDING does
-   **not** reuse §Phase C Implementer Handlers — those handlers
-   carry per-iteration bookkeeping (3-iteration counter, Progress
-   row, gate-check fan-out) tied to the pre-Completion review loop,
-   which has already exited by the time Completion's three-option
-   panel renders. The `Track-level code review` Progress row is
-   already `[x]` and stays that way; there is no iteration counter
-   at Completion (user-initiated, not budget-driven). The four
-   implementer outcomes feed Completion's re-render directly:
-
-   - **`SUCCESS`** (implementer committed a `Review fix:` on top of
-     HEAD). Re-read the cumulative track diff (`git diff
-     {base_commit}..HEAD`) and re-compile the track episode against
-     the new HEAD. If the user's fixes were substantial enough that
-     a gate-check run alone won't catch potential regressions, also
-     re-run track-level code review against the new HEAD (this is a
-     separate per-substance decision; not automatic). Present
-     updated results and re-render the three-option panel.
-   - **`FAILED`** (implementer returned `level=track, status=FAILED`
-     after exhausting its own internal retries). Do not write any
-     Progress row. Re-read the diff and re-compile the track episode
-     (the working tree may still have partial progress on HEAD).
-     Surface the unfixed findings to the user in the re-render with
-     a `**Review-mode fix attempt failed:**` line listing the
-     items that did not land. The user picks Review mode again to
-     refine, Approve to accept the track as-is despite the failure,
-     or ESCALATE.
-   - **`DESIGN_DECISION`** (implementer returned a deferred design
-     decision rather than a fix). Invoke
-     [`design-decision-escalation.md`](design-decision-escalation.md)
-     to walk the user through the alternatives. Treat the chosen
-     alternative as a new `FIX_FINDING` and re-enter the Review-mode
-     loop with that item pre-seeded — the user confirms it via the
-     action-set confirmation panel before another implementer
-     spawns.
-   - **`RESULT_MISSING`** (implementer exited without producing the
-     expected output — e.g., context exhaustion or crash). Present
-     three sub-options via `AskUserQuestion`: **commit-as-is**
-     (the implementer made partial progress on HEAD; treat it as
-     `SUCCESS` and re-compile the episode), **re-spawn** (one more
-     try with the same findings), **discard** (revert HEAD to
-     pre-Apply via `git reset --hard {pre_apply_sha}` and re-render
-     the panel as if Apply had not run).
+   **Completion outcome mapping.** For what each implementer
+   return status (`SUCCESS` / `FAILED` / `DESIGN_DECISION` /
+   `RESULT_MISSING`) means at Completion — including the
+   re-compile, the `**Review-mode fix attempt failed:**` surfacing,
+   the design-decision escalation flow, and the
+   `commit-as-is / re-spawn / discard` sub-panel for
+   `RESULT_MISSING` — see
+   [`review-mode.md`](review-mode.md) § Completion FIX_FINDING
+   outcome mapping. Completion FIX_FINDING does **not** reuse
+   §Phase C Implementer Handlers above; the spec lives at the
+   review-mode callsite because the four outcomes feed the
+   review-mode three-option re-render, not the iteration loop.
 
    The three-option panel re-renders after every review-mode Apply
    until the user picks **Approve** or **ESCALATE**.

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -343,8 +343,8 @@ any previously staged files go stale. Re-run the staging commands
 from Phase C Startup step 7 before composing the next fan-out's
 sub-agent prompts — this covers both the in-loop gate-check fan-out
 (§ Iteration loop) and the post-approval re-review fan-out triggered
-by user-requested fixes during § Track Completion (step 3, "Fixes
-needed" path). Within a single iteration, the dimensional reviewers
+by user-requested fixes during § Track Completion (step 3, **Review
+mode** path — `FIX_FINDING` items). Within a single iteration, the dimensional reviewers
 can share the same staged paths (they all review the same HEAD). If
 a `RESULT_MISSING` or `FAILED` iteration leaves HEAD unchanged, the
 previously staged files are still current — skip the re-run.
@@ -952,6 +952,18 @@ proceed directly to track completion **in the same session**.
    affected. If any iteration ended in a non-`SUCCESS` return, name
    the unfixed findings and why they were not addressed.
 
+   **This step is the single re-compile entry point.** It runs on
+   initial Completion entry, on post-Apply re-render after a
+   FIX_FINDING round, and on State C session re-entry (per
+   `workflow.md` § Startup Protocol State C sub-states row "All
+   steps `[x]`, code review `[x]`, track still `[ ]` in plan").
+   In all three cases, re-read `git diff {base_commit}..HEAD`
+   against current HEAD before compiling, so the episode reflects
+   any `Review fix:` commits a prior-session implementer may have
+   landed before the orchestrator could re-render. This subsumes
+   the mid-Apply-crash + session-restart case (see
+   [`review-mode.md`](review-mode.md) § State and resume).
+
 2. **Present track results to the user** (do NOT write to plan file yet):
    - Track episode (compiled but not yet persisted)
    - All step episodes from the step file
@@ -973,27 +985,65 @@ proceed directly to track completion **in the same session**.
      render, or one or more `Review fix:` commits on HEAD if
      earlier rounds applied `FIX_FINDING` items).
    - **Review mode** — enter the free-form refinement loop per
-     [`review-mode.md`](review-mode.md) § Loop. The loop produces
-     a typed action set the user confirms before Apply. On Apply,
-     `FIX_FINDING` items are collected into a synthesised findings
-     list (each item: location, issue, proposed fix) and a fresh
-     implementer is spawned with `level=track`,
-     `mode=FIX_REVIEW_FINDINGS`, using the same prompt template,
-     validity matrix, and handler dispatch as §Implementer Spawns
-     and §Phase C Implementer Handlers above. The implementer's
-     `Review fix:` commit lands on top of HEAD; the orchestrator
-     does not touch source files itself. `QUESTION` items are
-     answered inline at proposal time and have no side effect.
-     `EDIT_PLAN` / `EDIT_STEP_DESC` / `CLARIFY` are not available
-     on Completion (see [`review-mode.md`](review-mode.md) § Loop
-     step 2). After Apply, re-read the cumulative track diff
-     (`git diff {base_commit}..HEAD`) and re-compile the track
-     episode; if the user's fixes were substantial enough that a
-     gate-check run alone won't catch potential regressions, also
-     re-run track-level code review. Present updated results and
-     re-render this three-option panel.
+     [`review-mode.md`](review-mode.md) § Loop.
    - **ESCALATE** — trigger inline replanning per
      [`inline-replanning.md`](inline-replanning.md).
+
+   **Review mode side effects.** On Apply, `FIX_FINDING` items are
+   collected into a synthesised findings list (each item: location,
+   issue, proposed fix) and a fresh implementer is spawned with
+   `level=track`, `mode=FIX_REVIEW_FINDINGS`, using the same prompt
+   template and validity matrix as §Implementer Spawns above. The
+   implementer's `Review fix:` commit lands on top of HEAD; the
+   orchestrator does not touch source files itself. `QUESTION`
+   items are answered inline at proposal time and have no side
+   effect. `EDIT_PLAN` / `EDIT_STEP_DESC` / `SKIP_TRACK` / `CLARIFY`
+   are not available on Completion (see
+   [`review-mode.md`](review-mode.md) § Loop step 2).
+
+   **Completion outcome mapping.** Completion FIX_FINDING does
+   **not** reuse §Phase C Implementer Handlers — those handlers
+   carry per-iteration bookkeeping (3-iteration counter, Progress
+   row, gate-check fan-out) tied to the pre-Completion review loop,
+   which has already exited by the time Completion's three-option
+   panel renders. The `Track-level code review` Progress row is
+   already `[x]` and stays that way; there is no iteration counter
+   at Completion (user-initiated, not budget-driven). The four
+   implementer outcomes feed Completion's re-render directly:
+
+   - **`SUCCESS`** (implementer committed a `Review fix:` on top of
+     HEAD). Re-read the cumulative track diff (`git diff
+     {base_commit}..HEAD`) and re-compile the track episode against
+     the new HEAD. If the user's fixes were substantial enough that
+     a gate-check run alone won't catch potential regressions, also
+     re-run track-level code review against the new HEAD (this is a
+     separate per-substance decision; not automatic). Present
+     updated results and re-render the three-option panel.
+   - **`FAILED`** (implementer returned `level=track, status=FAILED`
+     after exhausting its own internal retries). Do not write any
+     Progress row. Re-read the diff and re-compile the track episode
+     (the working tree may still have partial progress on HEAD).
+     Surface the unfixed findings to the user in the re-render with
+     a `**Review-mode fix attempt failed:**` line listing the
+     items that did not land. The user picks Review mode again to
+     refine, Approve to accept the track as-is despite the failure,
+     or ESCALATE.
+   - **`DESIGN_DECISION`** (implementer returned a deferred design
+     decision rather than a fix). Invoke
+     [`design-decision-escalation.md`](design-decision-escalation.md)
+     to walk the user through the alternatives. Treat the chosen
+     alternative as a new `FIX_FINDING` and re-enter the Review-mode
+     loop with that item pre-seeded — the user confirms it via the
+     action-set confirmation panel before another implementer
+     spawns.
+   - **`RESULT_MISSING`** (implementer exited without producing the
+     expected output — e.g., context exhaustion or crash). Present
+     three sub-options via `AskUserQuestion`: **commit-as-is**
+     (the implementer made partial progress on HEAD; treat it as
+     `SUCCESS` and re-compile the episode), **re-spawn** (one more
+     try with the same findings), **discard** (revert HEAD to
+     pre-Apply via `git reset --hard {pre_apply_sha}` and re-render
+     the panel as if Apply had not run).
 
    The three-option panel re-renders after every review-mode Apply
    until the user picks **Approve** or **ESCALATE**.
@@ -1096,6 +1146,17 @@ proceed directly to track completion **in the same session**.
    If the user re-opens this track later (e.g., post-PR fixes), the
    regeneration rule from § Sub-agents → § "Pre-staged diff and
    changed-files list" stages fresh copies before the next fan-out.
+
+   **Budget rule for re-opened FIX_FINDING.** Any FIX_FINDING
+   spawn produced by a re-opened track's Completion gate (the user
+   re-enters Review mode and clicks Apply on a FIX_FINDING action
+   set) is **budgetless** — same rule as a same-session Completion
+   FIX_FINDING per § Track Completion step 3 "Completion outcome
+   mapping". The 3-iteration cap exists to bound autonomous
+   review-loop spinning; the user-in-the-loop check at each Apply
+   is the natural rate limit and replaces the autonomous cap. The
+   pre-Completion review loop's counter from the original session
+   is not consulted on re-open.
 
 6. **Run self-improvement reflection.** Load
    `.claude/workflow/self-improvement-reflection.md` on-demand and

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -107,6 +107,20 @@ three options: **Use the verified alternative** (orchestrator proposes
 the closest matching name), **Drop the mention** (remove the reference
 from the step body), **Escalate to inline replanning**.
 
+This rule applies to non-interactive orchestrator writes (Phase 1
+plan write, Phase A decomposition writes, inline-replanning writes,
+autonomous strategy-refresh writes). Interactive writes through
+review mode (Track Pre-Flight and Track Completion) follow the same
+verify mechanism, the same one-retry rule, and the same mcp-steroid
+state handling, but substitute the action-set confirmation panel
+for this hard-stop `AskUserQuestion` — see
+[`review-mode.md`](review-mode.md) § Loop step 3 for the mapping.
+The action-set panel renders the same warning information; the
+user's Refine / Cancel paths cover Use-alternative / Drop /
+Escalate; Apply-with-warnings is the explicit user consent step
+that does not exist (and could not exist) in the non-interactive
+path.
+
 This rule is the orchestrator-side complement to the sub-agent-side
 PSI rule in §Tooling above.
 
@@ -119,8 +133,8 @@ been skipped) with a forward-looking summary of the upcoming track.
 The gate is the user's chance to refine the plan / step file before
 sub-agents start reading them — via free-form review mode (see
 [`review-mode.md`](review-mode.md)) for light edits, clarifications,
-questions, and combinations thereof — or to escalate to inline
-replanning when the change is deep.
+questions, skipping a remaining track, and combinations thereof —
+or to escalate to inline replanning when the change is deep.
 
 The gate fires once per fresh Phase A entry. State C resume (the
 step file's `## Description` already carries the agreed-upon track
@@ -191,27 +205,27 @@ contract:
   (empty on the first render, populated if earlier rounds applied
   items).
 - **Review mode** — enter the free-form refinement loop per
-  [`review-mode.md`](review-mode.md) § Loop. The loop produces a
-  typed action set the user confirms before Apply; on Apply the
-  orchestrator executes `EDIT_PLAN` / `EDIT_STEP_DESC` items
-  against the plan / step files, appends `CLARIFY` items to the
-  in-conversation clarifications buffer (step 5 below), and
-  answers `QUESTION` items inline (no side effect). `FIX_FINDING`
-  is not available on Pre-Flight (see
-  [`review-mode.md`](review-mode.md) § Loop step 2). After Apply,
-  return here: re-render Panel 1 (re-running the strategy
-  assessment if any `EDIT_PLAN` item touched a remaining track —
-  the touched track may have changed the look-back picture) and
-  Panel 2 from the now-updated files; re-ask.
+  [`review-mode.md`](review-mode.md) § Loop.
+
+  On Apply, the orchestrator executes `EDIT_PLAN` /
+  `EDIT_STEP_DESC` items against the plan / step files, appends
+  `CLARIFY` items to the in-conversation clarifications buffer
+  (step 5 below), and answers `QUESTION` items inline (no side
+  effect). `FIX_FINDING` is not available on Pre-Flight (see
+  [`review-mode.md`](review-mode.md) § Loop step 2).
+
+  After Apply, return here: re-render Panel 1 (re-running the
+  strategy assessment if any `EDIT_PLAN` item touched a remaining
+  track, since the touched track may have changed the look-back
+  picture) and Panel 2 from the now-updated files; re-ask.
 - **ESCALATE** — route to inline replanning per
   [`inline-replanning.md`](inline-replanning.md).
 
 The three-option panel re-renders after every review-mode Apply
-until the user picks **Approve** or **ESCALATE**. The boundary
-between light edits (executable on Apply) and deep amendments
-(forced to ESCALATE) is defined in step 4 below; review mode's
-translator and Mixed-set policy (see
-[`review-mode.md`](review-mode.md) § Mixed-set policy) enforce it.
+until the user picks **Approve** or **ESCALATE**. Step 4 below
+defines the light-vs-deep boundary; review mode's translator and
+Mixed-set policy enforce it (see [`review-mode.md`](review-mode.md)
+§ Mixed-set policy).
 
 If an `EDIT_PLAN` reorder during review-mode Apply changes which
 track is "next", Panel 2 is rebuilt against the new upcoming track
@@ -221,7 +235,7 @@ contract.
 **4. Apply amendments — light vs deep boundary.**
 
 Light amendments are applied by review mode's Apply step per
-[`review-mode.md`](review-mode.md) § Loop step 5 — via `Edit` for
+[`review-mode.md`](review-mode.md) § Loop step 5, via `Edit` for
 single-site changes or `steroid_apply_patch` when more than two
 sites are touched. These are markdown edits, so the project
 CLAUDE.md "always route file edits through MCP Steroid" rule is
@@ -242,6 +256,11 @@ than after commit:
 - Reordering of remaining `[ ]` tracks within the plan checklist
   (only if dependencies still hold; re-render Panel 2 if the
   reorder changes the upcoming track)
+- Skipping a remaining track (`SKIP_TRACK` action item — single
+  user-initiated drop with a required reason; runs the full
+  [`track-skip.md`](track-skip.md) § Process on Apply, including
+  the terminal step-file delete; re-render Panel 1 with the
+  skipped track as the new look-back anchor)
 
 Deep amendments — route to inline replanning per
 [`inline-replanning.md`](inline-replanning.md) (trigger: "user
@@ -249,7 +268,10 @@ requests escalation during track pre-flight"):
 
 - Decision Records, Architecture Notes, Goals, or Constraints in
   the plan file
-- Adding or removing tracks
+- **Adding** a new track (requires authoring a fresh step file
+  `## Description`, dependency analysis, and design decisions).
+  **Removing** a remaining track is light — it is the `SKIP_TRACK`
+  action item above, not a deep amendment.
 - Cross-track interaction surfaces (i.e., the change would affect
   another track's scope beyond pure reordering)
 - Anything the user describes as "fundamental rework"
@@ -325,11 +347,11 @@ this round:
   asked for it to be removed).
 
 - **Plan/step-file amendments** (any `EDIT_PLAN` / `EDIT_STEP_DESC`
-  items applied during review-mode rounds): the edits already
-  landed in the working tree during review mode's Apply step
-  ([`review-mode.md`](review-mode.md) § Loop step 5). They are
-  committed alongside the strategy-refresh line and any
-  clarifications below.
+  / `SKIP_TRACK` items applied during review-mode rounds): the edits
+  already landed in the working tree during review mode's Apply step
+  ([`review-mode.md`](review-mode.md) § Loop step 5), including any
+  step-file deletions produced by `SKIP_TRACK`. They are committed
+  alongside the strategy-refresh line and any clarifications below.
 
 After all artifacts are in place, run a single Workflow update
 commit:

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -116,9 +116,11 @@ Before Phase A's reviews and decomposition begin, the orchestrator
 runs a single Pre-Flight gate that combines a backward-looking
 strategy assessment (when an earlier track has just completed or
 been skipped) with a forward-looking summary of the upcoming track.
-The gate is the user's chance to apply light edits to remaining
-tracks, attach clarifications to the upcoming track, or escalate to
-inline replanning before sub-agents start reading the plan.
+The gate is the user's chance to refine the plan / step file before
+sub-agents start reading them — via free-form review mode (see
+[`review-mode.md`](review-mode.md)) for light edits, clarifications,
+questions, and combinations thereof — or to escalate to inline
+replanning when the change is deep.
 
 The gate fires once per fresh Phase A entry. State C resume (the
 step file's `## Description` already carries the agreed-upon track
@@ -156,7 +158,7 @@ escalation** and **Override**. On **Accept**, route to
 [`inline-replanning.md`](inline-replanning.md) immediately and do
 NOT render Panel 2. On **Override** (the user disagrees with the
 ESCALATE recommendation), fall through to step 2: build Panel 2
-and present the full 4-option gate in step 3, treating the
+and present the full three-option gate in step 3, treating the
 overridden assessment as `CONTINUE` for the purpose of step 6's
 on-disk strategy-refresh line.
 
@@ -179,46 +181,58 @@ escalation`, the gate has already exited and this step does not
 run.
 
 Render Panel 1 (if active) followed by Panel 2, and use
-`AskUserQuestion` with four options:
+`AskUserQuestion` with three one-step options per the approval-panel
+contract in [`review-mode.md`](review-mode.md) § Approval-panel
+contract:
 
-- **Proceed** — accept the assessment (CONTINUE) and start Phase A
-  with the upcoming track as summarised.
-- **Adjust** — modify any remaining track's plan-file entry and/or
-  step file's `## Description`. Light edits only (see step 4 below
-  for the boundary). Reordering remaining `[ ]` tracks is a light
-  edit; if the reorder changes which track is "next", re-render
-  Panel 2 with the new upcoming track's summary before re-asking.
-- **Clarify** — attach guidance, must-/must-not- considerations,
-  or open questions to be carried into Phase A. Clarifications
-  target the **upcoming track only**; they do not modify the plan
-  or other tracks' step files and are written into the upcoming
-  track's step file's `## Description` as a `### Clarifications`
-  subsection on Proceed (see step 6 below).
-- **ESCALATE** — request "fundamental rework" → route to inline
-  replanning.
+- **Approve** — accept the assessment and proceed to step 6
+  (persist) below with whatever clarifications buffer (see step 5)
+  and on-disk amendments the review-mode loop has accumulated
+  (empty on the first render, populated if earlier rounds applied
+  items).
+- **Review mode** — enter the free-form refinement loop per
+  [`review-mode.md`](review-mode.md) § Loop. The loop produces a
+  typed action set the user confirms before Apply; on Apply the
+  orchestrator executes `EDIT_PLAN` / `EDIT_STEP_DESC` items
+  against the plan / step files, appends `CLARIFY` items to the
+  in-conversation clarifications buffer (step 5 below), and
+  answers `QUESTION` items inline (no side effect). `FIX_FINDING`
+  is not available on Pre-Flight (see
+  [`review-mode.md`](review-mode.md) § Loop step 2). After Apply,
+  return here: re-render Panel 1 (re-running the strategy
+  assessment if any `EDIT_PLAN` item touched a remaining track —
+  the touched track may have changed the look-back picture) and
+  Panel 2 from the now-updated files; re-ask.
+- **ESCALATE** — route to inline replanning per
+  [`inline-replanning.md`](inline-replanning.md).
 
-`AskUserQuestion` captures one option per round, so a user who
-wants to combine **Adjust** and **Clarify** spans multiple rounds.
-Each round: the user picks one option; the orchestrator applies it
-(edit the plan/step file for **Adjust**, append to the
-clarifications buffer for **Clarify**); then re-render Panel 1
-(re-running the strategy assessment if Panel 1 is active and the
-adjustment touched a remaining track) and Panel 2 from the
-(now-updated) files; re-ask. Loop until the user picks **Proceed**
-or **ESCALATE**.
+The three-option panel re-renders after every review-mode Apply
+until the user picks **Approve** or **ESCALATE**. The boundary
+between light edits (executable on Apply) and deep amendments
+(forced to ESCALATE) is defined in step 4 below; review mode's
+translator and Mixed-set policy (see
+[`review-mode.md`](review-mode.md) § Mixed-set policy) enforce it.
+
+If an `EDIT_PLAN` reorder during review-mode Apply changes which
+track is "next", Panel 2 is rebuilt against the new upcoming track
+per [`track-skip.md`](track-skip.md) step 2's panel-rendering
+contract.
 
 **4. Apply amendments — light vs deep boundary.**
 
-Light amendments (apply directly via `Edit`, or `steroid_apply_patch`
-when more than two sites are touched — these are markdown edits, no
-IntelliJ PSI/VFS refresh concern applies, so the project CLAUDE.md
-"always route file edits through MCP Steroid" rule is satisfied with
-native `Edit` for single-site changes here). Amendments that name
-production classes in the `**What/How/Constraints/Interactions**`
-blocks are bound by the §Pre-write rule above — PSI-verify every
-named class via `mcp-steroid` find-class **before applying the Edit**
-inside the Adjust round, so the user can correct a pattern-induced
-name in the same `AskUserQuestion` round rather than after commit:
+Light amendments are applied by review mode's Apply step per
+[`review-mode.md`](review-mode.md) § Loop step 5 — via `Edit` for
+single-site changes or `steroid_apply_patch` when more than two
+sites are touched. These are markdown edits, so the project
+CLAUDE.md "always route file edits through MCP Steroid" rule is
+satisfied with native `Edit` for single-site changes here.
+Amendments that name production classes in the
+`**What/How/Constraints/Interactions**` blocks are bound by the
+§Pre-write rule above — PSI-verify every named class via
+`mcp-steroid` find-class **before rendering the action-set
+confirmation panel** (review mode step 3), so the user can correct
+a pattern-induced name during the same review-mode round rather
+than after commit:
 
 - Track title, intro paragraph
 - Scope indicators in the plan-file checklist entries
@@ -249,14 +263,15 @@ relevant, then load `inline-replanning.md` and proceed.
 **5. Capture clarifications.** Keep a clarifications buffer in the
 orchestrator's conversation context — a bullet list of the user's
 notes plus any orchestrator-stated interpretations the user
-confirmed. The buffer is non-empty only if the user picked
-**Clarify** at least once during the loop. When the user picks
-**Proceed**, the buffer flows verbatim into the step file's
+confirmed. The buffer is non-empty only if at least one `CLARIFY`
+item was applied during a review-mode round (see
+[`review-mode.md`](review-mode.md) § Loop step 5). When the user
+picks **Approve**, the buffer flows verbatim into the step file's
 `## Description` in step 6 below.
 
 **6. Persist amendments + clarifications + strategy-refresh line.**
 
-After the user picks **Proceed**, write the on-disk artifacts of
+After the user picks **Approve**, write the on-disk artifacts of
 this round:
 
 - **Strategy-refresh line** (Panel 1 was active): append a
@@ -309,9 +324,11 @@ this round:
   preserved as-is in this case (the user neither re-clarified nor
   asked for it to be removed).
 
-- **Plan/step-file amendments** (any `Adjust` rounds in the loop):
-  the edits already landed in the working tree during step 4. They
-  are committed alongside the strategy-refresh line and any
+- **Plan/step-file amendments** (any `EDIT_PLAN` / `EDIT_STEP_DESC`
+  items applied during review-mode rounds): the edits already
+  landed in the working tree during review mode's Apply step
+  ([`review-mode.md`](review-mode.md) § Loop step 5). They are
+  committed alongside the strategy-refresh line and any
   clarifications below.
 
 After all artifacts are in place, run a single Workflow update
@@ -329,7 +346,7 @@ touched. If the round produced no amendments, no clarifications,
 and no strategy-refresh line (the gate was a pure no-op — only
 possible when Panel 1 was skipped or its outcome was already on
 disk from a prior interrupted session, and the user picked
-Proceed without Adjust/Clarify rounds), skip this commit
+**Approve** without entering review mode), skip this commit
 entirely.
 
 **7. Resume idempotency.** If the merged gate is re-entered on a
@@ -368,9 +385,9 @@ refresh:**` line is present on disk under the
 just-completed/skipped track's block, the prior session's edits
 are the new baseline — surface this in Panel 1's user-facing
 output so the user does not re-issue them in this round's
-`Adjust` rounds.
+review-mode rounds.
 
-**8. Proceed.** Continue to §What You Do sub-step 1 below.
+**8. Continue.** Move to §What You Do sub-step 1 below.
 
 ### What You Do
 

--- a/.claude/workflow/track-skip.md
+++ b/.claude/workflow/track-skip.md
@@ -8,8 +8,9 @@ A track can be skipped (`[~]`) in two situations:
 2. **User requests skip** — the user overrides at session start or during
    the Track Pre-Flight gate (e.g., "skip Track 4, we don't need it
    anymore"). When a skip is requested via a Pre-Flight review-mode
-   `EDIT_PLAN` item that drops a remaining track (see
-   [`review-mode.md`](review-mode.md) § Loop):
+   `SKIP_TRACK` item (see [`review-mode.md`](review-mode.md) § Loop —
+   `SKIP_TRACK` carries `{track_index, reason}` and on Apply runs the
+   full Process below):
    - If the skip would shift which track is "next", re-render
      Panel 2 against the new upcoming track per the gate's
      reordering rule.

--- a/.claude/workflow/track-skip.md
+++ b/.claude/workflow/track-skip.md
@@ -7,9 +7,10 @@ A track can be skipped (`[~]`) in two situations:
    this redundant"). The agent presents the finding to the user.
 2. **User requests skip** — the user overrides at session start or during
    the Track Pre-Flight gate (e.g., "skip Track 4, we don't need it
-   anymore"). When a skip is requested in the Pre-Flight gate's `Adjust`
-   loop:
-   - If the request would shift which track is "next", re-render
+   anymore"). When a skip is requested via a Pre-Flight review-mode
+   `EDIT_PLAN` item that drops a remaining track (see
+   [`review-mode.md`](review-mode.md) § Loop):
+   - If the skip would shift which track is "next", re-render
      Panel 2 against the new upcoming track per the gate's
      reordering rule.
    - If the skipped track was the upcoming track summarised in

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -81,8 +81,8 @@ flowchart TD
     READ -->|"All tracks done,\nPhase 4 not complete"| P4["Phase 4: Final\nArtifacts"]
 
     P2 --> END_P2["Session ends\n(plan review complete)"]
-    PREFLIGHT -->|Proceed| PA["Phase A: Review +\nDecomposition"]
-    PREFLIGHT -->|"Adjust / Clarify\n(re-render panels,\nre-ask)"| PREFLIGHT
+    PREFLIGHT -->|Approve| PA["Phase A: Review +\nDecomposition"]
+    PREFLIGHT -->|"Review mode\n(translate, confirm,\napply; re-render)"| PREFLIGHT
     PREFLIGHT -->|"ESCALATE\n(Panel 1 ESCALATE\nor deep amendment)"| REPLAN["Inline Replanning"]
 
     REPLAN -->|"Revised plan"| END_S["Session ends"]
@@ -93,9 +93,9 @@ flowchart TD
 
     PC --> REVIEW["Code review\n+ plan corrections"]
     REVIEW --> PRESENT["Present track results\nUser reviews"]
-    PRESENT -->|Approved| END_TRACK["Session ends\n(track complete)"]
-    PRESENT -->|"Fixes needed"| FIX["Apply fixes"] --> PRESENT
-    PRESENT -->|"Fundamental rework"| REPLAN
+    PRESENT -->|Approve| END_TRACK["Session ends\n(track complete)"]
+    PRESENT -->|"Review mode\n(translate, confirm,\nspawn fixer; re-present)"| PRESENT
+    PRESENT -->|ESCALATE| REPLAN
 
     P4 --> END_P4["Session ends\n(Phase 4 complete)"]
 
@@ -404,10 +404,10 @@ User interaction points:
 |---|---|---|
 | **Session start** | Auto-resume decision (which track, which phase, or State 0 plan review) | Confirm or override |
 | **State 0 design-decision findings** | Batched list of CR/S findings the consistency and/or structural sub-agents classified as `design-decision`, with proposed alternatives and recommendation | Resolve each finding (choose alternative, provide guidance, defer) |
-| **Track pre-flight (State A — pre-Phase-A)** | Two-panel summary: Panel 1 — strategy assessment (look-back: CONTINUE / ADJUST / ESCALATE) when an earlier track has just completed/skipped; Panel 2 — upcoming track summary built from the plan-file entry + the step file's `## Description` (intro, **What/How/Constraints/Interactions**, scope indicators, optional diagram). Panel 1 is skipped on the very first Phase A entry (no anchor track) and on resume when the strategy-refresh line is already on disk. | Proceed; adjust (light edits to any remaining track's plan / step file including reorder, applied directly); clarify (notes written into the upcoming track's step-file `## Description` as a `### Clarifications` subsection on Proceed); or ESCALATE (Panel 1 ESCALATE accepted, or deep amendment requested) → inline replanning. Skipped on State C resume. |
+| **Track pre-flight (State A — pre-Phase-A)** | Two-panel summary: Panel 1 — strategy assessment (look-back: CONTINUE / ADJUST / ESCALATE) when an earlier track has just completed/skipped; Panel 2 — upcoming track summary built from the plan-file entry + the step file's `## Description` (intro, **What/How/Constraints/Interactions**, scope indicators, optional diagram). Panel 1 is skipped on the very first Phase A entry (no anchor track) and on resume when the strategy-refresh line is already on disk. | Three one-step options per `review-mode.md` § Approval-panel contract: **Approve** (accept and start Phase A with any review-mode-accumulated amendments + clarifications); **Review mode** (free-form refinement loop — translator + action-set confirmation; on Apply, executes `EDIT_PLAN` / `EDIT_STEP_DESC` items, buffers `CLARIFY` items, answers `QUESTION` items inline; re-renders panels); **ESCALATE** (Panel 1 ESCALATE accepted, or review mode produced a deep amendment) → inline replanning. Skipped on State C resume. |
 | **Phase A/B complete (and State 0 complete)** | Phase summary, what was done, next phase | User clears session, re-runs `/execute-tracks` |
 | **Cross-track impact** | Which tracks affected, what broke, recommendation | Continue, pause, or escalate |
-| **Track complete (end of Phase C)** | Track episode, step episodes, git log of commits, plan corrections | Approve, request fixes, or rework |
+| **Track complete (end of Phase C)** | Track episode, step episodes, git log of commits, plan corrections | Three one-step options per `review-mode.md` § Approval-panel contract: **Approve** (write track episode + collapse + `[x]`); **Review mode** (free-form refinement loop — on Apply, `FIX_FINDING` items spawn a fresh implementer with `mode=FIX_REVIEW_FINDINGS`; `QUESTION` items are answered inline); **ESCALATE** → inline replanning. |
 | **Step failure (2nd attempt)** | What failed twice, what was tried, options | Retry differently, adjust, or escalate |
 | **Design decision needed** | Alternatives with trade-offs, recommendation | Choose an alternative or provide guidance |
 | **Self-improvement reflection (every session end)** | 0..N proposed YouTrack issues (capped at 3, deduped against existing `project: YTDB tag: dev-workflow` issues), each with title + Bug/Feature type + one-line summary; skipped with a notice when the YouTrack MCP server is unreachable | Pick which proposals to create in YouTrack (numbers, "all", or "none") |
@@ -428,9 +428,11 @@ inside Phase B.
 ## Inline Replanning (ESCALATE)
 
 Triggers when the Track Pre-Flight gate produces ESCALATE (Panel 1
-strategy assessment ESCALATE accepted by the user, or `Adjust` would
-touch a deep-amendment category — Decision Records, Architecture
-Notes, Goals, Constraints, adding/removing tracks, cross-track
+strategy assessment ESCALATE accepted by the user, or review mode
+produces an `ESCALATE` action item / a Mixed-set Escalate-now per
+[`review-mode.md`](review-mode.md) § ESCALATE detection — i.e., the
+requested change touches Decision Records, Architecture Notes,
+Goals, Constraints, adding/removing tracks, or cross-track
 interaction surfaces), cross-track impact detects fundamental
 assumption failure, or a step failure cannot be recovered with
 additional commits. Stops all new steps and enters a

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -233,8 +233,10 @@ backward-looking strategy assessment (when an earlier track has
 just completed or been skipped) with a forward-looking summary of
 the upcoming track. The user can apply light edits to remaining
 tracks, attach clarifications to the upcoming track, or escalate to
-inline replanning. The gate runs in the same session as Phase A —
-this is the only exception to mandatory phase boundaries.
+inline replanning — all via the free-form review-mode loop (see
+[`review-mode.md`](review-mode.md)). The gate runs in the same
+session as Phase A; this is the only exception to mandatory phase
+boundaries.
 
 **Full protocol:** [`track-review.md`](track-review.md) § Track Pre-Flight
 
@@ -404,7 +406,7 @@ User interaction points:
 |---|---|---|
 | **Session start** | Auto-resume decision (which track, which phase, or State 0 plan review) | Confirm or override |
 | **State 0 design-decision findings** | Batched list of CR/S findings the consistency and/or structural sub-agents classified as `design-decision`, with proposed alternatives and recommendation | Resolve each finding (choose alternative, provide guidance, defer) |
-| **Track pre-flight (State A — pre-Phase-A)** | Two-panel summary: Panel 1 — strategy assessment (look-back: CONTINUE / ADJUST / ESCALATE) when an earlier track has just completed/skipped; Panel 2 — upcoming track summary built from the plan-file entry + the step file's `## Description` (intro, **What/How/Constraints/Interactions**, scope indicators, optional diagram). Panel 1 is skipped on the very first Phase A entry (no anchor track) and on resume when the strategy-refresh line is already on disk. | Three one-step options per `review-mode.md` § Approval-panel contract: **Approve** (accept and start Phase A with any review-mode-accumulated amendments + clarifications); **Review mode** (free-form refinement loop — translator + action-set confirmation; on Apply, executes `EDIT_PLAN` / `EDIT_STEP_DESC` items, buffers `CLARIFY` items, answers `QUESTION` items inline; re-renders panels); **ESCALATE** (Panel 1 ESCALATE accepted, or review mode produced a deep amendment) → inline replanning. Skipped on State C resume. |
+| **Track pre-flight (State A — pre-Phase-A)** | Two-panel summary: Panel 1 — strategy assessment (look-back: CONTINUE / ADJUST / ESCALATE) when an earlier track has just completed/skipped; Panel 2 — upcoming track summary built from the plan-file entry + the step file's `## Description` (intro, **What/How/Constraints/Interactions**, scope indicators, optional diagram). Panel 1 is skipped on the very first Phase A entry (no anchor track) and on resume when the strategy-refresh line is already on disk. | Three one-step options per `review-mode.md` § Approval-panel contract: **Approve** (accept and start Phase A with any review-mode-accumulated amendments + clarifications); **Review mode** (free-form refinement loop — translator + action-set confirmation; on Apply, executes `EDIT_PLAN` / `EDIT_STEP_DESC` / `SKIP_TRACK` items, buffers `CLARIFY` items, answers `QUESTION` items inline; re-renders panels); **ESCALATE** (Panel 1 ESCALATE accepted, or review mode produced a deep amendment) → inline replanning. Skipped on State C resume. |
 | **Phase A/B complete (and State 0 complete)** | Phase summary, what was done, next phase | User clears session, re-runs `/execute-tracks` |
 | **Cross-track impact** | Which tracks affected, what broke, recommendation | Continue, pause, or escalate |
 | **Track complete (end of Phase C)** | Track episode, step episodes, git log of commits, plan corrections | Three one-step options per `review-mode.md` § Approval-panel contract: **Approve** (write track episode + collapse + `[x]`); **Review mode** (free-form refinement loop — on Apply, `FIX_FINDING` items spawn a fresh implementer with `mode=FIX_REVIEW_FINDINGS`; `QUESTION` items are answered inline); **ESCALATE** → inline replanning. |
@@ -432,11 +434,12 @@ strategy assessment ESCALATE accepted by the user, or review mode
 produces an `ESCALATE` action item / a Mixed-set Escalate-now per
 [`review-mode.md`](review-mode.md) § ESCALATE detection — i.e., the
 requested change touches Decision Records, Architecture Notes,
-Goals, Constraints, adding/removing tracks, or cross-track
-interaction surfaces), cross-track impact detects fundamental
-assumption failure, or a step failure cannot be recovered with
-additional commits. Stops all new steps and enters a
-propose → review → iterate cycle.
+Goals, Constraints, **adding** a new track, or cross-track
+interaction surfaces; **removing** a remaining track is light
+(`SKIP_TRACK`), not ESCALATE), cross-track impact detects
+fundamental assumption failure, or a step failure cannot be
+recovered with additional commits. Stops all new steps and enters
+a propose → review → iterate cycle.
 
 **Full protocol:** [`inline-replanning.md`](inline-replanning.md)
 


### PR DESCRIPTION
#### PR Title:

Add review-mode loop to gate approval panels

#### Motivation:

The Track Pre-Flight and Track Completion gates previously asked the user to pick a single bucket per round (Proceed / Adjust / Clarify / ESCALATE on Pre-Flight; Approved / Fixes needed / Fundamental rework on Completion). Combining concerns — "answer this question, also rename that variable, and add a clarification" — forced multiple rounds with `AskUserQuestion`, each round losing the previous context and re-rendering the same panels.

This change consolidates both gates onto a shared three-option approval contract — **Approve** / **Review mode** / **ESCALATE** — and adds a free-form review-mode loop that translates the user's input into a typed action set (`QUESTION`, `EDIT_PLAN`, `EDIT_STEP_DESC`, `SKIP_TRACK`, `CLARIFY`, `FIX_FINDING`, `ESCALATE`), shows a confirmation panel, and applies the items in one round before re-rendering. The user can combine refinements in a single chat reply instead of bucketed multi-round panels.

## Summary
- Add `.claude/workflow/review-mode.md` defining the shared approval-panel contract, the free-form input → translate → validate → confirm → apply loop, the typed action-set table (per-gate availability), Mixed-set / ESCALATE detection rules, Completion FIX_FINDING outcome mapping, and state-and-resume semantics.
- Replace the Pre-Flight 4-option panel and Completion 3-option panel in `track-review.md` and `track-code-review.md` with the shared three-option contract; route refinement work through the review-mode loop.
- Update `workflow.md` (state-machine diagram + interaction-point table) and `inline-replanning.md` to reflect ESCALATE entry from review mode (deep amendments, `ESCALATE` action items, Mixed-set Escalate-now).
- Touch-ups in `planning.md`, `track-skip.md`, and `execute-tracks/SKILL.md` for cross-reference consistency.

## Test plan
- [ ] Workflow-machinery change only — no source-code tests apply. Verification is by exercising the protocol on the next real `/execute-tracks` Track Pre-Flight and Track Completion gates.
- [ ] Confirm the three-option panel renders correctly at both gates and the review-mode loop applies items in order.
- [ ] Confirm a Mixed-set Escalate-now correctly routes to inline replanning while preserving completed light items.