### PR TITLE
Add design-doc readability rules and feedback skill

### DIFF
--- a/.claude/output-styles/house-conversation.md
+++ b/.claude/output-styles/house-conversation.md
@@ -22,7 +22,7 @@ Apply these four sections of `.claude/output-styles/house-style.md` to everythin
 
 - `## Banned vocabulary`: the Tier 1-4 word bans.
 - `## Banned sentence patterns`: negative parallelism ("not X, but Y"), roundabout negation, sycophantic openers, throat-clearing, closing connectives, trailing hedges, prompt-restating.
-- `## Banned analysis patterns`: superficial -ing clauses, copula avoidance, passive voice, nominalization and placeholder nouns, broken grammar around code identifiers, hedge stacking, vague attribution, generic positive conclusions, signposting, elegant variation, false ranges.
+- `## Banned analysis patterns`: superficial -ing clauses, copula avoidance, passive voice, nominalization and placeholder words, broken grammar around code identifiers, hedge stacking, vague attribution, generic positive conclusions, signposting, elegant variation, false ranges.
 - `### Em-dash discipline`: at most one em dash per paragraph; prefer a period.
 
 This is the same subset the workflow machinery already applies to chat-scale prose (status updates, escalation prompts, review-mode turns). See `.claude/workflow/conventions.md §1.5` for how the tiers map across artifacts and source.

--- a/.claude/output-styles/house-conversation.md
+++ b/.claude/output-styles/house-conversation.md
@@ -21,7 +21,7 @@ These rules replace Claude Code's default terminal-output tone. The coding, tool
 Apply these four sections of `.claude/output-styles/house-style.md` to everything you type in chat. Read them once per session if a reply starts drifting:
 
 - `## Banned vocabulary`: the Tier 1-4 word bans.
-- `## Banned sentence patterns`: negative parallelism ("not X, but Y"), double negation, sycophantic openers, throat-clearing, closing connectives, trailing hedges, prompt-restating.
+- `## Banned sentence patterns`: negative parallelism ("not X, but Y"), roundabout negation, sycophantic openers, throat-clearing, closing connectives, trailing hedges, prompt-restating.
 - `## Banned analysis patterns`: superficial -ing clauses, copula avoidance, passive voice, nominalization and placeholder nouns, broken grammar around code identifiers, hedge stacking, vague attribution, generic positive conclusions, signposting, elegant variation, false ranges.
 - `### Em-dash discipline`: at most one em dash per paragraph; prefer a period.
 

--- a/.claude/output-styles/house-conversation.md
+++ b/.claude/output-styles/house-conversation.md
@@ -21,8 +21,8 @@ These rules replace Claude Code's default terminal-output tone. The coding, tool
 Apply these four sections of `.claude/output-styles/house-style.md` to everything you type in chat. Read them once per session if a reply starts drifting:
 
 - `## Banned vocabulary`: the Tier 1-4 word bans.
-- `## Banned sentence patterns`: negative parallelism ("not X, but Y"), sycophantic openers, throat-clearing, closing connectives, trailing hedges, prompt-restating.
-- `## Banned analysis patterns`: superficial -ing clauses, copula avoidance, passive voice, hedge stacking, vague attribution, generic positive conclusions, signposting, elegant variation, false ranges.
+- `## Banned sentence patterns`: negative parallelism ("not X, but Y"), double negation, sycophantic openers, throat-clearing, closing connectives, trailing hedges, prompt-restating.
+- `## Banned analysis patterns`: superficial -ing clauses, copula avoidance, passive voice, nominalization and placeholder nouns, broken grammar around code identifiers, hedge stacking, vague attribution, generic positive conclusions, signposting, elegant variation, false ranges.
 - `### Em-dash discipline`: at most one em dash per paragraph; prefer a period.
 
 This is the same subset the workflow machinery already applies to chat-scale prose (status updates, escalation prompts, review-mode turns). See `.claude/workflow/conventions.md §1.5` for how the tiers map across artifacts and source.

--- a/.claude/output-styles/house-style.md
+++ b/.claude/output-styles/house-style.md
@@ -139,20 +139,25 @@ After:  The split path creates the new index entry.
 
 Name the subject. If the actor is genuinely unknown, name that ("on recovery the WAL replay creates…" beats "is created during recovery").
 
-### Nominalization and placeholder nouns
+### Nominalization and placeholder words
 
-Two related moves make prose abstract: turning a verb into a noun ("entry-population requires…" for "populating an entry requires…"), and using a placeholder noun ("material", "data", "content", "logic", "information") where the concrete thing belongs.
+Three related moves make prose abstract: turning a verb into a noun ("entry-population requires…" for "populating an entry requires…", or a hyphen-compound event-noun like "stream-pull-append" for "pull from the stream, then append"); using a placeholder noun ("material", "data", "content", "logic", "information") where the concrete thing belongs; and using a placeholder verb ("do so", "does this", "handles it") where the concrete action belongs.
 
 ```text
 Before: Entry-population for AGGREGATE_* shapes requires per-RID material to seed contributingValues and contributingRids.
 After:  To populate an AGGREGATE_* entry, each contributing RID supplies its value to contributingValues and its own id to contributingRids.
 ```
 
-Use a verb for the action and name the thing the placeholder noun stands for. If you cannot say what "material" or "data" refers to, you do not yet understand the mechanism well enough to write the sentence.
+```text
+Before: next() that pulls from the stream and appends MUST do so atomically with the local position++.
+After:  next() MUST pull from the stream, append, and increment position as one uninterrupted step.
+```
+
+Use a verb for the action and name the thing or action the placeholder word stands for. If you cannot say what "material" or "do so" refers to, you do not yet understand the mechanism well enough to write the sentence.
 
 ### Broken grammar around code identifiers
 
