### PR TITLE
[no-test-number-check] Fix BTreeTestIT underflow test broken by YTDB-958 wrapping cascade

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java
@@ -3663,10 +3663,46 @@ public abstract class AbstractStorage
   }
 
   public void moveToErrorStateIfNeeded(final Throwable error) {
-    if (error != null
-        && !((error instanceof HighLevelException)
-            || (error instanceof NeedRetryException)
-            || (error instanceof InternalErrorException))) {
+    if (error == null) {
+      return;
+    }
+    // Defense-in-depth, extends YTDB-958 Layer 2: if any AssertionError appears
+    // in the cause chain (up to MAX_CAUSE_DEPTH levels), treat the failure as a
+    // -ea-only invariant violation and do not poison the storage. The direct-type
+    // guard inside setInError already catches bare AssertionErrors. This walk
+    // covers the wrapped case: an AssertionError thrown from a lambda inside
+    // executeInsideComponentOperation is wrapped in CommonStorageComponentException
+    // by that wrapper, then bubbles through executeInsideAtomicOperation, which
+    // passes the wrapper (not the original AssertionError) to endAtomicOperation,
+    // which calls this method. Without the cause-chain walk, the wrapper passes
+    // setInError's instanceof check, the storage is flipped into in-error mode,
+    // and downstream cleanup cannot close the storage cleanly. That leaves
+    // direct-memory pointers unreleased and surfaces as a JVM-shutdown leak-check
+    // failure.
+    //
+    // The documented cascade is at most two levels deep
+    // (StorageException -> CommonStorageComponentException -> AssertionError),
+    // so MAX_CAUSE_DEPTH=8 is a generous bound that also defends against pathological
+    // cause chains. The walk also tracks visited Throwables via IdentityHashMap to
+    // defend against self-referential getCause() overrides or initCause cycles
+    // injected by third-party exception types — without that defense the loop
+    // could spin forever inside the atomic-op finally block, stranding locks held
+    // by the calling thread.
+    final int MAX_CAUSE_DEPTH = 8;
+    final var seen = Collections.newSetFromMap(
+        new java.util.IdentityHashMap<Throwable, Boolean>());
+    Throwable t = error;
+    int depth = 0;
+    while (t != null && depth < MAX_CAUSE_DEPTH && seen.add(t)) {
+      if (t instanceof AssertionError) {
+        return;
+      }
+      t = t.getCause();
+      depth++;
+    }
+    if (!((error instanceof HighLevelException)
+        || (error instanceof NeedRetryException)
+        || (error instanceof InternalErrorException))) {
       setInError(error);
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/SetInErrorAssertionErrorGuardTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/SetInErrorAssertionErrorGuardTest.java
@@ -200,6 +200,108 @@ public class SetInErrorAssertionErrorGuardTest {
         .isTrue();
   }
 
+  /**
+   * Pins the cause-chain walk in {@link AbstractStorage#moveToErrorStateIfNeeded}.
+   * When an {@link AssertionError} is thrown from a lambda inside
+   * {@code AtomicOperationsManager.executeInsideComponentOperation}, that wrapper
+   * catches it and re-throws as a {@code CommonStorageComponentException} with the
+   * {@code AssertionError} preserved as the cause. The outer
+   * {@code executeInsideAtomicOperation} then passes the wrapper (not the original
+   * {@code AssertionError}) to {@code endAtomicOperation}, which forwards it to
+   * {@code moveToErrorStateIfNeeded}. Without the cause-chain walk, the
+   * {@code instanceof AssertionError} check inside {@code setInError} misses the
+   * wrapped case and the storage is incorrectly flipped into in-error mode.
+   * The walk closes that residual cascade vector left by YTDB-958's Layer 2.
+   */
+  @Test
+  public void wrappedAssertionErrorInCauseChainDoesNotFlipReadOnlyMode() {
+    var underflow = new AssertionError("approximateEntriesCount underflow");
+    var wrapper = new RuntimeException("CommonStorageComponentException stand-in", underflow);
+    storage.moveToErrorStateIfNeeded(wrapper);
+    assertThat(storage.isInError())
+        .as("wrapper exception whose cause chain contains AssertionError must not"
+            + " flip the storage into permanent error state")
+        .isFalse();
+  }
+
+  /**
+   * Pins the negative side of the cause-chain walk: a regular failure (no
+   * AssertionError anywhere in the cause chain) must still flip the storage
+   * into in-error mode. Guards against a regression that broadens the
+   * skip-condition and accidentally swallows real errors.
+   */
+  @Test
+  public void nonAssertionErrorCauseChainStillFlipsReadOnlyMode() {
+    var innerCause = new IllegalStateException("inner");
+    var wrapper = new RuntimeException("outer", innerCause);
+    storage.moveToErrorStateIfNeeded(wrapper);
+    assertThat(storage.isInError())
+        .as("wrapper whose cause chain contains no AssertionError must still"
+            + " flip the storage flag")
+        .isTrue();
+  }
+
+  /**
+   * Pins the multi-level cause-chain walk: an AssertionError nested deeper than
+   * one level (mirroring the StorageException -> CommonStorageComponentException
+   * -> AssertionError chain produced when an assert fires inside a component
+   * operation that is then caught by the atomic-operation wrapper) must still
+   * be detected.
+   */
+  @Test
+  public void deeplyWrappedAssertionErrorIsAlsoSkipped() {
+    var underflow = new AssertionError("underflow at deepest level");
+    var inner = new RuntimeException("component wrapper", underflow);
+    var outer = new RuntimeException("atomic-op wrapper", inner);
+    storage.moveToErrorStateIfNeeded(outer);
+    assertThat(storage.isInError())
+        .as("AssertionError nested multiple levels deep must still be detected"
+            + " by the cause-chain walk")
+        .isFalse();
+  }
+
+  /**
+   * Pins the cycle-defense in {@link AbstractStorage#moveToErrorStateIfNeeded}'s
+   * cause-chain walk. A self-referential cause (constructed via two-element
+   * initCause cycle) must not cause the walk to spin forever. Without the
+   * IdentityHashMap-based visited-set defense, the walk would loop indefinitely
+   * inside an atomic-op finally block, stranding any locks held by the calling
+   * thread. The walk should terminate and proceed with the normal poison
+   * decision (flipping the storage into in-error mode because no AssertionError
+   * appears in the chain).
+   */
+  @Test(timeout = 5000)
+  public void cyclicCauseChainTerminatesAndStillFlipsReadOnlyMode() {
+    var a = new RuntimeException("a");
+    var b = new RuntimeException("b");
+    a.initCause(b);
+    b.initCause(a);
+    storage.moveToErrorStateIfNeeded(a);
+    assertThat(storage.isInError())
+        .as("cyclic cause chain with no AssertionError must still flip the storage")
+        .isTrue();
+  }
+
+  /**
+   * Pins the depth bound in the cause-chain walk. An AssertionError nested
+   * deeper than the documented cascade (StorageException ->
+   * CommonStorageComponentException -> AssertionError, depth 2) must still be
+   * found by the walk — the MAX_CAUSE_DEPTH bound is generous enough to cover
+   * pathological wrapping while still avoiding indefinite spin on cycles.
+   */
+  @Test
+  public void assertionErrorWithinDepthBoundIsStillSkipped() {
+    var underflow = new AssertionError("deep underflow");
+    Throwable chain = underflow;
+    for (int i = 0; i < 5; i++) {
+      chain = new RuntimeException("wrapper-" + i, chain);
+    }
+    storage.moveToErrorStateIfNeeded(chain);
+    assertThat(storage.isInError())
+        .as("AssertionError within the MAX_CAUSE_DEPTH bound must skip the poison flip")
+        .isFalse();
+  }
+
   // Stand-in for real-world AssertionError subclasses (e.g., JUnit's
   // org.opentest4j.AssertionFailedError, or hypothetical project-local invariants). The
   // guard's `instanceof AssertionError` check must match this subclass.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
@@ -12,6 +12,8 @@ import com.jetbrains.youtrackdb.internal.common.util.RawPair;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
+import com.jetbrains.youtrackdb.internal.core.exception.CommonStorageComponentException;
+import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
@@ -1121,10 +1123,20 @@ public class BTreeTestIT {
             singleValueTree.getApproximateEntriesCount(atomicOperation)));
   }
 
-  // Verifies that addToApproximateEntriesCount throws AssertionError when a
-  // negative delta would drive the count below zero (underflow). This is the
-  // last line of defense against count drift bugs propagating to the query
+  // Verifies that addToApproximateEntriesCount fails with the underflow guard
+  // when a negative delta would drive the count below zero. This is the last
+  // line of defense against count drift bugs propagating to the query
   // optimizer — a negative approximate count is never valid.
+  //
+  // Since YTDB-958, AssertionError thrown from inside an atomic-op consumer
+  // is caught by AtomicOperationsManager.executeInsideComponentOperation and
+  // wrapped in a CommonStorageComponentException, which in turn is caught by
+  // executeInsideAtomicOperation and wrapped in a StorageException. The test
+  // therefore catches the documented outer wrapper (StorageException) and
+  // unwraps the cause chain to find the underflow AssertionError rather than
+  // expecting it to escape unwrapped. The cause chain is bounded so a
+  // production-side regression that broke the wrapping structure fails this
+  // test loudly instead of silently passing on a coincidental match.
   @Test
   public void addToApproximateEntriesCountThrowsOnUnderflow() throws Exception {
     // Set known initial count
@@ -1138,11 +1150,22 @@ public class BTreeTestIT {
       atomicOperationsManager.executeInsideAtomicOperation(
           atomicOperation -> singleValueTree.addToApproximateEntriesCount(
               atomicOperation, -10L));
-      Assert.fail("Expected AssertionError for underflow delta");
-    } catch (AssertionError e) {
+      Assert.fail("Expected wrapped AssertionError for underflow delta");
+    } catch (StorageException e) {
+      // Document the wrapping structure: StorageException -> CommonStorageComponentException
+      // -> AssertionError. Asserting at each level catches a refactor that
+      // reshuffles the cascade as a test failure rather than a silent pass.
       Assert.assertTrue(
-          "Error message must mention 'underflow'",
-          e.getMessage().contains("underflow"));
+          "Direct cause of StorageException must be CommonStorageComponentException; got: "
+              + e.getCause(),
+          e.getCause() instanceof CommonStorageComponentException);
+      var inner = e.getCause().getCause();
+      Assert.assertTrue(
+          "Inner cause must be the underflow AssertionError; got: " + inner,
+          inner instanceof AssertionError);
+      Assert.assertTrue(
+          "AssertionError message must mention 'underflow'; got: " + inner.getMessage(),
+          inner.getMessage() != null && inner.getMessage().contains("underflow"));
     }
 
     // Verify count was NOT modified — the assert fires before the write


### PR DESCRIPTION
## Summary
- Updated `BTreeTestIT.addToApproximateEntriesCountThrowsOnUnderflow` to catch the new wrapped exception cascade introduced by YTDB-958.
- Extended `AbstractStorage.moveToErrorStateIfNeeded` to walk the cause chain (with cycle defense and depth bound) so wrapped `AssertionError`s no longer poison the storage.
- Added regression tests pinning the cause-chain walk, cycle termination, and depth bound.

## Root Cause
The failing test caught a bare `AssertionError`, but after YTDB-958 (commit f684630464) broadened the catches in `AtomicOperationsManager.executeInsideComponentOperation` and `executeInsideAtomicOperation` to also accept `AssertionError`, the underflow `assert` thrown by `BTree.addToApproximateEntriesCount` is now wrapped twice on the way out:

1. `AssertionError` thrown inside the component-op lambda.
2. `executeInsideComponentOperation` catches and rethrows as `CommonStorageComponentException` with the AssertionError as cause.
3. `executeInsideAtomicOperation` catches and rethrows as `StorageException` with `CommonStorageComponentException` as cause.

The test's `catch (AssertionError e)` therefore never matches, the wrapped `StorageException` escapes the test, and the test fails.

A second pre-existing issue was masked by the test failure: YTDB-958's Layer 2 skip-guard at `setInError(Throwable)` only checks `instanceof AssertionError` against the direct argument. The wrapper (`CommonStorageComponentException`) is not an `AssertionError`, so it bypassed the guard. `moveToErrorStateIfNeeded` therefore flipped the storage into in-error mode, the `@After` cleanup could no longer close the storage cleanly, and ~30+ WAL direct-memory pointers leaked. That leak only surfaced after fixing the test (because `JUnitTestListener.testRunFinished` only runs the shutdown leak check when `result.wasSuccessful()` is true). Fixing only the test would have traded one CI failure for another (JVM-shutdown leak-check `AssertionError`).

## Changes
- **`core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/AbstractStorage.java`** — `moveToErrorStateIfNeeded` now walks the cause chain looking for any `AssertionError`. Bounded by `MAX_CAUSE_DEPTH=8` and protected by an `IdentityHashMap` visited-set so cyclic `getCause()` overrides cannot spin the loop forever inside a `finally` block. Extends YTDB-958's Layer 2 intent to the wrapped-AssertionError case.
- **`core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java`** — `addToApproximateEntriesCountThrowsOnUnderflow` now catches the documented outer `StorageException` and asserts the cause chain matches `StorageException -> CommonStorageComponentException -> AssertionError(underflow)`. Tighter than the original `catch (AssertionError e)` so a future cascade refactor fails this test loudly.
- **`core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/SetInErrorAssertionErrorGuardTest.java`** — five new regression tests pinning the cause-chain walk:
  - `wrappedAssertionErrorInCauseChainDoesNotFlipReadOnlyMode` — happy path.
  - `nonAssertionErrorCauseChainStillFlipsReadOnlyMode` — negative case.
  - `deeplyWrappedAssertionErrorIsAlsoSkipped` — multi-level wrapping.
  - `cyclicCauseChainTerminatesAndStillFlipsReadOnlyMode` — `@Test(timeout=5000)`, validates cycle defense.
  - `assertionErrorWithinDepthBoundIsStillSkipped` — confirms `MAX_CAUSE_DEPTH=8` is generous enough.

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/26485710126 (Java CI/CD Integration Tests Pipeline). The publish-action reported `addToApproximateEntriesCountThrowsOnUnderflow` failure across multiple jobs (Linux x86 JDK 21/25, Linux arm JDK 21/25, macOS arm JDK 21/25) on commit ccb1882f1d.

## Test plan
- [x] Failing test passes locally with both fixes (`Tests run: 1, Failures: 0, Errors: 0` and `BUILD SUCCESS`, no JVM-shutdown leak).
- [x] All 11 tests in `SetInErrorAssertionErrorGuardTest` pass (6 existing + 5 new).
- [x] All 60 tests across the YTDB-958 cascade-containment suite pass.
- [x] All 56 `AbstractStorage*` tests pass (no regression in storage-level behavior).
- [x] Spotless formatting applied.
- [x] Dimensional code review (review-bugs-concurrency) addressed: cycle detection, depth bound, tightened test wrapper-type catch.