### PR TITLE
YTDB-949: Fix Sonatype Central deploy metadata

### DIFF
--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -446,4 +446,53 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!--
+      Override the sonatype-oss-release profile defined in the parent POM.
+      This module has no src/main/java so maven-source-plugin and
+      maven-javadoc-plugin are skipped (see the module-level <build> above);
+      Maven Central still requires -sources.jar and -javadoc.jar classifiers
+      on every published artifact, so we attach stub jars whose only payload
+      is release-stub/README.md (placed at the jar root for visibility) that
+      points consumers at youtrackdb-core for the real sources and Javadocs.
+      Bound to prepare-package to avoid an implicit ordering dependency on
+      maven-shade-plugin (which also runs in package and is declared first).
+    -->
+    <profile>
+      <id>sonatype-oss-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>release-stub-sources-jar</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>sources</classifier>
+                  <classesDirectory>${project.basedir}/release-stub</classesDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>release-stub-javadoc-jar</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <classesDirectory>${project.basedir}/release-stub</classesDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -476,6 +476,15 @@
                 <configuration>
                   <classifier>sources</classifier>
                   <classesDirectory>${project.basedir}/release-stub</classesDirectory>
+                  <!--
+                    Whitelist the README explicitly so that any file later
+                    added to release-stub/ does not silently ship inside the
+                    published artifact. Keep this list in sync with the
+                    release-stub/ contents.
+                  -->
+                  <includes>
+                    <include>README.md</include>
+                  </includes>
                 </configuration>
               </execution>
               <execution>
@@ -487,6 +496,9 @@
                 <configuration>
                   <classifier>javadoc</classifier>
                   <classesDirectory>${project.basedir}/release-stub</classesDirectory>
+                  <includes>
+                    <include>README.md</include>
+                  </includes>
                 </configuration>
               </execution>
             </executions>

--- a/embedded/release-stub/README.md
+++ b/embedded/release-stub/README.md
@@ -1,0 +1,13 @@
+youtrackdb-embedded release stub
+
+The youtrackdb-embedded module produces a shaded uber-jar with all third-party
+dependencies relocated under com.jetbrains.youtrackdb.shade. The module has no
+Java source files; every relocated class is built from a dependency declared
+in pom.xml.
+
+This stub exists so the release pipeline can attach -sources.jar and
+-javadoc.jar artifacts to the published GAV. Maven Central refuses
+deployments where any module is missing either classifier.
+
+For sources and Javadocs of the relocated code, see the matching version of
+youtrackdb-core, which exposes the same API without shading.

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,24 @@
 
   <name>YouTrackDB</name>
   <description>YouTrackDB NoSQL document graph DB</description>
+  <url>https://github.com/JetBrains/youtrackdb</url>
+  <organization>
+    <name>JetBrains</name>
+    <url>https://www.jetbrains.com</url>
+  </organization>
   <licenses>
     <license>
       <name>Apache 2</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
+  <developers>
+    <developer>
+      <id>jetbrains</id>
+      <name>JetBrains Team</name>
+      <url>https://github.com/JetBrains/youtrackdb</url>
+    </developer>
+  </developers>
 
   <modules>
     <module>test-commons</module>


### PR DESCRIPTION
#### Motivation:

The first real run of `weekly-beta-release.yml` ([2026-05-21 run 26212432914](https://github.com/JetBrains/youtrackdb/actions/runs/26212432914/job/77126747004)) failed at Sonatype Central's `central-publishing-maven-plugin` validation. Every prior weekly-beta run was classified `should_publish=false`, so the validator's metadata rules had never been exercised against this codebase before. The validator listed four classes of error; this PR addresses three of them. The fourth (SNAPSHOT dependency on the custom TinkerPop fork) is tracked as YTDB-948 and needs a separate-repo change before publication can succeed.

## Summary

- Add the project `<url>` (`https://github.com/JetBrains/youtrackdb`), a top-level `<organization>` block, and a team-style `<developers>` entry to the root POM. Maven Central resolves these via `<parent>` inheritance — `flatten-maven-plugin` runs in `resolveCiFriendliesOnly` mode, so every child's `.flattened-pom.xml` keeps the parent reference intact.
- Override the parent's `sonatype-oss-release` profile in `embedded/pom.xml` with two `maven-jar-plugin` executions that attach `-sources.jar` and `-javadoc.jar` classifier jars. The module has no `src/main/java` so the default source/javadoc plugins skip, but Central rejects any artifact missing either classifier. The stub jars carry only `release-stub/README.md`, which explains the situation and redirects consumers to `youtrackdb-core`.
- Stub-jar executions bind to `prepare-package` to avoid an implicit ordering dependency on `maven-shade-plugin` (which also runs in `package` and is declared first).

## Out of scope

- **YTDB-948** — release a non-SNAPSHOT coordinate of the `io.youtrackdb:gremlin-*` TinkerPop fork. Until that lands, the validator will still reject the deploy on rejection #4 even with this PR merged.
- The `<scm>` URLs reference `youtrackdb/youtrackdb` (pre-rename org) while the new `<url>` references `JetBrains/youtrackdb`. Pre-existing; out of scope here.

## Test plan

- [x] `./mvnw -pl embedded -am clean package -DskipTests -P sonatype-oss-release` succeeds; produces `target/youtrackdb-embedded-<v>-sources.jar` and `target/youtrackdb-embedded-<v>-javadoc.jar`, each containing `META-INF/MANIFEST.MF` + `README.md` at the jar root.
- [x] `./mvnw -pl embedded clean package -DskipTests` without the release profile produces only the shaded uber-jar — stub executions are correctly gated.
- [x] `./mvnw -pl .,embedded spotless:check` passes.
- [x] Parent `.flattened-pom.xml` carries `<url>`, `<organization>`, and `<developers>`.
- [ ] Next `weekly-beta-release.yml` run reports only rejection #4 (SNAPSHOT deps), confirming #1–#3 are fixed.

## Related

- Failing CI: https://github.com/JetBrains/youtrackdb/actions/runs/26212432914/job/77126747004
- Follow-up issue: YTDB-948