### PR TITLE
Add per-worktree daily cost to statusline

### DIFF
--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -8,24 +8,28 @@ Output (single line, second line of the statusline):
 
 The `day:` figure is today's spend across every project — the calendar-day
 analogue of `mo:` — and is always shown. When invoked with `--worktree` (the
-statusline adds it whenever the cwd is a linked git worktree) a cost figure for
-the current worktree's project is inserted at the front of the parenthetical:
+statusline adds it whenever the cwd is a linked git worktree) two worktree-
+scoped figures are inserted at the front of the parenthetical: `wt:` (the
+current worktree project's all-time spend) and `wtday:` (today's slice of that
+same spend):
 
-  $0.123 (wt:$1.85 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  …
+  $0.123 (wt:$1.85 wtday:$0.40 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  …
 
 The current session aggregates the orchestrator transcript plus every
 sub-agent transcript under <transcript-stem>/subagents/. The worktree-project
-figure (`wt:`) aggregates *every* session transcript that lives next to the
-current one — i.e. all sessions under ~/.claude/projects/<cwd-slug>/. Because
-a git worktree has its own cwd, it maps to its own project directory, so this
-figure is the cumulative spend of the current worktree across every session
-run in it. The monthly figure sums every JSONL transcript anywhere under
-~/.claude/projects whose records fall in the current calendar month.
+figures aggregate *every* session transcript that lives next to the current
+one — i.e. all sessions under ~/.claude/projects/<cwd-slug>/. Because a git
+worktree has its own cwd, it maps to its own project directory, so `wt:` is the
+cumulative spend of the current worktree across every session run in it, and
+`wtday:` is the same aggregation keeping only records dated today (UTC). The
+monthly figure sums every JSONL transcript anywhere under ~/.claude/projects
+whose records fall in the current calendar month.
 
-With `--worktree-cost-file PATH` the worktree-project cost is also written to
-PATH (the statusline points this at /tmp/claude-code-worktree-cost-<pid>.txt,
-mirroring the context-usage file) so the model can read the running spend on
-the current worktree on demand.
+With `--worktree-cost-file PATH` the all-time worktree-project cost (the `wt:`
+figure, not the `wtday:` slice) is also written to PATH (the statusline points
+this at /tmp/claude-code-worktree-cost-<pid>.txt, mirroring the context-usage
+file) so the model can read the running spend on the current worktree on
+demand.
 
 Two non-obvious mechanics, both required to match ccusage:
 
@@ -531,18 +535,31 @@ def session_totals(transcript_path):
     return _sum_records(merged)
 
 
-def project_totals(transcript_path):
-    """Aggregate every transcript in the current project's directory, deduped.
+def project_totals(transcript_path, now=None):
+    """Aggregate every transcript in the current project's directory into an
+    (all-time, today) pair of deduped totals.
 
     The project directory is the parent of the session transcript —
     ~/.claude/projects/<cwd-slug>/. A recursive glob picks up both the
     top-level <uuid>.jsonl session files and the nested
     <uuid>/subagents/agent-*.jsonl sub-agent files; the (msg_id, requestId)
-    dedup in `_sum_records` collapses records shared across them.
+    dedup via `_keep_larger_output` collapses records shared across them.
 
     Because a git worktree has its own cwd, it gets its own project directory,
     so summing this directory yields the cumulative cost of the current
     worktree across every session ever run in it — not just the live one.
+
+    Returns `(all_time, today)`. `all_time` sums every record (the `wt:`
+    figure); `today` keeps only records whose own date (payload index 0,
+    `ts[:10]`) equals the current UTC day (the `wtday:` figure), mirroring the
+    daily bucket in `calendar_totals`. Both are produced in one directory walk
+    so a statusline render does not re-stat every transcript twice. There is no
+    mtime pre-filter here (unlike `calendar_totals`): the all-time figure must
+    read every file regardless, so there is nothing to skip.
+
+    `now` defaults to the current UTC instant; it is injectable so the
+    today-bucketing can be exercised against a fixed date in tests. Records are
+    `Z`-suffixed UTC, so `cur_day` is derived in UTC too.
     """
     p = pathlib.Path(transcript_path).expanduser()
     # Mirror session_totals: short-circuit a non-existent transcript before the
@@ -550,15 +567,21 @@ def project_totals(transcript_path):
     # relative path resolving to /tmp/x.jsonl) would recursively scan that whole
     # parent directory for *.jsonl files.
     if not p.exists():
-        return _zero()
+        return _zero(), _zero()
     proj_dir = p.parent
     if not proj_dir.is_dir():
-        return _zero()
-    merged = {}
+        return _zero(), _zero()
+    if now is None:
+        now = _dt.datetime.now(_dt.timezone.utc)
+    cur_day = f"{now.year:04d}-{now.month:02d}-{now.day:02d}"
+    all_merged = {}
+    day_merged = {}
     for jsonl in proj_dir.rglob("*.jsonl"):
         for k, v in aggregate_file(jsonl).items():
-            _keep_larger_output(merged, k, v)  # max-output dedup
-    return _sum_records(merged)
+            _keep_larger_output(all_merged, k, v)  # max-output dedup
+            if v[0] == cur_day:
+                _keep_larger_output(day_merged, k, v)
+    return _sum_records(all_merged), _sum_records(day_merged)
 
 
 def calendar_totals(now=None):
@@ -649,35 +672,45 @@ def parse_args(argv):
     return transcript, show_worktree, wt_cost_file
 
 
-def format_stats_line(sess, day, month, proj=None, no_color=False):
+def format_stats_line(sess, day, month, proj=None, proj_day=None, no_color=False):
     """Render the second statusline row.
 
     The `day:$X` figure (today's spend across all projects) always appears; when
-    `proj` is given (worktree mode) a `wt:$X` figure for the current worktree's
-    project is inserted ahead of it.
+    `proj` is given (worktree mode) two worktree-scoped figures are inserted
+    ahead of it: `wt:$X` (the project's all-time spend) and `wtday:$X`
+    (`proj_day`, today's slice of that same spend). `proj_day` defaults to a
+    zeroed total when omitted so callers that only pass `proj` still render.
 
     Distinct colours so the cost figures are tellable apart at a glance:
     bright cyan = current session (active), bright blue = this worktree's
-    project (cumulative), bright white = today across all projects, bright
-    magenta = calendar month across all projects. Deliberately avoiding
-    red / yellow / green — those are reserved for the context-fill bar in
+    project all-time, dim blue = this worktree's project today (same hue as
+    `wt:` to group the two worktree figures; dimmer = the narrower today
+    window), bright white = today across all projects, bright magenta =
+    calendar month across all projects. Deliberately avoiding red / yellow /
+    green — those are reserved for the context-fill bar in
     statusline-command.sh (critical / warning / safe). Honour NO_COLOR for
     non-TTY consumers.
     """
     if no_color or os.environ.get("NO_COLOR"):
         sess_open = sess_close = mo_open = mo_close = wt_open = wt_close = ""
-        day_open = day_close = ""
+        day_open = day_close = wtd_open = wtd_close = ""
     else:
         sess_open = "\033[1;36m"   # bright cyan    — current session
-        wt_open = "\033[1;34m"     # bright blue    — this worktree's project
+        wt_open = "\033[1;34m"     # bright blue    — this worktree's project, all-time
+        wtd_open = "\033[2;34m"    # dim blue       — this worktree's project, today
         day_open = "\033[1;37m"    # bright white   — today, all projects
         mo_open = "\033[1;35m"     # bright magenta — calendar month, all projects
-        sess_close = mo_close = wt_close = day_close = "\033[0m"
+        sess_close = mo_close = wt_close = day_close = wtd_close = "\033[0m"
 
     day_str = f"day:{day_open}${day['cost']:.2f}{day_close}"
     mo_str = f"mo:{mo_open}${month['cost']:.2f}{mo_close}"
     if proj is not None:
-        scope = f"(wt:{wt_open}${proj['cost']:.2f}{wt_close} {day_str} {mo_str})"
+        # proj and proj_day always travel together from main(); fall back to a
+        # zeroed total if a caller passes proj alone so we never index None.
+        pd = proj_day if proj_day is not None else _zero()
+        wt_str = f"wt:{wt_open}${proj['cost']:.2f}{wt_close}"
+        wtd_str = f"wtday:{wtd_open}${pd['cost']:.2f}{wtd_close}"
+        scope = f"({wt_str} {wtd_str} {day_str} {mo_str})"
     else:
         scope = f"({day_str} {mo_str})"
 
@@ -700,14 +733,19 @@ def main(argv=None):
     try:
         sess = session_totals(transcript)
         day, month = calendar_totals()
-        proj = project_totals(transcript) if show_worktree else None
+        if show_worktree:
+            proj, proj_day = project_totals(transcript)
+        else:
+            proj = proj_day = None
     except Exception as exc:  # noqa: BLE001 — never break the statusline
         print(f"stats error: {exc}", file=sys.stderr)
         return 0
 
     # Publish the worktree-project cost to a per-session file for on-demand
     # reading by the model (mirrors the context-usage file the statusline
-    # writes). Best-effort — a write failure must never break the statusline.
+    # writes). The published figure is the all-time `wt:` cost; the today
+    # slice (`wtday:`) is statusline-only. Best-effort — a write failure must
+    # never break the statusline.
     if wt_cost_file and proj is not None:
         try:
             _atomic_write_text(
@@ -716,7 +754,7 @@ def main(argv=None):
         except Exception:  # noqa: BLE001 — publish is best-effort; never break the statusline
             pass
 
-    print(format_stats_line(sess, day, month, proj))
+    print(format_stats_line(sess, day, month, proj, proj_day))
     return 0
 
 

--- a/.claude/scripts/tests/test_session_stats.py
+++ b/.claude/scripts/tests/test_session_stats.py
@@ -3,11 +3,12 @@
 
 Running this script is the validation: it imports the stats helper as a module
 and exercises the worktree-project additions — CLI parsing of `--worktree` /
-`--worktree-cost-file`, the rendered cost line with and without the `wt:`
-figure, the recursive project aggregation (sessions + sub-agents, deduped by
-(msg_id, requestId)), the atomic plain-text publish file, and `main`'s
-end-to-end behaviour (file written only in worktree mode, `wt:` present/absent
-on the line accordingly).
+`--worktree-cost-file`, the rendered cost line with and without the `wt:` /
+`wtday:` figures, the recursive project aggregation (sessions + sub-agents,
+deduped by (msg_id, requestId)) split into all-time and today buckets, the
+atomic plain-text publish file, and `main`'s end-to-end behaviour (file written
+only in worktree mode, `wt:` / `wtday:` present/absent on the line
+accordingly).
 
 Invocation (from repo root):
 
@@ -227,18 +228,30 @@ def test_format_line_no_worktree_exact() -> None:
 
 
 def test_format_line_with_worktree_exact() -> None:
-    """A project total inserts `wt:$…` at the front of the parenthetical, ahead
+    """A project total inserts the two worktree figures at the front of the
+    parenthetical — `wt:$…` (all-time) then `wtday:$…` (today's slice) — ahead
     of the always-present `day:$…` and the `mo:$…` figure."""
     sess = _totals(0.123, **{"in": 1200, "out": 8000, "read": 230000, "w5": 40000, "w1": 0})
     day = _totals(2.34)
     month = _totals(4.56)
     proj = _totals(1.85)
-    line = MODULE.format_stats_line(sess, day, month, proj=proj, no_color=True)
+    proj_day = _totals(0.40)
+    line = MODULE.format_stats_line(sess, day, month, proj=proj, proj_day=proj_day, no_color=True)
     expected = (
-        "$0.123 (wt:$1.85 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
+        "$0.123 (wt:$1.85 wtday:$0.40 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
         "r/5m:5.8x r/1h:-"
     )
     assert line == expected, f"\n got: {line}\nwant: {expected}"
+
+
+def test_format_line_worktree_proj_day_defaults_to_zero() -> None:
+    """When `proj` is given but `proj_day` is omitted, the `wtday:` figure
+    renders `$0.00` rather than crashing on a None index — a defensive path for
+    callers that pass only the all-time total."""
+    line = MODULE.format_stats_line(
+        _totals(0.1), _totals(2.0), _totals(3.0), proj=_totals(1.85), no_color=True
+    )
+    assert "wt:$1.85 wtday:$0.00 " in line, line
 
 
 def test_format_line_no_color_has_no_ansi() -> None:
@@ -251,14 +264,16 @@ def test_format_line_no_color_has_no_ansi() -> None:
 
 
 def test_format_line_colours_when_enabled() -> None:
-    """With colour on, the worktree figure uses the distinct bright-blue code
-    (34), the new today figure uses bright white (37), and the existing
-    session/month codes are still present."""
+    """With colour on, the worktree all-time figure uses bright blue (1;34), the
+    worktree today figure uses dim blue (2;34), today-all-projects uses bright
+    white (37), and the existing session/month codes are still present."""
     with _env("NO_COLOR", None):
         line = MODULE.format_stats_line(
-            _totals(1.0), _totals(2.0), _totals(3.0), proj=_totals(4.0), no_color=False
+            _totals(1.0), _totals(2.0), _totals(3.0),
+            proj=_totals(4.0), proj_day=_totals(0.5), no_color=False,
         )
-    assert "\033[1;34m" in line, "worktree figure should be bright blue"
+    assert "\033[1;34m" in line, "worktree all-time figure should be bright blue"
+    assert "\033[2;34m" in line, "worktree today figure should be dim blue"
     assert "\033[1;36m" in line, "session figure should be bright cyan"
     assert "\033[1;37m" in line, "today figure should be bright white"
     assert "\033[1;35m" in line, "month figure should be bright magenta"
@@ -279,9 +294,11 @@ def test_format_line_no_color_env_respected() -> None:
 
 
 def test_project_totals_aggregates_sessions_and_subagents() -> None:
-    """Every *.jsonl under the project dir is summed — top-level session files
-    and nested subagents/agent-*.jsonl — with (msg_id, requestId) dedup so a
-    record duplicated into a sub-agent transcript is counted once."""
+    """Every *.jsonl under the project dir is summed into the all-time total —
+    top-level session files and nested subagents/agent-*.jsonl — with
+    (msg_id, requestId) dedup so a record duplicated into a sub-agent transcript
+    is counted once. The today element of the returned pair is asserted
+    separately (see test_project_totals_today_bucket)."""
     with tempfile.TemporaryDirectory() as tmp:
         cache = Path(tmp) / "cache"
         proj = Path(tmp) / "project"
@@ -296,25 +313,52 @@ def test_project_totals_aggregates_sessions_and_subagents() -> None:
             ],
         )
         with _patched(CACHE_DIR=cache):
-            out = MODULE.project_totals(str(proj / "sessionA.jsonl"))
+            all_time, _today = MODULE.project_totals(str(proj / "sessionA.jsonl"))
         # m1, m2, m3 distinct -> 3 * 1M input tokens.
-        assert out["in"] == 3_000_000, out["in"]
-        assert _approx(out["cost"], 3 * USD_PER_1M_IN), out["cost"]
+        assert all_time["in"] == 3_000_000, all_time["in"]
+        assert _approx(all_time["cost"], 3 * USD_PER_1M_IN), all_time["cost"]
+
+
+def test_project_totals_today_bucket() -> None:
+    """The second element of the pair keeps only records dated on the injected
+    UTC day. Two records share the project dir — one dated today, one dated
+    yesterday; all-time gets both, the today bucket gets only today's. Mirrors
+    the daily bucketing contract of calendar_totals, applied per worktree."""
+    import datetime as dt
+
+    now = dt.datetime(2026, 6, 8, 12, 0, 0, tzinfo=dt.timezone.utc)
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp) / "cache"
+        proj = Path(tmp) / "project"
+        write_jsonl(
+            proj / "session.jsonl",
+            [
+                _assistant_usage("m1", "r1", ts="2026-06-08T09:00:00.000Z", in_t=1_000_000),
+                _assistant_usage("m2", "r2", ts="2026-06-07T09:00:00.000Z", in_t=1_000_000),
+            ],
+        )
+        with _patched(CACHE_DIR=cache):
+            all_time, today = MODULE.project_totals(str(proj / "session.jsonl"), now=now)
+        # All-time gets both records; today gets only the 2026-06-08 one.
+        assert all_time["in"] == 2_000_000, all_time["in"]
+        assert _approx(all_time["cost"], 2 * USD_PER_1M_IN), all_time["cost"]
+        assert today["in"] == 1_000_000, today["in"]
+        assert _approx(today["cost"], 1 * USD_PER_1M_IN), today["cost"]
 
 
 def test_project_totals_missing_dir_is_zero() -> None:
-    """A transcript path whose parent is not a directory yields zeroed totals."""
+    """A transcript path whose parent is not a directory yields a zeroed pair."""
     out = MODULE.project_totals("/no/such/dir/x.jsonl")
-    assert out == MODULE._zero(), out
+    assert out == (MODULE._zero(), MODULE._zero()), out
 
 
 def test_project_totals_nonexistent_transcript_does_not_scan_parent() -> None:
-    """A non-existent transcript whose *parent* directory exists must yield zero
-    without recursively scanning that parent. Regression for a footgun where
-    project_totals only checked parent.is_dir(): a path like /tmp/nonexistent.jsonl
-    would have rglob'd all of /tmp. A decoy .jsonl carrying real usage sits in the
-    parent; if the parent were scanned the total would be non-zero, so asserting
-    zero proves the parent was never walked."""
+    """A non-existent transcript whose *parent* directory exists must yield a
+    zeroed pair without recursively scanning that parent. Regression for a
+    footgun where project_totals only checked parent.is_dir(): a path like
+    /tmp/nonexistent.jsonl would have rglob'd all of /tmp. A decoy .jsonl
+    carrying real usage sits in the parent; if the parent were scanned the total
+    would be non-zero, so asserting a zeroed pair proves it was never walked."""
     with tempfile.TemporaryDirectory() as tmp:
         cache = Path(tmp) / "cache"
         proj = Path(tmp) / "project"
@@ -322,7 +366,7 @@ def test_project_totals_nonexistent_transcript_does_not_scan_parent() -> None:
         write_jsonl(proj / "decoy.jsonl", [_assistant_usage("m1", "r1", in_t=1_000_000)])
         with _patched(CACHE_DIR=cache):
             out = MODULE.project_totals(str(proj / "nonexistent.jsonl"))
-        assert out == MODULE._zero(), out
+        assert out == (MODULE._zero(), MODULE._zero()), out
 
 
 def test_streaming_snapshots_in_one_file_keep_max_output() -> None:
@@ -345,12 +389,12 @@ def test_streaming_snapshots_in_one_file_keep_max_output() -> None:
             ],
         )
         with _patched(CACHE_DIR=cache):
