### PR TITLE
YTDB-953: Recalibrate single-value null count on load

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeSingleValueIndexEngine.java
@@ -51,9 +51,10 @@ public final class BTreeSingleValueIndexEngine
   // Recalibrated by buildInitialHistogram() as self-healing.
   private final AtomicLong approximateIndexEntriesCount = new AtomicLong();
 
-  // Approximate count of null-key entries. Set to 0 on load() (not separately
-  // persisted for single-value — at most off by 1). Adjusted at commit time,
-  // recalibrated by buildInitialHistogram().
+  // Approximate count of null-key entries. Recalibrated on load() from a
+  // direct null-key lookup (single-value engine stores at most one entry per
+  // key, so this is O(1)). Adjusted at commit time via applyIndexCountDeltas
+  // and recalibrated by buildInitialHistogram() during create/rebuild.
   private final AtomicLong approximateNullCount = new AtomicLong();
 
   public BTreeSingleValueIndexEngine(
@@ -189,9 +190,16 @@ public final class BTreeSingleValueIndexEngine
     assert count >= 0
         : "Persisted approximate entries count must be non-negative: " + count;
     approximateIndexEntriesCount.set(count);
-    // Null count is not separately persisted for single-value indexes (always
-    // 0 or 1). Set to 0; buildInitialHistogram() recalibrates it.
-    approximateNullCount.set(0);
+    // Recalibrate the in-memory null counter from on-disk state. The single-
+    // value engine has no separate persisted null counter (persistCountDelta
+    // intentionally ignores nullDelta because nulls live in the same tree as
+    // non-null keys), but AbstractStorage.applyIndexCountDeltas still feeds
+    // nullDelta into addToApproximateNullCount() polymorphically. Setting the
+    // counter to 0 unconditionally meant the first REMOVE of a persisted null
+    // entry after restart accumulated -1 and tripped the underflow assert at
+    // addToApproximateNullCount(). countNulls() is an O(1) direct null-key
+    // lookup (single-value semantics → at most one visible null entry).
+    approximateNullCount.set(countNulls(atomicOperation));
   }
 
   @Override

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeEnginePersistedCountIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/engine/v1/BTreeEnginePersistedCountIT.java
@@ -225,6 +225,108 @@ public class BTreeEnginePersistedCountIT extends DbTestBase {
   }
 
   // ═══════════════════════════════════════════════════════════════════════
