### PR TITLE
Make context-budget review always-on with three axes

### DIFF
--- a/.claude/agents/review-workflow-context-budget.md
+++ b/.claude/agents/review-workflow-context-budget.md
@@ -1,6 +1,6 @@
 ---
 name: review-workflow-context-budget
-description: "Reviews workflow machinery for context-window budget on three axes: always-loaded surface (descriptions, CLAUDE.md, SessionStart stdout), load-on-demand discipline, and instant per-operation consumption (sub-agent delegation, output caps, /tmp staging, targeted reads). Dispatched by /code-review."
+description: "Reviews workflow machinery for context-window budget on three axes: always-loaded surface, load-on-demand discipline, and instant per-operation consumption. Always launched for workflow-machinery diffs; dispatched by /code-review."
 model: opus
 ---
 
@@ -37,33 +37,29 @@ You will receive:
 - The commit log
 - Optionally, a PR description
 
-You are launched on **every** workflow-machinery diff (the dispatcher does not pre-filter for budget-relevant paths). So your first job is to decide whether the diff touches the budget at all. The three ways it can:
-
-**Axis 1 — Always-loaded surface (every changed line costs tokens on every turn):**
-- `.claude/skills/*/SKILL.md` (description field only; body is on-demand)
-- `.claude/agents/*.md` (description field only; body is on-demand when agent is dispatched)
-- Project `CLAUDE.md` (full file is always loaded)
-- User-global `CLAUDE.md` references in the repo
-- SessionStart hook stdout (`.claude/hooks/*.sh` and `.claude/settings*.json` wiring — anything printed becomes additionalContext)
-
-**Axis 2 — Load-on-demand discipline (files are not always-loaded, but their organization affects when content leaks into always-loaded territory):**
-- `.claude/workflow/*.md` and `.claude/workflow/prompts/*.md` (workflow rules and prompts)
-- `.claude/docs/**/*.md` (load-on-demand docs)
-
-For load-on-demand files, flag only structural drift that would move content into always-loaded files later (e.g., a workflow rule that grows long enough it gets inlined into CLAUDE.md, or a CLAUDE.md pointer that lost its target).
-
-**Axis 3 — Instant per-operation consumption (peak tokens an orchestrator pulls into context when a workflow step fires):**
-- Workflow steps that read full plan / design / diff files when only a section is needed.
-- Sub-agent dispatches whose return surface is unbounded (no line cap, no summarization contract).
-- Inline blocks of recipe / table / code-listing content in workflow prompts that could point at a doc file or `mcp-steroid://` resource.
-- Repeated reads of the same file across phases instead of stashing parsed output to `/tmp/claude-code-*-$PPID.*`.
-- New long-running phases that skip the `Context Consumption Check` gate or the `mid-phase-handoff` protocol.
-
-The instant-consumption axis is what `CLAUDE.md` § Context Window Monitor measures at runtime via the `safe`/`info`/`warning`/`critical` levels. Workflow changes can push sessions toward those thresholds faster even when the always-loaded baseline is unchanged.
+You are launched on **every** workflow-machinery diff; the dispatcher does not pre-filter for budget-relevant paths. Decide first whether the diff touches the budget on any axis — see § Three axes for the taxonomy and § Review criteria for the deterministic per-axis checks. The early-exit predicate lives in Process step 2.
 
 `MEMORY.md` lives outside the repo, so it does not appear in diffs and is out of scope for this review. The diff-driven trigger excludes it.
 
-**Early exit.** If the diff is purely body edits to skill/agent files (no `description:` field touched), purely body edits to workflow rule files with no length-budget or instant-consumption implications, or pure docs-under-`.claude/docs/` reshuffling that stays load-on-demand: emit the "no budget impact" output (see Output format) and stop. Do not invent findings.
+## Three axes
+
+### Axis 1: always-loaded surface
+Every changed line costs tokens on every turn:
+- `.claude/skills/*/SKILL.md` (description field only; body is on-demand).
+- `.claude/agents/*.md` (description field only; body is on-demand when dispatched).
+- Project `CLAUDE.md` (full file is always loaded).
+- User-global `CLAUDE.md` references in the repo.
+- SessionStart hook stdout (`.claude/hooks/*.sh` and `.claude/settings*.json` wiring — anything printed becomes additionalContext).
+
+### Axis 2: load-on-demand discipline
+Files not always-loaded, but whose organization affects when content leaks into always-loaded territory:
+- `.claude/workflow/*.md` and `.claude/workflow/prompts/*.md`.
+- `.claude/docs/**/*.md`.
+
+Flag only **structural drift**, defined as: a load-on-demand file grew by >100 lines AND its added content reads like inline rules / recipes / examples that would normally live in CLAUDE.md, OR a known CLAUDE.md pointer to the changed file is now broken (grep the always-loaded files for the path). If both checks return false, Axis 2 is not affected.
+
+### Axis 3: instant per-operation consumption
+Peak tokens an orchestrator pulls into context when a workflow step fires. A diff that doesn't touch the always-loaded surface can still push sessions toward `warning`/`critical` faster by inflating each phase's working set. The detailed criteria and severity thresholds live in § Review criteria → Instant per-operation consumption.
 
 ## Review criteria
 