-When the nouns in a sentence are code identifiers, keep the grammar intact anyway: a plain-noun subject, a copula, and the relative pronouns a reader would otherwise have to supply. Three failures recur.
+When the nouns in a sentence are code identifiers, keep the grammar intact anyway: a plain-noun subject, a copula, and the relative pronouns a reader would otherwise have to supply. Four failures recur.
 
 A class declaration or type signature in the subject slot, with no copula to anchor it:
 
@@ -173,6 +178,13 @@ A split coordinate predicate: one subject governing two verbs separated by a lon
 ```text
 Before: Each entry pairs the term with what it replaces, so the delta from the baseline is visible, and points at the section that elaborates it.
 After:  Each entry pairs the term with what it replaces and points at the section that elaborates it. The delta from the baseline is then visible at a glance.
+```
+
+A runtime expression in the subject slot: an assignment or comparison standing where a noun belongs.
+
+```text
+Before: was_extremum = rid.equals(extremumRid) sidesteps the cross-Number-subtype hazard.
+After:  Comparing by RID identity (was_extremum = rid.equals(extremumRid)) sidesteps the cross-Number-subtype hazard.
 ```
 
 Name the thing with a plain noun and attach the identifier as an appositive; never drop "is", "that", or "which" to save a word.
@@ -347,7 +359,7 @@ Heading words and the following paragraph must not have ≥50% content-word over
 
 ### Mechanism traces and inline citations
 
-A sentence that chains a sequence of distinct calls, each with its own arguments, is a run-on the reader has to disassemble. Present a multi-step mechanism as a numbered list, a fenced trace, or (in a design doc) a sequence diagram, one step per line. An inline `(1)… (2)… (3)…` enumeration crammed into one sentence is the same run-on; break it onto separate lines. Keep file:line citations and signature asides at the end of the sentence or in a References footer, never embedded mid-clause where they make the reader hold the main clause in memory while parsing a code reference. An illustrative multi-line code or query literal belongs in a fenced block or on its own line, not wedged into a sentence as a subject or object.
+A sentence that chains a sequence of distinct calls, each with its own arguments, is a run-on the reader has to disassemble. Present a multi-step mechanism as a numbered list, a fenced trace, or (in a design doc) a sequence diagram, one step per line. An inline `(1)… (2)… (3)…` enumeration crammed into one sentence is the same run-on; break it onto separate lines. Keep file:line citations and signature asides at the end of the sentence or in a References footer, never embedded mid-clause where they make the reader hold the main clause in memory while parsing a code reference. An illustrative multi-line code or query literal belongs in a fenced block or on its own line, not wedged into a sentence as a subject, object, or introductory frame.
 
 ```text
 Before: The tap step's internalStart(ctx) calls prev.start(ctx) (prev is the public field on AbstractExecutionStep:66) to obtain the upstream ExecutionStream, then returns a wrapping ExecutionStream whose next(ctx) invokes entry.aggregateState.observe(result) before forwarding the unchanged Result to the consumer.
@@ -412,7 +424,7 @@ If three or more sibling sections share the same internal heading sequence, cons
 
 ### Explanatory register
 
-Mechanism-overview prose under `##` sections carries the explanation. Lead each mechanism with its motivation, walk it in connected sentences whose transitions carry one step to the next, and close with the consequence. Compression here means cutting hedges, filler, and restatement, never the explanatory step that lets a reader follow the reasoning.
+Mechanism-overview prose under `##` and `###` mechanism sections (including `design-mechanics.md` Notes) carries the explanation. Lead each mechanism with its motivation, walk it in connected sentences whose transitions carry one step to the next, and close with the consequence. Compression here means cutting hedges, filler, and restatement, never the explanatory step that lets a reader follow the reasoning.
 
 The "bias toward less text" rule in § Voice and tone governs openers, summaries, and TL;DRs. It does not license a mechanism section built from disconnected one-line assertions. A reader who cannot reconstruct why each step follows from the last is reading prose that is too terse: a finding under § Why-before-what, the same way padding is a finding under § Padding-based finding criterion.
 
@@ -424,7 +436,7 @@ Before handing the output back, scan it for:
 2. **Em dashes.** Count per paragraph. More than one is a finding.
 3. **Negative parallelism and roundabout negation.** "It's not X, it's Y" / "Not just A, but B" / "not uncommon" / "does NOT track X, only Y". Rewrite as a positive statement.
 4. **Sycophantic openers, throat-clearing, closing phrases, trailing hedges, prompt-restating, knowledge-cutoff disclaimers.** Cut.
