### PR TITLE
Replace reflection gate prongs with single-inequality cost-benefit check

### DIFF
--- a/.claude/workflow/self-improvement-reflection.md
+++ b/.claude/workflow/self-improvement-reflection.md
@@ -107,11 +107,6 @@ Out of scope (do not record here):
   workflow-level fix.
 - General "I think the project should …" opinions unrelated to the
   workflow that produced them.
-- Frictions the agent recovered from cheaply in this session — a
-  re-read, one wrong turn caught on the next sentence, a single
-  sub-agent retry. The per-occurrence cost is below what a
-  preventive rule's load cost would justify; see §Frequency,
-  self-healing, and context-cost gate.
 
 The bar is: *the user, looking only at the YouTrack issue, should be
 able to act on it without re-deriving the context.* If the agent
@@ -141,15 +136,18 @@ All three prongs must hold:
    same way; a non-deterministic one-off (CI flake, network blip,
    unreproducible session state) fails both paths.
 
-2. **Self-healing cost.** Estimate the tokens the agent actually
-   spent recovering from the friction in this session — re-reading
-   one doc, retrying one sub-agent call, catching one wrong turn on
-   the next sentence. If recovery was cheap (roughly a few hundred
-   tokens or less), drop the candidate. The per-occurrence cost is
-   already below the per-session load cost of any preventive rule,
-   so a documented fix loses tokens on net even when its trigger
-   fires on every matching session. Friction that heals itself
-   faster than a rule could prevent it is not worth a rule.
+2. **Self-healing cost.** Pass (drop the candidate) if all five
+   hold: (a) the friction fired only once or twice this session,
+   (b) each recovery completed within ≤2 agent turns, (c) no sub-
+   agent re-spawn was needed, (d) the agent re-read at most one
+   doc, (e) the agent did not have to ask the user. When all five
+   hold, the per-session cost is below the per-session load cost
+   of any preventive rule, so a documented fix loses tokens on
+   net. *Worked example*: the agent caught a wrong section name
+   in `track-review.md` on re-read once. Trigger is deterministic
+   (Frequency 1a passes); sketched fix is a one-line caveat on an
+   every-Phase-A doc (Context-cost passes); recovery was one
+   re-read in one turn, fired once (Self-healing passes — drop).
 
 3. **Context-cost justification.** Sketch the workflow edit the fix
    would land and name the doc it would live in. Weigh the edit's
@@ -164,11 +162,11 @@ Quick tests before recording:
   ≥3 plausible future sessions, OR is the trigger deterministic and
   guaranteed to recur on every matching session? (Fail if neither
   path holds.)
