### PR TITLE
[YTDB-1035] Recalibrate context-window monitor thresholds for Opus 4.8

### DIFF
--- a/.claude/agents/review-workflow-context-budget.md
+++ b/.claude/agents/review-workflow-context-budget.md
@@ -34,7 +34,7 @@ Each Claude Code session in this repo automatically loads, at every turn:
 
 Anything outside that set is **load-on-demand**: skill body, agent body, workflow rule files, prompts under `.claude/workflow/prompts/`, docs under `.claude/docs/`, plan files, etc.
 
-The 1M-context Opus model has degradation thresholds at 20% (info), 30% (warning), 40% (critical) — see `CLAUDE.md` § Context Window Monitor. Every kilobyte added to the always-loaded surface accelerates the user reaching those thresholds.
+The 1M-context Opus model has degradation thresholds at 25% (info), 40% (warning), 50% (critical) — see `CLAUDE.md` § Context Window Monitor. Every kilobyte added to the always-loaded surface accelerates the user reaching those thresholds.
 
 ## Tooling
 
@@ -111,7 +111,7 @@ Peak tokens an orchestrator pulls into context when a workflow step fires. A dif
 ### Instant per-operation consumption
 The previous criteria target the always-loaded baseline. These target the *peak* an orchestrator hits when a workflow step fires.
 
-**Severity thresholds**, anchored to `CLAUDE.md` § Context Window Monitor (1M-context Opus, safe <20% / info 20% / warning 30% / critical 40%):
+**Severity thresholds**, anchored to `CLAUDE.md` § Context Window Monitor (1M-context Opus, safe <25% / info 25% / warning 40% / critical 50%):
 - **Critical**: a single new step pulls >30K tokens (~3000 lines) into the orchestrator without staging or delegation. One fire alone can push a fresh session past `warning`.
 - **Recommended**: 5–30K tokens (~500–3000 lines). Two or three fires accumulate to `warning`.
 - **Minor**: <5K tokens. Visible only over many fires; flag the pattern, not the line.

--- a/.claude/docs/context-monitor.md
+++ b/.claude/docs/context-monitor.md
@@ -15,14 +15,22 @@ The file is keyed by the `claude` process PID. The statusline walks up the proce
 
 ## Why these thresholds
 
-Calibrated for Claude Opus 4.7 on the 1M context window using published long-context retrieval data plus community Claude Code reports:
+Calibrated for Claude Opus 4.8 on the 1M context window, against the GraphWalks long-context benchmark. GraphWalks measures multi-hop reasoning over the whole context, the closest published proxy for agentic Claude Code work (which chains file paths, decisions, and conventions rather than retrieving one buried fact). The earlier Opus 4.7 bands were set against NIAH-style spot retrieval; every band moves up one notch here because Opus 4.8 degrades about half as fast on GraphWalks.
 
