### PR TITLE
Document mcp-steroid auto-open-project recipe

### DIFF
--- a/.claude/docs/mcp-steroid/recipes.md
+++ b/.claude/docs/mcp-steroid/recipes.md
@@ -53,3 +53,9 @@ Each recipe points at one or more `mcp-steroid://` resources — **fetch them vi
 - Trigger: adding a new parameter to a method with many overrides (SPI interfaces, abstract storage methods, heavily-overridden hooks).
 - Resource: `mcp-steroid://ide/change-signature` (uses `ChangeSignatureProcessor` to update every overrider and call site in one shot).
 - Use case: extending contracts like `IndexEngine.put` or `StorageComponent.flush` where raw text replace would miss polymorphic call sites and `super.method(...)` chains in subclasses.
+
+## Auto-open project (check-then-open-and-wait)
+
+- Trigger: a session or scripted task needs PSI / refactor access for a project that may not currently be open, and the user has explicitly authorized opening it. The cwd-mismatch preflight rule in `CLAUDE.md` § MCP Steroid still applies; this recipe does not bypass it, and the user is asked before the active project is switched.
+- Tools (no `mcp-steroid://` resource; composes top-level MCP tools): call `steroid_list_projects` first and short-circuit if the target absolute path is already listed. Otherwise call `steroid_open_project` with `trust_project: true` (the default), then poll `steroid_list_windows` until the entry matching the target path reports `projectInitialized: true`, `indexingInProgress: false`, and `modalDialogShowing: false`. Sleep ~2 s between polls. If `modalDialogShowing` stays true past two polls, stop and surface it to the user with `steroid_take_screenshot`; do not try to dismiss SDK or project-type prompts programmatically.
+- Use case: long-running automation (`/execute-tracks`, scripted refactor sweeps, multi-track plan execution) that should survive an IDE restart between sessions without falling back to grep-based analysis. Skip the recipe for one-off symbol questions; running `steroid_list_projects` once and asking the user is faster than introducing polling logic.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,5 +306,6 @@ The catalogue of concrete IDE-control recipes lives in `.claude/docs/mcp-steroid
 - **Project / module dependency graph** — answer "does X depend on Y?" without reading several `pom.xml` files.
 - **Class-shape refactors** — extract-interface / pull-up / push-down for consolidating sibling-class duplication.
 - **Add parameter via change-signature** — adding a parameter to a heavily-overridden method (SPI interface, abstract storage method) without missing polymorphic call sites.
+- **Auto-open project (check-then-open-and-wait)** — open a closed project for sessions that need PSI access, then poll `steroid_list_windows` for readiness. Composes top-level tools (`steroid_list_projects` → `steroid_open_project` → `steroid_list_windows`); doesn't override the cwd-mismatch preflight rule.
 
 Each recipe points at the matching `mcp-steroid://` resource(s) — fetch via `steroid_fetch_resource` and adapt rather than reconstruct from memory.


### PR DESCRIPTION
#### Motivation:

Long-running automation (`/execute-tracks`, scripted refactor sweeps, multi-track plan execution) needs PSI access to survive an IDE restart between sessions. Without a documented composition of `steroid_list_projects`, `steroid_open_project`, and `steroid_list_windows` readiness polling, agents either reinvent the pattern from scratch (skipping the trust-dialog / indexing-in-progress / modal-dialog checks) or silently fall back to grep, defeating the reference-accuracy guarantee the MCP Steroid preflight rule is meant to provide.

The recipe documents:

- Check first via `steroid_list_projects` and short-circuit when the target path is already open.
- Call `steroid_open_project` with `trust_project: true` (default) for the trust-dialog skip.
- Poll `steroid_list_windows` until the target entry reports `projectInitialized: true`, `indexingInProgress: false`, and `modalDialogShowing: false`.
- Stop and surface persistent modal dialogs (SDK / project-type prompts) to the user with `steroid_take_screenshot` rather than dismissing programmatically.

The recipe explicitly does not bypass the cwd-mismatch preflight rule in `CLAUDE.md` § MCP Steroid — the user is still asked before the active project is switched. The pattern is opt-in for sessions where opening has been explicitly authorized.

#### What changed:

- `.claude/docs/mcp-steroid/recipes.md` — new "Auto-open project (check-then-open-and-wait)" section using the existing trigger / tools / use-case structure.
- `CLAUDE.md` § Recipes — one-line pointer matching the existing catalogue table style.

No code changes, no build impact, no test impact.