+  // YTDB-953: single-value null-count recalibration on load
+  // ═══════════════════════════════════════════════════════════════════════
+
+  /**
+   * Regression for YTDB-953. Prior to the fix, BTreeSingleValueIndexEngine.load()
+   * unconditionally set the in-memory approximateNullCount to 0, ignoring whether
+   * the single tree actually held a persisted visible null entry. After a restart
+   * of an index that contained one null-key entry, getNullCount() returned 0
+   * instead of 1 until the next buildInitialHistogram(). The fix recalibrates
+   * the counter from a direct null-key lookup at load time.
+   *
+   * <p>The test creates a UNIQUE index, commits a single entity with the indexed
+   * property unset (yielding a null key in the index), closes and reopens the
+   * database, then asserts that getNullCount() reports 1 from in-memory state
+   * read by load() — without going through buildInitialHistogram().
+   */
+  @Test
+  public void singleValue_nullCountSurvivesRestart() throws Exception {
+    session.createClassIfNotExist("SVNullTest");
+    var cls = session.getClass("SVNullTest");
+    cls.createProperty("name", PropertyType.STRING);
+    cls.createIndex("SVNullTest.name", SchemaClass.INDEX_TYPE.UNIQUE, "name");
+
+    // Insert a single entity with no "name" property → one null-key entry in
+    // the index. Single-value UNIQUE caps at one entry per key, so the null
+    // range holds at most this one row.
+    session.begin();
+    session.newEntity("SVNullTest");
+    session.commit();
+
+    // Close and reopen to force load() to repopulate the in-memory counters
+    // from on-disk state.
+    session.close();
+    session = (DatabaseSessionEmbedded) youTrackDB.open(databaseName, adminUser, adminPassword);
+
+    var engine = getBTreeIndexEngine(session, "SVNullTest.name");
+    session.getStorage().getAtomicOperationsManager()
+        .executeInsideAtomicOperation(atomicOp -> {
+          assertEquals(
+              "Null count must be recalibrated to 1 on load() from persisted state",
+              1, engine.getNullCount(atomicOp));
+          assertEquals(
+              "Total count must still reflect the single persisted entry",
+              1, engine.getTotalCount(atomicOp));
+        });
+  }
+
+  /**
+   * End-to-end regression for YTDB-953 — the underflow cascade. Before the fix,
+   * load() forced approximateNullCount to 0 even when the on-disk tree held a
+   * visible null entry. AbstractStorage.applyIndexCountDeltas still feeds
+   * nullDelta polymorphically into addToApproximateNullCount(), so the first
+   * REMOVE of the persisted null entry after restart accumulated nullDelta=-1,
+   * driving the in-memory counter from 0 to -1 and tripping the
+   * "In-memory approximateNullCount underflow" assert. The escaping AssertionError
+   * was caught by AbstractStorage.commit()'s outer catch(Error), poisoning the
+   * storage via setInError.
+   *
+   * <p>The test reproduces the cascade trigger: create a single-value index with
+   * a persisted null entry, restart, remove the entity holding the null key,
+   * commit. With the fix, the commit succeeds and getNullCount() reads 0.
+   * Without the fix, the assert fires inside commit() (assertions are enabled
+   * in surefire by the {@code <argLine>} configuration).
+   */
+  @Test
+  public void singleValue_removeNullAfterRestart_noUnderflow() throws Exception {
+    session.createClassIfNotExist("SVNullRemoveTest");
+    var cls = session.getClass("SVNullRemoveTest");
+    cls.createProperty("name", PropertyType.STRING);
+    cls.createIndex(
+        "SVNullRemoveTest.name", SchemaClass.INDEX_TYPE.UNIQUE, "name");
+
+    // Persist one null-key entry.
+    session.begin();
+    session.newEntity("SVNullRemoveTest");
+    session.commit();
+
+    // Restart so load() repopulates the in-memory counters.
+    session.close();
+    session = (DatabaseSessionEmbedded) youTrackDB.open(databaseName, adminUser, adminPassword);
+
+    // Remove the only entity → index REMOVE on the null key → commit
+    // accumulates nullDelta=-1 and feeds it through applyIndexCountDeltas.
+    // Pre-fix: the in-memory counter goes 0 → -1 and the underflow assert
+    // fires inside commit(). Post-fix: the counter goes 1 → 0 cleanly.
+    session.begin();
+    session.command("DELETE FROM SVNullRemoveTest");
+    session.commit();
+
+    var engine = getBTreeIndexEngine(session, "SVNullRemoveTest.name");
+    session.getStorage().getAtomicOperationsManager()
+        .executeInsideAtomicOperation(atomicOp -> {
+          assertEquals(
+              "Null count must read 0 after the persisted null entry is removed",
+              0, engine.getNullCount(atomicOp));
+          assertEquals(
+              "Total count must read 0 after the only entry is removed",
+              0, engine.getTotalCount(atomicOp));
+        });
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════
   // Rollback: persisted count unchanged
   // ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
#### Motivation

`BTreeSingleValueIndexEngine.load()` unconditionally zeroed the in-memory `approximateNullCount`, but `AbstractStorage.applyIndexCountDeltas` still fed `nullDelta` polymorphically into `addToApproximateNullCount()`. After a restart of any index that held a visible persisted null key, the first REMOVE of that key accumulated `nullDelta=-1`, drove the counter from 0 to -1, and tripped the underflow assert at `BTreeSingleValueIndexEngine#addToApproximateNullCount`. The escaping `AssertionError` was then caught by `AbstractStorage.commit()`'s outer `catch(Error)`, poisoning the storage via `setInError` — i.e. a benign single-value index null removal could brick a storage on restart.

The persisted side of the asymmetry is intentional: `persistCountDelta` ignores `nullDelta` because the single-value engine stores nulls in the same B-tree as non-null keys, so there is no separate on-disk null counter to update. Only the in-memory side was wrong on load — load() needs to seed the counter from on-disk state rather than zeroing it.

#### What changed

- `load()` now calls `countNulls(atomicOperation)` to recalibrate `approximateNullCount` from on-disk state. The lookup is O(1) (single-value semantics cap the null range at one visible entry per key), so load cost is unchanged in practice.
- Two regression tests in `BTreeEnginePersistedCountIT` cover the recalibration on load and the end-to-end remove-after-restart path that previously triggered the assert.