-5. **Analysis patterns.** Superficial -ing, copula avoidance ("serves as"), passive voice, nominalization and placeholder nouns, broken grammar around code identifiers, hedge stacking, filler hedges, vague attribution, generic positive conclusions, persuasive authority ("at its core"), signposting ("let's dive in"), elegant variation, false ranges. Each gets the matching rewrite from § Banned analysis patterns.
+5. **Analysis patterns.** Superficial -ing, copula avoidance ("serves as"), passive voice, nominalization and placeholder words, broken grammar around code identifiers, hedge stacking, filler hedges, vague attribution, generic positive conclusions, persuasive authority ("at its core"), signposting ("let's dive in"), elegant variation, false ranges. Each gets the matching rewrite from § Banned analysis patterns.
 6. **Punctuation.** Hyphenated word-pair clusters in adjectival position (3+ distinct in one paragraph) → rewrite. Curly quotes → straight quotes. Excessive boldface → cap at 2 per section.
 7. **Structure.** Section length ≤200 words is a soft cap. Five template-bound categories are exempt regardless of length: ExecPlan structured-field paragraph blocks under `## Episodes`, edit-list subsections under `design-mechanics.md`, full state-machine tables under `design.md` or `design-mechanics.md`, file:line citation blocks under `design-mechanics.md`, and multi-step derivations under `design-mechanics.md`. The unit of evaluation is the smallest labeled block. For prose outside the exempt list, a >200-word unit is a finding only when it also contains padding — a banned term from § Banned vocabulary, a pattern from § Banned sentence patterns, or restatement per § Elegant variation. Length alone is not a finding. Also check: no faux-symmetry; no bullet-everything; no inline-header lists outside genuine definition lists; sentence case on H2+; no skipped heading levels; no fragmented headers (heading + ≤1-line paragraph with ≥50% content-word overlap); no run-on mechanism sentences or mid-clause file:line citations (present a multi-step sequence as a numbered list, fenced trace, or sequence diagram per § Mechanism traces and inline citations).
 8. **Document shape (design/ADR only).** Overview concept-first, audience-fit, glossary-introduction, why-before-what, navigability, explanatory register, Edge cases sub-section, References footer shape, same-shape sibling consolidation per § Document-shape rules.

--- a/.claude/output-styles/house-style.md
+++ b/.claude/output-styles/house-style.md
@@ -94,6 +94,7 @@ Update this section quarterly against the Wikipedia "Signs of AI writing" page. 
 These patterns are the highest-confidence AI tells at the sentence shape level. Cut every instance.
 
 - **Negative parallelism.** "It's not X — it's Y.", "It's not X, it's Y.", "Not just A, but B.", "You're not an X, you're a Y." Cut. The pattern adds no information; it performs depth. Rewrite as a positive statement: "Y." or "X plus Y."
+- **Double negation.** "does NOT track the original wrapper, only the bare X", "not unlike", "it is not uncommon". State what IS true: "tracks only the bare X".
 - **Sycophantic openers.** "Great question!", "Certainly!", "Absolutely!", "Of course!", "I'd be happy to…", "I'd love to help.", "I'm here to help.", "What a wonderful question!", "I love this prompt!". Cut the opener; if the sentence collapses without it, cut the sentence.
 - **Throat-clearing.** "It's worth noting that", "It is important to consider", "One thing to keep in mind", "It should be noted that…", "Interestingly,". State the thing directly.
 - **Closing phrases.** "In conclusion,", "In summary,", "Ultimately,", "To summarize,", "To wrap up,". The last paragraph is the conclusion by position; the connective is filler.
@@ -137,6 +138,39 @@ After:  The split path creates the new index entry.
 ```
 
 Name the subject. If the actor is genuinely unknown, name that ("on recovery the WAL replay creates…" beats "is created during recovery").
+
+### Nominalization and placeholder nouns
+
+Two related moves make prose abstract: turning a verb into a noun ("entry-population requires…" for "populating an entry requires…"), and using a placeholder noun ("material", "data", "content", "logic", "information") where the concrete thing belongs.
+
+```text
+Before: Entry-population for AGGREGATE_* shapes requires per-RID material to seed contributingValues and contributingRids.
+After:  To populate an AGGREGATE_* entry, each contributing RID supplies its value to contributingValues and its own id to contributingRids.
+```
+
+Use a verb for the action and name the thing the placeholder noun stands for. If you cannot say what "material" or "data" refers to, you do not yet understand the mechanism well enough to write the sentence.
+
+### Broken grammar around code identifiers
+
+When the nouns in a sentence are code identifiers, keep the grammar intact anyway: a plain-noun subject, a copula, and the relative pronouns a reader would otherwise have to supply. Three failures recur.
+
+A class declaration or type signature in the subject slot, with no copula to anchor it:
+
+```text
+Before: AggregateCacheTapStep extends AbstractExecutionStep is spliced into the plan chain upstream of AggregateProjectionCalculationStep.
+After:  AggregateCacheTapStep, an AbstractExecutionStep, is spliced into the plan chain upstream of AggregateProjectionCalculationStep.
+```
+
+A dropped relative pronoun, turning an appositive into a garden path:
+
+```text
+Before: sumAccumulator evolves through increment, the same call storage's SQLFunctionSum.sum and SQLFunctionAverage.sum make on every value.
+After:  sumAccumulator evolves through increment, the same call that SQLFunctionSum.sum and SQLFunctionAverage.sum make on every value.
+```
+
+A split coordinate predicate: one subject governing two verbs separated by a long clause, so the second verb dangles far from it. Put the second verb beside the first, or start a new sentence.
+
+Name the thing with a plain noun and attach the identifier as an appositive; never drop "is", "that", or "which" to save a word.
 
 ### Hedge stacking
 
@@ -306,6 +340,23 @@ On crash recovery, the WAL replay reads each segment, verifies the checksum, and
 
 Heading words and the following paragraph must not have ≥50% content-word overlap. If they do, either the heading is a label without content (write the paragraph) or the paragraph is filler (cut it and let the heading stand).
 
+### Mechanism traces and inline citations
+
+A sentence that chains a sequence of distinct calls, each with its own arguments, is a run-on the reader has to disassemble. Present a multi-step mechanism as a numbered list, a fenced trace, or (in a design doc) a sequence diagram, one step per line. An inline `(1)… (2)… (3)…` enumeration crammed into one sentence is the same run-on; break it onto separate lines. Keep file:line citations and signature asides at the end of the sentence or in a References footer, never embedded mid-clause where they make the reader hold the main clause in memory while parsing a code reference. An illustrative multi-line code or query literal belongs in a fenced block or on its own line, not wedged into a sentence as a subject or object.
+
+```text
+Before: The tap step's internalStart(ctx) calls prev.start(ctx) (prev is the public field on AbstractExecutionStep:66) to obtain the upstream ExecutionStream, then returns a wrapping ExecutionStream whose next(ctx) invokes entry.aggregateState.observe(result) before forwarding the unchanged Result to the consumer.
+After:
+The tap wraps the upstream stream without changing the rows it carries:
+1. `internalStart` calls `prev.start(ctx)` to get the upstream `ExecutionStream`.
+2. The wrapper's `next(ctx)` calls `entry.aggregateState.observe(result)`, then forwards the unchanged `Result` downstream.
+(`prev` is defined at `AbstractExecutionStep.java:66`.)
+```
+
+The test: read the sentence aloud once. If you cannot hold its structure to the end, split it.
+
+This expansion adds lines, and the per-section line cap counts them. Never compress a sequence back into a run-on to fit the cap: if the readable form pushes a `##` section past ~300 lines, that is the signal to move it to `design-mechanics.md`, not to re-cram.
+
 ## Document-shape rules (design / ADR-specific)
 
 These rules apply when the surface is a design document, ADR draft, or cold-read-reviewed artifact under `docs/adr/**`. They are not enforced on issue bodies, PR descriptions, or status prose, which use the BLUF rule alone.
