### PR TITLE
Gate artifact deploy on integration tests

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -348,7 +348,10 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'develop' }}
+          # Always publish develop. A workflow_dispatch run must not be able to
+          # publish an arbitrary branch or tag to Maven Central under the
+          # project's coordinates, so the ref is pinned regardless of trigger.
+          ref: 'develop'
 
       - name: Set Short SHA and Timestamp
         id: vars
@@ -433,10 +436,12 @@ jobs:
     name: Notify build fixed on Zulip
     # test-macos intentionally excluded during soak: a "fixed" signal should
     # fire when Linux/Windows/merge recover even if macOS is still flaky.
-    # deploy intentionally excluded: it is skipped on the nightly schedule
-    # (deploy runs on push/dispatch only), and a skipped need under the
-    # success() gate would suppress the fixed signal on scheduled runs.
-    needs: [ test-linux, test-windows, merge-to-main ]
+    # deploy IS included so a deploy failure suppresses the "fixed" signal —
+    # we must never report "build fixed" while artifact publishing is broken
+    # (a deploy-only failure already triggers notify-failure). deploy is
+    # skipped on the nightly schedule, but a skipped need does not make
+    # success() false, so the fixed signal still fires on scheduled runs.
+    needs: [ test-linux, test-windows, merge-to-main, deploy ]
     if: success() && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -232,12 +232,12 @@ jobs:
     #
     # Non-blocking during soak period: this job is excluded from the
     # needs: of merge-to-main (so a macOS failure does not block the
-    # develop→main promotion) and from notify-fixed (so "build fixed"
-    # still fires when Linux/Windows/merge recover). notify-failure
-    # still observes macOS so the team sees regressions, and the CI
-    # Fix Agent is auto-dispatched on macOS failures too so the agent
-    # can attempt a fix. Promote to blocking once the leg is proven
-    # stable on develop.
+    # develop→main promotion), deploy (so it does not block artifact
+    # publishing), and notify-fixed (so "build fixed" still fires when
+    # Linux/Windows/merge recover). notify-failure still observes macOS
+    # so the team sees regressions, and the CI Fix Agent is
+    # auto-dispatched on macOS failures too so the agent can attempt a
+    # fix. Promote to blocking once the leg is proven stable on develop.
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -331,9 +331,64 @@ jobs:
           git merge origin/develop --ff-only
           git push origin main
 
+  # ------------------------------------------------------------------
+  # JOB: DEPLOY
+  # Publishes artifacts to Maven Central, gated on the integration
+  # tests passing. Runs on develop pushes and manual dispatch only
+  # (skipped on the nightly schedule). Parallel to merge-to-main; both
+  # depend on test-linux + test-windows. Uses JDK 21.
+  # ------------------------------------------------------------------
+  deploy:
+    name: Deploy Artifacts
+    # test-macos intentionally excluded: non-blocking during soak period.
+    needs: [ test-linux, test-windows ]
+    if: success() && github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'develop' }}
+
+      - name: Set Short SHA and Timestamp
+        id: vars
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u +'%Y%m%d.%H%M%S')" >> $GITHUB_OUTPUT
+
+      - name: Set up JDK 21 settings
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+          overwrite-settings: false
+      - name: Maven deploy
+        #1. Deploy to Maven Central as -dev-SNAPSHOT
+        #2. Deploy to Maven Central with -TIMESTAMP-SHA-dev-SNAPSHOT suffix (sortable by date)
+        run: |
+          mvn -s .github/workflows/settings.xml clean deploy -Dchangelist=-dev-SNAPSHOT -DskipTests -Dspotless.check.skip=true -B
+          mvn -s .github/workflows/settings.xml clean deploy -Dchangelist=-dev-SNAPSHOT -Dsha1=-${{ steps.vars.outputs.timestamp }}-${{ steps.vars.outputs.sha_short }} -DskipTests=true -Dspotless.check.skip=true -B
+        env:
+          # Credentials mapped to environment variables
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
+          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+
+      - name: Annotate deployed versions
+        run: |
+          VERSION_SNAPSHOT=$(mvn -s .github/workflows/settings.xml help:evaluate -Dexpression=project.version -Dchangelist=-dev-SNAPSHOT -q -DforceStdout)
+          VERSION_SHA=$(mvn -s .github/workflows/settings.xml help:evaluate -Dexpression=project.version -Dchangelist=-dev-SNAPSHOT -Dsha1=-${{ steps.vars.outputs.timestamp }}-${{ steps.vars.outputs.sha_short }} -q -DforceStdout)
+          echo "::notice title=Maven Artifact Deployed::${VERSION_SNAPSHOT}"
+          echo "::notice title=Maven Artifact Deployed::${VERSION_SHA}"
+        env:
+          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
+          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+
   notify-failure:
     name: Notify build failure on Zulip