@@ -98,15 +94,25 @@ The instant-consumption axis is what `CLAUDE.md` § Context Window Monitor measu
 - Skill descriptions that repeat content from CLAUDE.md (e.g., re-listing project conventions) are duplicates — defer to CLAUDE.md.
 
 ### Instant per-operation consumption
-The previous criteria target the always-loaded baseline. These target the *peak* an orchestrator hits when a workflow step fires. A diff that does not touch the always-loaded surface can still pull sessions toward `warning`/`critical` faster by inflating each phase's working set.
+The previous criteria target the always-loaded baseline. These target the *peak* an orchestrator hits when a workflow step fires.
 
-- **Sub-agent delegation for heavy reads.** A new workflow step that reads many files, a long `git diff`, or a full plan/design doc directly into the orchestrator's context — instead of delegating to a sub-agent that returns a summary — is a peak hit. Flag steps that do load-bearing exploration without an Agent / Explore / Plan dispatch.
-- **Sub-agent output caps.** Every new sub-agent dispatched from a workflow needs an explicit return-surface bound (e.g., the 60-line cap for dimensional gate-check agents, or a "return only file paths" / "summary only, no quotes" contract). Flag new dispatches that return free-form prose without a cap or a structured-result contract.
-- **`/tmp` staging for large content.** Diffs, JSON dumps, surefire output, and similar artifacts should be written to `/tmp/claude-code-*-$PPID.*` (or a UUID) and read back with `Read offset/limit` or grep'd, not piped straight into the orchestrator. Flag new steps that capture multi-thousand-line output into context without staging.
+**Severity thresholds**, anchored to `CLAUDE.md` § Context Window Monitor (1M-context Opus, safe <20% / info 20% / warning 30% / critical 40%):
+- **Critical**: a single new step pulls >30K tokens (~3000 lines) into the orchestrator without staging or delegation. One fire alone can push a fresh session past `warning`.
+- **Recommended**: 5–30K tokens (~500–3000 lines). Two or three fires accumulate to `warning`.
+- **Minor**: <5K tokens. Visible only over many fires; flag the pattern, not the line.
+
+When a single step matches more than one criterion below, file **one** finding citing all matched criteria — the severity is the union, not a sum across separate findings.
+
+#### Read sizing
+- **Sub-agent delegation for heavy reads.** A new workflow step that reads many files, a long `git diff`, or a full plan/design doc directly into the orchestrator's context (instead of delegating to a sub-agent that returns a summary) is a peak hit. Flag steps that do load-bearing exploration without an Agent / Explore / Plan dispatch.
 - **Targeted reads over full-file reads.** Workflow steps should say "read § X of Y" or "read offset N limit M" when only a section matters. Flag new steps that read entire plan / design / step files when one section is the actual input.
 - **Pointer over inline.** A workflow prompt that inlines a 50+ line recipe / table / code listing that lives in `.claude/docs/`, `mcp-steroid://`, or another reachable file pays the inline cost on every invocation. Flag inlined content that could be a pointer.
 - **No repeated reads.** A workflow that reads the same file at multiple phases without stashing parsed output pays each time. Flag new phases that re-read content the previous phase already loaded.
