### PR TITLE
Queue integration test runs on push instead of cancelling

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -7,9 +7,17 @@ on:
     # Run at 2 AM CET (1 AM UTC)
     - cron: '0 1 * * *'
 
+# Concurrency policy is trigger-dependent:
+#   - push / schedule: cancel-in-progress=false. A new run does NOT kill the
+#     running build; it becomes "pending" and starts only after the current
+#     build finishes. GitHub keeps at most one pending run per group, so a
+#     burst of pushes collapses to the latest commit — the queued run checks
+#     out the develop tip, so it always tests the last change.
+#   - workflow_dispatch: cancel-in-progress=true. A manual trigger cancels the
+#     in-progress (and any pending) run and starts immediately.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 permissions:
   contents: write


### PR DESCRIPTION
#### Motivation

The integration-tests pipeline used `cancel-in-progress: true` for every trigger. A push landing during a running build killed that build and restarted from scratch — the in-flight run was thrown away, and the restart could itself be cancelled by the next push, so develop could go a long stretch without a completed run.

The desired policy is different per trigger:

- **Push / nightly schedule** — don't kill the running build. Wait for it, then run. A burst of pushes should collapse to a single run covering all the accumulated commits, not a stampede of restarts.
- **Manual `workflow_dispatch`** — pre-empt the running build and start immediately, so an operator can force a fresh run on demand.

#### Change

Make `cancel-in-progress` trigger-dependent:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
```

- `push` / `schedule` → `false` → the new run becomes pending and starts only after the current build finishes.
- `workflow_dispatch` → `true` → cancels the in-progress (and any pending) run and starts now.

#### Why it accumulates queued changes

GitHub keeps at most **one** pending run per concurrency group: queuing a new run cancels any previously pending one. So while a build runs, repeated pushes leave only the latest run queued. Because the checkout uses `ref: 'develop'` (the branch tip, not the triggering SHA), that surviving run builds the current head of develop and therefore covers every commit that landed while the queue was held.

The concurrency group itself is unchanged, so behaviour for other refs is untouched. No job logic changed — only the cancel policy.