### PR TITLE
YTDB-629: match rid from where extract

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -6,7 +6,9 @@ import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Direction;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.engine.SelectivityEstimator;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Schema;
@@ -40,6 +42,8 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLFromClause;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLFromItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLGroupBy;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIdentifier;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLInCondition;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLInteger;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLLimit;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchFilter;
@@ -307,6 +311,13 @@ public class MatchExecutionPlanner {
   private Map<String, SQLRid> aliasRids;
 
   /**
+   * Maps each alias to a static RID list promoted from {@code @rid IN [...]}
+   * in the WHERE clause. An alias has at most one of {@link #aliasRids} or
+   * {@code aliasRidLists} after {@link #promoteStaticRidsFromFilters}.
+   */
+  private Map<String, List<SQLRid>> aliasRidLists;
+
+  /**
    * Aliases whose class was inferred from edge LINK schema rather than
    * explicitly declared. Inferred aliases must NOT outcompete explicit
    * roots during scheduling — a low-cardinality inferred class can cause
@@ -412,6 +423,7 @@ public class MatchExecutionPlanner {
     // detectNotInAntiJoin() mutates this map to strip NOT IN conditions.
     this.aliasFilters = new HashMap<>(aliasFilters);
     this.aliasRids = Map.of();
+    this.aliasRidLists = Map.of();
   }
 
   /**
@@ -495,7 +507,7 @@ public class MatchExecutionPlanner {
 
     // Phase 3: Estimate how many root records each aliased node will produce.
     var estimatedRootEntries =
-        estimateRootEntries(aliasClasses, aliasRids, aliasFilters, context);
+        estimateRootEntries(aliasClasses, aliasRids, aliasRidLists, aliasFilters, context);
     // Inflate estimates for inferred-class aliases so they never outcompete
     // explicitly declared roots. A low-cardinality inferred class can cause
     // the scheduler to reverse traversal direction across while steps.
@@ -549,7 +561,7 @@ public class MatchExecutionPlanner {
     // Phase 6: Append NOT-pattern filter steps (nested-loop or hash anti-join)
     manageNotPatterns(
         result, pattern, notMatchExpressions, aliasClasses, aliasFilters, aliasRids,
-        context, enableProfiling);
+        aliasRidLists, context, enableProfiling);
 
     // Phase 7: If optional nodes were encountered, replace EMPTY_OPTIONAL sentinels with null
     if (foundOptional) {
@@ -677,6 +689,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context,
       boolean enableProfiling) {
     for (var exp : notMatchExpressions) {
@@ -713,10 +726,12 @@ public class MatchExecutionPlanner {
         lastFilter = item.getFilter();
       }
 
-      if (canUseHashJoin(exp, aliasClasses, aliasFilters, aliasRids, context)) {
+      if (canUseHashJoin(
+          exp, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context)) {
         // Hash anti-join path: materialize NOT sub-pattern, probe per upstream row
         var buildPlan = buildNotPatternPlan(
-            exp, matchSteps, aliasClasses, aliasFilters, aliasRids, context, enableProfiling);
+            exp, matchSteps, aliasClasses, aliasFilters, aliasRids, aliasRidLists,
+            context, enableProfiling);
         var sharedAliases = findSharedAliases(exp, pattern);
         result.chain(new HashJoinMatchStep(
             context, buildPlan, sharedAliases, JoinMode.ANTI_JOIN, enableProfiling));
@@ -836,6 +851,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context) {
     var originAlias = exp.getOrigin().getAlias();
     assert originAlias != null : "NOT expression origin must have an alias";
@@ -844,12 +860,13 @@ public class MatchExecutionPlanner {
     // return MAX_VALUE to force fallback to nested-loop.
     if (aliasClasses.get(originAlias) == null
         && aliasRids.get(originAlias) == null
+        && !aliasRidLists.containsKey(originAlias)
         && aliasFilters.get(originAlias) == null) {
       return Long.MAX_VALUE;
     }
     var session = context.getDatabaseSession();
     long estimate = estimateAliasCardinality(
-        originAlias, aliasClasses, aliasFilters, aliasRids, context);
+        originAlias, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
     var currentClass = aliasClasses.get(originAlias);
     for (var item : exp.getItems()) {
       // Estimate fan-out from schema statistics (edgeCount / sourceCount)
@@ -895,6 +912,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context) {
     if (notPatternDependsOnMatched(exp)) {
       return false;
@@ -903,8 +921,8 @@ public class MatchExecutionPlanner {
     if (originAlias == null || !aliasClasses.containsKey(originAlias)) {
       return false;
     }
-    var estimatedCardinality =
-        estimateNotPatternCardinality(exp, aliasClasses, aliasFilters, aliasRids, context);
+    var estimatedCardinality = estimateNotPatternCardinality(
+        exp, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
     return estimatedCardinality <= getHashJoinThreshold();
   }
 
@@ -1067,6 +1085,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context) {
     if (scheduledEdges.size() < 2) {
       // Need at least 2 edges: one branch edge + one consistency-check edge
@@ -1103,7 +1122,7 @@ public class MatchExecutionPlanner {
         // This is a consistency-check edge — target was already visited.
         var branch = traceBackwardBranch(
             scheduledEdges, i, visitedBefore, downstreamAliases,
-            aliasClasses, aliasFilters, aliasRids, context);
+            aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
         if (branch != null) {
           // Discard branch if any of its edges overlap with an already-claimed branch
           boolean overlaps = false;
@@ -1155,6 +1174,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context) {
     var checkEdge = scheduledEdges.get(checkIdx);
     var checkTarget = targetAlias(checkEdge);
@@ -1188,7 +1208,7 @@ public class MatchExecutionPlanner {
     // Phase 3: Cardinality estimation and cost-based guards
     long cardinality = estimateBranchCardinality(
         trace.branchRoot, trace.branchEdges, aliasClasses, aliasFilters,
-        aliasRids, context);
+        aliasRids, aliasRidLists, context);
     long threshold = getHashJoinThreshold();
     if (cardinality > threshold) {
       return null;
@@ -1208,7 +1228,7 @@ public class MatchExecutionPlanner {
       // Guard 1: Skip hash join when the upstream (probe side) is small.
       long upstreamCardinality = estimateUpstreamCardinality(
           scheduledEdges, checkIdx, trace.branchEdges,
-          aliasClasses, aliasFilters, aliasRids, context);
+          aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
       if (upstreamCardinality < upstreamMin) {
         return null;
       }
@@ -1236,7 +1256,7 @@ public class MatchExecutionPlanner {
     // The build plan needs a scan alias with a known class or RID.
     var scanAlias = findScanAlias(
         otherShared, trace.branchRoot, trace.intermediateAliases, aliasClasses,
-        aliasRids);
+        aliasRids, aliasRidLists);
     if (scanAlias == null) {
       return null;
     }
@@ -1389,11 +1409,12 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context) {
     var session = context.getDatabaseSession();
     // Start with branch root cardinality
     long rows = estimateAliasCardinality(
-        branchRoot, aliasClasses, aliasFilters, aliasRids, context);
+        branchRoot, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
 
     // Skip the last edge (consistency-check edge) — it doesn't expand cardinality,
     // it's a filter verifying the target alias matches an already-visited node (cost 0).
@@ -1449,6 +1470,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context) {
     var session = context.getDatabaseSession();
     var branchEdgeSet = new HashSet<>(branchEdges);
@@ -1456,7 +1478,7 @@ public class MatchExecutionPlanner {
     // Find the scan root alias (source of the first scheduled edge)
     var rootAlias = sourceAlias(scheduledEdges.get(0));
     long rows = estimateAliasCardinality(
-        rootAlias, aliasClasses, aliasFilters, aliasRids, context);
+        rootAlias, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
 
     var currentClass = aliasClasses.get(rootAlias);
     for (int i = 0; i < checkIdx; i++) {
@@ -1534,6 +1556,7 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context) {
     var cls = aliasClasses.get(alias);
     var filter = aliasFilters.get(alias);
@@ -1541,8 +1564,12 @@ public class MatchExecutionPlanner {
     var singleClasses = cls != null ? Map.of(alias, cls) : Map.<String, String>of();
     var singleFilters = filter != null ? Map.of(alias, filter) : Map.<String, SQLWhereClause>of();
     var singleRids = rid != null ? Map.of(alias, rid) : Map.<String, SQLRid>of();
+    var listRids = aliasRidLists.containsKey(alias)
+        ? Map.of(alias, aliasRidLists.get(alias))
+        : Map.<String, List<SQLRid>>of();
 
-    var rootEstimates = estimateRootEntries(singleClasses, singleRids, singleFilters, context);
+    var rootEstimates = estimateRootEntries(
+        singleClasses, singleRids, listRids, singleFilters, context);
     var count = rootEstimates.get(alias);
     return count != null ? Math.max(1, count) : THRESHOLD;
   }
@@ -1557,17 +1584,24 @@ public class MatchExecutionPlanner {
       String branchRoot,
       Set<String> intermediateAliases,
       Map<String, String> aliasClasses,
-      Map<String, SQLRid> aliasRids) {
+      Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists) {
     // Prefer shared aliases — they anchor the build plan at a join endpoint
-    if (aliasClasses.get(otherShared) != null || aliasRids.get(otherShared) != null) {
+    if (aliasClasses.get(otherShared) != null
+        || aliasRids.get(otherShared) != null
+        || aliasRidLists.containsKey(otherShared)) {
       return otherShared;
     }
-    if (aliasClasses.get(branchRoot) != null || aliasRids.get(branchRoot) != null) {
+    if (aliasClasses.get(branchRoot) != null
+        || aliasRids.get(branchRoot) != null
+        || aliasRidLists.containsKey(branchRoot)) {
       return branchRoot;
     }
     // Fall back to intermediates (relevant for INNER_JOIN where intermediates have classes)
     for (var alias : intermediateAliases) {
-      if (aliasClasses.get(alias) != null || aliasRids.get(alias) != null) {
+      if (aliasClasses.get(alias) != null
+          || aliasRids.get(alias) != null
+          || aliasRidLists.containsKey(alias)) {
         return alias;
       }
     }
@@ -1594,18 +1628,19 @@ public class MatchExecutionPlanner {
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext context,
       boolean enableProfiling) {
     var originAlias = exp.getOrigin().getAlias();
     var originClass = aliasClasses.get(originAlias);
-    var originRid = aliasRids.get(originAlias);
+    var originRids = pinnedRidsForAlias(originAlias, aliasRids, aliasRidLists);
     var originFilter = aliasFilters.get(originAlias);
 
     // Build the origin scan: SELECT FROM <class> [WHERE ...]
     // Copy the WHERE clause to prevent mutable filter corruption (same as
     // buildHashJoinBranchPlan and addStepsFor).
     var select = createSelectStatement(
-        originClass, originRid, originFilter == null ? null : originFilter.copy());
+        originClass, originRids, originFilter == null ? null : originFilter.copy());
 
     // Create PatternNode for the origin alias
     var originNode = new PatternNode();
@@ -1645,13 +1680,13 @@ public class MatchExecutionPlanner {
     // all branch aliases.
     var scanAlias = branch.scanAlias();
     var scanClass = aliasClasses.get(scanAlias);
-    var scanRid = aliasRids.get(scanAlias);
+    var scanRids = pinnedRidsForAlias(scanAlias);
     var scanFilter = aliasFilters.get(scanAlias);
 
     // Copy the WHERE clause to prevent mutable state from the main plan's
     // execution corrupting the build-side filter (matches addStepsFor behavior).
     var select = createSelectStatement(
-        scanClass, scanRid, scanFilter == null ? null : scanFilter.copy());
+        scanClass, scanRids, scanFilter == null ? null : scanFilter.copy());
     var scanNode = new PatternNode();
     scanNode.alias = scanAlias;
 
@@ -1811,7 +1846,8 @@ public class MatchExecutionPlanner {
       var downstreamAliases = collectDownstreamAliases(
           returnItems, groupBy, orderBy, unwind, pattern.aliasToNode.keySet());
       var hashJoinBranches = identifyHashJoinBranches(
-          sortedEdges, downstreamAliases, aliasClasses, aliasFilters, aliasRids, context);
+          sortedEdges, downstreamAliases, aliasClasses, aliasFilters, aliasRids,
+          aliasRidLists, context);
 
       // Collect edges that belong to hash join branches — skip them in the main loop.
       // Guards:
@@ -1864,9 +1900,9 @@ public class MatchExecutionPlanner {
         plan.chain(new MatchFirstStep(context, node, profilingEnabled));
       } else {
         var clazz = aliasClasses.get(node.alias);
-        var rid = aliasRids.get(node.alias);
+        var pinnedRids = pinnedRidsForAlias(node.alias);
         var filter = aliasFilters.get(node.alias);
-        var select = createSelectStatement(clazz, rid, filter);
+        var select = createSelectStatement(clazz, pinnedRids, filter);
         plan.chain(
             new MatchFirstStep(
                 context,
@@ -3986,6 +4022,7 @@ public class MatchExecutionPlanner {
     // The correlated alias must already be visited (it's in aliasClasses or known)
     if (aliasClasses.get(correlatedAlias) == null
         && aliasRids.get(correlatedAlias) == null
+        && !aliasRidLists.containsKey(correlatedAlias)
         && !pattern.aliasToNode.containsKey(correlatedAlias)) {
       return null;
     }
@@ -4219,15 +4256,15 @@ public class MatchExecutionPlanner {
     if (first) {
       var patternNode = edge.out ? edge.edge.out : edge.edge.in;
       var clazz = this.aliasClasses.get(patternNode.alias);
-      var rid = this.aliasRids.get(patternNode.alias);
+      var pinnedRids = pinnedRidsForAlias(patternNode.alias);
       var where = aliasFilters.get(patternNode.alias);
       var select = new SQLSelectStatement(-1);
       select.setTarget(new SQLFromClause(-1));
       select.getTarget().setItem(new SQLFromItem(-1));
       if (clazz != null) {
         select.getTarget().getItem().setIdentifier(new SQLIdentifier(clazz));
-      } else if (rid != null) {
-        select.getTarget().getItem().setRids(Collections.singletonList(rid));
+      } else if (pinnedRids != null) {
+        select.getTarget().getItem().setRids(pinnedRids);
       }
       select.setWhereClause(where == null ? null : where.copy());
       var subContxt = new BasicCommandContext();
@@ -4325,10 +4362,10 @@ public class MatchExecutionPlanner {
       boolean profilingEnabled) {
     for (var alias : aliasesToPrefetch) {
       var targetClass = aliasClasses.get(alias);
-      var targetRid = aliasRids.get(alias);
+      var pinnedRids = pinnedRidsForAlias(alias);
       var filter = aliasFilters.get(alias);
       var prefetchStm =
-          createSelectStatement(targetClass, targetRid, filter);
+          createSelectStatement(targetClass, pinnedRids, filter);
 
       var step =
           new MatchPrefetchStep(
@@ -4341,18 +4378,18 @@ public class MatchExecutionPlanner {
   }
 
   /**
-   * Builds a synthetic `SELECT` statement that scans a class, a single RID, or applies a
-   * `WHERE` filter. This is used to generate the initial record source for
+   * Builds a synthetic {@code SELECT} that fetches from a RID list, scans a class,
+   * or both (RID list plus {@code WHERE}). Used as the initial record source for
    * {@link MatchFirstStep} and {@link MatchPrefetchStep}.
    */
   private static SQLSelectStatement createSelectStatement(
-      String targetClass, SQLRid targetRid, SQLWhereClause filter) {
+      String targetClass, @Nullable List<SQLRid> targetRids, SQLWhereClause filter) {
     var prefetchStm = new SQLSelectStatement(-1);
     prefetchStm.setWhereClause(filter);
     var from = new SQLFromClause(-1);
     var fromItem = new SQLFromItem(-1);
-    if (targetRid != null) {
-      fromItem.setRids(Collections.singletonList(targetRid));
+    if (targetRids != null && !targetRids.isEmpty()) {
+      fromItem.setRids(targetRids);
     } else if (targetClass != null) {
       fromItem.setIdentifier(new SQLIdentifier(targetClass));
     }
@@ -4394,6 +4431,7 @@ public class MatchExecutionPlanner {
     Map<String, String> aliasClasses = new LinkedHashMap<>();
     Map<String, String> aliasCollections = new LinkedHashMap<>();
     Map<String, SQLRid> aliasRids = new LinkedHashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new LinkedHashMap<>();
     // Collect aliases that are directly part of a while-condition's recursive
     // zone (origin + while-item).  Class inference on these specific aliases
     // must be skipped — inferred classes change cost estimates which can
@@ -4410,36 +4448,41 @@ public class MatchExecutionPlanner {
     this.aliasFilters = aliasFilters;
     this.aliasClasses = aliasClasses;
     this.aliasRids = aliasRids;
+    this.aliasRidLists = aliasRidLists;
     this.inferredWhileExprAliases = inferredAliases;
 
-    // Promote `WHERE: (@rid = <literal|param>)` into aliasRids before
-    // estimateRootEntries() and the topological schedule run. With a RID slot
-    // populated, the estimate collapses to 1, so a 2M-row class restricted to
-    // one RID stops losing root selection to a 10K-row unfiltered class.
+    // Promote static `@rid = <literal|param>` and `@rid IN [...]` filters into
+    // aliasRids / aliasRidLists before estimateRootEntries() and the topological
+    // schedule run. With a RID slot populated, the estimate collapses to the list
+    // size, so a 2M-row class restricted to a few RIDs stops losing root selection
+    // to a 10K-row unfiltered class.
     // The promotion also lets createSelectStatement() take the FetchFromRids
     // fast path instead of a class scan with post-filter.
     // Back-refs (`@rid = $matched.X.@rid`) are skipped: those are bound at
     // runtime and are handled by EdgeRidLookup or Pattern A back-ref hash
     // join in the pre-filter pass.
-    // The @rid term stays in aliasFilters on purpose. When the alias is not
-    // picked as a root, the existing DirectRid pre-filter pass on the
-    // producing edge still relies on findRidEquality() to attach a singleton
-    // intersection descriptor.
-    promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    // The @rid term stays in aliasFilters on purpose. For {@code @rid = <expr>}
+    // on a non-root alias, the DirectRid pre-filter pass on the producing edge
+    // still relies on findRidEquality(). {@code @rid IN <list>} has no
+    // RidFilterDescriptor analogue; non-root IN lists are enforced via prefetch
+    // or post-fetch WHERE evaluation instead.
+    promoteStaticRidsFromFilters(aliasFilters, aliasRids, aliasRidLists, ctx);
 
     rebindFilters(aliasFilters);
   }
 
   /**
-   * Promotes static {@code @rid = <literal|param>} equalities from
-   * {@code aliasFilters} into {@code aliasRids} so that
-   * {@link #estimateRootEntries} returns 1 for those aliases and
+   * Promotes static {@code @rid = <literal|param>} equalities into {@code aliasRids}
+   * and {@code @rid IN <static-list>} into {@code aliasRidLists} so that
+   * {@link #estimateRootEntries} returns the pinned cardinality and
    * {@link #createSelectStatement} uses a direct RID fetch.
    *
    * <p>The original {@code @rid} term is intentionally left in the filter. When
    * the alias does not end up as a root, the pre-filter pass on the producing
-   * edge still relies on {@link SQLWhereClause#findRidEquality()} to attach a
-   * {@code DirectRid} intersection descriptor.
+   * edge uses {@link SQLWhereClause#findRidEquality()} to attach a
+   * {@code DirectRid} intersection descriptor for singleton equalities only.
+   * {@code @rid IN <list>} has no matching pre-filter descriptor; those aliases
+   * rely on prefetch / {@link #createSelectStatement} or post-fetch WHERE.
    *
    * <p>Skipped:
    * <ul>
@@ -4448,12 +4491,14 @@ public class MatchExecutionPlanner {
    *   <li>{@code @rid = $matched.X.@rid} back-refs (handled by
    *       {@code EdgeRidLookup} or Pattern A back-ref hash join)
    *   <li>expressions that are not early-calculable (depend on per-row context)
+   *   <li>{@code @rid IN <subquery>} or non-static right-hand sides
    * </ul>
    */
   // Visible for testing
   static void promoteStaticRidsFromFilters(
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       CommandContext ctx) {
     for (var entry : aliasFilters.entrySet()) {
       var alias = entry.getKey();
@@ -4462,33 +4507,142 @@ public class MatchExecutionPlanner {
         continue;
       }
       // Don't overwrite an explicit RID slot from the parser.
-      if (aliasRids.containsKey(alias)) {
+      if (aliasRids.containsKey(alias) || aliasRidLists.containsKey(alias)) {
         continue;
       }
       var ridExpr = filter.findRidEquality();
-      if (ridExpr == null) {
+      if (ridExpr != null) {
+        var involved = ridExpr.getMatchPatternInvolvedAliases();
+        if (involved != null && !involved.isEmpty()) {
+          continue;
+        }
+        if (!ridExpr.isEarlyCalculated(ctx)) {
+          continue;
+        }
+        var rid = new SQLRid(-1);
+        SQLRid.internalPromoteExpression(rid, ridExpr);
+        aliasRids.put(alias, rid);
+        logger.debug(
+            "MATCH planner: promoted @rid = filter to aliasRids for alias '{}'",
+            alias);
         continue;
       }
-      // Back-ref `@rid = $matched.X.@rid`: leave it for EdgeRidLookup.
-      var involved = ridExpr.getMatchPatternInvolvedAliases();
+
+      var ridIn = filter.findRidInList();
+      if (ridIn == null) {
+        continue;
+      }
+      var involved = ridIn.getMatchPatternInvolvedAliases();
       if (involved != null && !involved.isEmpty()) {
         continue;
       }
-      // Reject anything else that needs per-row context.
-      if (!ridExpr.isEarlyCalculated(ctx)) {
+      var promotedList = toPromotedSqlRidList(ridIn, ctx);
+      if (promotedList == null || promotedList.isEmpty()) {
         continue;
       }
-      // Wrap the value-side expression in a SQLRid via its non-legacy
-      // expression slot. SQLRid.toRecordId() executes the expression and
-      // unwraps the resulting Identifiable, which works for both literal
-      // RIDs (`#25:7`) and parameters (`:rid`).
-      var rid = new SQLRid(-1);
-      SQLRid.internalPromoteExpression(rid, ridExpr);
-      aliasRids.put(alias, rid);
+      aliasRidLists.put(alias, promotedList);
       logger.debug(
-          "MATCH planner: promoted @rid filter to aliasRids for alias '{}'",
+          "MATCH planner: promoted @rid IN filter ({} RIDs) for alias '{}'",
+          promotedList.size(),
           alias);
     }
+  }
+
+  /**
+   * Resolves a pinned RID list for an alias, preferring a promoted IN-list over a
+   * single parser/promoted equality slot.
+   */
+  @Nullable private List<SQLRid> pinnedRidsForAlias(String alias) {
+    return pinnedRidsForAlias(alias, aliasRids, aliasRidLists);
+  }
+
+  @Nullable private static List<SQLRid> pinnedRidsForAlias(
+      String alias,
+      Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists) {
+    var list = aliasRidLists.get(alias);
+    if (list != null) {
+      return list;
+    }
+    var single = aliasRids.get(alias);
+    return single != null ? List.of(single) : null;
+  }
+
+  /**
+   * Converts a static {@code @rid IN <expr>} condition into concrete {@link SQLRid}
+   * nodes suitable for {@code SELECT FROM [#a, #b, ...]}.
+   */
+  @Nullable static List<SQLRid> toPromotedSqlRidList(SQLInCondition inCond, CommandContext ctx) {
+    if (inCond.getRightStatement() != null) {
+      return null;
+    }
+    if (!isEarlyCalculableInRight(inCond, ctx)) {
+      return null;
+    }
+    Object rightVal;
+    if (inCond.getRightParam() != null) {
+      rightVal = inCond.getRightParam().getValue(ctx.getInputParameters());
+    } else if (inCond.getRightMathExpression() != null) {
+      rightVal = inCond.getRightMathExpression().execute((Result) null, ctx);
+    } else {
+      return null;
+    }
+    if (!(rightVal instanceof Iterable<?> iterable)) {
+      return null;
+    }
+    List<SQLRid> rids = new ArrayList<>();
+    for (var item : iterable) {
+      var sqlRid = sqlRidFromRuntimeValue(item);
+      if (sqlRid == null) {
+        return null;
+      }
+      rids.add(sqlRid);
+    }
+    return rids.isEmpty() ? null : rids;
+  }
+
+  private static boolean isEarlyCalculableInRight(SQLInCondition inCond, CommandContext ctx) {
+    if (inCond.getRightParam() != null) {
+      return true;
+    }
+    var math = inCond.getRightMathExpression();
+    return math != null && math.isEarlyCalculated(ctx);
+  }
+
+  @Nullable private static SQLRid sqlRidFromRuntimeValue(Object value) {
+    if (value instanceof Identifiable identifiable) {
+      var identity = identifiable.getIdentity();
+      var rid = new SQLRid(-1);
+      var collection = new SQLInteger(-1);
+      collection.setValue(identity.getCollectionId());
+      var position = new SQLInteger(-1);
+      position.setValue(identity.getCollectionPosition());
+      rid.setLegacy(true);
+      rid.setCollection(collection);
+      rid.setPosition(position);
+      return rid;
+    }
+    if (value instanceof String s) {
+      RecordIdInternal parsed;
+      try {
+        parsed = RecordIdInternal.fromString(s, false);
+      } catch (IllegalArgumentException ignored) {
+        return null;
+      }
+      if (parsed == null) {
+        return null;
+      }
+      var rid = new SQLRid(-1);
+      var collection = new SQLInteger(-1);
+      collection.setValue(parsed.getCollectionId());
+      var position = new SQLInteger(-1);
+      position.setValue(parsed.getCollectionPosition());
+      rid.setLegacy(true);
+      rid.setCollection(collection);
+      rid.setPosition(position);
+      return rid;
+    }
+    return null;
   }
 
   /**
@@ -4839,7 +4993,8 @@ public class MatchExecutionPlanner {
    * - **Root selection**: the topological scheduler starts from the cheapest root.
    *
    * <p>Estimation strategy per alias:
-   * - RID constraint → exactly 1 record.
+   * - Single RID constraint → exactly 1 record.
+   * - Static RID list constraint → list size records.
    * - Class constraint with `WHERE` → uses the filter's own
    *   {@link SQLWhereClause#estimate} method (which may use index statistics).
    * - Class constraint without filter → uses the class's record count.
@@ -4851,18 +5006,25 @@ public class MatchExecutionPlanner {
   static Map<String, Long> estimateRootEntries(
       Map<String, String> aliasClasses,
       Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasRidLists,
       Map<String, SQLWhereClause> aliasFilters,
       CommandContext ctx) {
     Set<String> allAliases = new LinkedHashSet<>();
     allAliases.addAll(aliasClasses.keySet());
     allAliases.addAll(aliasFilters.keySet());
     allAliases.addAll(aliasRids.keySet());
+    allAliases.addAll(aliasRidLists.keySet());
 
     var db = ctx.getDatabaseSession();
     var schema = db.getMetadata().getImmutableSchemaSnapshot();
 
     Map<String, Long> result = new LinkedHashMap<>();
     for (var alias : allAliases) {
+      var ridList = aliasRidLists.get(alias);
+      if (ridList != null) {
+        result.put(alias, (long) ridList.size());
+        continue;
+      }
       var rid = aliasRids.get(alias);
       if (rid != null) {
         result.put(alias, 1L);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -4536,7 +4536,8 @@ public class MatchExecutionPlanner {
   }
 
   /** Returns the sole pinned RID when the list has exactly one entry (for {@code setLeftRid}). */
-  @Nullable private static SQLRid singletonPinnedRid(@Nullable List<SQLRid> pinnedRids) {
+  // Visible for testing
+  @Nullable static SQLRid singletonPinnedRid(@Nullable List<SQLRid> pinnedRids) {
     return pinnedRids != null && pinnedRids.size() == 1 ? pinnedRids.get(0) : null;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -4412,7 +4412,83 @@ public class MatchExecutionPlanner {
     this.aliasRids = aliasRids;
     this.inferredWhileExprAliases = inferredAliases;
 
+    // Promote `WHERE: (@rid = <literal|param>)` into aliasRids before
+    // estimateRootEntries() and the topological schedule run. With a RID slot
+    // populated, the estimate collapses to 1, so a 2M-row class restricted to
+    // one RID stops losing root selection to a 10K-row unfiltered class.
+    // The promotion also lets createSelectStatement() take the FetchFromRids
+    // fast path instead of a class scan with post-filter.
+    // Back-refs (`@rid = $matched.X.@rid`) are skipped: those are bound at
+    // runtime and are handled by EdgeRidLookup or Pattern A back-ref hash
+    // join in the pre-filter pass.
+    // The @rid term stays in aliasFilters on purpose. When the alias is not
+    // picked as a root, the existing DirectRid pre-filter pass on the
+    // producing edge still relies on findRidEquality() to attach a singleton
+    // intersection descriptor.
+    promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
     rebindFilters(aliasFilters);
+  }
+
+  /**
+   * Promotes static {@code @rid = <literal|param>} equalities from
+   * {@code aliasFilters} into {@code aliasRids} so that
+   * {@link #estimateRootEntries} returns 1 for those aliases and
+   * {@link #createSelectStatement} uses a direct RID fetch.
+   *
+   * <p>The original {@code @rid} term is intentionally left in the filter. When
+   * the alias does not end up as a root, the pre-filter pass on the producing
+   * edge still relies on {@link SQLWhereClause#findRidEquality()} to attach a
+   * {@code DirectRid} intersection descriptor.
+   *
+   * <p>Skipped:
+   * <ul>
+   *   <li>aliases that already have a RID slot (e.g.
+   *       {@code {as: a, rid: #1:2}})
+   *   <li>{@code @rid = $matched.X.@rid} back-refs (handled by
+   *       {@code EdgeRidLookup} or Pattern A back-ref hash join)
+   *   <li>expressions that are not early-calculable (depend on per-row context)
+   * </ul>
+   */
+  // Visible for testing
+  static void promoteStaticRidsFromFilters(
+      Map<String, SQLWhereClause> aliasFilters,
+      Map<String, SQLRid> aliasRids,
+      CommandContext ctx) {
+    for (var entry : aliasFilters.entrySet()) {
+      var alias = entry.getKey();
+      var filter = entry.getValue();
+      if (filter == null) {
+        continue;
+      }
+      // Don't overwrite an explicit RID slot from the parser.
+      if (aliasRids.containsKey(alias)) {
+        continue;
+      }
+      var ridExpr = filter.findRidEquality();
+      if (ridExpr == null) {
+        continue;
+      }
+      // Back-ref `@rid = $matched.X.@rid`: leave it for EdgeRidLookup.
+      var involved = ridExpr.getMatchPatternInvolvedAliases();
+      if (involved != null && !involved.isEmpty()) {
+        continue;
+      }
+      // Reject anything else that needs per-row context.
+      if (!ridExpr.isEarlyCalculated(ctx)) {
+        continue;
+      }
+      // Wrap the value-side expression in a SQLRid via its non-legacy
+      // expression slot. SQLRid.toRecordId() executes the expression and
+      // unwraps the resulting Identifiable, which works for both literal
+      // RIDs (`#25:7`) and parameters (`:rid`).
+      var rid = new SQLRid(-1);
+      rid.setExpression(ridExpr);
+      aliasRids.put(alias, rid);
+      logger.debug(
+          "MATCH planner: promoted @rid filter to aliasRids for alias '{}'",
+          alias);
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -4483,7 +4483,7 @@ public class MatchExecutionPlanner {
       // unwraps the resulting Identifiable, which works for both literal
       // RIDs (`#25:7`) and parameters (`:rid`).
       var rid = new SQLRid(-1);
-      rid.setExpression(ridExpr);
+      SQLRid.internalPromoteExpression(rid, ridExpr);
       aliasRids.put(alias, rid);
       logger.debug(
           "MATCH planner: promoted @rid filter to aliasRids for alias '{}'",

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchExecutionPlanner.java
@@ -307,15 +307,12 @@ public class MatchExecutionPlanner {
   /** Maps each alias to the schema class name it is constrained to. */
   private Map<String, String> aliasClasses;
 
-  /** Maps each alias to a specific RID if one was provided in the pattern. */
-  private Map<String, SQLRid> aliasRids;
-
   /**
-   * Maps each alias to a static RID list promoted from {@code @rid IN [...]}
-   * in the WHERE clause. An alias has at most one of {@link #aliasRids} or
-   * {@code aliasRidLists} after {@link #promoteStaticRidsFromFilters}.
+   * Maps each alias to pinned RIDs from the pattern ({@code {as: a, rid: #1:2}})
+   * or promoted from static {@code @rid = ...} / {@code @rid IN [...]} WHERE filters.
+   * Singleton pins use {@code List.of(rid)}; multi-RID pins use the promoted list.
    */
-  private Map<String, List<SQLRid>> aliasRidLists;
+  private Map<String, List<SQLRid>> aliasPinnedRids;
 
   /**
    * Aliases whose class was inferred from edge LINK schema rather than
@@ -422,8 +419,7 @@ public class MatchExecutionPlanner {
     // Defensive copy: aliasFilters may be immutable (e.g. Map.of() from GQL).
     // detectNotInAntiJoin() mutates this map to strip NOT IN conditions.
     this.aliasFilters = new HashMap<>(aliasFilters);
-    this.aliasRids = Map.of();
-    this.aliasRidLists = Map.of();
+    this.aliasPinnedRids = Map.of();
   }
 
   /**
@@ -507,7 +503,7 @@ public class MatchExecutionPlanner {
 
     // Phase 3: Estimate how many root records each aliased node will produce.
     var estimatedRootEntries =
-        estimateRootEntries(aliasClasses, aliasRids, aliasRidLists, aliasFilters, context);
+        estimateRootEntries(aliasClasses, aliasPinnedRids, aliasFilters, context);
     // Inflate estimates for inferred-class aliases so they never outcompete
     // explicitly declared roots. A low-cardinality inferred class can cause
     // the scheduler to reverse traversal direction across while steps.
@@ -560,8 +556,8 @@ public class MatchExecutionPlanner {
 
     // Phase 6: Append NOT-pattern filter steps (nested-loop or hash anti-join)
     manageNotPatterns(
-        result, pattern, notMatchExpressions, aliasClasses, aliasFilters, aliasRids,
-        aliasRidLists, context, enableProfiling);
+        result, pattern, notMatchExpressions, aliasClasses, aliasFilters,
+        aliasPinnedRids, context, enableProfiling);
 
     // Phase 7: If optional nodes were encountered, replace EMPTY_OPTIONAL sentinels with null
     if (foundOptional) {
@@ -678,7 +674,7 @@ public class MatchExecutionPlanner {
    * @param notMatchExpressions  the list of negative match expressions
    * @param aliasClasses         per-alias class names (needed for hash join build-side)
    * @param aliasFilters         per-alias WHERE clauses
-   * @param aliasRids            per-alias RID constraints
+   * @param aliasPinnedRids            per-alias RID constraints
    * @param context              the command context
    * @param enableProfiling      whether to enable step profiling
    */
@@ -688,8 +684,7 @@ public class MatchExecutionPlanner {
       List<SQLMatchExpression> notMatchExpressions,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context,
       boolean enableProfiling) {
     for (var exp : notMatchExpressions) {
@@ -727,10 +722,10 @@ public class MatchExecutionPlanner {
       }
 
       if (canUseHashJoin(
-          exp, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context)) {
+          exp, aliasClasses, aliasFilters, aliasPinnedRids, context)) {
         // Hash anti-join path: materialize NOT sub-pattern, probe per upstream row
         var buildPlan = buildNotPatternPlan(
-            exp, matchSteps, aliasClasses, aliasFilters, aliasRids, aliasRidLists,
+            exp, matchSteps, aliasClasses, aliasFilters, aliasPinnedRids,
             context, enableProfiling);
         var sharedAliases = findSharedAliases(exp, pattern);
         result.chain(new HashJoinMatchStep(
@@ -850,8 +845,7 @@ public class MatchExecutionPlanner {
       SQLMatchExpression exp,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     var originAlias = exp.getOrigin().getAlias();
     assert originAlias != null : "NOT expression origin must have an alias";
@@ -859,14 +853,13 @@ public class MatchExecutionPlanner {
     // If the origin alias has no class, RID, or filter, we can't estimate —
     // return MAX_VALUE to force fallback to nested-loop.
     if (aliasClasses.get(originAlias) == null
-        && aliasRids.get(originAlias) == null
-        && !aliasRidLists.containsKey(originAlias)
+        && !aliasPinnedRids.containsKey(originAlias)
         && aliasFilters.get(originAlias) == null) {
       return Long.MAX_VALUE;
     }
     var session = context.getDatabaseSession();
     long estimate = estimateAliasCardinality(
-        originAlias, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
+        originAlias, aliasClasses, aliasFilters, aliasPinnedRids, context);
     var currentClass = aliasClasses.get(originAlias);
     for (var item : exp.getItems()) {
       // Estimate fan-out from schema statistics (edgeCount / sourceCount)
@@ -911,8 +904,7 @@ public class MatchExecutionPlanner {
       SQLMatchExpression exp,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     if (notPatternDependsOnMatched(exp)) {
       return false;
@@ -922,7 +914,7 @@ public class MatchExecutionPlanner {
       return false;
     }
     var estimatedCardinality = estimateNotPatternCardinality(
-        exp, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
+        exp, aliasClasses, aliasFilters, aliasPinnedRids, context);
     return estimatedCardinality <= getHashJoinThreshold();
   }
 
@@ -1044,7 +1036,7 @@ public class MatchExecutionPlanner {
    * @param joinMode            the join mode: SEMI_JOIN if no intermediates are downstream,
    *                            INNER_JOIN if any intermediate is referenced downstream
    * @param scanAlias           the alias to scan from in the build-side plan — must have a
-   *                            known class or RID in {@code aliasClasses}/{@code aliasRids}
+   *                            known class or RID in {@code aliasClasses}/{@code aliasPinnedRids}
    */
   record HashJoinBranch(
       List<String> sharedAliases,
@@ -1075,7 +1067,7 @@ public class MatchExecutionPlanner {
    * @param downstreamAliases  aliases referenced downstream of the MATCH traversal
    * @param aliasClasses       per-alias class names
    * @param aliasFilters       per-alias WHERE clauses
-   * @param aliasRids          per-alias RID constraints
+   * @param aliasPinnedRids          per-alias RID constraints
    * @param context            the command context
    * @return list of eligible hash join branches (may be empty)
    */
@@ -1084,8 +1076,7 @@ public class MatchExecutionPlanner {
       Set<String> downstreamAliases,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     if (scheduledEdges.size() < 2) {
       // Need at least 2 edges: one branch edge + one consistency-check edge
@@ -1122,7 +1113,7 @@ public class MatchExecutionPlanner {
         // This is a consistency-check edge — target was already visited.
         var branch = traceBackwardBranch(
             scheduledEdges, i, visitedBefore, downstreamAliases,
-            aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
+            aliasClasses, aliasFilters, aliasPinnedRids, context);
         if (branch != null) {
           // Discard branch if any of its edges overlap with an already-claimed branch
           boolean overlaps = false;
@@ -1173,8 +1164,7 @@ public class MatchExecutionPlanner {
       Set<String> downstreamAliases,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     var checkEdge = scheduledEdges.get(checkIdx);
     var checkTarget = targetAlias(checkEdge);
@@ -1208,7 +1198,7 @@ public class MatchExecutionPlanner {
     // Phase 3: Cardinality estimation and cost-based guards
     long cardinality = estimateBranchCardinality(
         trace.branchRoot, trace.branchEdges, aliasClasses, aliasFilters,
-        aliasRids, aliasRidLists, context);
+        aliasPinnedRids, context);
     long threshold = getHashJoinThreshold();
     if (cardinality > threshold) {
       return null;
@@ -1228,7 +1218,7 @@ public class MatchExecutionPlanner {
       // Guard 1: Skip hash join when the upstream (probe side) is small.
       long upstreamCardinality = estimateUpstreamCardinality(
           scheduledEdges, checkIdx, trace.branchEdges,
-          aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
+          aliasClasses, aliasFilters, aliasPinnedRids, context);
       if (upstreamCardinality < upstreamMin) {
         return null;
       }
@@ -1256,7 +1246,7 @@ public class MatchExecutionPlanner {
     // The build plan needs a scan alias with a known class or RID.
     var scanAlias = findScanAlias(
         otherShared, trace.branchRoot, trace.intermediateAliases, aliasClasses,
-        aliasRids, aliasRidLists);
+        aliasPinnedRids);
     if (scanAlias == null) {
       return null;
     }
@@ -1408,13 +1398,12 @@ public class MatchExecutionPlanner {
       List<EdgeTraversal> branchEdges,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     var session = context.getDatabaseSession();
     // Start with branch root cardinality
     long rows = estimateAliasCardinality(
-        branchRoot, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
+        branchRoot, aliasClasses, aliasFilters, aliasPinnedRids, context);
 
     // Skip the last edge (consistency-check edge) — it doesn't expand cardinality,
     // it's a filter verifying the target alias matches an already-visited node (cost 0).
@@ -1469,8 +1458,7 @@ public class MatchExecutionPlanner {
       List<EdgeTraversal> branchEdges,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     var session = context.getDatabaseSession();
     var branchEdgeSet = new HashSet<>(branchEdges);
@@ -1478,7 +1466,7 @@ public class MatchExecutionPlanner {
     // Find the scan root alias (source of the first scheduled edge)
     var rootAlias = sourceAlias(scheduledEdges.get(0));
     long rows = estimateAliasCardinality(
-        rootAlias, aliasClasses, aliasFilters, aliasRids, aliasRidLists, context);
+        rootAlias, aliasClasses, aliasFilters, aliasPinnedRids, context);
 
     var currentClass = aliasClasses.get(rootAlias);
     for (int i = 0; i < checkIdx; i++) {
@@ -1555,21 +1543,18 @@ public class MatchExecutionPlanner {
       String alias,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     var cls = aliasClasses.get(alias);
     var filter = aliasFilters.get(alias);
-    var rid = aliasRids.get(alias);
     var singleClasses = cls != null ? Map.of(alias, cls) : Map.<String, String>of();
     var singleFilters = filter != null ? Map.of(alias, filter) : Map.<String, SQLWhereClause>of();
-    var singleRids = rid != null ? Map.of(alias, rid) : Map.<String, SQLRid>of();
-    var listRids = aliasRidLists.containsKey(alias)
-        ? Map.of(alias, aliasRidLists.get(alias))
+    var singlePinnedRids = aliasPinnedRids.containsKey(alias)
+        ? Map.of(alias, aliasPinnedRids.get(alias))
         : Map.<String, List<SQLRid>>of();
 
     var rootEstimates = estimateRootEntries(
-        singleClasses, singleRids, listRids, singleFilters, context);
+        singleClasses, singlePinnedRids, singleFilters, context);
     var count = rootEstimates.get(alias);
     return count != null ? Math.max(1, count) : THRESHOLD;
   }
@@ -1584,24 +1569,20 @@ public class MatchExecutionPlanner {
       String branchRoot,
       Set<String> intermediateAliases,
       Map<String, String> aliasClasses,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists) {
+      Map<String, List<SQLRid>> aliasPinnedRids) {
     // Prefer shared aliases — they anchor the build plan at a join endpoint
     if (aliasClasses.get(otherShared) != null
-        || aliasRids.get(otherShared) != null
-        || aliasRidLists.containsKey(otherShared)) {
+        || aliasPinnedRids.containsKey(otherShared)) {
       return otherShared;
     }
     if (aliasClasses.get(branchRoot) != null
-        || aliasRids.get(branchRoot) != null
-        || aliasRidLists.containsKey(branchRoot)) {
+        || aliasPinnedRids.containsKey(branchRoot)) {
       return branchRoot;
     }
     // Fall back to intermediates (relevant for INNER_JOIN where intermediates have classes)
     for (var alias : intermediateAliases) {
       if (aliasClasses.get(alias) != null
-          || aliasRids.get(alias) != null
-          || aliasRidLists.containsKey(alias)) {
+          || aliasPinnedRids.containsKey(alias)) {
         return alias;
       }
     }
@@ -1617,7 +1598,7 @@ public class MatchExecutionPlanner {
    * @param matchSteps       the pre-built MatchStep chain for the NOT pattern's edges
    * @param aliasClasses     per-alias class names
    * @param aliasFilters     per-alias WHERE clauses
-   * @param aliasRids        per-alias RID constraints
+   * @param aliasPinnedRids    per-alias pinned RID lists
    * @param context          the command context
    * @param enableProfiling  whether to enable step profiling
    * @return a complete build-side execution plan
@@ -1627,13 +1608,12 @@ public class MatchExecutionPlanner {
       List<AbstractExecutionStep> matchSteps,
       Map<String, String> aliasClasses,
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context,
       boolean enableProfiling) {
     var originAlias = exp.getOrigin().getAlias();
     var originClass = aliasClasses.get(originAlias);
-    var originRids = pinnedRidsForAlias(originAlias, aliasRids, aliasRidLists);
+    var originRids = pinnedRidsForAlias(originAlias, aliasPinnedRids);
     var originFilter = aliasFilters.get(originAlias);
 
     // Build the origin scan: SELECT FROM <class> [WHERE ...]
@@ -1724,7 +1704,7 @@ public class MatchExecutionPlanner {
           // Left constraints = edge.out node's constraints (same as createPlanForPattern)
           traversal.setLeftClass(aliasClasses.get(outAlias));
           traversal.setLeftFilter(aliasFilters.get(outAlias));
-          traversal.setLeftRid(aliasRids.get(outAlias));
+          traversal.setLeftRid(singletonPinnedRid(aliasPinnedRids.get(outAlias)));
           buildPlan.chain(new MatchStep(context, traversal, profilingEnabled));
           current = inAlias;
           used[j] = true;
@@ -1738,7 +1718,7 @@ public class MatchExecutionPlanner {
           // constraints — the target in reverse mode is edge.out.
           traversal.setLeftClass(aliasClasses.get(outAlias));
           traversal.setLeftFilter(aliasFilters.get(outAlias));
-          traversal.setLeftRid(aliasRids.get(outAlias));
+          traversal.setLeftRid(singletonPinnedRid(aliasPinnedRids.get(outAlias)));
           buildPlan.chain(new MatchStep(context, traversal, profilingEnabled));
           current = outAlias;
           used[j] = true;
@@ -1833,7 +1813,7 @@ public class MatchExecutionPlanner {
       for (var edge : sortedEdges) {
         if (edge.edge.out.alias != null) {
           edge.setLeftClass(aliasClasses.get(edge.edge.out.alias));
-          edge.setLeftRid(aliasRids.get(edge.edge.out.alias));
+          edge.setLeftRid(singletonPinnedRid(aliasPinnedRids.get(edge.edge.out.alias)));
           edge.setLeftFilter(aliasFilters.get(edge.edge.out.alias));
         }
       }
@@ -1846,8 +1826,8 @@ public class MatchExecutionPlanner {
       var downstreamAliases = collectDownstreamAliases(
           returnItems, groupBy, orderBy, unwind, pattern.aliasToNode.keySet());
       var hashJoinBranches = identifyHashJoinBranches(
-          sortedEdges, downstreamAliases, aliasClasses, aliasFilters, aliasRids,
-          aliasRidLists, context);
+          sortedEdges, downstreamAliases, aliasClasses, aliasFilters,
+          aliasPinnedRids, context);
 
       // Collect edges that belong to hash join branches — skip them in the main loop.
       // Guards:
@@ -4021,8 +4001,7 @@ public class MatchExecutionPlanner {
 
     // The correlated alias must already be visited (it's in aliasClasses or known)
     if (aliasClasses.get(correlatedAlias) == null
-        && aliasRids.get(correlatedAlias) == null
-        && !aliasRidLists.containsKey(correlatedAlias)
+        && !aliasPinnedRids.containsKey(correlatedAlias)
         && !pattern.aliasToNode.containsKey(correlatedAlias)) {
       return null;
     }
@@ -4430,8 +4409,7 @@ public class MatchExecutionPlanner {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     Map<String, String> aliasClasses = new LinkedHashMap<>();
     Map<String, String> aliasCollections = new LinkedHashMap<>();
-    Map<String, SQLRid> aliasRids = new LinkedHashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new LinkedHashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new LinkedHashMap<>();
     // Collect aliases that are directly part of a while-condition's recursive
     // zone (origin + while-item).  Class inference on these specific aliases
     // must be skipped — inferred classes change cost estimates which can
@@ -4441,18 +4419,17 @@ public class MatchExecutionPlanner {
     var whileAliases = collectAliasesFromWhilePatterns(this.matchExpressions);
     var inferredAliases = new HashSet<String>();
     for (var expr : this.matchExpressions) {
-      addAliases(expr, aliasFilters, aliasClasses, aliasCollections, aliasRids,
+      addAliases(expr, aliasFilters, aliasClasses, aliasCollections, aliasPinnedRids,
           ctx, whileAliases, inferredAliases);
     }
 
     this.aliasFilters = aliasFilters;
     this.aliasClasses = aliasClasses;
-    this.aliasRids = aliasRids;
-    this.aliasRidLists = aliasRidLists;
+    this.aliasPinnedRids = aliasPinnedRids;
     this.inferredWhileExprAliases = inferredAliases;
 
     // Promote static `@rid = <literal|param>` and `@rid IN [...]` filters into
-    // aliasRids / aliasRidLists before estimateRootEntries() and the topological
+    // aliasPinnedRids before estimateRootEntries() and the topological
     // schedule run. With a RID slot populated, the estimate collapses to the list
     // size, so a 2M-row class restricted to a few RIDs stops losing root selection
     // to a 10K-row unfiltered class.
@@ -4466,14 +4443,14 @@ public class MatchExecutionPlanner {
     // still relies on findRidEquality(). {@code @rid IN <list>} has no
     // RidFilterDescriptor analogue; non-root IN lists are enforced via prefetch
     // or post-fetch WHERE evaluation instead.
-    promoteStaticRidsFromFilters(aliasFilters, aliasRids, aliasRidLists, ctx);
+    promoteStaticRidsFromFilters(aliasFilters, aliasPinnedRids, ctx);
 
     rebindFilters(aliasFilters);
   }
 
   /**
-   * Promotes static {@code @rid = <literal|param>} equalities into {@code aliasRids}
-   * and {@code @rid IN <static-list>} into {@code aliasRidLists} so that
+   * Promotes static {@code @rid = <literal|param>} equalities and
+   * {@code @rid IN <static-list>} into {@code aliasPinnedRids} so that
    * {@link #estimateRootEntries} returns the pinned cardinality and
    * {@link #createSelectStatement} uses a direct RID fetch.
    *
@@ -4497,8 +4474,7 @@ public class MatchExecutionPlanner {
   // Visible for testing
   static void promoteStaticRidsFromFilters(
       Map<String, SQLWhereClause> aliasFilters,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext ctx) {
     for (var entry : aliasFilters.entrySet()) {
       var alias = entry.getKey();
@@ -4507,7 +4483,7 @@ public class MatchExecutionPlanner {
         continue;
       }
       // Don't overwrite an explicit RID slot from the parser.
-      if (aliasRids.containsKey(alias) || aliasRidLists.containsKey(alias)) {
+      if (aliasPinnedRids.containsKey(alias)) {
         continue;
       }
       var ridExpr = filter.findRidEquality();
@@ -4521,9 +4497,9 @@ public class MatchExecutionPlanner {
         }
         var rid = new SQLRid(-1);
         SQLRid.internalPromoteExpression(rid, ridExpr);
-        aliasRids.put(alias, rid);
+        aliasPinnedRids.put(alias, List.of(rid));
         logger.debug(
-            "MATCH planner: promoted @rid = filter to aliasRids for alias '{}'",
+            "MATCH planner: promoted @rid = filter to aliasPinnedRids for alias '{}'",
             alias);
         continue;
       }
@@ -4540,7 +4516,7 @@ public class MatchExecutionPlanner {
       if (promotedList == null || promotedList.isEmpty()) {
         continue;
       }
-      aliasRidLists.put(alias, promotedList);
+      aliasPinnedRids.put(alias, promotedList);
       logger.debug(
           "MATCH planner: promoted @rid IN filter ({} RIDs) for alias '{}'",
           promotedList.size(),
@@ -4548,24 +4524,20 @@ public class MatchExecutionPlanner {
     }
   }
 
-  /**
-   * Resolves a pinned RID list for an alias, preferring a promoted IN-list over a
-   * single parser/promoted equality slot.
-   */
+  /** Returns the pinned RID list for an alias, or {@code null} if none. */
   @Nullable private List<SQLRid> pinnedRidsForAlias(String alias) {
-    return pinnedRidsForAlias(alias, aliasRids, aliasRidLists);
+    return aliasPinnedRids.get(alias);
   }
 
   @Nullable private static List<SQLRid> pinnedRidsForAlias(
       String alias,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists) {
-    var list = aliasRidLists.get(alias);
-    if (list != null) {
-      return list;
-    }
-    var single = aliasRids.get(alias);
-    return single != null ? List.of(single) : null;
+      Map<String, List<SQLRid>> aliasPinnedRids) {
+    return aliasPinnedRids.get(alias);
+  }
+
+  /** Returns the sole pinned RID when the list has exactly one entry (for {@code setLeftRid}). */
+  @Nullable private static SQLRid singletonPinnedRid(@Nullable List<SQLRid> pinnedRids) {
+    return pinnedRids != null && pinnedRids.size() == 1 ? pinnedRids.get(0) : null;
   }
 
   /**
@@ -4703,11 +4675,12 @@ public class MatchExecutionPlanner {
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, String> aliasClasses,
       Map<String, String> aliasCollections,
-      Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context,
       Set<String> whileAliases,
       Set<String> inferredWhileExprAliases) {
-    addAliases(expr.getOrigin(), aliasFilters, aliasClasses, aliasCollections, aliasRids, context);
+    addAliases(expr.getOrigin(), aliasFilters, aliasClasses, aliasCollections, aliasPinnedRids,
+        context);
 
     // Track the edge class set by the most recent outE/inE item, so that a
     // following inV/outV can look up the linked vertex class from the edge schema.
@@ -4716,7 +4689,7 @@ public class MatchExecutionPlanner {
 
     for (var item : expr.getItems()) {
       if (item.getFilter() != null) {
-        addAliases(item.getFilter(), aliasFilters, aliasClasses, aliasCollections, aliasRids,
+        addAliases(item.getFilter(), aliasFilters, aliasClasses, aliasCollections, aliasPinnedRids,
             context);
 
         // Skip class inference only for aliases in the recursive zone
@@ -4870,7 +4843,7 @@ public class MatchExecutionPlanner {
       Map<String, SQLWhereClause> aliasFilters,
       Map<String, String> aliasClasses,
       Map<String, String> aliasCollections,
-      Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       CommandContext context) {
     var alias = matchFilter.getAlias();
     var filter = matchFilter.getFilter();
@@ -4927,15 +4900,15 @@ public class MatchExecutionPlanner {
 
       var rid = matchFilter.getRid(context);
       if (rid != null) {
-        var previousRid = aliasRids.get(alias);
-        if (previousRid == null) {
-          aliasRids.put(alias, rid);
-        } else if (!previousRid.equals(rid)) {
+        var previousRids = aliasPinnedRids.get(alias);
+        if (previousRids == null) {
+          aliasPinnedRids.put(alias, List.of(rid));
+        } else if (previousRids.size() != 1 || !previousRids.get(0).equals(rid)) {
           throw new CommandExecutionException(context.getDatabaseSession(),
               "Invalid expression for alias "
                   + alias
                   + " cannot be of both RIDs "
-                  + previousRid
+                  + previousRids.get(0)
                   + " and "
                   + rid);
         }
@@ -5005,29 +4978,22 @@ public class MatchExecutionPlanner {
    */
   static Map<String, Long> estimateRootEntries(
       Map<String, String> aliasClasses,
-      Map<String, SQLRid> aliasRids,
-      Map<String, List<SQLRid>> aliasRidLists,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       Map<String, SQLWhereClause> aliasFilters,
       CommandContext ctx) {
     Set<String> allAliases = new LinkedHashSet<>();
     allAliases.addAll(aliasClasses.keySet());
     allAliases.addAll(aliasFilters.keySet());
-    allAliases.addAll(aliasRids.keySet());
-    allAliases.addAll(aliasRidLists.keySet());
+    allAliases.addAll(aliasPinnedRids.keySet());
 
     var db = ctx.getDatabaseSession();
     var schema = db.getMetadata().getImmutableSchemaSnapshot();
 
     Map<String, Long> result = new LinkedHashMap<>();
     for (var alias : allAliases) {
-      var ridList = aliasRidLists.get(alias);
+      var ridList = aliasPinnedRids.get(alias);
       if (ridList != null) {
         result.put(alias, (long) ridList.size());
-        continue;
-      }
-      var rid = aliasRids.get(alias);
-      if (rid != null) {
-        result.put(alias, 1L);
         continue;
       }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStep.java
@@ -130,7 +130,18 @@ public class MatchStep extends AbstractExecutionStep {
     if (edge.out) {
       result.append("     ---->\n");
     } else {
-      result.append("     <----\n");
+      result.append("     <----");
+      // In reverse mode, edge.leftRid (the original source node's pinned RID) is the
+      // TARGET constraint the reverse traverser validates against — see
+      // MatchReverseEdgeTraverser.targetRid(). It is otherwise invisible in the plan,
+      // so surface it here to make the size-1 @rid IN / @rid = promotion routing
+      // (singletonPinnedRid -> setLeftRid) observable in EXPLAIN. Printed only when
+      // non-null so plans without a reverse-pinned target stay byte-identical.
+      var leftRid = edge.getLeftRid();
+      if (leftRid != null) {
+        result.append(" [leftRid=").append(leftRid.toString("")).append("]");
+      }
+      result.append("\n");
     }
     result.append(spaces);
     result.append("  ");

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
@@ -10,6 +10,8 @@ import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
+import org.jspecify.annotations.NonNull;
+
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -140,17 +142,19 @@ public class SQLRid extends SimpleNode {
     this.legacy = b;
   }
 
-  public void setExpression(SQLExpression expression) {
+  void setExpression(SQLExpression expression) {
     this.expression = expression;
-    // Fully transition this node to the expression form, matching what the
-    // grammar produces for {"@rid": <expr>} (legacy=false, no literal pair).
-    // Otherwise a node previously holding a #c:p literal keeps a stale
-    // collection/position: toRecordId honours the guard and uses the
-    // expression, but toString(String)/equals/copy would still reflect the old
-    // pair, leaving a contradictory hybrid state.
     this.legacy = false;
     this.collection = null;
     this.position = null;
+  }
+
+  /**
+   * Internal bridge method to allow the MatchExecutionPlanner to promote static expressions
+   * without exposing a destructive multi-field setter to the public API surface.
+   */
+  public static void internalPromoteExpression(@NonNull SQLRid rid, SQLExpression expression) {
+    rid.setExpression(expression);
   }
 
   public SQLInteger getCollection() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
@@ -140,6 +140,10 @@ public class SQLRid extends SimpleNode {
     this.legacy = b;
   }
 
+  public void setExpression(SQLExpression expression) {
+    this.expression = expression;
+  }
+
   public SQLInteger getCollection() {
     if (expression != null) {
       var rid = toRecordId((Result) null, new BasicCommandContext());

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
@@ -142,10 +142,15 @@ public class SQLRid extends SimpleNode {
 
   public void setExpression(SQLExpression expression) {
     this.expression = expression;
-    // An expression-backed RID is by definition not a legacy literal pair.
-    // Without this, a stale legacy=true would make toRecordId short-circuit to
-    // the collection:position pair and ignore the expression.
+    // Fully transition this node to the expression form, matching what the
+    // grammar produces for {"@rid": <expr>} (legacy=false, no literal pair).
+    // Otherwise a node previously holding a #c:p literal keeps a stale
+    // collection/position: toRecordId honours the guard and uses the
+    // expression, but toString(String)/equals/copy would still reflect the old
+    // pair, leaving a contradictory hybrid state.
     this.legacy = false;
+    this.collection = null;
+    this.position = null;
   }
 
   public SQLInteger getCollection() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
@@ -142,6 +142,10 @@ public class SQLRid extends SimpleNode {
 
   public void setExpression(SQLExpression expression) {
     this.expression = expression;
+    // An expression-backed RID is by definition not a legacy literal pair.
+    // Without this, a stale legacy=true would make toRecordId short-circuit to
+    // the collection:position pair and ignore the expression.
+    this.legacy = false;
   }
 
   public SQLInteger getCollection() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRid.java
@@ -34,6 +34,10 @@ public class SQLRid extends SimpleNode {
 
   @Override
   public String toString(String prefix) {
+    if (expression != null) {
+      // node has been promoted, safely render expression text
+      return "#" + expression.toString(prefix);
+    }
     return "#" + collection.getValue() + ":" + position.getValue();
   }
 
@@ -144,6 +148,9 @@ public class SQLRid extends SimpleNode {
 
   void setExpression(SQLExpression expression) {
     this.expression = expression;
+    // Transition this node to pure expression form matching what grammar produces for {"@rid": <expr>}
+    // (legacy=false, no literal pair) to prevent toString/equals/copy from triggering NullPointerExceptions
+    // or operating on contradictory hybrid state.
     this.legacy = false;
     this.collection = null;
     this.position = null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLWhereClause.java
@@ -945,14 +945,14 @@ public class SQLWhereClause extends SimpleNode {
   }
 
   /**
-   * Recursively searches for {@code @rid = <expr>} in a possibly nested
-   * AND/OR structure. Handles the double-nesting created by
-   * {@code addAliases()} in {@code MatchExecutionPlanner}, where compound
-   * WHERE clauses like {@code @rid = #23:1 AND name = 'bob'} are wrapped
-   * in an extra AND layer.
+   * Recursively searches for a top-level {@code @rid} condition in a possibly
+   * nested AND/OR structure. Handles the double-nesting created by
+   * {@code addAliases()} in {@code MatchExecutionPlanner}.
    */
   @Nullable
-  private static SQLExpression findRidInExpression(SQLBooleanExpression expr) {
+  private static <T> T findRidConditionInExpression(
+      SQLBooleanExpression expr,
+      java.util.function.Function<SQLBooleanExpression, T> termExtractor) {
     if (expr instanceof SQLOrBlock orBlock) {
       if (orBlock.subBlocks.size() != 1) {
         return null;
@@ -961,19 +961,29 @@ public class SQLWhereClause extends SimpleNode {
     }
     if (expr instanceof SQLAndBlock andBlock) {
       for (var sub : andBlock.subBlocks) {
-        var ridExpr = tryExtractRidFromTerm(sub);
-        if (ridExpr != null) {
-          return ridExpr;
+        var result = termExtractor.apply(sub);
+        if (result != null) {
+          return result;
         }
-        // sub might be a nested AND/OR wrapping the compound condition —
-        // recurse to flatten it
-        ridExpr = findRidInExpression(sub);
-        if (ridExpr != null) {
-          return ridExpr;
+        result = findRidConditionInExpression(sub, termExtractor);
+        if (result != null) {
+          return result;
         }
       }
     }
     return null;
+  }
+
+  /**
+   * Recursively searches for {@code @rid = <expr>} in a possibly nested
+   * AND/OR structure. Handles the double-nesting created by
+   * {@code addAliases()} in {@code MatchExecutionPlanner}, where compound
+   * WHERE clauses like {@code @rid = #23:1 AND name = 'bob'} are wrapped
+   * in an extra AND layer.
+   */
+  @Nullable
+  private static SQLExpression findRidInExpression(SQLBooleanExpression expr) {
+    return findRidConditionInExpression(expr, SQLWhereClause::tryExtractRidFromTerm);
   }
 
   /**
@@ -1030,16 +1040,12 @@ public class SQLWhereClause extends SimpleNode {
   }
 
   /**
-   * Checks if a single AND term (possibly wrapped in a single-element OrBlock
-   * and/or a non-negated NotBlock) is {@code @rid = <expr>}. Returns the
-   * value-side expression or null.
+   * Unwraps single-element {@code OrBlock}/{@code AndBlock} wrappers and a
+   * non-negated {@code NotBlock} around one AND term. Returns {@code null} when
+   * the term cannot be reduced to a single leaf condition.
    */
   @Nullable
-  private static SQLExpression tryExtractRidFromTerm(SQLBooleanExpression term) {
-    // Unwrap single-element wrapper blocks. The parser produces deeply nested
-    // structures like OrBlock(AndBlock(OrBlock(BinaryCondition))) even for
-    // simple conditions. Peel off single-element OrBlock and AndBlock wrappers
-    // until we reach the actual condition.
+  private static SQLBooleanExpression unwrapSingleElementTerm(SQLBooleanExpression term) {
     while (true) {
       if (term instanceof SQLOrBlock orBlock) {
         if (orBlock.subBlocks.size() != 1) {
@@ -1055,14 +1061,28 @@ public class SQLWhereClause extends SimpleNode {
         break;
       }
     }
-    assert !(term instanceof SQLOrBlock) && !(term instanceof SQLAndBlock)
-        : "tryExtractRidFromTerm: loop should have unwrapped all single-element wrappers";
     if (term instanceof SQLNotBlock notBlock) {
       if (notBlock.negate) {
         return null;
       }
       term = notBlock.sub;
     }
+    return term;
+  }
+
+  /**
+   * Checks if a single AND term (possibly wrapped in a single-element OrBlock
+   * and/or a non-negated NotBlock) is {@code @rid = <expr>}. Returns the
+   * value-side expression or null.
+   */
+  @Nullable
+  private static SQLExpression tryExtractRidFromTerm(SQLBooleanExpression term) {
+    term = unwrapSingleElementTerm(term);
+    if (term == null) {
+      return null;
+    }
+    assert !(term instanceof SQLOrBlock) && !(term instanceof SQLAndBlock)
+        : "tryExtractRidFromTerm: loop should have unwrapped all single-element wrappers";
     if (!(term instanceof SQLBinaryCondition cond)) {
       return null;
     }
@@ -1080,20 +1100,69 @@ public class SQLWhereClause extends SimpleNode {
   @Nullable
   private static SQLExpression tryExtractRidValue(
       SQLExpression attrSide, SQLExpression valueSide) {
-    if (!(attrSide.mathExpression instanceof SQLBaseExpression attrBase)) {
+    if (!isBareRidExpression(attrSide)) {
       return null;
+    }
+    return valueSide;
+  }
+
+  /**
+   * Non-destructive version of RID-IN extraction: finds a
+   * {@code @rid IN <expr>} condition without modifying the WHERE clause.
+   *
+   * @return the {@link SQLInCondition}, or {@code null} if not found
+   */
+  @Nullable
+  public SQLInCondition findRidInList() {
+    if (baseExpression == null) {
+      return null;
+    }
+    return findRidInListInExpression(baseExpression);
+  }
+
+  /**
+   * Recursively searches for {@code @rid IN <expr>} in a possibly nested
+   * AND/OR structure.
+   */
+  @Nullable
+  private static SQLInCondition findRidInListInExpression(SQLBooleanExpression expr) {
+    return findRidConditionInExpression(expr, SQLWhereClause::tryExtractRidInFromTerm);
+  }
+
+  /**
+   * Checks if a single AND term is {@code @rid IN <expr>}. Returns the
+   * {@link SQLInCondition} or null.
+   */
+  @Nullable
+  private static SQLInCondition tryExtractRidInFromTerm(SQLBooleanExpression term) {
+    term = unwrapSingleElementTerm(term);
+    if (term == null) {
+      return null;
+    }
+    if (!(term instanceof SQLInCondition inCond)) {
+      return null;
+    }
+    if (!isBareRidExpression(inCond.getLeft())) {
+      return null;
+    }
+    return inCond;
+  }
+
+  /**
+   * Returns true when {@code expr} is a bare {@code @rid} record attribute
+   * without modifiers.
+   */
+  private static boolean isBareRidExpression(@Nullable SQLExpression expr) {
+    if (expr == null || !(expr.mathExpression instanceof SQLBaseExpression attrBase)) {
+      return false;
     }
     var ident = attrBase.getIdentifier();
     if (ident == null || ident.getSuffix() == null
         || ident.getSuffix().recordAttribute == null
         || attrBase.getModifier() != null) {
-      return null;
+      return false;
     }
-    if (!"@rid".equalsIgnoreCase(
-        ident.getSuffix().recordAttribute.getName())) {
-      return null;
-    }
-    return valueSide;
+    return "@rid".equalsIgnoreCase(ident.getSuffix().recordAttribute.getName());
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/CostModelEndToEndTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/CostModelEndToEndTest.java
@@ -134,7 +134,7 @@ public class CostModelEndToEndTest {
         null, 0);
 
     estimateRootEntries = MatchExecutionPlanner.class.getDeclaredMethod(
-        "estimateRootEntries", Map.class, Map.class, Map.class,
+        "estimateRootEntries", Map.class, Map.class, Map.class, Map.class,
         CommandContext.class);
     estimateRootEntries.setAccessible(true);
   }
@@ -727,7 +727,7 @@ public class CostModelEndToEndTest {
       Map<String, SQLWhereClause> aliasFilters) throws Exception {
     try {
       return (Map<String, Long>) estimateRootEntries.invoke(
-          null, aliasClasses, aliasRids, aliasFilters, ctx);
+          null, aliasClasses, aliasRids, Map.of(), aliasFilters, ctx);
     } catch (InvocationTargetException e) {
       if (e.getCause() instanceof RuntimeException re) {
         throw re;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/CostModelEndToEndTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/CostModelEndToEndTest.java
@@ -134,7 +134,7 @@ public class CostModelEndToEndTest {
         null, 0);
 
     estimateRootEntries = MatchExecutionPlanner.class.getDeclaredMethod(
-        "estimateRootEntries", Map.class, Map.class, Map.class, Map.class,
+        "estimateRootEntries", Map.class, Map.class, Map.class,
         CommandContext.class);
     estimateRootEntries.setAccessible(true);
   }
@@ -352,11 +352,11 @@ public class CostModelEndToEndTest {
 
     var aliasClasses = new LinkedHashMap<String, String>();
     aliasClasses.put("c", "City");
-    var aliasRids = new HashMap<String, SQLRid>();
-    aliasRids.put("r", mock(SQLRid.class));
+    var aliasPinnedRids = new HashMap<String, List<SQLRid>>();
+    aliasPinnedRids.put("r", List.of(mock(SQLRid.class)));
 
     var result = invokeEstimateRootEntries(
-        aliasClasses, aliasRids, Map.of());
+        aliasClasses, aliasPinnedRids, Map.of());
 
     assertEquals(1L, (long) result.get("r"));
     assertTrue(
@@ -723,11 +723,11 @@ public class CostModelEndToEndTest {
   @SuppressWarnings("unchecked")
   private Map<String, Long> invokeEstimateRootEntries(
       Map<String, String> aliasClasses,
-      Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       Map<String, SQLWhereClause> aliasFilters) throws Exception {
     try {
       return (Map<String, Long>) estimateRootEntries.invoke(
-          null, aliasClasses, aliasRids, Map.of(), aliasFilters, ctx);
+          null, aliasClasses, aliasPinnedRids, aliasFilters, ctx);
     } catch (InvocationTargetException e) {
       if (e.getCause() instanceof RuntimeException re) {
         throw re;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EstimateRootEntriesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EstimateRootEntriesTest.java
@@ -18,6 +18,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +52,7 @@ public class EstimateRootEntriesTest {
       Map<String, SQLRid> aliasRids,
       Map<String, SQLWhereClause> aliasFilters) {
     return MatchExecutionPlanner.estimateRootEntries(
-        aliasClasses, aliasRids, aliasFilters, ctx);
+        aliasClasses, aliasRids, Map.of(), aliasFilters, ctx);
   }
 
   private SchemaClassInternal mockClass(String name, long count) {
@@ -184,6 +185,34 @@ public class EstimateRootEntriesTest {
     var result = invoke(aliasClasses, aliasRids, Map.of());
 
     assertEquals(1L, (long) result.get("a"));
+  }
+
+  @Test
+  public void ridListUsesListSize() {
+    mockClass("Comment", 5000L);
+    var aliasRidLists = Map.of(
+        "c",
+        List.of(mock(SQLRid.class), mock(SQLRid.class), mock(SQLRid.class)));
+    var result = MatchExecutionPlanner.estimateRootEntries(
+        Map.of("c", "Comment"), Map.of(), aliasRidLists, Map.of(), ctx);
+
+    assertEquals(3L, (long) result.get("c"));
+  }
+
+  /**
+   * When both a singleton and a list are present for the same alias, the list
+   * estimate wins because {@code aliasRidLists} is checked first.
+   */
+  @Test
+  public void ridListPreferredOverSingleton() {
+    mockClass("Comment", 5000L);
+    var aliasRidLists = Map.of(
+        "c", List.of(mock(SQLRid.class), mock(SQLRid.class)));
+    var aliasRids = Map.of("c", mock(SQLRid.class));
+    var result = MatchExecutionPlanner.estimateRootEntries(
+        Map.of("c", "Comment"), aliasRids, aliasRidLists, Map.of(), ctx);
+
+    assertEquals(2L, (long) result.get("c"));
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EstimateRootEntriesTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/EstimateRootEntriesTest.java
@@ -49,10 +49,10 @@ public class EstimateRootEntriesTest {
 
   private Map<String, Long> invoke(
       Map<String, String> aliasClasses,
-      Map<String, SQLRid> aliasRids,
+      Map<String, List<SQLRid>> aliasPinnedRids,
       Map<String, SQLWhereClause> aliasFilters) {
     return MatchExecutionPlanner.estimateRootEntries(
-        aliasClasses, aliasRids, Map.of(), aliasFilters, ctx);
+        aliasClasses, aliasPinnedRids, aliasFilters, ctx);
   }
 
   private SchemaClassInternal mockClass(String name, long count) {
@@ -65,7 +65,7 @@ public class EstimateRootEntriesTest {
 
   @Test
   public void ridAliasReturnsOne() {
-    var rids = Map.of("a", mock(SQLRid.class));
+    var rids = Map.of("a", List.of(mock(SQLRid.class)));
     var result = invoke(Map.of(), rids, Map.of());
 
     assertEquals(1L, (long) result.get("a"));
@@ -125,12 +125,12 @@ public class EstimateRootEntriesTest {
     var aliasClasses = new LinkedHashMap<String, String>();
     aliasClasses.put("p", "Person");
     aliasClasses.put("c", "City");
-    var aliasRids = new HashMap<String, SQLRid>();
-    aliasRids.put("r", mock(SQLRid.class));
+    var aliasPinnedRids = new HashMap<String, List<SQLRid>>();
+    aliasPinnedRids.put("r", List.of(mock(SQLRid.class)));
     var aliasFilters = new HashMap<String, SQLWhereClause>();
     aliasFilters.put("p", filterPerson);
 
-    var result = invoke(aliasClasses, aliasRids, aliasFilters);
+    var result = invoke(aliasClasses, aliasPinnedRids, aliasFilters);
 
     assertEquals("RID alias", 1L, (long) result.get("r"));
     assertEquals("Capped filter", 1000L, (long) result.get("p"));
@@ -180,9 +180,9 @@ public class EstimateRootEntriesTest {
     mockClass("Person", 5000L);
 
     var aliasClasses = Map.of("a", "Person");
-    var aliasRids = Map.of("a", mock(SQLRid.class));
+    var aliasPinnedRids = Map.of("a", List.of(mock(SQLRid.class)));
 
-    var result = invoke(aliasClasses, aliasRids, Map.of());
+    var result = invoke(aliasClasses, aliasPinnedRids, Map.of());
 
     assertEquals(1L, (long) result.get("a"));
   }
@@ -190,29 +190,13 @@ public class EstimateRootEntriesTest {
   @Test
   public void ridListUsesListSize() {
     mockClass("Comment", 5000L);
-    var aliasRidLists = Map.of(
+    var aliasPinnedRids = Map.of(
         "c",
         List.of(mock(SQLRid.class), mock(SQLRid.class), mock(SQLRid.class)));
     var result = MatchExecutionPlanner.estimateRootEntries(
-        Map.of("c", "Comment"), Map.of(), aliasRidLists, Map.of(), ctx);
+        Map.of("c", "Comment"), aliasPinnedRids, Map.of(), ctx);
 
     assertEquals(3L, (long) result.get("c"));
-  }
-
-  /**
-   * When both a singleton and a list are present for the same alias, the list
-   * estimate wins because {@code aliasRidLists} is checked first.
-   */
-  @Test
-  public void ridListPreferredOverSingleton() {
-    mockClass("Comment", 5000L);
-    var aliasRidLists = Map.of(
-        "c", List.of(mock(SQLRid.class), mock(SQLRid.class)));
-    var aliasRids = Map.of("c", mock(SQLRid.class));
-    var result = MatchExecutionPlanner.estimateRootEntries(
-        Map.of("c", "Comment"), aliasRids, aliasRidLists, Map.of(), ctx);
-
-    assertEquals(2L, (long) result.get("c"));
   }
 
   @Test
@@ -279,11 +263,11 @@ public class EstimateRootEntriesTest {
     when(filter.estimate(any(), anyLong(), any())).thenReturn(200L);
 
     var aliasClasses = Map.of("a", "Person");
-    var aliasRids = Map.of("a", mock(SQLRid.class));
+    var aliasPinnedRids = Map.of("a", List.of(mock(SQLRid.class)));
     var aliasFilters = new HashMap<String, SQLWhereClause>();
     aliasFilters.put("a", filter);
 
-    var result = invoke(aliasClasses, aliasRids, aliasFilters);
+    var result = invoke(aliasClasses, aliasPinnedRids, aliasFilters);
 
     assertEquals("RID takes priority", 1L, (long) result.get("a"));
   }
@@ -329,7 +313,7 @@ public class EstimateRootEntriesTest {
 
   @Test
   public void filterOnlyAlias_noClassMapping_isOmitted() {
-    // Alias appears only in aliasFilters (not in aliasClasses or aliasRids).
+    // Alias appears only in aliasFilters (not in aliasClasses or aliasPinnedRids).
     // It's still in allAliases but className lookup returns null → skipped.
     var filter = mock(SQLWhereClause.class);
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchPlannerHelpersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchPlannerHelpersTest.java
@@ -274,7 +274,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Math.round(101 * TEST_FAN_OUT));
   }
 
@@ -289,7 +289,7 @@ public class MatchPlannerHelpersTest {
 
     // Empty maps — origin alias not found
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of(), Map.of(), Map.of(), Map.of(), ctx);
+        exp, Map.of(), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Long.MAX_VALUE);
   }
 
@@ -321,7 +321,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
     // (100+1) * TEST_FAN_OUT * TEST_FAN_OUT * TEST_SELECTIVITY
     long expected = Math.round(101 * TEST_FAN_OUT * TEST_FAN_OUT * TEST_SELECTIVITY);
     assertThat(estimate).isEqualTo(expected);
@@ -337,7 +337,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 50);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Math.round(51 * TEST_FAN_OUT));
   }
 
@@ -352,7 +352,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 999);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
         .isTrue();
   }
 
@@ -367,7 +367,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 1000);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -405,7 +405,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Huge", Long.MAX_VALUE / 5);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("big", "Huge"), Map.of(), Map.of(), Map.of(), ctx);
+        exp, Map.of("big", "Huge"), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Long.MAX_VALUE);
   }
 
@@ -424,7 +424,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 200);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
     // 200 + 1 (unfiltered bias) = 201, no fan-out
     assertThat(estimate).isEqualTo(201);
   }
@@ -441,7 +441,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
         .isTrue();
   }
 
@@ -455,7 +455,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -469,7 +469,7 @@ public class MatchPlannerHelpersTest {
 
     // Empty aliasClasses — origin has no class
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of(), Map.of(), Map.of(), Map.of(), ctx))
+        exp, Map.of(), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -483,7 +483,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 1_000_000);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -751,7 +751,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
 
     assertThat(result).hasSize(1);
     var branch = result.get(0);
@@ -810,7 +810,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
 
     assertThat(result).hasSize(1);
     var branch = result.get(0);
@@ -863,7 +863,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of("c", cFilter), Map.of(), Map.of(), ctx);
+        Map.of("c", cFilter), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -886,7 +886,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, Set.of("a", "b"),
         Map.of("a", "Person", "b", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -933,7 +933,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -964,7 +964,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, Set.of("a", "c"),
         Map.of("a", "Person", "b", "Person", "c", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -977,7 +977,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 50);
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         List.of(), Set.of("a"),
-        Map.of("a", "Person"), Map.of(), Map.of(), Map.of(), ctx);
+        Map.of("a", "Person"), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -995,7 +995,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1041,7 +1041,7 @@ public class MatchPlannerHelpersTest {
         schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person",
             "$YOUTRACKDB_DEFAULT_ALIAS_0", "Person", "d", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1058,7 +1058,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
     assertThat(result).hasSize(1);
     assertThat(result.get(0).scanAlias()).isEqualTo("a");
     assertThat(result.get(0).joinMode()).isEqualTo(JoinMode.SEMI_JOIN);
@@ -1076,7 +1076,7 @@ public class MatchPlannerHelpersTest {
     // No alias has a class → findScanAlias returns null → branch rejected
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
-        Map.of(), Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1093,7 +1093,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of("c", cFilter), Map.of(), Map.of(), ctx);
+        Map.of("c", cFilter), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1113,7 +1113,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of("d", dFilter), Map.of(), Map.of(), ctx);
+        Map.of("d", dFilter), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1129,7 +1129,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchPlannerHelpersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchPlannerHelpersTest.java
@@ -274,7 +274,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Math.round(101 * TEST_FAN_OUT));
   }
 
@@ -289,7 +289,7 @@ public class MatchPlannerHelpersTest {
 
     // Empty maps — origin alias not found
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of(), Map.of(), Map.of(), ctx);
+        exp, Map.of(), Map.of(), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Long.MAX_VALUE);
   }
 
@@ -321,7 +321,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
     // (100+1) * TEST_FAN_OUT * TEST_FAN_OUT * TEST_SELECTIVITY
     long expected = Math.round(101 * TEST_FAN_OUT * TEST_FAN_OUT * TEST_SELECTIVITY);
     assertThat(estimate).isEqualTo(expected);
@@ -337,7 +337,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 50);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Math.round(51 * TEST_FAN_OUT));
   }
 
@@ -352,7 +352,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 999);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
         .isTrue();
   }
 
@@ -367,7 +367,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 1000);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -405,7 +405,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Huge", Long.MAX_VALUE / 5);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("big", "Huge"), Map.of(), Map.of(), ctx);
+        exp, Map.of("big", "Huge"), Map.of(), Map.of(), Map.of(), ctx);
     assertThat(estimate).isEqualTo(Long.MAX_VALUE);
   }
 
@@ -424,7 +424,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 200);
 
     var estimate = MatchExecutionPlanner.estimateNotPatternCardinality(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx);
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx);
     // 200 + 1 (unfiltered bias) = 201, no fan-out
     assertThat(estimate).isEqualTo(201);
   }
@@ -441,7 +441,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
         .isTrue();
   }
 
@@ -455,7 +455,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 100);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -469,7 +469,7 @@ public class MatchPlannerHelpersTest {
 
     // Empty aliasClasses — origin has no class
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of(), Map.of(), Map.of(), ctx))
+        exp, Map.of(), Map.of(), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -483,7 +483,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 1_000_000);
 
     assertThat(MatchExecutionPlanner.canUseHashJoin(
-        exp, Map.of("person", "Person"), Map.of(), Map.of(), ctx))
+        exp, Map.of("person", "Person"), Map.of(), Map.of(), Map.of(), ctx))
         .isFalse();
   }
 
@@ -751,7 +751,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
 
     assertThat(result).hasSize(1);
     var branch = result.get(0);
@@ -810,7 +810,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
 
     assertThat(result).hasSize(1);
     var branch = result.get(0);
@@ -863,7 +863,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of("c", cFilter), Map.of(), ctx);
+        Map.of("c", cFilter), Map.of(), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -886,7 +886,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, Set.of("a", "b"),
         Map.of("a", "Person", "b", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -933,7 +933,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, downstream,
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -964,7 +964,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         schedule, Set.of("a", "c"),
         Map.of("a", "Person", "b", "Person", "c", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
 
     assertThat(result).isEmpty();
   }
@@ -977,7 +977,7 @@ public class MatchPlannerHelpersTest {
     var ctx = buildMockContext("Person", 50);
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         List.of(), Set.of("a"),
-        Map.of("a", "Person"), Map.of(), Map.of(), ctx);
+        Map.of("a", "Person"), Map.of(), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -995,7 +995,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1041,7 +1041,7 @@ public class MatchPlannerHelpersTest {
         schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person",
             "$YOUTRACKDB_DEFAULT_ALIAS_0", "Person", "d", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1058,7 +1058,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
     assertThat(result).hasSize(1);
     assertThat(result.get(0).scanAlias()).isEqualTo("a");
     assertThat(result.get(0).joinMode()).isEqualTo(JoinMode.SEMI_JOIN);
@@ -1076,7 +1076,7 @@ public class MatchPlannerHelpersTest {
     // No alias has a class → findScanAlias returns null → branch rejected
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
-        Map.of(), Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1093,7 +1093,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of("c", cFilter), Map.of(), ctx);
+        Map.of("c", cFilter), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1113,7 +1113,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of("d", dFilter), Map.of(), ctx);
+        Map.of("d", dFilter), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 
@@ -1129,7 +1129,7 @@ public class MatchPlannerHelpersTest {
     var result = MatchExecutionPlanner.identifyHashJoinBranches(
         diamond.schedule, Set.of("a", "d"),
         Map.of("a", "Person", "b", "Person", "c", "Person", "d", "Person"),
-        Map.of(), Map.of(), ctx);
+        Map.of(), Map.of(), Map.of(), ctx);
     assertThat(result).isEmpty();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -1,0 +1,191 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import org.junit.Test;
+
+/**
+ * End-to-end integration tests for the static-RID-in-WHERE promotion
+ * (YTDB-629). When a MATCH node carries a literal or parameter {@code @rid}
+ * equality in its WHERE clause,
+ * {@link MatchExecutionPlanner#promoteStaticRidsFromFilters} lifts it into
+ * {@code aliasRids}. This collapses that alias's root estimate to 1, so the
+ * topological scheduler picks it as the cheapest root (the {@code FetchFromRids}
+ * fast path) and reverses traversal direction along the rest of the chain.
+ *
+ * <p>Graph built in {@link #beforeTest}:
+ * <pre>
+ *   Person(alice) --Knows--> Person(bob)   --Likes--> Comment(c1)
+ *   Person(alice) --Knows--> Person(carol) --Likes--> Comment(c2)
+ *   Person(dave)  --Knows--> Person(erin)  --Likes--> Comment(c3)
+ * </pre>
+ *
+ * <p>Only {@code alice -> bob -> c1} reaches {@code c1}, so a chain pinned to
+ * {@code c1} matches exactly one path. The companion unit tests in
+ * {@link PromoteStaticRidsFromFiltersTest} cover the promoter in isolation;
+ * these tests verify the resulting plan shape and query results end to end.
+ */
+public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
+
+  @Override
+  public void beforeTest() throws Exception {
+    super.beforeTest();
+
+    session.execute("CREATE class Person extends V").close();
+    session.execute("CREATE property Person.name STRING").close();
+    session.execute("CREATE class Comment extends V").close();
+    session.execute("CREATE property Comment.name STRING").close();
+    session.execute("CREATE class Knows extends E").close();
+    session.execute("CREATE class Likes extends E").close();
+
+    session.begin();
+    for (var p : new String[] {"alice", "bob", "carol", "dave", "erin"}) {
+      session.execute("CREATE VERTEX Person set name = '" + p + "'").close();
+    }
+    for (var c : new String[] {"c1", "c2", "c3"}) {
+      session.execute("CREATE VERTEX Comment set name = '" + c + "'").close();
+    }
+    knows("alice", "bob");
+    knows("alice", "carol");
+    knows("dave", "erin");
+    likes("bob", "c1");
+    likes("carol", "c2");
+    likes("erin", "c3");
+    session.commit();
+  }
+
+  private void knows(String from, String to) {
+    session.execute(
+        "CREATE EDGE Knows FROM (SELECT FROM Person WHERE name = '" + from + "')"
+            + " TO (SELECT FROM Person WHERE name = '" + to + "')")
+        .close();
+  }
+
+  private void likes(String person, String comment) {
+    session.execute(
+        "CREATE EDGE Likes FROM (SELECT FROM Person WHERE name = '" + person + "')"
+            + " TO (SELECT FROM Comment WHERE name = '" + comment + "')")
+        .close();
+  }
+
+  /** Returns the RID string ({@code #cluster:position}) of a named record. */
+  private String ridOf(String clazz, String name) {
+    return session.query(
+        "SELECT @rid as rid FROM " + clazz + " WHERE name = '" + name + "'")
+        .toList().get(0).getProperty("rid").toString();
+  }
+
+  /**
+   * Multi-hop chain rooted at a Comment pinned by a literal {@code @rid} in the
+   * WHERE clause. Exactly one path (alice -> bob -> c1) reaches c1, so the query
+   * returns a single row. Confirms the promotion preserves query results.
+   */
+  @Test
+  public void multiHopStaticRidInWhere_returnsMatchingPath() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var result = session.query(
+        "MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid = " + c1 + ")}"
+            + " RETURN p.name as pName, m.name as mName")
+        .toList();
+    assertEquals(1, result.size());
+    assertEquals("alice", result.get(0).getProperty("pName"));
+    assertEquals("bob", result.get(0).getProperty("mName"));
+    session.commit();
+  }
+
+  /**
+   * The same chain with a non-existent RID (valid cluster, impossible position)
+   * returns no rows. Confirms the promoted root resolves to an empty RID set
+   * rather than falling back to a Comment class scan that would still match by
+   * class.
+   */
+  @Test
+  public void multiHopStaticRidInWhere_nonExistentRid_returnsEmpty() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var cluster = c1.substring(0, c1.indexOf(':'));
+    var missingRid = cluster + ":999999";
+    var result = session.query(
+        "MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid = " + missingRid + ")}"
+            + " RETURN p.name as pName")
+        .toList();
+    assertTrue("expected no rows for a non-existent RID, got: " + result.size(),
+        result.isEmpty());
+    session.commit();
+  }
+
+  /**
+   * The fix proper: EXPLAIN must show the pinned Comment promoted to the root
+   * via {@code FETCH FROM RIDs}, with the chain traversal reversed ({@code
+   * <----}) back toward Person. Without promotion the planner would scan a
+   * Person class and traverse forward ({@code ---->}).
+   */
+  @Test
+  public void multiHopStaticRidInWhere_planRootsAtFetchFromRids() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var result = session.query(
+        "EXPLAIN MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid = " + c1 + ")}"
+            + " RETURN p.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue("plan should fetch the pinned Comment by RID, got:\n" + plan,
+        plan.contains("FETCH FROM RIDs"));
+    assertTrue("plan should reverse the chain traversal, got:\n" + plan,
+        plan.contains("<----"));
+    session.commit();
+  }
+
+  /**
+   * Pre-existing RID slot wins (the YTDB-629 promoter guard). A node may carry
+   * both an explicit {@code rid:} slot and a WHERE {@code @rid} equality. The
+   * parser slot populates {@code aliasRids} first, so the promoter skips the
+   * alias and never overwrites it; the WHERE term then applies as a post-fetch
+   * filter. With slot {@code #c1} and a conflicting filter {@code #c2}
+   * (c1 != c2), the record fetched by the slot fails the filter, so the query
+   * returns no rows.
+   */
+  @Test
+  public void ridSlotConflictingWithWhereRid_returnsEmpty() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var c2 = ridOf("Comment", "c2");
+    var result = session.query(
+        "MATCH {class: Comment, as: c, rid: " + c1 + ", where: (@rid = " + c2 + ")}"
+            + " RETURN c.name as cName")
+        .toList();
+    assertTrue(
+        "slot #c1 drives the fetch; WHERE @rid=#c2 must drop it, got: " + result.size(),
+        result.isEmpty());
+    session.commit();
+  }
+
+  /**
+   * Companion to {@link #ridSlotConflictingWithWhereRid_returnsEmpty}: when the
+   * {@code rid:} slot and the WHERE {@code @rid} agree, the record fetched by the
+   * slot passes the post-fetch filter and the row is returned. Together the two
+   * tests show the slot drives the fetch while the redundant WHERE term is still
+   * evaluated.
+   */
+  @Test
+  public void ridSlotAgreeingWithWhereRid_returnsRow() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var result = session.query(
+        "MATCH {class: Comment, as: c, rid: " + c1 + ", where: (@rid = " + c1 + ")}"
+            + " RETURN c.name as cName")
+        .toList();
+    assertEquals(1, result.size());
+    assertEquals("c1", result.get(0).getProperty("cName"));
+    session.commit();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -178,10 +178,10 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
     var missingRid = "-1:0";
 
     var result = session.query(
-                    "EXPLAIN MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
-                            + ".out('Likes'){class: Comment, as: c, where: (@rid = " + missingRid + ")}"
-                            + " RETURN p.name")
-            .toList();
+        "EXPLAIN MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid = " + missingRid + ")}"
+            + " RETURN p.name")
+        .toList();
 
     assertEquals(1, result.size());
     String plan = result.getFirst().getProperty("executionPlanAsString");
@@ -189,11 +189,11 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
 
     var cBlock = prefetchBlock(plan, "c");
     assertFalse("pinned Comment 'c' should be prefetched, got:\n" + plan,
-            cBlock.isEmpty());
+        cBlock.isEmpty());
     assertTrue("'c' prefetch should fetch by RID, got:\n" + plan,
-            cBlock.contains("FETCH FROM RIDs"));
+        cBlock.contains("FETCH FROM RIDs"));
     assertFalse("'c' prefetch should not fall back to a class scan, got:\n" + plan,
-            cBlock.contains("FETCH FROM CLASS"));
+        cBlock.contains("FETCH FROM CLASS"));
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
  * (YTDB-629). When a MATCH node carries a literal or parameter {@code @rid}
  * equality or static {@code @rid IN [...]} in its WHERE clause,
  * {@link MatchExecutionPlanner#promoteStaticRidsFromFilters} lifts it into
- * {@code aliasRids} or {@code aliasRidLists}. That has two observable effects
+ * {@code aliasPinnedRids}. That has two observable effects
  * in the plan:
  *
  * <ol>
@@ -244,7 +244,7 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
    * literal. This is the only end-to-end exercise of the parameter path through
    * {@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid#setExpression}
    * and {@code SQLRid.toRecordId}, which resolves the bound value at execution
-   * time; the unit tests only verify that the alias reaches {@code aliasRids}.
+   * time; the unit tests only verify that the alias reaches {@code aliasPinnedRids}.
    * Asserts both correct results (one path) and that {@code c} is fetched by RID.
    */
   @Test
@@ -607,7 +607,7 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
   /**
    * Pre-existing RID slot wins (the YTDB-629 promoter guard). A node may carry
    * both an explicit {@code rid:} slot and a WHERE {@code @rid} equality. The
-   * parser slot populates {@code aliasRids} first, so the promoter skips the
+   * parser slot populates {@code aliasPinnedRids} first, so the promoter skips the
    * alias and never overwrites it; the WHERE term then applies as a post-fetch
    * filter. With slot {@code #c1} and a conflicting filter {@code #c2}
    * (c1 != c2), the record fetched by the slot fails the filter, so the query

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -414,4 +414,42 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
         java.util.Set.of("c1", "c2"), names);
     session.commit();
   }
+
+  /**
+   * Exercises the scenario where two different aliases both carry a static {@code @rid}
+   * in their WHERE clauses. The promoter must successfully process both aliases,
+   * dropping both estimates to 1, letting the planner's stable sort tie-break
+   * determine the root choice and traversal direction.
+   */
+  @Test
+  public void dualStaticRidInWhere_bothPromoted_plannerTieBreakDecidesRoot() {
+    session.begin();
+    var alice = ridOf("Person", "alice");
+    var bob = ridOf("Person", "bob");
+
+    var query = "EXPLAIN MATCH {class: Person, as: p, where: (@rid = " + alice + ")}"
+        + ".out('Knows'){class: Person, as: m, where: (@rid = " + bob + ")}"
+        + " RETURN p.name";
+
+    var result = session.query(query).toList();
+    assertEquals(1, result.size());
+    String plan = result.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+
+    var pBlock = prefetchBlock(plan, "p");
+    var mBlock = prefetchBlock(plan, "m");
+
+    assertTrue("Alias 'p' must be optimized to FETCH FROM RIDs, got:\n" + plan,
+        pBlock.contains("FETCH FROM RIDs"));
+    assertTrue("Alias 'm' must be optimized to FETCH FROM RIDs, got:\n" + plan,
+        mBlock.contains("FETCH FROM RIDs"));
+
+    assertFalse("Alias 'p' must not fallback to class scan", pBlock.contains("FETCH FROM CLASS"));
+    assertFalse("Alias 'm' must not fallback to class scan", mBlock.contains("FETCH FROM CLASS"));
+
+    assertEquals("Planner stable sort tie-break must select 'p' as the root node, got:\n" + plan,
+        "p", rootAlias(plan));
+
+    session.commit();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -7,29 +7,36 @@ import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
 /**
  * End-to-end integration tests for the static-RID-in-WHERE promotion
  * (YTDB-629). When a MATCH node carries a literal or parameter {@code @rid}
- * equality in its WHERE clause,
+ * equality or static {@code @rid IN [...]} in its WHERE clause,
  * {@link MatchExecutionPlanner#promoteStaticRidsFromFilters} lifts it into
- * {@code aliasRids}. That has two observable effects in the plan:
+ * {@code aliasRids} or {@code aliasRidLists}. That has two observable effects
+ * in the plan:
  *
  * <ol>
  *   <li>the pinned alias is fetched by {@code FETCH FROM RIDs} instead of a
  *       class scan with an {@code @rid} post-filter;
  *   <li>{@link MatchExecutionPlanner#estimateRootEntries} collapses the pinned
- *       alias's estimate to 1, which can flip root selection toward it.
+ *       alias's estimate to the list size (or 1 for equality), which can flip
+ *       root selection toward it.
  * </ol>
  *
  * <p>The two effects do not always coincide. In a small graph where the pinned
  * alias already sits on the smallest class, root selection picks it with or
  * without promotion (its class count alone wins), so only effect (1) is
- * observable; {@link #multiHopStaticRidInWhere_pinnedAliasFetchedByRid} pins
- * that case. Effect (2) needs a pinned alias on a larger class competing with a
- * smaller one; {@link #staticRid_winsRootSelectionOverSmallerClass} pins that.
+ * observable; {@link #multiHopStaticRidInWhere_pinnedAliasFetchedByRid} and
+ * {@link #multiHopStaticRidListInWhere_pinnedAliasFetchedByRid},
+ * {@link #multiHopStaticRidListInWhere_returnsMatchingPath}, and
+ * {@link #multiHopStaticRidListInWhere_parameterRidList_returnsMatchingPathAndFetchesByRid}
+ * pin that case. Effect (2) needs a pinned alias on a larger class competing with a smaller
+ * one; {@link #staticRid_winsRootSelectionOverSmallerClass} and
+ * {@link #staticRidList_winsRootSelectionOverSmallerClass} pin that.
  *
  * <p>Graph built in {@link #beforeTest}:
  * <pre>
@@ -264,6 +271,230 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
   }
 
   /**
+   * Production-style {@code @rid IN [#a, #b]} on a MATCH node promotes to a
+   * multi-RID fetch instead of scanning the class and filtering in memory.
+   */
+  @Test
+  public void staticRidList_inWhere_fetchesByRid() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var c2 = ridOf("Comment", "c2");
+    var query =
+        "MATCH {class: Comment, as: c, where: (@rid in [" + c1 + ", " + c2 + "])}"
+            + " RETURN c.name as name ORDER BY name";
+
+    var result = session.query(query).toList();
+    assertEquals(2, result.size());
+    assertEquals("c1", result.get(0).getProperty("name"));
+    assertEquals("c2", result.get(1).getProperty("name"));
+
+    var explain = session.query("EXPLAIN " + query).toList();
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue("@rid IN list should prefetch via FETCH FROM RIDs, got:\n" + plan,
+        prefetchBlock(plan, "c").contains("FETCH FROM RIDs"));
+    assertFalse("@rid IN list should not class-scan Comment, got:\n" + plan,
+        prefetchBlock(plan, "c").contains("FETCH FROM CLASS"));
+    session.commit();
+  }
+
+  /**
+   * Multi-hop chain with {@code @rid IN [c1]} returns the single matching path.
+   */
+  @Test
+  public void multiHopStaticRidListInWhere_returnsMatchingPath() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var result = session.query(
+        "MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid in [" + c1 + "])}"
+            + " RETURN p.name as pName, m.name as mName")
+        .toList();
+    assertEquals(1, result.size());
+    assertEquals("alice", result.getFirst().getProperty("pName"));
+    assertEquals("bob", result.getFirst().getProperty("mName"));
+    session.commit();
+  }
+
+  /**
+   * Multi-hop chain with a non-existent RID in the IN list returns no rows and
+   * still fetches the Comment alias by RID rather than class scan.
+   */
+  @Test
+  public void multiHopStaticRidListInWhere_nonExistentRid_returnsEmpty() {
+    session.begin();
+    var missingRid = "-1:0";
+
+    var query =
+        "MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid in [" + missingRid + "])}"
+            + " RETURN p.name";
+
+    var result = session.query(query).toList();
+    assertTrue("non-existent RID in IN list must match no paths", result.isEmpty());
+
+    var explain = session.query("EXPLAIN " + query).toList();
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    var cBlock = prefetchBlock(plan, "c");
+    assertTrue("'c' prefetch should fetch by RID, got:\n" + plan,
+        cBlock.contains("FETCH FROM RIDs"));
+    assertFalse("'c' prefetch should not class-scan Comment, got:\n" + plan,
+        cBlock.contains("FETCH FROM CLASS"));
+    session.commit();
+  }
+
+  /**
+   * Parameter-bound RID list ({@code @rid IN :rids}) drives the same promotion
+   * as literals through the multi-hop chain.
+   */
+  @Test
+  public void multiHopStaticRidListInWhere_parameterRidList_returnsMatchingPathAndFetchesByRid() {
+    session.begin();
+    Map<Object, Object> params = new HashMap<>();
+    params.put("rids", List.of(ridObjectOf("Comment", "c1")));
+    var query =
+        "MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid in :rids)}"
+            + " RETURN p.name as pName, m.name as mName";
+
+    var result = session.query(query, params).toList();
+    assertEquals(1, result.size());
+    assertEquals("alice", result.getFirst().getProperty("pName"));
+    assertEquals("bob", result.getFirst().getProperty("mName"));
+
+    var explain = session.query("EXPLAIN " + query, params).toList();
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue("parameter @rid IN list should prefetch by RID, got:\n" + plan,
+        prefetchBlock(plan, "c").contains("FETCH FROM RIDs"));
+    session.commit();
+  }
+
+  /**
+   * Multi-hop chain with {@code @rid IN [#c1]} on the Comment alias. The pinned
+   * Comment must be prefetched via {@code FETCH FROM RIDs}, not a class scan.
+   */
+  @Test
+  public void multiHopStaticRidListInWhere_pinnedAliasFetchedByRid() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var result = session.query(
+        "EXPLAIN MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid in [" + c1 + "])}"
+            + " RETURN p.name")
+        .toList();
+    assertEquals(1, result.size());
+    String plan = result.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    var cBlock = prefetchBlock(plan, "c");
+    assertFalse("pinned Comment 'c' should be prefetched, got:\n" + plan,
+        cBlock.isEmpty());
+    assertTrue("'c' prefetch should fetch by RID, got:\n" + plan,
+        cBlock.contains("FETCH FROM RIDs"));
+    assertFalse("'c' prefetch should not fall back to a class scan, got:\n" + plan,
+        cBlock.contains("FETCH FROM CLASS"));
+    session.commit();
+  }
+
+  /**
+   * Root-selection flip with a singleton {@code @rid IN [rid]} list — same
+   * estimate collapse (1) as {@link #staticRid_winsRootSelectionOverSmallerClass}.
+   */
+  @Test
+  public void staticRidList_winsRootSelectionOverSmallerClass() {
+    session.execute("CREATE class Big extends V").close();
+    session.execute("CREATE property Big.name STRING").close();
+    session.execute("CREATE class Small extends V").close();
+    session.execute("CREATE property Small.name STRING").close();
+    session.execute("CREATE class Rel extends E").close();
+
+    session.begin();
+    for (var i = 0; i < 40; i++) {
+      session.execute("CREATE VERTEX Big set name = 'b" + i + "'").close();
+    }
+    for (var i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX Small set name = 's" + i + "'").close();
+    }
+    session.execute(
+        "CREATE EDGE Rel FROM (SELECT FROM Big WHERE name = 'b0')"
+            + " TO (SELECT FROM Small WHERE name = 's0')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var b0 = ridOf("Big", "b0");
+    var explain = session.query(
+        "EXPLAIN MATCH {class: Big, as: b, where: (@rid in [" + b0 + "])}"
+            + ".out('Rel'){class: Small, as: s} RETURN b.name")
+        .toList();
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertEquals(
+        "IN-list promotion must flip the root to pinned Big alias 'b', got:\n" + plan,
+        "b", rootAlias(plan));
+    assertTrue("pinned Big alias should be fetched by RID, got:\n" + plan,
+        prefetchBlock(plan, "b").contains("FETCH FROM RIDs"));
+
+    var result = session.query(
+        "MATCH {class: Big, as: b, where: (@rid in [" + b0 + "])}"
+            + ".out('Rel'){class: Small, as: s} RETURN s.name as sName")
+        .toList();
+    assertEquals(1, result.size());
+    assertEquals("s0", result.getFirst().getProperty("sName"));
+    session.commit();
+  }
+
+  /**
+   * Root-selection flip with a two-RID {@code @rid IN [rid0, rid1]} list: estimate
+   * collapses to 2, still below Small's biased estimate of 4.
+   */
+  @Test
+  public void staticRidListTwoRids_winsRootSelectionOverSmallerClass() {
+    session.execute("CREATE class Big extends V").close();
+    session.execute("CREATE property Big.name STRING").close();
+    session.execute("CREATE class Small extends V").close();
+    session.execute("CREATE property Small.name STRING").close();
+    session.execute("CREATE class Rel extends E").close();
+
+    session.begin();
+    for (var i = 0; i < 40; i++) {
+      session.execute("CREATE VERTEX Big set name = 'b" + i + "'").close();
+    }
+    for (var i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX Small set name = 's" + i + "'").close();
+    }
+    session.execute(
+        "CREATE EDGE Rel FROM (SELECT FROM Big WHERE name = 'b0')"
+            + " TO (SELECT FROM Small WHERE name = 's0')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var b0 = ridOf("Big", "b0");
+    var b1 = ridOf("Big", "b1");
+    var explain = session.query(
+        "EXPLAIN MATCH {class: Big, as: b, where: (@rid in [" + b0 + ", " + b1 + "])}"
+            + ".out('Rel'){class: Small, as: s} RETURN b.name")
+        .toList();
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertEquals(
+        "two-RID IN list (estimate=2) must flip root to Big alias 'b', got:\n" + plan,
+        "b", rootAlias(plan));
+    assertTrue("pinned Big alias should be fetched by RID, got:\n" + plan,
+        prefetchBlock(plan, "b").contains("FETCH FROM RIDs"));
+
+    var result = session.query(
+        "MATCH {class: Big, as: b, where: (@rid in [" + b0 + ", " + b1 + "])}"
+            + ".out('Rel'){class: Small, as: s} RETURN s.name as sName ORDER BY sName")
+        .toList();
+    assertEquals(1, result.size());
+    assertEquals("s0", result.getFirst().getProperty("sName"));
+    session.commit();
+  }
+
+  /**
    * Root-selection flip, the optimization's stated purpose. The cost model in
    * {@link MatchExecutionPlanner#estimateRootEntries} gives an unpinned class
    * under the prefetch threshold an estimate of {@code count / 2} and a pinned
@@ -349,6 +580,31 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
   }
 
   /**
+   * Negative case: {@code @rid IN $matched.p.@rid} is a runtime correlation, not a
+   * static list, so the promoter must skip it and the plan must contain no
+   * {@code FETCH FROM RIDs}. Mirrors {@link #backRefRidEquality_isNotPromoted_noRidFetchInPlan}.
+   */
+  @Test
+  public void backRefRidInList_isNotPromoted_noRidFetchInPlan() {
+    session.begin();
+    var query =
+        "MATCH {class: Person, as: p}.out('Knows')"
+            + "{class: Person, as: m, where: (@rid in $matched.p.@rid)} RETURN p.name as pName";
+
+    var explain = session.query("EXPLAIN " + query).toList();
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse("back-ref @rid IN must not be promoted to a RID fetch, got:\n" + plan,
+        plan.contains("FETCH FROM RIDs"));
+
+    var result = session.query(query).toList();
+    assertTrue("no Person Knows itself, so the back-ref IN matches nothing, got: "
+        + result.size(),
+        result.isEmpty());
+    session.commit();
+  }
+
+  /**
    * Pre-existing RID slot wins (the YTDB-629 promoter guard). A node may carry
    * both an explicit {@code rid:} slot and a WHERE {@code @rid} equality. The
    * parser slot populates {@code aliasRids} first, so the promoter skips the
@@ -416,6 +672,27 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
   }
 
   /**
+   * OR correctness for IN lists: {@code where: (@rid in [#c1] OR name = 'c2')}
+   * must return both the pinned record (c1) and the name-matched record (c2).
+   * If the promoter wrongly pinned the root to the IN list alone, c2 would be lost.
+   */
+  @Test
+  public void singleNodeRidListOrName_returnsBothBranches() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var result = session.query(
+        "MATCH {class: Comment, as: c, where: (@rid in [" + c1 + "] OR name = 'c2')}"
+            + " RETURN c.name as cName")
+        .toList();
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("cName"))
+        .collect(java.util.stream.Collectors.toSet());
+    assertEquals("OR must match both the pinned RID list and the named record, got: " + names,
+        java.util.Set.of("c1", "c2"), names);
+    session.commit();
+  }
+
+  /**
    * Exercises the scenario where two different aliases both carry a static {@code @rid}
    * in their WHERE clauses. The promoter must successfully process both aliases,
    * dropping both estimates to 1, letting the planner's stable sort tie-break
@@ -450,6 +727,49 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
     assertEquals("Planner stable sort tie-break must select 'p' as the root node, got:\n" + plan,
         "p", rootAlias(plan));
 
+    session.commit();
+  }
+
+  /**
+   * Two aliases with singleton {@code @rid IN [rid]} lists — same estimate collapse
+   * (1 per alias) as {@link #dualStaticRidInWhere_bothPromoted_plannerTieBreakDecidesRoot}.
+   */
+  @Test
+  public void dualStaticRidListInWhere_bothPromoted_plannerTieBreakDecidesRoot() {
+    session.begin();
+    var alice = ridOf("Person", "alice");
+    var bob = ridOf("Person", "bob");
+
+    var query = "EXPLAIN MATCH {class: Person, as: p, where: (@rid in [" + alice + "])}"
+        + ".out('Knows'){class: Person, as: m, where: (@rid in [" + bob + "])}"
+        + " RETURN p.name";
+
+    var result = session.query(query).toList();
+    assertEquals(1, result.size());
+    String plan = result.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+
+    var pBlock = prefetchBlock(plan, "p");
+    var mBlock = prefetchBlock(plan, "m");
+
+    assertTrue("Alias 'p' must prefetch via FETCH FROM RIDs, got:\n" + plan,
+        pBlock.contains("FETCH FROM RIDs"));
+    assertTrue("Alias 'm' must prefetch via FETCH FROM RIDs, got:\n" + plan,
+        mBlock.contains("FETCH FROM RIDs"));
+    assertFalse("Alias 'p' must not class-scan Person", pBlock.contains("FETCH FROM CLASS"));
+    assertFalse("Alias 'm' must not class-scan Person", mBlock.contains("FETCH FROM CLASS"));
+    assertEquals(
+        "Planner stable sort tie-break must select 'p' as root for IN lists too, got:\n" + plan,
+        "p", rootAlias(plan));
+
+    var rows = session.query(
+        "MATCH {class: Person, as: p, where: (@rid in [" + alice + "])}"
+            + ".out('Knows'){class: Person, as: m, where: (@rid in [" + bob + "])}"
+            + " RETURN p.name as pName, m.name as mName")
+        .toList();
+    assertEquals(1, rows.size());
+    assertEquals("alice", rows.getFirst().getProperty("pName"));
+    assertEquals("bob", rows.getFirst().getProperty("mName"));
     session.commit();
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -90,14 +90,14 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
   private String ridOf(String clazz, String name) {
     return session.query(
         "SELECT @rid as rid FROM " + clazz + " WHERE name = '" + name + "'")
-        .toList().get(0).getProperty("rid").toString();
+        .toList().getFirst().getProperty("rid").toString();
   }
 
   /** Returns the RID value object (not its string form) of a named record. */
   private Object ridObjectOf(String clazz, String name) {
     return session.query(
         "SELECT @rid as rid FROM " + clazz + " WHERE name = '" + name + "'")
-        .toList().get(0).getProperty("rid");
+        .toList().getFirst().getProperty("rid");
   }
 
   /**
@@ -161,8 +161,8 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
             + " RETURN p.name as pName, m.name as mName")
         .toList();
     assertEquals(1, result.size());
-    assertEquals("alice", result.get(0).getProperty("pName"));
-    assertEquals("bob", result.get(0).getProperty("mName"));
+    assertEquals("alice", result.getFirst().getProperty("pName"));
+    assertEquals("bob", result.getFirst().getProperty("mName"));
     session.commit();
   }
 
@@ -175,16 +175,25 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
   @Test
   public void multiHopStaticRidInWhere_nonExistentRid_returnsEmpty() {
     session.begin();
-    var c1 = ridOf("Comment", "c1");
-    var cluster = c1.substring(0, c1.indexOf(':'));
-    var missingRid = cluster + ":999999";
+    var missingRid = "-1:0";
+
     var result = session.query(
-        "MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
-            + ".out('Likes'){class: Comment, as: c, where: (@rid = " + missingRid + ")}"
-            + " RETURN p.name as pName")
-        .toList();
-    assertTrue("expected no rows for a non-existent RID, got: " + result.size(),
-        result.isEmpty());
+                    "EXPLAIN MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+                            + ".out('Likes'){class: Comment, as: c, where: (@rid = " + missingRid + ")}"
+                            + " RETURN p.name")
+            .toList();
+
+    assertEquals(1, result.size());
+    String plan = result.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+
+    var cBlock = prefetchBlock(plan, "c");
+    assertFalse("pinned Comment 'c' should be prefetched, got:\n" + plan,
+            cBlock.isEmpty());
+    assertTrue("'c' prefetch should fetch by RID, got:\n" + plan,
+            cBlock.contains("FETCH FROM RIDs"));
+    assertFalse("'c' prefetch should not fall back to a class scan, got:\n" + plan,
+            cBlock.contains("FETCH FROM CLASS"));
     session.commit();
   }
 
@@ -211,7 +220,7 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
             + " RETURN p.name")
         .toList();
     assertEquals(1, result.size());
-    String plan = result.get(0).getProperty("executionPlanAsString");
+    String plan = result.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     var cBlock = prefetchBlock(plan, "c");
     assertFalse("pinned Comment 'c' should be prefetched, got:\n" + plan,
@@ -243,11 +252,11 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
 
     var result = session.query(query, params).toList();
     assertEquals(1, result.size());
-    assertEquals("alice", result.get(0).getProperty("pName"));
-    assertEquals("bob", result.get(0).getProperty("mName"));
+    assertEquals("alice", result.getFirst().getProperty("pName"));
+    assertEquals("bob", result.getFirst().getProperty("mName"));
 
     var explain = session.query("EXPLAIN " + query, params).toList();
-    String plan = explain.get(0).getProperty("executionPlanAsString");
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     assertTrue("parameter @rid should be promoted to a RID fetch, got:\n" + plan,
         prefetchBlock(plan, "c").contains("FETCH FROM RIDs"));
@@ -293,7 +302,7 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
         "EXPLAIN MATCH {class: Big, as: b, where: (@rid = " + b0 + ")}"
             + ".out('Rel'){class: Small, as: s} RETURN b.name")
         .toList();
-    String plan = explain.get(0).getProperty("executionPlanAsString");
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     assertEquals(
         "promotion must flip the root to the pinned Big alias 'b', got:\n" + plan,
@@ -307,7 +316,7 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
             + ".out('Rel'){class: Small, as: s} RETURN s.name as sName")
         .toList();
     assertEquals(1, result.size());
-    assertEquals("s0", result.get(0).getProperty("sName"));
+    assertEquals("s0", result.getFirst().getProperty("sName"));
     session.commit();
   }
 
@@ -327,7 +336,7 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
             + "{class: Person, as: m, where: (@rid = $matched.p.@rid)} RETURN p.name as pName";
 
     var explain = session.query("EXPLAIN " + query).toList();
-    String plan = explain.get(0).getProperty("executionPlanAsString");
+    String plan = explain.getFirst().getProperty("executionPlanAsString");
     assertNotNull(plan);
     assertFalse("back-ref @rid must not be promoted to a RID fetch, got:\n" + plan,
         plan.contains("FETCH FROM RIDs"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -382,4 +382,27 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
     assertEquals("c1", result.get(0).getProperty("cName"));
     session.commit();
   }
+
+  /**
+   * OR correctness, end to end: {@code where: (@rid = #c1 OR name = 'c2')} must
+   * return both the pinned record (c1) and the name-matched record (c2). The
+   * promoter must not fire for a disjunction; if it wrongly pinned the root to
+   * #c1 alone, the c2 row would be lost. Two distinct names confirm the OR
+   * branch survives.
+   */
+  @Test
+  public void singleNodeRidOrName_returnsBothBranches() {
+    session.begin();
+    var c1 = ridOf("Comment", "c1");
+    var result = session.query(
+        "MATCH {class: Comment, as: c, where: (@rid = " + c1 + " OR name = 'c2')}"
+            + " RETURN c.name as cName")
+        .toList();
+    var names = result.stream()
+        .map(r -> (String) r.getProperty("cName"))
+        .collect(java.util.stream.Collectors.toSet());
+    assertEquals("OR must match both the pinned RID and the named record, got: " + names,
+        java.util.Set.of("c1", "c2"), names);
+    session.commit();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -772,4 +772,85 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
     assertEquals("bob", rows.getFirst().getProperty("mName"));
     session.commit();
   }
+
+  /**
+   * The discriminating plan-shape test for the size-1 {@code @rid IN [#x]} to
+   * {@code setLeftRid} routing on the REVERSE traversal path. This is the case the
+   * reviewer flagged: post the aliasRids single-map consolidation, a size-1 IN list
+   * flows through {@link MatchExecutionPlanner#singletonPinnedRid} into
+   * {@link EdgeTraversal#setLeftRid}, and when the pinned node is the SOURCE
+   * ({@code edge.out}) of an edge scheduled in reverse, that RID becomes the reverse
+   * traverser's target constraint ({@link MatchReverseEdgeTraverser#targetRid}).
+   *
+   * <p>Why both ends must be pinned: a single size-1 pin always wins root selection
+   * (estimate collapses to 1), so the planner roots at it, prefetches it by RID, and
+   * traverses AWAY from it forward — the reverse routing never fires and stays
+   * hidden. Only when BOTH ends of an edge carry a size-1 pin can the planner root
+   * on one end and reverse-traverse into the other pinned end, populating the
+   * reverse edge's {@code leftRid} from the (pinned) {@code edge.out}.
+   *
+   * <p>The graph here is a triangle {@code a --Knows--> b --Ride--> t --Knows--> a}
+   * with both {@code a} and {@code t} pinned by singleton {@code @rid IN}. The
+   * planner roots at {@code a}, walks {@code a->b->t} forward, then closes the cycle
+   * with the consistency-check edge {@code {t}.out('Knows'){a}} scheduled in REVERSE.
+   * Because {@code t} (the closing edge's {@code edge.out}) is pinned, the closing
+   * reverse step carries {@code [leftRid=<t's RID>]} in the plan.
+   *
+   * <p>Discrimination: EXPLAIN asserts the {@code <----} closing step shows
+   * {@code leftRid=<t's RID>}. A broken {@code size() == 1} predicate in
+   * {@code singletonPinnedRid} drops that annotation (verified during development by
+   * mutating the predicate to {@code size() == 2}). Result-correctness alone cannot
+   * catch the mutation: {@code t} is still prefetched by RID (the prefetch uses the
+   * full pinned list, not {@code singletonPinnedRid}) and the retained WHERE
+   * {@code leftFilter} still validates the target, so the rows stay correct — the
+   * plan-shape {@code leftRid} annotation is the sole discriminating signal.
+   */
+  @Test
+  public void reverseEdgeIntoBothEndsPinned_leftRidPopulatedInPlan() {
+    // Inline triangle fixture: a --Knows--> b --Ride--> t --Knows--> a.
+    // 'Ride' is a fresh edge class so the middle hop is distinct from the two
+    // Knows hops; the closing Knows edge (t -> a) is what gets scheduled reverse.
+    session.execute("CREATE class Ride extends E").close();
+    session.begin();
+    knows("carol", "dave"); // a=carol -> b=dave (Knows already exists as a class)
+    ride("dave", "erin"); // b=dave -> t=erin (Ride)
+    knows("erin", "carol"); // t=erin -> a=carol (Knows) closes the triangle
+    session.commit();
+
+    session.begin();
+    var a = ridOf("Person", "carol");
+    var t = ridOf("Person", "erin");
+    // Pin BOTH a (root) and t (reverse target). t's RID must appear as leftRid on
+    // the closing reverse edge {t}.out('Knows'){a}.
+    var query =
+        "EXPLAIN MATCH {class: Person, as: a, where: (@rid in [" + a + "])}"
+            + ".out('Knows'){class: Person, as: b}"
+            + ".out('Ride'){class: Person, as: t, where: (@rid in [" + t + "])}"
+            + ".out('Knows'){class: Person, as: a} RETURN a.name";
+    var result = session.query(query).toList();
+    assertEquals(1, result.size());
+    String plan = result.getFirst().getProperty("executionPlanAsString");
+    assertNotNull(plan);
+
+    // Discriminating assertion: the reverse closing step carries t's pinned RID as
+    // leftRid. This is populated ONLY via singletonPinnedRid(size-1 list) ->
+    // setLeftRid on the reverse edge; a broken size()==1 predicate drops it.
+    assertTrue(
+        "reverse closing edge must carry [leftRid=" + t + "], got:\n" + plan,
+        plan.contains("<----") && plan.contains("[leftRid=" + t + "]"));
+
+    // Sanity: t is still prefetched by RID (the effect that masks the mutation at
+    // the result level), confirming leftRid — not the prefetch — is the signal.
+    assertTrue("pinned 't' should be prefetched by RID, got:\n" + plan,
+        prefetchBlock(plan, "t").contains("FETCH FROM RIDs"));
+    session.commit();
+  }
+
+  /** Creates a Ride edge between two named Persons (fresh edge class for the triangle). */
+  private void ride(String from, String to) {
+    session.execute(
+        "CREATE EDGE Ride FROM (SELECT FROM Person WHERE name = '" + from + "')"
+            + " TO (SELECT FROM Person WHERE name = '" + to + "')")
+        .close();
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStaticRidPromotionIntegrationTest.java
@@ -1,10 +1,13 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 
 /**
@@ -12,9 +15,21 @@ import org.junit.Test;
  * (YTDB-629). When a MATCH node carries a literal or parameter {@code @rid}
  * equality in its WHERE clause,
  * {@link MatchExecutionPlanner#promoteStaticRidsFromFilters} lifts it into
- * {@code aliasRids}. This collapses that alias's root estimate to 1, so the
- * topological scheduler picks it as the cheapest root (the {@code FetchFromRids}
- * fast path) and reverses traversal direction along the rest of the chain.
+ * {@code aliasRids}. That has two observable effects in the plan:
+ *
+ * <ol>
+ *   <li>the pinned alias is fetched by {@code FETCH FROM RIDs} instead of a
+ *       class scan with an {@code @rid} post-filter;
+ *   <li>{@link MatchExecutionPlanner#estimateRootEntries} collapses the pinned
+ *       alias's estimate to 1, which can flip root selection toward it.
+ * </ol>
+ *
+ * <p>The two effects do not always coincide. In a small graph where the pinned
+ * alias already sits on the smallest class, root selection picks it with or
+ * without promotion (its class count alone wins), so only effect (1) is
+ * observable; {@link #multiHopStaticRidInWhere_pinnedAliasFetchedByRid} pins
+ * that case. Effect (2) needs a pinned alias on a larger class competing with a
+ * smaller one; {@link #staticRid_winsRootSelectionOverSmallerClass} pins that.
  *
  * <p>Graph built in {@link #beforeTest}:
  * <pre>
@@ -78,6 +93,59 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
         .toList().get(0).getProperty("rid").toString();
   }
 
+  /** Returns the RID value object (not its string form) of a named record. */
+  private Object ridObjectOf(String clazz, String name) {
+    return session.query(
+        "SELECT @rid as rid FROM " + clazz + " WHERE name = '" + name + "'")
+        .toList().get(0).getProperty("rid");
+  }
+
+  /**
+   * Extracts the root alias of a MATCH plan: the alias printed on the first
+   * non-blank line after the {@code + SET} marker emitted by
+   * {@link MatchFirstStep}. The root determines which node the traversal starts
+   * from, so this is the cleanest signal that promotion changed root selection.
+   */
+  private static String rootAlias(String plan) {
+    var marker = "+ SET";
+    var i = plan.indexOf(marker);
+    if (i < 0) {
+      return "";
+    }
+    for (var line : plan.substring(i + marker.length()).split("\n")) {
+      var trimmed = line.trim();
+      if (!trimmed.isEmpty()) {
+        return trimmed;
+      }
+    }
+    return "";
+  }
+
+  /**
+   * Extracts the {@code + PREFETCH <alias>} block for one alias: the substring
+   * from that marker up to the next top-level step ({@code + PREFETCH},
+   * {@code + SET}, or {@code + MATCH}). Small aliases (estimate below the
+   * prefetch threshold) are eagerly loaded by a {@link MatchPrefetchStep}, so a
+   * pinned alias's RID fetch shows up here rather than in the root sub-plan.
+   * Returns the empty string when the alias is not prefetched.
+   */
+  private static String prefetchBlock(String plan, String alias) {
+    var marker = "+ PREFETCH " + alias + "\n";
+    var start = plan.indexOf(marker);
+    if (start < 0) {
+      return "";
+    }
+    var from = start + marker.length();
+    var end = plan.length();
+    for (var next : new String[] {"+ PREFETCH ", "+ SET", "+ MATCH"}) {
+      var idx = plan.indexOf(next, from);
+      if (idx >= 0 && idx < end) {
+        end = idx;
+      }
+    }
+    return plan.substring(start, end);
+  }
+
   /**
    * Multi-hop chain rooted at a Comment pinned by a literal {@code @rid} in the
    * WHERE clause. Exactly one path (alice -> bob -> c1) reaches c1, so the query
@@ -121,13 +189,20 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
   }
 
   /**
-   * The fix proper: EXPLAIN must show the pinned Comment promoted to the root
-   * via {@code FETCH FROM RIDs}, with the chain traversal reversed ({@code
-   * <----}) back toward Person. Without promotion the planner would scan a
-   * Person class and traverse forward ({@code ---->}).
+   * The fix proper for this chain: the pinned Comment is fetched by RID rather
+   * than scanned. EXPLAIN must show the {@code c} prefetch sourced from
+   * {@code FETCH FROM RIDs} with no {@code FETCH FROM CLASS} fallback inside that
+   * block. Without promotion the {@code c} prefetch is {@code FETCH FROM CLASS
+   * Comment} plus an {@code @rid} post-filter (verified by toggling the promoter
+   * off during development).
+   *
+   * <p>Root selection is deliberately not asserted here: Comment (3 rows) is
+   * already the smallest class in this chain, so the root is {@code c} with or
+   * without promotion. The root-selection flip is covered by
+   * {@link #staticRid_winsRootSelectionOverSmallerClass}.
    */
   @Test
-  public void multiHopStaticRidInWhere_planRootsAtFetchFromRids() {
+  public void multiHopStaticRidInWhere_pinnedAliasFetchedByRid() {
     session.begin();
     var c1 = ridOf("Comment", "c1");
     var result = session.query(
@@ -138,10 +213,129 @@ public class MatchStaticRidPromotionIntegrationTest extends DbTestBase {
     assertEquals(1, result.size());
     String plan = result.get(0).getProperty("executionPlanAsString");
     assertNotNull(plan);
-    assertTrue("plan should fetch the pinned Comment by RID, got:\n" + plan,
+    var cBlock = prefetchBlock(plan, "c");
+    assertFalse("pinned Comment 'c' should be prefetched, got:\n" + plan,
+        cBlock.isEmpty());
+    assertTrue("'c' prefetch should fetch by RID, got:\n" + plan,
+        cBlock.contains("FETCH FROM RIDs"));
+    assertFalse("'c' prefetch should not fall back to a class scan, got:\n" + plan,
+        cBlock.contains("FETCH FROM CLASS"));
+    session.commit();
+  }
+
+  /**
+   * Parameter-bound RID ({@code @rid = :rid}) drives the same promotion as a
+   * literal. This is the only end-to-end exercise of the parameter path through
+   * {@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid#setExpression}
+   * and {@code SQLRid.toRecordId}, which resolves the bound value at execution
+   * time; the unit tests only verify that the alias reaches {@code aliasRids}.
+   * Asserts both correct results (one path) and that {@code c} is fetched by RID.
+   */
+  @Test
+  public void multiHopStaticRidInWhere_parameterRid_returnsMatchingPathAndFetchesByRid() {
+    session.begin();
+    Map<Object, Object> params = new HashMap<>();
+    params.put("rid", ridObjectOf("Comment", "c1"));
+    var query =
+        "MATCH {class: Person, as: p}.out('Knows'){class: Person, as: m}"
+            + ".out('Likes'){class: Comment, as: c, where: (@rid = :rid)}"
+            + " RETURN p.name as pName, m.name as mName";
+
+    var result = session.query(query, params).toList();
+    assertEquals(1, result.size());
+    assertEquals("alice", result.get(0).getProperty("pName"));
+    assertEquals("bob", result.get(0).getProperty("mName"));
+
+    var explain = session.query("EXPLAIN " + query, params).toList();
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertTrue("parameter @rid should be promoted to a RID fetch, got:\n" + plan,
+        prefetchBlock(plan, "c").contains("FETCH FROM RIDs"));
+    session.commit();
+  }
+
+  /**
+   * Root-selection flip, the optimization's stated purpose. The cost model in
+   * {@link MatchExecutionPlanner#estimateRootEntries} gives an unpinned class
+   * under the prefetch threshold an estimate of {@code count / 2} and a pinned
+   * alias an estimate of 1. Big (40 rows) estimates to 20; Small (3 rows)
+   * estimates to 4. By class size alone Small is the cheaper root, so without
+   * promotion the planner roots at Small and traverses backward to Big. Pinning
+   * Big by {@code @rid} collapses its estimate to 1, so promotion flips the root
+   * to Big. Asserting the root is {@code b} proves promotion changed the root
+   * choice, not merely the fetch method.
+   */
+  @Test
+  public void staticRid_winsRootSelectionOverSmallerClass() {
+    session.execute("CREATE class Big extends V").close();
+    session.execute("CREATE property Big.name STRING").close();
+    session.execute("CREATE class Small extends V").close();
+    session.execute("CREATE property Small.name STRING").close();
+    session.execute("CREATE class Rel extends E").close();
+
+    session.begin();
+    for (var i = 0; i < 40; i++) {
+      session.execute("CREATE VERTEX Big set name = 'b" + i + "'").close();
+    }
+    for (var i = 0; i < 3; i++) {
+      session.execute("CREATE VERTEX Small set name = 's" + i + "'").close();
+    }
+    // One edge so the pinned Big has a path to a Small.
+    session.execute(
+        "CREATE EDGE Rel FROM (SELECT FROM Big WHERE name = 'b0')"
+            + " TO (SELECT FROM Small WHERE name = 's0')")
+        .close();
+    session.commit();
+
+    session.begin();
+    var b0 = ridOf("Big", "b0");
+    var explain = session.query(
+        "EXPLAIN MATCH {class: Big, as: b, where: (@rid = " + b0 + ")}"
+            + ".out('Rel'){class: Small, as: s} RETURN b.name")
+        .toList();
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertEquals(
+        "promotion must flip the root to the pinned Big alias 'b', got:\n" + plan,
+        "b", rootAlias(plan));
+    assertTrue("pinned Big alias should be fetched by RID, got:\n" + plan,
+        prefetchBlock(plan, "b").contains("FETCH FROM RIDs"));
+
+    // Correctness: the single Rel edge from the pinned Big reaches s0.
+    var result = session.query(
+        "MATCH {class: Big, as: b, where: (@rid = " + b0 + ")}"
+            + ".out('Rel'){class: Small, as: s} RETURN s.name as sName")
+        .toList();
+    assertEquals(1, result.size());
+    assertEquals("s0", result.get(0).getProperty("sName"));
+    session.commit();
+  }
+
+  /**
+   * Negative case: a {@code @rid = $matched.p.@rid} back-ref is a runtime
+   * correlation, not a static RID, so the promoter must skip it and the plan
+   * must contain no {@code FETCH FROM RIDs}. The self-Knows pattern (m must equal
+   * p) matches nothing in this graph because no Person Knows itself, which also
+   * confirms the back-ref is still applied as a post-fetch filter rather than
+   * silently dropped.
+   */
+  @Test
+  public void backRefRidEquality_isNotPromoted_noRidFetchInPlan() {
+    session.begin();
+    var query =
+        "MATCH {class: Person, as: p}.out('Knows')"
+            + "{class: Person, as: m, where: (@rid = $matched.p.@rid)} RETURN p.name as pName";
+
+    var explain = session.query("EXPLAIN " + query).toList();
+    String plan = explain.get(0).getProperty("executionPlanAsString");
+    assertNotNull(plan);
+    assertFalse("back-ref @rid must not be promoted to a RID fetch, got:\n" + plan,
         plan.contains("FETCH FROM RIDs"));
-    assertTrue("plan should reverse the chain traversal, got:\n" + plan,
-        plan.contains("<----"));
+
+    var result = session.query(query).toList();
+    assertTrue("no Person Knows itself, so the back-ref matches nothing, got: "
+        + result.size(),
+        result.isEmpty());
     session.commit();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
@@ -3577,6 +3577,80 @@ public class MatchStepUnitTest extends DbTestBase {
   }
 
   /**
+   * Pins the full size-1 {@code @rid IN [#x]} promotion path at the unit level:
+   * {@link MatchExecutionPlanner#singletonPinnedRid} unwraps a one-element pinned
+   * list, {@link EdgeTraversal#setLeftRid} stores it as the reverse target's left
+   * RID, and {@link MatchReverseEdgeTraverser#targetRid} returns exactly that RID.
+   *
+   * <p>Scenario: post the aliasRids single-map consolidation, a size-1 static IN
+   * list now flows to {@code setLeftRid} and, when its alias is reached by reverse
+   * traversal, that RID becomes the target constraint validated at runtime. This is
+   * the case the reviewer flagged as newly reachable and untested.
+   *
+   * <p>Why a unit test and not EXPLAIN: an earlier investigation established that
+   * {@code leftRid} is never rendered into the execution-plan string
+   * ({@link MatchStep#prettyPrint} emits only direction, aliases, method, and
+   * intersection descriptor), and its runtime effect is redundant with the
+   * {@code FETCH FROM RIDs} prefetch that always fires for a pinned alias (the
+   * prefetch uses the full pinned list via {@code pinnedRidsForAlias}, not
+   * {@code singletonPinnedRid}). Breaking the {@code size() == 1} predicate is
+   * therefore invisible to both plan-shape and result-correctness assertions at the
+   * integration level, so this internal-state assertion is the only discriminating
+   * check: a broken predicate would make {@code singletonPinnedRid} return null and
+   * {@code targetRid()} would then yield null instead of the pinned RID.
+   */
+  @Test
+  public void testReverseEdgeTraverserTargetRid_sizeOnePinnedList_flowsToTargetRid() {
+    var rid = new SQLRid(-1);
+    // Drive the real production predicate, not a hand-picked element, so a broken
+    // size()==1 check would surface here.
+    var leftRid = MatchExecutionPlanner.singletonPinnedRid(List.of(rid));
+    assertSame("singletonPinnedRid must unwrap the sole element of a size-1 list",
+        rid, leftRid);
+
+    var edge = createTestPatternEdge();
+    var edgeTraversal = new EdgeTraversal(edge, false); // reverse
+    edgeTraversal.setLeftRid(leftRid);
+    var sourceResult = new ResultInternal(session);
+
+    var traverser = new MatchReverseEdgeTraverser(sourceResult, edgeTraversal);
+    var ctx = createCommandContext();
+    // The reverse target's RID constraint is exactly the promoted singleton RID.
+    assertSame("reverse targetRid must be the promoted size-1 pinned RID",
+        rid, traverser.targetRid(null, ctx));
+  }
+
+  /**
+   * Boundary companion to
+   * {@link #testReverseEdgeTraverserTargetRid_sizeOnePinnedList_flowsToTargetRid}:
+   * a pinned list whose size is not 1 (here a two-element list) must NOT populate
+   * the single left RID. {@link MatchExecutionPlanner#singletonPinnedRid} returns
+   * null for a multi-element list, so {@code setLeftRid(null)} leaves the reverse
+   * target's RID constraint unset and {@link MatchReverseEdgeTraverser#targetRid}
+   * returns null. This pins the other side of the {@code size() == 1} predicate: a
+   * multi-RID IN pin is enforced via prefetch / post-fetch WHERE, never via the
+   * single left-RID slot.
+   */
+  @Test
+  public void testReverseEdgeTraverserTargetRid_multiElementPinnedList_noSingleLeftRid() {
+    var leftRidTwo =
+        MatchExecutionPlanner.singletonPinnedRid(List.of(new SQLRid(-1), new SQLRid(-1)));
+    assertNull("singletonPinnedRid must return null for a two-element list", leftRidTwo);
+    var leftRidEmpty = MatchExecutionPlanner.singletonPinnedRid(List.of());
+    assertNull("singletonPinnedRid must return null for an empty list", leftRidEmpty);
+
+    var edge = createTestPatternEdge();
+    var edgeTraversal = new EdgeTraversal(edge, false); // reverse
+    edgeTraversal.setLeftRid(leftRidTwo); // null: no single-RID target constraint
+    var sourceResult = new ResultInternal(session);
+
+    var traverser = new MatchReverseEdgeTraverser(sourceResult, edgeTraversal);
+    var ctx = createCommandContext();
+    assertNull("reverse targetRid must be null when the pinned list is not size 1",
+        traverser.targetRid(null, ctx));
+  }
+
+  /**
    * Verifies that getTargetFilter delegates to edge.getLeftFilter(),
    * returning the planner-provided WHERE clause for the reverse target.
    */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/MatchStepUnitTest.java
@@ -3587,17 +3587,18 @@ public class MatchStepUnitTest extends DbTestBase {
    * traversal, that RID becomes the target constraint validated at runtime. This is
    * the case the reviewer flagged as newly reachable and untested.
    *
-   * <p>Why a unit test and not EXPLAIN: an earlier investigation established that
-   * {@code leftRid} is never rendered into the execution-plan string
-   * ({@link MatchStep#prettyPrint} emits only direction, aliases, method, and
-   * intersection descriptor), and its runtime effect is redundant with the
-   * {@code FETCH FROM RIDs} prefetch that always fires for a pinned alias (the
-   * prefetch uses the full pinned list via {@code pinnedRidsForAlias}, not
-   * {@code singletonPinnedRid}). Breaking the {@code size() == 1} predicate is
-   * therefore invisible to both plan-shape and result-correctness assertions at the
-   * integration level, so this internal-state assertion is the only discriminating
-   * check: a broken predicate would make {@code singletonPinnedRid} return null and
-   * {@code targetRid()} would then yield null instead of the pinned RID.
+   * <p>Why a unit test in addition to EXPLAIN: {@code leftRid} surfaces in the plan
+   * string ({@link MatchStep#prettyPrint} appends {@code [leftRid=#x:y]} to the
+   * {@code <----} line) only in the narrow case where a reverse edge's source node
+   * is itself pinned — which requires BOTH edge ends pinned, because a single pin
+   * always wins root selection, prefetches by RID, and traverses forward, hiding the
+   * reverse routing. The both-ends-pinned EXPLAIN case is covered by
+   * {@code MatchStaticRidPromotionIntegrationTest#reverseEdgeIntoBothEndsPinned_leftRidPopulated}.
+   * This unit test is the direct, always-available guard of the
+   * {@link MatchExecutionPlanner#singletonPinnedRid} predicate itself: a broken
+   * {@code size() == 1} check would make {@code singletonPinnedRid} return null and
+   * {@code targetRid()} would then yield null instead of the pinned RID, independent
+   * of any query shape or scheduling outcome.
    */
   @Test
   public void testReverseEdgeTraverserTargetRid_sizeOnePinnedList_flowsToTargetRid() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
@@ -231,4 +231,19 @@ public class PromoteStaticRidsFromFiltersTest {
 
     assertThat(aliasRids).containsKey("c");
   }
+
+  /**
+   * Operand-reversed RID equality (literal on the left-hand side) must also be promoted
+   * to ensure order-independence across incoming user queries.
+   */
+  @Test
+  public void reversedOperandLiteralRid_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new HashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE #25:7 = @rid"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).containsKey("c");
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
@@ -163,4 +163,72 @@ public class PromoteStaticRidsFromFiltersTest {
 
     assertThat(aliasRids).isEmpty();
   }
+
+  /**
+   * Disjunction {@code @rid = #N:M OR <other>} must NOT promote. Pinning the
+   * root to the single RID would drop the OR branch and silently lose rows, so
+   * {@code findRidEquality()} returns null for a multi-element OR.
+   */
+  @Test
+  public void orWithLiteralRid_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid = #25:7 OR name = 'foo'"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * Two RID equalities under an OR ({@code @rid = #N:M OR @rid = #X:Y}) are also
+   * not promoted: the promoter builds a single-RID root, which cannot represent
+   * a two-RID union. Left unpromoted, both RIDs are matched by the normal path.
+   */
+  @Test
+  public void orOfTwoRids_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid = #25:7 OR @rid = #26:8"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * A RID equality nested inside an OR ({@code name = 'foo' AND (@rid = #N:M OR
+   * name = 'bar')}) is not promoted: the RID term is not a top-level conjunct,
+   * so it is not a necessary condition for the row.
+   */
+  @Test
+  public void nestedOrWithRid_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE name = 'foo' AND (@rid = #25:7 OR name = 'bar')"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * Parameter RID in an AND ({@code @rid = :rid AND <other>}) promotes, matching
+   * the literal-AND case. Complements {@link #compoundFilterWithLiteralRid_isPromoted}
+   * on the parameter side.
+   */
+  @Test
+  public void compoundFilterWithParameterRid_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid = :rid AND name = 'foo'"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).containsKey("c");
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
@@ -21,10 +21,16 @@ import org.junit.Test;
  * Unit tests for {@link MatchExecutionPlanner#promoteStaticRidsFromFilters}.
  *
  * <p>The promoter scans per-alias WHERE clauses for {@code @rid = <expr>}
- * equalities and, when the value-side is a literal or parameter (never a
+ * * equalities and, when the value-side is a literal or parameter (never a
  * {@code $matched.X.@rid} back-ref), copies it into {@code aliasRids} so that
  * {@link MatchExecutionPlanner#estimateRootEntries} collapses the alias's
  * estimate to 1 and root selection picks the fast path.
+ *
+ * <p><strong>Note on Test Structure:</strong> The concrete RID literals used across these tests
+ * (e.g., {@code #25:7}, {@code #26:8}, {@code #12:0}) are purely structural and illustrative. The
+ * promoter and underlying AST nodes operate entirely in-memory against mocked contexts and are
+ * never resolved against active storage clusters. Any syntactically valid RID payload can be used
+ * interchangeably without shifting test outcomes.
  */
 public class PromoteStaticRidsFromFiltersTest {
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
  * <p>The promoter scans per-alias WHERE clauses for static {@code @rid = <expr>}
  * equalities and {@code @rid IN <static-list>} conditions. Early-calculable
  * literals and parameters (never {@code $matched} back-refs or subqueries) are
- * copied into {@code aliasRids} or {@code aliasRidLists} so that
+ * copied into {@code aliasPinnedRids} so that
  * {@link MatchExecutionPlanner#estimateRootEntries} collapses cardinality and
  * root selection picks the RID-fetch fast path.
  *
@@ -64,44 +64,42 @@ public class PromoteStaticRidsFromFiltersTest {
     }
   }
 
-  /** Asserts promoted list size and each resolved legacy RID literal. */
-  private static void assertPromotedRidList(
-      Map<String, List<SQLRid>> aliasRidLists, String alias, String... expectedRids) {
-    assertThat(aliasRidLists).containsKey(alias);
-    assertThat(aliasRidLists.get(alias)).hasSize(expectedRids.length);
+  /** Asserts promoted RID list size and each resolved legacy RID literal. */
+  private static void assertPromotedRids(
+      Map<String, List<SQLRid>> aliasPinnedRids, String alias, String... expectedRids) {
+    assertThat(aliasPinnedRids).containsKey(alias);
+    assertThat(aliasPinnedRids.get(alias)).hasSize(expectedRids.length);
     for (var i = 0; i < expectedRids.length; i++) {
-      assertThat(aliasRidLists.get(alias).get(i).toRecordId((Result) null, CTX).toString())
+      assertThat(aliasPinnedRids.get(alias).get(i).toRecordId((Result) null, CTX).toString())
           .isEqualTo(expectedRids[i]);
     }
   }
 
-  /** Asserts a singleton promoted equality resolves to the expected legacy RID. */
-  private static void assertPromotedRid(
-      Map<String, SQLRid> aliasRids, String alias, String expectedRid) {
-    assertPromotedRid(aliasRids, alias, expectedRid, CTX);
-  }
-
-  private static void assertPromotedRid(
-      Map<String, SQLRid> aliasRids, String alias, String expectedRid, CommandContext ctx) {
-    assertThat(aliasRids).containsKey(alias);
-    assertThat(aliasRids.get(alias).toRecordId((Result) null, ctx).toString())
-        .isEqualTo(expectedRid);
+  private static void assertPromotedRids(
+      Map<String, List<SQLRid>> aliasPinnedRids, String alias, CommandContext ctx,
+      String... expectedRids) {
+    assertThat(aliasPinnedRids).containsKey(alias);
+    assertThat(aliasPinnedRids.get(alias)).hasSize(expectedRids.length);
+    for (var i = 0; i < expectedRids.length; i++) {
+      assertThat(aliasPinnedRids.get(alias).get(i).toRecordId((Result) null, ctx).toString())
+          .isEqualTo(expectedRids[i]);
+    }
   }
 
   /**
-   * Literal RID in a WHERE clause is promoted to aliasRids. After promotion,
+   * Literal RID in a WHERE clause is promoted to aliasPinnedRids as List.of(rid). After promotion,
    * estimateRootEntries() will see the alias as a singleton (estimate = 1).
    */
   @Test
   public void literalRid_isPromoted() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = #25:7"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRid(aliasRids, "c", "#25:7");
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7");
     // The filter is intentionally left intact for the DirectRid pre-filter
     // pass on non-root use; verify it was not stripped.
     assertThat(aliasFilters).containsKey("c");
@@ -117,12 +115,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid = #25:7 AND name = 'foo'"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRid(aliasRids, "c", "#25:7");
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7");
     assertThat(aliasFilters.get("c").findRidEquality()).isNotNull();
   }
 
@@ -135,14 +133,14 @@ public class PromoteStaticRidsFromFiltersTest {
   public void parameterRid_isPromoted() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = :rid"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     when(ctx.getInputParameters()).thenReturn(Map.of("rid", "#25:7"));
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRid(aliasRids, "c", "#25:7", ctx);
+    assertPromotedRids(aliasPinnedRids, "c", ctx, "#25:7");
   }
 
   /**
@@ -155,27 +153,27 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid = $matched.x.@rid"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
-   * Filter without any @rid equality leaves aliasRids untouched.
+   * Filter without any @rid equality leaves aliasPinnedRids untouched.
    */
   @Test
   public void filterWithoutRid_isNotPromoted() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE name = 'foo'"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).isEmpty();
+    assertThat(aliasPinnedRids).isEmpty();
   }
 
   /**
@@ -187,29 +185,30 @@ public class PromoteStaticRidsFromFiltersTest {
   public void existingAliasRid_isNotOverwritten() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = #25:7"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
     var existing = mock(SQLRid.class);
-    aliasRids.put("c", existing);
+    var existingList = List.of(existing);
+    aliasPinnedRids.put("c", existingList);
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).containsEntry("c", existing);
+    assertThat(aliasPinnedRids).containsEntry("c", existingList);
   }
 
   /**
-   * An empty filter map produces an empty aliasRids result. Smoke test for the
+   * An empty filter map produces an empty aliasPinnedRids result. Smoke test for the
    * empty-input edge case.
    */
   @Test
   public void emptyFilters_producesEmptyRids() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).isEmpty();
+    assertThat(aliasPinnedRids).isEmpty();
   }
 
   /**
@@ -222,12 +221,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid = #25:7 OR name = 'foo'"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -240,12 +239,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid = #25:7 OR @rid = #26:8"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -258,12 +257,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE name = 'foo' AND (@rid = #25:7 OR name = 'bar')"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -276,14 +275,14 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid = :rid AND name = 'foo'"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     when(ctx.getInputParameters()).thenReturn(Map.of("rid", "#25:7"));
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRid(aliasRids, "c", "#25:7", ctx);
+    assertPromotedRids(aliasPinnedRids, "c", ctx, "#25:7");
     assertThat(aliasFilters.get("c").findRidEquality()).isNotNull();
   }
 
@@ -295,16 +294,16 @@ public class PromoteStaticRidsFromFiltersTest {
   public void reversedOperandLiteralRid_isPromoted() {
     Map<String, SQLWhereClause> aliasFilters = new HashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE #25:7 = @rid"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, new HashMap<>(), ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRid(aliasRids, "c", "#25:7");
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7");
   }
 
   /**
-   * Literal RID list {@code @rid IN [#N:M, #X:Y]} promotes into aliasRidLists.
+   * Literal RID list {@code @rid IN [#N:M, #X:Y]} promotes into aliasPinnedRids as a list.
    * Production queries pin vertices with this form instead of a single equality.
    */
   @Test
@@ -312,14 +311,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put(
         "c", parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7", "#26:8");
     assertThat(aliasFilters).containsKey("c");
   }
 
@@ -332,14 +329,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid in [#25:7, #26:8] AND name = 'foo'"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7", "#26:8");
     assertThat(aliasFilters).containsKey("c");
     assertThat(aliasFilters.get("c").findRidInList()).isNotNull();
   }
@@ -351,17 +346,15 @@ public class PromoteStaticRidsFromFiltersTest {
   public void parameterRidList_isPromoted() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid in :rids"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     when(ctx.getInputParameters()).thenReturn(
         Map.of("rids", List.of("#25:7", "#26:8")));
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7", "#26:8");
   }
 
   /**
@@ -372,16 +365,15 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid in :rids AND name = 'foo'"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     when(ctx.getInputParameters()).thenReturn(
         Map.of("rids", List.of("#25:7", "#26:8")));
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7", "#26:8");
     assertThat(aliasFilters.get("c").findRidInList()).isNotNull();
   }
 
@@ -394,14 +386,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid in [#25:7, #26:8] OR name = 'foo'"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -414,14 +404,12 @@ public class PromoteStaticRidsFromFiltersTest {
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE name = 'foo'"
             + " AND (@rid in [#25:7, #26:8] OR name = 'bar')"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -433,14 +421,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid in $matched.x.@rid"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -451,14 +437,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid IN (SELECT @rid FROM Comment)"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -469,16 +453,15 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put(
         "c", parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
     var existing = List.of(mock(SQLRid.class));
 
-    aliasRidLists.put("c", existing);
+    aliasPinnedRids.put("c", existing);
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).containsEntry("c", existing);
+    assertThat(aliasPinnedRids).containsEntry("c", existing);
   }
 
   /**
@@ -488,14 +471,12 @@ public class PromoteStaticRidsFromFiltersTest {
   public void emptyRidList_isNotPromoted() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid in []"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -506,14 +487,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid in [#25:7, 'not-a-rid']"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -524,14 +503,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid in [#25:7, 42]"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -541,16 +518,14 @@ public class PromoteStaticRidsFromFiltersTest {
   public void nonIterableParameter_isNotPromoted() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid in :rids"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     when(ctx.getInputParameters()).thenReturn(Map.of("rids", 42));
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -561,14 +536,12 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid in [#25:7, #26:8] OR @rid in [#27:9, #28:0]"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).doesNotContainKey("c");
   }
 
   /**
@@ -580,35 +553,33 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put("c", parseWhere(
         "SELECT FROM Comment WHERE @rid = #25:7 AND @rid in [#26:8, #27:9]"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).containsKey("c");
-    assertThat(aliasRidLists).doesNotContainKey("c");
-    assertPromotedRid(aliasRids, "c", "#25:7");
+    assertThat(aliasPinnedRids).containsKey("c");
+    assertThat(aliasPinnedRids.get("c")).hasSize(1);
+    assertPromotedRids(aliasPinnedRids, "c", "#25:7");
   }
 
   /**
-   * Parser-provided {@code aliasRids} slot blocks {@code @rid IN} promotion.
+   * Parser-provided {@code aliasPinnedRids} slot blocks {@code @rid IN} promotion.
    */
   @Test
   public void existingAliasRid_blocksRidListPromotion() {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     aliasFilters.put(
         "c", parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]"));
-    Map<String, SQLRid> aliasRids = new HashMap<>();
-    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
     var existing = mock(SQLRid.class);
-    aliasRids.put("c", existing);
+    var existingList = List.of(existing);
+    aliasPinnedRids.put("c", existingList);
 
     MatchExecutionPlanner.promoteStaticRidsFromFilters(
-        aliasFilters, aliasRids, aliasRidLists, ctx);
+        aliasFilters, aliasPinnedRids, ctx);
 
-    assertThat(aliasRids).containsEntry("c", existing);
-    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasPinnedRids).containsEntry("c", existingList);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
@@ -1,0 +1,166 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.match;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLSelectStatement;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.YouTrackDBSql;
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MatchExecutionPlanner#promoteStaticRidsFromFilters}.
+ *
+ * <p>The promoter scans per-alias WHERE clauses for {@code @rid = <expr>}
+ * equalities and, when the value-side is a literal or parameter (never a
+ * {@code $matched.X.@rid} back-ref), copies it into {@code aliasRids} so that
+ * {@link MatchExecutionPlanner#estimateRootEntries} collapses the alias's
+ * estimate to 1 and root selection picks the fast path.
+ */
+public class PromoteStaticRidsFromFiltersTest {
+
+  private CommandContext ctx;
+
+  @Before
+  public void setUp() {
+    var db = mock(DatabaseSessionEmbedded.class);
+    ctx = mock(CommandContext.class);
+    when(ctx.getDatabaseSession()).thenReturn(db);
+  }
+
+  /**
+   * Parses a SELECT to lift its WHERE clause out of the AST. Convenient way to
+   * exercise the real parser without hand-building expression nodes.
+   */
+  private static SQLWhereClause parseWhere(String sql) {
+    try {
+      var parser = new YouTrackDBSql(new ByteArrayInputStream(sql.getBytes()));
+      var stm = (SQLSelectStatement) parser.parse();
+      return stm.getWhereClause();
+    } catch (Exception e) {
+      throw new AssertionError("Failed to parse: " + sql, e);
+    }
+  }
+
+  /**
+   * Literal RID in a WHERE clause is promoted to aliasRids. After promotion,
+   * estimateRootEntries() will see the alias as a singleton (estimate = 1).
+   */
+  @Test
+  public void literalRid_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = #25:7"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).containsKey("c");
+    // The filter is intentionally left intact for the DirectRid pre-filter
+    // pass on non-root use; verify it was not stripped.
+    assertThat(aliasFilters).containsKey("c");
+  }
+
+  /**
+   * Compound filter {@code @rid = #N:M AND <other>} still promotes the alias.
+   * The other terms remain in the filter and are evaluated post-fetch.
+   */
+  @Test
+  public void compoundFilterWithLiteralRid_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid = #25:7 AND name = 'foo'"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).containsKey("c");
+  }
+
+  /**
+   * Parameter-bound RID ({@code @rid = :param}) is early-calculable, so it
+   * promotes just like a literal. The parameter is resolved at execution time
+   * by SQLRid.toRecordId(expression).
+   */
+  @Test
+  public void parameterRid_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = :rid"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).containsKey("c");
+  }
+
+  /**
+   * Back-reference {@code @rid = $matched.X.@rid} is left alone. It depends on
+   * runtime bindings and is handled by EdgeRidLookup / Pattern A back-ref
+   * hash join in the downstream pre-filter pass.
+   */
+  @Test
+  public void matchedBackRef_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid = $matched.x.@rid"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * Filter without any @rid equality leaves aliasRids untouched.
+   */
+  @Test
+  public void filterWithoutRid_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE name = 'foo'"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).isEmpty();
+  }
+
+  /**
+   * An alias that already has a RID slot from the parser (e.g.
+   * {@code {as: c, rid: #1:2}}) is not overwritten, even when the filter also
+   * contains an @rid equality. The pre-existing entry wins.
+   */
+  @Test
+  public void existingAliasRid_isNotOverwritten() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = #25:7"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    var existing = mock(SQLRid.class);
+    aliasRids.put("c", existing);
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).containsEntry("c", existing);
+  }
+
+  /**
+   * An empty filter map produces an empty aliasRids result. Smoke test for the
+   * empty-input edge case.
+   */
+  @Test
+  public void emptyFilters_producesEmptyRids() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+
+    assertThat(aliasRids).isEmpty();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
@@ -4,8 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLInCondition;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLRid;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLSelectStatement;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
@@ -13,6 +16,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.YouTrackDBSql;
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,11 +24,12 @@ import org.junit.Test;
 /**
  * Unit tests for {@link MatchExecutionPlanner#promoteStaticRidsFromFilters}.
  *
- * <p>The promoter scans per-alias WHERE clauses for {@code @rid = <expr>}
- * * equalities and, when the value-side is a literal or parameter (never a
- * {@code $matched.X.@rid} back-ref), copies it into {@code aliasRids} so that
- * {@link MatchExecutionPlanner#estimateRootEntries} collapses the alias's
- * estimate to 1 and root selection picks the fast path.
+ * <p>The promoter scans per-alias WHERE clauses for static {@code @rid = <expr>}
+ * equalities and {@code @rid IN <static-list>} conditions. Early-calculable
+ * literals and parameters (never {@code $matched} back-refs or subqueries) are
+ * copied into {@code aliasRids} or {@code aliasRidLists} so that
+ * {@link MatchExecutionPlanner#estimateRootEntries} collapses cardinality and
+ * root selection picks the RID-fetch fast path.
  *
  * <p><strong>Note on Test Structure:</strong> The concrete RID literals used across these tests
  * (e.g., {@code #25:7}, {@code #26:8}, {@code #12:0}) are purely structural and illustrative. The
@@ -33,6 +38,8 @@ import org.junit.Test;
  * interchangeably without shifting test outcomes.
  */
 public class PromoteStaticRidsFromFiltersTest {
+
+  private static final BasicCommandContext CTX = new BasicCommandContext();
 
   private CommandContext ctx;
 
@@ -57,6 +64,30 @@ public class PromoteStaticRidsFromFiltersTest {
     }
   }
 
+  /** Asserts promoted list size and each resolved legacy RID literal. */
+  private static void assertPromotedRidList(
+      Map<String, List<SQLRid>> aliasRidLists, String alias, String... expectedRids) {
+    assertThat(aliasRidLists).containsKey(alias);
+    assertThat(aliasRidLists.get(alias)).hasSize(expectedRids.length);
+    for (var i = 0; i < expectedRids.length; i++) {
+      assertThat(aliasRidLists.get(alias).get(i).toRecordId((Result) null, CTX).toString())
+          .isEqualTo(expectedRids[i]);
+    }
+  }
+
+  /** Asserts a singleton promoted equality resolves to the expected legacy RID. */
+  private static void assertPromotedRid(
+      Map<String, SQLRid> aliasRids, String alias, String expectedRid) {
+    assertPromotedRid(aliasRids, alias, expectedRid, CTX);
+  }
+
+  private static void assertPromotedRid(
+      Map<String, SQLRid> aliasRids, String alias, String expectedRid, CommandContext ctx) {
+    assertThat(aliasRids).containsKey(alias);
+    assertThat(aliasRids.get(alias).toRecordId((Result) null, ctx).toString())
+        .isEqualTo(expectedRid);
+  }
+
   /**
    * Literal RID in a WHERE clause is promoted to aliasRids. After promotion,
    * estimateRootEntries() will see the alias as a singleton (estimate = 1).
@@ -67,12 +98,14 @@ public class PromoteStaticRidsFromFiltersTest {
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = #25:7"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
-    assertThat(aliasRids).containsKey("c");
+    assertPromotedRid(aliasRids, "c", "#25:7");
     // The filter is intentionally left intact for the DirectRid pre-filter
     // pass on non-root use; verify it was not stripped.
     assertThat(aliasFilters).containsKey("c");
+    assertThat(aliasFilters.get("c").findRidEquality()).isNotNull();
   }
 
   /**
@@ -86,9 +119,11 @@ public class PromoteStaticRidsFromFiltersTest {
         "SELECT FROM Comment WHERE @rid = #25:7 AND name = 'foo'"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
-    assertThat(aliasRids).containsKey("c");
+    assertPromotedRid(aliasRids, "c", "#25:7");
+    assertThat(aliasFilters.get("c").findRidEquality()).isNotNull();
   }
 
   /**
@@ -102,9 +137,12 @@ public class PromoteStaticRidsFromFiltersTest {
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = :rid"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    when(ctx.getInputParameters()).thenReturn(Map.of("rid", "#25:7"));
 
-    assertThat(aliasRids).containsKey("c");
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
+
+    assertPromotedRid(aliasRids, "c", "#25:7", ctx);
   }
 
   /**
@@ -119,7 +157,8 @@ public class PromoteStaticRidsFromFiltersTest {
         "SELECT FROM Comment WHERE @rid = $matched.x.@rid"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
     assertThat(aliasRids).doesNotContainKey("c");
   }
@@ -133,7 +172,8 @@ public class PromoteStaticRidsFromFiltersTest {
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE name = 'foo'"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
     assertThat(aliasRids).isEmpty();
   }
@@ -151,7 +191,8 @@ public class PromoteStaticRidsFromFiltersTest {
     var existing = mock(SQLRid.class);
     aliasRids.put("c", existing);
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
     assertThat(aliasRids).containsEntry("c", existing);
   }
@@ -165,7 +206,8 @@ public class PromoteStaticRidsFromFiltersTest {
     Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
     assertThat(aliasRids).isEmpty();
   }
@@ -182,7 +224,8 @@ public class PromoteStaticRidsFromFiltersTest {
         "SELECT FROM Comment WHERE @rid = #25:7 OR name = 'foo'"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
     assertThat(aliasRids).doesNotContainKey("c");
   }
@@ -199,7 +242,8 @@ public class PromoteStaticRidsFromFiltersTest {
         "SELECT FROM Comment WHERE @rid = #25:7 OR @rid = #26:8"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
     assertThat(aliasRids).doesNotContainKey("c");
   }
@@ -216,7 +260,8 @@ public class PromoteStaticRidsFromFiltersTest {
         "SELECT FROM Comment WHERE name = 'foo' AND (@rid = #25:7 OR name = 'bar')"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
 
     assertThat(aliasRids).doesNotContainKey("c");
   }
@@ -233,9 +278,13 @@ public class PromoteStaticRidsFromFiltersTest {
         "SELECT FROM Comment WHERE @rid = :rid AND name = 'foo'"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    when(ctx.getInputParameters()).thenReturn(Map.of("rid", "#25:7"));
 
-    assertThat(aliasRids).containsKey("c");
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
+
+    assertPromotedRid(aliasRids, "c", "#25:7", ctx);
+    assertThat(aliasFilters.get("c").findRidEquality()).isNotNull();
   }
 
   /**
@@ -248,8 +297,334 @@ public class PromoteStaticRidsFromFiltersTest {
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE #25:7 = @rid"));
     Map<String, SQLRid> aliasRids = new HashMap<>();
 
-    MatchExecutionPlanner.promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx);
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, new HashMap<>(), ctx);
+
+    assertPromotedRid(aliasRids, "c", "#25:7");
+  }
+
+  /**
+   * Literal RID list {@code @rid IN [#N:M, #X:Y]} promotes into aliasRidLists.
+   * Production queries pin vertices with this form instead of a single equality.
+   */
+  @Test
+  public void literalRidList_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put(
+        "c", parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
+    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasFilters).containsKey("c");
+  }
+
+  /**
+   * Compound {@code @rid IN [...] AND <other>} still promotes the RID list while
+   * leaving the extra predicate in the filter.
+   */
+  @Test
+  public void compoundFilterWithLiteralRidList_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid in [#25:7, #26:8] AND name = 'foo'"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
+    assertThat(aliasRids).doesNotContainKey("c");
+    assertThat(aliasFilters).containsKey("c");
+    assertThat(aliasFilters.get("c").findRidInList()).isNotNull();
+  }
+
+  /**
+   * {@code @rid IN :rids} with an early-calculable parameter promotes like literals.
+   */
+  @Test
+  public void parameterRidList_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid in :rids"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    when(ctx.getInputParameters()).thenReturn(
+        Map.of("rids", List.of("#25:7", "#26:8")));
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * Compound {@code @rid IN :rids AND <other>} promotes the list and keeps the filter.
+   */
+  @Test
+  public void compoundFilterWithParameterRidList_isPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid in :rids AND name = 'foo'"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    when(ctx.getInputParameters()).thenReturn(
+        Map.of("rids", List.of("#25:7", "#26:8")));
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertPromotedRidList(aliasRidLists, "c", "#25:7", "#26:8");
+    assertThat(aliasFilters.get("c").findRidInList()).isNotNull();
+  }
+
+  /**
+   * Disjunction {@code @rid IN [...] OR <other>} must NOT promote — same rule as
+   * equality: pinning would drop the OR branch.
+   */
+  @Test
+  public void orWithLiteralRidList_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid in [#25:7, #26:8] OR name = 'foo'"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * {@code @rid IN [...]} nested inside an OR is not a top-level conjunct and
+   * must not be promoted.
+   */
+  @Test
+  public void nestedOrWithRidList_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE name = 'foo'"
+            + " AND (@rid in [#25:7, #26:8] OR name = 'bar')"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * Back-reference {@code @rid IN $matched.X.@rid} is left alone — runtime
+   * correlation, not a static list.
+   */
+  @Test
+  public void matchedBackRefInList_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid in $matched.x.@rid"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * {@code @rid IN (SELECT ...)} is not early-calculable and must not promote.
+   */
+  @Test
+  public void subqueryRidList_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid IN (SELECT @rid FROM Comment)"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * An alias that already has a promoted RID list slot is not overwritten.
+   */
+  @Test
+  public void existingAliasRidList_isNotOverwritten() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put(
+        "c", parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    var existing = List.of(mock(SQLRid.class));
+
+    aliasRidLists.put("c", existing);
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).containsEntry("c", existing);
+  }
+
+  /**
+   * Empty {@code @rid IN []} yields no promotable list.
+   */
+  @Test
+  public void emptyRidList_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid in []"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * A list mixing RID literals with a non-numeric, non-RID string aborts promotion.
+   */
+  @Test
+  public void invalidStringRidInList_abortsPromotion() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid in [#25:7, 'not-a-rid']"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * A list mixing RID literals with a non-RID numeric value aborts promotion.
+   */
+  @Test
+  public void invalidNumericListElement_abortsPromotion() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid in [#25:7, 42]"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * Parameter bound to a non-iterable value cannot form a RID list.
+   */
+  @Test
+  public void nonIterableParameter_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid in :rids"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    when(ctx.getInputParameters()).thenReturn(Map.of("rids", 42));
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * Two RID lists under OR cannot be represented as a single pinned root.
+   */
+  @Test
+  public void orOfTwoRidLists_isNotPromoted() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid in [#25:7, #26:8] OR @rid in [#27:9, #28:0]"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertThat(aliasRids).doesNotContainKey("c");
+  }
+
+  /**
+   * When both {@code @rid =} and {@code @rid IN} appear in the same AND filter,
+   * equality promotion wins because it is checked first.
+   */
+  @Test
+  public void equalityWinsOverInList_whenBothPresent() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put("c", parseWhere(
+        "SELECT FROM Comment WHERE @rid = #25:7 AND @rid in [#26:8, #27:9]"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
 
     assertThat(aliasRids).containsKey("c");
+    assertThat(aliasRidLists).doesNotContainKey("c");
+    assertPromotedRid(aliasRids, "c", "#25:7");
+  }
+
+  /**
+   * Parser-provided {@code aliasRids} slot blocks {@code @rid IN} promotion.
+   */
+  @Test
+  public void existingAliasRid_blocksRidListPromotion() {
+    Map<String, SQLWhereClause> aliasFilters = new LinkedHashMap<>();
+    aliasFilters.put(
+        "c", parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]"));
+    Map<String, SQLRid> aliasRids = new HashMap<>();
+    Map<String, List<SQLRid>> aliasRidLists = new HashMap<>();
+    var existing = mock(SQLRid.class);
+    aliasRids.put("c", existing);
+
+    MatchExecutionPlanner.promoteStaticRidsFromFilters(
+        aliasFilters, aliasRids, aliasRidLists, ctx);
+
+    assertThat(aliasRids).containsEntry("c", existing);
+    assertThat(aliasRidLists).doesNotContainKey("c");
+  }
+
+  /**
+   * {@link MatchExecutionPlanner#toPromotedSqlRidList} materializes legacy
+   * {@link SQLRid} nodes from a parsed IN condition.
+   */
+  @Test
+  public void toPromotedSqlRidList_resolvesLiteralList() {
+    var where = parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]");
+    SQLInCondition inCond = where.findRidInList();
+    assertThat(inCond).isNotNull();
+
+    var promoted = MatchExecutionPlanner.toPromotedSqlRidList(inCond, ctx);
+
+    assertThat(promoted).hasSize(2);
+    assertThat(promoted.get(0).toRecordId((Result) null, CTX).toString()).isEqualTo("#25:7");
+    assertThat(promoted.get(1).toRecordId((Result) null, CTX).toString()).isEqualTo("#26:8");
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/match/PromoteStaticRidsFromFiltersTest.java
@@ -64,7 +64,14 @@ public class PromoteStaticRidsFromFiltersTest {
     }
   }
 
-  /** Asserts promoted RID list size and each resolved legacy RID literal. */
+  /**
+   * Asserts promoted RID list size and each resolved legacy RID literal, resolving
+   * every RID against the static {@link #CTX}. Use this no-ctx overload for
+   * literal-RID tests (e.g. {@code @rid = #25:7}, {@code @rid IN [#25:7, #26:8]}),
+   * where resolution needs no per-test parameter bindings. For parameter-bound
+   * RIDs, use the {@link #assertPromotedRids(Map, String, CommandContext, String...)
+   * ctx-taking overload} instead.
+   */
   private static void assertPromotedRids(
       Map<String, List<SQLRid>> aliasPinnedRids, String alias, String... expectedRids) {
     assertThat(aliasPinnedRids).containsKey(alias);
@@ -75,6 +82,14 @@ public class PromoteStaticRidsFromFiltersTest {
     }
   }
 
+  /**
+   * Same as {@link #assertPromotedRids(Map, String, String...)} but resolves every
+   * RID against the caller-supplied {@code ctx} (the per-test mock) rather than the
+   * static {@link #CTX}. Use this overload for parameter-bound RID tests
+   * ({@code @rid = :param} / {@code @rid IN :params}) that stub
+   * {@code ctx.getInputParameters()}, because the promoted {@link SQLRid} carries a
+   * parameter expression that only resolves against that mock's bindings.
+   */
   private static void assertPromotedRids(
       Map<String, List<SQLRid>> aliasPinnedRids, String alias, CommandContext ctx,
       String... expectedRids) {
@@ -187,6 +202,8 @@ public class PromoteStaticRidsFromFiltersTest {
     aliasFilters.put("c", parseWhere("SELECT FROM Comment WHERE @rid = #25:7"));
     Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
     var existing = mock(SQLRid.class);
+    // Immutable list: an in-place append by a buggy promoter would throw, so
+    // reference-identity below is not the only guard against mutation.
     var existingList = List.of(existing);
     aliasPinnedRids.put("c", existingList);
 
@@ -194,6 +211,12 @@ public class PromoteStaticRidsFromFiltersTest {
         aliasFilters, aliasPinnedRids, ctx);
 
     assertThat(aliasPinnedRids).containsEntry("c", existingList);
+    // Post single-map consolidation there is no second map to prove placement
+    // against, so distinctness is recaptured by reference-identity plus map size:
+    // the pre-existing slot is the exact same object (no append or replacement)
+    // and the promotion added no new entry.
+    assertThat(aliasPinnedRids.get("c")).isSameAs(existingList);
+    assertThat(aliasPinnedRids).hasSize(1);
   }
 
   /**
@@ -573,6 +596,8 @@ public class PromoteStaticRidsFromFiltersTest {
         "c", parseWhere("SELECT FROM Comment WHERE @rid in [#25:7, #26:8]"));
     Map<String, List<SQLRid>> aliasPinnedRids = new HashMap<>();
     var existing = mock(SQLRid.class);
+    // Immutable list: an in-place append by a buggy promoter would throw, so
+    // reference-identity below is not the only guard against mutation.
     var existingList = List.of(existing);
     aliasPinnedRids.put("c", existingList);
 
@@ -580,6 +605,12 @@ public class PromoteStaticRidsFromFiltersTest {
         aliasFilters, aliasPinnedRids, ctx);
 
     assertThat(aliasPinnedRids).containsEntry("c", existingList);
+    // Post single-map consolidation there is no second map to prove placement
+    // against, so distinctness is recaptured by reference-identity plus map size:
+    // the pre-existing slot is the exact same object (the IN-list promotion did
+    // not append or replace) and it added no new entry.
+    assertThat(aliasPinnedRids.get("c")).isSameAs(existingList);
+    assertThat(aliasPinnedRids).hasSize(1);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/PatternTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/PatternTest.java
@@ -675,6 +675,65 @@ public class PatternTest extends ParserTestAbstract {
     assertNull("findRidEquality should return null for @rid <>", result);
   }
 
+  /** @rid in [#23:1, #24:2] → findRidInList detects the IN condition */
+  @Test
+  public void testFindRidInList_literalList() throws ParseException {
+    var where = parseWhere("@rid in [#23:1, #24:2]");
+    var result = where.findRidInList();
+    assertRidInListOnLeft(result);
+    assertNull("literal list must not use a subquery RHS", result.getRightStatement());
+    assertNotNull("literal list RHS must be a math expression", result.getRightMathExpression());
+  }
+
+  /** @rid in [#23:1, #24:2] AND name = 'x' → still finds the IN condition */
+  @Test
+  public void testFindRidInList_compound() throws ParseException {
+    var where = parseWhere("@rid in [#23:1, #24:2] AND name = 'x'");
+    var result = where.findRidInList();
+    assertRidInListOnLeft(result);
+  }
+
+  /** name in ['x'] → not @rid IN, must return null */
+  @Test
+  public void testFindRidInList_nonRidField() throws ParseException {
+    var where = parseWhere("name in ['x', 'y']");
+    var result = where.findRidInList();
+    assertNull("findRidInList must ignore IN on non-@rid fields", result);
+  }
+
+  /** name = 'x' → no @rid IN */
+  @Test
+  public void testFindRidInList_noRid() throws ParseException {
+    var where = parseWhere("name = 'x'");
+    var result = where.findRidInList();
+    assertNull("findRidInList should return null when no @rid IN", result);
+  }
+
+  /**
+   * MATCH-style nested filter wrapping (as produced by {@code addAliases}) must
+   * still expose {@code @rid IN <expr>} to {@link SQLWhereClause#findRidInList}.
+   */
+  @Test
+  public void testFindRidInList_matchStyleFilter() throws ParseException {
+    var innerWhere = parseWhere("@rid in [#23:1, #24:2]");
+
+    var outerWhere = new SQLWhereClause(-1);
+    var andBlock = new SQLAndBlock(-1);
+    andBlock.getSubBlocks().add(innerWhere.getBaseExpression());
+    outerWhere.setBaseExpression(andBlock);
+
+    var result = outerWhere.findRidInList();
+    assertRidInListOnLeft(result);
+  }
+
+  private static void assertRidInListOnLeft(SQLInCondition inCond) {
+    assertNotNull("expected @rid IN condition", inCond);
+    assertNotNull("IN condition must have a left expression", inCond.getLeft());
+    assertTrue(
+        "left side must be bare @rid, got: " + inCond.getLeft().toString(""),
+        inCond.getLeft().toString("").toLowerCase().contains("@rid"));
+  }
+
   /**
    * Tests the aliasFilter-style WHERE clause that the MATCH planner constructs.
    * The MATCH planner creates a WHERE clause with:
@@ -742,6 +801,17 @@ public class PatternTest extends ParserTestAbstract {
         "findRidEquality should detect @rid equality when filters are "
             + "added as separate sub-blocks",
         result);
+  }
+
+  /**
+   * OR condition: @rid in [#1:1, #2:2] OR @rid in [#3:3, #4:4]. Multi-element
+   * OrBlocks must NOT be unwrapped — findRidInList should return null.
+   */
+  @Test
+  public void testFindRidInList_orConditionNotUnwrapped() throws ParseException {
+    var where = parseWhere("@rid in [#1:1, #2:2] OR @rid in [#3:3, #4:4]");
+    var result = where.findRidInList();
+    assertNull("findRidInList should return null for OR conditions", result);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRidTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRidTest.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrackdb.internal.core.sql.parser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
@@ -47,5 +48,30 @@ public class SQLRidTest {
 
     assertNotNull("expression branch should resolve the RID", recordId);
     assertEquals("#12:0", recordId.toString());
+  }
+
+  /**
+   * setExpression on a node that already holds a legacy {@code #c:p} literal
+   * must fully transition it to the expression form: the new expression
+   * resolves the RID and the stale collection/position pair is cleared, so no
+   * contradictory hybrid state survives.
+   */
+  @Test
+  public void setExpression_onLegacyLiteral_clearsPairAndUsesExpression() {
+    var rid = new SQLRid(-1);
+    var c = new SQLInteger(-1);
+    c.setValue(99);
+    var p = new SQLInteger(-1);
+    p.setValue(9);
+    rid.setCollection(c);
+    rid.setPosition(p);
+    rid.setLegacy(true);
+
+    rid.setExpression(parseRidValueExpression("@rid = #12:0"));
+
+    assertEquals("#12:0",
+        rid.toRecordId((Result) null, new BasicCommandContext()).toString());
+    assertNull("legacy collection must be cleared", rid.collection);
+    assertNull("legacy position must be cleared", rid.position);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRidTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRidTest.java
@@ -1,0 +1,51 @@
+package com.jetbrains.youtrackdb.internal.core.sql.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import java.io.ByteArrayInputStream;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SQLRid} value resolution, focused on the interaction
+ * between {@link SQLRid#setExpression} and the {@code legacy} flag.
+ */
+public class SQLRidTest {
+
+  /** Parses a WHERE clause and returns the value-side of its {@code @rid = ...}. */
+  private static SQLExpression parseRidValueExpression(String whereSql) {
+    try {
+      var parser = new YouTrackDBSql(new ByteArrayInputStream(
+          ("SELECT FROM X WHERE " + whereSql).getBytes()));
+      var stm = (SQLSelectStatement) parser.parse();
+      return stm.getWhereClause().findRidEquality();
+    } catch (Exception e) {
+      throw new AssertionError("Failed to parse: " + whereSql, e);
+    }
+  }
+
+  /**
+   * Regression guard for the setExpression / legacy interaction.
+   * {@link SQLRid#toRecordId} short-circuits to the literal
+   * {@code collection:position} pair whenever {@code legacy} is true (the
+   * {@code if (legacy || ...)} guard). Setting an expression on a legacy
+   * instance must therefore flip {@code legacy} off, or the expression is
+   * ignored. Here the legacy pair is never set (null collection/position), so
+   * without the reset the guard would dereference a null collection and throw;
+   * with the reset the expression ({@code #12:0}) is evaluated and returned.
+   */
+  @Test
+  public void setExpression_flipsLegacyOff_soToRecordIdUsesExpression() {
+    var expr = parseRidValueExpression("@rid = #12:0");
+    var rid = new SQLRid(-1);
+    rid.setLegacy(true);
+    rid.setExpression(expr);
+
+    var recordId = rid.toRecordId((Result) null, new BasicCommandContext());
+
+    assertNotNull("expression branch should resolve the RID", recordId);
+    assertEquals("#12:0", recordId.toString());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRidTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLRidTest.java
@@ -1,19 +1,32 @@
 package com.jetbrains.youtrackdb.internal.core.sql.parser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import java.io.ByteArrayInputStream;
+import java.util.Map;
 import org.junit.Test;
 
 /**
  * Unit tests for {@link SQLRid} value resolution, focused on the interaction
  * between {@link SQLRid#setExpression} and the {@code legacy} flag.
+ *
+ * <p>{@link SQLRid#toRecordId} already honours the expression guard; these tests
+ * cover the observers named in the {@code setExpression} comment — {@code
+ * toString}, {@code equals}, {@code copy}, and expression-branch serialization.
  */
 public class SQLRidTest {
+
+  private static final BasicCommandContext CTX = new BasicCommandContext();
 
   /** Parses a WHERE clause and returns the value-side of its {@code @rid = ...}. */
   private static SQLExpression parseRidValueExpression(String whereSql) {
@@ -25,6 +38,25 @@ public class SQLRidTest {
     } catch (Exception e) {
       throw new AssertionError("Failed to parse: " + whereSql, e);
     }
+  }
+
+  /** Builds a legacy {@code #c:p} RID node as the parser would for a literal slot. */
+  private static SQLRid legacyLiteralRid(int collection, int position) {
+    var rid = new SQLRid(-1);
+    var c = new SQLInteger(-1);
+    c.setValue(collection);
+    var p = new SQLInteger(-1);
+    p.setValue(position);
+    rid.setCollection(c);
+    rid.setPosition(p);
+    rid.setLegacy(true);
+    return rid;
+  }
+
+  /** Promotes {@code exprSql} onto a legacy literal, matching MATCH planner usage. */
+  private static SQLRid promoteLegacyLiteral(SQLRid rid, String exprSql) {
+    rid.setExpression(parseRidValueExpression(exprSql));
+    return rid;
   }
 
   /**
@@ -44,7 +76,7 @@ public class SQLRidTest {
     rid.setLegacy(true);
     rid.setExpression(expr);
 
-    var recordId = rid.toRecordId((Result) null, new BasicCommandContext());
+    var recordId = rid.toRecordId((Result) null, CTX);
 
     assertNotNull("expression branch should resolve the RID", recordId);
     assertEquals("#12:0", recordId.toString());
@@ -58,20 +90,115 @@ public class SQLRidTest {
    */
   @Test
   public void setExpression_onLegacyLiteral_clearsPairAndUsesExpression() {
-    var rid = new SQLRid(-1);
-    var c = new SQLInteger(-1);
-    c.setValue(99);
-    var p = new SQLInteger(-1);
-    p.setValue(9);
-    rid.setCollection(c);
-    rid.setPosition(p);
-    rid.setLegacy(true);
+    var rid = legacyLiteralRid(99, 9);
+    promoteLegacyLiteral(rid, "@rid = #12:0");
 
-    rid.setExpression(parseRidValueExpression("@rid = #12:0"));
-
-    assertEquals("#12:0",
-        rid.toRecordId((Result) null, new BasicCommandContext()).toString());
+    assertEquals("#12:0", rid.toRecordId((Result) null, CTX).toString());
     assertNull("legacy collection must be cleared", rid.collection);
     assertNull("legacy position must be cleared", rid.position);
+  }
+
+  /**
+   * {@link SQLRid#toString(String)} on a promoted node must render via the
+   * expression branch. Without clearing the stale {@code #99:9} pair, the
+   * legacy path would still print the old literal or NPE on a null collection.
+   */
+  @Test
+  public void setExpression_onLegacyLiteral_toStringUsesExpressionNotStalePair() {
+    var rid = promoteLegacyLiteral(legacyLiteralRid(99, 9), "@rid = #12:0");
+
+    var rendered = rid.toString("");
+
+    assertFalse("stale legacy pair must not appear in toString", rendered.contains("99:9"));
+    assertTrue("expression text must appear in toString", rendered.contains("12:0"));
+  }
+
+  /**
+   * Parametric {@link SQLRid#toString(Map, StringBuilder)} must take the
+   * {@code {"@rid": <expr>}} branch after promotion, not the legacy
+   * {@code #c:p} literal form.
+   */
+  @Test
+  public void setExpression_onLegacyLiteral_parametricToStringUsesExpressionBranch() {
+    var rid = promoteLegacyLiteral(legacyLiteralRid(99, 9), "@rid = #12:0");
+    var builder = new StringBuilder();
+
+    rid.toString(Map.of(), builder);
+
+    var rendered = builder.toString();
+    assertFalse("stale legacy pair must not appear", rendered.contains("99:9"));
+    assertTrue("must use expression JSON shape", rendered.contains("{\"@rid\":"));
+    assertTrue("expression RID must appear", rendered.contains("12:0"));
+  }
+
+  /**
+   * After promotion, {@link SQLRid#copy()} must reproduce pure expression form:
+   * {@code legacy=false}, no literal pair, and a deep-copied {@code expression}.
+   * {@code copy()} mirrors all fields as-is; if {@code setExpression} left a stale
+   * pair, the copy would inherit it and compare unequal to expression-only nodes
+   * with the same RID.
+   */
+  @Test
+  public void setExpression_onLegacyLiteral_copyReflectsExpressionForm() {
+    var rid = promoteLegacyLiteral(legacyLiteralRid(99, 9), "@rid = #12:0");
+    var copy = rid.copy();
+
+    assertNull(copy.collection);
+    assertNull(copy.position);
+    assertFalse(copy.legacy);
+    assertNotNull(copy.expression);
+    assertEquals(rid, copy);
+    assertEquals("#12:0", copy.toRecordId((Result) null, CTX).toString());
+    assertFalse(copy.toString("").contains("99:9"));
+  }
+
+  /**
+   * Two promoted nodes carrying the same expression must be equal even when one
+   * was transitioned from a different legacy literal. Stale pairs must not
+   * participate in {@link SQLRid#equals}.
+   */
+  @Test
+  public void setExpression_onLegacyLiteral_equalsIgnoresFormerLegacyPair() {
+    var fromLegacy = promoteLegacyLiteral(legacyLiteralRid(99, 9), "@rid = #12:0");
+    var expressionOnly = new SQLRid(-1);
+    expressionOnly.setExpression(parseRidValueExpression("@rid = #12:0"));
+
+    assertEquals("same expression must compare equal after promotion", fromLegacy, expressionOnly);
+
+    var differentLegacy = promoteLegacyLiteral(legacyLiteralRid(1, 1), "@rid = #12:0");
+    assertEquals(fromLegacy, differentLegacy);
+
+    var otherRid = promoteLegacyLiteral(legacyLiteralRid(99, 9), "@rid = #13:1");
+    assertNotEquals("different expressions must not compare equal", fromLegacy, otherRid);
+  }
+
+  /**
+   * A promoted node must round-trip through {@link SQLRid#serialize} /
+   * {@link SQLRid#deserialize} on the expression branch: no legacy pair in the
+   * payload, {@code legacy=false}, and the restored node still resolves the RID.
+   */
+  @Test
+  public void setExpression_promotedNode_serializesViaExpressionBranch() {
+    var rid = promoteLegacyLiteral(legacyLiteralRid(99, 9), "@rid = #12:0");
+    var session = mock(DatabaseSessionEmbedded.class);
+    when(session.assertIfNotActive()).thenReturn(true);
+
+    var payload = rid.serialize(session);
+
+    assertNull("promoted node must not serialize a collection slot", payload.getProperty("collection"));
+    assertNull("promoted node must not serialize a position slot", payload.getProperty("position"));
+    assertNotNull("expression slot must be present", payload.getProperty("expression"));
+    assertEquals(Boolean.FALSE, payload.getProperty("legacy"));
+
+    var restored = new SQLRid(-1);
+    restored.deserialize(payload);
+
+    assertNull(restored.collection);
+    assertNull(restored.position);
+    assertFalse(restored.legacy);
+    assertNotNull(restored.expression);
+    assertEquals("#12:0", restored.toRecordId((Result) null, CTX).toString());
+    assertEquals(rid, restored);
+    assertFalse(restored.toString("").contains("99:9"));
   }
 }

--- a/docs/adr/match-rid-from-where-extract/_workflow/design.md
+++ b/docs/adr/match-rid-from-where-extract/_workflow/design.md
@@ -1,0 +1,156 @@
+# MATCH Static-RID-in-WHERE Promotion — Design
+
+## Overview
+
+When a MATCH node carries a static RID equality inside its WHERE clause
+(`WHERE: (@rid = #25:7)` or `WHERE: (@rid = :param)`), the planner does not
+treat it as a singleton root candidate. `estimateRootEntries()` only collapses
+to 1 for aliases present in `aliasRids`, and `aliasRids` is populated solely
+from the parser's dedicated `{rid: #N:M}` slot. RID equalities living in
+`aliasFilters` fall through to the `count/2` heuristic in
+`SQLWhereClause.estimate`.
+
+The proposed change adds one pass at the end of `buildPatterns()`:
+`promoteStaticRidsFromFilters` walks each per-alias filter, locates a static
+`@rid` equality, and copies it into `aliasRids` while leaving the filter
+intact. This fixes two downstream effects:
+
+1. `estimateRootEntries()` collapses the alias's estimate to 1, so the
+   topological scheduler picks it as the cheapest root.
+2. `createSelectStatement()` takes the `FetchFromRids` fast path instead of
+   a class scan plus post-filter.
+
+The fix is planner-only. No parser, runtime, public-API, or storage surface
+is touched. Reverse traversal code (`MatchReverseEdgeTraverser`,
+`updateScheduleStartingAt`) already handles the resulting plan shape.
+
+## Class Design
+
+```mermaid
+classDiagram
+    class MatchExecutionPlanner {
+        -aliasFilters: Map~String, SQLWhereClause~
+        -aliasRids: Map~String, SQLRid~
+        +buildPatterns(ctx)
+        +promoteStaticRidsFromFilters(aliasFilters, aliasRids, ctx)
+        +estimateRootEntries(aliasClasses, aliasRids, aliasFilters, ctx)
+    }
+
+    class SQLWhereClause {
+        +findRidEquality() SQLExpression
+        +extractAndRemoveRidEquality() RidExtractionResult
+    }
+
+    class SQLExpression {
+        +getMatchPatternInvolvedAliases() List~String~
+        +isEarlyCalculated(ctx) boolean
+    }
+
+    class SQLRid {
+        -expression: SQLExpression
+        +setExpression(SQLExpression)
+        +toRecordId(target, ctx) RecordIdInternal
+    }
+
+    MatchExecutionPlanner ..> SQLWhereClause : findRidEquality
+    MatchExecutionPlanner ..> SQLExpression : isEarlyCalculated
+    MatchExecutionPlanner ..> SQLRid : wraps value side
+```
+
+The promoter reuses three existing helpers:
+
+- `SQLWhereClause.findRidEquality()` returns the value-side `SQLExpression`
+  of a non-destructive `@rid = <expr>` match, handling the AND/OR wrapping
+  produced by `addAliases`.
+- `SQLExpression.getMatchPatternInvolvedAliases()` returns the list of
+  `$matched.X` references inside the expression; non-empty means back-ref.
+- `SQLExpression.isEarlyCalculated(ctx)` returns true for literals, params,
+  and other context-independent expressions.
+
+The value-side `SQLExpression` is wrapped via `SQLRid.setExpression(...)`
+(new setter; the field was previously protected and unreachable from the
+`executor.match` package). `SQLRid.toRecordId()` already evaluates the
+expression slot at execution time and unwraps the resulting `Identifiable`.
+
+## Why Keep the @rid Term in the Filter
+
+`MatchExecutionPlanner` already has a pre-filter pass (around line 3050)
+that walks the edge schedule and attaches `RidFilterDescriptor.DirectRid`
+on the producing edge whenever the target alias's WHERE contains a literal
+or parameter `@rid`. That pass reads from `aliasFilters` via
+`findRidEquality()`.
+
+If the promoter stripped the `@rid` term, the pre-filter would no longer
+fire for aliases that ended up as non-roots, regressing existing behaviour.
+Keeping the term in place is safe:
+
+- When the alias becomes a root, the post-fetch filter evaluates
+  `@rid = #25:7` against the singleton RID set returned by `FetchFromRids`.
+  The check is true, so the only cost is one boolean evaluation per record.
+- When the alias is a non-root, the existing `DirectRid` pre-filter narrows
+  the link bag to a singleton, unchanged.
+
+A future change could split the term, attach `DirectRid` from `aliasRids`,
+and remove it from the filter. That is out of scope here.
+
+## Skipped Cases
+
+The promoter only handles equalities that resolve without per-row context.
+Three filters are explicitly skipped:
+
+1. **Pre-existing RID slot.** When `aliasRids.containsKey(alias)`, the
+   parser has already populated the slot via the `{rid: #N:M}` grammar.
+   Overwriting would discard a stronger signal.
+2. **`$matched.X.@rid` back-refs.** Detected via
+   `getMatchPatternInvolvedAliases()`. These need runtime bindings and are
+   handled by `EdgeRidLookup`, Pattern A back-ref hash join, or Chain
+   Semi-Join in the downstream pre-filter pass. Promoting them would break
+   those handlers and produce an unresolvable RID at plan time.
+3. **Non-early-calculable expressions.** Anything that depends on the
+   current row context (`$currentMatch.something`, computed expressions
+   needing input data) cannot resolve to a RID at planning time.
+
+The skip list is enforced by three guards in order, so the promoter is a
+no-op on any expression it cannot prove is safe.
+
+## Risks
+
+- **Filter shape coverage.** `findRidEquality` recognises AND-of-equalities
+  with the standard parser-emitted wrapper shapes. Filters that nest the
+  `@rid` term inside an OR, NOT, or other non-AND boolean would not match,
+  so the promoter quietly leaves them untreated. Acceptable: those queries
+  are degenerate and rare; the pre-existing behaviour is preserved.
+- **Duplicate evaluation.** When the alias is picked as a root, the WHERE
+  post-filter re-evaluates `@rid = #N:M` against the singleton RID set.
+  Cost is one boolean per record (the singleton). Negligible.
+- **Cache-key churn.** `YqlExecutionPlanCache` keys plans by statement text.
+  `aliasFilters` is mutated only by removing redundant terms today; the
+  promoter does not strip, so the cache key remains identical. No churn.
+
+## Test Plan
+
+Unit (in place, `PromoteStaticRidsFromFiltersTest`, 7 tests):
+
+- literal RID is promoted
+- compound `@rid = X AND name = 'foo'` is promoted
+- parameter RID `:param` is promoted
+- `$matched.X.@rid` back-ref is left alone
+- non-RID filter is left alone
+- pre-existing `aliasRids` entry is not overwritten
+- empty input produces empty output
+
+Integration (to add):
+
+- Multi-hop MATCH from the issue example
+  (`{Person, as: p}.out('Knows'){Person}.out('Likes'){Comment, WHERE: (@rid = #N:M)}`)
+  that asserts the produced plan has `FetchFromRids` as the root step and
+  reverses traversal direction.
+- End-to-end run against a real schema (Person/Comment/Knows/Likes) that
+  asserts row count equals 1 for a known-good RID and 0 for a non-existent
+  RID, with execution time within a sane budget.
+
+Benchmark (optional, post-merge):
+
+- LDBC-style query with one side restricted to a singleton RID and the
+  other to a large class. Expect a one-shot O(degree) traversal instead
+  of the full class scan + edge expansion.


### PR DESCRIPTION
#### PR Title:

YTDB-629: match rid from where extract

#### Motivation:

`estimateRootEntries()` treats only RIDs from the parser's `{rid: #N:M}` slot as pinned (cardinality = list size). Static `@rid = <literal|param>` and `@rid IN <static-list>` living in a node's `WHERE` clause are invisible to the planner: cardinality falls back to `SQLWhereClause.estimate()` (often `count/2`), and `MatchFirstStep` generates a class scan with post-filter instead of `FETCH FROM` the pinned RIDs.

#### Finding

When a MATCH node pins records via WHERE instead of the `{rid: …}` slot, the planner underestimates how selective that alias is.

**Singleton equality** — e.g. `{class: Comment, as: comment, WHERE: (@rid = #25:7)}`:

```sql
MATCH {class: Person, as: person} .out('Knows'){class: Person, as: friend}
.out('Likes'){class: Comment, as: comment, WHERE: (@rid = #25:7)}
RETURN person, friend
```

"People whose friends liked a specific comment." With Person ≈ 10K and Comment ≈ 2M:

* person (no filter) → 10K
* friend (no filter) → 10K
* comment (`@rid = #25:7` in WHERE) → min(estimate(), 2M) ≈ 1M

The planner picks `person` as root (10K < 1M) and expands the Person graph forward — O(N × degree²). The better plan fetches the comment by RID (O(1)), reverse-traverses `in_Likes` → `in_Knows`.

Even if `comment` were chosen as root, without a pinned RID list `MatchFirstStep` would emit `SELECT FROM Comment WHERE @rid = #25:7` — a 2M-record class scan, not a direct RID fetch.

**Static IN list** — same gap for `@rid IN [#a, #b, …]`: the planner has no pinned list, so cardinality and root selection ignore the constraint. Review feedback on the first draft called this out explicitly.

#### Proposed fix

At the end of `buildPatterns()`, `promoteStaticRidsFromFilters()` walks per-alias WHERE filters and copies early-calculable static RID constraints into `aliasPinnedRids: Map<String, List<SQLRid>>`:

| Source | `aliasPinnedRids` entry |
|--------|-------------------------|
| `{rid: #N:M}` (parser slot) | `List.of(rid)` — unchanged |
| `@rid = <literal\|param>` | `List.of(rid)` |
| `@rid IN <static-list>` | full promoted list |

The original `@rid` term stays in the filter (pre-filter and post-fetch WHERE still apply where relevant).

Downstream effects:

1. **`estimateRootEntries()`** — pinned alias gets cardinality = `list.size()` (1 for equality, N for IN) → cheaper root in the topological schedule.
2. **`createSelectStatement()`** — `MatchFirstStep` / prefetch use `FETCH FROM` the RID list instead of a class scan.
3. **Pre-filter `DirectRid`** — still only for singleton `@rid =` (via `findRidEquality()`). `@rid IN` has no matching pre-filter descriptor; those aliases rely on prefetch / direct fetch or post-fetch WHERE.

New / extended surfaces:

* `SQLWhereClause.findRidInList()` — non-destructive `@rid IN` detection (shared AND/OR unwrapping with `findRidEquality()`).
* `SQLRid.setExpression()` — wrap promoted value-side expressions for deferred evaluation.

No new traversal machinery: `getTopologicalSortedSchedule()`, `MatchReverseEdgeTraverser`, and edge-direction flipping in the topological DFS already handle the resulting plan shape.

#### Scope / skipped cases

Promotion is skipped when:

* the alias already has a parser `{rid: …}` slot (explicit slot wins),
* the expression contains `$matched.X` back-references (not resolvable at plan time),
* the right-hand side is not early-calculable,
* `@rid IN` is a subquery or otherwise non-static,
* the RID list materializes empty or contains invalid entries (e.g. `'not-a-rid'`).

**Not in this PR:** mixed OR (`@rid IN [#a] OR name = 'x'`) and pure multi-RID OR (`#a OR #b`) — `findRidEquality()` / `findRidInList()` require a single AND term, so these correctly stay unpromoted.

#### Impact

MATCH queries where a node is constrained to one or a small static set of RIDs move from O(N × degree^d) forward expansion to O(k) direct lookup + O(k) reverse traversal (k = pinned list size).

#### Assessment

Low-risk planner-only change on existing infrastructure. Regression coverage: `PromoteStaticRidsFromFiltersTest`, `MatchStaticRidPromotionIntegrationTest`, `PatternTest` (`findRidInList`), `EstimateRootEntriesTest`, `SQLRidTest`.
