### PR TITLE
[no-test-number-check] Fix CommandTimeoutCheckerTest race window on contended CI

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/CommandTimeoutCheckerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/CommandTimeoutCheckerTest.java
@@ -292,18 +292,50 @@ public class CommandTimeoutCheckerTest implements SchedulerInternal {
    * endCommand() removes the entry from the running map, so a subsequent timeout sweep
    * must not interrupt a thread that has already called endCommand. Pins isolation between
    * a finished command and a later sleep on the same thread.
+   *
+   * <p>Constants encode one invariant: {@code PHASE_2_SLEEP_MS > TIMEOUT_MS}, so Phase 2
+   * stays sleeping past the deadline and at least one sweep tick fires while the worker
+   * is unregistered. A future edit that bumps the timeout without bumping Phase 2 would
+   * silently break the contract this test pins; making the invariant a Java expression
+   * surfaces that drift in code review.
+   *
+   * <p>Sweep liveness during Phase 2 is pinned by sibling tests ({@link #testTimeout},
+   * {@link #onlyRegisteredThreadsAreInterrupted}); this test assumes the periodic
+   * scheduler is firing and asserts that none of those ticks interrupt the unregistered
+   * thread.
+   *
+   * <p>Timing rationale: the 500 ms timeout gives ~480 ms of slack between Phase 1's
+   * sleep waking up and the first "deadline expired" sweep tick. The original 80 ms
+   * timeout left only ~60 ms of slack, which a contended macOS arm JDK 21 CI runner
+   * consumed (run 26573938792). When the OS preempts the worker between Phase 1's
+   * sleep ending and endCommand() returning, a sweep tick that fires inside that
+   * preemption sets the interrupted flag, and Phase 2's Thread.sleep then sees it on
+   * entry and throws. No defensive interrupt-flag clear is added: that would mask a
+   * real regression where a sweep tick fires after endCommand (e.g., due to a future
+   * weakly-consistent iterator hazard).
    */
   @Test
   public void endCommandUnregistersBeforeTimeoutFires() throws InterruptedException {
-    var checker = new CommandTimeoutChecker(80, this);
+    // 500 ms timeout pins the race window at ~480 ms (see method Javadoc).
+    final long timeoutMs = 500L;
+    // Phase 1 sleep is short; only constraint is < timeoutMs.
+    final long phase1SleepMs = 20L;
+    // Phase 2 must sleep past the deadline so any post-endCommand sweep tick is observed.
+    final long phase2SleepMs = timeoutMs + 200L;
+    // Worker happy-path is ~720 ms; 5 s leaves ample headroom while staying well under
+    // joinSpawnedWorkersAndShutdownScheduler's 5 s per-worker interrupt+join budget.
+    // The class-wide AWAIT_SECS=15 is reserved for the 60 s sleeper regression tests.
+    final long awaitSecs = 5L;
+
+    var checker = new CommandTimeoutChecker(timeoutMs, this);
     var phase2Interrupted = new AtomicBoolean(false);
     var done = new CountDownLatch(1);
 
     spawn(() -> {
       checker.startCommand(null);
-      // Phase 1: legitimate work, well under the timeout — endCommand cleans up.
+      // Phase 1: legitimate work, well under the timeout; endCommand cleans up.
       try {
-        Thread.sleep(20);
+        Thread.sleep(phase1SleepMs);
       } catch (InterruptedException e) {
         // Spurious — should not happen here.
       }
@@ -312,14 +344,14 @@ public class CommandTimeoutCheckerTest implements SchedulerInternal {
       // Phase 2: now sleep past the timeout window. We expect NO interrupt because we
       // are no longer registered.
       try {
-        Thread.sleep(300);
+        Thread.sleep(phase2SleepMs);
       } catch (InterruptedException e) {
         phase2Interrupted.set(true);
       }
       done.countDown();
     });
 
-    assertTrue(done.await(3, TimeUnit.SECONDS));
+    assertTrue(done.await(awaitSecs, TimeUnit.SECONDS));
     assertFalse("post-endCommand sleep must not be interrupted",
         phase2Interrupted.get());
 


### PR DESCRIPTION
## Summary
- Widens the timeout in `CommandTimeoutCheckerTest.endCommandUnregistersBeforeTimeoutFires` from 80 ms to 500 ms so the Phase 1 work + `endCommand` budget is no longer race-prone on a contended macOS arm JDK 21 CI runner.
- Extends Phase 2 sleep to 700 ms so it still spans past the new deadline window (`PHASE_2_SLEEP_MS > TIMEOUT_MS`).
- Extracts magic numbers into local constants so the invariant is enforced by code, not prose.
- No production code touched; no defensive `Thread.interrupted()` added (that would mask a real regression where a sweep tick fires after `endCommand`).

## Root Cause
Original test used `CommandTimeoutChecker(80, this)` with a 20 ms Phase 1 sleep and a 300 ms Phase 2 sleep. The sweep period is `timeout/10` = 8 ms; the deadline expires at `start + 80 ms`. After Phase 1's sleep wakes naturally, the worker calls `endCommand()` and then `Thread.sleep(300)`. The contract under test is that no FUTURE sweep tick interrupts the worker after `endCommand` returned.

Under integration-test load on macOS arm JDK 21 (run [26573938792](https://github.com/JetBrains/youtrackdb/actions/runs/26573938792)), the OS can preempt the worker between Phase 1's sleep ending and `endCommand` returning. A sweep tick that fires at `+88 ms` inside that preemption finds the still-registered entry expired, calls `thread.interrupt()`, and removes the entry. The worker eventually resumes, calls `endCommand` (now a no-op), and enters Phase 2's `Thread.sleep(300)`, which observes the lingering interrupt flag and throws on entry, flipping `phase2Interrupted` to true.

The race window was the slack between Phase 1 sleep end (`+20 ms`) and the first expired-deadline sweep tick (`+88 ms`): only 60 ms. A 60+ ms preemption between two adjacent Java statements is plausible on a heavily loaded CI runner during the full integration test phase.

## Changes
- `core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/CommandTimeoutCheckerTest.java`
  - Timeout 80 to 500 ms (slack 60 to 480 ms).
  - Phase 2 sleep 300 to 700 ms (still spans past the new deadline window).
  - `done.await` 3 to 5 seconds (worker happy-path is ~720 ms; 5 s is comfortable but stays well under the 5 s `@After joinSpawnedWorkersAndShutdownScheduler` per-worker budget).
  - Magic numbers extracted to local `final long` constants encoding the `PHASE_2_SLEEP_MS > TIMEOUT_MS` invariant.
  - Javadoc expanded with timing rationale, sweep-liveness reference to sibling tests, and explicit reasoning for not adding a defensive `Thread.interrupted()` clear.

## Motivation
CI failure on develop: https://github.com/JetBrains/youtrackdb/actions/runs/26573938792 (macOS arm JDK 21, integration tests).

## Test plan
- [x] Failing test passes locally (single and stress loop, 15 runs all green at ~0.73 s each).
- [x] Full `CommandTimeoutCheckerTest` class passes (11/11).
- [x] Full `core` module unit + VMLens test suite passes: BUILD SUCCESS in 34:52 (2012 surefire tests + 18 VMLens, 0 failures, 0 errors, 13 skipped).
- [x] Dimensional code review across review-test-concurrency, review-test-behavior, review-test-completeness, review-test-structure, and review-code-quality. All blocker/should-fix findings addressed.
- [ ] CI integration test suite (will run on this PR).