-- **Self-healing prong:** Roughly how many tokens did self-
-  correction cost in this session? If recovery was cheap (a doc
-  re-read, one retry, one wrong turn caught immediately), drop the
-  candidate — the friction was cheaper than a preventive rule's
-  load cost.
+- **Self-healing prong:** Did the friction fire ≤2 times this
+  session, with each recovery completing in ≤2 turns, no sub-
+  agent re-spawn, ≤1 doc re-read, and no user prompt? If yes on
+  all five, drop the candidate — the friction was cheaper than a
+  preventive rule's load cost.
 - **Context-cost prong:** Sketch the edit and name the target doc.
   Does (edit length × that doc's load frequency) feel worth the
   saved friction? (Fail if the sketched edit would not earn its
@@ -244,10 +242,11 @@ correct outcome, not a failure to look hard enough.
       §Severity guide). Low-severity annoyances are noise — do not
       file them, and do not promote them to medium just to keep the
       proposal alive.
-   2. Drop any friction that fails the §Frequency and context-cost
-      gate. Run the quick tests in that section explicitly — both
-      the recurrence assessment and the rough sketch of what
-      workflow content the fix would add. A friction that survives
+   2. Drop any friction that fails the §Frequency, self-healing,
+      and context-cost gate. Run the quick tests in that section
+      explicitly — the recurrence assessment, the self-healing
+      cost check, and the rough sketch of what workflow content
+      the fix would add. A friction that survives
       severity but fails the gate is a project- or ADR-shaped
       finding; mention it in the session's normal output if useful,
       but do not file it.
@@ -507,11 +506,12 @@ When in doubt: content describes "broken" → `Bug`; content describes
 in this project — `Feature` is the closest match and is used for all
 gap-fill work surfaced by reflection.
 
-Both `Bug` and `Feature` candidates must clear the §Frequency and
-context-cost gate. There is no Bug-vs-Feature asymmetry: the
-question is whether the friction recurs often enough to justify the
-per-session token cost of whatever workflow change the fix would
-land, not whether the issue is framed as "broken" or "missing".
+Both `Bug` and `Feature` candidates must clear all three prongs of
+the §Frequency, self-healing, and context-cost gate. There is no
+Bug-vs-Feature asymmetry: the question is whether the friction
+recurs often enough, costs enough per occurrence, and earns back
+its load cost — not whether the issue is framed as "broken" or
+"missing".
 
 ---
 
@@ -532,7 +532,10 @@ it and do not relabel it to medium to keep it alive.
   - *Example*: a Phase A review sub-agent (technical, risk, or
     adversarial) repeatedly returns the same low-value finding
     that the orchestrator must override every iteration; no
-    upstream filter exists.
+    upstream filter exists. (Survives the Self-healing prong:
+    fires once per iteration, so clause (a) fails — the
+    cumulative cost across iterations exceeds the per-session
+    load cost of an upstream filter rule.)
 - `high` — blocks a phase, causes silent wrong outputs, or pushes
   the agent into an unrecoverable state. A `high` finding should
   be rare and almost always points to a missing rule or a
@@ -596,11 +599,11 @@ the triager can verify it.
   mapping) and set it at creation. The triager can re-calibrate,
   but the default priority is the agent's responsibility.
 - **Do not** record any candidate (Bug or Feature) that fails the
-  §Frequency, self-healing, and context-cost gate. The bar is recurrence high
-  enough to justify the per-session token cost of the workflow
-  change the fix would require; one-off, cheaply self-healed,
-  non-deterministic, or ADR-specific frictions do not qualify,
-  regardless of how the issue is framed.
+  §Frequency, self-healing, and context-cost gate. The bar is
+  recurrence high enough to justify the per-session token cost of
+  the workflow change the fix would require; one-off, cheaply
+  self-healed, non-deterministic, or ADR-specific frictions do
+  not qualify, regardless of how the issue is framed.
 - **Do not** write local `workflow-issues/*.md` files or any other
   local issue buffer. The YouTrack sink is the only output channel;
   local files are intentionally gone.

--- a/.claude/workflow/self-improvement-reflection.md
+++ b/.claude/workflow/self-improvement-reflection.md
@@ -115,70 +115,108 @@ ready to record — drop it or sharpen it.
 
 ---
 
-## Frequency, self-healing, and context-cost gate
+## Cost-benefit gate
 
-Every candidate (Bug or Feature) must clear a single cost-benefit
-check before it is recorded. A fix lands in some specific workflow
-doc — a phase doc like `track-review.md`, a recipe loaded only when
-ESCALATE fires, this reflection guide, or an always-loaded base file
-like `conventions.md` or `workflow.md`. The added content is paid in
-tokens by every future session that loads that doc. File the issue
-only when the friction is frequent enough to justify the per-session
-cost at the target doc's actual load frequency.
+Every candidate (Bug or Feature) must clear a single inequality
+before it is recorded. The gate compares the cost of carrying a
+preventive rule in a workflow doc against the cost of letting the
+friction recur and self-heal across future sessions. Both costs are
+expressed in **turn-equivalents** (one turn-equivalent ≈ one agent
+turn of work) so the two sides can be compared directly without
+tracking raw tokens.
 
-All three prongs must hold:
+```
+file if:  load_cost  <  self_fix_cost
+```
 
-1. **Frequency.** Pass if EITHER (a) the trigger is deterministic
-   and will fire on every matching future session, OR (b) the
-   situation arises across ≥3 plausible future ADRs, tracks, or
-   phases. A deterministic Bug that fires once still passes via (a),
-   because the next session hitting the same trigger will fail the
-   same way; a non-deterministic one-off (CI flake, network blip,
-   unreproducible session state) fails both paths.
+Horizon for both sides: **6 months**, capped earlier if a planned
+restructure of the target doc would carry the rule away.
 
