### PR TITLE
Disable publish-action prior-commit lookup to fix flaky 403

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -150,6 +150,7 @@ jobs:
           action_fail: true
           large_files: true
           comment_mode: off
+          compare_to_earlier_commit: false
           check_name: Integration Tests Results (Linux ${{ matrix.arch }}, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
@@ -207,6 +208,7 @@ jobs:
           action_fail: true
           large_files: true
           comment_mode: off
+          compare_to_earlier_commit: false
           check_name: Integration Tests Results (Windows x64, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
@@ -275,6 +277,7 @@ jobs:
           action_fail: true
           large_files: true
           comment_mode: off
+          compare_to_earlier_commit: false
           check_name: Integration Tests Results (macOS arm, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -233,6 +233,7 @@ jobs:
           action_fail: true
           large_files: true
           comment_mode: off
+          compare_to_earlier_commit: false
           check_name: Tests Results (Linux ${{ matrix.arch }}, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
@@ -304,6 +305,7 @@ jobs:
           action_fail: true
           large_files: true
           comment_mode: off
+          compare_to_earlier_commit: false
           check_name: Tests Results (Windows x64, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
@@ -368,6 +370,7 @@ jobs:
           action_fail: true
           large_files: true
           comment_mode: off
+          compare_to_earlier_commit: false
           check_name: Tests Results (macOS arm, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
@@ -425,6 +428,7 @@ jobs:
           action_fail: true
           large_files: true
           comment_mode: off
+          compare_to_earlier_commit: false
           check_name: Tests Results (Small Cache IT)
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
#### Motivation

`EnricoMi/publish-unit-test-result-action@v2` defaults to `compare_to_earlier_commit: true`, which makes it call `GET /repos/.../commits/<previous-sha>` to find the prior run's check for the same `check_name`. On the 2026-05-26 develop run ([runs/26440818374](https://github.com/JetBrains/youtrackdb/actions/runs/26440818374)) this call returned `403 "Your account was suspended"` on three matrix legs (Linux x86 JDK 21, Linux x86 JDK 25, macOS arm JDK 25) while the same auto-generated `GITHUB_TOKEN` successfully created check runs on other matrix legs in the same run (e.g., Linux arm JDK 21 published a check on the same commit at 13:31Z).

Run actor was `github-merge-queue[bot]` (Dependabot PR promoted through the merge queue). The 403 is endpoint-specific to `GET /commits/{sha}`; the rest of the same token's API calls in the same step (creating the check run, uploading artifacts) worked. The most likely cause is a per-token / per-runner anomaly on the merge-queue-issued `GITHUB_TOKEN` against that one endpoint under high concurrency.

The `compare_to_earlier_commit` feature only provides a "compared to earlier commit" summary annotation. `action_fail: true` is set on every Publish Test Results block, so test failures still fail the job. Disabling the comparison removes the failure-prone API call without losing the load-bearing behavior.

Applied to all 7 `Publish Test Results` steps across the two pipeline files:

- `.github/workflows/maven-integration-tests-pipeline.yml` (Linux / Windows / macOS)
- `.github/workflows/maven-pipeline.yml` (Linux / Windows / macOS / Small Cache IT)

#### Test plan

- [ ] CI passes on this PR — all `Publish Test Results` steps complete without 403.
- [ ] After merge, watch the next merge-queue-triggered run on develop to confirm the failure no longer reproduces.