### PR TITLE
[YTDB-1007] Gate workflow TOC check and fix the violation it failed to block

### DIFF
--- a/.claude/workflow/workflow-drift-check.md
+++ b/.claude/workflow/workflow-drift-check.md
@@ -36,7 +36,7 @@ capsule (workflow-format commits enter the branch's view only when the
 user explicitly rebases or merges `develop`), so the walk ranges
 against the branch's own HEAD and never fetches `develop`
 independently. The plan dir the
-caller resolved at startup (see `conventions.md` `§1.2` and `§1.6(g)`)
+caller resolved at startup (see conventions.md:orchestrator,planner:1,2,3A `§1.2` and `§1.6(g)`)
 scopes the walk; cross-plan folding is out of scope (D13). Migration
 itself stays in the `/migrate-workflow` skill — the gate detects and
 gates, the skill replays. The skill assumes a fresh session, so the
@@ -49,11 +49,11 @@ re-invoke `/migrate-workflow` from this worktree.
 <!-- roles=orchestrator,planner phases=1,2,3A summary="Detection moved to the script's --mode full drift walk; this section cites the JSON the gate reads." -->
 
 Detection no longer lives in this file. The two-phase drift walk runs
-inside `.claude/scripts/workflow-startup-precheck.sh` under `--mode
-full`. Phase 1 is the `conventions.md` `§1.6(h)` artifact walk that
-classifies each `_workflow/**` artifact as stamped or unstamped; Phase
-2 is the pairwise `git merge-base` fold to `BASE_SHA` plus the
-`git log BASE_SHA..HEAD` over the workflow pathspecs.
+inside `.claude/scripts/workflow-startup-precheck.sh` under
+`--mode full`. Phase 1 is the conventions.md:orchestrator,planner:1,2,3A `§1.6(h)` artifact
+walk that classifies each `_workflow/**` artifact as stamped or
+unstamped; Phase 2 is the pairwise `git merge-base` fold to `BASE_SHA`
+plus the `git log BASE_SHA..HEAD` over the workflow pathspecs.
 The script is the single behavioral home; this file owns only the
 resolution UX below. Cite the script's `emit_json` function for the
 exact field contract, not any frozen design draft.
@@ -99,11 +99,11 @@ The five outcomes the gate routes on, keyed off `drift.detected` and
   the walk runs.
 - **`detected == false`, `kind == null`**: no stampable artifact under
   the active plan's `_workflow/` (both the stamped and unstamped sets
-  are empty). Silent skip per `conventions.md` `§1.6(h)`; the gate
+  are empty). Silent skip per conventions.md:orchestrator,planner:1,2,3A `§1.6(h)`; the gate
   reports no drift and startup continues.
 - **`detected == true`, `kind == "merge-base-failed"`**: a stamp sits
   on a pruned or unreachable commit. The script routes the failing pair
-  to the unstamped short-circuit per `conventions.md` `§1.6(c)`; the
+  to the unstamped short-circuit per conventions.md:orchestrator,planner:1,2,3A `§1.6(c)`; the
   gate signals drift and the bootstrap prompt in `§1.6(d)` covers the
   failing set alongside any other unstamped artifacts in one batched
   user prompt.
@@ -113,7 +113,7 @@ is the byte-source shared with `/migrate-workflow`'s Step 2 range
 computation. The range definition (`BASE_SHA..HEAD`, pairwise fold via
 `git merge-base`, merge-base-failure recovery), the canonical parser
 regex (`workflow-sha:` anchor plus `[0-9a-f]{40}` extraction), and the
-active-plan scope rule live in `conventions.md` `§1.6(c)`, `§1.6(h)`,
+active-plan scope rule live in conventions.md:orchestrator,planner:1,2,3A `§1.6(c)`, `§1.6(h)`,
 and `§1.6(a1)` respectively. The script conforms to that spec, checked
 by the byte-source conformance fixture in `.claude/scripts/tests/`.
 
@@ -200,7 +200,7 @@ skip semantics the gate relies on. Skip #1 and Skip #2 are cheap
 pre-walk on-disk reads (no `git log` needed); Skip #3 is post-fold
 (after `drift.base_sha` is derived and the range `git log` returns its
 result). All three scope to the active plan dir (the plan dir resolved
-at startup per `conventions.md` `§1.6(g)` and `§1.2`); cross-plan
+at startup per conventions.md:orchestrator,planner:1,2,3A `§1.6(g)` and `§1.2`); cross-plan
 folding is out of scope (D13). Order matters for fail-fast: check the
 cheapest first:
 