-    needs: [ test-linux, test-windows, test-macos, merge-to-main ]
+    needs: [ test-linux, test-windows, test-macos, merge-to-main, deploy ]
     if: >-
       always() &&
       github.event_name != 'workflow_dispatch' &&
@@ -341,7 +396,8 @@ jobs:
         needs.test-linux.result == 'failure' ||
         needs.test-windows.result == 'failure' ||
         needs.test-macos.result == 'failure' ||
-        needs.merge-to-main.result == 'failure'
+        needs.merge-to-main.result == 'failure' ||
+        needs.deploy.result == 'failure'
       )
     runs-on: ubuntu-latest
     steps:
@@ -377,6 +433,9 @@ jobs:
     name: Notify build fixed on Zulip
     # test-macos intentionally excluded during soak: a "fixed" signal should
     # fire when Linux/Windows/merge recover even if macOS is still flaky.
+    # deploy intentionally excluded: it is skipped on the nightly schedule
+    # (deploy runs on push/dispatch only), and a skipped need under the
+    # success() gate would suppress the fixed signal on scheduled runs.
     needs: [ test-linux, test-windows, merge-to-main ]
     if: success() && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -330,11 +330,11 @@ jobs:
     # than the Hetzner CPX42 nodes).
     #
     # Non-blocking during soak period: this job is excluded from the
-    # needs: of deploy, save-test-counts, and the ci-status blocking
-    # check, so a macOS failure does not block merge or deploy. The
-    # notify-failure/notify-fixed jobs still observe it so the team
-    # sees macOS regressions. Promote to blocking once the leg is
-    # proven stable on develop.
+    # needs: of save-test-counts and the ci-status blocking check, so a
+    # macOS failure does not block the build. The notify-failure/
+    # notify-fixed jobs still observe it so the team sees macOS
+    # regressions. Promote to blocking once the leg is proven stable on
+    # develop.
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -710,56 +710,6 @@ jobs:
           cat /tmp/test-counts/test-counts.json
 
   # ------------------------------------------------------------------
-  # JOB 6: DEPLOY
-  # Runs only if all Test jobs pass. Uses JDK 21
-  # ------------------------------------------------------------------
-  deploy:
-    # test-macos intentionally excluded: non-blocking during soak period.
-    needs: [ detect-changes, test-linux, test-windows ]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && needs.detect-changes.outputs.should_build == 'true'
-
-    steps:
-      - name: Checkout Source Code
-        uses: actions/checkout@v6
-
-      - name: Set Short SHA and Timestamp
-        id: vars
-        run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "timestamp=$(date -u +'%Y%m%d.%H%M%S')" >> $GITHUB_OUTPUT
-
-      - name: Set up JDK 21 settings
-        uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
-          overwrite-settings: false
-      - name: Maven deploy
-        #1. Deploy to Maven Central as -dev-SNAPSHOT
-        #2. Deploy to Maven Central with -TIMESTAMP-SHA-dev-SNAPSHOT suffix (sortable by date)
-        run: |
-          mvn -s .github/workflows/settings.xml clean deploy -Dchangelist=-dev-SNAPSHOT -DskipTests -Dspotless.check.skip=true -B
-          mvn -s .github/workflows/settings.xml clean deploy -Dchangelist=-dev-SNAPSHOT -Dsha1=-${{ steps.vars.outputs.timestamp }}-${{ steps.vars.outputs.sha_short }} -DskipTests=true -Dspotless.check.skip=true -B
-        env:
-          # Credentials mapped to environment variables
-          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
-          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
-          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
-
-      - name: Annotate deployed versions
-        run: |
-          VERSION_SNAPSHOT=$(mvn -s .github/workflows/settings.xml help:evaluate -Dexpression=project.version -Dchangelist=-dev-SNAPSHOT -q -DforceStdout)
-          VERSION_SHA=$(mvn -s .github/workflows/settings.xml help:evaluate -Dexpression=project.version -Dchangelist=-dev-SNAPSHOT -Dsha1=-${{ steps.vars.outputs.timestamp }}-${{ steps.vars.outputs.sha_short }} -q -DforceStdout)
-          echo "::notice title=Maven Artifact Deployed::${VERSION_SNAPSHOT}"
-          echo "::notice title=Maven Artifact Deployed::${VERSION_SHA}"
-        env:
-          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
-          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
-
-  # ------------------------------------------------------------------
   # GATE JOB: CI STATUS
   # Always runs — reports success when build is skipped or all jobs pass.
   # Configure this as the single required status check in branch protection.