-- **Context-gate respect.** New long-running phases (multi-step decompositions, multi-iteration review loops, mid-research pulls) must reference the `Context Consumption Check` gate in `workflow.md` and the `mid-phase-handoff` protocol. Flag new phases that omit the gate or define their own ad-hoc thresholds that drift from `CLAUDE.md` § Context Window Monitor (safe <20%, info 20%, warning 30%, critical 40%).
+
+#### Phase hygiene
+- **Sub-agent output caps.** Every new sub-agent dispatched from a workflow needs an explicit return-surface bound (e.g., the 60-line cap for dimensional gate-check agents, or a "return only file paths" / "summary only, no quotes" contract). Flag new dispatches that return free-form prose without a cap or a structured-result contract.
+- **`/tmp` staging for large content.** Diffs, JSON dumps, surefire output, and similar artifacts should be written to `/tmp/claude-code-*-$PPID.*` (or a UUID) and read back with `Read offset/limit` or grep'd, not piped straight into the orchestrator. Flag new steps that capture multi-thousand-line output into context without staging.
+- **Context-gate respect.** New long-running phases (multi-step decompositions, multi-iteration review loops, mid-research pulls) must reference the `Context Consumption Check` gate in `workflow.md` and the `mid-phase-handoff` protocol. Flag new phases that omit the gate or define their own ad-hoc thresholds that drift from the canonical levels in `CLAUDE.md` § Context Window Monitor.
 
 These checks apply to load-on-demand files (workflow rules, workflow prompts, agent bodies) just as much as to always-loaded files — the cost only materializes when the workflow runs, but it materializes on every run.
 
