### PR TITLE
Add today's spend figure to the statusline

### DIFF
--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
-"""Compute current-session and calendar-month cost/token stats for the Claude
-Code statusline.
+"""Compute current-session, today, and calendar-month cost/token stats for the
+Claude Code statusline.
 
 Output (single line, second line of the statusline):
 
-  $0.123 (mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  r/5m:5.7x r/1h:-
+  $0.123 (day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  r/5m:5.7x r/1h:-
 
-When invoked with `--worktree` (the statusline adds it whenever the cwd is a
-linked git worktree) a third cost figure for the current worktree's project
-is inserted before the month figure:
+The `day:` figure is today's spend across every project — the calendar-day
+analogue of `mo:` — and is always shown. When invoked with `--worktree` (the
+statusline adds it whenever the cwd is a linked git worktree) a cost figure for
+the current worktree's project is inserted at the front of the parenthetical:
 
-  $0.123 (wt:$1.85 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  …
+  $0.123 (wt:$1.85 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  …
 
 The current session aggregates the orchestrator transcript plus every
 sub-agent transcript under <transcript-stem>/subagents/. The worktree-project
@@ -29,8 +30,8 @@ the current worktree on demand.
 Two non-obvious mechanics, both required to match ccusage:
 
   1. **Record-timestamp bucketing** (not file mtime). A file modified in May
-     can contain April records, and vice versa, so the monthly bucket is
-     decided per record using its own `timestamp` field.
+     can contain April records, and vice versa, so the daily and monthly
+     buckets are each decided per record using its own `timestamp` field.
 
   2. **(message.id, requestId) dedup, max-output wins.** ~40% of records appear
      in multiple transcripts (sub-agent transcripts duplicate their parent's
@@ -96,7 +97,10 @@ CACHE_DIR = pathlib.Path.home() / ".cache" / "claude-code-stats" / "transcripts"
 # from scratch and the stale entries are unlinked lazily by _load_cache.
 # v7: dedup keeps the max-output_tokens snapshot (was first-occurrence); caches
 # written under v6 hold partial-output payloads and must be rebuilt.
-CACHE_VERSION = 7
+# v8: payload index 0 holds the full record date `ts[:10]` (was the month
+# `ts[:7]`) so one cache feeds both the daily and monthly buckets; v7 caches
+# store only the month and must be rebuilt.
+CACHE_VERSION = 8
 PROJECTS_ROOT = pathlib.Path.home() / ".claude" / "projects"
 
 
@@ -314,7 +318,7 @@ def _model_pricing(m):
 
 
 def _record_from_line(raw):
-    """Parse one assistant-turn line into (key, [month, model, in, out, read, w5, w1]).
+    """Parse one assistant-turn line into (key, [date, model, in, out, read, w5, w1]).
 
     The cache stores raw tokens + model id so a future price update takes
     effect on the next render without requiring per-file cache invalidation.
@@ -337,7 +341,10 @@ def _record_from_line(raw):
         # double-count.
         return None
     ts = obj.get("timestamp") or ""
-    month = ts[:7] if len(ts) >= 7 else ""
+    # Full record date `YYYY-MM-DD`: the month bucket slices `date[:7]` and the
+    # day bucket compares the whole string. A short / malformed timestamp yields
+    # "" which matches no current day or month (same as the old month logic).
+    date = ts[:10] if len(ts) >= 10 else ""
     model = msg.get("model") or DEFAULT_MODEL
     # `… or 0` (without the explicit default) handles both missing keys and
     # explicit nulls in one expression — the API emits `null` for some
@@ -351,7 +358,7 @@ def _record_from_line(raw):
     if not (w5 or w1):
         # Older turns only emit the top-level total; treat as 5 m.
         w5 = usage.get("cache_creation_input_tokens") or 0
-    return f"{msg_id}:{req_id}", [month, model, in_t, out_t, read_t, w5, w1]
+    return f"{msg_id}:{req_id}", [date, model, in_t, out_t, read_t, w5, w1]
 
 
 def _cache_path_for(path):
@@ -407,7 +414,7 @@ def _keep_larger_output(records, rid, payload):
 
 
 def aggregate_file(path):
-    """Return {record_id: [month, model, in, out, read, w5, w1]} for one file.
+    """Return {record_id: [date, model, in, out, read, w5, w1]} for one file.
 
     Cost is recomputed at sum time by `_sum_records` against the current
     price table, so a price refresh takes effect on the next render without
@@ -481,12 +488,12 @@ def aggregate_file(path):
 
 
 def _sum_records(records):
-    """Sum a {record_id: [month, model, in, out, read, w5, w1]} dict applying current prices."""
+    """Sum a {record_id: [date, model, in, out, read, w5, w1]} dict applying current prices."""
     out = _zero()
     # Pricing-dict cache, since one model dominates a typical aggregation pass.
     price_cache = {}
     for v in records.values():
-        # v = [month, model, in, out, read, w5, w1]
+        # v = [date, model, in, out, read, w5, w1]
         model = v[1]
         in_t, out_t, read_t, w5, w1 = v[2], v[3], v[4], v[5], v[6]
         out["in"] += in_t
@@ -554,22 +561,39 @@ def project_totals(transcript_path):
     return _sum_records(merged)
 
 
-def month_totals():
-    """Sum every record across all projects whose UTC timestamp is this month.
+def calendar_totals(now=None):
+    """Sum records across all projects into (today, this-month) totals.
 
-    Both the bucket key (`ts[:7]` of the JSONL `timestamp` field, which
-    Claude Code emits as a `Z`-suffixed UTC ISO-8601 string) and `cur_month`
-    must be in the same timezone, otherwise records near the month boundary
-    fall on the wrong side. We standardise on UTC.
+    Returns a `(day, month)` pair of totals dicts. Both are produced in a single
+    walk of ~/.claude/projects: a second full `rglob` purely for the daily figure
+    would re-stat every transcript and re-read every per-file cache entry on each
+    statusline render, so we bucket each record into both accumulators as we go.
+
+    Bucketing is per record (not file mtime): one file can hold records from more
+    than one day, so each record's own date (payload index 0, `ts[:10]`) decides
+    its bucket. The month bucket compares `date[:7]`; the day bucket compares the
+    whole `YYYY-MM-DD`. Claude Code emits `timestamp` as a `Z`-suffixed UTC
+    ISO-8601 string, so `cur_day` / `cur_month` are derived in UTC too —
+    otherwise records near a midnight or month boundary fall on the wrong side.
+
+    The month-start mtime pre-filter bounds both buckets: today lies within the
+    current month, so a file untouched since before the month began cannot hold a
+    current-month *or* current-day record (append always bumps mtime).
+
+    `now` defaults to the current UTC instant; it is injectable so the
+    calendar-bucketing logic can be exercised against fixed dates in tests.
     """
     if not PROJECTS_ROOT.is_dir():
-        return _zero()
-    now = _dt.datetime.now(_dt.timezone.utc)
+        return _zero(), _zero()
+    if now is None:
+        now = _dt.datetime.now(_dt.timezone.utc)
     cur_month = f"{now.year:04d}-{now.month:02d}"
+    cur_day = f"{now.year:04d}-{now.month:02d}-{now.day:02d}"
     month_start_ts = _dt.datetime(
         now.year, now.month, 1, tzinfo=_dt.timezone.utc
     ).timestamp()
-    merged = {}
+    month_merged = {}
+    day_merged = {}
     for proj in PROJECTS_ROOT.iterdir():
         if not proj.is_dir():
             continue
@@ -582,9 +606,12 @@ def month_totals():
             except OSError:
                 continue
             for k, v in aggregate_file(jsonl).items():
-                if v[0] == cur_month:
-                    _keep_larger_output(merged, k, v)  # max-output dedup
-    return _sum_records(merged)
+                if v[0][:7] != cur_month:
+                    continue
+                _keep_larger_output(month_merged, k, v)  # max-output dedup
+                if v[0] == cur_day:
+                    _keep_larger_output(day_merged, k, v)
+    return _sum_records(day_merged), _sum_records(month_merged)
 
 
 def fmt_tokens(n):
@@ -622,34 +649,37 @@ def parse_args(argv):
     return transcript, show_worktree, wt_cost_file
 
 
-def format_stats_line(sess, month, proj=None, no_color=False):
+def format_stats_line(sess, day, month, proj=None, no_color=False):
     """Render the second statusline row.
 
-    When `proj` is given (worktree mode) a `wt:$X` figure for the current
-    worktree's project is inserted ahead of the month figure.
+    The `day:$X` figure (today's spend across all projects) always appears; when
+    `proj` is given (worktree mode) a `wt:$X` figure for the current worktree's
+    project is inserted ahead of it.
 
     Distinct colours so the cost figures are tellable apart at a glance:
     bright cyan = current session (active), bright blue = this worktree's
-    project (cumulative), bright magenta = calendar month across all projects.
-    Deliberately avoiding red / yellow / green — those are reserved for the
-    context-fill bar in statusline-command.sh (critical / warning / safe).
-    Honour NO_COLOR for non-TTY consumers.
+    project (cumulative), bright white = today across all projects, bright
+    magenta = calendar month across all projects. Deliberately avoiding
+    red / yellow / green — those are reserved for the context-fill bar in
+    statusline-command.sh (critical / warning / safe). Honour NO_COLOR for
+    non-TTY consumers.
     """
     if no_color or os.environ.get("NO_COLOR"):
         sess_open = sess_close = mo_open = mo_close = wt_open = wt_close = ""
+        day_open = day_close = ""
     else:
         sess_open = "\033[1;36m"   # bright cyan    — current session
         wt_open = "\033[1;34m"     # bright blue    — this worktree's project
+        day_open = "\033[1;37m"    # bright white   — today, all projects
         mo_open = "\033[1;35m"     # bright magenta — calendar month, all projects
-        sess_close = mo_close = wt_close = "\033[0m"
+        sess_close = mo_close = wt_close = day_close = "\033[0m"
 
+    day_str = f"day:{day_open}${day['cost']:.2f}{day_close}"
+    mo_str = f"mo:{mo_open}${month['cost']:.2f}{mo_close}"
     if proj is not None:
-        scope = (
-            f"(wt:{wt_open}${proj['cost']:.2f}{wt_close} "
-            f"mo:{mo_open}${month['cost']:.2f}{mo_close})"
-        )
+        scope = f"(wt:{wt_open}${proj['cost']:.2f}{wt_close} {day_str} {mo_str})"
     else:
-        scope = f"(mo:{mo_open}${month['cost']:.2f}{mo_close})"
+        scope = f"({day_str} {mo_str})"
 
     return (
         f"{sess_open}${sess['cost']:.3f}{sess_close} "
@@ -669,7 +699,7 @@ def main(argv=None):
     transcript, show_worktree, wt_cost_file = parse_args(argv)
     try:
         sess = session_totals(transcript)
-        month = month_totals()
+        day, month = calendar_totals()
         proj = project_totals(transcript) if show_worktree else None
     except Exception as exc:  # noqa: BLE001 — never break the statusline
         print(f"stats error: {exc}", file=sys.stderr)
@@ -686,7 +716,7 @@ def main(argv=None):
         except Exception:  # noqa: BLE001 — publish is best-effort; never break the statusline
             pass
 
-    print(format_stats_line(sess, month, proj))
+    print(format_stats_line(sess, day, month, proj))
     return 0
 
 

--- a/.claude/scripts/statusline-command.sh
+++ b/.claude/scripts/statusline-command.sh
@@ -127,8 +127,10 @@ else
   printf "%s  |  ctx: %s" "$model" "$ctx_str"
 fi
 
-# Second line: cost (current session + calendar month) and per-session token
-# totals across orchestrator + sub-agents. In a linked worktree, also pass the
+# Second line: cost (current session, today, and calendar month) and
+# per-session token totals across orchestrator + sub-agents. The today and
+# month figures are computed by session-stats.py with no shell involvement.
+# In a linked worktree, also pass the
 # per-worktree-project figure (--worktree) and publish its cost to a /tmp file
 # (--worktree-cost-file). Best-effort — never break the primary status line if
 # the helper errors out.

--- a/.claude/scripts/tests/test_session_stats.py
+++ b/.claude/scripts/tests/test_session_stats.py
@@ -213,25 +213,29 @@ def test_parse_args_cost_file_missing_value() -> None:
 
 
 def test_format_line_no_worktree_exact() -> None:
-    """Without a project total the line keeps the original `(mo:$…)` shape."""
+    """Without a project total the line shows `(day:$… mo:$…)` — today's spend
+    immediately before the month figure, no worktree figure."""
     sess = _totals(0.123, **{"in": 1200, "out": 8000, "read": 230000, "w5": 40000, "w1": 0})
+    day = _totals(2.34)
     month = _totals(4.56)
-    line = MODULE.format_stats_line(sess, month, proj=None, no_color=True)
+    line = MODULE.format_stats_line(sess, day, month, proj=None, no_color=True)
     expected = (
-        "$0.123 (mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
+        "$0.123 (day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
         "r/5m:5.8x r/1h:-"
     )
     assert line == expected, f"\n got: {line}\nwant: {expected}"
 
 
 def test_format_line_with_worktree_exact() -> None:
-    """A project total inserts `wt:$…` immediately before the month figure."""
+    """A project total inserts `wt:$…` at the front of the parenthetical, ahead
+    of the always-present `day:$…` and the `mo:$…` figure."""
     sess = _totals(0.123, **{"in": 1200, "out": 8000, "read": 230000, "w5": 40000, "w1": 0})
+    day = _totals(2.34)
     month = _totals(4.56)
     proj = _totals(1.85)
-    line = MODULE.format_stats_line(sess, month, proj=proj, no_color=True)
+    line = MODULE.format_stats_line(sess, day, month, proj=proj, no_color=True)
     expected = (
-        "$0.123 (wt:$1.85 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
+        "$0.123 (wt:$1.85 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
         "r/5m:5.8x r/1h:-"
     )
     assert line == expected, f"\n got: {line}\nwant: {expected}"
@@ -240,24 +244,32 @@ def test_format_line_with_worktree_exact() -> None:
 def test_format_line_no_color_has_no_ansi() -> None:
     """no_color=True strips every ANSI escape even if NO_COLOR is unset."""
     with _env("NO_COLOR", None):
-        line = MODULE.format_stats_line(_totals(1.0), _totals(2.0), proj=_totals(3.0), no_color=True)
+        line = MODULE.format_stats_line(
+            _totals(1.0), _totals(2.0), _totals(3.0), proj=_totals(4.0), no_color=True
+        )
     assert "\033" not in line, "expected no ANSI escapes under no_color"
 
 
 def test_format_line_colours_when_enabled() -> None:
     """With colour on, the worktree figure uses the distinct bright-blue code
-    (34) and the existing session/month codes are still present."""
+    (34), the new today figure uses bright white (37), and the existing
+    session/month codes are still present."""
     with _env("NO_COLOR", None):
-        line = MODULE.format_stats_line(_totals(1.0), _totals(2.0), proj=_totals(3.0), no_color=False)
+        line = MODULE.format_stats_line(
+            _totals(1.0), _totals(2.0), _totals(3.0), proj=_totals(4.0), no_color=False
+        )
     assert "\033[1;34m" in line, "worktree figure should be bright blue"
     assert "\033[1;36m" in line, "session figure should be bright cyan"
+    assert "\033[1;37m" in line, "today figure should be bright white"
     assert "\033[1;35m" in line, "month figure should be bright magenta"
 
 
 def test_format_line_no_color_env_respected() -> None:
     """NO_COLOR in the environment disables colour even with no_color=False."""
     with _env("NO_COLOR", "1"):
-        line = MODULE.format_stats_line(_totals(1.0), _totals(2.0), proj=_totals(3.0), no_color=False)
+        line = MODULE.format_stats_line(
+            _totals(1.0), _totals(2.0), _totals(3.0), proj=_totals(4.0), no_color=False
+        )
     assert "\033" not in line, "NO_COLOR env should strip ANSI"
 
 
@@ -365,6 +377,59 @@ def test_streaming_final_snapshot_wins_across_cache_reads() -> None:
 
 
 # ---------------------------------------------------------------------------
+# calendar_totals.
+# ---------------------------------------------------------------------------
+
+
+def test_calendar_totals_buckets_today_and_month() -> None:
+    """calendar_totals returns (today, this-month) totals in a single walk,
+    bucketing per record by its own date (not file mtime). With a fixed `now` of
+    2026-06-15 and three records in one file — dated today, earlier this month,
+    and a prior month — the day bucket gets only today's record while the month
+    bucket gets today + the earlier-this-month record (prior month excluded).
+    The file's mtime is forced past the month-start so the pre-filter, which is
+    keyed off the injected month start, never drops it regardless of run time."""
+    import datetime as dt
+
+    now = dt.datetime(2026, 6, 15, 12, 0, 0, tzinfo=dt.timezone.utc)
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp) / "cache"
+        projects = Path(tmp) / "projects"
+        session = projects / "proj-a" / "session.jsonl"
+        write_jsonl(
+            session,
+            [
+                _assistant_usage("m1", "r1", ts="2026-06-15T12:00:00.000Z", in_t=1_000_000),
+                _assistant_usage("m2", "r2", ts="2026-06-03T09:00:00.000Z", in_t=1_000_000),
+                _assistant_usage("m3", "r3", ts="2026-05-20T09:00:00.000Z", in_t=1_000_000),
+            ],
+        )
+        # Pin mtime just after the injected month start so the mtime pre-filter
+        # (st_mtime < month_start_ts) keeps the file no matter when this runs.
+        month_start_ts = dt.datetime(2026, 6, 1, tzinfo=dt.timezone.utc).timestamp()
+        os.utime(session, (month_start_ts + 10, month_start_ts + 10))
+        with _patched(CACHE_DIR=cache, PROJECTS_ROOT=projects):
+            day, month = MODULE.calendar_totals(now=now)
+        # Day bucket: only the 2026-06-15 record.
+        assert day["in"] == 1_000_000, day["in"]
+        assert _approx(day["cost"], 1 * USD_PER_1M_IN), day["cost"]
+        # Month bucket: 2026-06-15 + 2026-06-03; the 2026-05-20 record is excluded.
+        assert month["in"] == 2_000_000, month["in"]
+        assert _approx(month["cost"], 2 * USD_PER_1M_IN), month["cost"]
+
+
+def test_calendar_totals_missing_projects_root_is_zero_pair() -> None:
+    """When the projects root is not a directory, calendar_totals yields a pair
+    of zeroed totals rather than raising — the statusline must never break."""
+    with tempfile.TemporaryDirectory() as tmp:
+        missing = Path(tmp) / "does-not-exist"
+        with _patched(PROJECTS_ROOT=missing):
+            day, month = MODULE.calendar_totals()
+        assert day == MODULE._zero(), day
+        assert month == MODULE._zero(), month
+
+
+# ---------------------------------------------------------------------------
 # _atomic_write_text.
 # ---------------------------------------------------------------------------
 
@@ -388,35 +453,39 @@ def test_atomic_write_text_writes_and_overwrites() -> None:
 
 
 def test_main_worktree_writes_cost_file_and_shows_wt() -> None:
-    """`main` in worktree mode prints the `wt:` figure and publishes the cost
-    file containing exactly `wt_cost: $<proj cost>`."""
+    """`main` in worktree mode prints the `wt:` and `day:` figures and publishes
+    the cost file containing exactly `wt_cost: $<proj cost>`. `calendar_totals`
+    is stubbed to return the (today, month) pair main now unpacks."""
     with tempfile.TemporaryDirectory() as tmp:
         wt_file = Path(tmp) / "claude-code-worktree-cost-1234.txt"
         buf = io.StringIO()
         with _patched(
             session_totals=lambda _t: _totals(0.123),
-            month_totals=lambda: _totals(4.56),
+            calendar_totals=lambda: (_totals(2.34), _totals(4.56)),
             project_totals=lambda _t: _totals(1.85),
         ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
             rc = MODULE.main(["t.jsonl", "--worktree", "--worktree-cost-file", str(wt_file)])
         assert rc == 0, rc
         assert wt_file.read_text() == "wt_cost: $1.85", wt_file.read_text()
         assert "wt:$1.85" in buf.getvalue(), buf.getvalue()
+        assert "day:$2.34" in buf.getvalue(), buf.getvalue()
 
 
 def test_main_no_worktree_omits_wt_and_writes_no_file() -> None:
-    """Without worktree flags `main` omits `wt:` and writes no publish file."""
+    """Without worktree flags `main` omits `wt:`, still shows the always-present
+    `day:` figure, and writes no publish file."""
     with tempfile.TemporaryDirectory() as tmp:
         wt_file = Path(tmp) / "should-not-exist.txt"
         buf = io.StringIO()
         with _patched(
             session_totals=lambda _t: _totals(0.123),
-            month_totals=lambda: _totals(4.56),
+            calendar_totals=lambda: (_totals(2.34), _totals(4.56)),
             project_totals=lambda _t: _totals(1.85),
         ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
             rc = MODULE.main(["t.jsonl"])
         assert rc == 0, rc
         assert "wt:" not in buf.getvalue(), buf.getvalue()
+        assert "day:$2.34" in buf.getvalue(), buf.getvalue()
         assert not wt_file.exists(), "no cost file should be written without the flag"
 
 
@@ -450,6 +519,8 @@ def main() -> int:
         ("project_totals nonexistent file w/ existing parent -> zero", test_project_totals_nonexistent_transcript_does_not_scan_parent),
         ("streaming snapshots in one file keep max output", test_streaming_snapshots_in_one_file_keep_max_output),
         ("streaming final snapshot wins across cache reads", test_streaming_final_snapshot_wins_across_cache_reads),
+        ("calendar_totals buckets today + month", test_calendar_totals_buckets_today_and_month),
+        ("calendar_totals missing projects root -> zero pair", test_calendar_totals_missing_projects_root_is_zero_pair),
         ("atomic_write_text writes + overwrites", test_atomic_write_text_writes_and_overwrites),
         ("main worktree writes file + shows wt", test_main_worktree_writes_cost_file_and_shows_wt),
         ("main no worktree omits wt + no file", test_main_no_worktree_omits_wt_and_writes_no_file),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ If you change a threshold here, grep for the others and update them in the same 
 
 ## Cost Monitor
 
-The statusline's second line shows session and calendar-month cost. When the cwd is a linked git worktree, it also shows `wt:$X`, the cumulative spend on the *current worktree's project* (every session ever run in this worktree, orchestrator + sub-agents, deduped). The figure sits between the session and month totals: `$0.123 (wt:$1.85 mo:$4.56) …`.
+The statusline's second line shows session, today, and calendar-month cost. The `day:$X` figure is today's spend across every project (the calendar-day analogue of the month figure, deduped the same way) and always appears: `$0.123 (day:$2.34 mo:$4.56) …`. When the cwd is a linked git worktree, the line also shows `wt:$X`, the cumulative spend on the *current worktree's project* (every session ever run in this worktree, orchestrator + sub-agents, deduped), inserted at the front of the parenthetical: `$0.123 (wt:$1.85 day:$2.34 mo:$4.56) …`.
 
 In a worktree that cost is also published to a per-session file, mirroring the context-usage file, so it can be read on demand:
 ```bash


### PR DESCRIPTION
#### Motivation

The statusline cost line already showed session, worktree, and calendar-month spend, but not today's. Day-level granularity is the missing signal for burn rate within a single day: how much you've spent so far today, without waiting for the month figure to move.

This adds a `day:$X` figure — today's cost across every project, deduped the same way as the month total and always shown. It is computed in the same single walk of `~/.claude/projects` that already produces the month total, not a second tree scan. The statusline renders on every prompt, so a duplicate `rglob` plus per-file cache re-read each render would be real overhead. `month_totals()` becomes `calendar_totals()` returning `(day, month)`, and the per-file cache payload now stores the full record date (`ts[:10]`) instead of just the month (`ts[:7]`) so one walk feeds both buckets. `CACHE_VERSION` bumps 7 to 8 so stale v7 entries rebuild automatically.

#### Changes

- `session-stats.py`: `month_totals()` becomes `calendar_totals()` returning `(day, month)`; cache payload stores `ts[:10]`; `CACHE_VERSION` 7 to 8; `format_stats_line` renders `day:$X` in bright white.
- `statusline-command.sh`: threads the new figure into the second cost line.
- `test_session_stats.py`: two new `calendar_totals` cases plus updated exact-match format assertions for both worktree and non-worktree output.
- `CLAUDE.md` Cost Monitor section: documents the always-present `day:$X` figure and the `wt:` to `day:` to `mo:` ordering.

#### Testing

`python3 .claude/scripts/tests/test_session_stats.py` passes all 20 cases.
