### PR TITLE
Add per-worktree project cost to the statusline

### DIFF
--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -6,10 +6,25 @@ Output (single line, second line of the statusline):
 
   $0.123 (mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  r/5m:5.7x r/1h:-
 
+When invoked with `--worktree` (the statusline adds it whenever the cwd is a
+linked git worktree) a third cost figure for the current worktree's project
+is inserted before the month figure:
+
+  $0.123 (wt:$1.85 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  …
+
 The current session aggregates the orchestrator transcript plus every
-sub-agent transcript under <transcript-stem>/subagents/. The monthly figure
-sums every JSONL transcript anywhere under ~/.claude/projects whose records
-fall in the current calendar month.
+sub-agent transcript under <transcript-stem>/subagents/. The worktree-project
+figure (`wt:`) aggregates *every* session transcript that lives next to the
+current one — i.e. all sessions under ~/.claude/projects/<cwd-slug>/. Because
+a git worktree has its own cwd, it maps to its own project directory, so this
+figure is the cumulative spend of the current worktree across every session
+run in it. The monthly figure sums every JSONL transcript anywhere under
+~/.claude/projects whose records fall in the current calendar month.
+
+With `--worktree-cost-file PATH` the worktree-project cost is also written to
+PATH (the statusline points this at /tmp/claude-code-worktree-cost-<pid>.txt,
+mirroring the context-usage file) so the model can read the running spend on
+the current worktree on demand.
 
 Two non-obvious mechanics, both required to match ccusage:
 
@@ -181,6 +196,31 @@ def _atomic_write_json(target, payload):
     try:
         with os.fdopen(fd, "w") as f:
             json.dump(payload, f)
+    except Exception:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    os.replace(tmp, target)
+
+
+def _atomic_write_text(target, text):
+    """Atomically write plain `text` to `target` (per-process temp + O_NOFOLLOW
+    0600), mirroring `_atomic_write_json`'s safety properties.
+
+    Used for the worktree-cost publish file. The target lives in /tmp, which is
+    world-writable, so the same defences apply: a per-pid temp name avoids torn
+    interleaving between two concurrent renders, O_NOFOLLOW refuses to open a
+    symlink planted at the temp path, and `os.replace` renames over any symlink
+    at the target without following it. Caller ensures `target.parent` exists.
+    """
+    tmp = target.parent / f"{target.name}.{os.getpid()}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(tmp, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
     except Exception:
         try:
             tmp.unlink()
@@ -455,6 +495,30 @@ def session_totals(transcript_path):
     return _sum_records(merged)
 
 
+def project_totals(transcript_path):
+    """Aggregate every transcript in the current project's directory, deduped.
+
+    The project directory is the parent of the session transcript —
+    ~/.claude/projects/<cwd-slug>/. A recursive glob picks up both the
+    top-level <uuid>.jsonl session files and the nested
+    <uuid>/subagents/agent-*.jsonl sub-agent files; the (msg_id, requestId)
+    dedup in `_sum_records` collapses records shared across them.
+
+    Because a git worktree has its own cwd, it gets its own project directory,
+    so summing this directory yields the cumulative cost of the current
+    worktree across every session ever run in it — not just the live one.
+    """
+    p = pathlib.Path(transcript_path).expanduser()
+    proj_dir = p.parent
+    if not proj_dir.is_dir():
+        return _zero()
+    merged = {}
+    for jsonl in proj_dir.rglob("*.jsonl"):
+        for k, v in aggregate_file(jsonl).items():
+            merged.setdefault(k, v)  # first-wins dedup
+    return _sum_records(merged)
+
+
 def month_totals():
     """Sum every record across all projects whose UTC timestamp is this month.
 
@@ -504,39 +568,90 @@ def fmt_ratio(read, write):
     return f"{read / write:.1f}x"
 
 
-def main():
-    if len(sys.argv) < 2 or not sys.argv[1]:
-        return 0
-    transcript = sys.argv[1]
-    try:
-        sess = session_totals(transcript)
-        month = month_totals()
-    except Exception as exc:  # noqa: BLE001 — never break the statusline
-        print(f"stats error: {exc}", file=sys.stderr)
-        return 0
+def parse_args(argv):
+    """Parse the helper's CLI into (transcript, show_worktree, wt_cost_file).
 
-    # Distinct colours for the two cost figures so they're tellable apart at
-    # a glance: bright cyan = current session (active), bright magenta = month
-    # so far (cumulative). Deliberately avoiding red / yellow / green — those
-    # are reserved for the context-fill bar in statusline-command.sh
-    # (critical / warning / safe). Honour NO_COLOR for non-TTY consumers.
-    if os.environ.get("NO_COLOR"):
-        sess_open = sess_close = mo_open = mo_close = ""
+    Positional arg 0 is the transcript path. `--worktree` turns on the `wt:`
+    figure; `--worktree-cost-file PATH` additionally publishes the cost to
+    PATH and implies `--worktree` (asking to write the file means we need it).
+    """
+    transcript = argv[0] if argv else ""
+    show_worktree = "--worktree" in argv
+    wt_cost_file = None
+    if "--worktree-cost-file" in argv:
+        i = argv.index("--worktree-cost-file")
+        if i + 1 < len(argv):
+            wt_cost_file = argv[i + 1]
+    if wt_cost_file:
+        show_worktree = True
+    return transcript, show_worktree, wt_cost_file
+
+
+def format_stats_line(sess, month, proj=None, no_color=False):
+    """Render the second statusline row.
+
+    When `proj` is given (worktree mode) a `wt:$X` figure for the current
+    worktree's project is inserted ahead of the month figure.
+
+    Distinct colours so the cost figures are tellable apart at a glance:
+    bright cyan = current session (active), bright blue = this worktree's
+    project (cumulative), bright magenta = calendar month across all projects.
+    Deliberately avoiding red / yellow / green — those are reserved for the
+    context-fill bar in statusline-command.sh (critical / warning / safe).
+    Honour NO_COLOR for non-TTY consumers.
+    """
+    if no_color or os.environ.get("NO_COLOR"):
+        sess_open = sess_close = mo_open = mo_close = wt_open = wt_close = ""
     else:
-        sess_open = "\033[1;36m"   # bright cyan
-        mo_open = "\033[1;35m"     # bright magenta
-        sess_close = mo_close = "\033[0m"
+        sess_open = "\033[1;36m"   # bright cyan    — current session
+        wt_open = "\033[1;34m"     # bright blue    — this worktree's project
+        mo_open = "\033[1;35m"     # bright magenta — calendar month, all projects
+        sess_close = mo_close = wt_close = "\033[0m"
 
-    line = (
+    if proj is not None:
+        scope = (
+            f"(wt:{wt_open}${proj['cost']:.2f}{wt_close} "
+            f"mo:{mo_open}${month['cost']:.2f}{mo_close})"
+        )
+    else:
+        scope = f"(mo:{mo_open}${month['cost']:.2f}{mo_close})"
+
+    return (
         f"{sess_open}${sess['cost']:.3f}{sess_close} "
-        f"(mo:{mo_open}${month['cost']:.2f}{mo_close})  "
+        f"{scope}  "
         f"in:{fmt_tokens(sess['in'])} out:{fmt_tokens(sess['out'])} "
         f"read:{fmt_tokens(sess['read'])} w5m:{fmt_tokens(sess['w5'])} "
         f"w1h:{fmt_tokens(sess['w1'])}  "
         f"r/5m:{fmt_ratio(sess['read'], sess['w5'])} "
         f"r/1h:{fmt_ratio(sess['read'], sess['w1'])}"
     )
-    print(line)
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    if not argv or not argv[0]:
+        return 0
+    transcript, show_worktree, wt_cost_file = parse_args(argv)
+    try:
+        sess = session_totals(transcript)
+        month = month_totals()
+        proj = project_totals(transcript) if show_worktree else None
+    except Exception as exc:  # noqa: BLE001 — never break the statusline
+        print(f"stats error: {exc}", file=sys.stderr)
+        return 0
+
+    # Publish the worktree-project cost to a per-session file for on-demand
+    # reading by the model (mirrors the context-usage file the statusline
+    # writes). Best-effort — a write failure must never break the statusline.
+    if wt_cost_file and proj is not None:
+        try:
+            _atomic_write_text(
+                pathlib.Path(wt_cost_file), f"wt_cost: ${proj['cost']:.2f}"
+            )
+        except OSError:
+            pass
+
+    print(format_stats_line(sess, month, proj))
     return 0
 
 

--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -219,7 +219,7 @@ def _atomic_write_text(target, text):
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
     fd = os.open(tmp, flags, 0o600)
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(text)
     except Exception:
         try:
@@ -509,6 +509,12 @@ def project_totals(transcript_path):
     worktree across every session ever run in it — not just the live one.
     """
     p = pathlib.Path(transcript_path).expanduser()
+    # Mirror session_totals: short-circuit a non-existent transcript before the
+    # rglob below. Without this, a path whose *parent* exists (e.g. a stale or
+    # relative path resolving to /tmp/x.jsonl) would recursively scan that whole
+    # parent directory for *.jsonl files.
+    if not p.exists():
+        return _zero()
     proj_dir = p.parent
     if not proj_dir.is_dir():
         return _zero()

--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -648,7 +648,7 @@ def main(argv=None):
             _atomic_write_text(
                 pathlib.Path(wt_cost_file), f"wt_cost: ${proj['cost']:.2f}"
             )
-        except OSError:
+        except Exception:  # noqa: BLE001 — publish is best-effort; never break the statusline
             pass
 
     print(format_stats_line(sess, month, proj))

--- a/.claude/scripts/statusline-command.sh
+++ b/.claude/scripts/statusline-command.sh
@@ -5,6 +5,12 @@
 # /tmp/claude-code-context-usage-<claude_pid>.txt so the model can read it
 # on demand via Bash. Wired up via .claude/settings.json `statusLine`.
 # Threshold rationale: see CLAUDE.md § Context Window Monitor.
+#
+# When the cwd is a *linked* git worktree, the second (cost) line gains a
+# `wt:$X` figure for the spend on the current worktree's project, and that
+# cost is also written to /tmp/claude-code-worktree-cost-<claude_pid>.txt for
+# on-demand reading (the worktree figure and file are produced by
+# session-stats.py — this script only detects the worktree and passes flags).
 
 input=$(cat)
 
@@ -31,6 +37,27 @@ build_bar() {
   for (( i=0; i<filled; i++ )); do bar="${bar}#"; done
   for (( i=0; i<empty; i++ )); do bar="${bar}-"; done
   printf "%s" "$bar"
+}
+
+# Walk up the process tree to the root `claude` process PID — the same key the
+# model uses via $PPID from its Bash tool. This PID names both the on-disk
+# context-usage file and the worktree-cost file. Uses `ps` (portable across
+# Linux/macOS) rather than /proc (Linux-only). Echoes the PID, or nothing if
+# the walk hits PID 1 without finding `claude`. ($$ is the script shell's PID
+# and stays stable inside this command-substitution call.)
+resolve_claude_pid() {
+  local pid=$$ ps_out ppid comm comm_base
+  while [ "$pid" -gt 1 ] 2>/dev/null; do
+    ps_out=$(ps -p "$pid" -o ppid=,comm= 2>/dev/null)
+    [ -z "$ps_out" ] && break
+    ppid=$(printf "%s" "$ps_out" | awk '{print $1}')
+    comm=$(printf "%s" "$ps_out" | awk '{print $2}')
+    # macOS ps prints comm as a full path; strip to basename for the match.
+    comm_base=$(basename "$comm" 2>/dev/null)
+    if [ "$comm_base" = "claude" ]; then printf "%s" "$pid"; return 0; fi
+    pid=$ppid
+  done
+  return 0
 }
 
 # Determine threshold level. Also used for the on-disk usage file below.
@@ -65,26 +92,31 @@ else
   ctx_str="[----------] --%"
 fi
 
+# Resolve the root claude PID once — it keys both per-session /tmp files below.
+claude_pid=$(resolve_claude_pid)
+
 # Write context usage to a per-session file for on-demand reading by the model.
-# Walk up the process tree to find the root `claude` process PID — same key
-# the model uses via $PPID from its Bash tool. Uses `ps` (portable across
-# Linux/macOS) rather than /proc (Linux-only).
-if [ -n "$used_pct" ]; then
-  claude_pid=""
-  pid=$$
-  while [ "$pid" -gt 1 ] 2>/dev/null; do
-    ps_out=$(ps -p "$pid" -o ppid=,comm= 2>/dev/null)
-    [ -z "$ps_out" ] && break
-    ppid=$(printf "%s" "$ps_out" | awk '{print $1}')
-    comm=$(printf "%s" "$ps_out" | awk '{print $2}')
-    # macOS ps prints comm as a full path; strip to basename for the match.
-    comm_base=$(basename "$comm" 2>/dev/null)
-    if [ "$comm_base" = "claude" ]; then claude_pid=$pid; break; fi
-    pid=$ppid
-  done
-  if [ -n "$claude_pid" ]; then
-    printf "ctx: %s%% level=%s" "$pct_int" "$level" \
-      > "/tmp/claude-code-context-usage-${claude_pid}.txt"
+if [ -n "$used_pct" ] && [ -n "$claude_pid" ]; then
+  printf "ctx: %s%% level=%s" "$pct_int" "$level" \
+    > "/tmp/claude-code-context-usage-${claude_pid}.txt"
+fi
+
+# Detect a *linked* git worktree: its git-dir lives under <common>/worktrees/,
+# so the resolved --git-dir differs from --git-common-dir. The main checkout
+# has them equal. Both are resolved to physical absolute paths so a relative
+# ".git" (returned at a main checkout's root) compares equal to its absolute
+# form — only a linked worktree ends up differing. When detected, the cost
+# line gains the per-worktree-project figure.
+is_worktree=0
+if [ -n "$cwd" ]; then
+  wt_gitdir=$(git -C "$cwd" rev-parse --git-dir 2>/dev/null)
+  wt_common=$(git -C "$cwd" rev-parse --git-common-dir 2>/dev/null)
+  if [ -n "$wt_gitdir" ] && [ -n "$wt_common" ]; then
+    gd_abs=$( cd "$cwd" 2>/dev/null && cd "$wt_gitdir" 2>/dev/null && pwd -P )
+    cd_abs=$( cd "$cwd" 2>/dev/null && cd "$wt_common" 2>/dev/null && pwd -P )
+    if [ -n "$gd_abs" ] && [ -n "$cd_abs" ] && [ "$gd_abs" != "$cd_abs" ]; then
+      is_worktree=1
+    fi
   fi
 fi
 
@@ -96,11 +128,20 @@ else
 fi
 
 # Second line: cost (current session + calendar month) and per-session token
-# totals across orchestrator + sub-agents. Best-effort — never break the
-# primary status line if the helper errors out.
+# totals across orchestrator + sub-agents. In a linked worktree, also pass the
+# per-worktree-project figure (--worktree) and publish its cost to a /tmp file
+# (--worktree-cost-file). Best-effort — never break the primary status line if
+# the helper errors out.
 if [ -n "$transcript_path" ]; then
   script_dir=$(dirname "$0")
-  stats_line=$(python3 "${script_dir}/session-stats.py" "$transcript_path" 2>/dev/null)
+  stats_args=("$transcript_path")
+  if [ "$is_worktree" -eq 1 ]; then
+    stats_args+=(--worktree)
+    if [ -n "$claude_pid" ]; then
+      stats_args+=(--worktree-cost-file "/tmp/claude-code-worktree-cost-${claude_pid}.txt")
+    fi
+  fi
+  stats_line=$(python3 "${script_dir}/session-stats.py" "${stats_args[@]}" 2>/dev/null)
   if [ -n "$stats_line" ]; then
     printf "\n%s" "$stats_line"
   fi

--- a/.claude/scripts/tests/test_session_stats.py
+++ b/.claude/scripts/tests/test_session_stats.py
@@ -296,6 +296,23 @@ def test_project_totals_missing_dir_is_zero() -> None:
     assert out == MODULE._zero(), out
 
 
+def test_project_totals_nonexistent_transcript_does_not_scan_parent() -> None:
+    """A non-existent transcript whose *parent* directory exists must yield zero
+    without recursively scanning that parent. Regression for a footgun where
+    project_totals only checked parent.is_dir(): a path like /tmp/nonexistent.jsonl
+    would have rglob'd all of /tmp. A decoy .jsonl carrying real usage sits in the
+    parent; if the parent were scanned the total would be non-zero, so asserting
+    zero proves the parent was never walked."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp) / "cache"
+        proj = Path(tmp) / "project"
+        proj.mkdir()
+        write_jsonl(proj / "decoy.jsonl", [_assistant_usage("m1", "r1", in_t=1_000_000)])
+        with _patched(CACHE_DIR=cache):
+            out = MODULE.project_totals(str(proj / "nonexistent.jsonl"))
+        assert out == MODULE._zero(), out
+
+
 # ---------------------------------------------------------------------------
 # _atomic_write_text.
 # ---------------------------------------------------------------------------
@@ -379,6 +396,7 @@ def main() -> int:
         ("format line NO_COLOR env respected", test_format_line_no_color_env_respected),
         ("project_totals sessions + subagents deduped", test_project_totals_aggregates_sessions_and_subagents),
         ("project_totals missing dir -> zero", test_project_totals_missing_dir_is_zero),
+        ("project_totals nonexistent file w/ existing parent -> zero", test_project_totals_nonexistent_transcript_does_not_scan_parent),
         ("atomic_write_text writes + overwrites", test_atomic_write_text_writes_and_overwrites),
         ("main worktree writes file + shows wt", test_main_worktree_writes_cost_file_and_shows_wt),
         ("main no worktree omits wt + no file", test_main_no_worktree_omits_wt_and_writes_no_file),

--- a/.claude/scripts/tests/test_session_stats.py
+++ b/.claude/scripts/tests/test_session_stats.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Validation runner for `.claude/scripts/session-stats.py`.
+
+Running this script is the validation: it imports the stats helper as a module
+and exercises the worktree-project additions — CLI parsing of `--worktree` /
+`--worktree-cost-file`, the rendered cost line with and without the `wt:`
+figure, the recursive project aggregation (sessions + sub-agents, deduped by
+(msg_id, requestId)), the atomic plain-text publish file, and `main`'s
+end-to-end behaviour (file written only in worktree mode, `wt:` present/absent
+on the line accordingly).
+
+Invocation (from repo root):
+
+    python3 .claude/scripts/tests/test_session_stats.py
+
+Exit code 0: every test case passed. Exit code 1: one or more failed; each
+failure prints a clear message naming the test case.
+
+Runner shape mirrors `.claude/scripts/tests/test_measure_read_share.py`
+(stand-alone, no pytest collection, exit-code semantics, single file). Pytest
+is not installed on the project's CI image; the stand-alone runner keeps the
+test executable on any Python 3 host.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / ".claude" / "scripts" / "session-stats.py"
+
+
+# ---------------------------------------------------------------------------
+# Module loader. The dash in the filename blocks `import`, so load directly.
+# ---------------------------------------------------------------------------
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("session_stats", str(SCRIPT_PATH))
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to load module spec for {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["session_stats"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = load_module()
+
+# Use the offline fallback price table exclusively so costs are deterministic
+# regardless of network / on-disk LiteLLM cache state. claude-opus-4-7 in the
+# fallback table is $5.00 / 1M input tokens, which the fixtures rely on.
+MODULE._LIVE_PRICES = {}
+MODEL = "claude-opus-4-7"
+USD_PER_1M_IN = MODULE.FALLBACK_PRICES[MODEL]["in"]  # 5.0
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders.
+# ---------------------------------------------------------------------------
+
+
+def _assistant_usage(
+    msg_id: str,
+    req_id: str,
+    *,
+    ts: str = "2026-06-01T12:00:00.000Z",
+    model: str = MODEL,
+    in_t: int = 0,
+    out_t: int = 0,
+    read_t: int = 0,
+    w5: int = 0,
+    w1: int = 0,
+) -> dict:
+    """An assistant record carrying a usage block, the shape session-stats reads.
+
+    Both `message.id` and top-level `requestId` are present because the helper
+    drops any record missing either (it cannot dedup it safely)."""
+    usage = {
+        "input_tokens": in_t,
+        "output_tokens": out_t,
+        "cache_read_input_tokens": read_t,
+        "cache_creation": {
+            "ephemeral_5m_input_tokens": w5,
+            "ephemeral_1h_input_tokens": w1,
+        },
+    }
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "requestId": req_id,
+        "message": {"id": msg_id, "model": model, "usage": usage},
+    }
+
+
+def write_jsonl(path: Path, records: List[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _totals(cost: float, **toks) -> dict:
+    """A totals dict shaped like `_zero()` with a chosen cost + token fields."""
+    base = MODULE._zero()
+    base["cost"] = cost
+    base.update(toks)
+    return base
+
+
+@contextlib.contextmanager
+def _patched(**attrs):
+    """Temporarily set MODULE attributes (e.g. CACHE_DIR, totals fns), restore."""
+    saved = {k: getattr(MODULE, k) for k in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(MODULE, k, v)
+        yield
+    finally:
+        for k, v in saved.items():
+            setattr(MODULE, k, v)
+
+
+@contextlib.contextmanager
+def _env(name: str, value: Optional[str]):
+    """Temporarily set (value != None) or unset (value is None) an env var."""
+    had = name in os.environ
+    prev = os.environ.get(name)
+    try:
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+        yield
+    finally:
+        if had:
+            os.environ[name] = prev  # type: ignore[arg-type]
+        else:
+            os.environ.pop(name, None)
+
+
+def _approx(a: float, b: float, tol: float = 1e-9) -> bool:
+    return abs(a - b) < tol
+
+
+# ---------------------------------------------------------------------------
+# Test runner.
+# ---------------------------------------------------------------------------
+
+
+_FAILURES: List[Tuple[str, str]] = []
+
+
+def run_test(name: str, fn: Callable[[], None]) -> None:
+    try:
+        fn()
+        print(f"  PASS  {name}")
+    except AssertionError as exc:
+        print(f"  FAIL  {name}: {exc}", file=sys.stderr)
+        _FAILURES.append((name, str(exc)))
+    except Exception:
+        tb = traceback.format_exc()
+        print(f"  ERROR {name}:\n{tb}", file=sys.stderr)
+        _FAILURES.append((name, tb))
+
+
+# ---------------------------------------------------------------------------
+# parse_args.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_plain() -> None:
+    """No flags: worktree off, no cost file."""
+    transcript, show, wt_file = MODULE.parse_args(["t.jsonl"])
+    assert transcript == "t.jsonl", transcript
+    assert show is False and wt_file is None, (show, wt_file)
+
+
+def test_parse_args_worktree_flag() -> None:
+    """`--worktree` turns the figure on without requesting a file."""
+    _, show, wt_file = MODULE.parse_args(["t.jsonl", "--worktree"])
+    assert show is True and wt_file is None, (show, wt_file)
+
+
+def test_parse_args_cost_file_implies_worktree() -> None:
+    """`--worktree-cost-file PATH` captures the path and implies `--worktree`."""
+    _, show, wt_file = MODULE.parse_args(
+        ["t.jsonl", "--worktree-cost-file", "/tmp/wt.txt"]
+    )
+    assert show is True, "cost file should imply worktree display"
+    assert wt_file == "/tmp/wt.txt", wt_file
+
+
+def test_parse_args_cost_file_missing_value() -> None:
+    """A trailing `--worktree-cost-file` with no path does not crash or set it."""
+    _, show, wt_file = MODULE.parse_args(["t.jsonl", "--worktree-cost-file"])
+    assert wt_file is None, wt_file
+    assert show is False, show
+
+
+# ---------------------------------------------------------------------------
+# format_stats_line.
+# ---------------------------------------------------------------------------
+
+
+def test_format_line_no_worktree_exact() -> None:
+    """Without a project total the line keeps the original `(mo:$…)` shape."""
+    sess = _totals(0.123, **{"in": 1200, "out": 8000, "read": 230000, "w5": 40000, "w1": 0})
+    month = _totals(4.56)
+    line = MODULE.format_stats_line(sess, month, proj=None, no_color=True)
+    expected = (
+        "$0.123 (mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
+        "r/5m:5.8x r/1h:-"
+    )
+    assert line == expected, f"\n got: {line}\nwant: {expected}"
+
+
+def test_format_line_with_worktree_exact() -> None:
+    """A project total inserts `wt:$…` immediately before the month figure."""
+    sess = _totals(0.123, **{"in": 1200, "out": 8000, "read": 230000, "w5": 40000, "w1": 0})
+    month = _totals(4.56)
+    proj = _totals(1.85)
+    line = MODULE.format_stats_line(sess, month, proj=proj, no_color=True)
+    expected = (
+        "$0.123 (wt:$1.85 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
+        "r/5m:5.8x r/1h:-"
+    )
+    assert line == expected, f"\n got: {line}\nwant: {expected}"
+
+
+def test_format_line_no_color_has_no_ansi() -> None:
+    """no_color=True strips every ANSI escape even if NO_COLOR is unset."""
+    with _env("NO_COLOR", None):
+        line = MODULE.format_stats_line(_totals(1.0), _totals(2.0), proj=_totals(3.0), no_color=True)
+    assert "\033" not in line, "expected no ANSI escapes under no_color"
+
+
+def test_format_line_colours_when_enabled() -> None:
+    """With colour on, the worktree figure uses the distinct bright-blue code
+    (34) and the existing session/month codes are still present."""
+    with _env("NO_COLOR", None):
+        line = MODULE.format_stats_line(_totals(1.0), _totals(2.0), proj=_totals(3.0), no_color=False)
+    assert "\033[1;34m" in line, "worktree figure should be bright blue"
+    assert "\033[1;36m" in line, "session figure should be bright cyan"
+    assert "\033[1;35m" in line, "month figure should be bright magenta"
+
+
+def test_format_line_no_color_env_respected() -> None:
+    """NO_COLOR in the environment disables colour even with no_color=False."""
+    with _env("NO_COLOR", "1"):
+        line = MODULE.format_stats_line(_totals(1.0), _totals(2.0), proj=_totals(3.0), no_color=False)
+    assert "\033" not in line, "NO_COLOR env should strip ANSI"
+
+
+# ---------------------------------------------------------------------------
+# project_totals.
+# ---------------------------------------------------------------------------
+
+
+def test_project_totals_aggregates_sessions_and_subagents() -> None:
+    """Every *.jsonl under the project dir is summed — top-level session files
+    and nested subagents/agent-*.jsonl — with (msg_id, requestId) dedup so a
+    record duplicated into a sub-agent transcript is counted once."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp) / "cache"
+        proj = Path(tmp) / "project"
+        # Session A and a record duplicated into its sub-agent transcript.
+        write_jsonl(proj / "sessionA.jsonl", [_assistant_usage("m1", "r1", in_t=1_000_000)])
+        write_jsonl(proj / "sessionB.jsonl", [_assistant_usage("m2", "r2", in_t=1_000_000)])
+        write_jsonl(
+            proj / "sessionA" / "subagents" / "agent-1.jsonl",
+            [
+                _assistant_usage("m1", "r1", in_t=1_000_000),  # duplicate of A
+                _assistant_usage("m3", "r3", in_t=1_000_000),  # unique
+            ],
+        )
+        with _patched(CACHE_DIR=cache):
+            out = MODULE.project_totals(str(proj / "sessionA.jsonl"))
+        # m1, m2, m3 distinct -> 3 * 1M input tokens.
+        assert out["in"] == 3_000_000, out["in"]
+        assert _approx(out["cost"], 3 * USD_PER_1M_IN), out["cost"]
+
+
+def test_project_totals_missing_dir_is_zero() -> None:
+    """A transcript path whose parent is not a directory yields zeroed totals."""
+    out = MODULE.project_totals("/no/such/dir/x.jsonl")
+    assert out == MODULE._zero(), out
+
+
+# ---------------------------------------------------------------------------
+# _atomic_write_text.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_write_text_writes_and_overwrites() -> None:
+    """The helper writes the exact bytes and overwrites a pre-existing file."""
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "wt.txt"
+        MODULE._atomic_write_text(target, "wt_cost: $1.85")
+        assert target.read_text() == "wt_cost: $1.85"
+        MODULE._atomic_write_text(target, "wt_cost: $2.00")
+        assert target.read_text() == "wt_cost: $2.00"
+        # No stray per-pid temp file left behind.
+        leftovers = [p.name for p in Path(tmp).iterdir() if p.name != "wt.txt"]
+        assert leftovers == [], leftovers
+
+
+# ---------------------------------------------------------------------------
+# main (orchestration). Totals functions are stubbed for determinism / speed.
+# ---------------------------------------------------------------------------
+
+
+def test_main_worktree_writes_cost_file_and_shows_wt() -> None:
+    """`main` in worktree mode prints the `wt:` figure and publishes the cost
+    file containing exactly `wt_cost: $<proj cost>`."""
+    with tempfile.TemporaryDirectory() as tmp:
+        wt_file = Path(tmp) / "claude-code-worktree-cost-1234.txt"
+        buf = io.StringIO()
+        with _patched(
+            session_totals=lambda _t: _totals(0.123),
+            month_totals=lambda: _totals(4.56),
+            project_totals=lambda _t: _totals(1.85),
+        ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
+            rc = MODULE.main(["t.jsonl", "--worktree", "--worktree-cost-file", str(wt_file)])
+        assert rc == 0, rc
+        assert wt_file.read_text() == "wt_cost: $1.85", wt_file.read_text()
+        assert "wt:$1.85" in buf.getvalue(), buf.getvalue()
+
+
+def test_main_no_worktree_omits_wt_and_writes_no_file() -> None:
+    """Without worktree flags `main` omits `wt:` and writes no publish file."""
+    with tempfile.TemporaryDirectory() as tmp:
+        wt_file = Path(tmp) / "should-not-exist.txt"
+        buf = io.StringIO()
+        with _patched(
+            session_totals=lambda _t: _totals(0.123),
+            month_totals=lambda: _totals(4.56),
+            project_totals=lambda _t: _totals(1.85),
+        ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
+            rc = MODULE.main(["t.jsonl"])
+        assert rc == 0, rc
+        assert "wt:" not in buf.getvalue(), buf.getvalue()
+        assert not wt_file.exists(), "no cost file should be written without the flag"
+
+
+def test_main_no_transcript_arg_is_noop() -> None:
+    """Empty / missing transcript arg exits 0 with no output."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert MODULE.main([]) == 0
+        assert MODULE.main([""]) == 0
+    assert buf.getvalue() == "", repr(buf.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# Runner.
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    tests: List[Tuple[str, Callable[[], None]]] = [
+        ("parse_args plain", test_parse_args_plain),
+        ("parse_args --worktree", test_parse_args_worktree_flag),
+        ("parse_args cost-file implies worktree", test_parse_args_cost_file_implies_worktree),
+        ("parse_args cost-file missing value", test_parse_args_cost_file_missing_value),
+        ("format line no worktree (exact)", test_format_line_no_worktree_exact),
+        ("format line with worktree (exact)", test_format_line_with_worktree_exact),
+        ("format line no_color strips ANSI", test_format_line_no_color_has_no_ansi),
+        ("format line colours when enabled", test_format_line_colours_when_enabled),
+        ("format line NO_COLOR env respected", test_format_line_no_color_env_respected),
+        ("project_totals sessions + subagents deduped", test_project_totals_aggregates_sessions_and_subagents),
+        ("project_totals missing dir -> zero", test_project_totals_missing_dir_is_zero),
+        ("atomic_write_text writes + overwrites", test_atomic_write_text_writes_and_overwrites),
+        ("main worktree writes file + shows wt", test_main_worktree_writes_cost_file_and_shows_wt),
+        ("main no worktree omits wt + no file", test_main_no_worktree_omits_wt_and_writes_no_file),
+        ("main no transcript arg is no-op", test_main_no_transcript_arg_is_noop),
+    ]
+    print(f"Running {len(tests)} test(s) for session-stats.py\n")
+    for name, fn in tests:
+        run_test(name, fn)
+    print()
+    if _FAILURES:
+        print(f"FAILED — {len(_FAILURES)} test(s) failed:", file=sys.stderr)
+        for name, _ in _FAILURES:
+            print(f"  - {name}", file=sys.stderr)
+        return 1
+    print(f"OK — {len(tests)} test(s) passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,11 @@ cat /tmp/claude-code-worktree-cost-$PPID.txt
 ```
 Output example: `wt_cost: $1.85`. The file is absent in the main checkout (no `wt:` figure there). Implementation: `.claude/scripts/statusline-command.sh` detects the worktree and passes `--worktree` / `--worktree-cost-file` to `.claude/scripts/session-stats.py`, which computes the figure and writes the file.
 
+The example output format above MUST stay in sync with:
+- `.claude/scripts/statusline-command.sh` — renders the `wt:$X` figure on the statusline's second line
+- `.claude/scripts/session-stats.py` — computes the figure and writes the `wt_cost:` file
+- `.claude/scripts/tests/test_session_stats.py` — pins both formats with exact-match assertions
+
 ### Recipes
 
 - **Read the current worktree's running cost** — when you want to know the cumulative spend on this worktree before wrapping up or reporting cost, `cat /tmp/claude-code-worktree-cost-$PPID.txt` (the statusline refreshes it each render). Empty result means the cwd is the main checkout or the file has not been written yet this session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,20 @@ The thresholds in this section MUST stay in sync with:
 
 If you change a threshold here, grep for the others and update them in the same commit.
 
+## Cost Monitor
+
+The statusline's second line shows session and calendar-month cost. When the cwd is a linked git worktree, it also shows `wt:$X`, the cumulative spend on the *current worktree's project* (every session ever run in this worktree, orchestrator + sub-agents, deduped). The figure sits between the session and month totals: `$0.123 (wt:$1.85 mo:$4.56) …`.
+
+In a worktree that cost is also published to a per-session file, mirroring the context-usage file, so it can be read on demand:
+```bash
+cat /tmp/claude-code-worktree-cost-$PPID.txt
+```
+Output example: `wt_cost: $1.85`. The file is absent in the main checkout (no `wt:` figure there). Implementation: `.claude/scripts/statusline-command.sh` detects the worktree and passes `--worktree` / `--worktree-cost-file` to `.claude/scripts/session-stats.py`, which computes the figure and writes the file.
+
+### Recipes
+
+- **Read the current worktree's running cost** — when you want to know the cumulative spend on this worktree before wrapping up or reporting cost, `cat /tmp/claude-code-worktree-cost-$PPID.txt` (the statusline refreshes it each render). Empty result means the cwd is the main checkout or the file has not been written yet this session.
+
 ## MCP Steroid — IntelliJ IDE Control
 
 When the `localhost-6315` MCP server (mcp-steroid) is connected, its skill guides are exposed as MCP resources and fetched via `steroid_fetch_resource` (resolve the exact `mcp-steroid://` URI from the server's resource list if needed — upstream source: https://github.com/jonnyzzz/mcp-steroid/tree/main/prompts/src/main/prompts/skill). Do NOT vendor or copy these guides into the project — fetch lazily; some are large (the Spring guide is ~100 KB).


### PR DESCRIPTION
#### Motivation

The statusline cost line reported only the current session and the calendar-month total across all projects. In a worktree-heavy workflow that left no view of what a single worktree had cost across its sessions, which is the figure that maps to one unit of work.

Each linked worktree has its own cwd and therefore its own `~/.claude/projects/<slug>` directory, so summing that directory yields the worktree's cumulative spend. The statusline now detects a linked worktree (resolved `--git-dir` differs from `--git-common-dir`) and, when in one, shows `wt:$X` between the session and month figures. It also publishes that cost to `/tmp/claude-code-worktree-cost-<pid>.txt` for on-demand reading, mirroring the existing context-usage file. The main checkout is unchanged.

#### Changes

- `session-stats.py`: `project_totals()` sums every `*.jsonl` under the worktree project dir (orchestrator + sub-agent sessions, deduped) and `main()` publishes the figure to the per-session file. The publish is best-effort and cannot break the status line.
- `statusline-command.sh`: detects the linked worktree and passes `--worktree` / `--worktree-cost-file` to the stats script.
- `CLAUDE.md`: documents the figure under a new `## Cost Monitor` section with a read recipe and a stay-in-sync footer pointing at the two scripts and the test.
- `test_session_stats.py`: stand-alone 16-case runner pinning the line format, dedup, the publish / no-publish paths, and the parent-dir-scan guard. All 16 pass.

#### Review

Two automated review passes, no blockers:

- `/code-review` (four workflow-machinery reviewers): widened the best-effort publish to catch any exception (not only `OSError`) so it can never drop the status line, and added the Cost Monitor stay-in-sync footer. Two suggestions accepted as-is after discussion: `project_totals` render cost is bounded because long-lived worktrees are not expected, and the greppable Recipes bullet follows the established `CLAUDE.md` convention.
- Gemini Code Assist: guarded `project_totals` with a `p.exists()` check mirroring `session_totals` so a non-existent transcript whose parent exists can no longer trigger a recursive `*.jsonl` scan of that parent (with a regression test that fails on the pre-fix code), and set `encoding="utf-8"` on the worktree-cost file write.