-2. **Self-healing cost.** Pass (drop the candidate) if all five
-   hold: (a) the friction fired only once or twice this session,
-   (b) each recovery completed within ≤2 agent turns, (c) no sub-
-   agent re-spawn was needed, (d) the agent re-read at most one
-   doc, (e) the agent did not have to ask the user. When all five
-   hold, the per-session cost is below the per-session load cost
-   of any preventive rule, so a documented fix loses tokens on
-   net. *Worked example*: the agent caught a wrong section name
-   in `track-review.md` on re-read once. Trigger is deterministic
-   (Frequency 1a passes); sketched fix is a one-line caveat on an
-   every-Phase-A doc (Context-cost passes); recovery was one
-   re-read in one turn, fired once (Self-healing passes — drop).
+### load_cost — what the fix costs to carry
 
-3. **Context-cost justification.** Sketch the workflow edit the fix
-   would land and name the doc it would live in. Weigh the edit's
-   length (roughly, in added lines or sections) against that doc's
-   load frequency — every session, every Phase-A session, every
-   reflection session, only on ESCALATE, etc. Is the saved friction
-   worth that running cost?
+```
+load_cost = paragraphs_added × per-paragraph cost from the table below
+```
 
-Quick tests before recording:
+Pick the tier of the doc the fix would land in:
 
