### PR TITLE
Raise ticker-lag tolerance to 30x for macOS arm JDK 25

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
@@ -49,20 +49,28 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
     // Used as the upper bound on `executionTimeNanos = endNano - nano`, i.e., the
     // allowance for how much more than the real elapsed time the ticker-measured
     // duration can be. Both `endNano` and `nano` are past `System.nanoTime()` samples
-    // captured by the ticker's scheduled thread, so the ticker-measured duration can
-    // exceed real time by at most one scheduler period. On virtualized CI that period
-    // can stretch well beyond the configured granularity:
+    // captured by the ticker's scheduled thread, so under nominal conditions the
+    // ticker-measured duration exceeds real time by roughly one scheduler period.
+    // On virtualized CI multiple periods of staleness can stack:
     //   * Windows: ~15.6 ms OS timer quantum; scheduleAtFixedRate(10 ms) actually fires
-    //     at ~15.6 ms intervals, plus CPU contention adds another quantum — worst-case
-    //     staleness ~31 ms for a 10 ms granularity.
+    //     at ~15.6 ms intervals, plus CPU contention adds another quantum, so
+    //     worst-case staleness reaches ~31 ms (~3 periods) for a 10 ms granularity.
     //   * GitHub-hosted macOS arm (virtualized Apple Silicon): per-fire ticker lag up
-    //     to ~75 ms observed for a 10 ms granularity. Less predictable than the
-    //     Hetzner bare-metal nodes the Linux legs run on.
-    // A 10x multiplier (100 ms for a 10 ms granularity) covers both worst cases with
-    // headroom while still catching a ticker that drifts much further behind real time.
-    // The tight "ticker never runs ahead of wall-clock" direction on `startedAtMillis`
-    // is guarded independently by a bound at one granularity + ALLOWED_TICKER_JITTER_MS.
-    TICKER_POSSIBLE_LAG_NANOS = granularity * 10;
+    //     to ~191 ms (~19 periods) observed once on the JDK 25 leg of PR #1097 for a
+    //     10 ms granularity. The macOS arm runners are less predictable than the
+    //     Hetzner bare-metal nodes the Linux legs run on. Prior bumps from 5x to 10x
+    //     covered observed lag up to ~75 ms; the 10x bound continued to trip after
+    //     that, hence this further bump.
+    // A 30x multiplier (300 ms for a 10 ms granularity) covers the observed 191 ms
+    // worst case plus ~57% headroom. Picked over 20x so a similar-magnitude
+    // worsening on a future runner does not force another bump immediately; if 30x
+    // also trips, the next step should be an environment-conditional bound or an
+    // aggregate cross-iteration check rather than another multiplier bump.
+    // The tight "ticker never runs ahead of wall-clock" direction on
+    // `startedAtMillis` is guarded independently by a bound at one granularity +
+    // ALLOWED_TICKER_JITTER_MS, so this multiplier only affects the upper bound on
+    // `executionTimeNanos`.
+    TICKER_POSSIBLE_LAG_NANOS = granularity * 30;
   }
 
   @Before
@@ -929,8 +937,11 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
   /// [Ticker#approximateCurrentTimeMillis()] is updated by a background thread that can be delayed
   /// by OS scheduling, making any single-iteration lower bound flaky. So we check per-iteration
   /// approximate monotonicity (allowing up to 1 ms backward jitter from ticker recalibration)
-  /// and upper bound, then verify after the loop that the ticker has kept pace with real elapsed
-  /// time overall.
+  /// and a loose per-iteration upper bound on `executionTimeNanos` sized to absorb worst-case
+  /// scheduler-thread staleness on virtualized CI (see [#TICKER_POSSIBLE_LAG_NANOS] for the
+  /// derivation). The loose upper bound only catches gross over-reporting (drift much larger
+  /// than scheduler staleness); a complementary aggregate cross-iteration check would catch a
+  /// systematic small drift, but is not yet implemented.
   private void testQuery(
       QueryMonitoringMode mode, RememberingListener listener, Random random) throws Exception {
     long prevStartedAtMillis = 0;


### PR DESCRIPTION
#### Motivation

The macOS arm JDK 25 leg of [PR #1097's CI run](https://github.com/JetBrains/youtrackdb/actions/runs/26559127971/job/78237669229) tripped the per-iteration upper bound in `YTDBQueryMetricsStrategyTest.testQueryMonitoringLightweight`. The ticker reported 361 ms for a real ~170 ms query, exceeding the prior 100 ms (`granularity * 10`) tolerance. Virtualized Apple Silicon under contention starved the ticker's scheduled-executor thread for ~191 ms, so the cached `System.nanoTime()` snapshot was that stale when the query started.

Prior bumps to this tolerance (1.5x → 3x → 5x → 10x) chased Windows quantum noise and the first macOS arm batch. The 10x bound held until the JDK 25 leg added a noisier observation; on the same PR run, all nine other platform legs (Linux x86/arm JDK 21/25, Windows JDK 21/25, macOS arm JDK 21) passed cleanly.

This change bumps the multiplier to 30x (300 ms for the default 10 ms granularity), giving ~57% headroom over the observed 191 ms worst case. The tight "ticker never runs ahead of wall-clock" direction on `startedAtMillis` is unchanged and remains bounded at `granularity + ALLOWED_TICKER_JITTER_MS` (~11 ms), so this bump affects only the upper bound on `executionTimeNanos` — gross-drift detection (a ticker reporting seconds for a 50 ms query) still works.

Trade-off: at 300 ms vs the typical 10-50 ms per-iteration `duration`, the per-iteration bound is now a coarse sanity floor rather than a tight contract. A complementary aggregate cross-iteration check would catch a systematic small drift the looser per-iteration bound misses, but it is out of scope for this CI fix. The deferred-work hook is documented in the updated `testQuery` Javadoc and in the comment block at `@BeforeClass` (the comment also says that another similar-magnitude bump should not be the answer — the next escalation should be an environment-conditional bound or aggregate check).

Also rewrote the `@BeforeClass` comment block for internal consistency (the prior wording said "at most one scheduler period" while justifying a 30-period tolerance) and fixed a stale `testQuery` Javadoc that promised a post-loop aggregate ticker-drift check that does not exist.

#### Test plan

- [ ] Unit-test legs on Linux x86/arm and Windows still pass (multiplier increase is a strict relaxation; cannot turn a passing case into a failure).
- [ ] macOS arm JDK 25 leg now passes the `testQueryMonitoringLightweight` upper bound.
- [ ] Spotless check passes (verified locally).