### PR TITLE
Add Fable 5 pricing and split worktree cost into main/sub

### DIFF
--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -8,12 +8,17 @@ Output (single line, second line of the statusline):
 
 The `day:` figure is today's spend across every project — the calendar-day
 analogue of `mo:` — and is always shown. When invoked with `--worktree` (the
-statusline adds it whenever the cwd is a linked git worktree) two worktree-
-scoped figures are inserted at the front of the parenthetical: `wt:` (the
-current worktree project's all-time spend) and `wtday:` (today's slice of that
-same spend):
+statusline adds it whenever the cwd is a linked git worktree) worktree-scoped
+figures are inserted at the front of the parenthetical: `wt:` (the current
+worktree project's all-time spend) immediately followed by its split into
+`[main:` (top-level orchestrator / main-session spend) and `sub:` (sub-agent
+spend) — the two sum to `wt:` — and then `wtday:` (today's slice of `wt:`):
 
-  $0.123 (wt:$1.85 wtday:$0.40 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  …
+  $0.123 (wt:$1.85 [main:$1.20 sub:$0.65] wtday:$0.40 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K …
+
+The main/sub split is exact: a sub-agent's records live only under
+<session>/subagents/, never in a top-level session file, so the two record
+sets are disjoint and partition the worktree total.
 
 The current session aggregates the orchestrator transcript plus every
 sub-agent transcript under <transcript-stem>/subagents/. The worktree-project
@@ -29,7 +34,9 @@ With `--worktree-cost-file PATH` the all-time worktree-project cost (the `wt:`
 figure, not the `wtday:` slice) is also written to PATH (the statusline points
 this at /tmp/claude-code-worktree-cost-<pid>.txt, mirroring the context-usage
 file) so the model can read the running spend on the current worktree on
-demand.
+demand. The file carries the same main/sub split as the statusline:
+
+  wt_cost: $1.85 (main: $1.20 sub: $0.65)
 
 Two non-obvious mechanics, both required to match ccusage:
 
@@ -72,14 +79,17 @@ import urllib.request
 #
 # 1 h cache write = 2.0× input price (Anthropic published ratio); LiteLLM
 # only publishes the 5 m write rate, so 1 h is derived as 2.0× input.
+# read = 0.1× input, write_5m = 1.25× input — the same Anthropic ratios.
 FALLBACK_PRICES = {
-    "claude-opus-4-7":           {"in":  5.0, "out": 25.0, "read": 0.50, "write_5m": 6.25, "write_1h": 10.0},
-    "claude-opus-4-6":           {"in":  5.0, "out": 25.0, "read": 0.50, "write_5m": 6.25, "write_1h": 10.0},
-    "claude-sonnet-4-6":         {"in":  3.0, "out": 15.0, "read": 0.30, "write_5m": 3.75, "write_1h":  6.0},
-    "claude-haiku-4-5":          {"in":  1.0, "out":  5.0, "read": 0.10, "write_5m": 1.25, "write_1h":  2.0},
-    "claude-haiku-4-5-20251001": {"in":  1.0, "out":  5.0, "read": 0.10, "write_5m": 1.25, "write_1h":  2.0},
+    "claude-fable-5":            {"in": 10.0, "out": 50.0, "read": 1.00, "write_5m": 12.50, "write_1h": 20.0},
+    "claude-opus-4-8":           {"in":  5.0, "out": 25.0, "read": 0.50, "write_5m":  6.25, "write_1h": 10.0},
+    "claude-opus-4-7":           {"in":  5.0, "out": 25.0, "read": 0.50, "write_5m":  6.25, "write_1h": 10.0},
+    "claude-opus-4-6":           {"in":  5.0, "out": 25.0, "read": 0.50, "write_5m":  6.25, "write_1h": 10.0},
+    "claude-sonnet-4-6":         {"in":  3.0, "out": 15.0, "read": 0.30, "write_5m":  3.75, "write_1h":  6.0},
+    "claude-haiku-4-5":          {"in":  1.0, "out":  5.0, "read": 0.10, "write_5m":  1.25, "write_1h":  2.0},
+    "claude-haiku-4-5-20251001": {"in":  1.0, "out":  5.0, "read": 0.10, "write_5m":  1.25, "write_1h":  2.0},
 }
-DEFAULT_MODEL = "claude-opus-4-7"
+DEFAULT_MODEL = "claude-opus-4-8"
 
 LITELLM_URL = (
     "https://raw.githubusercontent.com/BerriAI/litellm/main/"
@@ -536,8 +546,8 @@ def session_totals(transcript_path):
 
 
 def project_totals(transcript_path, now=None):
-    """Aggregate every transcript in the current project's directory into an
-    (all-time, today) pair of deduped totals.
+    """Aggregate every transcript in the current project's directory into
+    (all_time, today, main, sub) deduped totals.
 
     The project directory is the parent of the session transcript —
     ~/.claude/projects/<cwd-slug>/. A recursive glob picks up both the
@@ -549,13 +559,23 @@ def project_totals(transcript_path, now=None):
     so summing this directory yields the cumulative cost of the current
     worktree across every session ever run in it — not just the live one.
 
-    Returns `(all_time, today)`. `all_time` sums every record (the `wt:`
-    figure); `today` keeps only records whose own date (payload index 0,
-    `ts[:10]`) equals the current UTC day (the `wtday:` figure), mirroring the
-    daily bucket in `calendar_totals`. Both are produced in one directory walk
-    so a statusline render does not re-stat every transcript twice. There is no
-    mtime pre-filter here (unlike `calendar_totals`): the all-time figure must
-    read every file regardless, so there is nothing to skip.
+    Returns `(all_time, today, main, sub)`:
+      - `all_time` sums every record (the `wt:` figure).
+      - `today` keeps only records whose own date (payload index 0, `ts[:10]`)
+        equals the current UTC day (the `wtday:` figure), mirroring the daily
+        bucket in `calendar_totals`.
+      - `main` / `sub` split `all_time` by where each record lives: a file
+        directly under the project dir is a top-level (orchestrator / main)
+        session, while a file whose parent dir is `subagents` is a sub-agent
+        transcript. A sub-agent's records never appear in a top-level file
+        (verified: zero (msg_id, requestId) overlap across sampled projects),
+        so the two record sets are disjoint and `main['cost'] + sub['cost']`
+        equals `all_time['cost']` by construction.
+
+    All four are produced in one directory walk so a statusline render does not
+    re-stat every transcript more than once. There is no mtime pre-filter here
+    (unlike `calendar_totals`): the all-time figure must read every file
+    regardless, so there is nothing to skip.
 
     `now` defaults to the current UTC instant; it is injectable so the
     today-bucketing can be exercised against a fixed date in tests. Records are
@@ -567,21 +587,42 @@ def project_totals(transcript_path, now=None):
     # relative path resolving to /tmp/x.jsonl) would recursively scan that whole
     # parent directory for *.jsonl files.
     if not p.exists():
-        return _zero(), _zero()
+        return _zero(), _zero(), _zero(), _zero()
     proj_dir = p.parent
     if not proj_dir.is_dir():
-        return _zero(), _zero()
+        return _zero(), _zero(), _zero(), _zero()
     if now is None:
         now = _dt.datetime.now(_dt.timezone.utc)
     cur_day = f"{now.year:04d}-{now.month:02d}-{now.day:02d}"
     all_merged = {}
     day_merged = {}
+    sub_keys = set()
     for jsonl in proj_dir.rglob("*.jsonl"):
+        # A sub-agent transcript lives at <proj>/<uuid>/subagents/agent-*.jsonl,
+        # so its immediate parent dir is named `subagents`; everything else is a
+        # top-level (orchestrator / main) session file.
+        is_sub = jsonl.parent.name == "subagents"
         for k, v in aggregate_file(jsonl).items():
             _keep_larger_output(all_merged, k, v)  # max-output dedup
+            if is_sub:
+                sub_keys.add(k)
             if v[0] == cur_day:
                 _keep_larger_output(day_merged, k, v)
-    return _sum_records(all_merged), _sum_records(day_merged)
+    # Partition the deduped all-time records into sub (key seen in any subagent
+    # file) and main (everything else). Partitioning the already-deduped set —
+    # rather than summing two independently-merged buckets — keeps
+    # main['cost'] + sub['cost'] == all_time['cost'] unconditionally, even if a
+    # record were duplicated across a top-level and a sub-agent file. (It isn't
+    # in practice — verified zero (msg_id, requestId) overlap — but the
+    # partition makes the invariant hold regardless.)
+    main_merged = {k: v for k, v in all_merged.items() if k not in sub_keys}
+    sub_merged = {k: v for k, v in all_merged.items() if k in sub_keys}
+    return (
+        _sum_records(all_merged),
+        _sum_records(day_merged),
+        _sum_records(main_merged),
+        _sum_records(sub_merged),
+    )
 
 
 def calendar_totals(now=None):
@@ -672,22 +713,25 @@ def parse_args(argv):
     return transcript, show_worktree, wt_cost_file
 
 
-def format_stats_line(sess, day, month, proj=None, proj_day=None, no_color=False):
+def format_stats_line(sess, day, month, proj=None, proj_day=None,
+                      proj_main=None, proj_sub=None, no_color=False):
     """Render the second statusline row.
 
     The `day:$X` figure (today's spend across all projects) always appears; when
-    `proj` is given (worktree mode) two worktree-scoped figures are inserted
-    ahead of it: `wt:$X` (the project's all-time spend) and `wtday:$X`
-    (`proj_day`, today's slice of that same spend). `proj_day` defaults to a
-    zeroed total when omitted so callers that only pass `proj` still render.
+    `proj` is given (worktree mode) the worktree-scoped figures are inserted
+    ahead of it: `wt:$X` (the project's all-time spend), immediately followed by
+    its `[main:$X sub:$X]` split (`proj_main` / `proj_sub`, the top-level and
+    sub-agent shares of `wt:`, which sum to it), then `wtday:$X` (`proj_day`,
+    today's slice of `wt:`). `proj_day` / `proj_main` / `proj_sub` each default
+    to a zeroed total when omitted so callers that pass only `proj` still render.
 
     Distinct colours so the cost figures are tellable apart at a glance:
     bright cyan = current session (active), bright blue = this worktree's
-    project all-time, dim blue = this worktree's project today (same hue as
-    `wt:` to group the two worktree figures; dimmer = the narrower today
-    window), bright white = today across all projects, bright magenta =
-    calendar month across all projects. Deliberately avoiding red / yellow /
-    green — those are reserved for the context-fill bar in
+    project all-time, dim blue = this worktree's project today plus the
+    main/sub split (same hue as `wt:` to group the worktree figures; dimmer =
+    the narrower / derived windows), bright white = today across all projects,
+    bright magenta = calendar month across all projects. Deliberately avoiding
+    red / yellow / green — those are reserved for the context-fill bar in
     statusline-command.sh (critical / warning / safe). Honour NO_COLOR for
     non-TTY consumers.
     """
@@ -697,7 +741,7 @@ def format_stats_line(sess, day, month, proj=None, proj_day=None, no_color=False
     else:
         sess_open = "\033[1;36m"   # bright cyan    — current session
         wt_open = "\033[1;34m"     # bright blue    — this worktree's project, all-time
-        wtd_open = "\033[2;34m"    # dim blue       — this worktree's project, today
+        wtd_open = "\033[2;34m"    # dim blue       — this worktree's project, today + main/sub split
         day_open = "\033[1;37m"    # bright white   — today, all projects
         mo_open = "\033[1;35m"     # bright magenta — calendar month, all projects
         sess_close = mo_close = wt_close = day_close = wtd_close = "\033[0m"
@@ -705,12 +749,19 @@ def format_stats_line(sess, day, month, proj=None, proj_day=None, no_color=False
     day_str = f"day:{day_open}${day['cost']:.2f}{day_close}"
     mo_str = f"mo:{mo_open}${month['cost']:.2f}{mo_close}"
     if proj is not None:
-        # proj and proj_day always travel together from main(); fall back to a
-        # zeroed total if a caller passes proj alone so we never index None.
+        # proj/proj_day/proj_main/proj_sub always travel together from main();
+        # fall back to a zeroed total if a caller passes proj alone so we never
+        # index None.
         pd = proj_day if proj_day is not None else _zero()
+        pm = proj_main if proj_main is not None else _zero()
+        ps = proj_sub if proj_sub is not None else _zero()
         wt_str = f"wt:{wt_open}${proj['cost']:.2f}{wt_close}"
+        split_str = (
+            f"[main:{wtd_open}${pm['cost']:.2f}{wtd_close} "
+            f"sub:{wtd_open}${ps['cost']:.2f}{wtd_close}]"
+        )
         wtd_str = f"wtday:{wtd_open}${pd['cost']:.2f}{wtd_close}"
-        scope = f"({wt_str} {wtd_str} {day_str} {mo_str})"
+        scope = f"({wt_str} {split_str} {wtd_str} {day_str} {mo_str})"
     else:
         scope = f"({day_str} {mo_str})"
 
@@ -734,27 +785,29 @@ def main(argv=None):
         sess = session_totals(transcript)
         day, month = calendar_totals()
         if show_worktree:
-            proj, proj_day = project_totals(transcript)
+            proj, proj_day, proj_main, proj_sub = project_totals(transcript)
         else:
-            proj = proj_day = None
+            proj = proj_day = proj_main = proj_sub = None
     except Exception as exc:  # noqa: BLE001 — never break the statusline
         print(f"stats error: {exc}", file=sys.stderr)
         return 0
 
     # Publish the worktree-project cost to a per-session file for on-demand
     # reading by the model (mirrors the context-usage file the statusline
-    # writes). The published figure is the all-time `wt:` cost; the today
-    # slice (`wtday:`) is statusline-only. Best-effort — a write failure must
-    # never break the statusline.
+    # writes). The published figure is the all-time `wt:` cost with its
+    # main/sub split; the today slice (`wtday:`) is statusline-only.
+    # Best-effort — a write failure must never break the statusline.
     if wt_cost_file and proj is not None:
         try:
             _atomic_write_text(
-                pathlib.Path(wt_cost_file), f"wt_cost: ${proj['cost']:.2f}"
+                pathlib.Path(wt_cost_file),
+                f"wt_cost: ${proj['cost']:.2f} "
+                f"(main: ${proj_main['cost']:.2f} sub: ${proj_sub['cost']:.2f})",
             )
         except Exception:  # noqa: BLE001 — publish is best-effort; never break the statusline
             pass
 
-    print(format_stats_line(sess, day, month, proj, proj_day))
+    print(format_stats_line(sess, day, month, proj, proj_day, proj_main, proj_sub))
     return 0
 
 

--- a/.claude/scripts/session-stats.py
+++ b/.claude/scripts/session-stats.py
@@ -12,7 +12,7 @@ statusline adds it whenever the cwd is a linked git worktree) worktree-scoped
 figures are inserted at the front of the parenthetical: `wt:` (the current
 worktree project's all-time spend) immediately followed by its split into
 `[main:` (top-level orchestrator / main-session spend) and `sub:` (sub-agent
-spend) — the two sum to `wt:` — and then `wtday:` (today's slice of `wt:`):
+spend) that together sum to `wt:`, and then `wtday:` (today's slice of `wt:`):
 
   $0.123 (wt:$1.85 [main:$1.20 sub:$0.65] wtday:$0.40 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K …
 
@@ -566,11 +566,12 @@ def project_totals(transcript_path, now=None):
         bucket in `calendar_totals`.
       - `main` / `sub` split `all_time` by where each record lives: a file
         directly under the project dir is a top-level (orchestrator / main)
-        session, while a file whose parent dir is `subagents` is a sub-agent
-        transcript. A sub-agent's records never appear in a top-level file
-        (verified: zero (msg_id, requestId) overlap across sampled projects),
-        so the two record sets are disjoint and `main['cost'] + sub['cost']`
-        equals `all_time['cost']` by construction.
+        session, while a file under a `subagents/` dir at any depth (including
+        the nested `subagents/workflows/wf_*/` layout for workflow-spawned
+        agents) is a sub-agent transcript. A sub-agent's records never appear in
+        a top-level file (verified: zero (msg_id, requestId) overlap across
+        sampled projects), so the two record sets are disjoint and
+        `main['cost'] + sub['cost']` equals `all_time['cost']` by construction.
 
     All four are produced in one directory walk so a statusline render does not
     re-stat every transcript more than once. There is no mtime pre-filter here
@@ -598,10 +599,13 @@ def project_totals(transcript_path, now=None):
     day_merged = {}
     sub_keys = set()
     for jsonl in proj_dir.rglob("*.jsonl"):
-        # A sub-agent transcript lives at <proj>/<uuid>/subagents/agent-*.jsonl,
-        # so its immediate parent dir is named `subagents`; everything else is a
-        # top-level (orchestrator / main) session file.
-        is_sub = jsonl.parent.name == "subagents"
+        # A sub-agent transcript lives somewhere under a `subagents/` dir:
+        # directly at <proj>/<uuid>/subagents/agent-*.jsonl, or nested deeper at
+        # <proj>/<uuid>/subagents/workflows/wf_*/agent-*.jsonl for workflow-spawned
+        # agents. Test for `subagents` anywhere in the path below the project dir
+        # (not just the immediate parent), so both depths count as sub; everything
+        # else is a top-level (orchestrator / main) session file.
+        is_sub = "subagents" in jsonl.relative_to(proj_dir).parts
         for k, v in aggregate_file(jsonl).items():
             _keep_larger_output(all_merged, k, v)  # max-output dedup
             if is_sub:
@@ -609,12 +613,12 @@ def project_totals(transcript_path, now=None):
             if v[0] == cur_day:
                 _keep_larger_output(day_merged, k, v)
     # Partition the deduped all-time records into sub (key seen in any subagent
-    # file) and main (everything else). Partitioning the already-deduped set —
-    # rather than summing two independently-merged buckets — keeps
+    # file) and main (everything else). Partitioning the already-deduped set
+    # (rather than summing two independently-merged buckets) keeps
     # main['cost'] + sub['cost'] == all_time['cost'] unconditionally, even if a
     # record were duplicated across a top-level and a sub-agent file. (It isn't
-    # in practice — verified zero (msg_id, requestId) overlap — but the
-    # partition makes the invariant hold regardless.)
+    # in practice; verified zero (msg_id, requestId) overlap.) The partition
+    # makes the invariant hold regardless.
     main_merged = {k: v for k, v in all_merged.items() if k not in sub_keys}
     sub_merged = {k: v for k, v in all_merged.items() if k in sub_keys}
     return (

--- a/.claude/scripts/statusline-command.sh
+++ b/.claude/scripts/statusline-command.sh
@@ -7,9 +7,11 @@
 # Threshold rationale: see CLAUDE.md § Context Window Monitor.
 #
 # When the cwd is a *linked* git worktree, the second (cost) line gains a
-# `wt:$X` figure for the spend on the current worktree's project, and that
-# cost is also written to /tmp/claude-code-worktree-cost-<claude_pid>.txt for
-# on-demand reading (the worktree figure and file are produced by
+# `wt:$X` figure for the spend on the current worktree's project, its
+# `[main:$X sub:$X]` split (orchestrator/main-session vs sub-agent spend, which
+# sum to `wt:`), and a `wtday:$X` today-slice. The all-time `wt:` cost with its
+# split is also written to /tmp/claude-code-worktree-cost-<claude_pid>.txt for
+# on-demand reading (the worktree figures and file are produced by
 # session-stats.py — this script only detects the worktree and passes flags).
 
 input=$(cat)

--- a/.claude/scripts/tests/test_session_stats.py
+++ b/.claude/scripts/tests/test_session_stats.py
@@ -252,8 +252,8 @@ def test_format_line_no_worktree_exact() -> None:
 
 def test_format_line_with_worktree_exact() -> None:
     """A project total inserts the worktree figures at the front of the
-    parenthetical — `wt:$…` (all-time) immediately followed by its
-    `[main:$… sub:$…]` split, then `wtday:$…` (today's slice) — ahead of the
+    parenthetical (`wt:$…` all-time, immediately followed by its
+    `[main:$… sub:$…]` split, then `wtday:$…` today's slice), ahead of the
     always-present `day:$…` and the `mo:$…` figure."""
     sess = _totals(0.123, **{"in": 1200, "out": 8000, "read": 230000, "w5": 40000, "w1": 0})
     day = _totals(2.34)
@@ -350,14 +350,20 @@ def test_project_totals_aggregates_sessions_and_subagents() -> None:
 
 
 def test_project_totals_main_sub_split() -> None:
-    """The 3rd/4th tuple elements split the all-time total by transcript origin:
-    `main` is the top-level (orchestrator / main-session) spend, `sub` is the
-    sub-agent spend (files under a `subagents/` dir). The split partitions the
-    deduped all-time set — a key seen in any sub-agent file goes to `sub`, every
-    other key to `main` — so `main['cost'] + sub['cost']` equals the all-time
-    cost even though m1 is duplicated into the sub-agent transcript here. With
-    m2 unique to a top-level file (main) and m1+m3 attributed to the sub-agent
-    file (sub), main = 1M and sub = 2M, summing to the 3M all-time total."""
+    """The 3rd/4th tuple elements split the all-time total by transcript origin.
+    `main` is the top-level (orchestrator / main-session) spend; `sub` is the
+    sub-agent spend (any file under a `subagents/` dir, at any depth). The split
+    partitions the deduped all-time set (a key seen in any sub-agent file goes to
+    `sub`, every other key to `main`), so `main['cost'] + sub['cost']` equals the
+    all-time cost even though m1 is duplicated into the sub-agent transcript here.
+
+    Two sub-agent layouts are exercised so the classifier is pinned to recognise
+    both depths: m3 sits directly under `subagents/` (immediate parent), and m4
+    sits under the nested `subagents/workflows/wf_*/` layout used by
+    workflow-spawned agents. With m2 unique to a top-level file (main) and
+    m1 + m3 + m4 attributed to sub-agent files (sub), main = 1M and sub = 3M,
+    summing to the 4M all-time total. A classifier that only matched the
+    immediate-parent layout would misbucket m4 into main."""
     with tempfile.TemporaryDirectory() as tmp:
         cache = Path(tmp) / "cache"
         proj = Path(tmp) / "project"
@@ -367,16 +373,21 @@ def test_project_totals_main_sub_split() -> None:
             proj / "sessionA" / "subagents" / "agent-1.jsonl",
             [
                 _assistant_usage("m1", "r1", in_t=1_000_000),  # duplicate of A -> attributed to sub
-                _assistant_usage("m3", "r3", in_t=1_000_000),  # unique sub-agent record
+                _assistant_usage("m3", "r3", in_t=1_000_000),  # unique sub-agent record (immediate parent)
             ],
+        )
+        write_jsonl(
+            proj / "sessionA" / "subagents" / "workflows" / "wf_abc" / "agent-2.jsonl",
+            [_assistant_usage("m4", "r4", in_t=1_000_000)],  # nested workflow sub-agent record
         )
         with _patched(CACHE_DIR=cache):
             all_time, _today, main, sub = MODULE.project_totals(str(proj / "sessionA.jsonl"))
-        # main = {m2}; sub = {m1, m3}; the partition is disjoint and exhaustive.
+        # main = {m2}; sub = {m1, m3, m4}; the partition is disjoint and exhaustive.
         assert main["in"] == 1_000_000, main["in"]
-        assert sub["in"] == 2_000_000, sub["in"]
+        assert sub["in"] == 3_000_000, sub["in"]
         assert _approx(main["cost"], 1 * USD_PER_1M_IN), main["cost"]
-        assert _approx(sub["cost"], 2 * USD_PER_1M_IN), sub["cost"]
+        assert _approx(sub["cost"], 3 * USD_PER_1M_IN), sub["cost"]
+        assert all_time["in"] == 4_000_000, all_time["in"]
         # The invariant the statusline display depends on.
         assert _approx(main["cost"] + sub["cost"], all_time["cost"]), (main, sub, all_time)
 

--- a/.claude/scripts/tests/test_session_stats.py
+++ b/.claude/scripts/tests/test_session_stats.py
@@ -209,6 +209,29 @@ def test_parse_args_cost_file_missing_value() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Fallback pricing.
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_prices_have_fable5_and_opus48() -> None:
+    """Fable 5 and Opus 4.8 are present in the offline fallback table with the
+    published per-1M rates, so their cost is computed (not silently zeroed) when
+    the live LiteLLM table is unavailable. Fable 5 is $10/$50 in/out with cache
+    read 0.1x, write-5m 1.25x, write-1h 2.0x; Opus 4.8 matches Opus 4.7 at
+    $5/$25. `_model_pricing` resolves both exactly and longest-prefix-matches a
+    dated Fable 5 SKU. (MODULE._LIVE_PRICES is emptied at load, so these
+    exercise the fallback path.)"""
+    fable = MODULE.FALLBACK_PRICES["claude-fable-5"]
+    assert (fable["in"], fable["out"]) == (10.0, 50.0), fable
+    assert (fable["read"], fable["write_5m"], fable["write_1h"]) == (1.0, 12.5, 20.0), fable
+    opus48 = MODULE.FALLBACK_PRICES["claude-opus-4-8"]
+    assert (opus48["in"], opus48["out"]) == (5.0, 25.0), opus48
+    assert MODULE._model_pricing("claude-fable-5") == fable
+    assert MODULE._model_pricing("claude-fable-5-20260601") == fable, "dated SKU should prefix-match"
+    assert MODULE._model_pricing("claude-opus-4-8") == opus48
+
+
+# ---------------------------------------------------------------------------
 # format_stats_line.
 # ---------------------------------------------------------------------------
 
@@ -228,30 +251,36 @@ def test_format_line_no_worktree_exact() -> None:
 
 
 def test_format_line_with_worktree_exact() -> None:
-    """A project total inserts the two worktree figures at the front of the
-    parenthetical — `wt:$…` (all-time) then `wtday:$…` (today's slice) — ahead
-    of the always-present `day:$…` and the `mo:$…` figure."""
+    """A project total inserts the worktree figures at the front of the
+    parenthetical — `wt:$…` (all-time) immediately followed by its
+    `[main:$… sub:$…]` split, then `wtday:$…` (today's slice) — ahead of the
+    always-present `day:$…` and the `mo:$…` figure."""
     sess = _totals(0.123, **{"in": 1200, "out": 8000, "read": 230000, "w5": 40000, "w1": 0})
     day = _totals(2.34)
     month = _totals(4.56)
     proj = _totals(1.85)
     proj_day = _totals(0.40)
-    line = MODULE.format_stats_line(sess, day, month, proj=proj, proj_day=proj_day, no_color=True)
+    proj_main = _totals(1.20)
+    proj_sub = _totals(0.65)
+    line = MODULE.format_stats_line(
+        sess, day, month, proj=proj, proj_day=proj_day,
+        proj_main=proj_main, proj_sub=proj_sub, no_color=True,
+    )
     expected = (
-        "$0.123 (wt:$1.85 wtday:$0.40 day:$2.34 mo:$4.56)  in:1.2K out:8.0K read:230K w5m:40K w1h:0  "
-        "r/5m:5.8x r/1h:-"
+        "$0.123 (wt:$1.85 [main:$1.20 sub:$0.65] wtday:$0.40 day:$2.34 mo:$4.56)  "
+        "in:1.2K out:8.0K read:230K w5m:40K w1h:0  r/5m:5.8x r/1h:-"
     )
     assert line == expected, f"\n got: {line}\nwant: {expected}"
 
 
-def test_format_line_worktree_proj_day_defaults_to_zero() -> None:
-    """When `proj` is given but `proj_day` is omitted, the `wtday:` figure
-    renders `$0.00` rather than crashing on a None index — a defensive path for
-    callers that pass only the all-time total."""
+def test_format_line_worktree_split_defaults_to_zero() -> None:
+    """When `proj` is given but `proj_day` / `proj_main` / `proj_sub` are
+    omitted, each renders `$0.00` rather than crashing on a None index — a
+    defensive path for callers that pass only the all-time total."""
     line = MODULE.format_stats_line(
         _totals(0.1), _totals(2.0), _totals(3.0), proj=_totals(1.85), no_color=True
     )
-    assert "wt:$1.85 wtday:$0.00 " in line, line
+    assert "wt:$1.85 [main:$0.00 sub:$0.00] wtday:$0.00 " in line, line
 
 
 def test_format_line_no_color_has_no_ansi() -> None:
@@ -297,8 +326,9 @@ def test_project_totals_aggregates_sessions_and_subagents() -> None:
     """Every *.jsonl under the project dir is summed into the all-time total —
     top-level session files and nested subagents/agent-*.jsonl — with
     (msg_id, requestId) dedup so a record duplicated into a sub-agent transcript
-    is counted once. The today element of the returned pair is asserted
-    separately (see test_project_totals_today_bucket)."""
+    is counted once. The today element of the returned tuple is asserted
+    separately (see test_project_totals_today_bucket); the main/sub split has
+    its own test (test_project_totals_main_sub_split)."""
     with tempfile.TemporaryDirectory() as tmp:
         cache = Path(tmp) / "cache"
         proj = Path(tmp) / "project"
@@ -313,10 +343,42 @@ def test_project_totals_aggregates_sessions_and_subagents() -> None:
             ],
         )
         with _patched(CACHE_DIR=cache):
-            all_time, _today = MODULE.project_totals(str(proj / "sessionA.jsonl"))
+            all_time, _today, _main, _sub = MODULE.project_totals(str(proj / "sessionA.jsonl"))
         # m1, m2, m3 distinct -> 3 * 1M input tokens.
         assert all_time["in"] == 3_000_000, all_time["in"]
         assert _approx(all_time["cost"], 3 * USD_PER_1M_IN), all_time["cost"]
+
+
+def test_project_totals_main_sub_split() -> None:
+    """The 3rd/4th tuple elements split the all-time total by transcript origin:
+    `main` is the top-level (orchestrator / main-session) spend, `sub` is the
+    sub-agent spend (files under a `subagents/` dir). The split partitions the
+    deduped all-time set — a key seen in any sub-agent file goes to `sub`, every
+    other key to `main` — so `main['cost'] + sub['cost']` equals the all-time
+    cost even though m1 is duplicated into the sub-agent transcript here. With
+    m2 unique to a top-level file (main) and m1+m3 attributed to the sub-agent
+    file (sub), main = 1M and sub = 2M, summing to the 3M all-time total."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = Path(tmp) / "cache"
+        proj = Path(tmp) / "project"
+        write_jsonl(proj / "sessionA.jsonl", [_assistant_usage("m1", "r1", in_t=1_000_000)])
+        write_jsonl(proj / "sessionB.jsonl", [_assistant_usage("m2", "r2", in_t=1_000_000)])
+        write_jsonl(
+            proj / "sessionA" / "subagents" / "agent-1.jsonl",
+            [
+                _assistant_usage("m1", "r1", in_t=1_000_000),  # duplicate of A -> attributed to sub
+                _assistant_usage("m3", "r3", in_t=1_000_000),  # unique sub-agent record
+            ],
+        )
+        with _patched(CACHE_DIR=cache):
+            all_time, _today, main, sub = MODULE.project_totals(str(proj / "sessionA.jsonl"))
+        # main = {m2}; sub = {m1, m3}; the partition is disjoint and exhaustive.
+        assert main["in"] == 1_000_000, main["in"]
+        assert sub["in"] == 2_000_000, sub["in"]
+        assert _approx(main["cost"], 1 * USD_PER_1M_IN), main["cost"]
+        assert _approx(sub["cost"], 2 * USD_PER_1M_IN), sub["cost"]
+        # The invariant the statusline display depends on.
+        assert _approx(main["cost"] + sub["cost"], all_time["cost"]), (main, sub, all_time)
 
 
 def test_project_totals_today_bucket() -> None:
@@ -338,7 +400,7 @@ def test_project_totals_today_bucket() -> None:
             ],
         )
         with _patched(CACHE_DIR=cache):
-            all_time, today = MODULE.project_totals(str(proj / "session.jsonl"), now=now)
+            all_time, today, _main, _sub = MODULE.project_totals(str(proj / "session.jsonl"), now=now)
         # All-time gets both records; today gets only the 2026-06-08 one.
         assert all_time["in"] == 2_000_000, all_time["in"]
         assert _approx(all_time["cost"], 2 * USD_PER_1M_IN), all_time["cost"]
@@ -347,9 +409,9 @@ def test_project_totals_today_bucket() -> None:
 
 
 def test_project_totals_missing_dir_is_zero() -> None:
-    """A transcript path whose parent is not a directory yields a zeroed pair."""
+    """A transcript path whose parent is not a directory yields a zeroed 4-tuple."""
     out = MODULE.project_totals("/no/such/dir/x.jsonl")
-    assert out == (MODULE._zero(), MODULE._zero()), out
+    assert out == (MODULE._zero(), MODULE._zero(), MODULE._zero(), MODULE._zero()), out
 
 
 def test_project_totals_nonexistent_transcript_does_not_scan_parent() -> None:
@@ -366,7 +428,7 @@ def test_project_totals_nonexistent_transcript_does_not_scan_parent() -> None:
         write_jsonl(proj / "decoy.jsonl", [_assistant_usage("m1", "r1", in_t=1_000_000)])
         with _patched(CACHE_DIR=cache):
             out = MODULE.project_totals(str(proj / "nonexistent.jsonl"))
-        assert out == (MODULE._zero(), MODULE._zero()), out
+        assert out == (MODULE._zero(), MODULE._zero(), MODULE._zero(), MODULE._zero()), out
 
 
 def test_streaming_snapshots_in_one_file_keep_max_output() -> None:
@@ -389,7 +451,7 @@ def test_streaming_snapshots_in_one_file_keep_max_output() -> None:
             ],
         )
         with _patched(CACHE_DIR=cache):
-            all_time, _today = MODULE.project_totals(str(proj / "session.jsonl"))
+            all_time, _today, _main, _sub = MODULE.project_totals(str(proj / "session.jsonl"))
         # m1 -> 276 (final snapshot), m2 -> 100; first-wins would give 101, no
         # dedup would give 378.
         assert all_time["out"] == 376, all_time["out"]
@@ -497,42 +559,44 @@ def test_atomic_write_text_writes_and_overwrites() -> None:
 
 
 def test_main_worktree_writes_cost_file_and_shows_wt() -> None:
-    """`main` in worktree mode prints the `wt:`, `wtday:`, and `day:` figures and
-    publishes the cost file containing exactly `wt_cost: $<all-time proj cost>`
-    (the today slice is statusline-only). `project_totals` is stubbed to return
-    the (all-time, today) pair main now unpacks; `calendar_totals` returns the
-    (today, month) pair."""
+    """`main` in worktree mode prints `wt:`, its `[main: sub:]` split, `wtday:`,
+    and `day:`, and publishes the cost file containing the all-time proj cost
+    with the same split — `wt_cost: $1.85 (main: $1.20 sub: $0.65)` (the today
+    slice is statusline-only). `project_totals` is stubbed to return the
+    (all-time, today, main, sub) tuple main now unpacks; `calendar_totals`
+    returns the (today, month) pair."""
     with tempfile.TemporaryDirectory() as tmp:
         wt_file = Path(tmp) / "claude-code-worktree-cost-1234.txt"
         buf = io.StringIO()
         with _patched(
             session_totals=lambda _t: _totals(0.123),
             calendar_totals=lambda: (_totals(2.34), _totals(4.56)),
-            project_totals=lambda _t: (_totals(1.85), _totals(0.40)),
+            project_totals=lambda _t: (_totals(1.85), _totals(0.40), _totals(1.20), _totals(0.65)),
         ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
             rc = MODULE.main(["t.jsonl", "--worktree", "--worktree-cost-file", str(wt_file)])
         assert rc == 0, rc
-        assert wt_file.read_text() == "wt_cost: $1.85", wt_file.read_text()
-        assert "wt:$1.85" in buf.getvalue(), buf.getvalue()
+        assert wt_file.read_text() == "wt_cost: $1.85 (main: $1.20 sub: $0.65)", wt_file.read_text()
+        assert "wt:$1.85 [main:$1.20 sub:$0.65]" in buf.getvalue(), buf.getvalue()
         assert "wtday:$0.40" in buf.getvalue(), buf.getvalue()
         assert "day:$2.34" in buf.getvalue(), buf.getvalue()
 
 
 def test_main_no_worktree_omits_wt_and_writes_no_file() -> None:
-    """Without worktree flags `main` omits both `wt:` and `wtday:`, still shows
-    the always-present `day:` figure, and writes no publish file."""
+    """Without worktree flags `main` omits `wt:`, its split, and `wtday:`, still
+    shows the always-present `day:` figure, and writes no publish file."""
     with tempfile.TemporaryDirectory() as tmp:
         wt_file = Path(tmp) / "should-not-exist.txt"
         buf = io.StringIO()
         with _patched(
             session_totals=lambda _t: _totals(0.123),
             calendar_totals=lambda: (_totals(2.34), _totals(4.56)),
-            project_totals=lambda _t: (_totals(1.85), _totals(0.40)),
+            project_totals=lambda _t: (_totals(1.85), _totals(0.40), _totals(1.20), _totals(0.65)),
         ), _env("NO_COLOR", "1"), contextlib.redirect_stdout(buf):
             rc = MODULE.main(["t.jsonl"])
         assert rc == 0, rc
         assert "wt:" not in buf.getvalue(), buf.getvalue()
         assert "wtday:" not in buf.getvalue(), buf.getvalue()
+        assert "[main:" not in buf.getvalue(), buf.getvalue()
         assert "day:$2.34" in buf.getvalue(), buf.getvalue()
         assert not wt_file.exists(), "no cost file should be written without the flag"
 
@@ -559,11 +623,13 @@ def main() -> int:
         ("parse_args cost-file missing value", test_parse_args_cost_file_missing_value),
         ("format line no worktree (exact)", test_format_line_no_worktree_exact),
         ("format line with worktree (exact)", test_format_line_with_worktree_exact),
-        ("format line worktree proj_day defaults to zero", test_format_line_worktree_proj_day_defaults_to_zero),
+        ("format line worktree split defaults to zero", test_format_line_worktree_split_defaults_to_zero),
         ("format line no_color strips ANSI", test_format_line_no_color_has_no_ansi),
         ("format line colours when enabled", test_format_line_colours_when_enabled),
         ("format line NO_COLOR env respected", test_format_line_no_color_env_respected),
+        ("fallback prices have fable5 + opus48", test_fallback_prices_have_fable5_and_opus48),
         ("project_totals sessions + subagents deduped", test_project_totals_aggregates_sessions_and_subagents),
+        ("project_totals main/sub split", test_project_totals_main_sub_split),
         ("project_totals today bucket", test_project_totals_today_bucket),
         ("project_totals missing dir -> zero", test_project_totals_missing_dir_is_zero),
         ("project_totals nonexistent file w/ existing parent -> zero", test_project_totals_nonexistent_transcript_does_not_scan_parent),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ cat /tmp/claude-code-worktree-cost-$PPID.txt
 ```
 Output example: `wt_cost: $1.85 (main: $1.20 sub: $0.65)`. The file is absent in the main checkout (no `wt:` figure there). Implementation: `.claude/scripts/statusline-command.sh` detects the worktree and passes `--worktree` / `--worktree-cost-file` to `.claude/scripts/session-stats.py`, which computes the figures and writes the file.
 
-Pricing is fetched live from LiteLLM (24 h disk cache) with a hardcoded offline fallback table in `session-stats.py`; the fallback covers the current models (Fable 5 at $10/$50 in/out, Opus 4.8/4.7/4.6, Sonnet 4.6, Haiku 4.5) so cold-start / offline cost is still computed rather than zeroed.
+Pricing is fetched live from LiteLLM (24 h disk cache) with a hardcoded offline fallback in `session-stats.py`'s `FALLBACK_PRICES` table, so cold-start / offline cost is still computed rather than zeroed. The fallback's model list is owned by that table — see the sync-list entry below.
 
 The example output format above MUST stay in sync with:
 - `.claude/scripts/statusline-command.sh` — detects the worktree and passes the flags that produce the `wt:$X` / `[main:$X sub:$X]` / `wtday:$X` figures on the statusline's second line

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,17 +264,19 @@ If you change a threshold here, grep for the others and update them in the same 
 
 ## Cost Monitor
 
-The statusline's second line shows session, today, and calendar-month cost. The `day:$X` figure is today's spend across every project (the calendar-day analogue of the month figure, deduped the same way) and always appears: `$0.123 (day:$2.34 mo:$4.56) …`. When the cwd is a linked git worktree, the line gains two worktree-scoped figures at the front of the parenthetical: `wt:$X`, the cumulative spend on the *current worktree's project* (every session ever run in this worktree, orchestrator + sub-agents, deduped), and `wtday:$X`, today's slice of that same spend (the worktree analogue of the global `day:` figure, bucketed per record by UTC date): `$0.123 (wt:$1.85 wtday:$0.40 day:$2.34 mo:$4.56) …`.
+The statusline's second line shows session, today, and calendar-month cost. The `day:$X` figure is today's spend across every project (the calendar-day analogue of the month figure, deduped the same way) and always appears: `$0.123 (day:$2.34 mo:$4.56) …`. When the cwd is a linked git worktree, the line gains worktree-scoped figures at the front of the parenthetical: `wt:$X`, the cumulative spend on the *current worktree's project* (every session ever run in this worktree, orchestrator + sub-agents, deduped), immediately followed by its `[main:$X sub:$X]` split, and then `wtday:$X`, today's slice of `wt:` (the worktree analogue of the global `day:` figure, bucketed per record by UTC date): `$0.123 (wt:$1.85 [main:$1.20 sub:$0.65] wtday:$0.40 day:$2.34 mo:$4.56) …`. In the split, `main` is the top-level orchestrator / main-session spend and `sub` is the sub-agent spend; the two sum to `wt:` exactly, because a sub-agent's records live only under `<session>/subagents/` and never in a top-level session file, so the record sets are disjoint.
 
-In a worktree the all-time `wt:` cost (not the `wtday:` slice) is also published to a per-session file, mirroring the context-usage file, so it can be read on demand:
+In a worktree the all-time `wt:` cost (not the `wtday:` slice), with its main/sub split, is also published to a per-session file, mirroring the context-usage file, so it can be read on demand:
 ```bash
 cat /tmp/claude-code-worktree-cost-$PPID.txt
 ```
-Output example: `wt_cost: $1.85`. The file is absent in the main checkout (no `wt:` figure there). Implementation: `.claude/scripts/statusline-command.sh` detects the worktree and passes `--worktree` / `--worktree-cost-file` to `.claude/scripts/session-stats.py`, which computes the figure and writes the file.
+Output example: `wt_cost: $1.85 (main: $1.20 sub: $0.65)`. The file is absent in the main checkout (no `wt:` figure there). Implementation: `.claude/scripts/statusline-command.sh` detects the worktree and passes `--worktree` / `--worktree-cost-file` to `.claude/scripts/session-stats.py`, which computes the figures and writes the file.
+
+Pricing is fetched live from LiteLLM (24 h disk cache) with a hardcoded offline fallback table in `session-stats.py`; the fallback covers the current models (Fable 5 at $10/$50 in/out, Opus 4.8/4.7/4.6, Sonnet 4.6, Haiku 4.5) so cold-start / offline cost is still computed rather than zeroed.
 
 The example output format above MUST stay in sync with:
-- `.claude/scripts/statusline-command.sh` — detects the worktree and passes the flags that produce the `wt:$X` / `wtday:$X` figures on the statusline's second line
-- `.claude/scripts/session-stats.py` — computes the figure and writes the `wt_cost:` file
+- `.claude/scripts/statusline-command.sh` — detects the worktree and passes the flags that produce the `wt:$X` / `[main:$X sub:$X]` / `wtday:$X` figures on the statusline's second line
+- `.claude/scripts/session-stats.py` — computes the figures and writes the `wt_cost:` file; holds the `FALLBACK_PRICES` table
 - `.claude/scripts/tests/test_session_stats.py` — pins both formats with exact-match assertions
 
 ### Recipes


### PR DESCRIPTION
#### Motivation

A worktree's `wt:` cost blends the main/orchestrator session with the sub-agents it spawns, and that blend hides where spend actually goes. Splitting `wt:` into `[main: sub:]` makes it visible: a review that fanned out a dozen agents reads very differently from one long main-loop session. This also adds Fable 5 to the offline fallback pricing table (Opus 4.8 becomes the default model) so cold-start cost is computed rather than zeroed before the live LiteLLM table loads.

#### What changed

- `session-stats.py` — `project_totals()` now returns `(all_time, today, main, sub)`. The split partitions the already-deduped record set (a key seen in any `subagents/` file at any depth is `sub`, everything else `main`), so `main + sub == all_time` by construction. The statusline and the published `wt_cost:` file both carry the split.
- `FALLBACK_PRICES` — Fable 5 at $10/$50 in/out; `DEFAULT_MODEL` bumped to Opus 4.8.
- `CLAUDE.md` § Cost Monitor — documents the new figure, the format strings, and the live-vs-fallback pricing source.

#### Validation

24 unit tests pass. A `/code-review` pass caught and fixed a blocker before push: the sub-agent classifier originally matched only the immediate `subagents/` parent and missed the nested `subagents/workflows/wf_*/` layout, misbucketing 489 of 583 real sub-agent transcripts into `main` (sub undercounted ~7x). On the develop project the corrected split lands at sub ≈ 40% of the worktree total with the invariant intact; a nested fixture pins the regression.
