### PR TITLE
Fix CI change-detection to use merge-base diff

### DIFF
--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -79,7 +79,14 @@ jobs:
             exit 0
           fi
 
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD)
+          # Three-dot (merge-base) diff, NOT two-dot. BASE_SHA is the base
+          # branch tip at event time, which may be ahead of where this branch
+          # forked. A two-dot "git diff BASE_SHA HEAD" would then report every
+          # commit the base branch gained since the fork as a phantom change on
+          # this branch, flagging unrelated code files and forcing a needless
+          # build on docs/workflow-only PRs that have fallen behind develop.
+          # The three-dot form scopes the diff to this branch's own commits.
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA...HEAD")
 
           if [[ -z "$CHANGED_FILES" ]]; then
             echo "No changed files detected — skipping build"


### PR DESCRIPTION
#### Motivation:

The `detect-changes` gate in `maven-pipeline.yml` decides whether a PR contains build-relevant (non-`.md`, in-module) files and skips the test matrix when it does not. It computed the changed-file set with a **two-dot** diff:

```bash
CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD)
```

`$BASE_SHA` is `github.event.pull_request.base.sha` — the base branch tip *at event time*, which is usually ahead of the commit where the PR branch forked. A two-dot `git diff base_tip head` reports every commit the base branch gained since the fork as a phantom change on the branch. So a docs- or workflow-only PR that has fallen behind `develop` sees unrelated Java files in its diff and triggers the full multi-OS / multi-JDK build matrix it should have skipped.

This was observed on PR #1109 (workflow-only, 14 `.md` files): the gate logged

```
Build-relevant file found: core/.../storage/cache/WriteCache.java (module: core)
```

`WriteCache.java` was changed by YTDB-1039 on `develop`, not by that PR. The branch had forked at `ea865d6` and `develop` had since advanced past it, so the two-dot diff surfaced 19 phantom non-`.md` files and ran the whole matrix needlessly.

#### Fix

Switch to the **three-dot** form, which scopes the diff to the branch's own commits via the merge-base:

```bash
CHANGED_FILES=$(git diff --name-only "$BASE_SHA...HEAD")
```

Safe for all three trigger paths:
- `pull_request` / `merge_group` — scoped correctly to the branch's commits.
- `push` — `event.before` is an ancestor of `HEAD`, so two-dot and three-dot are identical.

A genuinely code-changing PR that is behind `develop` still builds: the three-dot diff includes the branch's own code commits, so `should_build` stays `true`.