-            out = MODULE.project_totals(str(proj / "session.jsonl"))
+            all_time, _today = MODULE.project_totals(str(proj / "session.jsonl"))
         # m1 -> 276 (final snapshot), m2 -> 100; first-wins would give 101, no
         # dedup would give 378.
-        assert out["out"] == 376, out["out"]
+        assert all_time["out"] == 376, all_time["out"]
         out_price = MODULE.FALLBACK_PRICES[MODEL]["out"]  # $25 / 1M
-        assert _approx(out["cost"], 376 * out_price / 1_000_000), out["cost"]
+        assert _approx(all_time["cost"], 376 * out_price / 1_000_000), all_time["cost"]
 
 
 def test_streaming_final_snapshot_wins_across_cache_reads() -> None:
@@ -453,38 +497,42 @@ def test_atomic_write_text_writes_and_overwrites() -> None:
 
 
 def test_main_worktree_writes_cost_file_and_shows_wt() -> None:
-    """`main` in worktree mode prints the `wt:` and `day:` figures and publishes
-    the cost file containing exactly `wt_cost: $<proj cost>`. `calendar_totals`
-    is stubbed to return the (today, month) pair main now unpacks."""
+    """`main` in worktree mode prints the `wt:`, `wtday:`, and `day:` figures and
+    publishes the cost file containing exactly `wt_cost: $<all-time proj cost>`
+    (the today slice is statusline-only). `project_totals` is stubbed to return
+    the (all-time, today) pair main now unpacks; `calendar_totals` returns the
+    (today, month) pair."""
     with tempfile.TemporaryDirectory() as tmp:
         wt_file = Path(tmp) / "claude-code-worktree-cost-1234.txt"
         buf = io.StringIO()
         with _patched(
             session_totals=lambda _t: _totals(0.123),
             calendar_totals=lambda: (_totals(2.34), _totals(4.56)),
-            project_totals=lambda _t: _totals(1.85),
+            project_totals=lambda _t: (_totals(1.85), _totals(0.40)),
         ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
             rc = MODULE.main(["t.jsonl", "--worktree", "--worktree-cost-file", str(wt_file)])
         assert rc == 0, rc
         assert wt_file.read_text() == "wt_cost: $1.85", wt_file.read_text()
         assert "wt:$1.85" in buf.getvalue(), buf.getvalue()
+        assert "wtday:$0.40" in buf.getvalue(), buf.getvalue()
         assert "day:$2.34" in buf.getvalue(), buf.getvalue()
 
 
 def test_main_no_worktree_omits_wt_and_writes_no_file() -> None:
-    """Without worktree flags `main` omits `wt:`, still shows the always-present
-    `day:` figure, and writes no publish file."""
+    """Without worktree flags `main` omits both `wt:` and `wtday:`, still shows
+    the always-present `day:` figure, and writes no publish file."""
     with tempfile.TemporaryDirectory() as tmp:
         wt_file = Path(tmp) / "should-not-exist.txt"
         buf = io.StringIO()
         with _patched(
             session_totals=lambda _t: _totals(0.123),
             calendar_totals=lambda: (_totals(2.34), _totals(4.56)),
-            project_totals=lambda _t: _totals(1.85),
+            project_totals=lambda _t: (_totals(1.85), _totals(0.40)),
         ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
             rc = MODULE.main(["t.jsonl"])
         assert rc == 0, rc
         assert "wt:" not in buf.getvalue(), buf.getvalue()
+        assert "wtday:" not in buf.getvalue(), buf.getvalue()
         assert "day:$2.34" in buf.getvalue(), buf.getvalue()
         assert not wt_file.exists(), "no cost file should be written without the flag"
 
@@ -511,10 +559,12 @@ def main() -> int:
         ("parse_args cost-file missing value", test_parse_args_cost_file_missing_value),
         ("format line no worktree (exact)", test_format_line_no_worktree_exact),
         ("format line with worktree (exact)", test_format_line_with_worktree_exact),
+        ("format line worktree proj_day defaults to zero", test_format_line_worktree_proj_day_defaults_to_zero),
         ("format line no_color strips ANSI", test_format_line_no_color_has_no_ansi),
         ("format line colours when enabled", test_format_line_colours_when_enabled),
         ("format line NO_COLOR env respected", test_format_line_no_color_env_respected),
         ("project_totals sessions + subagents deduped", test_project_totals_aggregates_sessions_and_subagents),
+        ("project_totals today bucket", test_project_totals_today_bucket),
         ("project_totals missing dir -> zero", test_project_totals_missing_dir_is_zero),
         ("project_totals nonexistent file w/ existing parent -> zero", test_project_totals_nonexistent_transcript_does_not_scan_parent),
         ("streaming snapshots in one file keep max output", test_streaming_snapshots_in_one_file_keep_max_output),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,16 +264,16 @@ If you change a threshold here, grep for the others and update them in the same 
 
 ## Cost Monitor
 
-The statusline's second line shows session, today, and calendar-month cost. The `day:$X` figure is today's spend across every project (the calendar-day analogue of the month figure, deduped the same way) and always appears: `$0.123 (day:$2.34 mo:$4.56) …`. When the cwd is a linked git worktree, the line also shows `wt:$X`, the cumulative spend on the *current worktree's project* (every session ever run in this worktree, orchestrator + sub-agents, deduped), inserted at the front of the parenthetical: `$0.123 (wt:$1.85 day:$2.34 mo:$4.56) …`.
+The statusline's second line shows session, today, and calendar-month cost. The `day:$X` figure is today's spend across every project (the calendar-day analogue of the month figure, deduped the same way) and always appears: `$0.123 (day:$2.34 mo:$4.56) …`. When the cwd is a linked git worktree, the line gains two worktree-scoped figures at the front of the parenthetical: `wt:$X`, the cumulative spend on the *current worktree's project* (every session ever run in this worktree, orchestrator + sub-agents, deduped), and `wtday:$X`, today's slice of that same spend (the worktree analogue of the global `day:` figure, bucketed per record by UTC date): `$0.123 (wt:$1.85 wtday:$0.40 day:$2.34 mo:$4.56) …`.
 
-In a worktree that cost is also published to a per-session file, mirroring the context-usage file, so it can be read on demand:
+In a worktree the all-time `wt:` cost (not the `wtday:` slice) is also published to a per-session file, mirroring the context-usage file, so it can be read on demand:
 ```bash
 cat /tmp/claude-code-worktree-cost-$PPID.txt
 ```
 Output example: `wt_cost: $1.85`. The file is absent in the main checkout (no `wt:` figure there). Implementation: `.claude/scripts/statusline-command.sh` detects the worktree and passes `--worktree` / `--worktree-cost-file` to `.claude/scripts/session-stats.py`, which computes the figure and writes the file.
 
 The example output format above MUST stay in sync with:
-- `.claude/scripts/statusline-command.sh` — renders the `wt:$X` figure on the statusline's second line
+- `.claude/scripts/statusline-command.sh` — detects the worktree and passes the flags that produce the `wt:$X` / `wtday:$X` figures on the statusline's second line
 - `.claude/scripts/session-stats.py` — computes the figure and writes the `wt_cost:` file
 - `.claude/scripts/tests/test_session_stats.py` — pins both formats with exact-match assertions
 


### PR DESCRIPTION
#### Motivation:

The statusline already shows all-time worktree spend (`wt:$X`) when the cwd is a linked worktree, alongside the global daily figure (`day:$X`). What it could not answer is "how much have I spent on *this* worktree *today*" — the worktree-scoped analogue of `day:`. You had to read the global `day:` figure (every project) and the all-time `wt:` figure and infer the rest.

This adds `wtday:$X` next to `wt:$X`: today's slice of the current worktree's project spend, bucketed per record by UTC date the same way `day:` and `mo:` already are. The figure is computed inside the existing single directory walk `project_totals` already performs for `wt:`, so there is no added I/O on the statusline hot path and no cache-version bump. Dedup-by-`(message.id, requestId)` is preserved, so a record duplicated across orchestrator and sub-agent transcripts is still counted once.

The all-time `wt:` cost remains the value published to `/tmp/claude-code-worktree-cost-<pid>.txt`; `wtday:` is statusline-only. `CLAUDE.md` § Cost Monitor and the sync-list pointer are updated to document both figures, and `test_session_stats.py` pins the full second-line format with an exact-match assertion plus a today/yesterday bucketing test.