-- **Frequency prong:** Would the proposed fix prevent friction on
-  ≥3 plausible future sessions, OR is the trigger deterministic and
-  guaranteed to recur on every matching session? (Fail if neither
-  path holds.)
-- **Self-healing prong:** Did the friction fire ≤2 times this
-  session, with each recovery completing in ≤2 turns, no sub-
-  agent re-spawn, ≤1 doc re-read, and no user prompt? If yes on
-  all five, drop the candidate — the friction was cheaper than a
-  preventive rule's load cost.
-- **Context-cost prong:** Sketch the edit and name the target doc.
-  Does (edit length × that doc's load frequency) feel worth the
-  saved friction? (Fail if the sketched edit would not earn its
-  tokens against the target doc's load frequency.)
+| Target doc tier                                                     | Per-paragraph cost (turn-equiv / horizon) |
+|---------------------------------------------------------------------|-------------------------------------------|
+| Always-loaded base (`CLAUDE.md`, `conventions.md`, `workflow.md`)   | ~5                                        |
+| Phase doc (`track-review.md`, `step-implementation.md`, this guide) | ~2                                        |
+| ESCALATE / on-demand recipe                                         | ~0.3                                      |
 
-If any prong fails, drop the candidate. The friction may still be
-real, but the fix is project- or ADR-shaped, not workflow-shaped —
-or the saved friction does not justify the context cost.
-Project-shaped findings can still be valuable; surface them to the
-user in the session's normal output, but do not file them under
-`dev-workflow`. When uncertain, prefer to drop: the workflow's
-signal-to-noise ratio matters more than completeness.
+Rough paragraph counts: a 1-line caveat ≈ 0.2 paragraphs, a new
+sub-section ≈ 1, a new recipe ≈ 3–5. The per-paragraph numbers
+encode order-of-magnitude differences between tiers (always-loaded
+paragraphs cost roughly 25× more than ESCALATE-only paragraphs over
+the horizon, because they ride every session); calibrate by tier,
+not by significant figures.
+
+### self_fix_cost — what the friction costs if left alone
+
+```
+self_fix_cost = turns_per_occurrence × occurrences_in_horizon
+```
+
+- **turns_per_occurrence**: the cost of one recovery this session.
+  A doc re-read counts as 1, a sub-agent re-spawn as 3, a user
+  prompt as 2; chain them as needed.
+- **occurrences_in_horizon**:
+  - **Deterministic-recur trigger**: every matching session fires.
+    Use the matching tier's session count over the horizon
+    (always-loaded ≈ 100, phase doc ≈ 50, on-demand ≈ 5).
+  - **Non-deterministic, plausible on ≥3 future sessions**: use 3.
+  - **Non-deterministic, no reason to expect ≥3 future hits**: the
+    candidate fails the recurrence floor; drop without computing.
+
+### Worked examples
+
+1. **Drop — recurrence floor fails.** Agent misread one heading
+   once, recovered in 1 turn, no reason to expect it recurs. Fails
+   the recurrence floor; drop without computing either side.
+
+2. **File — deterministic, cheap self-fix.** A wrong section name
+   in `track-review.md` deterministically fires on every Phase A
+   session.
+   - `self_fix_cost = 1 turn × 50 sessions = 50`
+   - Fix is a 1-line caveat (0.2 paragraphs) in a phase doc:
+     `load_cost = 0.2 × 2 = 0.4`
+   - `0.4 << 50` → **file**. The old three-prong gate dropped this
+     case (all five self-healing clauses passed for this session),
+     missing the cumulative cost across 50 future sessions.
+
+3. **File — expensive per occurrence.** Phase A reviewer re-flags
+   the same low-value finding on every iteration (~3 / Phase A,
+   deterministic).
+   - `self_fix_cost = 1 turn × (3 × 50) = 150`
+   - Fix is a 1-paragraph upstream filter in the reviewer prompt
+     (phase doc): `load_cost = 1 × 2 = 2`
+   - `2 << 150` → **file**.
+
+4. **Drop — load cost dominates.** Agent re-read two docs and
+   asked the user once (5 turns of recovery). Plausible on ~3
+   future sessions, not deterministic.
+   - `self_fix_cost = 5 × 3 = 15`
+   - The only place a preventive rule fits is `conventions.md`
+     (always-loaded). A 1-paragraph clarification:
+     `load_cost = 1 × 5 = 5`
+   - `5 < 15` but within 2× margin → **drop** (see checklist).
+     Surface as project-shaped guidance in the session's normal
+     output, not under `dev-workflow`.
+
+### Quick checklist
+
+- Did you actually compute both sides? If you wrote "feels worth
+  it" without numbers, you skipped the gate.
+- `load_cost` smaller than `self_fix_cost` by ≥2× → **record**.
+- Ratio between 0.5× and 2× (tie or near-tie) → **drop**. The
+  unit is coarse; only clear wins should make it through, and the
+  workflow's signal-to-noise ratio matters more than completeness.
+- `self_fix_cost` smaller → **drop**. The friction may still be
+  real, but the fix is project- or ADR-shaped, not workflow-
+  shaped. Surface it in the session's normal output if useful, but
+  do not file it under `dev-workflow`.
 
 ---
 
@@ -242,11 +280,11 @@ correct outcome, not a failure to look hard enough.
       §Severity guide). Low-severity annoyances are noise — do not
       file them, and do not promote them to medium just to keep the
       proposal alive.
-   2. Drop any friction that fails the §Frequency, self-healing,
-      and context-cost gate. Run the quick tests in that section
-      explicitly — the recurrence assessment, the self-healing
-      cost check, and the rough sketch of what workflow content
-      the fix would add. A friction that survives
+   2. Drop any friction that fails the §Cost-benefit gate. Compute
+      both sides of the inequality explicitly — `load_cost` from
+      the doc-tier table and `self_fix_cost` from
+      `turns_per_occurrence × occurrences_in_horizon` — and apply
+      the checklist's 2× margin rule. A friction that survives
       severity but fails the gate is a project- or ADR-shaped
       finding; mention it in the session's normal output if useful,
       but do not file it.
@@ -506,12 +544,10 @@ When in doubt: content describes "broken" → `Bug`; content describes
 in this project — `Feature` is the closest match and is used for all
 gap-fill work surfaced by reflection.
 
-Both `Bug` and `Feature` candidates must clear all three prongs of
-the §Frequency, self-healing, and context-cost gate. There is no
-Bug-vs-Feature asymmetry: the question is whether the friction
-recurs often enough, costs enough per occurrence, and earns back
-its load cost — not whether the issue is framed as "broken" or
-"missing".
+Both `Bug` and `Feature` candidates must clear the §Cost-benefit
+gate. There is no Bug-vs-Feature asymmetry: the inequality compares
+`load_cost` against `self_fix_cost` the same way for either type.
+Framing the issue as "broken" or "missing" does not change the math.
 
 ---
 
@@ -532,10 +568,10 @@ it and do not relabel it to medium to keep it alive.
   - *Example*: a Phase A review sub-agent (technical, risk, or
     adversarial) repeatedly returns the same low-value finding
     that the orchestrator must override every iteration; no
-    upstream filter exists. (Survives the Self-healing prong:
-    fires once per iteration, so clause (a) fails — the
-    cumulative cost across iterations exceeds the per-session
-    load cost of an upstream filter rule.)
+    upstream filter exists. (Clears the §Cost-benefit gate:
+    `self_fix_cost = 1 turn × 3 iterations × 50 Phase A sessions
+    = 150`; an upstream-filter paragraph in a phase doc costs
+    `load_cost = 1 × 2 = 2`; 2 << 150.)
 - `high` — blocks a phase, causes silent wrong outputs, or pushes
   the agent into an unrecoverable state. A `high` finding should
   be rare and almost always points to a missing rule or a
@@ -599,11 +635,12 @@ the triager can verify it.
   mapping) and set it at creation. The triager can re-calibrate,
   but the default priority is the agent's responsibility.
 - **Do not** record any candidate (Bug or Feature) that fails the