@@ -265,13 +265,13 @@ Pick one (no default).
 Do **not** pick a default. The user must choose one of the three
 resolutions before startup proceeds. Malformed answers (`yes`, `ok`)
 trigger a re-prompt using the same shape. The retry is bounded at
-three attempts per the policy in `conventions.md` `§1.6(d)`; after
+three attempts per the policy in conventions.md:orchestrator,planner:1,2,3A `§1.6(d)`; after
 three malformed answers the gate halts and the user `/clear`s the
 session.
 
 **Unstamped short-circuit rendering.** When `drift.kind` is
 `"unstamped"` or `"merge-base-failed"` (the unstamped path or a
-`git merge-base` failure routed there per `conventions.md` `§1.6(c)`),
+`git merge-base` failure routed there per conventions.md:orchestrator,planner:1,2,3A `§1.6(c)`),
 the script runs no range `git log` and neither `drift.base_sha` nor
 `drift.commit_count` is derived (both null). The Resolutions prompt
 substitutes:

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -733,6 +733,18 @@ jobs:
       - name: Verify embedded code examples in documentation
         run: npx embedme --verify **/*.md
 
+      # Fold workflow TOC + annotation validation into the required CI Status
+      # gate. The standalone `workflow-toc-check.yml` workflow gives fast,
+      # path-filtered PR feedback, but it is not a required status check, so a
+      # red TOC check there cannot block a merge (this is how a schema
+      # violation reached develop unblocked). Running `--check` here makes a
+      # violation fail CI Status — the blocking gate — on pull requests and on
+      # develop pushes alike. The check is stdlib-only and finishes in ~1s, and
+      # it runs before the should_build early-exit below so it also covers
+      # workflow-only PRs that skip the build matrix.
+      - name: Validate workflow TOC + annotations
+        run: python3 .claude/scripts/workflow-reindex.py --check
+
       - name: Check results
         env:
           DETECT_RESULT: ${{ needs.detect-changes.result }}


### PR DESCRIPTION
#### Motivation

PR #1116 squash-merged into `develop` with its `toc-check` red. That was possible because the workflow TOC and annotation validator runs only in the standalone `workflow-toc-check.yml` workflow, which is not a required status check and triggers only on `pull_request`. A failing TOC check therefore cannot block a merge, and never runs on `develop` pushes. As a result `develop` now carries a schema violation in `workflow-drift-check.md`, and because the validator checks the whole tree, every future workflow-touching PR would fail `toc-check` on that pre-existing violation.

The violation itself: a multi-line inline code span (`--mode full` wrapping across two lines in the Detection section) desynced `workflow-reindex.py`'s per-line backtick pairing, leaving the line's `conventions.md` and `§1.6(h)` references exposed outside any code span. Rules 6 and 8 then fired.

#### Changes

1. **Fix the TOC violation** (`workflow-drift-check.md`): reflow so no inline code span straddles a newline, and normalize all eight `conventions.md` cross-file references to the §1.8(e) suffixed form (`conventions.md:orchestrator,planner:1,2,3A`, the most-closed scope matching every section's audience). The tree-wide cleanup of the same backtick-wrapping pattern (~447 refs across 67 files) and the rule-6 hardening that would enforce it are tracked in YTDB-1067.
2. **Make the TOC check a blocking gate** (`maven-pipeline.yml`): fold `workflow-reindex.py --check` into the required `CI Status` job, beside the existing `embedme` doc-check. `CI Status` runs on `pull_request` and `push: develop` with `always()`, so the validator now blocks merges and runs post-merge on `develop`. The step precedes the `should_build` early-exit, so workflow-only PRs that skip the build matrix are covered. The standalone `workflow-toc-check.yml` stays as fast, path-filtered PR feedback.

The two changes land together by necessity: the gating step would fail on develop's existing violation if the file fix did not ride along.

#### Test plan

- [x] `python3 .claude/scripts/workflow-reindex.py --check` exits 0 (the gate's own command).
- [x] `test_workflow_reindex.py` 124/124 and `test_workflow_startup_precheck.py` 74/74 pass unchanged.
- [x] `maven-pipeline.yml` parses as valid YAML; the new step mirrors the existing `embedme` step.
- [ ] CI: `CI Status` green on this PR (it now includes the TOC check).

Refs: #1116 (merged), YTDB-1067.
