### PR TITLE
Set default effort level to xhigh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
     "pr": ""
   },
   "model": "opus[1m]",
+  "effortLevel": "xhigh",
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "300000",
     "BASH_MAX_TIMEOUT_MS": "21600000",


### PR DESCRIPTION
#### Motivation:

Pin the persisted effort level for this project's Claude Code sessions to `xhigh` so every contributor gets the highest reasoning budget by default, without having to toggle it manually each session.

The new `effortLevel` key sits next to the existing committed `model` pin (`opus[1m]`) in `.claude/settings.json`, keeping model and effort configuration together and applied team-wide. This is a configuration-only change — no source or test files are touched.