### PR TITLE
YTDB-681: Canonical finding-synthesis recipe for Phase C reviews

### DIFF
--- a/.claude/workflow/code-review-protocol.md
+++ b/.claude/workflow/code-review-protocol.md
@@ -23,9 +23,10 @@ For both levels:
 - **Conditional agents (up to 6)** are added based on the step/track
   description and changed files.
 
-After all selected agents complete, findings are deduplicated,
-severity-assigned (blocker / should-fix / suggestion), and attributed to
-source dimension(s). Max 3 iterations per level.
+After all selected agents complete, findings are synthesised per
+[`finding-synthesis-recipe.md`](finding-synthesis-recipe.md):
+deduplicated, severity-assigned (blocker / should-fix / suggestion),
+and attributed to source dimension(s). Max 3 iterations per level.
 
 ---
 

--- a/.claude/workflow/finding-synthesis-recipe.md
+++ b/.claude/workflow/finding-synthesis-recipe.md
@@ -195,9 +195,10 @@ not a contract.
 a prior Review-mode pass, the guidance overrides the default
 bucketing for the items it named. Review-mode guidance names
 contributing dimension IDs (`BC3`, `TX1`, …), not `M<n>` IDs (which
-are fresh per synthesis). Walk the §Synthesis audit trail's
-contributing-dimensions list for each merged row and apply the
-user's bucket override before final assignment.
+are assigned during synthesis, after the Review-mode pass ran).
+Walk the §Synthesis audit trail's contributing-dimensions list for
+each merged row and apply the user's bucket override before final
+assignment.
 
 Step-level synthesis (per
 [`step-implementation.md`](step-implementation.md) §Per-Step
@@ -321,7 +322,7 @@ are the canonical names cited from elsewhere in this recipe and from
 synthesis decisions that do not appear in the in-scope or deferred
 lists land here.
 
-The `M<n>` prefix is fresh for the synthesised list. The
+The `M<n>` prefix is assigned at synthesis time. The
 per-dimension finding IDs (e.g., `BC3`, `TX1`) live only in the
 audit trail of which dimension contributed each merged row; the
 implementer's `findings:` block carries only the `M<n>` IDs and
@@ -370,9 +371,9 @@ After mapping, fold any `New findings` from the gate-check reports
 into the resulting list and run Steps 1–4 across the union. The
 output format from Step 5 applies unchanged.
 
-If the synthesised in-scope list is empty after Steps 1–4 AND no
-`REGRESSION` verdict was seen, return PASS and exit the review loop
-without respawning the implementer. A `REGRESSION` verdict always
-forces `FAIL` even when it produced no merged in-scope row — the
-regression's `revert-or-repair` guidance carries the iteration
-regardless of dedup outcome.
+If the synthesised in-scope list is empty after Steps 1–4, return
+PASS and exit the review loop without respawning the implementer.
+A `REGRESSION` verdict always forces `FAIL` and is forwarded as a
+standalone in-scope entry per Step 1 above, so an empty list and a
+`REGRESSION` verdict cannot co-occur; the regression's
+`revert-or-repair` guidance always reaches the implementer.

--- a/.claude/workflow/finding-synthesis-recipe.md
+++ b/.claude/workflow/finding-synthesis-recipe.md
@@ -27,6 +27,16 @@ Synthesis produces three outputs, in this order:
 Apply the steps below in order. Skip a step that is inapplicable
 (e.g., a 4-finding fan-out has no deduplication to do).
 
+If every selected agent returned zero findings, emit:
+
+```markdown
+## Synthesised findings — iteration {N}/3
+
+(no findings)
+```
+
+and signal PASS to the caller. Do not respawn the implementer.
+
 ---
 
 ## Step 1 — Deduplicate across dimensions
@@ -50,20 +60,32 @@ Each level breaks ties for the level above. Walk the raw findings
 once in dimension order (baseline first, then conditional), inserting
 each into the running merged list at this key:
 
-1. **`file:line`** — exact code location. Two findings at the same
-   file and line are candidates to merge.
-2. **Issue shape** — the substantive complaint, ignoring how each
+Some findings have no single `file:line` — missing-test flags
+(`review-test-completeness`), missing-invariant flags
+(`review-crash-safety`), architectural plan-vs-code drift. For
+these, substitute the affected component or test class as the
+level-1 key (e.g., `core/.../CASDiskWAL` or
+`BTreeMultiValueIndexTest`). When even a component cannot be named,
+skip directly to level 2 (issue shape) and rely on suggested-fix
+shape for the merge decision.
+
+1. **`file:line`**: exact code location. Two findings at the same
+   file and line are candidates to merge. Two findings whose line
+   ranges overlap, or whose lines fall within ±5 lines of each
+   other in the same method body, share the level-1 key. Distant
+   lines in the same file stay separate.
+2. **Issue shape**: the substantive complaint, ignoring how each
    reviewer framed it. "Polling loop with fixed sleep", "race-prone
    flake on slow CI", "wasted CPU per assertion", "no deterministic
    synchronisation" — same issue. When two findings at the same
    `file:line` express genuinely different complaints (e.g.,
    "incorrect lock order" vs "missing null check"), they stay
    separate even though `file:line` matches.
-3. **Suggested fix shape** — the concrete change the finding asks
+3. **Suggested fix shape**: the concrete change the finding asks
    for. Two findings at adjacent lines proposing the same fix merge
    under one row; two findings at the same line proposing different
    fixes stay separate.
-4. **Severity (tie-break only)** — when the merged finding inherits
+4. **Severity (tie-break only)**: when the merged finding inherits
    severities from multiple agents, take the **strictest** (blocker
    > should-fix > suggestion). Record the contributing dimensions so
    the gate-check fan-out re-runs only the implicated reviewers.
@@ -93,6 +115,13 @@ After dedup, one merged row:
 Severity is `blocker` — strictest of the five contributing severities,
 inherited from `review-test-concurrency`.
 
+The example covers Step 1 in full. Step 2 does not apply because M1
+is a multi-contributor row, not a singleton. In Step 3 the `blocker`
+severity routes M1 to **In-scope this iteration**. In Step 4 a
+1-finding spawn is well under the 8–12 target, so no split is
+needed. The Step 5 output carries M1 as the sole entry in the
+**In-scope this iteration** section.
+
 ---
 
 ## Step 2 — Assign severity to singletons
@@ -101,22 +130,22 @@ Findings that survive Step 1 as singletons keep their original
 severity unless it conflicts with the standard scale in
 [`review-iteration.md`](review-iteration.md) §Severity levels:
 
-- **blocker** — must fix before merge: bugs, security vulns, crash
+- **blocker**: must fix before merge — bugs, security vulns, crash
   safety, data corruption, tests giving false confidence, CI-hang
   risks.
-- **should-fix** — should fix before merge: likely bugs, performance
+- **should-fix**: should fix before merge — likely bugs, performance
   issues, concurrency risks, missing critical test coverage,
   falsifiability gaps in newly-added tests.
-- **suggestion** — recommended improvements: minor style, optional
+- **suggestion**: recommended improvements — minor style, optional
   optimisations, additional test scenarios.
 
 When an agent assigned a severity higher than the criteria above
 support (e.g., `blocker` for a style preference), downgrade during
-synthesis with a one-line justification in the iteration record so
-the next reviewer instance does not re-raise the same finding at the
-same severity. Conversely, when a singleton's stated impact reads
-clearly above its assigned severity, upgrade with the same
-justification trail.
+synthesis and log an `OVERRIDE` entry in the §Synthesis audit trail
+(Step 5 output) so the next reviewer instance does not re-raise the
+same finding at the same severity. Conversely, when a singleton's
+stated impact reads clearly above its assigned severity, upgrade and
+log the same `OVERRIDE` entry.
 
 ---
 
@@ -154,15 +183,27 @@ For each merged finding, choose one of three buckets:
   hierarchy" surfaced during a 2-line bug-fix track). Plan
   correction.
 - Findings the orchestrator judges out-of-scope on re-read despite
-  the reviewer flagging them. Record the rationale in the iteration
-  record; if the rationale is purely "low value", treat as a
-  rejected `suggestion` and drop from the list entirely instead of
-  routing it to a plan correction.
+  the reviewer flagging them. Log a `DROP` entry in the §Synthesis
+  audit trail (Step 5 output) with the rationale; if the rationale
+  is purely "low value", treat as a rejected `suggestion` and drop
+  from the list entirely instead of routing it to a plan correction.
 
 The split is a judgement call; the buckets above are the default,
-not a contract. When the user gave explicit guidance during a prior
-Review-mode pass, the guidance overrides the default bucketing for
-the items it named.
+not a contract.
+
+**At track level only**, when the user gave explicit guidance during
+a prior Review-mode pass, the guidance overrides the default
+bucketing for the items it named. Review-mode guidance names
+contributing dimension IDs (`BC3`, `TX1`, …), not `M<n>` IDs (which
+are fresh per synthesis). Walk the §Synthesis audit trail's
+contributing-dimensions list for each merged row and apply the
+user's bucket override before final assignment.
+
+Step-level synthesis (per
+[`step-implementation.md`](step-implementation.md) §Per-Step
+Orchestration Loop sub-step 4(b)) runs before any Review-mode pass
+exists; this override is unreachable there and the default
+bucketing always wins.
 
 ---
 
@@ -172,6 +213,8 @@ The hard ceiling from
 [`track-code-review.md`](track-code-review.md) §Review loop step 2 is
 ~15 in-scope findings or ~10 distinct source files per implementer
 spawn.
+
+### Why the headroom matters
 
 **Aim lower than the ceiling.** Target 8–12 findings touching ≤ 6–8
 files per iteration. The headroom matters because:
@@ -185,10 +228,11 @@ files per iteration. The headroom matters because:
   fills faster when the originating iteration covered more
   ground; splitting now leaves room for carry-overs without
   re-tripping the ceiling.
-- Opus implementers truncated mid-iteration in past Phase C
-  sessions when the spawn hit 22 findings × 14 files (the Track-18
-  incident, 2026-05-07). A 12-finding target keeps the
-  message-budget margin healthy on cache-cold spawns.
+- Cache-cold Opus spawns truncated mid-iteration at 22 findings ×
+  14 files in past Phase C sessions. A 12-finding target keeps the
+  message-budget margin healthy.
+
+### Splitting vs accepting a larger spawn
 
 When the deduped in-scope set exceeds 12 findings, split it: take
 the highest-severity 8–12 items first, displace the rest to
@@ -201,7 +245,29 @@ independent and the per-finding fix is small (e.g., 20
 identical-pattern Javadoc fixes touching 10 files), one large
 iteration is still fine. When iteration counts are already tight
 (2 of 3 used) and the remaining findings cohere, accept the larger
-spawn and document the choice in the iteration record.
+spawn and log an `OVER-BUDGET` entry in the §Synthesis audit trail
+(Step 5 output) with the rationale.
+
+When a single merged finding inherently spans more files than the
+per-iteration ceiling (systematic rename, polymorphic SPI signature
+change, package move), keep it as one finding and log the
+over-ceiling decision with an `OVER-BUDGET` entry in the §Synthesis
+audit trail. Splitting an atomic refactor across iterations is
+worse than the over-budget spawn — the partial states between
+iterations would not compile.
+
+### High-volume synthesis and handoff
+
+When the deduped in-scope set is so large that the binary split
+cascades across iterations (≳24 findings), do not surface a
+decision to the user. The context-consumption gate at the end of
+each iteration is the natural pause point — high-volume synthesis
+drives context pressure into `warning` / `critical`, which fires
+the handoff per [`mid-phase-handoff.md`](mid-phase-handoff.md). The
+synthesised list and §Synthesis audit trail are preserved across
+the handoff as work-in-progress; a fresh-context orchestrator on
+resume can decide whether to continue, `ESCALATE`, or route some
+items to plan corrections with cache headroom intact.
 
 ---
 
@@ -236,13 +302,24 @@ section; this recipe produces the canonical merged list.
   [`track-code-review.md`](track-code-review.md) §Plan Corrections
   from Deferred Findings.
 
-### Dropped during synthesis (audit trail only)
+### Synthesis audit trail
 
-- BC7 — rejected on re-read: covered by existing test
+- `DROP BC7` — rejected on re-read: covered by existing test
   `<class>#<method>`; reviewer missed the assertion.
-- PF4 — downgraded from `blocker` to `suggestion` and dropped:
-  ~50 µs improvement on a non-hot path.
+- `OVERRIDE PF4 blocker→suggestion` — ~50 µs improvement on a
+  non-hot path; criteria support `suggestion` only. Dropped from
+  in-scope list.
+- `OVER-BUDGET 14 findings` — iteration counts already 2/3 used
+  and the remaining findings cohere; accepted one larger spawn.
+- `REJECTED-VERDICT BC9` — gate-check reviewer recanted: original
+  finding was a misread of the `volatile` semantics.
 ```
+
+Entry-kind tags (`DROP`, `OVERRIDE`, `OVER-BUDGET`, `REJECTED-VERDICT`)
+are the canonical names cited from elsewhere in this recipe and from
+[`review-iteration.md`](review-iteration.md) §Verdict handling. All
+synthesis decisions that do not appear in the in-scope or deferred
+lists land here.
 
 The `M<n>` prefix is fresh for the synthesised list. The
 per-dimension finding IDs (e.g., `BC3`, `TX1`) live only in the
@@ -251,6 +328,15 @@ implementer's `findings:` block carries only the `M<n>` IDs and
 their merged bodies. The implementer does not need to know which
 reviewer framing originated each item.
 
+`M<n>` IDs are cumulative across iterations of the same review loop.
+Iteration N's first new finding starts at `M<last+1>` where `<last>`
+is the highest M-ID seen in iteration N−1's synthesised list,
+regardless of which earlier findings cleared. Cumulative numbering
+keeps implementer commit messages and gate-check verdicts unambiguous
+across the loop.
+
+Omit empty sections; never emit a heading with no content beneath it.
+
 ---
 
 ## Gate-check synthesis
@@ -258,17 +344,35 @@ reviewer framing originated each item.
 When this recipe runs against gate-check returns (per
 [`review-iteration.md`](review-iteration.md) §Gate-check synthesis
 routing), the inputs are verdicts plus optional `New findings`
-blocks, not raw dimensional findings. Map the verdicts as follows
-before walking Steps 1–4:
+blocks, not raw dimensional findings.
+
+### Verdict-to-action mapping
+
+Map the verdicts as follows before walking Steps 1–4:
 
 | Gate-check verdict | Action |
 |---|---|
 | `VERIFIED` | Drop from the forwarded list. Cleared this iteration. |
-| `REJECTED` | Drop from the forwarded list. Reviewer recanted; log the rationale. |
+| `REJECTED` | Drop from the forwarded list. Reviewer recanted; log a `REJECTED-VERDICT` entry in the §Synthesis audit trail (Step 5 output) with the rationale. |
 | `MOOT` | Drop from the forwarded list. Code path no longer reachable. |
 | `STILL OPEN` | Forward verbatim with the original `M<n>` ID and severity. |
 | `REGRESSION` | Escalate to `blocker` with `revert-or-repair` guidance; carry the regression's `file:line` plus the original finding ID into the next implementer spawn. A `REGRESSION` forces the iteration `FAIL` even if every other verdict is `VERIFIED`. |
 
+### Dedup and termination
+
+`REGRESSION` rows never merge with other rows during Step 1, even
+at the same `file:line`. Their `revert-or-repair` guidance is
+load-bearing and must reach the implementer unmerged. Forward
+`REGRESSION` findings as standalone entries; other findings at the
+same location continue through normal dedup.
+
 After mapping, fold any `New findings` from the gate-check reports
 into the resulting list and run Steps 1–4 across the union. The
 output format from Step 5 applies unchanged.
+
+If the synthesised in-scope list is empty after Steps 1–4 AND no
+`REGRESSION` verdict was seen, return PASS and exit the review loop
+without respawning the implementer. A `REGRESSION` verdict always
+forces `FAIL` even when it produced no merged in-scope row — the
+regression's `revert-or-repair` guidance carries the iteration
+regardless of dedup outcome.

--- a/.claude/workflow/finding-synthesis-recipe.md
+++ b/.claude/workflow/finding-synthesis-recipe.md
@@ -1,0 +1,274 @@
+# Finding Synthesis Recipe
+
+Shared procedure for collapsing a multi-agent dimensional review
+fan-out into a single, deduplicated, iteration-ready findings list.
+
+**Load on demand** at every synthesis call site:
+
+- [`track-code-review.md`](track-code-review.md) §Synthesis (Phase C
+  track-level review — initial spawn and the post-gate-check
+  re-synthesis).
+- [`step-implementation.md`](step-implementation.md) §Per-Step
+  Orchestration Loop sub-step 4(b) (Phase B `risk: high` step-level
+  review).
+- [`review-iteration.md`](review-iteration.md) §Gate-check synthesis
+  routing (re-run on aggregated gate-check `New findings` blocks
+  before composing the next implementer input).
+
+Synthesis produces three outputs, in this order:
+
+1. A unified list of distinct findings, each annotated with the
+   dimension(s) that flagged it.
+2. A severity per finding (`blocker` / `should-fix` / `suggestion`,
+   per [`review-iteration.md`](review-iteration.md) §Severity levels).
+3. A split into **in-scope this iteration**, **deferred to next
+   iteration**, and **plan correction / out-of-track** buckets.
+
+Apply the steps below in order. Skip a step that is inapplicable
+(e.g., a 4-finding fan-out has no deduplication to do).
+
+---
+
+## Step 1 — Deduplicate across dimensions
+
+When the fan-out is wide (baseline 4 + at least 2 conditional groups,
+typical for any track that touches storage or perf-sensitive paths),
+expect 30–80 raw findings with 30–60 % cross-dimension overlap.
+
+The deduplication trap is **reviewer framing**: five reviewers can
+flag the same code site through five different lenses. A
+`Thread.sleep(10)` polling loop in a CAS WAL test gets flagged as a
+flake risk (`review-bugs-concurrency`), as a CI-hang risk
+(`review-test-concurrency`), as wasted CPU (`review-performance`), as
+a slow-test smell (`review-test-structure`), and as poor style
+(`review-code-quality`). All five point at the same `file:line` and
+propose the same fix shape (await the condition instead of polling).
+
+### Pivot order
+
+Each level breaks ties for the level above. Walk the raw findings
+once in dimension order (baseline first, then conditional), inserting
+each into the running merged list at this key:
+
+1. **`file:line`** — exact code location. Two findings at the same
+   file and line are candidates to merge.
+2. **Issue shape** — the substantive complaint, ignoring how each
+   reviewer framed it. "Polling loop with fixed sleep", "race-prone
+   flake on slow CI", "wasted CPU per assertion", "no deterministic
+   synchronisation" — same issue. When two findings at the same
+   `file:line` express genuinely different complaints (e.g.,
+   "incorrect lock order" vs "missing null check"), they stay
+   separate even though `file:line` matches.
+3. **Suggested fix shape** — the concrete change the finding asks
+   for. Two findings at adjacent lines proposing the same fix merge
+   under one row; two findings at the same line proposing different
+   fixes stay separate.
+4. **Severity (tie-break only)** — when the merged finding inherits
+   severities from multiple agents, take the **strictest** (blocker
+   > should-fix > suggestion). Record the contributing dimensions so
+   the gate-check fan-out re-runs only the implicated reviewers.
+
+### Worked example — 5-way `Thread.sleep` dedup
+
+Raw findings, condensed:
+
+| Dimension | Raw finding |
+|---|---|
+| `review-bugs-concurrency` | `BC3 should-fix` — `Thread.sleep(10)` polling loop in `CASDiskWriteAheadLogLifecycleTest:142` can mask races; replace with await-condition. |
+| `review-test-concurrency` | `TX1 blocker` — Same `:142` polling; on a slow CI runner the 30 s test timeout fires before the WAL flushes and the suite hangs. |
+| `review-performance` | `PF2 suggestion` — `:142` busy-loops; ~100 ms wasted per invocation, ~6 s across the suite. |
+| `review-test-structure` | `TS5 should-fix` — Slow-test smell; long polls indicate weak isolation between WAL state and the assertion. |
+| `review-code-quality` | `CQ9 should-fix` — Use `CountDownLatch` or `Awaitility` instead of bare `Thread.sleep`. |
+
+After dedup, one merged row:
+
+```markdown
+### Finding M1 [blocker]
+**Location**: core/src/test/.../CASDiskWriteAheadLogLifecycleTest.java:142
+**Dimensions**: bugs-concurrency, test-concurrency, performance, test-structure, code-quality
+**Issue**: `Thread.sleep(10)` polling loop instead of awaiting the WAL-flushed condition; risks CI hangs on slow runners (severity-driving) and masks the underlying race.
+**Proposed fix**: Replace the loop with an `Awaitility` await on the flushed-condition predicate. Remove the test's wall-clock dependency on the 30 s timeout.
+```
+
+Severity is `blocker` — strictest of the five contributing severities,
+inherited from `review-test-concurrency`.
+
+---
+
+## Step 2 — Assign severity to singletons
+
+Findings that survive Step 1 as singletons keep their original
+severity unless it conflicts with the standard scale in
+[`review-iteration.md`](review-iteration.md) §Severity levels:
+
+- **blocker** — must fix before merge: bugs, security vulns, crash
+  safety, data corruption, tests giving false confidence, CI-hang
+  risks.
+- **should-fix** — should fix before merge: likely bugs, performance
+  issues, concurrency risks, missing critical test coverage,
+  falsifiability gaps in newly-added tests.
+- **suggestion** — recommended improvements: minor style, optional
+  optimisations, additional test scenarios.
+
+When an agent assigned a severity higher than the criteria above
+support (e.g., `blocker` for a style preference), downgrade during
+synthesis with a one-line justification in the iteration record so
+the next reviewer instance does not re-raise the same finding at the
+same severity. Conversely, when a singleton's stated impact reads
+clearly above its assigned severity, upgrade with the same
+justification trail.
+
+---
+
+## Step 3 — Bucket the deduped list
+
+For each merged finding, choose one of three buckets:
+
+### In-scope, this iteration
+
+- All `blocker` findings.
+- `should-fix` findings touching concurrency correctness,
+  crash-safety invariants, CI-hang risks, or the falsifiability of
+  newly-added tests.
+- `should-fix` findings whose fix shape is small enough to fit
+  alongside the items above within the pre-spawn budget (Step 4).
+
+### In-scope, next iteration
+
+- `should-fix` findings touching style, naming, boundary cases,
+  minor falsifiability tightenings, dead-code removal, or comment
+  clarity.
+- Cleanup that depends on this iteration's fixes landing first
+  (e.g., a rename of a helper introduced in this iteration).
+- `should-fix` items displaced from iteration 1 by the pre-spawn
+  budget (Step 4).
+
+### Deferred — plan correction or episode note
+
+- `suggestion`-severity findings that genuinely belong in a
+  different track. Route via
+  [`track-code-review.md`](track-code-review.md) §Plan Corrections
+  from Deferred Findings.
+- Structural refactors whose scope exceeds the current track's
+  goals (e.g., "extract this 200-line method into a new class
+  hierarchy" surfaced during a 2-line bug-fix track). Plan
+  correction.
+- Findings the orchestrator judges out-of-scope on re-read despite
+  the reviewer flagging them. Record the rationale in the iteration
+  record; if the rationale is purely "low value", treat as a
+  rejected `suggestion` and drop from the list entirely instead of
+  routing it to a plan correction.
+
+The split is a judgement call; the buckets above are the default,
+not a contract. When the user gave explicit guidance during a prior
+Review-mode pass, the guidance overrides the default bucketing for
+the items it named.
+
+---
+
+## Step 4 — Pre-spawn budget check
+
+The hard ceiling from
+[`track-code-review.md`](track-code-review.md) §Review loop step 2 is
+~15 in-scope findings or ~10 distinct source files per implementer
+spawn.
+
+**Aim lower than the ceiling.** Target 8–12 findings touching ≤ 6–8
+files per iteration. The headroom matters because:
+
+- The implementer's per-test re-runs scale with the number of
+  touched test classes; a 12-file spawn already implies 4–6
+  targeted `-Dtest=…` invocations
+  ([`implementer-rules.md`](implementer-rules.md) §Pacing
+  long-running tasks → "Prefer targeted `-Dtest=…` re-runs").
+- The gate-check fan-out's per-agent `New findings` cap of ≤ 3
+  fills faster when the originating iteration covered more
+  ground; splitting now leaves room for carry-overs without
+  re-tripping the ceiling.
+- Opus implementers truncated mid-iteration in past Phase C
+  sessions when the spawn hit 22 findings × 14 files (the Track-18
+  incident, 2026-05-07). A 12-finding target keeps the
+  message-budget margin healthy on cache-cold spawns.
+
+When the deduped in-scope set exceeds 12 findings, split it: take
+the highest-severity 8–12 items first, displace the rest to
+iteration 2. The displaced items re-surface in iteration 2's
+gate-check fan-out and consume an iteration counter normally — they
+are not lost.
+
+**Soft pacing, not a hard split.** When the findings are genuinely
+independent and the per-finding fix is small (e.g., 20
+identical-pattern Javadoc fixes touching 10 files), one large
+iteration is still fine. When iteration counts are already tight
+(2 of 3 used) and the remaining findings cohere, accept the larger
+spawn and document the choice in the iteration record.
+
+---
+
+## Step 5 — Output format
+
+Present the synthesised list to the caller in this shape. The caller
+classifies further (in-scope subset, plan corrections) per its own
+section; this recipe produces the canonical merged list.
+
+```markdown
+## Synthesised findings — iteration {N}/3
+
+### In-scope this iteration
+
+#### Finding M1 [blocker]
+**Location**: <file:line>
+**Dimensions**: <comma-separated review-agent suffixes>
+**Issue**: <merged description, one paragraph>
+**Proposed fix**: <fix shape, one paragraph>
+
+#### Finding M2 [should-fix]
+... (one entry per in-scope finding)
+
+### Deferred to next iteration
+
+- M7 (should-fix style) — displaced by pre-spawn budget.
+- M8 (should-fix boundary case) — depends on M3 landing first.
+
+### Plan corrections (route to other tracks)
+
+- M9 — belongs in Track <N+M>: <title>. Route via
+  [`track-code-review.md`](track-code-review.md) §Plan Corrections
+  from Deferred Findings.
+
+### Dropped during synthesis (audit trail only)
+
+- BC7 — rejected on re-read: covered by existing test
+  `<class>#<method>`; reviewer missed the assertion.
+- PF4 — downgraded from `blocker` to `suggestion` and dropped:
+  ~50 µs improvement on a non-hot path.
+```
+
+The `M<n>` prefix is fresh for the synthesised list. The
+per-dimension finding IDs (e.g., `BC3`, `TX1`) live only in the
+audit trail of which dimension contributed each merged row; the
+implementer's `findings:` block carries only the `M<n>` IDs and
+their merged bodies. The implementer does not need to know which
+reviewer framing originated each item.
+
+---
+
+## Gate-check synthesis
+
+When this recipe runs against gate-check returns (per
+[`review-iteration.md`](review-iteration.md) §Gate-check synthesis
+routing), the inputs are verdicts plus optional `New findings`
+blocks, not raw dimensional findings. Map the verdicts as follows
+before walking Steps 1–4:
+
+| Gate-check verdict | Action |
+|---|---|
+| `VERIFIED` | Drop from the forwarded list. Cleared this iteration. |
+| `REJECTED` | Drop from the forwarded list. Reviewer recanted; log the rationale. |
+| `MOOT` | Drop from the forwarded list. Code path no longer reachable. |
+| `STILL OPEN` | Forward verbatim with the original `M<n>` ID and severity. |
+| `REGRESSION` | Escalate to `blocker` with `revert-or-repair` guidance; carry the regression's `file:line` plus the original finding ID into the next implementer spawn. A `REGRESSION` forces the iteration `FAIL` even if every other verdict is `VERIFIED`. |
+
+After mapping, fold any `New findings` from the gate-check reports
+into the resulting list and run Steps 1–4 across the union. The
+output format from Step 5 applies unchanged.

--- a/.claude/workflow/implementer-rules.md
+++ b/.claude/workflow/implementer-rules.md
@@ -760,9 +760,12 @@ EPISODE_DRAFT:                    # populated only at level=step
 FIX_NOTES:                        # populated only at level=track
   what_was_fixed: |
     <factual summary of which findings the iteration addressed,
-    1–4 sentences. Cite finding IDs (CQ7, BC3, …) freely — these
-    are branch-only-commit-message-scope identifiers and never
-    leak into durable content.>
+    1–4 sentences. Cite the synthesised `M<n>` finding IDs from
+    the `findings:` input block (e.g., M3, M7) — these are
+    branch-only-commit-message-scope identifiers and never leak
+    into durable content. Per-dimension IDs (CQ7, BC3, …) are
+    orchestrator-internal audit-trail concepts and are not visible
+    to the implementer.>
   what_was_skipped: |
     <or "none". Findings the implementer chose not to address
     inside this iteration — typically because they would expand

--- a/.claude/workflow/review-iteration.md
+++ b/.claude/workflow/review-iteration.md
@@ -122,15 +122,21 @@ The orchestrator processes each gate-check verdict as follows:
 ### Gate-check synthesis routing
 
 After collecting gate-check returns from all re-spawned agents,
-re-run § Synthesis (as defined in
-[`track-code-review.md`](track-code-review.md) § Synthesis) on the
-aggregated `New findings` blocks before composing the next iteration's
-implementer input. This deduplicates across dimensions and enforces
-the global pre-spawn budget (~15 findings), so the per-agent ≤ 3
-cap × N agents cannot silently inflate the total. The same routing
-applies at step level: re-run `step-implementation.md` sub-step 4(b)
-**Synthesise** on the aggregated gate-check returns before composing
-the next implementer spawn.
+re-run the canonical synthesis procedure in
+[`finding-synthesis-recipe.md`](finding-synthesis-recipe.md) before
+composing the next iteration's implementer input. The recipe's
+§"Gate-check synthesis" section maps the five verdicts
+(`VERIFIED` / `REJECTED` / `MOOT` / `STILL OPEN` / `REGRESSION`) to
+forward / drop actions, then walks the aggregated `New findings`
+blocks through dedup, severity, and bucketing as for any initial
+synthesis. This deduplicates across dimensions and enforces the
+global pre-spawn budget (~15 findings), so the per-agent ≤ 3
+new-findings cap × N agents cannot silently inflate the total. The
+routing applies identically at both review levels — track-level
+re-enters from [`track-code-review.md`](track-code-review.md)
+§Review loop, step-level from
+[`step-implementation.md`](step-implementation.md) §Per-Step
+Orchestration Loop sub-step 4(d).
 
 ### Gate-check budget enforcement is best-effort
 

--- a/.claude/workflow/review-iteration.md
+++ b/.claude/workflow/review-iteration.md
@@ -104,8 +104,10 @@ The orchestrator processes each gate-check verdict as follows:
 - `REJECTED` — the reviewer on re-read concluded the original
   finding was not a real issue (misread, false positive). Clears
   identically to `VERIFIED`; do not pass to the next implementer.
-  Log the rejection rationale in the iteration record so the next
-  reviewer instance does not re-raise the same finding.
+  Log a `REJECTED-VERDICT` entry in the §Synthesis audit trail of
+  [`finding-synthesis-recipe.md`](finding-synthesis-recipe.md)
+  Step 5 output so the next reviewer instance does not re-raise the
+  same finding.
 - `MOOT` — finding is no longer reachable (file deleted, code moved,
   approach changed). Clears for loop-termination purposes, identical
   to `VERIFIED`; do not pass to the next implementer.
@@ -136,7 +138,8 @@ routing applies identically at both review levels — track-level
 re-enters from [`track-code-review.md`](track-code-review.md)
 §Review loop, step-level from
 [`step-implementation.md`](step-implementation.md) §Per-Step
-Orchestration Loop sub-step 4(d).
+Orchestration Loop sub-step 4(d) (gate-check collection), which
+re-enters sub-step 4(b) for synthesis.
 
 ### Gate-check budget enforcement is best-effort
 

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -496,7 +496,10 @@ finding ID prefixes, and gate format.
       `FIX_REVIEW_FINDINGS` respawn. Items the orchestrator judges
       out of scope for the step are recorded in the `EPISODE_DRAFT`
       instead, not routed via §Plan Corrections (that flow is
-      track-level only).
+      track-level only). The orchestrator stages these notes
+      alongside the sub-step 5 cross-track-impact observations;
+      sub-step 7's episode merge folds both into
+      `EPISODE_DRAFT.what_was_discovered`.
    c. **If findings need fixes**, respawn the implementer with
       `mode=FIX_REVIEW_FINDINGS` and the synthesised findings as
       input. The implementer applies the fixes on top of the
@@ -551,7 +554,7 @@ finding ID prefixes, and gate format.
       [`review-iteration.md`](review-iteration.md) §"Dimensional-review
       gate-check budget" for the YTDB-696 rationale, the verdict-
       handling rules (VERIFIED / REJECTED / MOOT / STILL OPEN /
-      REGRESSION), and the §Synthesis routing for gate-check returns.
+      REGRESSION), and the §Gate-check synthesis routing.
       Step-level review only fires for `risk: high` steps, so this
       path is rarer than Phase C track-level review, but the burn
       rate is identical when it does fire.
@@ -726,7 +729,8 @@ The episode includes:
 - **What was done** — factual summary from `EPISODE_DRAFT.what_was_done`.
 - **What was discovered** — unexpected findings; merge
   `EPISODE_DRAFT.what_was_discovered` with any cross-track impact
-  observations.
+  observations from sub-step 5 and any out-of-step items the
+  orchestrator deferred during sub-step 4(b) review synthesis.
 - **What changed from the plan** — deviations from
   `EPISODE_DRAFT.what_changed_from_plan`, naming affected future
   steps.

--- a/.claude/workflow/step-implementation.md
+++ b/.claude/workflow/step-implementation.md
@@ -481,10 +481,22 @@ finding ID prefixes, and gate format.
       `{M}`, and `{commit}` with concrete values when composing each
       prompt.
 
-   b. **Synthesise.** After all selected agents complete,
-      deduplicate findings across dimensions and prioritise
-      (blocker > should-fix > suggestion). Merge findings that
-      multiple agents flagged for the same code location.
+   b. **Synthesise.** After all selected agents complete, run the
+      canonical procedure in
+      [`finding-synthesis-recipe.md`](finding-synthesis-recipe.md):
+      deduplicate across dimensions by `file:line` → issue shape →
+      suggested fix shape, prioritise on the
+      `blocker` / `should-fix` / `suggestion` scale (per
+      [`review-iteration.md`](review-iteration.md) §Severity
+      levels), and emit the merged list in the format the
+      implementer's `findings:` block consumes. Step-level review
+      operates on a single step's diff, so the deferred /
+      plan-correction buckets in the recipe are typically empty
+      here — most surfaced findings are in-scope for the next
+      `FIX_REVIEW_FINDINGS` respawn. Items the orchestrator judges
+      out of scope for the step are recorded in the `EPISODE_DRAFT`
+      instead, not routed via §Plan Corrections (that flow is
+      track-level only).
    c. **If findings need fixes**, respawn the implementer with
       `mode=FIX_REVIEW_FINDINGS` and the synthesised findings as
       input. The implementer applies the fixes on top of the

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -381,26 +381,34 @@ synthesis.
 
 ## Synthesis
 
-After all selected sub-agents complete, produce a unified findings list:
+After all selected sub-agents complete, produce a unified findings list
+by running the canonical procedure in
+[`finding-synthesis-recipe.md`](finding-synthesis-recipe.md). The recipe
+covers:
 
-1. **Deduplicate**: If multiple agents flagged the same issue (e.g., a
-   missing crash-recovery test flagged by both `review-test-crash-safety`
-   and `review-crash-safety`), merge into one finding and note which
-   dimensions identified it.
+1. **Deduplication** by pivot order (`file:line` → issue shape →
+   suggested fix shape → severity tie-break), with a worked example
+   showing a 5-way cross-dimension merge.
+2. **Severity assignment** against the standard `blocker` /
+   `should-fix` / `suggestion` scale defined in
+   [`review-iteration.md`](review-iteration.md) §Severity levels,
+   including the rules for downgrading or upgrading singletons whose
+   stated impact does not match the agent's assigned severity.
+3. **Bucketing** into in-scope this iteration, deferred to next
+   iteration, and plan-correction / out-of-track.
+4. **Pre-spawn budget** (target 8–12 findings, ≤ 6–8 files per
+   iteration — soft pacing under the ~15 / ~10 ceiling enforced in
+   §Review loop step 2 below).
+5. **Output format** for the synthesised list, including the
+   per-finding shape the implementer's `findings:` block consumes.
 
-2. **Prioritize**: Assign severity using the standard review severity
-   levels:
-   - **blocker** — must fix before merge (bugs, security vulns, crash
-     safety, data corruption, tests giving false confidence)
-   - **should-fix** — should fix before merge (likely bugs, performance
-     issues, concurrency risks, missing critical test coverage)
-   - **suggestion** — recommended improvements (minor style, optional
-     optimizations, additional test scenarios)
+The recipe also covers gate-check synthesis (mapping `VERIFIED` /
+`REJECTED` / `MOOT` / `STILL OPEN` / `REGRESSION` verdicts and folding
+any `New findings` into the next iteration's input) — that is the same
+procedure routed from [`review-iteration.md`](review-iteration.md)
+§Gate-check synthesis routing.
 
-3. **Attribute**: For each finding, indicate which review dimension(s)
-   identified it and use the appropriate finding prefix.
-
-Present the synthesized findings list to proceed to the review loop.
+Present the synthesised findings list to proceed to the review loop.
 
 ---
 

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -508,14 +508,14 @@ orchestrator never edits source files itself in Phase C.
      [`review-iteration.md`](review-iteration.md) §"Dimensional-review
      gate-check budget" for the YTDB-696 rationale, the verdict-handling
      rules (VERIFIED / REJECTED / MOOT / STILL OPEN / REGRESSION), and
-     the §Synthesis routing for gate-check returns. Re-using the full
+     the §Gate-check synthesis routing. Re-using the full
      dimensional review prompt at gate-check time burns roughly three
      times the budget for no extra signal and is the load-bearing
      cause of mid-Phase-C session pauses.
    - **After collecting all gate-check returns, run them through
      §Synthesis** before composing the next iteration's implementer
-     input (per [`review-iteration.md`](review-iteration.md) §
-     "Synthesis routing for gate-check returns"). Treat
+     input (per [`review-iteration.md`](review-iteration.md)
+     §Gate-check synthesis routing). Treat
      `REGRESSION` verdicts as blocker-severity carry-forwards with
      `revert-or-repair` guidance; treat `REJECTED` and `MOOT`
      verdicts as cleared (identical to `VERIFIED`); carry


### PR DESCRIPTION
#### Motivation

Phase C orchestrators were reinventing the dedup + iteration-bucketing strategy each track because `track-code-review.md` §Synthesis was only three bullets ("Deduplicate / Prioritize / Attribute"). On the Track-20 unit-test-coverage session a 9-agent fan-out returned ~74 raw findings with five reviewers all flagging the same `Thread.sleep` polling loop. The orchestrator burned ~5 min cross-deduping the framings and picking an iteration split, with no rule guaranteeing the same finding-set would be split the same way on a resume.

This PR codifies the procedure in a single canonical recipe and routes the three Phase C call-sites at it.

#### Summary

1. **New recipe** `finding-synthesis-recipe.md`:
   - Pivot order: `file:line` → issue shape → suggested fix → severity tie-break, with a substitution rule for findings that lack a `file:line` (missing-test, missing-invariant, architectural drift) and a ±5-line overlap rule at the file:line level.
   - Severity assignment, three-bucket classification (in-scope this iter / next iter / plan correction), pre-spawn budget (target 8-12 findings, <=6-8 files under the existing ~15/~10 soft ceiling).
   - `### Synthesis audit trail` output section with four canonical entry tags (`DROP`, `OVERRIDE`, `OVER-BUDGET`, `REJECTED-VERDICT`) plus a cumulative `M<n>` counter rule so implementer commits and gate-check verdicts can reference findings unambiguously.
   - Terminal clauses for empty initial fan-out and all-cleared gate-check returns; `REGRESSION` carve-out next to the gate-check termination.
   - Verdict-to-action table for gate-check synthesis and a 5-way `Thread.sleep` worked example traced through Steps 2-4.

2. **Three call-sites route through the recipe** instead of repeating dedup/prioritise/attribute prose inline:
   - `track-code-review.md` §Synthesis
   - `step-implementation.md` sub-step 4(b) (step-level keeps a small carve-out: out-of-scope items go through the existing sub-step 7 episode merge, not plan corrections, since plan corrections are a track-level concept).
   - `review-iteration.md` §Gate-check synthesis routing.

3. **Adjacent rule fixes** surfaced by the `/code-review` pass over the recipe:
   - `implementer-rules.md` `FIX_NOTES` now cites `M<n>` IDs (which the implementer actually receives) instead of orchestrator-internal `BC3 / CQ7` dimension IDs.
   - Review-mode bucket-override clause clarified as track-level only, keyed by contributing dimension IDs.
   - >24-finding cascades now rely on the existing context-consumption gate plus `mid-phase-handoff.md` rather than a separate user-facing decision branch.
   - `code-review-protocol.md` overview routes at the canonical recipe instead of inlining a three-bullet summary.
   - Phantom anchor `§Synthesis routing for gate-check returns` renamed to `§Gate-check synthesis routing` at three sites; em-dash definition-list glosses converted to colons; Step 4 and Gate-check synthesis split to stay under the 200-word section cap.

#### Test plan

Workflow-machinery only; no production code paths touched.

- [x] Cross-file reference check: all anchors referenced from `code-review-protocol.md`, `track-code-review.md`, `step-implementation.md`, `review-iteration.md`, and `implementer-rules.md` resolve in `finding-synthesis-recipe.md`.
- [x] `/code-review` pass on commit `6013749` surfaced four blockers and six should-fix gaps; commit `cd13643` resolves all ten.
- [ ] Validate end-to-end on the next Phase C track that goes through `/execute-tracks`: confirm the orchestrator can produce a `### Synthesis audit trail` section, that `M<n>` IDs survive across iterations, and that `FIX_NOTES` references `M<n>` not dimension IDs.