### PR TITLE
Keep max-output snapshot in statusline cost dedup

### DIFF
--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -32,16 +32,21 @@ Two non-obvious mechanics, both required to match ccusage:
      can contain April records, and vice versa, so the monthly bucket is
      decided per record using its own `timestamp` field.
 
-  2. **(message.id, requestId) dedup.** ~40% of records appear in multiple
-     transcripts (sub-agent transcripts duplicate their parent's records, and
-     forked sessions share message IDs). Without dedup the cost is inflated
-     several-fold.
+  2. **(message.id, requestId) dedup, max-output wins.** ~40% of records appear
+     in multiple transcripts (sub-agent transcripts duplicate their parent's
+     records, and forked sessions share message IDs). Without dedup the cost is
+     inflated several-fold. Within a single transcript the same key also recurs
+     as streaming snapshots whose output_tokens grows from a partial value to
+     the final count; collapsing a key to its *largest*-output snapshot matches
+     ccusage, which reports the completed turn. Keeping the first snapshot
+     instead undercut output — the priciest token — by ~15% over a month.
 
 Per-file totals are cached under ~/.cache/claude-code-stats/transcripts/<sha1>.json
 keyed by (mtime, size). Each cache entry stores a {record_id: bucket_data}
-map; cross-file merge uses first-occurrence-wins (`setdefault`). The mtime/size
-cache key guarantees colliding entries already hold identical content, so
-the choice between first- and last-wins is immaterial for correctness.
+map; both the in-file and cross-file merge keep the larger-output payload per
+key (see `_keep_larger_output`). Max is order-independent, so a key's partial
+and final snapshots reconcile correctly even when they fall in different read
+chunks across renders (the incremental byte-offset cache) or in different files.
 """
 from __future__ import annotations
 
@@ -89,7 +94,9 @@ PRICING_FETCH_TIMEOUT = 2.0
 CACHE_DIR = pathlib.Path.home() / ".cache" / "claude-code-stats" / "transcripts"
 # Bump on layout / dedup changes; older cache files are silently re-read
 # from scratch and the stale entries are unlinked lazily by _load_cache.
-CACHE_VERSION = 6
+# v7: dedup keeps the max-output_tokens snapshot (was first-occurrence); caches
+# written under v6 hold partial-output payloads and must be rebuilt.
+CACHE_VERSION = 7
 PROJECTS_ROOT = pathlib.Path.home() / ".claude" / "projects"
 
 
@@ -376,6 +383,29 @@ def _store_cache(cache_file, payload):
         pass
 
 
+def _keep_larger_output(records, rid, payload):
+    """Merge `payload` into `records[rid]`, keeping the snapshot whose
+    output_tokens (payload index 3) is larger.
+
+    Claude Code writes a streaming assistant turn as several records sharing one
+    (msg_id, requestId): output_tokens grows from a partial value (often 1) to
+    the final count, while the other token fields are fixed at request time. The
+    completed record is also byte-copied across transcripts (orchestrator +
+    sub-agent + forked sessions). ccusage reports the final (largest) snapshot,
+    so we keep the max-output payload to match its monthly figure. Keeping the
+    *first* snapshot instead — the previous behaviour — locked in the partial
+    output count and undercut the priciest token by ~15% over a month.
+
+    Using max (not first- or last-seen) is order-independent, so the result is
+    correct whether the partial and final snapshots arrive in the same read, in
+    different read chunks across renders (the incremental byte-offset cache may
+    already hold the partial when the final arrives), or in different files.
+    """
+    prev = records.get(rid)
+    if prev is None or payload[3] > prev[3]:
+        records[rid] = payload
+
+
 def aggregate_file(path):
     """Return {record_id: [month, model, in, out, read, w5, w1]} for one file.
 
@@ -435,11 +465,10 @@ def aggregate_file(path):
         if rec is None:
             continue
         rid, payload = rec