@@ -340,6 +391,8 @@ Excluded: shape-exempt reference sections (Core Concepts, Class Design, Workflow
 
 Section headers communicate purpose, not just a mechanism name. Each section's opening sentence or TL;DR lets a skimming reader decide whether to drill in. Cross-references to deeper detail (Mechanics links, references to sibling Parts) are present where a reader would need them.
 
+A structure roadmap is one sentence with a verb. A verbless colon-dump of section names ("Subsections below: a, b, c, …") is the failure; when there are too many children to fit one sentence, name the grouping instead of listing every one.
+
 ### Edge cases sub-section required
 
 Every mechanism-overview section ends with an Edge cases / Gotchas sub-section. If there are no edge cases, justify the N/A in one prose sentence. The reviewer treats a missing sub-section without justification as a should-fix.
@@ -352,18 +405,24 @@ Every mechanism-overview section ends with a `### References` footer listing D-r
 
 If three or more sibling sections share the same internal heading sequence, consolidate them under the consolidation form: one TL;DR + comparison table + per-instance short bodies. Three sibling sections each with "Problem", "Solution", "Trade-offs", "References" is the canonical trigger.
 
+### Explanatory register
+
+Mechanism-overview prose under `##` sections carries the explanation. Lead each mechanism with its motivation, walk it in connected sentences whose transitions carry one step to the next, and close with the consequence. Compression here means cutting hedges, filler, and restatement, never the explanatory step that lets a reader follow the reasoning.
+
+The "bias toward less text" rule in § Voice and tone governs openers, summaries, and TL;DRs. It does not license a mechanism section built from disconnected one-line assertions. A reader who cannot reconstruct why each step follows from the last is reading prose that is too terse: a finding under § Why-before-what, the same way padding is a finding under § Padding-based finding criterion.
+
 ## Self-check
 
 Before handing the output back, scan it for:
 
 1. **Banned vocabulary.** Tier 1 (hard ban): replace. Tier 2 (strongly avoid): replace or justify. Tier 3 (promotional): replace. Tier 4 (era-specific): replace.
 2. **Em dashes.** Count per paragraph. More than one is a finding.
-3. **Negative parallelism.** "It's not X, it's Y" / "Not just A, but B". Rewrite as a positive statement.
+3. **Negative parallelism and double negation.** "It's not X, it's Y" / "Not just A, but B" / "does NOT track X, only Y". Rewrite as a positive statement.
 4. **Sycophantic openers, throat-clearing, closing phrases, trailing hedges, prompt-restating, knowledge-cutoff disclaimers.** Cut.
-5. **Analysis patterns.** Superficial -ing, copula avoidance ("serves as"), passive voice, hedge stacking, filler hedges, vague attribution, generic positive conclusions, persuasive authority ("at its core"), signposting ("let's dive in"), elegant variation, false ranges. Each gets the matching rewrite from § Banned analysis patterns.
+5. **Analysis patterns.** Superficial -ing, copula avoidance ("serves as"), passive voice, nominalization and placeholder nouns, broken grammar around code identifiers, hedge stacking, filler hedges, vague attribution, generic positive conclusions, persuasive authority ("at its core"), signposting ("let's dive in"), elegant variation, false ranges. Each gets the matching rewrite from § Banned analysis patterns.
 6. **Punctuation.** Hyphenated word-pair clusters in adjectival position (3+ distinct in one paragraph) → rewrite. Curly quotes → straight quotes. Excessive boldface → cap at 2 per section.
-7. **Structure.** Section length ≤200 words is a soft cap. Five template-bound categories are exempt regardless of length: ExecPlan structured-field paragraph blocks under `## Episodes`, edit-list subsections under `design-mechanics.md`, full state-machine tables under `design.md` or `design-mechanics.md`, file:line citation blocks under `design-mechanics.md`, and multi-step derivations under `design-mechanics.md`. The unit of evaluation is the smallest labeled block. For prose outside the exempt list, a >200-word unit is a finding only when it also contains padding — a banned term from § Banned vocabulary, a pattern from § Banned sentence patterns, or restatement per § Elegant variation. Length alone is not a finding. Also check: no faux-symmetry; no bullet-everything; no inline-header lists outside genuine definition lists; sentence case on H2+; no skipped heading levels; no fragmented headers (heading + ≤1-line paragraph with ≥50% content-word overlap).
-8. **Document shape (design/ADR only).** Overview concept-first, audience-fit, glossary-introduction, why-before-what, navigability, Edge cases sub-section, References footer shape, same-shape sibling consolidation per § Document-shape rules.
+7. **Structure.** Section length ≤200 words is a soft cap. Five template-bound categories are exempt regardless of length: ExecPlan structured-field paragraph blocks under `## Episodes`, edit-list subsections under `design-mechanics.md`, full state-machine tables under `design.md` or `design-mechanics.md`, file:line citation blocks under `design-mechanics.md`, and multi-step derivations under `design-mechanics.md`. The unit of evaluation is the smallest labeled block. For prose outside the exempt list, a >200-word unit is a finding only when it also contains padding — a banned term from § Banned vocabulary, a pattern from § Banned sentence patterns, or restatement per § Elegant variation. Length alone is not a finding. Also check: no faux-symmetry; no bullet-everything; no inline-header lists outside genuine definition lists; sentence case on H2+; no skipped heading levels; no fragmented headers (heading + ≤1-line paragraph with ≥50% content-word overlap); no run-on mechanism sentences or mid-clause file:line citations (present a multi-step sequence as a numbered list, fenced trace, or sequence diagram per § Mechanism traces and inline citations).
+8. **Document shape (design/ADR only).** Overview concept-first, audience-fit, glossary-introduction, why-before-what, navigability, explanatory register, Edge cases sub-section, References footer shape, same-shape sibling consolidation per § Document-shape rules.
 9. **BLUF.** The first paragraph states the decision or symptom directly. Section openers don't restate the section heading.
 10. **Paragraphs that don't add information beyond the previous one.** Delete.
 

--- a/.claude/output-styles/house-style.md
+++ b/.claude/output-styles/house-style.md
@@ -94,7 +94,7 @@ Update this section quarterly against the Wikipedia "Signs of AI writing" page. 
 These patterns are the highest-confidence AI tells at the sentence shape level. Cut every instance.
 
 - **Negative parallelism.** "It's not X — it's Y.", "It's not X, it's Y.", "Not just A, but B.", "You're not an X, you're a Y." Cut. The pattern adds no information; it performs depth. Rewrite as a positive statement: "Y." or "X plus Y."
-- **Double negation.** "does NOT track the original wrapper, only the bare X", "not unlike", "it is not uncommon". State what IS true: "tracks only the bare X".
+- **Roundabout negation.** Litotes ("not uncommon", "not unlike") and negation-then-exception ("does NOT track X, only the bare Y"). State what IS true: "common", "tracks only the bare Y".
 - **Sycophantic openers.** "Great question!", "Certainly!", "Absolutely!", "Of course!", "I'd be happy to…", "I'd love to help.", "I'm here to help.", "What a wonderful question!", "I love this prompt!". Cut the opener; if the sentence collapses without it, cut the sentence.
 - **Throat-clearing.** "It's worth noting that", "It is important to consider", "One thing to keep in mind", "It should be noted that…", "Interestingly,". State the thing directly.
 - **Closing phrases.** "In conclusion,", "In summary,", "Ultimately,", "To summarize,", "To wrap up,". The last paragraph is the conclusion by position; the connective is filler.
@@ -164,11 +164,16 @@ After:  AggregateCacheTapStep, an AbstractExecutionStep, is spliced into the pla
 A dropped relative pronoun, turning an appositive into a garden path:
 
 ```text
-Before: sumAccumulator evolves through increment, the same call storage's SQLFunctionSum.sum and SQLFunctionAverage.sum make on every value.
+Before: sumAccumulator evolves through increment, the same call SQLFunctionSum.sum and SQLFunctionAverage.sum make on every value.
 After:  sumAccumulator evolves through increment, the same call that SQLFunctionSum.sum and SQLFunctionAverage.sum make on every value.
 ```
 
 A split coordinate predicate: one subject governing two verbs separated by a long clause, so the second verb dangles far from it. Put the second verb beside the first, or start a new sentence.
+
+```text
+Before: Each entry pairs the term with what it replaces, so the delta from the baseline is visible, and points at the section that elaborates it.
+After:  Each entry pairs the term with what it replaces and points at the section that elaborates it. The delta from the baseline is then visible at a glance.
+```
 
 Name the thing with a plain noun and attach the identifier as an appositive; never drop "is", "that", or "which" to save a word.
 
@@ -417,7 +422,7 @@ Before handing the output back, scan it for:
 
 1. **Banned vocabulary.** Tier 1 (hard ban): replace. Tier 2 (strongly avoid): replace or justify. Tier 3 (promotional): replace. Tier 4 (era-specific): replace.
 2. **Em dashes.** Count per paragraph. More than one is a finding.
-3. **Negative parallelism and double negation.** "It's not X, it's Y" / "Not just A, but B" / "does NOT track X, only Y". Rewrite as a positive statement.
+3. **Negative parallelism and roundabout negation.** "It's not X, it's Y" / "Not just A, but B" / "not uncommon" / "does NOT track X, only Y". Rewrite as a positive statement.
 4. **Sycophantic openers, throat-clearing, closing phrases, trailing hedges, prompt-restating, knowledge-cutoff disclaimers.** Cut.
 5. **Analysis patterns.** Superficial -ing, copula avoidance ("serves as"), passive voice, nominalization and placeholder nouns, broken grammar around code identifiers, hedge stacking, filler hedges, vague attribution, generic positive conclusions, persuasive authority ("at its core"), signposting ("let's dive in"), elegant variation, false ranges. Each gets the matching rewrite from § Banned analysis patterns.
 6. **Punctuation.** Hyphenated word-pair clusters in adjectival position (3+ distinct in one paragraph) → rewrite. Curly quotes → straight quotes. Excessive boldface → cap at 2 per section.

--- a/.claude/skills/readability-feedback/SKILL.md
+++ b/.claude/skills/readability-feedback/SKILL.md
@@ -71,7 +71,7 @@ STEP 1 — Read the authoritative ruleset IN FULL: `.claude/output-styles/house-
 
 STEP 2 — Read `{TARGET_PATH}`, lines {START}-{END} only.
 
-STEP 3 — Find every obscure passage in that range: run-on multi-clause sentences; dense identifier soup with no connective tissue; nominalizations and placeholder nouns; file:line or signature asides wedged mid-clause; inline (1)(2)(3) enumerations; broken or telegraphic grammar (a signature in the subject slot, a missing copula, a dropped relative pronoun, a split predicate); disconnected one-line assertions with no motivation. Audit prose and bullets only — skip Mermaid bodies, D/S codes, References footers, and headings.
+STEP 3 — Find every obscure passage in that range: run-on multi-clause sentences; dense identifier soup with no connective tissue; nominalizations and placeholder words (nouns or pro-verbs); file:line, signature, or code-literal asides wedged into a sentence; inline (1)(2)(3) enumerations; broken or telegraphic grammar (a signature or runtime expression in the subject slot, a missing copula, a dropped relative pronoun, a split predicate); disconnected one-line assertions with no motivation. Audit prose and bullets only — skip Mermaid bodies, D/S codes, References footers, and headings.
 
 STEP 4 — Classify each finding as `CAUGHT by § <exact section>` or `GAP`. Mark GAP only after checking every relevant section; for a GAP, name in one sentence the dimension of unreadability no current rule addresses.
 

--- a/.claude/skills/readability-feedback/SKILL.md
+++ b/.claude/skills/readability-feedback/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: readability-feedback
+description: "Audit a finished design document for hard-to-read or hard-to-understand paragraphs, then harden the house-style rules so future design docs avoid them. Fans out audit sub-agents, classifies each obscure passage as caught-by-an-existing-rule or a gap, and proposes plus (on approval) applies rule changes across the style docs. Use when the user wants to feed a design doc back into the style guide, find obscure paragraphs and fix the rules, harden the writing rules from a real DD, or close the readability feedback loop. Accepts a design-doc path, an adr dir name, or defaults to the current branch's design. Reports the doc's own violations; does not rewrite the doc."
+argument-hint: "[design-doc-path | adr-dir | (default: current branch's design)]"
+user-invocable: true
+---
+
+Audit a design document for obscure prose and harden the house-style rules so the next design doc avoids the same trouble. The output is rule changes, not a rewrite of the audited doc.
+
+This is the codified form of the manual loop: read a real DD, find the paragraphs a reviewer has to re-read, check whether a rule already forbids each one, and for the ones no rule catches, add or sharpen a rule in the style docs.
+
+## When to use this, and when not
+
+Use it when the user points at a finished or near-finished design document and wants the *rules* improved from it: "harden the style from this design", "find the hard-to-read paragraphs and fix the rules", "feed this DD back into the style guide".
+
+Distinct from three neighbors: `ai-tells` rewrites a draft; `review-docs` validates a doc's grammar and query correctness; `self-improvement-reflection` files YouTrack friction issues. This one edits the prose rules in `house-style.md` and its sync set, driven by a real DD.
+
+It does not rewrite the audited design document. Design docs are frozen after Phase 1 or live on another branch, so the skill reports their obscure paragraphs for the author to fix separately and changes only the rule docs.
+
+## Inputs
+
+`$ARGUMENTS` resolves in this order:
+
+1. A file path to `design.md`, `design-final.md`, or `design-mechanics.md` — audit that file (and its companion if both exist).
+2. An adr dir name — audit `docs/adr/<dir>/_workflow/design.md` plus `design-mechanics.md`, or `docs/adr/<dir>/design-final.md` if the working copy is gone.
+3. Empty — discover the current branch's design under `docs/adr/`. If more than one candidate exists, ask which.
+
+The authoritative ruleset is always the live `.claude/output-styles/house-style.md` in the repo, never a copy.
+
+## Procedure
+
+1. **Resolve the target.** Confirm the file(s) exist. Capture section boundaries with `grep -nE '^#{1,3} ' <file>` and the line count.
+2. **Partition.** Split the doc into ~200-line ranges on `##` / `# Part` boundaries; give each companion file (`design-mechanics.md`) its own range. Cap at ~6 sub-agents.
+3. **Fan out the audit.** Launch one `general-purpose` sub-agent per range, in parallel, with the dispatch prompt in `## Audit sub-agent prompt` below (fill `{TARGET_PATH}`, `{START}`, `{END}`). Each agent reads `house-style.md` in full, audits only its range, and classifies every obscure passage as `CAUGHT by § <section>` or `GAP`.
+4. **Synthesize.** Merge the findings. Split them into CAUGHT (the doc's own violations) and GAP (no rule catches). Group the GAPs by underlying tell, and fold an aggravated-but-caught residual into the nearest group.
+5. **Draft one rule change per GAP group.** Name the rule, the target section (general tells go under Banned vocabulary / Banned sentence patterns / Banned analysis patterns / Structural rules; design-doc-shape tells go under Document-shape rules), the scope, a Before/After grounded in the real finding, and the sync set it triggers (see `## Rule sync map`).
+6. **Gate.** Present two things and stop for approval: (a) the obscure-paragraph report with `file:line` for both CAUGHT and GAP, and (b) the proposed rule changes grouped by tell. Apply only what the user approves. Editing the rules is never automatic, because every rule applies to every future design doc.
+7. **Apply through the sync discipline.** For each approved rule, walk `## Rule sync map` and edit every file the rule's scope touches in one pass.
+8. **Validate and report.** Run the checks in `## Validation`, report what changed, and offer to commit. Re-runs converge: because step 3 reads the current rules, a paragraph that was a GAP last time is CAUGHT next time.
+
+## Rule sync map
+
+When a rule is added or renamed, update every file its scope touches:
+
+- `.claude/output-styles/house-style.md` — the rule prose **and** the matching `## Self-check` item (1-10). Always.
+- `.claude/output-styles/house-conversation.md` — the matching AI-tell enumeration line, only if the rule is general (it then applies to chat too). Skip for design-only rules.
+- `.claude/workflow/prompts/design-review.md` — a `### Human-reader cold-read additions` bullet, the `§ Tone and depth` count, and the TOC-row summary, only if the rule is a design-doc-shape rule the cold-read reviewer must verify.
+- `.claude/workflow/design-document-rules.md` — the `## Mechanical checks` table and/or the `design-sync` Human-reader enumeration, only if the rule is design-doc-scoped.
+- `.claude/scripts/design-mechanical-checks.py` — a regex constant wired into `check_dsc_ai_tell`, only if the pattern is cleanly regex-detectable. Most readability tells are judgment-only; say so and skip the script.
+
+On a rename, run the governance grep from `conventions.md §1.5` to find every pointer and update them in the same commit:
+
+```bash
+grep -rn 'Banned vocabulary\|Banned sentence patterns\|Banned analysis patterns\|Em-dash discipline' .claude/ CLAUDE.md
+```
+
+## Validation
+
+- `python3 .claude/scripts/workflow-reindex.py --check` — run after editing any `.claude/workflow/**` file; confirms the TOC regions still resolve.
+- Code-fence balance — after adding a Before/After block, confirm each fenced block has a matching closer. A raw fence count can mislead, because an inline code span may itself contain backtick delimiters.
+- After a rename, grep that no stale rule name survives anywhere under `.claude/`.
+
+## Audit sub-agent prompt
+
+Dispatch this to each range agent, substituting the three placeholders:
+
+```text
+Audit a YouTrackDB design document for hard-to-read prose and classify each finding against the house-style ruleset.
+
+STEP 1 — Read the authoritative ruleset IN FULL: `.claude/output-styles/house-style.md`. Note especially § Banned vocabulary, § Banned sentence patterns, § Banned analysis patterns (and its subsections), § Punctuation and typography, § Structural rules (and its subsections), and § Document-shape rules.
+
+STEP 2 — Read `{TARGET_PATH}`, lines {START}-{END} only.
+
+STEP 3 — Find every obscure passage in that range: run-on multi-clause sentences; dense identifier soup with no connective tissue; nominalizations and placeholder nouns; file:line or signature asides wedged mid-clause; inline (1)(2)(3) enumerations; broken or telegraphic grammar (a signature in the subject slot, a missing copula, a dropped relative pronoun, a split predicate); disconnected one-line assertions with no motivation. Audit prose and bullets only — skip Mermaid bodies, D/S codes, References footers, and headings.
+
+STEP 4 — Classify each finding as `CAUGHT by § <exact section>` or `GAP`. Mark GAP only after checking every relevant section; for a GAP, name in one sentence the dimension of unreadability no current rule addresses.
+
+Do NOT propose rewrites. Return EXACTLY this Markdown, no preamble:
+
+## Summary
+- Range audited: {TARGET_PATH}:{START}-{END}
+- Total findings: <n>
+- Caught: <n>   GAP: <n>
+
+## Findings
+### F1
+- Location: <file>:<line(s)>
+- Phrase: "<verbatim quote>"
+- Why obscure: <one sentence>
+- Verdict: CAUGHT by § <section> | GAP
+- If GAP — uncovered dimension: <one sentence>
+```

--- a/.claude/workflow/design-document-rules.md
+++ b/.claude/workflow/design-document-rules.md
@@ -413,7 +413,7 @@ The sync's cold-read sub-agent gets an extended instruction:
 accurately summarizes the current mechanics file's content for
 the same-named section."* It also runs the Human-reader
 cold-read additions (audience-fit, glossary-introduction,
-why-before-what, navigability — see
+why-before-what, navigability, explanatory register — see
 prompts/design-review.md:reviewer-design:1,4
 § Human-reader cold-read additions), since the rewritten
 Overview is a freshly human-facing artifact that can drift in

--- a/.claude/workflow/prompts/design-review.md
+++ b/.claude/workflow/prompts/design-review.md
@@ -19,7 +19,7 @@ Inline refs you find inside workflow files carry the same `name:roles:phases` su
 |---|---|---|---|
 | §Inputs | reviewer-design | 1,4 | The design paths, scope, mutation kind, and optional plan/track paths passed to the cold-read reviewer. |
 | §Mutation-kind specific instructions | reviewer-design | 1,4 | Extra checks per mutation kind: phase1-creation, design-sync, and the higher bar for committed phase4 artifacts. |
-| §Human-reader cold-read additions | reviewer-design | 1,4 | Audience-fit, glossary-introduction, why-before-what, and navigability checks; reviewer tone relaxes to quote evidence. |
+| §Human-reader cold-read additions | reviewer-design | 1,4 | Audience-fit, glossary-introduction, why-before-what, navigability, and explanatory-register checks; reviewer tone relaxes to quote evidence. |
 | §Reading rules | reviewer-design | 1,4 | Read only the provided design files; bounded vs whole-doc scope; grep-only plan reads; fetch house-style on demand. |
 | §Comprehension questions | reviewer-design | 1,4 | Seven ordered questions a cold reader answers with citations; insufficient material is itself a finding. |
 | §Structural findings (always check) | reviewer-design | 1,4 | Always-on checks: edge-cases sub-section, References footer, sibling consolidation, TL;DR, length budgets, Mechanics. |
@@ -115,10 +115,12 @@ addition to the standard cold-read, verify:
 - Verify glossary-introduction per `.claude/output-styles/house-style.md § Glossary-introduction`.
 - Verify why-before-what per `.claude/output-styles/house-style.md § Why-before-what`.
 - Verify navigability per `.claude/output-styles/house-style.md § Navigability`.
+- Verify explanatory register per `.claude/output-styles/house-style.md § Explanatory register`.
 
-**Reviewer tone** for these four rules relaxes the "one-sentence answers"
+**Reviewer tone** for these five rules relaxes the "one-sentence answers"
 rule in § Tone and depth: quote the prose, list undefined terms, name the
-audience the prose fails, and (for navigability) the opaque section.
+audience the prose fails, and (for navigability) the opaque section or
+(for explanatory register) the disconnected assertions.
 
 ## Reading rules
 <!-- roles=reviewer-design phases=1,4 summary="Read only the provided design files; bounded vs whole-doc scope; grep-only plan reads; fetch house-style on demand." -->
@@ -231,7 +233,7 @@ attempt the fix automatically.>
 ## Tone and depth
 <!-- roles=reviewer-design phases=1,4 summary="One-sentence answers, cite don't paraphrase, flag insufficiency, no intent-speculation; human-reader rules excepted." -->
 
-- One-sentence answers where one suffices. **Exception**: the four Human-reader rules require evidence (see the Reviewer tone note under § Human-reader cold-read additions).
+- One-sentence answers where one suffices. **Exception**: the five Human-reader rules require evidence (see the Reviewer tone note under § Human-reader cold-read additions).
 - Cite, don't paraphrase.
 - If unanswerable, say "Insufficient — see finding below" and add the structural finding.
 - Don't speculate about intent the doc doesn't state.


### PR DESCRIPTION
#### Motivation:

Design documents produced by the workflow read as terse, identifier-dense prose a reviewer has to disassemble. The house style was almost entirely subtractive: it stripped AI tells and pushed toward less text, but never gave a positive target for explanatory flow, and its line-based per-section caps rewarded cramming a mechanism into one run-on sentence over expanding it into a readable list. The result is correct-but-unreadable mechanism prose; the YTDB-820 transaction-scoped-result-cache design was the trigger case.

This shifts the register toward a technical writer's without re-introducing padding. The anti-AI-tell bans and the line caps stay; the change adds positive guidance for explanatory prose and names the specific grammar and structure tells that produce dense, hard-to-parse sentences.

#### What changed

Rules across the two style files, plus reviewer wiring:

- **Explanatory register** (design-doc-only, under `## Document-shape rules`): mechanism prose leads with motivation, connects steps with transitions, closes with the consequence. "Bias toward less text" governs openers and TL;DRs only. Scope covers `##` and `###` mechanism sections.
- **Nominalization and placeholder words**: use a verb and name the concrete thing or action instead of "entry-population requires per-RID material to seed" or "MUST do so atomically".
- **Mechanism traces and inline citations**: present a multi-step sequence as a numbered list, fenced trace, or sequence diagram; keep file:line citations out of mid-clause; put code or query literals in a fenced block (not as subject, object, or introductory frame); if the readable form pushes a section past ~300 lines, split to `design-mechanics.md` rather than re-cram.
- **Broken grammar around code identifiers**: keep subject, copula, and relative pronouns intact when the nouns are code; do not put a type signature or a runtime expression in the subject slot.
- **Roundabout negation** (litotes and negation-by-exception); **verbless colon-dump roadmaps**.

The base rules were derived by auditing the YTDB-820 design (959 lines) with sub-agents: they caught 35 of 64 obscure passages, and the residual gaps drove the broken-grammar, roundabout-negation, and verbless-roadmap additions.

The design cold-read reviewer (`prompts/design-review.md`) verifies the explanatory-register rule, and the chat-register style (`house-conversation.md`) picks up the new general rules. The self-check list and both `house-conversation.md` enumerations are synced.

#### Tooling

Adds the `readability-feedback` skill (`.claude/skills/readability-feedback/SKILL.md`), which codifies this PR's own derivation loop: audit a finished design document for hard-to-read paragraphs, classify each as caught-by-a-rule or a gap, and propose rule changes (gated on approval) that harden the style docs against the gaps. It edits only the rule docs, never the audited design (often frozen or on another branch), and carries the full rule sync map plus the validation steps.

Running the skill back on YTDB-820 with every rule in place classified 73 of 81 passages as caught (confirming convergence) and fed four gap-driven extensions into the rules: placeholder verbs, a runtime expression in the subject slot, code literals used as an introductory frame, and the broadened Explanatory-register scope.

#### Review

Three medium-priority Gemini findings addressed in `e569d7fb57`: renamed the mislabeled "Double negation" rule to "Roundabout negation", isolated the dropped-relative-pronoun Before/After to the missing `that`, and added the missing split-coordinate-predicate example.