-  §Frequency, self-healing, and context-cost gate. The bar is
-  recurrence high enough to justify the per-session token cost of
-  the workflow change the fix would require; one-off, cheaply
-  self-healed, non-deterministic, or ADR-specific frictions do
-  not qualify, regardless of how the issue is framed.
+  §Cost-benefit gate. The bar is `load_cost < self_fix_cost` with
+  at least a 2× margin: `load_cost` is paragraphs added × the
+  doc-tier multiplier; `self_fix_cost` is turns per occurrence ×
+  occurrences in horizon. Non-deterministic one-offs fail the
+  recurrence floor, and ADR-specific frictions are project-shaped,
+  not workflow-shaped.
 - **Do not** write local `workflow-issues/*.md` files or any other
   local issue buffer. The YouTrack sink is the only output channel;
   local files are intentionally gone.

--- a/.claude/workflow/self-improvement-reflection.md
+++ b/.claude/workflow/self-improvement-reflection.md
@@ -126,11 +126,10 @@ turn of work) so the two sides can be compared directly without
 tracking raw tokens.
 
 ```
-file if:  load_cost  <  self_fix_cost
+file if:  load_cost  ≤  self_fix_cost / 2     # at least a 2× margin
 ```
 
-Horizon for both sides: **6 months**, capped earlier if a planned
-restructure of the target doc would carry the rule away.
+Horizon for both sides: **6 months**.
 
 ### load_cost — what the fix costs to carry
 
@@ -162,12 +161,17 @@ self_fix_cost = turns_per_occurrence × occurrences_in_horizon
 - **turns_per_occurrence**: the cost of one recovery this session.
   A doc re-read counts as 1, a sub-agent re-spawn as 3, a user
   prompt as 2; chain them as needed.
-- **occurrences_in_horizon**:
+- **occurrences_in_horizon**: a trigger is **deterministic** if a
+  code path or doc rule will make the same input produce the same
+  friction on every future session that hits it; it is
+  **non-deterministic** if the friction depends on session-specific
+  context (this branch's code, this user's prompt, this run's
+  timing).
   - **Deterministic-recur trigger**: every matching session fires.
     Use the matching tier's session count over the horizon
     (always-loaded ≈ 100, phase doc ≈ 50, on-demand ≈ 5).
   - **Non-deterministic, plausible on ≥3 future sessions**: use 3.
-  - **Non-deterministic, no reason to expect ≥3 future hits**: the
+  - **Non-deterministic, fewer than 3 plausible future hits**: the
     candidate fails the recurrence floor; drop without computing.
 
 ### Worked examples
@@ -182,9 +186,9 @@ self_fix_cost = turns_per_occurrence × occurrences_in_horizon
    - `self_fix_cost = 1 turn × 50 sessions = 50`
    - Fix is a 1-line caveat (0.2 paragraphs) in a phase doc:
      `load_cost = 0.2 × 2 = 0.4`