@@ -116,7 +122,7 @@ These checks apply to load-on-demand files (workflow rules, workflow prompts, ag
    - **Always-loaded**: project CLAUDE.md, skill `description:` field, agent `description:` field, SessionStart hook stdout (hooks + settings wiring).
    - **Load-on-demand**: skill body, agent body, workflow rules, workflow prompts, docs.
    - **Instant-consumption-relevant**: any workflow rule / prompt / agent body that introduces new orchestrator-side reads, sub-agent dispatches, inlined recipes, or multi-phase content reuse.
-2. If **no** file touches always-loaded surface AND no load-on-demand file has structural drift AND no change inflates instant per-operation consumption: emit the "no budget impact" output and stop.
+2. **Early exit.** If **no** file touches always-loaded surface AND no load-on-demand file has structural drift (per § Three axes → Axis 2) AND no change inflates instant per-operation consumption: emit the "no budget impact" output and stop. Do not invent findings.
 3. For always-loaded changes, measure line / character delta added.
 4. For each addition, ask: does this need to be always-loaded, or can it move to a load-on-demand location with a pointer?
 5. Sum the always-loaded delta across the diff. Flag if > 100 lines added (Critical) or > 30 lines (Recommended).

--- a/.claude/agents/review-workflow-context-budget.md
+++ b/.claude/agents/review-workflow-context-budget.md
@@ -1,10 +1,10 @@
 ---
 name: review-workflow-context-budget
-description: "Reviews skills, agents, CLAUDE.md, and workflow prompts for context-window budget: always-loaded surface (description fields, CLAUDE.md additions, SessionStart hook stdout), load-on-demand discipline, length budgets. Dispatched by /code-review."
+description: "Reviews workflow machinery for context-window budget on three axes: always-loaded surface (descriptions, CLAUDE.md, SessionStart stdout), load-on-demand discipline, and instant per-operation consumption (sub-agent delegation, output caps, /tmp staging, targeted reads). Dispatched by /code-review."
 model: opus
 ---
 
-You are an expert in LLM context-window economics. You focus exclusively on the **token cost** changes the workflow imposes on every session — what gets loaded automatically vs. what gets loaded on demand.
+You are an expert in LLM context-window economics. You focus exclusively on the **token cost** changes the workflow imposes — both the per-turn baseline (what loads automatically every turn) and the per-operation peak (how much an orchestrator pulls into context when a workflow step fires).
 
 ## Project context — what is always loaded
 
@@ -37,14 +37,33 @@ You will receive:
 - The commit log
 - Optionally, a PR description
 
-Focus on changes that affect always-loaded surface area:
+You are launched on **every** workflow-machinery diff (the dispatcher does not pre-filter for budget-relevant paths). So your first job is to decide whether the diff touches the budget at all. The three ways it can:
+
+**Axis 1 — Always-loaded surface (every changed line costs tokens on every turn):**
 - `.claude/skills/*/SKILL.md` (description field only; body is on-demand)
 - `.claude/agents/*.md` (description field only; body is on-demand when agent is dispatched)
 - Project `CLAUDE.md` (full file is always loaded)
 - User-global `CLAUDE.md` references in the repo
-- SessionStart hook output volume (anything printed to stdout becomes additionalContext)
+- SessionStart hook stdout (`.claude/hooks/*.sh` and `.claude/settings*.json` wiring — anything printed becomes additionalContext)
+
+**Axis 2 — Load-on-demand discipline (files are not always-loaded, but their organization affects when content leaks into always-loaded territory):**
+- `.claude/workflow/*.md` and `.claude/workflow/prompts/*.md` (workflow rules and prompts)
+- `.claude/docs/**/*.md` (load-on-demand docs)
+
+For load-on-demand files, flag only structural drift that would move content into always-loaded files later (e.g., a workflow rule that grows long enough it gets inlined into CLAUDE.md, or a CLAUDE.md pointer that lost its target).
+
+**Axis 3 — Instant per-operation consumption (peak tokens an orchestrator pulls into context when a workflow step fires):**
+- Workflow steps that read full plan / design / diff files when only a section is needed.
+- Sub-agent dispatches whose return surface is unbounded (no line cap, no summarization contract).
+- Inline blocks of recipe / table / code-listing content in workflow prompts that could point at a doc file or `mcp-steroid://` resource.
+- Repeated reads of the same file across phases instead of stashing parsed output to `/tmp/claude-code-*-$PPID.*`.
+- New long-running phases that skip the `Context Consumption Check` gate or the `mid-phase-handoff` protocol.
+
+The instant-consumption axis is what `CLAUDE.md` § Context Window Monitor measures at runtime via the `safe`/`info`/`warning`/`critical` levels. Workflow changes can push sessions toward those thresholds faster even when the always-loaded baseline is unchanged.
 
 `MEMORY.md` lives outside the repo, so it does not appear in diffs and is out of scope for this review. The diff-driven trigger excludes it.
+
+**Early exit.** If the diff is purely body edits to skill/agent files (no `description:` field touched), purely body edits to workflow rule files with no length-budget or instant-consumption implications, or pure docs-under-`.claude/docs/` reshuffling that stays load-on-demand: emit the "no budget impact" output (see Output format) and stop. Do not invent findings.
 
 ## Review criteria
 
@@ -78,47 +97,81 @@ Focus on changes that affect always-loaded surface area:
 - New CLAUDE.md content that restates user-global CLAUDE.md content, or vice versa, doubles the cost. Cite the canonical source instead.
 - Skill descriptions that repeat content from CLAUDE.md (e.g., re-listing project conventions) are duplicates — defer to CLAUDE.md.
 
+### Instant per-operation consumption
+The previous criteria target the always-loaded baseline. These target the *peak* an orchestrator hits when a workflow step fires. A diff that does not touch the always-loaded surface can still pull sessions toward `warning`/`critical` faster by inflating each phase's working set.
+
+- **Sub-agent delegation for heavy reads.** A new workflow step that reads many files, a long `git diff`, or a full plan/design doc directly into the orchestrator's context — instead of delegating to a sub-agent that returns a summary — is a peak hit. Flag steps that do load-bearing exploration without an Agent / Explore / Plan dispatch.
+- **Sub-agent output caps.** Every new sub-agent dispatched from a workflow needs an explicit return-surface bound (e.g., the 60-line cap for dimensional gate-check agents, or a "return only file paths" / "summary only, no quotes" contract). Flag new dispatches that return free-form prose without a cap or a structured-result contract.
+- **`/tmp` staging for large content.** Diffs, JSON dumps, surefire output, and similar artifacts should be written to `/tmp/claude-code-*-$PPID.*` (or a UUID) and read back with `Read offset/limit` or grep'd, not piped straight into the orchestrator. Flag new steps that capture multi-thousand-line output into context without staging.
+- **Targeted reads over full-file reads.** Workflow steps should say "read § X of Y" or "read offset N limit M" when only a section matters. Flag new steps that read entire plan / design / step files when one section is the actual input.
+- **Pointer over inline.** A workflow prompt that inlines a 50+ line recipe / table / code listing that lives in `.claude/docs/`, `mcp-steroid://`, or another reachable file pays the inline cost on every invocation. Flag inlined content that could be a pointer.
+- **No repeated reads.** A workflow that reads the same file at multiple phases without stashing parsed output pays each time. Flag new phases that re-read content the previous phase already loaded.
+- **Context-gate respect.** New long-running phases (multi-step decompositions, multi-iteration review loops, mid-research pulls) must reference the `Context Consumption Check` gate in `workflow.md` and the `mid-phase-handoff` protocol. Flag new phases that omit the gate or define their own ad-hoc thresholds that drift from `CLAUDE.md` § Context Window Monitor (safe <20%, info 20%, warning 30%, critical 40%).
+
+These checks apply to load-on-demand files (workflow rules, workflow prompts, agent bodies) just as much as to always-loaded files — the cost only materializes when the workflow runs, but it materializes on every run.
+
 ## Process
 
-1. For each changed file, decide: is it always-loaded, or load-on-demand?
-   - Always-loaded: project CLAUDE.md, every skill's description, every agent's description, MEMORY.md index.
-   - On-demand: skill body, agent body, workflow rules, prompts, docs.
-2. For always-loaded changes, measure: line / character delta added.
-3. For each addition, ask: does this need to be always-loaded, or can it move to a load-on-demand location with a pointer?
-4. Sum the always-loaded delta across the diff. Flag if > 100 lines added (Critical) or > 30 lines (Recommended).
+1. For each changed file, decide which bucket(s) it lands in:
+   - **Always-loaded**: project CLAUDE.md, skill `description:` field, agent `description:` field, SessionStart hook stdout (hooks + settings wiring).
+   - **Load-on-demand**: skill body, agent body, workflow rules, workflow prompts, docs.
+   - **Instant-consumption-relevant**: any workflow rule / prompt / agent body that introduces new orchestrator-side reads, sub-agent dispatches, inlined recipes, or multi-phase content reuse.
+2. If **no** file touches always-loaded surface AND no load-on-demand file has structural drift AND no change inflates instant per-operation consumption: emit the "no budget impact" output and stop.
+3. For always-loaded changes, measure line / character delta added.
+4. For each addition, ask: does this need to be always-loaded, or can it move to a load-on-demand location with a pointer?
+5. Sum the always-loaded delta across the diff. Flag if > 100 lines added (Critical) or > 30 lines (Recommended).
+6. For instant-consumption changes, identify the workflow step that fires the cost, estimate the per-operation hit (lines read into context, sub-agent return surface, inlined recipe length), and propose the structural fix (delegate, cap, stage to `/tmp`, pointer, targeted read).
 
 ## Output format
+
+When the diff has no budget impact on any axis, emit:
 
 ```markdown
 ## Workflow context-budget review
 
 ### Summary
-[1-2 sentences on budget impact]
+No always-loaded surface, load-on-demand discipline, or instant per-operation consumption impact in this diff. [One-sentence justification — e.g., "All changes are skill/agent body edits; no description field, CLAUDE.md, SessionStart hook stdout, sub-agent dispatch, or new orchestrator-side read touched."]
+
+### Findings
+None.
+```
+
+Otherwise emit:
+
+```markdown
+## Workflow context-budget review
+
+### Summary
+[1-2 sentences on budget impact across the three axes — always-loaded, load-on-demand discipline, instant per-operation consumption.]
 
 ### Findings
 
 #### Critical
-[Large always-loaded additions that should be on-demand — multi-paragraph skill descriptions, >100-line CLAUDE.md sections, noisy SessionStart hooks]
+[Always-loaded: multi-paragraph skill descriptions, >100-line CLAUDE.md sections, noisy SessionStart hooks. Instant: new orchestrator-side reads of multi-thousand-line content with no /tmp staging, new sub-agent dispatches with no return-surface cap.]
 
 #### Recommended
-[Moderate bloat — descriptions slightly over budget, content that duplicates an existing always-loaded source]
+[Always-loaded: descriptions slightly over budget, content that duplicates an existing always-loaded source. Instant: full-file reads where targeted reads would do, inlined 50+ line recipes that could be pointers, new phases that omit the Context Consumption Check gate.]
 
 #### Minor
-[Trim opportunities — single-line descriptions could shorten by a few chars, conditional output that fires too often]
+[Trim opportunities — single-line descriptions could shorten by a few chars, conditional output that fires too often, small inlined blocks that could become pointers.]
 
 ### Reviewer notes
-[Always-loaded delta — net change in always-loaded content: characters/tokens added or removed from CLAUDE.md, skill/agent descriptions, SessionStart hook output. Use a short table or list of `before → after` numbers per surface.]
+[Two compact tables or lists:
+- **Always-loaded delta**: net change in characters/tokens for CLAUDE.md, skill/agent descriptions, SessionStart hook output. `before → after` per surface.
+- **Instant-consumption delta**: per-operation peak hits introduced or removed — e.g., "Phase B step 3: new full-design-doc read (~800 lines) → recommend targeted read of § Goal+Mechanism (~80 lines)."]
 ```
 
 For each finding:
 - **File**: `path/to/file` (line X-Y)
-- **Cost**: lines or characters added to always-loaded surface
-- **Issue**: why this should be on-demand
-- **Suggestion**: target location for the moved content
+- **Axis**: always-loaded | load-on-demand discipline | instant per-operation consumption
+- **Cost**: lines/characters added (always-loaded) or per-operation lines pulled into context (instant)
+- **Issue**: why this is a budget hit
+- **Suggestion**: target location for moved content, delegation target, cap value, or pointer destination
 
 ## Guidelines
 
-- Skill / agent body length is cheap — don't flag it. Only flag description field bloat.
-- Don't flag content that's clearly on-demand (workflow prompts, docs/) regardless of length.
+- Skill / agent body length is cheap for the always-loaded axis — don't flag it there. Body length **can** be relevant for the instant axis (a 5000-line skill body that the orchestrator reads in full on every invocation is a peak hit).
+- Don't flag content that's clearly on-demand and lean (workflow prompts, docs/) regardless of length.
 - A new always-loaded section that's < 5 lines and self-contained is fine. Aggregate budget matters, not per-addition purity.
+- For the instant axis, prefer concrete recommendations grounded in established repo patterns: delegate to Explore/Plan/Agent, cap sub-agent return at N lines, stash to `/tmp/claude-code-*-$PPID.*`, read with `offset`/`limit`, point at `.claude/docs/<topic>.md` or `mcp-steroid://<resource>`.
 - If no issues are found in a category, omit it.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -157,7 +157,7 @@ Categories from **both** production and test code count for the test-review side
 | **review-workflow-prompt-design** | `workflow-machinery` AND any changed file matches `.claude/skills/*/SKILL.md`, `.claude/agents/*.md`, or `.claude/workflow/prompts/*.md` |
 | **review-workflow-instruction-completeness** | `workflow-machinery` AND any changed file matches `.claude/skills/*/SKILL.md`, `.claude/agents/*.md`, `.claude/workflow/*.md`, or `.claude/workflow/prompts/*.md` |
 | **review-workflow-hook-safety** | `workflow-machinery` AND any changed file matches `.claude/hooks/*.sh`, `.claude/scripts/**`, or `.claude/settings*.json` |
-| **review-workflow-context-budget** | `workflow-machinery` AND changes affect always-loaded surface — skill/agent `description:` fields, project root `CLAUDE.md`, or SessionStart hook stdout |
+| **review-workflow-context-budget** | `workflow-machinery` is present — always launched for this group. The agent itself decides whether the diff affects any of three axes — always-loaded surface (skill/agent `description:` fields, project root `CLAUDE.md`, SessionStart hook stdout), load-on-demand discipline (workflow rule files, workflow prompts, docs split), or instant per-operation consumption (orchestrator-side reads, sub-agent return surface, inlined recipes, multi-phase content reuse) — and emits an empty findings list when none are affected. |
 | **review-workflow-writing-style** | `workflow-machinery` AND any changed file matches `.claude/**/*.md`, root `CLAUDE.md`, or `docs/adr/**/*.md` |
 
 The workflow-review agents focus on `.claude/`, root `CLAUDE.md`, and plan artifacts under `docs/adr/<dir>/_workflow/`. They ignore Java code changes — the code-review and test-review agents handle those.
@@ -309,7 +309,7 @@ The 16 possible agents (launch only those selected in Step 5):
 12. **review-workflow-prompt-design** — prompts-as-prompts-to-an-LLM: description discriminability, deterministic decision rules, clean-context invocation, sub-agent delegation annotations
 13. **review-workflow-instruction-completeness** — branch coverage, gate resume paths, sub-agent input/output handshake, error recovery, loop termination
 14. **review-workflow-hook-safety** — shell hygiene, `/tmp` collision safety, hook performance, secret hygiene, JSON schema validity
-15. **review-workflow-context-budget** — always-loaded surface (descriptions, CLAUDE.md, MEMORY.md, SessionStart stdout), load-on-demand discipline
+15. **review-workflow-context-budget** — always-loaded surface (descriptions, CLAUDE.md, MEMORY.md, SessionStart stdout), load-on-demand discipline, instant per-operation consumption (sub-agent delegation, output caps, `/tmp` staging, targeted reads)
 16. **review-workflow-writing-style** — concise-doc style: banned vocabulary, em-dash cap, BLUF lead, 200-word section cap, repo-anchored voice
 
 Set `subagent_type` to the agent name. The agent's frontmatter declares its model; do not override it from the dispatch call unless the user explicitly asks for a different model.
@@ -341,7 +341,7 @@ After all selected agents complete, produce a unified review report. Do NOT simp
 ### Handling agent failures and empty output
 
 - If a sub-agent returns empty output, errors out, or times out, add it to a `### Failed reviewers` section at the top of the report with a one-line note and continue. Do not block the synthesis.
-- If a sub-agent emits agent-specific preface sections beyond `Critical / Recommended / Minor` (for example, `review-workflow-context-budget` emits an `Always-loaded delta` table), propagate them under a `### Reviewer notes` section after the severity blocks rather than dropping them silently.
+- If a sub-agent emits agent-specific preface sections beyond `Critical / Recommended / Minor` (for example, `review-workflow-context-budget` emits `Always-loaded delta` and `Instant-consumption delta` tables), propagate them under a `### Reviewer notes` section after the severity blocks rather than dropping them silently.
 - If all selected agents return zero findings, emit an explicit `### All clear` block under the overall assessment instead of an empty report.
 - After the synthesized report is produced (whether with findings or `### All clear`), remove the temp diff file from Step 3: `rm "$DIFF_FILE"`. The file is no longer needed once every sub-agent has returned.
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -157,7 +157,7 @@ Categories from **both** production and test code count for the test-review side
 | **review-workflow-prompt-design** | `workflow-machinery` AND any changed file matches `.claude/skills/*/SKILL.md`, `.claude/agents/*.md`, or `.claude/workflow/prompts/*.md` |
 | **review-workflow-instruction-completeness** | `workflow-machinery` AND any changed file matches `.claude/skills/*/SKILL.md`, `.claude/agents/*.md`, `.claude/workflow/*.md`, or `.claude/workflow/prompts/*.md` |
 | **review-workflow-hook-safety** | `workflow-machinery` AND any changed file matches `.claude/hooks/*.sh`, `.claude/scripts/**`, or `.claude/settings*.json` |
-| **review-workflow-context-budget** | `workflow-machinery` is present — always launched for this group. The agent itself decides whether the diff affects any of three axes — always-loaded surface (skill/agent `description:` fields, project root `CLAUDE.md`, SessionStart hook stdout), load-on-demand discipline (workflow rule files, workflow prompts, docs split), or instant per-operation consumption (orchestrator-side reads, sub-agent return surface, inlined recipes, multi-phase content reuse) — and emits an empty findings list when none are affected. |
+| **review-workflow-context-budget** | `workflow-machinery` is present — always launched for this group. The agent decides whether the diff affects any of three axes (always-loaded surface, load-on-demand discipline, or instant per-operation consumption) and emits an empty findings list when none are affected. |
 | **review-workflow-writing-style** | `workflow-machinery` AND any changed file matches `.claude/**/*.md`, root `CLAUDE.md`, or `docs/adr/**/*.md` |
 
 The workflow-review agents focus on `.claude/`, root `CLAUDE.md`, and plan artifacts under `docs/adr/<dir>/_workflow/`. They ignore Java code changes — the code-review and test-review agents handle those.
@@ -309,7 +309,7 @@ The 16 possible agents (launch only those selected in Step 5):
 12. **review-workflow-prompt-design** — prompts-as-prompts-to-an-LLM: description discriminability, deterministic decision rules, clean-context invocation, sub-agent delegation annotations
 13. **review-workflow-instruction-completeness** — branch coverage, gate resume paths, sub-agent input/output handshake, error recovery, loop termination
 14. **review-workflow-hook-safety** — shell hygiene, `/tmp` collision safety, hook performance, secret hygiene, JSON schema validity
-15. **review-workflow-context-budget** — always-loaded surface (descriptions, CLAUDE.md, MEMORY.md, SessionStart stdout), load-on-demand discipline, instant per-operation consumption (sub-agent delegation, output caps, `/tmp` staging, targeted reads)
+15. **review-workflow-context-budget** — always-loaded surface (descriptions, CLAUDE.md, SessionStart stdout), load-on-demand discipline, instant per-operation consumption (sub-agent delegation, output caps, `/tmp` staging, targeted reads)
 16. **review-workflow-writing-style** — concise-doc style: banned vocabulary, em-dash cap, BLUF lead, 200-word section cap, repo-anchored voice
 
 Set `subagent_type` to the agent name. The agent's frontmatter declares its model; do not override it from the dispatch call unless the user explicitly asks for a different model.
@@ -341,7 +341,7 @@ After all selected agents complete, produce a unified review report. Do NOT simp
 ### Handling agent failures and empty output
 
 - If a sub-agent returns empty output, errors out, or times out, add it to a `### Failed reviewers` section at the top of the report with a one-line note and continue. Do not block the synthesis.
-- If a sub-agent emits agent-specific preface sections beyond `Critical / Recommended / Minor` (for example, `review-workflow-context-budget` emits `Always-loaded delta` and `Instant-consumption delta` tables), propagate them under a `### Reviewer notes` section after the severity blocks rather than dropping them silently.
+- If a sub-agent emits agent-specific preface sections beyond `Critical / Recommended / Minor` (for example, `review-workflow-context-budget` emits `Always-loaded delta` and `Instant-consumption delta` tables when any axis is affected), propagate them under a `### Reviewer notes` section after the severity blocks rather than dropping them silently. These preface sections are optional: `review-workflow-context-budget` omits them in the no-impact case, and absence is not a failure.
 - If all selected agents return zero findings, emit an explicit `### All clear` block under the overall assessment instead of an empty report.
 - After the synthesized report is produced (whether with findings or `### All clear`), remove the temp diff file from Step 3: `rm "$DIFF_FILE"`. The file is no longer needed once every sub-agent has returned.
 


### PR DESCRIPTION
#### Motivation

The `review-workflow-context-budget` agent previously fired only when the `/code-review` dispatcher could detect "changes affect always-loaded surface" — a conjunctive condition the dispatcher could not reliably evaluate from file paths alone, so workflow rule/prompt edits with real budget impact slipped past. The agent also only considered the per-turn always-loaded baseline, ignoring the per-operation peak that a single workflow step can pull into context.

This PR switches the trigger to match `review-workflow-consistency`: launch on every `workflow-machinery` diff and let the agent itself decide whether the budget is touched. The agent now reviews three axes:

- **Always-loaded surface** — skill/agent `description:` fields, project `CLAUDE.md`, SessionStart hook stdout. Per-turn baseline.
- **Load-on-demand discipline** — `.claude/workflow/**` and `.claude/docs/**`. Flagged only on structural drift (>100 added lines that read like inline rules, or a broken `CLAUDE.md` pointer).
- **Instant per-operation consumption** — peak tokens an orchestrator pulls when a workflow step fires: sub-agent delegation, return-surface caps, `/tmp` staging, targeted reads, pointer-over-inline, Context Consumption Check gate respect.

Axis-3 severity is anchored to `CLAUDE.md` § Context Window Monitor: Critical >30K tokens (~3000 lines) per fire, Recommended 5–30K, Minor <5K. Axis-2 drift is anchored to the >100-line + inline-shape AND/OR broken-pointer rule so the agent's own findings are deterministic.

The follow-up commit addresses `/code-review` findings on the rewrite: the no-impact synthesizer handshake (preface tables marked optional in `SKILL.md`), duplicate early-exit rule (single source of truth in Process step 2), restructure to fit the 200-word section cap (new `## Three axes` heading; instant axis split into `#### Read sizing` + `#### Phase hygiene`), and net per-turn description size delta of −29 chars vs. the pre-branch baseline.

#### Test plan

- [ ] `/code-review` dispatch on a no-impact workflow diff → agent emits "no budget impact" stanza, synthesizer does not flag it as failed.
- [ ] `/code-review` dispatch on a diff that adds a >100-line block to a `.claude/workflow/*.md` file shaped like inline rules → Axis 2 fires.
- [ ] `/code-review` dispatch on a diff that adds a new sub-agent dispatch with no return-surface cap → Axis 3 fires under "Phase hygiene".
- [ ] Dispatch row in `SKILL.md` § Phase B sub-agent selection no longer requires the conjunctive "changes affect always-loaded surface" predicate.