### PR TITLE
Mark fixed YouTrack issues after deploy

### DIFF
--- a/.github/scripts/youtrack-fixed-notifier-test.py
+++ b/.github/scripts/youtrack-fixed-notifier-test.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Stand-alone tests for youtrack-fixed-notifier.py.
+
+Run directly (no pytest dependency, matching the other .github/scripts
+test runners):
+
+    python3 .github/scripts/youtrack-fixed-notifier-test.py
+
+Exit code 0 means all tests passed; non-zero prints the failing cases.
+The notifier module is loaded by path because its filename contains
+hyphens and is not importable as a normal module.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+_MODULE_PATH = pathlib.Path(__file__).with_name("youtrack-fixed-notifier.py")
+_spec = importlib.util.spec_from_file_location("notifier", _MODULE_PATH)
+notifier = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(notifier)
+
+
+class FakeClient:
+    """In-memory stand-in for YouTrackClient.
+
+    `states` maps issue ID -> (state_name, is_resolved). A missing key
+    models a 404 (issue not found). Recorded `comments` and `set_fixed`
+    let tests assert that writes happened (or did not, under --dry-run).
+    """
+
+    def __init__(self, states):
+        self.states = states
+        self.comments = []
+        self.set_fixed = []
+
+    def get_issue_state(self, issue_id):
+        if issue_id not in self.states:
+            return {"found": False, "state": None, "is_resolved": False}
+        name, is_resolved = self.states[issue_id]
+        return {"found": True, "state": name, "is_resolved": is_resolved}
+
+    def add_comment(self, issue_id, text):
+        self.comments.append((issue_id, text))
+
+    def set_state_fixed(self, issue_id):
+        self.set_fixed.append(issue_id)
+
+
+_failures = []
+
+
+def check(name, condition):
+    if condition:
+        print(f"  PASS  {name}")
+    else:
+        print(f"  FAIL  {name}")
+        _failures.append(name)
+
+
+def test_extract_issue_ids():
+    # Colon form, the most common shape on develop.
+    check("colon form", notifier.extract_issue_ids(["YTDB-123: fix a bug"]) == ["YTDB-123"])
+    # Bracket form, also produced by the PR-title prefixer.
+    check("bracket form", notifier.extract_issue_ids(["[YTDB-958] do a thing"]) == ["YTDB-958"])
+    # Comma-separated pair in a single title -> both issues.
+    check(
+        "comma pair",
+        notifier.extract_issue_ids(["YTDB-1, YTDB-2: two issues"]) == ["YTDB-1", "YTDB-2"],
+    )
+    # A PR-number suffix uses '#', not YTDB-, so it must not match.
+    check("no false positive on pr number", notifier.extract_issue_ids(["Tidy things (#1101)"]) == [])
+    # A title with no reference at all.
+    check("no reference", notifier.extract_issue_ids(["Set default effort to xhigh"]) == [])
+    # The same issue across several commits collapses to one entry, order kept.
+    check(
+        "dedup across commits, order preserved",
+        notifier.extract_issue_ids(["YTDB-5: part one", "YTDB-3: other", "YTDB-5: part two"])
+        == ["YTDB-5", "YTDB-3"],
+    )
+    # Lower-case reference is normalized to upper case.
+    check("case-insensitive normalize", notifier.extract_issue_ids(["ytdb-9: lower"]) == ["YTDB-9"])
+    # `\b` must prevent matching inside a larger leading token.
+    check("no match inside larger token", notifier.extract_issue_ids(["MYTDB-1: noise"]) == [])
+
+
+def test_process_issue_skips_resolved():
+    client = FakeClient({"YTDB-10": ("Fixed", True)})
+    outcome = notifier.process_issue(client, "YTDB-10", "v1", dry_run=False)
+    check("resolved -> skipped_resolved", outcome == notifier.SKIPPED_RESOLVED)
+    check("resolved -> no comment", client.comments == [])
+    check("resolved -> no state change", client.set_fixed == [])
+
+
+def test_process_issue_updates_open():
+    client = FakeClient({"YTDB-11": ("Open", False)})
+    outcome = notifier.process_issue(client, "YTDB-11", "v2", dry_run=False)
+    check("open -> updated", outcome == notifier.UPDATED)
+    check("open -> comment carries version", client.comments == [("YTDB-11", "Fixed in v2")])
+    check("open -> state set to fixed", client.set_fixed == ["YTDB-11"])
+
+
+def test_process_issue_not_found():
+    client = FakeClient({})
+    outcome = notifier.process_issue(client, "YTDB-99", "v3", dry_run=False)
+    check("missing -> not_found", outcome == notifier.NOT_FOUND)
+    check("missing -> no writes", client.comments == [] and client.set_fixed == [])
+
+
+def test_process_issue_dry_run_writes_nothing():
+    client = FakeClient({"YTDB-12": ("In progress", False)})
+    outcome = notifier.process_issue(client, "YTDB-12", "v4", dry_run=True)
+    check("dry-run open -> would_update", outcome == notifier.WOULD_UPDATE)
+    check("dry-run -> no comment", client.comments == [])
+    check("dry-run -> no state change", client.set_fixed == [])
+
+
+def test_process_issue_dry_run_still_skips_resolved():
+    # A resolved issue is skipped even in dry-run, so the preview count
+    # matches what a live run would actually touch.
+    client = FakeClient({"YTDB-13": ("Verified", True)})
+    outcome = notifier.process_issue(client, "YTDB-13", "v5", dry_run=True)
+    check("dry-run resolved -> skipped_resolved", outcome == notifier.SKIPPED_RESOLVED)
+
+
+def main():
+    test_extract_issue_ids()
+    test_process_issue_skips_resolved()
+    test_process_issue_updates_open()
+    test_process_issue_not_found()
+    test_process_issue_dry_run_writes_nothing()
+    test_process_issue_dry_run_still_skips_resolved()
+    if _failures:
+        print(f"\n{len(_failures)} test(s) failed.")
+        return 1
+    print("\nAll tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/youtrack-fixed-notifier-test.py
+++ b/.github/scripts/youtrack-fixed-notifier-test.py
@@ -17,6 +17,7 @@ import importlib.util
 import os
 import pathlib
 import sys
+import urllib.request
 
 _MODULE_PATH = pathlib.Path(__file__).with_name("youtrack-fixed-notifier.py")
 _spec = importlib.util.spec_from_file_location("notifier", _MODULE_PATH)
@@ -184,11 +185,16 @@ def test_extract_issue_ids_boundaries():
 
 def test_extract_issue_ids_skips_reverts():
     """A revert commit must not re-mark the reverted issue as fixed: a subject
-    beginning with 'Revert ' is skipped entirely (the canonical git/GitHub
-    revert subject is 'Revert "<original>"'). A title that merely contains the
-    word 'revert' later is unaffected."""
+    beginning with 'revert ' (matched case-insensitively) is skipped entirely.
+    Covers the canonical git/GitHub form ('Revert "<original>"') and a
+    hand-written lower-case revert. A title that merely contains the word
+    'revert' later is unaffected."""
     check("revert title skipped",
           notifier.extract_issue_ids(['Revert "YTDB-5: fix a bug"']) == [])
+    # The match is case-insensitive, so a hand-written lower-case revert subject
+    # is skipped too.
+    check("lower-case revert title skipped",
+          notifier.extract_issue_ids(['revert "YTDB-6: fix a bug"']) == [])
     # A revert alongside a genuine fix in the same range: only the fix counts.
     check("revert skipped, real fix kept",
           notifier.extract_issue_ids(
@@ -260,6 +266,47 @@ def test_get_issue_state_parsing():
     ).get_issue_state("YTDB-1")
     check("missing isResolved -> unresolved",
           open_value["state"] == "Open" and not open_value["is_resolved"])
+
+
+# --- YouTrackClient construction -------------------------------------------
+
+
+def test_client_timeout_configured():
+    """YouTrackClient carries a per-request timeout so an unresponsive YouTrack
+    server fails the CI step fast instead of hanging for the full runner budget:
+    the default is 30s and an explicit value overrides it."""
+    default = notifier.YouTrackClient("https://example.test", "token")
+    check("default request timeout is 30s", default.timeout == 30)
+    custom = notifier.YouTrackClient("https://example.test", "token", timeout=5)
+    check("explicit timeout overrides default", custom.timeout == 5)
+
+
+# --- _AuthStrippingRedirectHandler (token-leak guard) ----------------------
+
+
+def test_redirect_strips_auth_cross_host():
+    """The redirect handler is a token-leak guard: on a cross-host 30x it drops
+    the Authorization header so the Bearer token is never forwarded to another
+    host, while keeping non-secret headers; on a same-host redirect it keeps
+    Authorization so the retried request still authenticates."""
+    handler = notifier._AuthStrippingRedirectHandler()
+    req = urllib.request.Request(
+        "https://youtrack.jetbrains.com/api/issues/YTDB-1",
+        headers={"Authorization": "Bearer SECRET", "Accept": "application/json"},
+        method="GET",
+    )
+    cross = handler.redirect_request(
+        req, fp=None, code=302, msg="Found", headers={},
+        newurl="https://evil.example.com/x")
+    check("cross-host redirect strips Authorization",
+          not cross.has_header("Authorization"))
+    check("cross-host redirect keeps non-secret headers",
+          cross.has_header("Accept"))
+    same = handler.redirect_request(
+        req, fp=None, code=302, msg="Found", headers={},
+        newurl="https://youtrack.jetbrains.com/api/other")
+    check("same-host redirect keeps Authorization",
+          same.has_header("Authorization"))
 
 
 # --- process_issue ---------------------------------------------------------
@@ -406,6 +453,38 @@ def test_main_partial_failure_exit_code():
           client.set_fixed == ["YTDB-1", "YTDB-3"])
     check("partial failure -> both healthy issues commented",
           client.comments == [("YTDB-1", "Fixed in v9"), ("YTDB-3", "Fixed in v9")])
+
+
+def test_main_handles_network_oserror():
+    """A network-level OSError (e.g. the socket TimeoutError raised when the
+    request timeout fires) is caught like any other per-issue failure: the issue
+    is recorded as failed and the run exits 1, while the remaining healthy issues
+    are still updated rather than the whole run crashing. Guards the broadened
+    `except (YouTrackError, OSError, ValueError)` — a bare urllib.error.URLError
+    catch would have let this TimeoutError abort the run."""
+    built = {}
+
+    class TimingOutClient(FakeClient):
+        def get_issue_state(self, issue_id):
+            if issue_id == "YTDB-2":
+                raise TimeoutError("timed out")
+            return {"found": True, "state": "Open", "is_resolved": False}
+
+    def fake_client_factory(base_url, token):
+        built["client"] = TimingOutClient({})
+        return built["client"]
+
+    with _patched_attr(notifier, "is_ancestor", lambda *a, **k: True), \
+            _patched_attr(notifier, "get_commit_titles",
+                          lambda *a, **k: ["YTDB-1: a", "YTDB-2: b", "YTDB-3: c"]), \
+            _patched_attr(notifier, "YouTrackClient", fake_client_factory), \
+            _env("YOUTRACK_TOKEN", "dummy-token"):
+        rc = notifier.main(["--from-sha", "aaa", "--to-sha", "bbb", "--version", "v9"])
+
+    client = built["client"]
+    check("network OSError -> exit 1", rc == 1)
+    check("network OSError -> healthy issues still updated",
+          client.set_fixed == ["YTDB-1", "YTDB-3"])
 
 
 def main():

--- a/.github/scripts/youtrack-fixed-notifier-test.py
+++ b/.github/scripts/youtrack-fixed-notifier-test.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python3
 """Stand-alone tests for youtrack-fixed-notifier.py.
 
-Run directly (no pytest dependency, matching the other .github/scripts
-test runners):
+Run directly, with no pytest dependency, like the other .github/scripts
+helpers:
 
     python3 .github/scripts/youtrack-fixed-notifier-test.py
 
-Exit code 0 means all tests passed; non-zero prints the failing cases.
-The notifier module is loaded by path because its filename contains
-hyphens and is not importable as a normal module.
+Exit code 0 means all checks passed; non-zero prints the failing cases.
+Test functions (any module-level `test_*`) are discovered automatically, so
+adding one needs no edit to `main()`. The notifier module is loaded by path
+because its filename contains hyphens and is not importable as a normal module.
 """
 
+import contextlib
 import importlib.util
+import os
 import pathlib
 import sys
 
@@ -20,19 +23,26 @@ _spec = importlib.util.spec_from_file_location("notifier", _MODULE_PATH)
 notifier = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(notifier)
 
+# Repo root = <repo>/.github/scripts/<this file>; used by the is_ancestor test
+# so it works regardless of the caller's cwd (CI runs from the repo root, but a
+# local run may not).
+_REPO_DIR = str(_MODULE_PATH.parents[2])
+
 
 class FakeClient:
     """In-memory stand-in for YouTrackClient.
 
-    `states` maps issue ID -> (state_name, is_resolved). A missing key
-    models a 404 (issue not found). Recorded `comments` and `set_fixed`
-    let tests assert that writes happened (or did not, under --dry-run).
+    `states` maps issue ID -> (state_name, is_resolved); a state_name of None
+    models a found issue that exposes no State value. A missing key models a
+    404 (issue not found). `comments` and `set_fixed` record writes for "did it
+    happen" assertions; `calls` records them in order for ordering assertions.
     """
 
     def __init__(self, states):
         self.states = states
         self.comments = []
         self.set_fixed = []
+        self.calls = []
 
     def get_issue_state(self, issue_id):
         if issue_id not in self.states:
@@ -42,9 +52,11 @@ class FakeClient:
 
     def add_comment(self, issue_id, text):
         self.comments.append((issue_id, text))
+        self.calls.append(("comment", issue_id, text))
 
     def set_state_fixed(self, issue_id):
         self.set_fixed.append(issue_id)
+        self.calls.append(("set_fixed", issue_id))
 
 
 _failures = []
@@ -58,33 +70,204 @@ def check(name, condition):
         _failures.append(name)
 
 
+# --- helpers ---------------------------------------------------------------
+
+
+def _raises_youtrack_error(fn):
+    """True iff calling `fn` raises notifier.YouTrackError."""
+    try:
+        fn()
+        return False
+    except notifier.YouTrackError:
+        return True
+
+
+def _client_returning(status, data):
+    """A real YouTrackClient whose _request yields a canned (status, data).
+
+    Lets the tests drive the genuine get_issue_state parser (the FakeClient
+    seam bypasses it everywhere else) with no network.
+    """
+    client = notifier.YouTrackClient("https://example.test", "token")
+    client._request = lambda method, path, body=None: (status, data)
+    return client
+
+
+@contextlib.contextmanager
+def _patched_attr(obj, name, value):
+    """Temporarily replace obj.name with value, restoring it afterward."""
+    original = getattr(obj, name)
+    setattr(obj, name, value)
+    try:
+        yield
+    finally:
+        setattr(obj, name, original)
+
+
+@contextlib.contextmanager
+def _env(name, value):
+    """Set env var `name` to `value` (or delete it when value is None) for the
+    duration of the block, then restore the previous value."""
+    original = os.environ.get(name)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = original
+
+
+# --- extract_issue_ids -----------------------------------------------------
+
+
 def test_extract_issue_ids():
+    """The recognized YTDB reference shapes are extracted, deduplicated in
+    first-occurrence order, and normalized to upper case; a token with a larger
+    leading prefix (MYTDB-1) is rejected by the leading word boundary."""
     # Colon form, the most common shape on develop.
-    check("colon form", notifier.extract_issue_ids(["YTDB-123: fix a bug"]) == ["YTDB-123"])
+    check("colon form",
+          notifier.extract_issue_ids(["YTDB-123: fix a bug"]) == ["YTDB-123"])
     # Bracket form, also produced by the PR-title prefixer.
-    check("bracket form", notifier.extract_issue_ids(["[YTDB-958] do a thing"]) == ["YTDB-958"])
+    check("bracket form",
+          notifier.extract_issue_ids(["[YTDB-958] do a thing"]) == ["YTDB-958"])
     # Comma-separated pair in a single title -> both issues.
-    check(
-        "comma pair",
-        notifier.extract_issue_ids(["YTDB-1, YTDB-2: two issues"]) == ["YTDB-1", "YTDB-2"],
-    )
+    check("comma pair",
+          notifier.extract_issue_ids(["YTDB-1, YTDB-2: two issues"]) == ["YTDB-1", "YTDB-2"])
     # A PR-number suffix uses '#', not YTDB-, so it must not match.
-    check("no false positive on pr number", notifier.extract_issue_ids(["Tidy things (#1101)"]) == [])
+    check("no false positive on pr number",
+          notifier.extract_issue_ids(["Tidy things (#1101)"]) == [])
     # A title with no reference at all.
-    check("no reference", notifier.extract_issue_ids(["Set default effort to xhigh"]) == [])
+    check("no reference",
+          notifier.extract_issue_ids(["Set default effort to xhigh"]) == [])
     # The same issue across several commits collapses to one entry, order kept.
-    check(
-        "dedup across commits, order preserved",
-        notifier.extract_issue_ids(["YTDB-5: part one", "YTDB-3: other", "YTDB-5: part two"])
-        == ["YTDB-5", "YTDB-3"],
-    )
+    check("dedup across commits, order preserved",
+          notifier.extract_issue_ids(
+              ["YTDB-5: part one", "YTDB-3: other", "YTDB-5: part two"]) == ["YTDB-5", "YTDB-3"])
     # Lower-case reference is normalized to upper case.
-    check("case-insensitive normalize", notifier.extract_issue_ids(["ytdb-9: lower"]) == ["YTDB-9"])
-    # `\b` must prevent matching inside a larger leading token.
-    check("no match inside larger token", notifier.extract_issue_ids(["MYTDB-1: noise"]) == [])
+    check("case-insensitive normalize",
+          notifier.extract_issue_ids(["ytdb-9: lower"]) == ["YTDB-9"])
+    # Leading `\b` prevents matching inside a larger leading token.
+    check("no match inside larger leading token",
+          notifier.extract_issue_ids(["MYTDB-1: noise"]) == [])
+
+
+def test_extract_issue_ids_boundaries():
+    """Boundary and degenerate inputs: the trailing word boundary rejects a
+    digit run glued to letters or an underscore, an empty range and a bare
+    'YTDB-' yield nothing, a repeated reference within one title dedups, and
+    surrounding punctuation is tolerated."""
+    # Trailing `\b`: letters right after the digits break the match, so a glued
+    # build/coordinate token is not mis-parsed as an issue (symmetric to the
+    # MYTDB-1 leading-boundary case).
+    check("no match with trailing letters",
+          notifier.extract_issue_ids(["YTDB-12abc: x"]) == [])
+    # '_' is a word character too, so the trailing boundary also rejects this.
+    check("no match with trailing underscore",
+          notifier.extract_issue_ids(["YTDB-5_x: x"]) == [])
+    # An empty range (e.g. only merge commits, all filtered out) yields no IDs.
+    check("empty input", notifier.extract_issue_ids([]) == [])
+    # A bare 'YTDB-' with no number must not match (the digit group is required).
+    check("no digits after prefix",
+          notifier.extract_issue_ids(["YTDB-: nothing"]) == [])
+    # The same issue twice within a single title collapses to one entry.
+    check("dedup within one title",
+          notifier.extract_issue_ids(["YTDB-5 and YTDB-5 again"]) == ["YTDB-5"])
+    # Surrounding punctuation is fine.
+    check("parenthesized ref matches",
+          notifier.extract_issue_ids(["(YTDB-5) done"]) == ["YTDB-5"])
+
+
+def test_extract_issue_ids_skips_reverts():
+    """A revert commit must not re-mark the reverted issue as fixed: a subject
+    beginning with 'Revert ' is skipped entirely (the canonical git/GitHub
+    revert subject is 'Revert "<original>"'). A title that merely contains the
+    word 'revert' later is unaffected."""
+    check("revert title skipped",
+          notifier.extract_issue_ids(['Revert "YTDB-5: fix a bug"']) == [])
+    # A revert alongside a genuine fix in the same range: only the fix counts.
+    check("revert skipped, real fix kept",
+          notifier.extract_issue_ids(
+              ['Revert "YTDB-5: fix"', "YTDB-6: real fix"]) == ["YTDB-6"])
+    # 'revert' appearing mid-title (not as the subject prefix) still matches.
+    check("word revert mid-title still matches",
+          notifier.extract_issue_ids(["YTDB-7: revert the cache flag"]) == ["YTDB-7"])
+
+
+# --- is_ancestor (the rewritten-develop range guard) -----------------------
+
+
+def test_is_ancestor():
+    """is_ancestor gates the range diff: a commit is its own ancestor (git exit
+    0 -> True), while an unknown SHA (git exit 128) is rejected (-> False) so a
+    rewritten or garbage-collected boundary becomes a clean no-op in main()
+    instead of a crash or a silently wrong range."""
+    check("HEAD is its own ancestor",
+          notifier.is_ancestor("HEAD", "HEAD", _REPO_DIR) is True)
+    check("unknown sha is not an ancestor",
+          notifier.is_ancestor("0" * 40, "HEAD", _REPO_DIR) is False)
+
+
+# --- get_issue_state (the real parser, via a canned _request) --------------
+
+
+def test_get_issue_state_parsing():
+    """get_issue_state turns a raw YouTrack response into {found, state,
+    is_resolved}. Exercises the real parser: the 404 skip, the hard-error raise
+    on 5xx and malformed bodies, the missing/null/empty State fallbacks, the
+    robustness path for a null customFields, and the isResolved-flag (not the
+    state name) deciding resolution."""
+    # 404 -> a benign "not found" skip, never a hard failure.
+    check("404 -> not found",
+          _client_returning(404, "Not Found").get_issue_state("YTDB-1")["found"] is False)
+    # 500 -> hard failure so the CI step is flagged, not silently skipped.
+    check("500 -> raises",
+          _raises_youtrack_error(lambda: _client_returning(500, "boom").get_issue_state("YTDB-1")))
+    # A non-dict 200 body is treated as a hard failure.
+    check("malformed body -> raises",
+          _raises_youtrack_error(
+              lambda: _client_returning(200, "not-an-object").get_issue_state("YTDB-1")))
+    # Issue present but no State field at all -> unresolved (so it gets updated).
+    no_state = _client_returning(
+        200, {"customFields": [{"name": "Priority", "value": {"name": "Major"}}]}
+    ).get_issue_state("YTDB-1")
+    check("no State field -> found and unresolved",
+          no_state["found"] and not no_state["is_resolved"] and no_state["state"] is None)
+    # State present with a null value -> unresolved.
+    null_value = _client_returning(
+        200, {"customFields": [{"name": "State", "value": None}]}
+    ).get_issue_state("YTDB-1")
+    check("null State value -> unresolved",
+          null_value["found"] and null_value["state"] is None and not null_value["is_resolved"])
+    # Robustness: a null customFields (not the normal []) must not crash.
+    null_fields = _client_returning(200, {"customFields": None}).get_issue_state("YTDB-1")
+    check("null customFields -> found and unresolved",
+          null_fields["found"] and not null_fields["is_resolved"])
+    # Resolution is decided by the isResolved flag, not the state name: a
+    # non-obvious resolved name like 'Obsolete' is still skipped.
+    obsolete_value = {"name": "Obsolete", "isResolved": True}
+    obsolete = _client_returning(
+        200, {"customFields": [{"name": "State", "value": obsolete_value}]}
+    ).get_issue_state("YTDB-1")
+    check("isResolved flag drives skip regardless of name", obsolete["is_resolved"])
+    # A value with no isResolved key defaults to unresolved.
+    open_value = _client_returning(
+        200, {"customFields": [{"name": "State", "value": {"name": "Open"}}]}
+    ).get_issue_state("YTDB-1")
+    check("missing isResolved -> unresolved",
+          open_value["state"] == "Open" and not open_value["is_resolved"])
+
+
+# --- process_issue ---------------------------------------------------------
 
 
 def test_process_issue_skips_resolved():
+    """An already-resolved issue is skipped with no writes, so a
+    Verified/Closed/Fixed issue is never re-opened or re-commented."""
     client = FakeClient({"YTDB-10": ("Fixed", True)})
     outcome = notifier.process_issue(client, "YTDB-10", "v1", dry_run=False)
     check("resolved -> skipped_resolved", outcome == notifier.SKIPPED_RESOLVED)
@@ -93,14 +276,33 @@ def test_process_issue_skips_resolved():
 
 
 def test_process_issue_updates_open():
+    """An open (unresolved) issue is commented and moved to Fixed, with the
+    comment posted before the state change so a later rejected transition still
+    leaves the 'Fixed in <version>' audit note."""
     client = FakeClient({"YTDB-11": ("Open", False)})
     outcome = notifier.process_issue(client, "YTDB-11", "v2", dry_run=False)
     check("open -> updated", outcome == notifier.UPDATED)
-    check("open -> comment carries version", client.comments == [("YTDB-11", "Fixed in v2")])
+    check("open -> comment carries version",
+          client.comments == [("YTDB-11", "Fixed in v2")])
     check("open -> state set to fixed", client.set_fixed == ["YTDB-11"])
+    check("open -> comment precedes state change",
+          client.calls == [("comment", "YTDB-11", "Fixed in v2"), ("set_fixed", "YTDB-11")])
+
+
+def test_process_issue_updates_when_state_missing():
+    """A found issue with no State value is unresolved by definition and must
+    be updated, not skipped — otherwise a stateless issue would never be marked
+    fixed."""
+    client = FakeClient({"YTDB-14": (None, False)})
+    outcome = notifier.process_issue(client, "YTDB-14", "v6", dry_run=False)
+    check("no-state -> updated", outcome == notifier.UPDATED)
+    check("no-state -> comment + state set",
+          client.comments == [("YTDB-14", "Fixed in v6")] and client.set_fixed == ["YTDB-14"])
 
 
 def test_process_issue_not_found():
+    """A referenced issue that 404s (typo or cross-project ref) is reported as
+    not-found and never written to."""
     client = FakeClient({})
     outcome = notifier.process_issue(client, "YTDB-99", "v3", dry_run=False)
     check("missing -> not_found", outcome == notifier.NOT_FOUND)
@@ -108,6 +310,8 @@ def test_process_issue_not_found():
 
 
 def test_process_issue_dry_run_writes_nothing():
+    """In dry-run an open issue reports would_update but performs no writes, so
+    a preview never mutates the tracker."""
     client = FakeClient({"YTDB-12": ("In progress", False)})
     outcome = notifier.process_issue(client, "YTDB-12", "v4", dry_run=True)
     check("dry-run open -> would_update", outcome == notifier.WOULD_UPDATE)
@@ -116,24 +320,108 @@ def test_process_issue_dry_run_writes_nothing():
 
 
 def test_process_issue_dry_run_still_skips_resolved():
-    # A resolved issue is skipped even in dry-run, so the preview count
-    # matches what a live run would actually touch.
+    """A resolved issue is skipped even in dry-run, so the preview count matches
+    what a live run would actually touch."""
     client = FakeClient({"YTDB-13": ("Verified", True)})
     outcome = notifier.process_issue(client, "YTDB-13", "v5", dry_run=True)
     check("dry-run resolved -> skipped_resolved", outcome == notifier.SKIPPED_RESOLVED)
 
 
+def test_process_issue_propagates_api_error():
+    """A hard API error must propagate out of process_issue (not be swallowed
+    into a normal outcome), because main()'s per-issue handler relies on the
+    exception to record a failure and exit non-zero. Covers both the read path
+    (get_issue_state) and a write path (add_comment)."""
+    class RaisingOnRead(FakeClient):
+        def get_issue_state(self, issue_id):
+            raise notifier.YouTrackError("GET YTDB-14 returned 500: boom")
+
+    check("read error propagates",
+          _raises_youtrack_error(
+              lambda: notifier.process_issue(RaisingOnRead({}), "YTDB-14", "v", dry_run=False)))
+
+    class RaisingOnComment(FakeClient):
+        def add_comment(self, issue_id, text):
+            raise notifier.YouTrackError("comment on YTDB-15 returned 403")
+
+    write_client = RaisingOnComment({"YTDB-15": ("Open", False)})
+    check("write error propagates",
+          _raises_youtrack_error(
+              lambda: notifier.process_issue(write_client, "YTDB-15", "v", dry_run=False)))
+    # The comment failed before the state write, so no Fixed transition leaked.
+    check("failed comment -> no state change", write_client.set_fixed == [])
+
+
+# --- main() orchestration --------------------------------------------------
+
+
+def test_main_no_op_on_empty_from_sha():
+    """An empty --from-sha (first run / no prior successful deploy) is a clean
+    no-op returning 0, short-circuiting before any git or network access."""
+    check("empty from-sha -> exit 0",
+          notifier.main(["--from-sha", "", "--version", "v1"]) == 0)
+
+
+def test_main_no_token():
+    """With commits in range but YOUTRACK_TOKEN unset, a live run exits 1 (so a
+    misconfigured secret fails the CI step) while --dry-run lists the issues and
+    exits 0. The ancestor check and range walk are stubbed so no real history is
+    needed."""
+    with _patched_attr(notifier, "is_ancestor", lambda *a, **k: True), \
+            _patched_attr(notifier, "get_commit_titles", lambda *a, **k: ["YTDB-1: x"]), \
+            _env("YOUTRACK_TOKEN", None):
+        live = notifier.main(["--from-sha", "aaa", "--to-sha", "bbb", "--version", "v1"])
+        check("no token + live -> exit 1", live == 1)
+        dry = notifier.main(
+            ["--from-sha", "aaa", "--to-sha", "bbb", "--version", "v1", "--dry-run"])
+        check("no token + dry-run -> exit 0", dry == 0)
+
+
+def test_main_partial_failure_exit_code():
+    """One failing issue (a raised YouTrackError) must not abort the others: the
+    run still updates the healthy issues and exits 1 to flag the failure for
+    follow-up. YouTrackClient and the range walk are stubbed."""
+    built = {}
+
+    class OneBadClient(FakeClient):
+        def get_issue_state(self, issue_id):
+            if issue_id == "YTDB-2":
+                raise notifier.YouTrackError("GET YTDB-2 returned 500")
+            return {"found": True, "state": "Open", "is_resolved": False}
+
+    def fake_client_factory(base_url, token):
+        built["client"] = OneBadClient({})
+        return built["client"]
+
+    with _patched_attr(notifier, "is_ancestor", lambda *a, **k: True), \
+            _patched_attr(notifier, "get_commit_titles",
+                          lambda *a, **k: ["YTDB-1: a", "YTDB-2: b", "YTDB-3: c"]), \
+            _patched_attr(notifier, "YouTrackClient", fake_client_factory), \
+            _env("YOUTRACK_TOKEN", "dummy-token"):
+        rc = notifier.main(["--from-sha", "aaa", "--to-sha", "bbb", "--version", "v9"])
+
+    client = built["client"]
+    check("partial failure -> exit 1", rc == 1)
+    check("partial failure -> healthy issues still updated",
+          client.set_fixed == ["YTDB-1", "YTDB-3"])
+    check("partial failure -> both healthy issues commented",
+          client.comments == [("YTDB-1", "Fixed in v9"), ("YTDB-3", "Fixed in v9")])
+
+
 def main():
-    test_extract_issue_ids()
-    test_process_issue_skips_resolved()
-    test_process_issue_updates_open()
-    test_process_issue_not_found()
-    test_process_issue_dry_run_writes_nothing()
-    test_process_issue_dry_run_still_skips_resolved()
+    # Discover and run every module-level test_* function, so adding a test
+    # needs no manual registration here.
+    tests = sorted(
+        ((name, fn) for name, fn in globals().items()
+         if name.startswith("test_") and callable(fn)),
+        key=lambda kv: kv[0],
+    )
+    for _name, fn in tests:
+        fn()
     if _failures:
-        print(f"\n{len(_failures)} test(s) failed.")
+        print(f"\n{len(_failures)} check(s) failed.")
         return 1
-    print("\nAll tests passed.")
+    print(f"\nAll checks passed across {len(tests)} test function(s).")
     return 0
 
 

--- a/.github/scripts/youtrack-fixed-notifier.py
+++ b/.github/scripts/youtrack-fixed-notifier.py
@@ -18,9 +18,11 @@ Issue references are matched as `YTDB-<n>` (case-insensitive) anywhere in
 a commit title, which covers all the shapes the repo produces:
 `YTDB-123: ...`, `[YTDB-123] ...`, and the comma-separated pair
 `YTDB-123, YTDB-456: ...`. Duplicate references across the range are
-processed once. A commit whose subject begins with `Revert ` is skipped:
-reverting a change undoes it, so it must not re-mark the reverted issue as
-fixed (git and GitHub both produce the canonical `Revert "<subject>"` form).
+processed once. A commit whose subject begins with `revert ` (matched
+case-insensitively) is skipped: reverting a change undoes it, so it must not
+re-mark the reverted issue as fixed (git and GitHub produce the canonical
+`Revert "<subject>"` form; the case-insensitive match also catches a
+hand-written lower-case revert).
 
 A single bad issue (network error, transition rejected) does not abort
 the run: the failure is logged and the script exits non-zero at the end
@@ -91,10 +93,12 @@ def extract_issue_ids(titles):
     seen_set = set()
     for title in titles:
         # A revert undoes a change, so a "Revert "...""  commit must not
-        # re-mark the reverted issue as fixed. Skip the canonical git/GitHub
-        # revert subject; a title that merely contains the word later (e.g.
-        # "YTDB-7: revert the cache flag") is unaffected.
-        if title.lstrip().startswith("Revert "):
+        # re-mark the reverted issue as fixed. Skip a subject beginning with
+        # "revert " (case-insensitive): this is the canonical git/GitHub revert
+        # form and also catches a hand-written lower-case revert. A title that
+        # merely contains the word later (e.g. "YTDB-7: revert the cache flag")
+        # is unaffected.
+        if title.lstrip().lower().startswith("revert "):
             continue
         for match in ISSUE_RE.finditer(title):
             issue_id = "YTDB-" + match.group(1)
@@ -158,15 +162,17 @@ class _AuthStrippingRedirectHandler(urllib.request.HTTPRedirectHandler):
             old_host = urllib.parse.urlsplit(req.full_url).netloc
             new_host = urllib.parse.urlsplit(newurl).netloc
             if old_host != new_host:
-                # Request stores header keys capitalized ("Authorization").
-                new_req.headers.pop("Authorization", None)
+                # remove_header drops the key from both `headers` and
+                # `unredirected_hdrs`, case-insensitively — the robust way to
+                # strip a header from a Request.
+                new_req.remove_header("Authorization")
         return new_req
 
 
 class YouTrackClient:
     """Thin REST wrapper over the YouTrack issue + comment endpoints."""
 
-    def __init__(self, base_url, token):
+    def __init__(self, base_url, token, timeout=30):
         # Refuse to send the Bearer token over a non-TLS connection.
         scheme = urllib.parse.urlsplit(base_url).scheme
         if scheme != "https":
@@ -176,6 +182,10 @@ class YouTrackClient:
             )
         self.base_url = base_url.rstrip("/")
         self.token = token
+        # Per-request socket timeout (seconds). urllib has no default timeout,
+        # so an unresponsive YouTrack server would otherwise hang the CI step
+        # for the full runner budget; fail fast instead.
+        self.timeout = timeout
         # Own opener so a cross-host redirect cannot forward the token.
         self._opener = urllib.request.build_opener(_AuthStrippingRedirectHandler())
 
@@ -190,7 +200,7 @@ class YouTrackClient:
             headers["Content-Type"] = "application/json"
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
         try:
-            with self._opener.open(req) as resp:
+            with self._opener.open(req, timeout=self.timeout) as resp:
                 payload = resp.read().decode("utf-8")
                 return resp.status, (json.loads(payload) if payload else None)
         except urllib.error.HTTPError as exc:
@@ -324,10 +334,14 @@ def main(argv=None):
     for issue_id in issue_ids:
         try:
             outcome = process_issue(client, issue_id, args.version, args.dry_run)
-        except (YouTrackError, urllib.error.URLError, ValueError) as exc:
-            # ValueError also covers a malformed (non-JSON) 200 body, whose
-            # json.loads failure propagates out of _request. One bad issue is
-            # recorded and the loop continues to the next.
+        except (YouTrackError, OSError, ValueError) as exc:
+            # OSError is the broad network bucket: it covers a urllib URLError,
+            # a refused/reset connection, a DNS failure, and the socket-level
+            # TimeoutError raised when the request timeout fires — so none of
+            # them crashes the run and skips the remaining issues. ValueError
+            # also covers a malformed (non-JSON) 200 body, whose json.loads
+            # failure propagates out of _request. One bad issue is recorded and
+            # the loop continues to the next.
             failures.append(issue_id)
             print(f"  FAILED  {issue_id}: {_truncate(exc)}", file=sys.stderr)
             continue

--- a/.github/scripts/youtrack-fixed-notifier.py
+++ b/.github/scripts/youtrack-fixed-notifier.py
@@ -18,7 +18,9 @@ Issue references are matched as `YTDB-<n>` (case-insensitive) anywhere in
 a commit title, which covers all the shapes the repo produces:
 `YTDB-123: ...`, `[YTDB-123] ...`, and the comma-separated pair
 `YTDB-123, YTDB-456: ...`. Duplicate references across the range are
-processed once.
+processed once. A commit whose subject begins with `Revert ` is skipped:
+reverting a change undoes it, so it must not re-mark the reverted issue as
+fixed (git and GitHub both produce the canonical `Revert "<subject>"` form).
 
 A single bad issue (network error, transition rejected) does not abort
 the run: the failure is logged and the script exits non-zero at the end
@@ -45,6 +47,7 @@ import re
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 
 DEFAULT_BASE_URL = "https://youtrack.jetbrains.com"
@@ -62,6 +65,20 @@ SKIPPED_RESOLVED = "skipped_resolved"
 WOULD_UPDATE = "would_update"
 UPDATED = "updated"
 
+# Cap on how much of a YouTrack response body we put into an error message.
+# Those messages are printed to a public-by-default CI log, and an API error
+# body can echo back request context; GitHub's secret masking only redacts the
+# exact token string, not adjacent content, so we keep the logged slice small.
+_MAX_ERROR_DETAIL = 200
+
+
+def _truncate(detail, limit=_MAX_ERROR_DETAIL):
+    """Shorten a server response body for safe, bounded CI logging."""
+    text = str(detail)
+    if len(text) > limit:
+        return f"{text[:limit]}... [{len(text)} chars, truncated]"
+    return text
+
 
 def extract_issue_ids(titles):
     """Return the unique YTDB issue IDs across the given commit titles.
@@ -73,12 +90,40 @@ def extract_issue_ids(titles):
     seen = []
     seen_set = set()
     for title in titles:
+        # A revert undoes a change, so a "Revert "...""  commit must not
+        # re-mark the reverted issue as fixed. Skip the canonical git/GitHub
+        # revert subject; a title that merely contains the word later (e.g.
+        # "YTDB-7: revert the cache flag") is unaffected.
+        if title.lstrip().startswith("Revert "):
+            continue
         for match in ISSUE_RE.finditer(title):
             issue_id = "YTDB-" + match.group(1)
             if issue_id not in seen_set:
                 seen_set.add(issue_id)
                 seen.append(issue_id)
     return seen
+
+
+def is_ancestor(from_sha, to_sha, repo_dir):
+    """Return True only if `from_sha` is reachable as an ancestor of `to_sha`.
+
+    This guards the range diff against a rewritten develop. If the recorded
+    last-success SHA is no longer an ancestor of the deployed SHA — develop was
+    rebased/force-pushed and the old SHA was garbage-collected, or it now sits
+    on an abandoned line of history — then `git log from..to` would either fail
+    with an unknown-object error (exit 128) or silently compute the
+    `merge-base(from,to)..to` range and mark the wrong set of issues fixed.
+    `git merge-base --is-ancestor` distinguishes the three cases by exit code:
+    0 = ancestor, 1 = reachable but not an ancestor, 128 = unknown object. Only
+    exit 0 is safe to diff, so anything else is treated as "do not run".
+    """
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", from_sha, to_sha],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
 
 
 def get_commit_titles(from_sha, to_sha, repo_dir):
@@ -97,12 +142,42 @@ class YouTrackError(Exception):
     """A non-recoverable error talking to the YouTrack REST API."""
 
 
+class _AuthStrippingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Strip the Authorization header on a cross-host redirect.
+
+    `urllib` follows redirects automatically and, by default, re-sends every
+    original request header — including `Authorization: Bearer <token>` — to
+    the redirect target. A 30x from the YouTrack host to a different host would
+    otherwise forward the token to that host. We keep the header on a same-host
+    redirect and drop it the moment the host changes.
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req is not None:
+            old_host = urllib.parse.urlsplit(req.full_url).netloc
+            new_host = urllib.parse.urlsplit(newurl).netloc
+            if old_host != new_host:
+                # Request stores header keys capitalized ("Authorization").
+                new_req.headers.pop("Authorization", None)
+        return new_req
+
+
 class YouTrackClient:
     """Thin REST wrapper over the YouTrack issue + comment endpoints."""
 
     def __init__(self, base_url, token):
+        # Refuse to send the Bearer token over a non-TLS connection.
+        scheme = urllib.parse.urlsplit(base_url).scheme
+        if scheme != "https":
+            raise ValueError(
+                f"base-url must be https (got {scheme or 'no scheme'!r}); "
+                "refusing to send the YouTrack token in cleartext."
+            )
         self.base_url = base_url.rstrip("/")
         self.token = token
+        # Own opener so a cross-host redirect cannot forward the token.
+        self._opener = urllib.request.build_opener(_AuthStrippingRedirectHandler())
 
     def _request(self, method, path, body=None):
         url = f"{self.base_url}{path}"
@@ -115,7 +190,7 @@ class YouTrackClient:
             headers["Content-Type"] = "application/json"
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
         try:
-            with urllib.request.urlopen(req) as resp:
+            with self._opener.open(req) as resp:
                 payload = resp.read().decode("utf-8")
                 return resp.status, (json.loads(payload) if payload else None)
         except urllib.error.HTTPError as exc:
@@ -134,11 +209,18 @@ class YouTrackClient:
         if status == 404:
             return {"found": False, "state": None, "is_resolved": False}
         if status >= 400 or not isinstance(data, dict):
-            raise YouTrackError(f"GET {issue_id} returned {status}: {data}")
-        for field in data.get("customFields", []):
+            raise YouTrackError(f"GET {issue_id} returned {status}: {_truncate(data)}")
+        # `or []` covers both an absent key and an explicit null; the per-field
+        # isinstance guards tolerate a null array entry or a non-object value
+        # so an abnormal payload yields "unresolved" rather than crashing the
+        # whole run with a TypeError/AttributeError that bypasses the caller's
+        # per-issue handler.
+        for field in data.get("customFields") or []:
+            if not isinstance(field, dict):
+                continue
             if field.get("name") == "State":
                 value = field.get("value")
-                if not value:
+                if not isinstance(value, dict) or not value:
                     return {"found": True, "state": None, "is_resolved": False}
                 return {
                     "found": True,
@@ -152,7 +234,7 @@ class YouTrackClient:
         path = f"/api/issues/{issue_id}/comments?fields=id"
         status, data = self._request("POST", path, {"text": text})
         if status >= 400:
-            raise YouTrackError(f"comment on {issue_id} returned {status}: {data}")
+            raise YouTrackError(f"comment on {issue_id} returned {status}: {_truncate(data)}")
 
     def set_state_fixed(self, issue_id):
         path = f"/api/issues/{issue_id}?fields=id"
@@ -167,14 +249,15 @@ class YouTrackClient:
         }
         status, data = self._request("POST", path, body)
         if status >= 400:
-            raise YouTrackError(f"set State on {issue_id} returned {status}: {data}")
+            raise YouTrackError(f"set State on {issue_id} returned {status}: {_truncate(data)}")
 
 
 def process_issue(client, issue_id, version, dry_run):
     """Apply the fixed-notification policy to a single issue.
 
-    Returns one of the module-level outcome constants. Raises on a hard
-    API error so the caller can record it as a failure.
+    Returns one of the module-level outcome constants. Propagates
+    `YouTrackError` from the client on a hard API error so the caller can
+    record the issue as a failure and continue with the rest.
     """
     info = client.get_issue_state(issue_id)
     if not info["found"]:
@@ -204,6 +287,17 @@ def main(argv=None):
         print("No from-sha given (no prior successful deploy); nothing to do.")
         return 0
 
+    # If develop was rewritten, the recorded last-success SHA may no longer be
+    # an ancestor of the deployed SHA. Diffing such a range would crash or
+    # silently compute the wrong commit set (see is_ancestor), so skip cleanly.
+    if not is_ancestor(args.from_sha, args.to_sha, args.repo_dir):
+        print(
+            f"from-sha {args.from_sha} is not an ancestor of {args.to_sha} "
+            "(history rewritten or SHA unreachable); nothing to do.",
+            file=sys.stderr,
+        )
+        return 0
+
     titles = get_commit_titles(args.from_sha, args.to_sha, args.repo_dir)
     issue_ids = extract_issue_ids(titles)
     print(
@@ -230,9 +324,12 @@ def main(argv=None):
     for issue_id in issue_ids:
         try:
             outcome = process_issue(client, issue_id, args.version, args.dry_run)
-        except (YouTrackError, urllib.error.URLError) as exc:
+        except (YouTrackError, urllib.error.URLError, ValueError) as exc:
+            # ValueError also covers a malformed (non-JSON) 200 body, whose
+            # json.loads failure propagates out of _request. One bad issue is
+            # recorded and the loop continues to the next.
             failures.append(issue_id)
-            print(f"  FAILED  {issue_id}: {exc}", file=sys.stderr)
+            print(f"  FAILED  {issue_id}: {_truncate(exc)}", file=sys.stderr)
             continue
         counts[outcome] += 1
         if outcome == NOT_FOUND:

--- a/.github/scripts/youtrack-fixed-notifier.py
+++ b/.github/scripts/youtrack-fixed-notifier.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Mark YouTrack issues fixed for the commits in a deployed range.
+
+Walks the commit titles in a git range (typically "since the last
+successful deploy" .. "the commit this run deployed"), extracts every
+YTDB issue reference, and for each referenced issue:
+
+  1. Reads the issue's current State.
+  2. Skips the issue if that State is already resolved (Fixed, Verified,
+     Closed, Won't fix, Duplicate, Obsolete, Done, ...). "Resolved" is
+     decided by YouTrack's own `isResolved` flag on the state value, not
+     by a hardcoded name list, so the set stays correct as states are
+     added or renamed.
+  3. Otherwise adds a "Fixed in <version>" comment and moves the State to
+     Fixed.
+
+Issue references are matched as `YTDB-<n>` (case-insensitive) anywhere in
+a commit title, which covers all the shapes the repo produces:
+`YTDB-123: ...`, `[YTDB-123] ...`, and the comma-separated pair
+`YTDB-123, YTDB-456: ...`. Duplicate references across the range are
+processed once.
+
+A single bad issue (network error, transition rejected) does not abort
+the run: the failure is logged and the script exits non-zero at the end
+so the CI step is marked failed for follow-up, while every other issue is
+still processed.
+
+Usage:
+    YOUTRACK_TOKEN=perm:... python3 youtrack-fixed-notifier.py \
+        --from-sha <last-success-sha> \
+        --to-sha <deployed-sha> \
+        --version 0.5.0-20260529.101500-abc1234-dev-SNAPSHOT
+
+    # Preview without writing anything (GETs still run if a token is set,
+    # so skip decisions are shown; without a token only the extracted
+    # issue list is printed):
+    python3 youtrack-fixed-notifier.py \
+        --from-sha <sha> --to-sha HEAD --version <v> --dry-run
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE_URL = "https://youtrack.jetbrains.com"
+
+# `\b` anchors keep us from matching inside a larger token (e.g. a stray
+# "MYTDB-1"); the digit run is the issue number. Case-insensitive because
+# PR-title / branch-hook prefixing is normalized to upper case but we do
+# not want to depend on that.
+ISSUE_RE = re.compile(r"\bYTDB-(\d+)\b", re.IGNORECASE)
+
+# Per-issue outcomes, used both for logging and for the test suite's
+# assertions.
+NOT_FOUND = "not_found"
+SKIPPED_RESOLVED = "skipped_resolved"
+WOULD_UPDATE = "would_update"
+UPDATED = "updated"
+
+
+def extract_issue_ids(titles):
+    """Return the unique YTDB issue IDs across the given commit titles.
+
+    Order is preserved (first occurrence wins) so the log reads in commit
+    order; IDs are normalized to upper case so `ytdb-9` and `YTDB-9`
+    collapse to one entry.
+    """
+    seen = []
+    seen_set = set()
+    for title in titles:
+        for match in ISSUE_RE.finditer(title):
+            issue_id = "YTDB-" + match.group(1)
+            if issue_id not in seen_set:
+                seen_set.add(issue_id)
+                seen.append(issue_id)
+    return seen
+
+
+def get_commit_titles(from_sha, to_sha, repo_dir):
+    """Return the subject line of every non-merge commit in from..to."""
+    result = subprocess.run(
+        ["git", "log", f"{from_sha}..{to_sha}", "--no-merges", "--format=%s"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+class YouTrackError(Exception):
+    """A non-recoverable error talking to the YouTrack REST API."""
+
+
+class YouTrackClient:
+    """Thin REST wrapper over the YouTrack issue + comment endpoints."""
+
+    def __init__(self, base_url, token):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    def _request(self, method, path, body=None):
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/json",
+        }
+        if data is not None:
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req) as resp:
+                payload = resp.read().decode("utf-8")
+                return resp.status, (json.loads(payload) if payload else None)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")
+            return exc.code, detail
+
+    def get_issue_state(self, issue_id):
+        """Return {found, state, is_resolved} for the issue's State field.
+
+        `found` is False on a 404 (typo'd or cross-project reference). A
+        present issue with no State value yields state=None / is_resolved
+        =False so it is treated as unresolved and gets updated.
+        """
+        path = f"/api/issues/{issue_id}?fields=customFields(name,value(name,isResolved))"
+        status, data = self._request("GET", path)
+        if status == 404:
+            return {"found": False, "state": None, "is_resolved": False}
+        if status >= 400 or not isinstance(data, dict):
+            raise YouTrackError(f"GET {issue_id} returned {status}: {data}")
+        for field in data.get("customFields", []):
+            if field.get("name") == "State":
+                value = field.get("value")
+                if not value:
+                    return {"found": True, "state": None, "is_resolved": False}
+                return {
+                    "found": True,
+                    "state": value.get("name"),
+                    "is_resolved": bool(value.get("isResolved")),
+                }
+        # Issue exists but exposes no State field at all.
+        return {"found": True, "state": None, "is_resolved": False}
+
+    def add_comment(self, issue_id, text):
+        path = f"/api/issues/{issue_id}/comments?fields=id"
+        status, data = self._request("POST", path, {"text": text})
+        if status >= 400:
+            raise YouTrackError(f"comment on {issue_id} returned {status}: {data}")
+
+    def set_state_fixed(self, issue_id):
+        path = f"/api/issues/{issue_id}?fields=id"
+        body = {
+            "customFields": [
+                {
+                    "name": "State",
+                    "$type": "StateIssueCustomField",
+                    "value": {"name": "Fixed"},
+                }
+            ]
+        }
+        status, data = self._request("POST", path, body)
+        if status >= 400:
+            raise YouTrackError(f"set State on {issue_id} returned {status}: {data}")
+
+
+def process_issue(client, issue_id, version, dry_run):
+    """Apply the fixed-notification policy to a single issue.
+
+    Returns one of the module-level outcome constants. Raises on a hard
+    API error so the caller can record it as a failure.
+    """
+    info = client.get_issue_state(issue_id)
+    if not info["found"]:
+        return NOT_FOUND
+    if info["is_resolved"]:
+        return SKIPPED_RESOLVED
+    if dry_run:
+        return WOULD_UPDATE
+    client.add_comment(issue_id, f"Fixed in {version}")
+    client.set_state_fixed(issue_id)
+    return UPDATED
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from-sha", required=True, help="Range start (exclusive)")
+    parser.add_argument("--to-sha", default="HEAD", help="Range end (inclusive)")
+    parser.add_argument("--version", required=True, help="Deployed version string")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--repo-dir", default=".")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    # No prior successful deploy (first run) or an empty boundary: nothing
+    # to diff against, so this is a clean no-op rather than an error.
+    if not args.from_sha:
+        print("No from-sha given (no prior successful deploy); nothing to do.")
+        return 0
+
+    titles = get_commit_titles(args.from_sha, args.to_sha, args.repo_dir)
+    issue_ids = extract_issue_ids(titles)
+    print(
+        f"Range {args.from_sha}..{args.to_sha}: {len(titles)} commit(s), "
+        f"{len(issue_ids)} referenced issue(s)."
+    )
+    if not issue_ids:
+        return 0
+
+    token = os.environ.get("YOUTRACK_TOKEN")
+    if not token:
+        if args.dry_run:
+            print("No YOUTRACK_TOKEN set; listing referenced issues only "
+                  "(cannot check resolved state):")
+            for issue_id in issue_ids:
+                print(f"  would consider {issue_id}")
+            return 0
+        print("ERROR: YOUTRACK_TOKEN is not set.", file=sys.stderr)
+        return 1
+
+    client = YouTrackClient(args.base_url, token)
+    counts = {NOT_FOUND: 0, SKIPPED_RESOLVED: 0, WOULD_UPDATE: 0, UPDATED: 0}
+    failures = []
+    for issue_id in issue_ids:
+        try:
+            outcome = process_issue(client, issue_id, args.version, args.dry_run)
+        except (YouTrackError, urllib.error.URLError) as exc:
+            failures.append(issue_id)
+            print(f"  FAILED  {issue_id}: {exc}", file=sys.stderr)
+            continue
+        counts[outcome] += 1
+        if outcome == NOT_FOUND:
+            print(f"  skip    {issue_id}: not found")
+        elif outcome == SKIPPED_RESOLVED:
+            print(f"  skip    {issue_id}: already resolved")
+        elif outcome == WOULD_UPDATE:
+            print(f"  dry-run {issue_id}: would comment + set Fixed")
+        else:
+            print(f"  updated {issue_id}: commented + set Fixed in {args.version}")
+
+    print(
+        "Summary: "
+        f"{counts[UPDATED]} updated, "
+        f"{counts[WOULD_UPDATE]} would-update, "
+        f"{counts[SKIPPED_RESOLVED]} already-resolved, "
+        f"{counts[NOT_FOUND]} not-found, "
+        f"{len(failures)} failed."
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -7,9 +7,17 @@ on:
     # Run at 2 AM CET (1 AM UTC)
     - cron: '0 1 * * *'
 
+# Concurrency policy is trigger-dependent:
+#   - push / schedule: cancel-in-progress=false. A new run does NOT kill the
+#     running build; it becomes "pending" and starts only after the current
+#     build finishes. GitHub keeps at most one pending run per group, so a
+#     burst of pushes collapses to the latest commit — the queued run checks
+#     out the develop tip, so it always tests the last change.
+#   - workflow_dispatch: cancel-in-progress=true. A manual trigger cancels the
+#     in-progress (and any pending) run and starts immediately.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' }}
 
 permissions:
   contents: write

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -31,6 +31,10 @@ jobs:
     # Define outputs so the next job can read them
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
+      # Range boundaries for the YouTrack fixed-notifier: the SHA this run
+      # tested/deployed, and the SHA of the previous successful deploy.
+      current_sha: ${{ steps.check.outputs.current_sha }}
+      last_success_sha: ${{ steps.check.outputs.last_success_sha }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v6
@@ -65,6 +69,11 @@ jobs:
 
           echo "Current SHA: $CURRENT_SHA"
           echo "Last Success SHA: $LAST_SUCCESS_SHA"
+
+          # Expose both SHAs so the post-deploy update-youtrack job can
+          # diff the commit range "since the last successful deploy".
+          echo "current_sha=$CURRENT_SHA" >> $GITHUB_OUTPUT
+          echo "last_success_sha=$LAST_SUCCESS_SHA" >> $GITHUB_OUTPUT
 
           # 4. Compare
           if [ "$CURRENT_SHA" == "$LAST_SUCCESS_SHA" ]; then
@@ -352,6 +361,10 @@ jobs:
     needs: [ test-linux, test-windows ]
     if: success() && github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    # The timestamped coordinate is the uniquely addressable artifact just
+    # published; update-youtrack quotes it in the "Fixed in <version>" comment.
+    outputs:
+      version: ${{ steps.deployed.outputs.version }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v6
@@ -388,14 +401,71 @@ jobs:
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
 
       - name: Annotate deployed versions
+        id: deployed
         run: |
           VERSION_SNAPSHOT=$(mvn -s .github/workflows/settings.xml help:evaluate -Dexpression=project.version -Dchangelist=-dev-SNAPSHOT -q -DforceStdout)
           VERSION_SHA=$(mvn -s .github/workflows/settings.xml help:evaluate -Dexpression=project.version -Dchangelist=-dev-SNAPSHOT -Dsha1=-${{ steps.vars.outputs.timestamp }}-${{ steps.vars.outputs.sha_short }} -q -DforceStdout)
           echo "::notice title=Maven Artifact Deployed::${VERSION_SNAPSHOT}"
           echo "::notice title=Maven Artifact Deployed::${VERSION_SHA}"
+          # Hand the timestamped coordinate to the update-youtrack job.
+          echo "version=${VERSION_SHA}" >> "$GITHUB_OUTPUT"
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+
+  # ------------------------------------------------------------------
+  # JOB: UPDATE-YOUTRACK
+  # After a successful deploy, walk the commits "since the last
+  # successful deploy" and, for every YTDB issue referenced in a commit
+  # title, post a "Fixed in <version>" comment and move the issue to the
+  # Fixed state. Issues already in a resolved state are skipped, so a
+  # Verified/Closed issue is never re-opened and re-runs are idempotent.
+  #
+  # Push-only: a manual workflow_dispatch deploys an artifact but must not
+  # mutate the issue tracker (it may target an arbitrary develop commit,
+  # and the range math assumes the linear push history). Skipped entirely
+  # on the first run / when no prior successful deploy exists, and when
+  # the current commit equals the last successful one.
+  #
+  # A failure here does NOT fire the build-failure siren and does NOT
+  # dispatch the CI Fix Agent (a sync failure is operational — token /
+  # API / rejected transition — not a code or test bug the agent can
+  # fix), nor does it suppress the "build fixed" signal. Instead the
+  # dedicated notify-youtrack-failure job below pages 'ci status' at low
+  # severity, and the job's own red status shows in the Actions UI.
+  # ------------------------------------------------------------------
+  update-youtrack:
+    name: Mark fixed issues in YouTrack
+    needs: [ check-changes, deploy ]
+    if: >-
+      success() &&
+      github.event_name == 'push' &&
+      needs.check-changes.outputs.last_success_sha != '' &&
+      needs.check-changes.outputs.last_success_sha != needs.check-changes.outputs.current_sha
+    runs-on: ubuntu-latest
+    # Least privilege: the only write target is YouTrack (via YOUTRACK_TOKEN).
+    # checkout needs read access to clone the range; nothing here uses the
+    # GITHUB_TOKEN write scopes granted at the workflow level.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v6
+        with:
+          # Pin to the exact commit this run deployed so the range end
+          # matches the published artifact, and fetch full history so the
+          # last-success SHA is reachable for the git-log diff.
+          ref: ${{ needs.check-changes.outputs.current_sha }}
+          fetch-depth: 0
+
+      - name: Mark fixed issues in YouTrack
+        env:
+          YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}
+        run: |
+          python3 .github/scripts/youtrack-fixed-notifier.py \
+            --from-sha "${{ needs.check-changes.outputs.last_success_sha }}" \
+            --to-sha "${{ needs.check-changes.outputs.current_sha }}" \
+            --version "${{ needs.deploy.outputs.version }}"
 
   notify-failure:
     name: Notify build failure on Zulip
@@ -439,6 +509,35 @@ jobs:
             Integration tests or merge failed on branch `${{ github.ref_name }}` for commit ${{ github.sha }} for repo ${{ github.repository }}.
             [View Run Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             :robot: Automated fix agent has been dispatched and is investigating...
+
+  notify-youtrack-failure:
+    name: Notify YouTrack sync failure on Zulip
+    needs: [ update-youtrack ]
+    # The deploy itself succeeded; only the post-deploy YouTrack issue
+    # sync (comment + State transition) failed. This is operational —
+    # token expired or under-scoped, YouTrack API down, or a State
+    # transition rejected — not a code/test regression, so we page at low
+    # severity (:warning:) and never dispatch the CI Fix Agent. always()
+    # is required so this job still runs after its dependency failed;
+    # update-youtrack only runs on push, so its result is 'failure' only
+    # in that context (it is 'skipped' on dispatch / schedule).
+    if: always() && needs.update-youtrack.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Send Zulip Notification
+        uses: zulip/github-actions-zulip/send-message@v2
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: ci-status-bot@youtrackdb.zulipchat.com
+          organization-url: 'https://youtrackdb.zulipchat.com'
+          to: 'ytdb'
+          type: 'stream'
+          topic: 'ci status'
+          content: |
+            **YOUTRACK SYNC FAILED** :warning:
+            Deploy succeeded, but marking fixed issues in YouTrack failed on branch `${{ github.ref_name }}` for commit ${{ github.sha }} (repo ${{ github.repository }}). Likely a token/permissions issue, a YouTrack API outage, or a rejected State transition — the build and published artifact are fine and no code fix is needed. Re-running the workflow retries the commit range; already-resolved issues are skipped, so successfully-updated issues are not touched twice.
+            [View Run Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
   notify-fixed:
     name: Notify build fixed on Zulip

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -461,11 +461,17 @@ jobs:
       - name: Mark fixed issues in YouTrack
         env:
           YOUTRACK_TOKEN: ${{ secrets.YOUTRACK_TOKEN }}
+          # Pass run inputs through env rather than interpolating ${{ }} into the
+          # run: shell, so a value can never be expanded as shell syntax (the
+          # GitHub-recommended pattern for untrusted-or-derived expansions).
+          FROM_SHA: ${{ needs.check-changes.outputs.last_success_sha }}
+          TO_SHA: ${{ needs.check-changes.outputs.current_sha }}
+          DEPLOYED_VERSION: ${{ needs.deploy.outputs.version }}
         run: |
           python3 .github/scripts/youtrack-fixed-notifier.py \
-            --from-sha "${{ needs.check-changes.outputs.last_success_sha }}" \
-            --to-sha "${{ needs.check-changes.outputs.current_sha }}" \
-            --version "${{ needs.deploy.outputs.version }}"
+            --from-sha "$FROM_SHA" \
+            --to-sha "$TO_SHA" \
+            --version "$DEPLOYED_VERSION"
 
   notify-failure:
     name: Notify build failure on Zulip

--- a/.github/workflows/youtrack-notifier-tests.yml
+++ b/.github/workflows/youtrack-notifier-tests.yml
@@ -1,0 +1,41 @@
+name: YouTrack notifier unit tests
+
+# Run on every change that could affect the fixed-notifier logic. The notifier
+# mutates the issue tracker after a deploy, but it only runs post-merge on the
+# integration pipeline, so its parsing/policy logic is otherwise untested in
+# CI — this job catches a regression on the PR, before it can mis-mark issues.
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - '.github/scripts/youtrack-fixed-notifier.py'
+      - '.github/scripts/youtrack-fixed-notifier-test.py'
+      - '.github/workflows/youtrack-notifier-tests.yml'
+  pull_request:
+    paths:
+      - '.github/scripts/youtrack-fixed-notifier.py'
+      - '.github/scripts/youtrack-fixed-notifier-test.py'
+      - '.github/workflows/youtrack-notifier-tests.yml'
+  # Allow manual re-runs (e.g. after a transient GitHub Actions outage)
+  # without having to push an empty commit.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # The is_ancestor test shells out to git against the checked-out repo,
+      # so a normal (shallow) checkout is required; HEAD is enough.
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Run unit tests
+        run: python3 .github/scripts/youtrack-fixed-notifier-test.py


### PR DESCRIPTION
## Summary

After the integration pipeline deploys an artifact, the YTDB issues fixed in that release are now transitioned automatically. A new `update-youtrack` job walks the commit range since the last successful deploy, extracts every `YTDB-<n>` reference from the commit titles (handling `YTDB-1:`, `[YTDB-1]`, and comma-separated pairs), and for each issue posts a "Fixed in `<version>`" comment and moves its State to Fixed.

Two supporting changes ride along: integration runs now queue behind a running build instead of cancelling it, and the notifier ships with a stand-alone self-test that runs in CI on every PR that touches it.

#### Motivation:

Marking fixed issues in YouTrack after a release was a manual step that drifted out of sync with what actually shipped. The new job keys the "already done" decision on YouTrack's own `isResolved` flag (resolved in the YTDB config) rather than a hardcoded state-name list, so a Verified/Closed issue is never re-opened and re-runs are idempotent. The job is push-only: a manual `workflow_dispatch` can deploy against an arbitrary commit, and the range math assumes the linear push history, so a dispatch must not mutate the tracker.

Separately, the pipeline used `cancel-in-progress: true` for every trigger, so a push landing during a running build killed that build and restarted from scratch. The in-flight run was wasted, and the restart could itself be cancelled by the next push, leaving `develop` without a completed run for a while. Concurrency is now trigger-dependent: pushes and the nightly schedule queue (`false`), while a manual dispatch still pre-empts (`true`). GitHub keeps one pending run per group, so a burst of pushes collapses to a single run against the `develop` tip.

Finally, a multi-dimensional review found the notifier's load-bearing logic untested and flagged a few reliability and security gaps; a follow-up Gemini review added four more (case-insensitive revert skip, robust header removal, request timeout, broader network-error handling). All were addressed before merge.

#### What changed:

- **`update-youtrack` job** (`maven-integration-tests-pipeline.yml`): runs after a successful deploy on `push`, diffs the range from the last successful deploy to the deployed SHA, and marks each referenced issue. Least-privilege (`contents: read`); inputs passed via env, not interpolated into the shell.
- **`youtrack-fixed-notifier.py`**: the marking logic. Skips the range cleanly unless the last-success boundary is a true ancestor (a rebased or garbage-collected SHA no longer crashes or diffs the wrong range), truncates API error bodies before they reach the public CI log, refuses a non-HTTPS base URL, and strips the `Authorization` header on a cross-host redirect so the token cannot leak. Every REST call carries a 30s timeout so an unresponsive YouTrack server fails the step fast instead of hanging the runner. A malformed payload, a rejected transition, or any network error (connection reset, DNS failure, timeout) degrades to one failed issue instead of aborting the batch. A revert commit (case-insensitive) does not re-mark the reverted issue.
- **`youtrack-fixed-notifier-test.py` + `youtrack-notifier-tests.yml`**: a stand-alone runner exercising the state parser, the `process_issue` raise-on-error contract, ID-extraction shapes, the `main()` exit-code paths, and the range guard, wired to run on every PR that touches the script.
- **Failure handling**: a sync failure fails the job loud and pages `ci status` on Zulip at low severity (`notify-youtrack-failure`). It deliberately does not dispatch the CI Fix Agent, since a token/API/rejected-transition failure is operational rather than a code bug, and it does not suppress the "build fixed" signal. A red run keeps the last-success boundary stale, so the next push retries the range with already-fixed issues skipping themselves.

#### Requirements:

A new `YOUTRACK_TOKEN` repository secret: a permanent token able to comment and change State on YTDB issues.

#### Testing:

`python3 .github/scripts/youtrack-fixed-notifier-test.py` passes locally (18 test functions, all checks green). The new `youtrack-notifier-tests.yml` workflow runs the same suite in CI.

