### PR TITLE
[no-test-number-check] Fix flaky TruncateOrphansAfterRecoveryIT orphan-truncation assertion

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/TruncateOrphansAfterRecoveryIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/TruncateOrphansAfterRecoveryIT.java
@@ -952,16 +952,45 @@ public class TruncateOrphansAfterRecoveryIT {
   // ---------------------------------------------------------------------------
 
   /**
-   * Builds a configuration that selects the given checksum mode and disables the double
-   * write log. The recovery pass itself is checksum-agnostic — it only reads the EP page
-   * (which is valid because the production stack wrote it), then dispatches a shrink
-   * that doesn't read the orphan pages at all — so the mode parameter is the lever for
-   * "did the pass accidentally start reading orphan bodies?" regression detection.
+   * Builds a configuration that selects the given checksum mode, disables the double
+   * write log, and pins one collection per class. The recovery pass itself is
+   * checksum-agnostic: it only reads the EP page (which is valid because the production
+   * stack wrote it), then dispatches a shrink that does not read the orphan pages at all,
+   * so the mode parameter is the lever for "did the pass accidentally start reading orphan
+   * bodies?" regression detection.
+   *
+   * <p>The single-collection pin ({@link GlobalConfiguration#CLASS_COLLECTIONS_COUNT} = 1)
+   * is load-bearing for the {@code .pcl} and {@code .cpm} scenarios. At the default count
+   * (8) a class is backed by eight collections, and the {@code "default"} collection
+   * selection strategy routes every inserted record to {@code collectionIds[0]}, leaving
+   * the other seven {@code .pcl}/{@code .cpm} files empty (state-page {@code fileSize == 0},
+   * one physical page). The scenario helpers select their target file with
+   * {@code files().keySet().stream()...findFirst()}, whose order is the file map's hash
+   * order rather than the insertion target, so they could land on an empty cluster. An
+   * orphan tail fabricated on a logical-empty file trips the recovery pass's intentional
+   * corruption guard ({@code logicalPages == 0 && physical > 1 page} skips the truncate
+   * with a WARN) instead of the truncate path the size assertion expects, producing a
+   * flaky failure that depends only on which collection the hash order surfaced first.
+   * Pinning a single collection guarantees the selected file carries the inserted data
+   * ({@code logicalPages >= 1}), so the truncate path is the one under test.
+   *
+   * <p>The index and SLBB scenarios ({@code .cbt}, {@code $null.cbt}, {@code .grb}) were
+   * never exposed to this race, even though they use the same {@code findFirst()} selection
+   * pattern: an index engine is one structure per class (not multiplied by the collection
+   * count), and its data file always carries real entries, so {@code logicalPages >= 1}; a
+   * SLBB's EP {@code init()} seeds {@code pagesSize} at 1, so even a record-free SLBB reports
+   * {@code logicalPages == 1} and never matches the {@code logicalPages == 0} guard clause.
+   * Only PCV2 and CPMV2 EPs seed their counter at 0, which is the legitimate empty-cluster
+   * state the guard is designed to leave untouched. For those scenarios the pin is therefore
+   * harmless but still useful: with one collection per class there is exactly one matching
+   * file, so the {@code findFirst()} selection is deterministic rather than hash-order
+   * dependent.
    */
   private static BaseConfiguration makeConfig(ChecksumMode checksumMode) {
     var config = new BaseConfiguration();
     config.setProperty(GlobalConfiguration.STORAGE_CHECKSUM_MODE.getKey(), checksumMode.name());
     config.setProperty(GlobalConfiguration.STORAGE_USE_DOUBLE_WRITE_LOG.getKey(), false);
+    config.setProperty(GlobalConfiguration.CLASS_COLLECTIONS_COUNT.getKey(), 1);
     return config;
   }
 


### PR DESCRIPTION
## Summary
Fixes a flaky failure in `TruncateOrphansAfterRecoveryIT` that surfaced on `develop` as a red "Publish Test Results" check (the Maven build runs with `-Dmaven.test.failure.ignore=true`, so the EnricoMi publish step is the gate that fails the job when any test result is a failure). The fix is **test-only**; production code is unchanged.

## Root Cause
The failing assertion was `truncatesOrphansOnPaginatedCollectionFileZeroByteUnderStoreAndThrow` (`expected: 9216L but was: 41984L`). The CI log carried the smoking gun:

```
WARNING: Storage corruption signal: PaginatedCollectionV2 'orphans_11' EP reports
state page fileSize=0 but physical file holds 5 pages (> 1). Skipping
orphan-truncation; investigate manually.
```

A class is created with the default `CLASS_COLLECTIONS_COUNT` (8) collections. The scenario helpers select their target `.pcl`/`.cpm` file with `files().keySet().stream()...findFirst()`, i.e. by the file map's **hash order**, which is unrelated to where records land. When `findFirst()` surfaced an **empty** cluster (state-page `fileSize == 0`), the orphan tail the test fabricates produced a `logicalPages == 0 && physical > 1 page` shape. That shape is exactly the one the recovery pass's corruption guard (`StorageComponent.verifyAndTruncateOrphans`) **intentionally refuses to truncate** — it cannot distinguish a fresh-create partial-flush orphan from real corruption, so it skips with a WARN and relies on the allocator-only contract to surface it loudly at first write. The size assertion then failed, but only when the hash order happened to surface an empty cluster first — hence flaky (1 of 24 variants in the failed run, the other 23 green).

Production behavior is correct by design; the test was feeding the guard the wrong file shape.

## Changes
- `core/.../TruncateOrphansAfterRecoveryIT.java`: pin `GlobalConfiguration.CLASS_COLLECTIONS_COUNT = 1` in `makeConfig`, so each class has a single cluster that always holds the inserted records (`logicalPages >= 1`). The selected `.pcl`/`.cpm` therefore always exercises the truncate path the assertion targets, deterministically and independent of hash order or environment. Expanded the `makeConfig` Javadoc to document why the pin is load-bearing for `.pcl`/`.cpm` and why the index/SLBB scenarios (`.cbt`, `$null.cbt`, `.grb`) were never at risk.

## Why this is the right layer
The multi-collection iteration of `AbstractStorage.truncateOrphansAfterRecovery` and the corruption-guard skip path both retain dedicated, deterministic unit-test coverage (`AbstractStorageTruncateOrphansAfterRecoveryTest`, and the per-component `verifyAndTruncateOrphansSkipsOnCorruptionSignal` tests), so pinning a single collection here loses no coverage — it only removes the hash-order roulette that made this IT flaky.

## Motivation
CI failure on `develop`: https://github.com/JetBrains/youtrackdb/actions/runs/26741805227

## Test plan
- [x] `TruncateOrphansAfterRecoveryIT` passes with the fix: `Tests run: 28, Failures: 0, Errors: 0` (disk storage, `youtrackdb.test.env=ci`)
- [x] Reproduced and diagnosed the empty-cluster selection mechanism with an instrumented run (8 clusters under default count; exactly 1 data-bearing cluster under the pin)
- [x] `spotless:check` green
- [x] Dimensional review (code-quality, test-behavior, test-completeness, test-structure): no blockers; the one converging documentation finding was addressed
- [ ] Full unit + integration suite — delegated to this PR's CI integration pipeline (the change is isolated to one test file's private config method; a local full-suite run would duplicate CI)