-   - `0.4 << 50` → **file**. The old three-prong gate dropped this
-     case (all five self-healing clauses passed for this session),
-     missing the cumulative cost across 50 future sessions.
+   - `0.4 << 50` → **file**. A naïve "feels cheap to self-fix"
+     reading would miss the cumulative cost across 50 future
+     sessions; the recurrence-floor branch catches it.
 
 3. **File — expensive per occurrence.** Phase A reviewer re-flags
    the same low-value finding on every iteration (~3 / Phase A,
@@ -194,29 +198,33 @@ self_fix_cost = turns_per_occurrence × occurrences_in_horizon
      (phase doc): `load_cost = 1 × 2 = 2`
    - `2 << 150` → **file**.
 
-4. **Drop — load cost dominates.** Agent re-read two docs and
-   asked the user once (5 turns of recovery). Plausible on ~3
-   future sessions, not deterministic.
-   - `self_fix_cost = 5 × 3 = 15`
+4. **Drop — near-tie.** Agent re-read one doc and asked the user
+   once (3 turns of recovery). Plausible on ~3 future sessions,
+   not deterministic.
+   - `self_fix_cost = 3 × 3 = 9`
    - The only place a preventive rule fits is `conventions.md`
      (always-loaded). A 1-paragraph clarification:
      `load_cost = 1 × 5 = 5`
-   - `5 < 15` but within 2× margin → **drop** (see checklist).
-     Surface as project-shaped guidance in the session's normal
-     output, not under `dev-workflow`.
+   - Ratio `self_fix / load = 9 / 5 = 1.8×`, inside the 2× margin
+     → **drop** (see checklist). Surface as project-shaped
+     guidance in the session's normal output, not under
+     `dev-workflow`.
 
 ### Quick checklist
 
 - Did you actually compute both sides? If you wrote "feels worth
   it" without numbers, you skipped the gate.
-- `load_cost` smaller than `self_fix_cost` by ≥2× → **record**.
-- Ratio between 0.5× and 2× (tie or near-tie) → **drop**. The
-  unit is coarse; only clear wins should make it through, and the
-  workflow's signal-to-noise ratio matters more than completeness.
-- `self_fix_cost` smaller → **drop**. The friction may still be
-  real, but the fix is project- or ADR-shaped, not workflow-
-  shaped. Surface it in the session's normal output if useful, but
-  do not file it under `dev-workflow`.
+- Compute the ratio `r = self_fix_cost / load_cost` and read off
+  the verdict:
+  - `r ≥ 2` (self-fix dominates by ≥2×) → **record**.
+  - `0.5 < r < 2` (tie or near-tie) → **drop**. The unit is
+    coarse; only clear wins should make it through, and the
+    workflow's signal-to-noise ratio matters more than
+    completeness.
+  - `r ≤ 0.5` (load dominates by ≥2×) → **drop**. The friction
+    may still be real, but the fix is project- or ADR-shaped,
+    not workflow-shaped. Surface it in the session's normal
+    output if useful, but do not file it under `dev-workflow`.
 
 ---
 
@@ -281,13 +289,16 @@ correct outcome, not a failure to look hard enough.
       file them, and do not promote them to medium just to keep the
       proposal alive.
    2. Drop any friction that fails the §Cost-benefit gate. Compute
-      both sides of the inequality explicitly — `load_cost` from
-      the doc-tier table and `self_fix_cost` from
-      `turns_per_occurrence × occurrences_in_horizon` — and apply
-      the checklist's 2× margin rule. A friction that survives
-      severity but fails the gate is a project- or ADR-shaped
-      finding; mention it in the session's normal output if useful,
-      but do not file it.
+      both sides of the inequality explicitly: `load_cost` from the
+      doc-tier table and `self_fix_cost` from
+      `turns_per_occurrence × occurrences_in_horizon`. Apply the
+      checklist's 2× margin rule. A friction that survives severity
+      but fails the gate is a project- or ADR-shaped finding;
+      mention it in the session's normal output if useful, but do
+      not file it. The computed numbers stay in the agent's draft
+      and are not persisted into the issue body; a later triager
+      who challenges the verdict re-runs the gate from the
+      reproduction context.
    3. Cap the surviving list at 3 (highest severity, most frequent,
       or blocking the most downstream work — see §Per-session cap).
 
@@ -635,12 +646,12 @@ the triager can verify it.
   mapping) and set it at creation. The triager can re-calibrate,
   but the default priority is the agent's responsibility.
 - **Do not** record any candidate (Bug or Feature) that fails the