-        # First-occurrence wins, matching ccusage. Streaming responses emit
-        # multiple snapshots of the same (msg_id, requestId) with growing
-        # output_tokens; we deliberately keep the earliest snapshot so the
-        # cost figure aligns with ccusage's number.
-        records.setdefault(rid, payload)
+        # Keep the largest-output snapshot of each (msg_id, requestId) so the
+        # partial counts emitted mid-stream don't undercount output. See
+        # _keep_larger_output for why max (not first/last) is the right rule.
+        _keep_larger_output(records, rid, payload)
 
     _store_cache(cache_file, {
         "v": CACHE_VERSION,
@@ -486,12 +515,12 @@ def session_totals(transcript_path):
         return _zero()
     merged = {}
     for k, v in aggregate_file(p).items():
-        merged.setdefault(k, v)
+        _keep_larger_output(merged, k, v)
     sub_dir = p.parent / p.stem / "subagents"
     if sub_dir.is_dir():
         for sub in sub_dir.glob("agent-*.jsonl"):
             for k, v in aggregate_file(sub).items():
-                merged.setdefault(k, v)  # first-wins dedup
+                _keep_larger_output(merged, k, v)  # max-output dedup
     return _sum_records(merged)
 
 
@@ -521,7 +550,7 @@ def project_totals(transcript_path):
     merged = {}
     for jsonl in proj_dir.rglob("*.jsonl"):
         for k, v in aggregate_file(jsonl).items():
-            merged.setdefault(k, v)  # first-wins dedup
+            _keep_larger_output(merged, k, v)  # max-output dedup
     return _sum_records(merged)
 
 
@@ -554,7 +583,7 @@ def month_totals():
                 continue
             for k, v in aggregate_file(jsonl).items():
                 if v[0] == cur_month:
-                    merged.setdefault(k, v)
+                    _keep_larger_output(merged, k, v)  # max-output dedup
     return _sum_records(merged)
 
 

--- a/.claude/scripts/tests/test_session_stats.py
+++ b/.claude/scripts/tests/test_session_stats.py
@@ -313,6 +313,57 @@ def test_project_totals_nonexistent_transcript_does_not_scan_parent() -> None:
         assert out == MODULE._zero(), out
 
 
+def test_streaming_snapshots_in_one_file_keep_max_output() -> None:
+    """Three records sharing one (msg_id, requestId) — the streaming snapshot
+    sequence output_tokens = 1, 1, 276 — must collapse to the largest (276), the
+    completed turn, not the first partial (1) and not their sum (278). A second,
+    distinct turn (output_tokens = 100) confirms unrelated keys are untouched.
+    Regression for first-occurrence dedup, which kept a mid-stream partial and
+    undercounted output — the priciest token."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp) / "cache"
+        proj = Path(tmp) / "project"
+        write_jsonl(
+            proj / "session.jsonl",
+            [
+                _assistant_usage("m1", "r1", out_t=1),
+                _assistant_usage("m1", "r1", out_t=1),
+                _assistant_usage("m1", "r1", out_t=276),
+                _assistant_usage("m2", "r2", out_t=100),
+            ],
+        )
+        with _patched(CACHE_DIR=cache):
+            out = MODULE.project_totals(str(proj / "session.jsonl"))
+        # m1 -> 276 (final snapshot), m2 -> 100; first-wins would give 101, no
+        # dedup would give 378.
+        assert out["out"] == 376, out["out"]
+        out_price = MODULE.FALLBACK_PRICES[MODEL]["out"]  # $25 / 1M
+        assert _approx(out["cost"], 376 * out_price / 1_000_000), out["cost"]
+
+
+def test_streaming_final_snapshot_wins_across_cache_reads() -> None:
+    """A streaming turn's partial snapshot can be consumed in one render and its
+    final snapshot in a later render, because the incremental byte-offset cache
+    splits them: aggregate_file persists the partial, then re-reads only the
+    appended bytes next time. The final (larger-output) snapshot must win on the
+    second read. Regression for first-occurrence dedup, which locked in the
+    cached partial and ignored the completed count forever."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp) / "cache"
+        f = Path(tmp) / "session.jsonl"
+        # Render 1: only the partial snapshot exists yet.
+        write_jsonl(f, [_assistant_usage("m1", "r1", out_t=1)])
+        with _patched(CACHE_DIR=cache):
+            recs1 = MODULE.aggregate_file(f)
+            assert recs1["m1:r1"][3] == 1, recs1["m1:r1"]  # payload[3] = output
+            # Render 2: the final snapshot is appended (file grows), so the
+            # next aggregate_file reads only the new line and merges it in.
+            with f.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(_assistant_usage("m1", "r1", out_t=276)) + "\n")
+            recs2 = MODULE.aggregate_file(f)
+        assert recs2["m1:r1"][3] == 276, recs2["m1:r1"]
+
+
 # ---------------------------------------------------------------------------
 # _atomic_write_text.
 # ---------------------------------------------------------------------------
@@ -397,6 +448,8 @@ def main() -> int:
         ("project_totals sessions + subagents deduped", test_project_totals_aggregates_sessions_and_subagents),
         ("project_totals missing dir -> zero", test_project_totals_missing_dir_is_zero),
         ("project_totals nonexistent file w/ existing parent -> zero", test_project_totals_nonexistent_transcript_does_not_scan_parent),
+        ("streaming snapshots in one file keep max output", test_streaming_snapshots_in_one_file_keep_max_output),
+        ("streaming final snapshot wins across cache reads", test_streaming_final_snapshot_wins_across_cache_reads),
         ("atomic_write_text writes + overwrites", test_atomic_write_text_writes_and_overwrites),
         ("main worktree writes file + shows wt", test_main_worktree_writes_cost_file_and_shows_wt),
         ("main no worktree omits wt + no file", test_main_no_worktree_omits_wt_and_writes_no_file),


### PR DESCRIPTION
#### Motivation

The statusline's monthly cost figure (`mo:$X`, second line) ran consistently below `npx ccusage@latest monthly` — ~3% low, about $9 for the prior calendar month. Both tools read the same `~/.claude/projects/**` JSONL transcripts with the same pricing table and the same `(message.id, requestId)` dedup, so the gap pointed at a methodology bug, not noise.

Root cause: `session-stats.py` deduped streaming assistant turns by **first occurrence**. Claude Code writes each streaming turn as several records sharing one `(msg_id, requestId)`, with `output_tokens` growing from a partial value (often 1) to the final count while the other token fields stay fixed at request time. Keeping the first snapshot locked in the partial output count and undercut output — the priciest token at $25/M. Measured on live June data: 585 of 1773 keys carried varying output across snapshots; summing the first snapshot gave 2.08M output tokens vs ccusage's 2.41M, and that ~348K-token delta at $25/M is the entire ~$9 gap. The module docstring had even asserted the opposite (first-wins "aligns with ccusage"), which is what the old code believed.

#### What changed

- Collapse each `(msg_id, requestId)` to its **largest-output snapshot** via a single `_keep_larger_output` helper, applied at all five merge sites: the in-file merge in `aggregate_file` plus the cross-file merges in `session_totals`, `project_totals`, and `month_totals`. Max is order-independent, so a turn's partial and final snapshots reconcile correctly whether they arrive in the same read, in different read chunks across renders (the incremental byte-offset cache may already hold the partial when the final lands), or byte-copied into different files.
- Bump `CACHE_VERSION` 6 → 7 so per-file caches written under first-wins (holding partial-output payloads) are rebuilt rather than trusted.
- Correct the module docstring, which described the old first-wins rule.

#### Testing

- `python3 .claude/scripts/tests/test_session_stats.py` — 18/18 pass, including two new regressions: an in-file snapshot sequence (`1, 1, 276 → 276`, not first-wins `1` and not no-dedup `278`) and the final-snapshot-wins-across-cache-reads path (partial consumed in one render, final appended and merged on the next).
- Live validation, captured back-to-back: patched statusline **$293.14** vs ccusage **$293.24** (0.03% / $0.10, within streaming jitter), down from a ~$9 gap.

This touches only the statusline cost helper and its test — no production database code.