@@ -819,7 +769,7 @@ jobs:
 
   notify-failure:
     name: Notify build failure on Zulip
-    needs: [ detect-changes, test-linux, test-windows, test-macos, deploy ]
+    needs: [ detect-changes, test-linux, test-windows, test-macos ]
     if: >-
       failure() &&
       needs.detect-changes.outputs.should_build == 'true' &&
@@ -857,8 +807,8 @@ jobs:
   notify-fixed:
     name: Notify build fixed on Zulip
     # test-macos intentionally excluded during soak: a "fixed" signal should
-    # fire when Linux/Windows/deploy recover even if macOS is still flaky.
-    needs: [ detect-changes, test-linux, test-windows, deploy ]
+    # fire when Linux/Windows recover even if macOS is still flaky.
+    needs: [ detect-changes, test-linux, test-windows ]
     if: >-
       always() &&
       needs.detect-changes.outputs.should_build == 'true' &&


### PR DESCRIPTION
#### Motivation:

Artifacts were publishing to Maven Central too early and a broken publish was being misreported as a healthy build.

The `deploy` job lived in the unit-test pipeline (`maven-pipeline.yml`), so it fired as soon as unit tests passed — before the integration suite ran. Anything that the integration tests would have caught could still reach Maven Central. Moving `deploy` into the integration-test pipeline (`maven-integration-tests-pipeline.yml`) raises the bar: artifacts publish only after the IT suite is green.

Two correctness problems in the surrounding wiring are fixed in the same change:

- **Arbitrary-ref publish on dispatch.** The relocated gate (`github.event_name != 'schedule'`) admits `workflow_dispatch`, and the old checkout used the dispatch-chosen ref. That let any write-access actor publish an arbitrary branch or tag to Maven Central under the project's coordinates with the real Central credentials. The deploy checkout is now pinned to `develop` regardless of trigger, so manual re-publish of `develop` stays available but arbitrary-ref publish does not.
- **"Build fixed" firing over a broken publish.** `notify-failure` observed `deploy` but `notify-fixed` did not, so a deploy-only failure on a push fired both "BUILD FAILED" and "BUILD FIXED" in the same run. `notify-fixed` now depends on `deploy`, so a publish failure suppresses the fixed signal. A skipped `deploy` (nightly schedule) does not make `success()` false, so the fixed signal still fires on scheduled runs. The old comment justified the exclusion with an incorrect claim about `success()`-vs-skipped semantics; the comment is corrected to state the real reason.

#### Summary of changes:

- Move the `deploy` job from `maven-pipeline.yml` into `maven-integration-tests-pipeline.yml`, gated on `test-linux` + `test-windows` passing (parallel to `merge-to-main`, same gating; `test-macos` stays excluded during the soak period).
- Deploy runs on `develop` pushes and manual dispatch only, skipped on the nightly schedule where there is nothing new to publish.
- Pin the deploy checkout to `develop` so `workflow_dispatch` cannot publish an arbitrary ref.
- Add `deploy` to `notify-failure`'s `needs` in the IT pipeline so a publish failure alerts Zulip; remove `deploy` from the unit-pipeline notify jobs.
- Add `deploy` to `notify-fixed`'s `needs` so a broken publish is never reported as fixed.
- Update the `test-macos` soak-period comments in both pipelines to reflect the relocated `deploy`.

#### Testing:

Workflow-only change; no application code touched. Reviewed for YAML correctness and `needs`/`if` gating semantics.