-  §Cost-benefit gate. The bar is `load_cost < self_fix_cost` with
-  at least a 2× margin: `load_cost` is paragraphs added × the
-  doc-tier multiplier; `self_fix_cost` is turns per occurrence ×
-  occurrences in horizon. Non-deterministic one-offs fail the
-  recurrence floor, and ADR-specific frictions are project-shaped,
-  not workflow-shaped.
+  §Cost-benefit gate. The bar is `load_cost ≤ self_fix_cost / 2`
+  (a 2× margin between the sides): `load_cost` is paragraphs added
+  × the doc-tier multiplier; `self_fix_cost` is turns per
+  occurrence × occurrences in horizon. Non-deterministic one-offs
+  fail the recurrence floor, and ADR-specific frictions are
+  project-shaped, not workflow-shaped.
 - **Do not** write local `workflow-issues/*.md` files or any other
   local issue buffer. The YouTrack sink is the only output channel;
   local files are intentionally gone.

--- a/.claude/workflow/self-improvement-reflection.md
+++ b/.claude/workflow/self-improvement-reflection.md
@@ -107,6 +107,11 @@ Out of scope (do not record here):
   workflow-level fix.
 - General "I think the project should …" opinions unrelated to the
   workflow that produced them.
+- Frictions the agent recovered from cheaply in this session — a
+  re-read, one wrong turn caught on the next sentence, a single
+  sub-agent retry. The per-occurrence cost is below what a
+  preventive rule's load cost would justify; see §Frequency,
+  self-healing, and context-cost gate.
 
 The bar is: *the user, looking only at the YouTrack issue, should be
 able to act on it without re-deriving the context.* If the agent
@@ -115,7 +120,7 @@ ready to record — drop it or sharpen it.
 
 ---
 
-## Frequency and context-cost gate
+## Frequency, self-healing, and context-cost gate
 
 Every candidate (Bug or Feature) must clear a single cost-benefit
 check before it is recorded. A fix lands in some specific workflow
@@ -126,7 +131,7 @@ tokens by every future session that loads that doc. File the issue
 only when the friction is frequent enough to justify the per-session
 cost at the target doc's actual load frequency.
 
-Both prongs must hold:
+All three prongs must hold:
 
 1. **Frequency.** Pass if EITHER (a) the trigger is deterministic
    and will fire on every matching future session, OR (b) the
@@ -136,7 +141,17 @@ Both prongs must hold:
    same way; a non-deterministic one-off (CI flake, network blip,
    unreproducible session state) fails both paths.
 
-2. **Context-cost justification.** Sketch the workflow edit the fix
+2. **Self-healing cost.** Estimate the tokens the agent actually
+   spent recovering from the friction in this session — re-reading
+   one doc, retrying one sub-agent call, catching one wrong turn on
+   the next sentence. If recovery was cheap (roughly a few hundred
+   tokens or less), drop the candidate. The per-occurrence cost is
+   already below the per-session load cost of any preventive rule,
+   so a documented fix loses tokens on net even when its trigger
+   fires on every matching session. Friction that heals itself
+   faster than a rule could prevent it is not worth a rule.
+
+3. **Context-cost justification.** Sketch the workflow edit the fix
    would land and name the doc it would live in. Weigh the edit's
    length (roughly, in added lines or sections) against that doc's
    load frequency — every session, every Phase-A session, every
@@ -149,12 +164,17 @@ Quick tests before recording:
   ≥3 plausible future sessions, OR is the trigger deterministic and
   guaranteed to recur on every matching session? (Fail if neither
   path holds.)