-- **Single-needle retrieval** holds at ~99% accuracy through 200K tokens, then drops to ~89% at 1M (Opus 4.7, NIAH-style benchmarks). Below 20% (≤200K) the model is essentially at full quality — no need to slow down.
-- **Multi-needle retrieval** (which agentic Claude Code work resembles, since it must recall multiple file paths, decisions, and conventions) drops from ~96% at 200K to ~56% at 1M for Opus 4.7. The published "effective context for production multi-needle workloads" sits in the **200–400K** band — this maps directly to the warning (300K) → critical (400K) boundary.
-- **Auto-compaction** triggers around 83–95% in Claude Code, but quality has already significantly degraded by then — the critical threshold fires well before that point so the session can be saved and restarted cleanly.
-- **Self-reported degradation** (Claude observing its own behavior in long Claude Code sessions): noticeable circular reasoning and forgotten earlier decisions begin around 40–50% on Opus 4.6 with the 1M window. Opus 4.7 improves long-context tracking (Anthropic's own claim: "most consistent long-context performance of any model tested"), but the underlying multi-needle drop curve hasn't been eliminated, so the critical 40% line stays put.
+The Opus 4.8 System Card (May 28, 2026, §8.9) reports long context only via GraphWalks, split into 256K and 1M subsets. The 256K point sits inside the old info→warning band, so the bands are fit to measured data rather than extrapolated from it.
 
-Sources: GitHub issue [anthropics/claude-code#34685](https://github.com/anthropics/claude-code/issues/34685); [Claude Opus 4.7 launch notes](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7); [Long-Context Retrieval 2026 (digitalapplied.com)](https://www.digitalapplied.com/blog/long-context-retrieval-needle-in-haystack-2026); community guides like spacecake.ai's Claude Code context management.
+GraphWalks F1:
+
+| Subset | 4.8 @256K | 4.8 @1M | 4.7 @256K | 4.7 @1M |
+|---|---|---|---|---|
+| BFS (hard) | 85.9 | 68.1 | 76.9 | 40.3 |
+| Parents | 99.3 | 83.3 | 93.6 | 56.6 |
+
+- **Slope halved.** On the hard BFS subset, Opus 4.7 loses 4.9 F1 points per 100K tokens across the 256K→1M span; Opus 4.8 loses 2.4, about half the decay rate, and scores higher at every measured point. Extrapolating Opus 4.7's steeper slope, Opus 4.8 at the full 1M window lands near Opus 4.7's quality at ~400K — the old critical line. The whole Opus 4.8 window is about as reliable as Opus 4.7's first 400K, so each band moves up one notch (info 20→25%, warning 30→40%, critical 40→50%). The one-band shift is conservative against what the slope-halving alone would justify.
+- **No retrieval-precision cliff.** A local multi-needle probe (10 distinct buried keys, exact-match grading, question placed after the haystack) scored 60/60 on both Opus 4.8 and 4.7 out to 82% of the window. Exact distinct-key recall, the analog of remembering a specific file path or config value, stays saturated well past the bands, so there is no separate retrieval cliff below the reasoning curve. This is why critical sits at 50% rather than a more cautious 45%. Scope: the probe covered distinct-key recall, not MRCR-style ordinal-instance disambiguation, at one trial per depth.
+- **Auto-compaction** triggers around 83–95% in Claude Code, by which point quality has already degraded badly. Critical (50%) fires far enough below that point to save and restart a session cleanly.
+
+Sources: Claude Opus 4.8 System Card, May 28, 2026 (§8.9 Long context: GraphWalks); local multi-needle retrieval probe (60/60 exact match across 408K / 640K / 819K, both models), recorded in YTDB-1035.
 
 ## Configuration
 

--- a/.claude/scripts/statusline-command.sh
+++ b/.claude/scripts/statusline-command.sh
@@ -36,11 +36,11 @@ build_bar() {
 # Determine threshold level. Also used for the on-disk usage file below.
 if [ -n "$used_pct" ]; then
   pct_int=$(printf "%.0f" "$used_pct")
-  if [ "$pct_int" -ge 40 ]; then
+  if [ "$pct_int" -ge 50 ]; then
     level="critical"
-  elif [ "$pct_int" -ge 30 ]; then
+  elif [ "$pct_int" -ge 40 ]; then
     level="warning"
-  elif [ "$pct_int" -ge 20 ]; then
+  elif [ "$pct_int" -ge 25 ]; then
     level="info"
   else
     level="safe"

--- a/.claude/skills/migrate-workflow/SKILL.md
+++ b/.claude/skills/migrate-workflow/SKILL.md
@@ -547,7 +547,9 @@ Then iterate. For each commit in the queue, in order:
 cat /tmp/claude-code-context-usage-$PPID.txt 2>/dev/null || echo "ctx: unknown"
 ```
 
-If the level is `warning` (≥30%) or `critical` (≥40%):
+The `level=` word in that output is authoritative — branch on it directly. The numeric band behind each level lives in `.claude/workflow/workflow.md` § Context Consumption Check; do not restate it here.
+
+If the level is `warning` or `critical`:
 
 1. Do NOT start the next commit.
 2. Report progress to the user: which commits are done, which is next, where the progress file lives.
@@ -556,7 +558,7 @@ If the level is `warning` (≥30%) or `critical` (≥40%):
 
 Reflection at Step 6 is deliberately skipped on this early-exit path to protect the already-tight context budget; the next session's reflection at Step 6 (once the migration completes successfully) reports this halt as friction.
 
-If `info` (`20% ≤ ctx < 30%`): continue, but delegate to sub-agents for any commit whose `git show --stat <sha>` shows either (a) more than 5 files touched under `.claude/workflow/` or `.claude/skills/`, or (b) total changed lines greater than 500. The trigger is derivable from `git show --stat` before the full diff is read into orchestrator context, so the delegation decision itself does not burn context.
+If `info`: continue, but delegate to sub-agents for any commit whose `git show --stat <sha>` shows either (a) more than 5 files touched under `.claude/workflow/` or `.claude/skills/`, or (b) total changed lines greater than 500. The trigger is derivable from `git show --stat` before the full diff is read into orchestrator context, so the delegation decision itself does not burn context.
 
 **Sub-agent contracts.** The orchestrator must interpolate `$ARGUMENTS` and per-commit values into the sub-agent prompt before launch; sub-agents inherit no conversation context and operate against the current worktree.
 
@@ -569,7 +571,7 @@ If `info` (`20% ≤ ctx < 30%`): continue, but delegate to sub-agents for any co
 
 This is a docs-only migration: sub-agents should use `git show`, `Read`, and `Grep`; mcp-steroid PSI is not required.
 
-If `safe` (`ctx < 20%`): continue normally. The `ctx: unknown` fallback (file missing or `$PPID` resolution failed) is treated as `safe` — the file is best-effort, not load-bearing.
+If `safe`: continue normally. The `ctx: unknown` fallback (file missing or `$PPID` resolution failed) is treated as `safe` — the file is best-effort, not load-bearing.
 
 ### 4.2 Read the commit
 <!-- roles=migrator phases=any summary="Read the commit's diff and message to determine what workflow-format change it introduced." -->

--- a/.claude/workflow/implementation-review.md
+++ b/.claude/workflow/implementation-review.md
@@ -266,7 +266,7 @@ rework the plan/design before re-entering.
 **Context consumption check** (mandatory between consistency review,
 structural review, and any iteration boundary, except after the final
 gate-PASS commit): run `cat /tmp/claude-code-context-usage-$PPID.txt`.
-If the level is `warning` (≥30%) or `critical` (≥40%), do NOT start
+If the level is `warning` (≥40%) or `critical` (≥50%), do NOT start
 the next review or iteration. Save all work and ask the user for a
 session refresh (see `workflow.md` §Context Consumption Check). If the
 pause leaves State 0 mid-flight (for example, consistency review

--- a/.claude/workflow/mid-phase-handoff.md
+++ b/.claude/workflow/mid-phase-handoff.md
@@ -44,8 +44,8 @@ Loaded on-demand by:
 ## When this protocol fires
 <!-- roles=orchestrator,planner phases=0,1,2,3A,3B,3C,4 summary="Fire a handoff at warning/critical context when WIP has not yet landed in durable files; examples and counter-examples." -->
 
-Trigger: a context-consumption check returns `warning` (≥30%) or
-`critical` (≥40%) **and** either
+Trigger: a context-consumption check returns `warning` (≥40%) or
+`critical` (≥50%) **and** either
 
 - the user asks to pause, or
 - the current phase boundary has not yet landed in the durable

--- a/.claude/workflow/prompts/create-final-design.md
+++ b/.claude/workflow/prompts/create-final-design.md
@@ -204,7 +204,7 @@ Rules (these are enforced by the discipline; listed here for orientation):
 **Context consumption check between artifacts.** After
 `design-final.md` is written and committed, run
 `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
-`warning` (≥30%) or `critical` (≥40%), do NOT start `adr.md`. Save
+`warning` (≥40%) or `critical` (≥50%), do NOT start `adr.md`. Save
 all work and ask the user for a session refresh (see
 `workflow.md` §Context Consumption Check). Write a handoff file at
 `docs/adr/<dir-name>/_workflow/handoff-phase4.md` per

--- a/.claude/workflow/track-code-review.md
+++ b/.claude/workflow/track-code-review.md
@@ -588,7 +588,7 @@ orchestrator never edits source files itself in Phase C.
    - **Context consumption check** (mandatory after each iteration,
      except the last): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
-     `warning` (≥30%) or `critical` (≥40%), do NOT start the next
+     `warning` (≥40%) or `critical` (≥50%), do NOT start the next
      iteration. Save all work (update Progress section with current
      iteration count, commit) and ask the user for a session refresh
      (see workflow.md:any,final-designer,orchestrator,planner:any,2,3A,3B,3C,4 §Context Consumption Check). If the pause leaves

--- a/.claude/workflow/track-review.md
+++ b/.claude/workflow/track-review.md
@@ -514,7 +514,7 @@ review-mode rounds.
    - **Context consumption check** (mandatory after each review, except
      after the last action of the phase): run
      `cat /tmp/claude-code-context-usage-$PPID.txt`. If the level is
-     `warning` (≥30%) or `critical` (≥40%), do NOT start the next review
+     `warning` (≥40%) or `critical` (≥50%), do NOT start the next review
      or decomposition. Save all work and ask the user for a session
      refresh (see `workflow.md` §Context Consumption Check). If the pause
      leaves Phase A mid-flight (for example, technical review PASSed

--- a/.claude/workflow/workflow.md
+++ b/.claude/workflow/workflow.md
@@ -347,7 +347,7 @@ exactly one phase:
   plan, end the session. The next session starts fresh with the revised plan.
 
 - **Context consumption too high** — if an active context check (see
-  §Context Consumption Check below) shows usage at `warning` level (≥30%)
+  §Context Consumption Check below) shows usage at `warning` level (≥40%)
   or above, finish the current unit of work, save progress, and end the
   session.
 
@@ -372,10 +372,10 @@ The output looks like: `ctx: 7% level=safe`
 
 | Level | Trigger | Action |
 |---|---|---|
-| `safe` | <20% | Continue normally. |
-| `info` | 20–29% | Continue, but prefer delegating exploration to sub-agents and avoid reading large files. |
-| `warning` | 30–39% | **Do not start next unit of work.** Save progress and ask for session refresh. |
-| `critical` | ≥40% | **Do not start next unit of work.** Save progress and ask for session refresh. |
+| `safe` | <25% | Continue normally. |
+| `info` | 25–39% | Continue, but prefer delegating exploration to sub-agents and avoid reading large files. |
+| `warning` | 40–49% | **Do not start next unit of work.** Save progress and ask for session refresh. |
+| `critical` | ≥50% | **Do not start next unit of work.** Save progress and ask for session refresh. |
 
 **If the file does not exist or the command fails**, treat as `safe` and
 continue normally — the statusline script may not have written the file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,21 +240,24 @@ Output example: `ctx: 7% level=safe`
 
 | Level | Trigger | What it means |
 |---|---|---|
-| **safe** | <20% | Plenty of room. |
-| **info** | 20% (~200K of 1M) | Context growing. Delegate exploration to subagents, avoid reading large files, write decisions to files. |
-| **warning** | 30% (~300K of 1M) | Quality degradation likely. Save state to files, run `/compact` with key context, or delegate remaining work to subagents. |
-| **critical** | 40% (~400K of 1M) | Severe degradation. Stop immediately, save all state to `/tmp/claude-code-session-state.md`, tell the user to `/clear` and resume. |
+| **safe** | <25% | Plenty of room. |
+| **info** | 25% (~250K of 1M) | Context growing. Delegate exploration to subagents, avoid reading large files, write decisions to files. |
+| **warning** | 40% (~400K of 1M) | Quality degradation likely. Save state to files, run `/compact` with key context, or delegate remaining work to subagents. |
+| **critical** | 50% (~500K of 1M) | Severe degradation. Stop immediately, save all state to `/tmp/claude-code-session-state.md`, tell the user to `/clear` and resume. |
 
-For the threshold rationale (Opus 4.7 retrieval data, calibration sources), statusline implementation, session isolation, and configuration paths: see `.claude/docs/context-monitor.md`.
+For the threshold rationale (Opus 4.8 GraphWalks data, calibration sources), statusline implementation, session isolation, and configuration paths: see `.claude/docs/context-monitor.md`.
 
 The thresholds in this section MUST stay in sync with:
 - `.claude/scripts/statusline-command.sh` — the line that writes `level=...`
+- `.claude/docs/context-monitor.md` — § Why these thresholds (the GraphWalks calibration rationale that cites the band numbers)
 - `.claude/workflow/workflow.md` — § Context Consumption Check (the level table)
-- `.claude/workflow/track-review.md` and `.claude/workflow/track-code-review.md` — the inline "warning (≥30%) or critical (≥40%)" gates
+- `.claude/workflow/track-review.md` and `.claude/workflow/track-code-review.md` — the inline "warning (≥40%) or critical (≥50%)" gates
 - `.claude/workflow/implementation-review.md` — the State 0 inline gate
-- `.claude/workflow/step-implementation.md` — the Phase B inline gate
+- `.claude/workflow/step-implementation.md` — the Phase B inline gate (symbolic `warning`/`critical`, no numbers — does not move when the bands move, but verify it stays threshold-agnostic)
 - `.claude/workflow/prompts/create-final-design.md` — the Phase 4 inline gate
 - `.claude/workflow/mid-phase-handoff.md` — § When this protocol fires (defines the trigger thresholds)
+- `.claude/agents/review-workflow-context-budget.md` — the budget-review agent's severity-threshold anchor (two inline references to the band numbers)
+- `.claude/skills/migrate-workflow/SKILL.md` — § 4.1 Context check inline gate (symbolic `warning`/`critical`/`info`/`safe`, no numbers — does not move when the bands move, but verify it stays threshold-agnostic)
 
 If you change a threshold here, grep for the others and update them in the same commit.
 


### PR DESCRIPTION
#### Motivation

The context-window monitor's degradation bands were calibrated for Opus 4.7 against NIAH-style spot retrieval. Opus 4.8 holds long-context quality far better: on GraphWalks (the System Card's only long-context benchmark, §8.9) it loses about half the F1 per 100K tokens that 4.7 does, and a local multi-needle probe scored 60/60 exact-match on both models out to 82% of the window. The old 20/30/40 bands would pause sessions and force refreshes far earlier than the model's quality curve warrants, wasting usable context.

This raises each band one notch (info 20→25%, warning 30→40%, critical 40→50%) so a session runs to a realistic budget before the gates fire, while still pausing well before auto-compaction (83–95%) degrades quality. The shift is one band, conservative against what the slope-halving alone would justify.

#### What changed

- Thresholds updated to 25/40/50 across every synced location: the statusline script, the `CLAUDE.md` and `workflow.md` band tables, the inline phase gates (`track-review`, `track-code-review`, `implementation-review`, `create-final-design`, `mid-phase-handoff`), and the budget-review agent's severity anchors.
- `.claude/docs/context-monitor.md` § Why these thresholds rewritten with the GraphWalks rationale, the F1 data table, and the multi-needle-probe result.
- Two previously-untracked files that hard-coded the bands (the budget-review agent and the migrate-workflow skill) are updated and added to `CLAUDE.md`'s sync list.
- `migrate-workflow` §4.1 now branches on the `level=` word alone, with a single pointer to the `workflow.md` table, instead of carrying its own copy of the numbers, so it stays threshold-agnostic on future recalibrations. `step-implementation.md` was already symbolic and needed no numeric edit.

#### Follow-up

- Orphan per-PID statusline usage files accumulating in `/tmp` is tracked separately in [YTDB-1044](https://youtrack.jetbrains.com/issue/YTDB-1044).

#### Testing

Workflow-machinery only: no Java code or tests changed. Verified the statusline ladder empirically (24.6→info, 39.6→warning, 49.6→critical, no fall-through), confirmed four-way numeric agreement across the band tables and the shell script, and ran a `/code-review` pass (all six workflow-review agents) that is now clean.