+- **Self-healing prong:** Roughly how many tokens did self-
+  correction cost in this session? If recovery was cheap (a doc
+  re-read, one retry, one wrong turn caught immediately), drop the
+  candidate — the friction was cheaper than a preventive rule's
+  load cost.
 - **Context-cost prong:** Sketch the edit and name the target doc.
   Does (edit length × that doc's load frequency) feel worth the
   saved friction? (Fail if the sketched edit would not earn its
   tokens against the target doc's load frequency.)
 
-If either prong fails, drop the candidate. The friction may still be
+If any prong fails, drop the candidate. The friction may still be
 real, but the fix is project- or ADR-shaped, not workflow-shaped —
 or the saved friction does not justify the context cost.
 Project-shaped findings can still be valuable; surface them to the
@@ -576,11 +596,11 @@ the triager can verify it.
   mapping) and set it at creation. The triager can re-calibrate,
   but the default priority is the agent's responsibility.
 - **Do not** record any candidate (Bug or Feature) that fails the
-  §Frequency and context-cost gate. The bar is recurrence high
+  §Frequency, self-healing, and context-cost gate. The bar is recurrence high
   enough to justify the per-session token cost of the workflow
-  change the fix would require; one-off, non-deterministic, or ADR-
-  specific frictions do not qualify, regardless of how the issue is
-  framed.
+  change the fix would require; one-off, cheaply self-healed,
+  non-deterministic, or ADR-specific frictions do not qualify,
+  regardless of how the issue is framed.
 - **Do not** write local `workflow-issues/*.md` files or any other
   local issue buffer. The YouTrack sink is the only output channel;
   local files are intentionally gone.

--- a/.claude/workflow/self-improvement-reflection.md
+++ b/.claude/workflow/self-improvement-reflection.md
@@ -148,9 +148,9 @@ Pick the tier of the doc the fix would land in:
 Rough paragraph counts: a 1-line caveat ≈ 0.2 paragraphs, a new
 sub-section ≈ 1, a new recipe ≈ 3–5. The per-paragraph numbers
 encode order-of-magnitude differences between tiers (always-loaded
-paragraphs cost roughly 25× more than ESCALATE-only paragraphs over
-the horizon, because they ride every session); calibrate by tier,
-not by significant figures.
+paragraphs cost roughly 15–20× more than `ESCALATE`-only paragraphs
+over the horizon, because they ride every session); calibrate by
+tier, not by significant figures.
 
 ### self_fix_cost — what the friction costs if left alone
 


### PR DESCRIPTION
#### Motivation:

The reflection step's cost-benefit gate started as two binary prongs (Frequency, Context-cost) and never multiplied per-occurrence cost by future frequency. A deterministic-recur friction that happened to self-heal cheaply in the source session was dropped, even when its cumulative cost across 50 future sessions would have dwarfed the load cost of a one-line caveat. Several dev-workflow candidates filed before this change admitted cheap self-correction in their own bodies (one error-message re-read + retry, redundant reviewers catching the same bug independently, an adjacent paragraph re-read resolving a contradiction), yet each proposed fix would have added 5-10 lines to a per-session-loaded doc.

This branch replaces the prong structure with a single inequality, `load_cost ≤ self_fix_cost / 2`, both sides expressed in turn-equivalents. `load_cost` uses a doc-tier table (always-loaded ≈ 5, phase doc ≈ 2, on-demand ≈ 0.3 turn-equiv per paragraph over a 6-month horizon); `self_fix_cost` is the explicit product of `turns_per_occurrence` and `occurrences_in_horizon`. The 2× margin on the Quick checklist preserves the bias toward not filing without re-introducing the asymmetry that wrongly dropped deterministic-recur cases. A worked example shows the arithmetic on a near-tie candidate so triagers can re-run the gate from the reproduction context.

A follow-up code-review pass unifies the threshold across the three sites where it appeared (headline formula, Quick checklist, "must not do" bar) so two agents reading the same friction cannot anchor to different numbers, recalibrates the near-tie example so its ratio lands inside the band it claims, collapses overlapping Quick-checklist bands into three non-overlapping ratio ranges, adds a deterministic-vs-non-deterministic definition so the 1-2-future-hits case has a single rule, drops a horizon-cap clause that the spec never said how to trigger, and states explicitly that the computed `load_cost` and `self_fix_cost` numbers stay in the agent's draft rather than going into the issue body. House-style em-dash count in the Step 5.2 sub-item is brought back under the cap.

Scope is limited to `.claude/workflow/self-improvement-reflection.md`. No code changes, no behavior changes outside the reflection workflow, no other docs reference the changed sections.