### PR TITLE
Track 2 review: aggregate query caching

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -120,8 +120,15 @@ import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.Re
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.binary.RecordSerializerBinary;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.record.string.JSONSerializerJackson;
 import com.jetbrains.youtrackdb.internal.core.sql.SQLEngine;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.AbstractExecutionStep;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.AggregateProjectionCalculationStep;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ExecutionStepInternal;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.InternalExecutionPlan;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.InternalResultSet;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ProjectionCalculationStep;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.SelectExecutionPlan;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.cache.AggregateCacheTapStep;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.cache.AggregateState;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.cache.CacheKey;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.cache.CacheableShape;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.cache.CachedEntry;
@@ -722,9 +729,10 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
    * cacheCodeDepth > 0}, the re-entrancy guard, so a {@code query()} issued from a UDF in a WHERE
    * clause does not recurse into the cache); the statement is not a SELECT or MATCH; the statement
    * references a non-deterministic function or per-row context variable; or the classified shape is
-   * not one whose delta/view path is wired yet (only {@code RECORD} and {@code K0_NONE} route through
-   * the cache — {@code AGGREGATE_*} and {@code MATCH_TUPLE_MULTI} are classified but not yet wired,
-   * so they bypass here).
+   * not one whose delta/view path is wired yet ({@code RECORD}, {@code K0_NONE}, and the {@code
+   * AGGREGATE_*} family route through the cache; {@code MATCH_TUPLE_MULTI} is classified but not yet
+   * wired, so it bypasses here. The {@code AGGREGATE_*} miss takes its own eager-drive populate path
+   * with a side-tap splice, and falls back uncached on an untappable plan shape).
    *
    * @param statement the parsed, idempotent query statement
    * @param args      the positional {@code Object[]} or named {@code Map<Object,Object>} parameters
@@ -788,9 +796,22 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
         return executeUncached(statement, args);
       }
       var shape = ShapeClassifier.classify(statement);
+      if (isAggregateShape(shape) && statement instanceof SQLSelectStatement select) {
+        // AGGREGATE_* shapes take a separate populate path: the side-tap must observe every
+        // contributing record, so the miss builds a per-execution plan copy, splices the tap upstream
+        // of the aggregation step, and eager-drives it (RECORD/K0_NONE lazy-pull cannot seed an
+        // aggregate). On any unexpected plan shape (e.g. a hardwired CountFromClassStep) it falls back
+        // to uncached execution and counts a splice failure. The two-guard contract is preserved: a
+        // built CachedResultSetView owns the cache-code guard, an uncached fallback leaves
+        // viewOwnsGuard false so the finally below releases it — identical to the RECORD path.
+        var aggregateResult =
+            populateAndBuildAggregateView(select, args, key, shape, tx, cache);
+        viewOwnsGuard = aggregateResult instanceof CachedResultSetView;
+        return aggregateResult;
+      }
       if (shape != CacheableShape.RECORD && shape != CacheableShape.K0_NONE) {
-        // AGGREGATE_* and MATCH_TUPLE_MULTI are classified but their delta/view paths are not wired
-        // yet; route them to uncached execution until those paths land.
+        // MATCH_TUPLE_MULTI is classified but its delta/view path is not wired yet; route it to
+        // uncached execution until that path lands.
         return executeUncached(statement, args);
       }
       var result = populateAndBuildView(statement, args, key, shape, tx, cache);
@@ -884,6 +905,167 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
     return buildView(entry, tx, args);
   }
 
+  /** Whether a classified shape is one of the {@code AGGREGATE_*} family the aggregate path serves. */
+  private static boolean isAggregateShape(@Nonnull CacheableShape shape) {
+    return shape == CacheableShape.AGGREGATE_COUNT
+        || shape == CacheableShape.AGGREGATE_SUM
+        || shape == CacheableShape.AGGREGATE_AVG
+        || shape == CacheableShape.AGGREGATE_MIN
+        || shape == CacheableShape.AGGREGATE_MAX
+        || shape == CacheableShape.AGGREGATE_COUNT_DISTINCT;
+  }
+
+  /**
+   * Populates a fresh cache entry for an aggregate-shape miss and returns a view over it, or falls back
+   * to a plain uncached execution (counting a splice failure) on any unexpected plan shape.
+   *
+   * <p>Unlike the RECORD/K0_NONE populate, the aggregate path cannot reuse {@link
+   * #populateAndBuildView}: a collapsed aggregate result carries only the scalar, so the per-RID
+   * material a delta replay needs must be seeded by a side-tap that observes every contributing record
+   * before the aggregation collapses them. The path therefore builds its own per-execution plan copy
+   * ({@code select.createExecutionPlan} returns a private {@code copy(ctx)} or a fresh plan, never the
+   * shared cached instance, so rewiring its {@code prev} pointers cannot corrupt other callers), finds
+   * the aggregation step, splices an {@link AggregateCacheTapStep} upstream of it, and eager-drives the
+   * plan to full drain so the tap observes every contributor. The single resulting scalar is fully
+   * computed at populate, so the entry holds no live stream (its stream/plan/ctx are {@code null} on the
+   * {@link CachedEntry}).
+   *
+   * <p>It independently re-mirrors the three Track-1 populate contracts: stamp the populate mutation
+   * version BEFORE driving so the delta builder admits only post-populate ops; release the cache-code
+   * guard on every exit (the caller's {@code viewOwnsGuard} transfer covers the view-built path, this
+   * method's own fallbacks return an uncached result so the guard is released by the caller's finally);
+   * and close the plan idempotently (the outer finally closes it, the entry holds no stream to close).
+   *
+   * @param select the parsed single-aggregate SELECT (already shape-gated by the caller)
+   */
+  private ResultSet populateAndBuildAggregateView(
+      @Nonnull SQLSelectStatement select,
+      @Nullable Object args,
+      @Nonnull CacheKey key,
+      @Nonnull CacheableShape shape,
+      @Nonnull FrontendTransactionImpl tx,
+      @Nonnull QueryResultCache cache) {
+    var metadata = ShapeClassifier.aggregateMetadata(select);
+    if (metadata == null || metadata.kind() != shape) {
+      // The classifier accepted the shape but the metadata derivation found no clean single-aggregate
+      // (e.g. a computed-expression argument that classify routed elsewhere): there is nothing to seed,
+      // so run uncached and count a splice failure.
+      cache.incrementSpliceFailures();
+      return executeUncached(select, args);
+    }
+
+    // Build a command context mirroring SQLSelectStatement.execute's setup so :param bindings resolve
+    // identically when the side-tap drives the plan.
+    var ctx = freshContext(args);
+
+    // Stamp BEFORE building/driving the plan so the delta builder later admits only post-populate ops.
+    var populateMutationVersion = tx.getMutationVersion();
+
+    var plan = select.createExecutionPlan(ctx, false);
+    if (!(plan instanceof SelectExecutionPlan selectPlan)) {
+      plan.close();
+      cache.incrementSpliceFailures();
+      return executeUncached(select, args);
+    }
+
+    var aggregateStep = findAggregateStep(selectPlan);
+    if (aggregateStep == null) {
+      // No AggregateProjectionCalculationStep to splice above — e.g. a bare or single-field-indexed
+      // COUNT(*) the planner hardwired to a CountFromClassStep. Fall back uncached and count the splice
+      // failure (the global splice-failure rate picks it up through the metric bridge).
+      selectPlan.close();
+      cache.incrementSpliceFailures();
+      return executeUncached(select, args);
+    }
+
+    var state = new AggregateState(metadata.kind(), metadata.propertyName(), metadata.alias());
+    // Install the contributor cap BEFORE driving so an over-cap populate routes the key non-cacheable
+    // mid-drive; the put below is then a no-op (the cache's nonCacheableKeys guard closes the entry).
+    cache.installAggregateOverflowGuard(key, state);
+    spliceTap(aggregateStep, new AggregateCacheTapStep(state, ctx));
+
+    try {
+      // Eager-drive: pull the plan's single-row stream to exhaustion. The aggregation is blocking, so
+      // draining it forces every upstream (tapped) record to be observed before the scalar is emitted.
+      var stream = plan.start();
+      try {
+        while (stream.hasNext(ctx)) {
+          stream.next(ctx);
+        }
+      } finally {
+        stream.close(ctx);
+      }
+    } finally {
+      // The entry holds no live stream (the scalar is fully computed), so the plan is closed here and
+      // the entry is built with null stream/plan/ctx. Idempotent close mirrors the uncached path.
+      plan.close();
+    }
+
+    // The scalar is fully in the seeded state; the entry carries no stream/plan/ctx to lazy-pull.
+    var entry = new CachedEntry(
+        shape,
+        effectiveFromClasses(select),
+        select.getWhereClause(),
+        select.getOrderBy(),
+        null,
+        null,
+        null,
+        populateMutationVersion);
+    entry.setAggregateState(state);
+    // put is a no-op if the cap already routed the key non-cacheable during the drive; otherwise it
+    // stores the entry. Either way the view below is built directly over this entry's seeded state.
+    cache.put(key, entry);
+
+    return buildView(entry, tx, args);
+  }
+
+  /**
+   * Finds the aggregation step the side-tap splices above. Returns the first {@link
+   * AggregateProjectionCalculationStep} in the plan's step chain, or {@code null} when the plan has none
+   * (the hardwired-COUNT fallback case). The plan is a SELECT plan, so a present aggregation step is the
+   * single one the planner emits for a single-aggregate query.
+   */
+  @Nullable private static AggregateProjectionCalculationStep findAggregateStep(
+      @Nonnull SelectExecutionPlan plan) {
+    for (var step : plan.getSteps()) {
+      if (step instanceof AggregateProjectionCalculationStep aggregateStep) {
+        return aggregateStep;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Splices {@code tap} into the plan chain immediately upstream of the aggregation step. When a
+   * pre-aggregate {@link ProjectionCalculationStep} sits directly above the aggregation (every value
+   * aggregate carries one, projecting the per-row field), the tap is spliced ABOVE that projection: the
+   * projection strips record identity, and {@link AggregateState#observe} requires a non-null RID, so the
+   * tap must see the raw filtered records. The projection still sits between the tap and the aggregation,
+   * leaving the collapsed scalar unchanged. Otherwise (e.g. COUNT(*) over a WHERE, no pre-aggregate
+   * projection) the tap is spliced directly upstream of the aggregation.
+   */
+  private static void spliceTap(
+      @Nonnull AggregateProjectionCalculationStep aggregateStep,
+      @Nonnull AggregateCacheTapStep tap) {
+    // AggregateProjectionCalculationStep extends ProjectionCalculationStep, so the instanceof must
+    // exclude the aggregation step itself; only a *plain* pre-aggregate projection is the splice-above
+    // case. Both step types expose prev through AbstractExecutionStep.
+    ExecutionStepInternal spliceBelow = aggregateStep;
+    var prev = aggregateStep.prev;
+    if (prev instanceof ProjectionCalculationStep
+        && !(prev instanceof AggregateProjectionCalculationStep)) {
+      spliceBelow = (AbstractExecutionStep) prev;
+    }
+    var below = (AbstractExecutionStep) spliceBelow;
+    var upstream = below.prev;
+    tap.setPrevious(upstream);
+    if (upstream != null) {
+      upstream.setNext(tap);
+    }
+    below.setPrevious(tap);
+    tap.setNext(below);
+  }
+
   /**
    * Builds the consumer-facing view over a cached entry. RECORD entries carry a {@link TxDeltaCursor}
    * reconciling post-populate mutations; K0_NONE entries replay directly (the lookup-time version
@@ -908,14 +1090,21 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
       // because the wired delta-path shapes carry no non-param context state (see method Javadoc).
       ctx = freshContext(args);
     }
-    TxDeltaCursor delta = entry.getShape() == CacheableShape.RECORD
-        ? DeltaBuilder.buildForRecord(entry, tx, ctx)
-        : null;
     // The view takes ownership of the open cache-code guard (entered in serveThroughCache) and holds
     // it for its whole iteration lifetime, releasing it exactly once on close / exhaustion. This
     // keeps a re-entrant query() — e.g. a UDF in WHERE evaluated during the lazy stream pull, which
     // happens after serveThroughCache has returned — bypassed for the entire view consumption, not
     // just the synchronous lookup window.
+    if (isAggregateShape(entry.getShape())) {
+      // Aggregate: copy the seeded state and replay the post-populate mutations onto the copy; the view
+      // emits the single replayed scalar. The entry holds no stream, so the view's plan slot is null.
+      var aggregateDelta = DeltaBuilder.buildForAggregate(entry, tx, ctx);
+      return CachedResultSetView.forAggregate(entry, aggregateDelta, this, tx, entry.getPlan(),
+          ctx);
+    }
+    TxDeltaCursor delta = entry.getShape() == CacheableShape.RECORD
+        ? DeltaBuilder.buildForRecord(entry, tx, ctx)
+        : null;
     return new CachedResultSetView(entry, delta, this, tx, entry.getPlan(), ctx);
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheTapStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheTapStep.java
@@ -1,0 +1,99 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
+
+import com.jetbrains.youtrackdb.internal.common.concur.TimeoutException;
+import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.AbstractExecutionStep;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ExecutionStepInternal;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.resultset.ExecutionStream;
+import javax.annotation.Nonnull;
+
+/**
+ * A transparent observe-then-forward execution step the tx-result cache splices upstream of a query's
+ * aggregation step so it can seed an {@link AggregateState} from every contributing record before the
+ * aggregation collapses them into a single scalar (D10). The step forwards every row downstream
+ * unchanged; its only effect is the side {@link AggregateState#observe} call, so the aggregation result
+ * is identical to the un-spliced plan's.
+ *
+ * <p><b>Splice position.</b> The cache rewires this step's {@code prev} to the aggregation step's
+ * original predecessor and rewires the aggregation step's {@code prev} to this step, so the tap sits
+ * immediately upstream of the aggregation. When a pre-aggregate {@code ProjectionCalculationStep} is
+ * present (every value aggregate such as {@code SUM(price)} carries one, projecting the per-row field),
+ * the cache splices ABOVE that projection rather than directly under the aggregation: the pre-aggregate
+ * projection strips record identity, and {@link AggregateState#observe} requires a non-null RID, so the
+ * tap must observe the raw filtered records (identity and property both present). The projection still
+ * sits between the tap and the aggregation, so the collapsed scalar is unchanged.
+ *
+ * <p><b>Single-drive contract.</b> The cache eager-drives the populating plan exactly once at cache-put
+ * (the aggregation is blocking, so it pulls every upstream row before emitting its single output row),
+ * so every contributing record is observed exactly once per populate. The step is never re-run.
+ *
+ * <p><b>Not copyable.</b> The step is constructed and spliced into an already-built per-execution plan
+ * copy; it is never itself deep-copied (the plan is driven once and discarded), so {@link #copy} throws.
+ *
+ * <p>Single-transaction state observed only by the owning thread; no field is synchronised.
+ */
+public final class AggregateCacheTapStep extends AbstractExecutionStep {
+
+  private final AggregateState state;
+
+  public AggregateCacheTapStep(@Nonnull AggregateState state, @Nonnull CommandContext ctx) {
+    super(ctx, false);
+    this.state = state;
+  }
+
+  @Override
+  protected ExecutionStream internalStart(CommandContext ctx) throws TimeoutException {
+    // The cache splices this step in only when a real upstream exists; a null prev would mean the tap
+    // is acting as a source step, which it never is. Assert it (no-op without -ea) so a broken splice
+    // fails loudly in tests rather than NPEing on the prev.start below.
+    assert prev != null : "AggregateCacheTapStep spliced with no upstream step";
+    var upstream = prev.start(ctx);
+    return new ObservingStream(upstream, state);
+  }
+
+  /**
+   * Wraps the upstream stream and feeds every row to {@link AggregateState#observe} before forwarding it
+   * downstream unchanged. {@code hasNext} / {@code close} delegate verbatim, so the only observable
+   * difference from the un-tapped stream is the side observe call.
+   */
+  private static final class ObservingStream implements ExecutionStream {
+
+    private final ExecutionStream upstream;
+    private final AggregateState state;
+
+    private ObservingStream(@Nonnull ExecutionStream upstream, @Nonnull AggregateState state) {
+      this.upstream = upstream;
+      this.state = state;
+    }
+
+    @Override
+    public boolean hasNext(CommandContext ctx) {
+      return upstream.hasNext(ctx);
+    }
+
+    @Override
+    public Result next(CommandContext ctx) {
+      var r = upstream.next(ctx);
+      state.observe(r);
+      return r;
+    }
+
+    @Override
+    public void close(CommandContext ctx) {
+      upstream.close(ctx);
+    }
+  }
+
+  @Override
+  public ExecutionStepInternal copy(CommandContext ctx) {
+    // Spliced post-construction into a one-shot plan copy that is driven once and discarded; the step is
+    // never deep-copied. A copy request signals the step reached a code path it was never meant to.
+    throw new UnsupportedOperationException("AggregateCacheTapStep is not copyable");
+  }
+
+  @Override
+  public String prettyPrint(int depth, int indent) {
+    return ExecutionStepInternal.getIndent(depth, indent) + "+ AGGREGATE CACHE TAP";
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -94,8 +95,16 @@ public final class AggregateState {
    * The post-state value each contributing RID supplies, kept so a set-changing mutation can re-fold
    * (SUM/AVG), rescan for a new extremum (MIN/MAX), or re-bucket (COUNT_DISTINCT). This is the blocking
    * dependency every value-aggregate carries; its O(n) memory is the price of incremental replay.
+   *
+   * <p>A {@link LinkedHashMap} so iteration order equals contributor insertion order, which is the
+   * populate-time observe order (== storage's plan scan order). The SUM/AVG re-fold folds these values
+   * in iteration order, so an insertion-ordered map reproduces storage's scan-order fold bit-for-bit;
+   * a plain {@code HashMap} would fold in hash-bucket order and diverge on order-sensitive arithmetic
+   * (IEEE-754 float/double non-associativity, Integer&rarr;Long overflow-promotion typing). {@link
+   * #copy} preserves the ordering ({@code LinkedHashMap.putAll} from a {@code LinkedHashMap} source
+   * copies in source iteration order).
    */
-  private final Map<RID, Object> contributingValues = new HashMap<>();
+  private final Map<RID, Object> contributingValues = new LinkedHashMap<>();
 
   // ---- SUM / AVG ----
   /** Running SUM/AVG total, folded through {@link PropertyTypeInternal#increment} (D19). Seeded null. */
@@ -103,6 +112,17 @@ public final class AggregateState {
 
   /** Contributor count, the AVG divisor; recomputed alongside {@link #sumAccumulator} on every re-fold. */
   private int count;
+
+  /**
+   * Whether {@link #sumAccumulator}/{@link #count} are stale and a re-fold is owed before the next read.
+   * SUM/AVG contributor changes (observe-time seeds and replay-time add/remove/update) set this rather
+   * than re-folding eagerly; {@link #ensureSumFolded} performs the single O(n) fold on the next read of
+   * the scalar. Deferring collapses a build that replays {@code m} mutations from {@code m} folds
+   * (O(m&middot;n)) to one fold (O(n + m)) without weakening storage-fold parity: only the final
+   * scalar is observable, and a single fold over the final contributor set is the same fold a fresh
+   * execution runs.
+   */
+  private boolean sumDirty;
 
   // ---- MIN / MAX ----
   /** The current extremum value (MIN/MAX). */
@@ -273,7 +293,7 @@ public final class AggregateState {
     switch (kind) {
       case AGGREGATE_SUM, AGGREGATE_AVG -> {
         contributingValues.put(rid, value);
-        refoldSum();
+        sumDirty = true;
       }
       case AGGREGATE_MIN, AGGREGATE_MAX -> {
         contributingValues.put(rid, value);
@@ -295,7 +315,7 @@ public final class AggregateState {
     switch (kind) {
       case AGGREGATE_SUM, AGGREGATE_AVG -> {
         contributingValues.remove(rid);
-        refoldSum();
+        sumDirty = true;
       }
       case AGGREGATE_MIN, AGGREGATE_MAX -> {
         var wasExtremum = rid.equals(extremumRid);
@@ -317,7 +337,7 @@ public final class AggregateState {
     switch (kind) {
       case AGGREGATE_SUM, AGGREGATE_AVG -> {
         contributingValues.put(rid, newValue);
-        refoldSum();
+        sumDirty = true;
       }
       case AGGREGATE_MIN, AGGREGATE_MAX -> {
         var wasExtremum = rid.equals(extremumRid);
@@ -352,11 +372,26 @@ public final class AggregateState {
   }
 
   /**
+   * Folds {@link #sumAccumulator}/{@link #count} from {@link #contributingValues} only when {@link
+   * #sumDirty} is set, then clears the flag. Called lazily on every read of the SUM/AVG scalar so the
+   * fold runs once per build (after the replay loop has applied all membership/value changes) rather
+   * than once per mutation.
+   */
+  private void ensureSumFolded() {
+    if (sumDirty) {
+      refoldSum();
+      sumDirty = false;
+    }
+  }
+
+  /**
    * Re-folds the entire {@link #contributingValues} through {@link PropertyTypeInternal#increment}
    * from a verbatim first-value seed, exactly as storage's SUM/AVG accumulate. A full re-fold (rather
    * than an incremental add/subtract) is mandated by D19: {@code PropertyTypeInternal} exposes no
    * symmetric subtract, and only re-folding from scratch reproduces storage's numeric-promotion and
-   * overflow behaviour bit-for-bit. Also recomputes {@link #count} (the AVG divisor).
+   * overflow behaviour bit-for-bit. The fold walks {@link #contributingValues} in insertion (==
+   * observe == scan) order so the result matches storage's scan-order fold bit-for-bit. Also recomputes
+   * {@link #count} (the AVG divisor).
    */
   private void refoldSum() {
     Number acc = null;
@@ -478,6 +513,7 @@ public final class AggregateState {
     c.contributingValues.putAll(contributingValues);
     c.sumAccumulator = sumAccumulator;
     c.count = count;
+    c.sumDirty = sumDirty;
     c.currentScalar = currentScalar;
     c.extremumRid = extremumRid;
     for (var e : distinctBuckets.entrySet()) {
@@ -506,8 +542,14 @@ public final class AggregateState {
       case AGGREGATE_COUNT -> (long) contributingRids.size();
       case AGGREGATE_COUNT_DISTINCT -> (long) distinctBuckets.size();
       // SQLFunctionSum.getResult returns 0 (an int) for an empty sum, not null; match it exactly.
-      case AGGREGATE_SUM -> sumAccumulator == null ? 0 : sumAccumulator;
-      case AGGREGATE_AVG -> computeAverage(sumAccumulator, count);
+      case AGGREGATE_SUM -> {
+        ensureSumFolded();
+        yield sumAccumulator == null ? 0 : sumAccumulator;
+      }
+      case AGGREGATE_AVG -> {
+        ensureSumFolded();
+        yield computeAverage(sumAccumulator, count);
+      }
       case AGGREGATE_MIN, AGGREGATE_MAX -> currentScalar;
       default -> throw new IllegalStateException("scalar() on non-aggregate kind " + kind);
     };
@@ -537,10 +579,12 @@ public final class AggregateState {
   // ---- Test / inspection accessors (package-private; the replay path uses the methods above) ----
 
   @Nullable Number getSumAccumulator() {
+    ensureSumFolded();
     return sumAccumulator;
   }
 
   int getCount() {
+    ensureSumFolded();
     return count;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java
@@ -1,0 +1,566 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
+
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.record.RecordOperation;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * The replay state for one cached single-aggregate query ({@code SELECT
+ * COUNT|SUM|AVG|MIN|MAX|COUNT(DISTINCT prop) FROM C [WHERE p]}). It is seeded at cache-put by the
+ * aggregate side-tap, which {@link #observe}s every contributing record before the aggregation step
+ * collapses them into a scalar; at view construction the delta builder {@link #copy copies} it and
+ * {@link #applyMutation replays} the transaction's post-populate mutations onto the copy, so {@link
+ * #toResult} returns exactly the scalar a fresh uncached execution would compute at that moment
+ * (invariant I4).
+ *
+ * <p><b>Storage parity (D19).</b> SUM and AVG fold their values through the same {@link
+ * PropertyTypeInternal#increment} call storage's {@code SQLFunctionSum.sum} / {@code
+ * SQLFunctionAverage.sum} make: the first contributing value is seeded verbatim, every later value is
+ * {@code increment}ed onto the running {@link #sumAccumulator}. Because {@code PropertyTypeInternal}
+ * exposes no symmetric subtract, a mutation that changes the contributing set (T&rarr;T value change,
+ * T&rarr;F drop, F&rarr;T add) triggers a full re-fold of {@link #contributingValues} from scratch
+ * rather than an incremental adjust. This reproduces storage's numeric-promotion, Long-overflow, and
+ * Long&rarr;Double precision-loss behaviour bit-for-bit. AVG additionally tracks the contributor
+ * count in {@link #count} and finalises through the same type-dispatched division {@code
+ * SQLFunctionAverage.computeAverage} uses (integer truncation for Integer/Long, {@code HALF_UP} for
+ * BigDecimal), not a plain {@code sum / count}.
+ *
+ * <p><b>MIN/MAX.</b> The running extremum is held in {@link #currentScalar} with the RID that
+ * produced it in {@link #extremumRid}. Per-value material lives in {@link #contributingValues} so the
+ * two extremum-leaving transitions (the holder drops out, or the holder's value moves away from the
+ * extremum direction) can recompute the new extremum with an O(n) scan; every other transition is
+ * O(1) via a single comparison against {@link #currentScalar}. {@code was_extremum} is decided by RID
+ * identity ({@code rid.equals(extremumRid)}), never by {@code Number.equals}, to sidestep the
+ * cross-{@code Number}-subtype equality hazard.
+ *
+ * <p><b>COUNT(DISTINCT) (D20).</b> {@link #distinctBuckets} maps each distinct value to the set of
+ * RIDs currently contributing it; the scalar is the live bucket count, recomputed at {@link
+ * #toResult}. Bucket keys use raw {@code Object.equals}/{@code hashCode}, mirroring {@code
+ * SQLFunctionDistinct}'s {@code LinkedHashSet<Object>}, so {@code Long(5)} and {@code Integer(5)} are
+ * distinct buckets exactly as in storage.
+ *
+ * <p><b>Membership-derived dispatch (D21 collapse safety).</b> Every {@link #applyMutation} derives
+ * its transition from two facts rather than from the operation type: {@code was_contributing} from
+ * cache membership ({@link #contributingValues}{@code .containsKey(rid)}, or {@link #contributingRids}
+ * for COUNT), and {@code now_contributing = (status == DELETED) ? false : matchAfter}. {@code status}
+ * is consulted only to fold {@code DELETED} into {@code now_contributing = false}, never as a
+ * stand-in for the before-state. This is required because {@code addRecordOperation} keeps a
+ * collapsed pre-populate CREATE typed {@code CREATED} while bumping its version past populate, so a
+ * {@code CREATED} op can carry a record already observed by the populate-time tap and already a
+ * contributor; keying on {@code op.type} would misread it as brand-new and leave a stale contributor.
+ *
+ * <p><b>Memory cap.</b> The cache installs a contributor cap and a one-shot overflow callback at put
+ * time (mirroring {@link CachedEntry}'s record cap, but bounding the per-contributor collections
+ * rather than {@code results}: high-cardinality COUNT(DISTINCT)/MIN/MAX is the real OOM vector for an
+ * aggregate, whose {@code results} holds a single scalar row). The first {@link #observe} that pushes
+ * a tracked collection past the cap fires the callback once; the cache then removes the entry and
+ * routes the key non-cacheable, while the in-flight populate still completes.
+ *
+ * <p>Single-transaction state observed only by the owning thread; no field is synchronised.
+ */
+public final class AggregateState {
+
+  /** One of the {@code AGGREGATE_*} {@link CacheableShape} values; selects the fold/dispatch logic. */
+  private final CacheableShape kind;
+
+  /**
+   * The property the aggregate reads from each contributing record ({@code SUM(price)} &rarr; {@code
+   * price}). {@code null} for {@code COUNT(*)}, which observes membership only and reads no value.
+   */
+  @Nullable private final String propertyName;
+
+  /** The projection alias the single scalar row carries in {@link #toResult} (e.g. {@code count(*)}). */
+  private final String alias;
+
+  // ---- COUNT(*) ----
+  /** RIDs contributing to a {@code COUNT(*)}; the scalar is its size. Unused for the other kinds. */
+  private final Set<RID> contributingRids = new HashSet<>();
+
+  // ---- SUM / AVG / MIN / MAX / COUNT_DISTINCT ----
+  /**
+   * The post-state value each contributing RID supplies, kept so a set-changing mutation can re-fold
+   * (SUM/AVG), rescan for a new extremum (MIN/MAX), or re-bucket (COUNT_DISTINCT). This is the blocking
+   * dependency every value-aggregate carries; its O(n) memory is the price of incremental replay.
+   */
+  private final Map<RID, Object> contributingValues = new HashMap<>();
+
+  // ---- SUM / AVG ----
+  /** Running SUM/AVG total, folded through {@link PropertyTypeInternal#increment} (D19). Seeded null. */
+  @Nullable private Number sumAccumulator;
+
+  /** Contributor count, the AVG divisor; recomputed alongside {@link #sumAccumulator} on every re-fold. */
+  private int count;
+
+  // ---- MIN / MAX ----
+  /** The current extremum value (MIN/MAX). */
+  @Nullable private Object currentScalar;
+
+  /** The RID that produced {@link #currentScalar}; {@code was_extremum} is RID identity against it. */
+  @Nullable private RID extremumRid;
+
+  // ---- COUNT_DISTINCT ----
+  /** Distinct value &rarr; contributing RIDs (D20). The scalar is the live bucket count. */
+  private final Map<Object, Set<RID>> distinctBuckets = new HashMap<>();
+
+  // ---- Memory cap (installed by the cache at put time) ----
+  private int maxContributors = Integer.MAX_VALUE;
+
+  @Nullable private Runnable onOverflow;
+
+  private boolean overflowed;
+
+  public AggregateState(
+      @Nonnull CacheableShape kind, @Nullable String propertyName, @Nonnull String alias) {
+    assert kind == CacheableShape.AGGREGATE_COUNT
+        || kind == CacheableShape.AGGREGATE_SUM
+        || kind == CacheableShape.AGGREGATE_AVG
+        || kind == CacheableShape.AGGREGATE_MIN
+        || kind == CacheableShape.AGGREGATE_MAX
+        || kind == CacheableShape.AGGREGATE_COUNT_DISTINCT
+        : "AggregateState requires an AGGREGATE_* shape, got " + kind;
+    this.kind = kind;
+    this.propertyName = propertyName;
+    this.alias = alias;
+  }
+
+  public CacheableShape getKind() {
+    return kind;
+  }
+
+  @Nullable public String getPropertyName() {
+    return propertyName;
+  }
+
+  public String getAlias() {
+    return alias;
+  }
+
+  /**
+   * Installs the contributor cap and the one-shot overflow callback the cache fires when an {@link
+   * #observe} crosses it. Called once by the cache when the entry is stored. A cap of {@code
+   * Integer.MAX_VALUE} (the default for a state never stored) disables the check.
+   */
+  public void setOverflowGuard(int maxContributors, @Nonnull Runnable onOverflow) {
+    this.maxContributors = maxContributors;
+    this.onOverflow = onOverflow;
+  }
+
+  /**
+   * Observes one contributing record at populate time (called by the side-tap before the aggregation
+   * step collapses the stream). Reads the RID and, for value aggregates, the target property from the
+   * post-projection {@link Result}, then folds it into the running state exactly as storage would. The
+   * side-tap drives the populating plan once, so every contributing RID is observed exactly once per
+   * populate.
+   */
+  public void observe(@Nonnull Result result) {
+    var rid = result.getIdentity();
+    // The aggregate side-tap forwards post-projection records that always carry an identity; a null
+    // RID would corrupt the per-RID contributor maps the replay depends on. Assert it (no-op without
+    // -ea) so a broken upstream invariant fails loudly in tests rather than silently miscounting.
+    assert rid != null : "aggregate tap observed a result with a null identity";
+    if (kind == CacheableShape.AGGREGATE_COUNT) {
+      contributingRids.add(rid);
+      checkOverflow(contributingRids.size());
+      return;
+    }
+    var value = propertyName == null ? null : result.<Object>getProperty(propertyName);
+    if (value == null) {
+      // Storage's aggregate functions skip null values entirely (they never enter the running total,
+      // the extremum comparison, or a distinct bucket), so a null contributor is not tracked here
+      // either; it simply does not contribute, matching fresh execution.
+      return;
+    }
+    addContributor(rid, value);
+    checkOverflow(trackedSize());
+  }
+
+  /**
+   * Replays one post-populate mutation onto this (copied) state during delta build. {@code status} is
+   * the {@link RecordOperation} type; {@code matchAfter} is whether the post-mutation record still
+   * satisfies the query's WHERE (membership only). The transition is derived from cache membership and
+   * {@code now_contributing}, never from {@code status} alone (D21). For a record that still
+   * contributes, the post-state value is read from the mutated record.
+   */
+  public void applyMutation(@Nonnull RecordAbstract record, byte status, boolean matchAfter) {
+    var rid = record.getIdentity();
+    var wasContributing = isContributing(rid);
+    var nowContributing = status != RecordOperation.DELETED && matchAfter;
+
+    if (!wasContributing && !nowContributing) {
+      // F->F: a non-contributor that still does not contribute. No-op for every kind.
+      return;
+    }
+
+    if (kind == CacheableShape.AGGREGATE_COUNT) {
+      // COUNT(*) tracks membership only; the post-state value is irrelevant.
+      if (nowContributing) {
+        contributingRids.add(rid);
+      } else {
+        contributingRids.remove(rid);
+      }
+      return;
+    }
+
+    // Value aggregates read the new value only when the record still contributes; a drop (T->F) needs
+    // no value because the contributor is being removed.
+    Object newValue = null;
+    if (nowContributing) {
+      newValue = readValue(record);
+      if (newValue == null) {
+        // A null post-state value does not contribute (storage skips nulls), so a record that "matches"
+        // WHERE but has a null aggregate property is treated as a non-contributor.
+        nowContributing = false;
+      }
+    }
+
+    if (!wasContributing) {
+      // F->T add of a genuinely new contributor (or a collapsed pre-populate create the membership
+      // test correctly sees as new because the populate-time tap never observed it).
+      if (nowContributing) {
+        addContributor(rid, newValue);
+      }
+      return;
+    }
+
+    if (!nowContributing) {
+      // T->F drop of an existing contributor.
+      removeContributor(rid);
+      return;
+    }
+
+    // T->T: an existing contributor whose value may have changed. Update the per-RID value, then
+    // re-derive the scalar per kind (full re-fold for SUM/AVG, comparison/scan for MIN/MAX, re-bucket
+    // for COUNT_DISTINCT).
+    updateContributor(rid, newValue);
+  }
+
+  /** Whether {@code rid} currently contributes, by cache membership (D21), not by op type. */
+  private boolean isContributing(@Nonnull RID rid) {
+    if (kind == CacheableShape.AGGREGATE_COUNT) {
+      return contributingRids.contains(rid);
+    }
+    return contributingValues.containsKey(rid);
+  }
+
+  /** Reads the aggregate's target property off a mutated record, as an Entity (null when no property). */
+  @Nullable private Object readValue(@Nonnull RecordAbstract record) {
+    if (propertyName == null) {
+      return null;
+    }
+    // A value aggregate's target is always a schema property on an Entity record; non-Entity records
+    // (Blobs) never satisfy a property predicate and are class-filtered out before reaching here.
+    if (record instanceof Entity entity) {
+      return entity.getProperty(propertyName);
+    }
+    return null;
+  }
+
+  /** F->T add: route to the kind-specific accumulator and record the per-RID value. */
+  private void addContributor(@Nonnull RID rid, @Nonnull Object value) {
+    switch (kind) {
+      case AGGREGATE_SUM, AGGREGATE_AVG -> {
+        contributingValues.put(rid, value);
+        refoldSum();
+      }
+      case AGGREGATE_MIN, AGGREGATE_MAX -> {
+        contributingValues.put(rid, value);
+        if (currentScalar == null || beatsExtremum(value, currentScalar)) {
+          currentScalar = value;
+          extremumRid = rid;
+        }
+      }
+      case AGGREGATE_COUNT_DISTINCT -> {
+        contributingValues.put(rid, value);
+        distinctBuckets.computeIfAbsent(value, k -> new HashSet<>()).add(rid);
+      }
+      default -> throw new IllegalStateException("addContributor on non-value kind " + kind);
+    }
+  }
+
+  /** T->F drop: remove the per-RID value and re-derive the scalar per kind. */
+  private void removeContributor(@Nonnull RID rid) {
+    switch (kind) {
+      case AGGREGATE_SUM, AGGREGATE_AVG -> {
+        contributingValues.remove(rid);
+        refoldSum();
+      }
+      case AGGREGATE_MIN, AGGREGATE_MAX -> {
+        var wasExtremum = rid.equals(extremumRid);
+        contributingValues.remove(rid);
+        if (wasExtremum) {
+          recomputeExtremum();
+        }
+      }
+      case AGGREGATE_COUNT_DISTINCT -> {
+        var oldKey = contributingValues.remove(rid);
+        removeFromBucket(oldKey, rid);
+      }
+      default -> throw new IllegalStateException("removeContributor on non-value kind " + kind);
+    }
+  }
+
+  /** T->T value change of an existing contributor: update per-RID value and re-derive the scalar. */
+  private void updateContributor(@Nonnull RID rid, @Nonnull Object newValue) {
+    switch (kind) {
+      case AGGREGATE_SUM, AGGREGATE_AVG -> {
+        contributingValues.put(rid, newValue);
+        refoldSum();
+      }
+      case AGGREGATE_MIN, AGGREGATE_MAX -> {
+        var wasExtremum = rid.equals(extremumRid);
+        contributingValues.put(rid, newValue);
+        if (!wasExtremum) {
+          // A non-holder moved; it can only become the new extremum, never invalidate the old one.
+          if (currentScalar == null || beatsExtremum(newValue, currentScalar)) {
+            currentScalar = newValue;
+            extremumRid = rid;
+          }
+        } else if (staysInExtremumDirection(newValue, currentScalar)) {
+          // The holder moved further into (or stayed at) the extremum direction: it is still the
+          // extremum, only its value changed. O(1).
+          currentScalar = newValue;
+        } else {
+          // The holder moved away from the extremum direction; the new extremum is unknown without a
+          // scan over the remaining contributors. O(n).
+          recomputeExtremum();
+        }
+      }
+      case AGGREGATE_COUNT_DISTINCT -> {
+        var oldKey = contributingValues.put(rid, newValue);
+        if (oldKey != null && oldKey.equals(newValue)) {
+          // Same bucket in DISTINCT terms: nothing changes.
+          return;
+        }
+        removeFromBucket(oldKey, rid);
+        distinctBuckets.computeIfAbsent(newValue, k -> new HashSet<>()).add(rid);
+      }
+      default -> throw new IllegalStateException("updateContributor on non-value kind " + kind);
+    }
+  }
+
+  /**
+   * Re-folds the entire {@link #contributingValues} through {@link PropertyTypeInternal#increment}
+   * from a verbatim first-value seed, exactly as storage's SUM/AVG accumulate. A full re-fold (rather
+   * than an incremental add/subtract) is mandated by D19: {@code PropertyTypeInternal} exposes no
+   * symmetric subtract, and only re-folding from scratch reproduces storage's numeric-promotion and
+   * overflow behaviour bit-for-bit. Also recomputes {@link #count} (the AVG divisor).
+   */
+  private void refoldSum() {
+    Number acc = null;
+    var n = 0;
+    for (var v : contributingValues.values()) {
+      var num = (Number) v;
+      if (acc == null) {
+        // FIRST TIME: seed verbatim, matching SQLFunctionSum.sum's first-value branch.
+        acc = num;
+      } else {
+        acc = PropertyTypeInternal.increment(acc, num);
+      }
+      n++;
+    }
+    sumAccumulator = acc;
+    count = n;
+  }
+
+  /** Recomputes the MIN/MAX extremum by scanning {@link #contributingValues}. O(n). */
+  private void recomputeExtremum() {
+    currentScalar = null;
+    extremumRid = null;
+    for (var e : contributingValues.entrySet()) {
+      var value = e.getValue();
+      if (currentScalar == null || beatsExtremum(value, currentScalar)) {
+        currentScalar = value;
+        extremumRid = e.getKey();
+      }
+    }
+  }
+
+  /** Removes {@code rid} from {@code key}'s distinct bucket, dropping the bucket when it empties. */
+  private void removeFromBucket(@Nullable Object key, @Nonnull RID rid) {
+    if (key == null) {
+      return;
+    }
+    var bucket = distinctBuckets.get(key);
+    if (bucket != null) {
+      bucket.remove(rid);
+      if (bucket.isEmpty()) {
+        distinctBuckets.remove(key);
+      }
+    }
+  }
+
+  /**
+   * Whether {@code candidate} beats {@code current} in this kind's extremum direction (MAX: strictly
+   * greater; MIN: strictly less). Cross-{@code Number}-subtype comparison goes through {@code
+   * PropertyTypeInternal.castComparableNumber} first, exactly as {@code SQLFunctionMin}/{@code
+   * SQLFunctionMax} do, so e.g. {@code Integer} vs {@code Long} compares numerically.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private boolean beatsExtremum(@Nonnull Object candidate, @Nonnull Object current) {
+    var c = candidate;
+    var cur = current;
+    if (c instanceof Number && cur instanceof Number) {
+      var casted = PropertyTypeInternal.castComparableNumber((Number) c, (Number) cur);
+      c = casted[0];
+      cur = casted[1];
+    }
+    var cmp = ((Comparable) c).compareTo(cur);
+    return kind == CacheableShape.AGGREGATE_MAX ? cmp > 0 : cmp < 0;
+  }
+
+  /**
+   * Whether {@code newValue} keeps the holder at-or-beyond the current extremum in its direction (MAX:
+   * {@code new >= old}; MIN: {@code new <= old}). When true the holder is still the extremum and the
+   * scalar can be updated in O(1); when false the holder lost the extremum and a rescan is needed.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private boolean staysInExtremumDirection(@Nonnull Object newValue, @Nonnull Object oldExtremum) {
+    var nv = newValue;
+    var oe = oldExtremum;
+    if (nv instanceof Number && oe instanceof Number) {
+      var casted = PropertyTypeInternal.castComparableNumber((Number) nv, (Number) oe);
+      nv = casted[0];
+      oe = casted[1];
+    }
+    var cmp = ((Comparable) nv).compareTo(oe);
+    return kind == CacheableShape.AGGREGATE_MAX ? cmp >= 0 : cmp <= 0;
+  }
+
+  /** The number of tracked contributors for the cap check; COUNT(*) uses its own RID set. */
+  private int trackedSize() {
+    if (kind == CacheableShape.AGGREGATE_COUNT) {
+      return contributingRids.size();
+    }
+    // For every value aggregate (including COUNT_DISTINCT, whose bucket map carries at most one entry
+    // per contributing RID) contributingValues is the authoritative, largest collection to bound.
+    return contributingValues.size();
+  }
+
+  /**
+   * Fires the one-shot overflow callback the first time a tracked collection crosses the cap. The
+   * cache reacts by removing the entry and routing the key non-cacheable; the in-flight populate still
+   * completes (the populating view holds the entry directly), so the result is served once but never
+   * retained for reuse.
+   */
+  private void checkOverflow(int size) {
+    if (!overflowed && size > maxContributors) {
+      overflowed = true;
+      if (onOverflow != null) {
+        onOverflow.run();
+      }
+    }
+  }
+
+  /**
+   * A deep-enough copy for replay: a fresh {@code AggregateState} with new mutable containers (so
+   * {@link #applyMutation} on the copy never disturbs the entry's seeded state) but reuse of the
+   * underlying immutable RID, {@code Number}, and bucket-key references. The overflow guard is NOT
+   * copied: the cap fires only during populate ({@link #observe}); a delta-build copy never observes
+   * new contributors, only replays a bounded set of mutations.
+   */
+  @Nonnull
+  public AggregateState copy() {
+    var c = new AggregateState(kind, propertyName, alias);
+    c.contributingRids.addAll(contributingRids);
+    c.contributingValues.putAll(contributingValues);
+    c.sumAccumulator = sumAccumulator;
+    c.count = count;
+    c.currentScalar = currentScalar;
+    c.extremumRid = extremumRid;
+    for (var e : distinctBuckets.entrySet()) {
+      c.distinctBuckets.put(e.getKey(), new HashSet<>(e.getValue()));
+    }
+    return c;
+  }
+
+  /**
+   * The single scalar row this aggregate produces, shaped like the original execution's output: one
+   * property under the projection {@link #alias} carrying the finalised scalar. SUM over an empty set
+   * is {@code 0} (matching {@code SQLFunctionSum.getResult}); COUNT is the contributor count;
+   * COUNT(DISTINCT) is the live bucket count; AVG finalises through the same type-dispatched division
+   * storage uses; MIN/MAX is the current extremum (null when no contributor remains).
+   */
+  @Nonnull
+  public Result toResult(@Nullable DatabaseSessionEmbedded session) {
+    var row = new ResultInternal(session, 1);
+    row.setProperty(alias, scalar());
+    return row;
+  }
+
+  /** The finalised scalar value per kind (the value {@link #toResult} stores under the alias). */
+  @Nullable private Object scalar() {
+    return switch (kind) {
+      case AGGREGATE_COUNT -> (long) contributingRids.size();
+      case AGGREGATE_COUNT_DISTINCT -> (long) distinctBuckets.size();
+      // SQLFunctionSum.getResult returns 0 (an int) for an empty sum, not null; match it exactly.
+      case AGGREGATE_SUM -> sumAccumulator == null ? 0 : sumAccumulator;
+      case AGGREGATE_AVG -> computeAverage(sumAccumulator, count);
+      case AGGREGATE_MIN, AGGREGATE_MAX -> currentScalar;
+      default -> throw new IllegalStateException("scalar() on non-aggregate kind " + kind);
+    };
+  }
+
+  /**
+   * Finalises AVG with the same type-dispatched division {@code SQLFunctionAverage.computeAverage}
+   * performs (that method is private to the function, so the storage-parity logic is reproduced here
+   * verbatim — integer truncation for Integer/Long, float/double division, BigDecimal {@code
+   * HALF_UP}). Returns {@code null} for an empty set, matching {@code computeAverage(null, 0)}.
+   */
+  @Nullable private static Object computeAverage(@Nullable Number sum, int total) {
+    if (sum instanceof Integer) {
+      return sum.intValue() / total;
+    } else if (sum instanceof Long) {
+      return sum.longValue() / total;
+    } else if (sum instanceof Float) {
+      return sum.floatValue() / total;
+    } else if (sum instanceof Double) {
+      return sum.doubleValue() / total;
+    } else if (sum instanceof BigDecimal bd) {
+      return bd.divide(new BigDecimal(total), RoundingMode.HALF_UP);
+    }
+    return null;
+  }
+
+  // ---- Test / inspection accessors (package-private; the replay path uses the methods above) ----
+
+  @Nullable Number getSumAccumulator() {
+    return sumAccumulator;
+  }
+
+  int getCount() {
+    return count;
+  }
+
+  @Nullable RID getExtremumRid() {
+    return extremumRid;
+  }
+
+  Set<RID> getContributingRids() {
+    return contributingRids;
+  }
+
+  Map<RID, Object> getContributingValues() {
+    return contributingValues;
+  }
+
+  Map<Object, Set<RID>> getDistinctBuckets() {
+    return distinctBuckets;
+  }
+
+  boolean isOverflowed() {
+    return overflowed;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CacheKey.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CacheKey.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLStatement;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CacheableShape.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CacheableShape.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedEntry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedEntry.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedEntry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedEntry.java
@@ -76,6 +76,14 @@ public final class CachedEntry {
   /** Mutation version captured before the populating execution started (D21 anchor). */
   private final long populateMutationVersion;
 
+  /**
+   * The aggregate replay state for an {@code AGGREGATE_*} entry, seeded by the side-tap at populate and
+   * copied-then-replayed per view by {@link DeltaBuilder#buildForAggregate}. {@code null} for every
+   * non-aggregate shape (RECORD / K0_NONE / MATCH), which reconcile through {@link #results} and a
+   * {@link TxDeltaCursor} instead. Set once at cache-put by the aggregate eager-drive path.
+   */
+  @Nullable private AggregateState aggregateState;
+
   // Lazy-populate machinery: the live stream + its plan/context, nulled on close/exhaustion.
   @Nullable private ExecutionStream stream;
 
@@ -174,6 +182,20 @@ public final class CachedEntry {
 
   public long getPopulateMutationVersion() {
     return populateMutationVersion;
+  }
+
+  /**
+   * The aggregate replay state for an {@code AGGREGATE_*} entry, or {@code null} for any other shape.
+   * {@link DeltaBuilder#buildForAggregate} copies it and replays the post-populate mutations onto the
+   * copy; {@link CachedResultSetView} returns the copy's {@link AggregateState#toResult}.
+   */
+  @Nullable public AggregateState getAggregateState() {
+    return aggregateState;
+  }
+
+  /** Sets the aggregate replay state at cache-put for an {@code AGGREGATE_*} entry. */
+  public void setAggregateState(@Nullable AggregateState aggregateState) {
+    this.aggregateState = aggregateState;
   }
 
   @Nullable public ExecutionStream getStream() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedResultSetView.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedResultSetView.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedResultSetView.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/CachedResultSetView.java
@@ -33,6 +33,12 @@ import javax.annotation.Nullable;
  * view replays {@link CachedEntry#getResults()} directly, lazy-pulling the stream tail with no skip-set
  * filtering, exactly as a non-cached re-run of that deterministic plan would.
  *
+ * <p><b>Aggregate path (single scalar row).</b> An {@code AGGREGATE_*} entry carries no cache cursor
+ * and no stream to pull: the side-tap already drove the populating plan to exhaustion at cache-put, so
+ * the per-RID material lives entirely in the entry's {@link AggregateState}. The view carries the
+ * replayed delta copy ({@link DeltaBuilder#buildForAggregate}) and emits exactly one row, {@link
+ * AggregateState#toResult}, then drains. {@code hasNext()} is true once.
+ *
  * <p><b>Stream-pull unification.</b> Both paths share one {@link #pullOneFromStream} helper. On the
  * RECORD path it drops any pulled row whose RID is in the delta skip-set (closing the lazy-pull gap:
  * a mutated RID living beyond the cached prefix must not surface from storage with stale state); on the
@@ -64,8 +70,17 @@ public final class CachedResultSetView implements ResultSet {
 
   private final CachedEntry entry;
 
-  /** Null for K0_NONE (direct replay); non-null for RECORD (sorted-merge). */
+  /** Null for K0_NONE (direct replay) and aggregate; non-null for RECORD (sorted-merge). */
   @Nullable private final TxDeltaCursor delta;
+
+  /**
+   * Non-null for an {@code AGGREGATE_*} view: the replayed {@link AggregateState} copy whose {@link
+   * AggregateState#toResult} is the view's single output row. Null for every other shape.
+   */
+  @Nullable private final AggregateState aggregateDelta;
+
+  /** True once the aggregate view has emitted its single scalar row; then the view is drained. */
+  private boolean aggregateEmitted;
 
   @Nullable private DatabaseSessionEmbedded session;
 
@@ -102,8 +117,38 @@ public final class CachedResultSetView implements ResultSet {
       @Nonnull FrontendTransactionImpl tx,
       @Nullable InternalExecutionPlan executionPlan,
       @Nonnull CommandContext ctx) {
+    this(entry, delta, null, session, tx, executionPlan, ctx);
+  }
+
+  /**
+   * Aggregate-shape factory: the view carries a replayed {@link AggregateState} copy instead of a
+   * {@link TxDeltaCursor} and emits its single {@link AggregateState#toResult} row. A static factory
+   * (rather than an overloaded constructor) keeps the {@code TxDeltaCursor}-arg constructor the only
+   * one of its arity, so a {@code null} delta on the record/K0 path stays unambiguous. The pin and the
+   * cache-code-guard lifetime are identical to the record/K0 path.
+   */
+  @Nonnull
+  public static CachedResultSetView forAggregate(
+      @Nonnull CachedEntry entry,
+      @Nonnull AggregateState aggregateDelta,
+      @Nullable DatabaseSessionEmbedded session,
+      @Nonnull FrontendTransactionImpl tx,
+      @Nullable InternalExecutionPlan executionPlan,
+      @Nonnull CommandContext ctx) {
+    return new CachedResultSetView(entry, null, aggregateDelta, session, tx, executionPlan, ctx);
+  }
+
+  private CachedResultSetView(
+      @Nonnull CachedEntry entry,
+      @Nullable TxDeltaCursor delta,
+      @Nullable AggregateState aggregateDelta,
+      @Nullable DatabaseSessionEmbedded session,
+      @Nonnull FrontendTransactionImpl tx,
+      @Nullable InternalExecutionPlan executionPlan,
+      @Nonnull CommandContext ctx) {
     this.entry = entry;
     this.delta = delta;
+    this.aggregateDelta = aggregateDelta;
     this.session = session;
     this.tx = tx;
     this.executionPlan = executionPlan;
@@ -143,14 +188,30 @@ public final class CachedResultSetView implements ResultSet {
   }
 
   /**
-   * Produces the next merged row, or {@code null} when both the cache cursor and the delta cursor are
-   * exhausted. K0_NONE routes to a delta-free replay; RECORD runs the sorted-merge.
+   * Produces the next merged row, or {@code null} when the view is drained. Aggregate emits its single
+   * scalar row once; K0_NONE routes to a delta-free replay; RECORD runs the sorted-merge.
    */
   @Nullable private Result computeNext() {
+    if (aggregateDelta != null) {
+      return computeNextAggregate();
+    }
     if (delta == null) {
       return computeNextK0None();
     }
     return computeNextRecord();
+  }
+
+  /**
+   * Aggregate single-row emit: returns the replayed {@link AggregateState#toResult} the first time and
+   * {@code null} thereafter, so {@code hasNext()} is true exactly once. There is no stream to pull and
+   * no cache cursor; the scalar was fully computed at delta build.
+   */
+  @Nullable private Result computeNextAggregate() {
+    if (aggregateEmitted) {
+      return null;
+    }
+    aggregateEmitted = true;
+    return aggregateDelta.toResult(session);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/DeltaBuilder.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/DeltaBuilder.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/DeltaBuilder.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/DeltaBuilder.java
@@ -196,4 +196,69 @@ public final class DeltaBuilder {
 
     return new TxDeltaCursor(sharedSkipSet, sharedInjectList);
   }
+
+  /**
+   * Builds the aggregate-shape replay state for {@code entry} against the transaction's current
+   * mutation state. Copies the entry's seeded {@link AggregateState} (so the entry's populate-time
+   * state is never disturbed) and replays every post-populate mutation onto the copy, then returns the
+   * copy for the view to finalise through {@link AggregateState#toResult}.
+   *
+   * <p><b>Populate-version filter (D21).</b> Like {@link #buildForRecord}, only operations whose
+   * {@link RecordOperation#version} exceeds {@link CachedEntry#getPopulateMutationVersion()} enter the
+   * replay: pre-populate mutations were already observed by the side-tap at populate and are baked into
+   * the seeded state, so replaying them would double-apply.
+   *
+   * <p><b>Class filter.</b> Non-Entity records and entities outside the query's class closure cannot
+   * contribute to this aggregate and are skipped, mirroring the record path.
+   *
+   * <p><b>Membership dispatch (D21 collapse safety).</b> {@link AggregateState#applyMutation} derives
+   * its transition from cache membership and {@code matchAfter}, not from the operation type, so a
+   * collapsed pre-populate CREATE that the version filter admits is reconciled correctly. {@code
+   * matchAfter} re-evaluates the entry's WHERE against the post-mutation record using the original
+   * query's context, so {@code :param} bindings resolve identically to the populating execution.
+   *
+   * <p>Unlike the record path, the aggregate state is not cross-view cached on the entry: a single
+   * call produces a fresh copy per view. Aggregate views are not consumer-paced (the scalar is fully
+   * computed at build), so there is no pause/resume to share.
+   *
+   * @param entry the cached {@code AGGREGATE_*} entry whose seeded state to reconcile
+   * @param tx    the active transaction whose {@code recordOperations} carry the post-populate deltas
+   * @param ctx   the original query's command context, reused so WHERE {@code :param} bindings resolve
+   *              identically to the populating execution
+   */
+  @Nonnull
+  public static AggregateState buildForAggregate(
+      @Nonnull CachedEntry entry,
+      @Nonnull FrontendTransactionImpl tx,
+      @Nonnull CommandContext ctx) {
+    final var seeded = entry.getAggregateState();
+    // An AGGREGATE_* entry always carries a seeded state from the eager-drive populate; a null here is
+    // a wiring bug (a non-aggregate entry routed to this builder). Assert it (no-op without -ea) so the
+    // contract violation fails loudly in tests rather than NPEing mid-replay.
+    assert seeded != null : "buildForAggregate on an entry with no aggregateState";
+    final var deltaState = seeded.copy();
+
+    final var effectiveFromClasses = entry.getEffectiveFromClasses();
+    final var whereClause = entry.getWhereClause();
+    for (final var op : tx.getRecordOperationsInternal()) {
+      if (op.version <= entry.getPopulateMutationVersion()) {
+        // Already observed by the populate-time side-tap and baked into the seeded state.
+        continue;
+      }
+      final var record = op.record;
+      if (!(record instanceof Entity entity)) {
+        continue;
+      }
+      final var className = entity.getSchemaClassName();
+      if (className == null || !effectiveFromClasses.contains(className)) {
+        continue;
+      }
+      // matchAfter carries WHERE-membership only; the new value for a still-contributing record is read
+      // from the mutated record inside applyMutation. A null WHERE matches every record.
+      final var matchAfter = whereClause == null || whereClause.matchesFilters(record, ctx);
+      deltaState.applyMutation(record, op.type, matchAfter);
+    }
+
+    return deltaState;
+  }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/IdempotentExecutionStream.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/IdempotentExecutionStream.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/NonDeterministicQueryDetector.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/NonDeterministicQueryDetector.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.sql.parser.Node;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryCacheMetrics.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryCacheMetrics.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryCacheMetrics.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryCacheMetrics.java
@@ -1,14 +1,25 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.CoreMetrics;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricDefinition;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricScope.Global;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.MetricsRegistry;
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.TimeRate;
+import com.jetbrains.youtrackdb.internal.core.YouTrackDBEnginesManager;
+
 /**
  * Per-transaction counter holder for the tx-result cache. Lives on the cache instance owned by a
  * single {@code FrontendTransactionImpl}, so it observes only the owning thread and needs no
  * synchronisation: plain {@code long} fields suffice.
  *
- * <p>The counters are cumulative for the lifetime of the transaction and are discarded with it.
- * Later steps wire the increments at the lookup/put/eviction sites; this step establishes the
- * holder and its API so the cache classes can reference it without forward declarations. No call
- * site increments any counter yet.
+ * <p>The counters are cumulative for the lifetime of the transaction and are discarded with it. Each
+ * {@code increment*} call also feeds the matching engine-global {@link CoreMetrics} rate, so the
+ * per-transaction counters and the cross-transaction rate-per-second metrics stay derived from the
+ * same events — the global metric is the rolling rate of the per-tx increments, not a separate
+ * counting path. The global sinks are resolved once at construction from the {@link MetricsRegistry};
+ * when the registry is unavailable (for example before the profiler is initialised, or in a unit test
+ * with no engine running) each sink falls back to {@link TimeRate#NOOP} and only the per-tx counter
+ * advances.
  *
  * <ul>
  *   <li>{@code hits} — lookups that returned a usable cached entry.
@@ -30,24 +41,84 @@ public final class QueryCacheMetrics {
   private long k0Invalidations;
   private long overflows;
 
+  /**
+   * Engine-global rate sinks, one per counter, resolved once from the {@link MetricsRegistry}. Each is
+   * {@link TimeRate#NOOP} when no registry is available, so an increment is always safe to record.
+   */
+  private final TimeRate hitRate;
+  private final TimeRate missRate;
+  private final TimeRate spliceFailureRate;
+  private final TimeRate k0InvalidationRate;
+  private final TimeRate overflowRate;
+
+  public QueryCacheMetrics() {
+    this(YouTrackDBEnginesManager.instance().getMetricsRegistry());
+  }
+
+  /**
+   * Resolves the five global rate sinks from {@code registry} (or {@link TimeRate#NOOP} when it is
+   * null). Package-visible so a test can pass a registry built on a deterministic ticker and assert the
+   * bridge records into the global metric, without standing up a full engine.
+   */
+  QueryCacheMetrics(MetricsRegistry registry) {
+    this(
+        globalRate(registry, CoreMetrics.QUERY_CACHE_HIT_RATE),
+        globalRate(registry, CoreMetrics.QUERY_CACHE_MISS_RATE),
+        globalRate(registry, CoreMetrics.QUERY_CACHE_SPLICE_FAILURE_RATE),
+        globalRate(registry, CoreMetrics.QUERY_CACHE_K0_INVALIDATION_RATE),
+        globalRate(registry, CoreMetrics.QUERY_CACHE_OVERFLOW_RATE));
+  }
+
+  /**
+   * Direct-injection constructor for the five global rate sinks. Package-visible so a test can pass
+   * recording stubs and assert each {@code increment*} call feeds the matching sink exactly once.
+   */
+  QueryCacheMetrics(
+      TimeRate hitRate,
+      TimeRate missRate,
+      TimeRate spliceFailureRate,
+      TimeRate k0InvalidationRate,
+      TimeRate overflowRate) {
+    this.hitRate = hitRate;
+    this.missRate = missRate;
+    this.spliceFailureRate = spliceFailureRate;
+    this.k0InvalidationRate = k0InvalidationRate;
+    this.overflowRate = overflowRate;
+  }
+
+  /**
+   * Resolves the global {@link TimeRate} for {@code definition}, or {@link TimeRate#NOOP} when the
+   * registry is null (profiler not initialised, or a test with no running engine). Mirrors the
+   * registry-null guard the other global-metric consumers (e.g. {@code EdgeTraversal}) use.
+   */
+  private static TimeRate globalRate(
+      MetricsRegistry registry, MetricDefinition<Global, TimeRate> definition) {
+    return registry != null ? registry.globalMetric(definition) : TimeRate.NOOP;
+  }
+
   public void incrementHits() {
     hits++;
+    hitRate.record();
   }
 
   public void incrementMisses() {
     misses++;
+    missRate.record();
   }
 
   public void incrementSpliceFailures() {
     spliceFailures++;
+    spliceFailureRate.record();
   }
 
   public void incrementK0Invalidations() {
     k0Invalidations++;
+    k0InvalidationRate.record();
   }
 
   public void incrementOverflows() {
     overflows++;
+    overflowRate.record();
   }
 
   public long getHits() {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryResultCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryResultCache.java
@@ -251,6 +251,36 @@ public final class QueryResultCache {
     }
   }
 
+  /**
+   * Installs the aggregate contributor cap and a one-shot overflow callback on {@code state}, mirroring
+   * the per-entry record cap {@link #put} installs on a {@link CachedEntry}. The cap bounds the
+   * aggregate's per-contributor collections (not its single-scalar {@code results}); the callback fires
+   * the first time {@link AggregateState#observe} crosses {@code maxRecordsPerEntry} during the eager
+   * populate drive, routing {@code key} non-cacheable and counting an overflow. Unlike the record cap,
+   * the entry is not yet in the map at populate-time overflow (the cache-put happens after the drive), so
+   * the callback adds the key directly rather than removing a mapped entry; a later {@link #put} of that
+   * now-overflowed key is a no-op (the {@link #nonCacheableKeys} guard in {@code put} closes it).
+   */
+  public void installAggregateOverflowGuard(
+      @Nonnull CacheKey key, @Nonnull AggregateState state) {
+    state.setOverflowGuard(maxRecordsPerEntry, () -> {
+      // Idempotent on the key: nonCacheableKeys is a Set and the metric counts once because the state's
+      // own one-shot latch fires this callback at most once per populate.
+      nonCacheableKeys.add(key);
+      metrics.incrementOverflows();
+    });
+  }
+
+  /**
+   * Counts an aggregate-splice fallback: a miss whose populating plan had no {@code
+   * AggregateProjectionCalculationStep} to splice the side-tap above (e.g. a hardwired {@code
+   * CountFromClassStep}, or any unexpected plan shape), so the query ran uncached. Routes through the
+   * metric bridge to the global splice-failure rate.
+   */
+  public void incrementSpliceFailures() {
+    metrics.incrementSpliceFailures();
+  }
+
   /** Number of live cache entries. */
   public int size() {
     return entries.size();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryResultCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryResultCache.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifier.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifier.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.sql.parser.Node;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLFunctionCall;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchStatement;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMathExpression;
@@ -11,6 +12,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLStatement;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SimpleNode;
 import java.util.Locale;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Maps a parsed statement to the {@link CacheableShape} that drives its delta-reconciliation path.
@@ -51,6 +53,81 @@ import javax.annotation.Nonnull;
 public final class ShapeClassifier {
 
   private ShapeClassifier() {
+  }
+
+  /**
+   * The per-shape facts the aggregate cache-miss path needs to build an {@link AggregateState} and shape
+   * its output row: the {@code AGGREGATE_*} {@code kind}, the {@code propertyName} the value aggregate
+   * reads from each contributing record ({@code null} for {@code COUNT(*)}, which reads no value), and
+   * the {@code alias} the single scalar row carries (the projection alias the aggregation step emits).
+   */
+  public record AggregateMetadata(
+      @Nonnull CacheableShape kind, @Nullable String propertyName, @Nonnull String alias) {
+
+  }
+
+  /**
+   * Returns the {@link AggregateMetadata} for a statement the aggregate cache miss path can populate, or
+   * {@code null} when the statement is not a cacheable single-aggregate shape. The kind matches {@link
+   * #classify} exactly: this method returns non-null precisely for the statements {@code classify}
+   * returns an {@code AGGREGATE_*} shape for, so a caller that already gated on the shape can derive the
+   * metadata without re-classifying. {@code COUNT(DISTINCT prop)} returns {@code null} (it classifies
+   * {@code K0_NONE} and never reaches the aggregate path), as do bare {@code COUNT(*)} and every
+   * non-aggregate shape.
+   */
+  @Nullable public static AggregateMetadata aggregateMetadata(@Nonnull SQLSelectStatement select) {
+    var shape = classify(select);
+    if (!isAggregateKind(shape)) {
+      return null;
+    }
+    var item = select.getProjection().getItems().getFirst();
+    var call = rootAggregateCall(item);
+    if (call == null) {
+      // classify already proved this is a clean single-aggregate item, so the call is always present;
+      // the guard keeps the derivation total in the face of a future classify/derive divergence.
+      return null;
+    }
+    var alias = item.getProjectionAlias().getStringValue();
+    var propertyName = call.isStar() ? null : baseIdentifierArg(call);
+    return new AggregateMetadata(shape, propertyName, alias);
+  }
+
+  private static boolean isAggregateKind(@Nonnull CacheableShape shape) {
+    return shape == CacheableShape.AGGREGATE_COUNT
+        || shape == CacheableShape.AGGREGATE_SUM
+        || shape == CacheableShape.AGGREGATE_AVG
+        || shape == CacheableShape.AGGREGATE_MIN
+        || shape == CacheableShape.AGGREGATE_MAX
+        || shape == CacheableShape.AGGREGATE_COUNT_DISTINCT;
+  }
+
+  /**
+   * The property name a single-argument value aggregate reads, when its argument is a bare property
+   * reference ({@code SUM(price)} &rarr; {@code price}); {@code null} for anything else (no argument, a
+   * computed-expression argument, multiple arguments). A computed or multi-argument aggregate classifies
+   * {@code K0_NONE} upstream, so a {@code null} here on a shape that reached the aggregate path means the
+   * caller falls back to uncached execution.
+   */
+  @Nullable private static String baseIdentifierArg(@Nonnull SQLFunctionCall call) {
+    var params = call.getParams();
+    if (params == null || params.size() != 1) {
+      return null;
+    }
+    return basePropertyName(params.getFirst());
+  }
+
+  /**
+   * The bare property name an aggregate argument expression refers to, or {@code null} when the argument
+   * is anything other than a single base identifier. {@code SQLExpression.getDefaultAlias} yields the
+   * identifier text for a base-property expression (e.g. {@code price}); a computed expression has no
+   * such base alias and yields {@code null}.
+   */
+  @Nullable private static String basePropertyName(@Nonnull SQLExpression arg) {
+    var defaultAlias = arg.getDefaultAlias();
+    if (defaultAlias == null) {
+      return null;
+    }
+    return defaultAlias.getStringValue();
   }
 
   public static CacheableShape classify(@Nonnull SQLStatement statement) {
@@ -135,6 +212,15 @@ public final class ShapeClassifier {
       return null;
     }
     var shape = aggregateShapeForCall(call);
+    if (shape == CacheableShape.AGGREGATE_COUNT && isDistinct(call)) {
+      // COUNT(DISTINCT prop) is routed to K0_NONE rather than a distinct-count aggregate shape: the
+      // engine has no native distinct-count and computes count(distinct(prop)) as a plain row count, so
+      // the K0 version gate (re-execute on any mutation) already reproduces the engine's result exactly,
+      // and modelling a true distinct-count in the aggregate replay would diverge from that native
+      // semantics. The AggregateState COUNT_DISTINCT machinery is retained for a future engine with a
+      // true distinct-count, but no production path reaches it in v1.
+      return CacheableShape.K0_NONE;
+    }
     if (shape == CacheableShape.AGGREGATE_COUNT && call.isStar() && !hasWhereClause) {
       // Bare COUNT(*) FROM C (no WHERE) is hardwired in the planner to a CountFromClassStep before any
       // AggregateProjectionCalculationStep is built, so the aggregate side-tap can never reach it.
@@ -227,10 +313,12 @@ public final class ShapeClassifier {
   }
 
   /**
-   * Maps a recognised aggregate function name to its shape. {@code COUNT(DISTINCT prop)} is the
-   * count-distinct shape; a non-DISTINCT count is {@code AGGREGATE_COUNT}. {@code SUM/AVG/MIN/MAX}
-   * map directly. Any other function name (a non-aggregate scalar like {@code lower(name)}, or an
-   * aggregate this foundation does not model such as {@code median}) returns {@code null}.
+   * Maps a recognised aggregate function name to its shape. Every {@code count} (DISTINCT or not) maps
+   * to {@code AGGREGATE_COUNT} here; the DISTINCT form is split off to {@code K0_NONE} by {@link
+   * #singleAggregateShape}, while keeping the name recognised so {@link #projectionContainsAggregate}
+   * still treats it as an aggregate. {@code SUM/AVG/MIN/MAX} map directly. Any other function name (a
+   * non-aggregate scalar like {@code lower(name)}, or an aggregate this foundation does not model such
+   * as {@code median}) returns {@code null}.
    */
   private static CacheableShape aggregateShapeForCall(@Nonnull SQLFunctionCall call) {
     var name = call.getName();
@@ -239,8 +327,7 @@ public final class ShapeClassifier {
     }
     var lower = name.getStringValue().toLowerCase(Locale.ROOT);
     return switch (lower) {
-      case "count" -> isDistinct(call) ? CacheableShape.AGGREGATE_COUNT_DISTINCT
-          : CacheableShape.AGGREGATE_COUNT;
+      case "count" -> CacheableShape.AGGREGATE_COUNT;
       case "sum" -> CacheableShape.AGGREGATE_SUM;
       case "avg" -> CacheableShape.AGGREGATE_AVG;
       case "min" -> CacheableShape.AGGREGATE_MIN;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifier.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifier.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.Node;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLFunctionCall;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMatchStatement;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMathExpression;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLProjection;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLProjectionItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLSelectStatement;
@@ -30,9 +31,12 @@ import javax.annotation.Nonnull;
  *       no LET, no UNWIND, a class (not subquery) target, and no aggregate function anywhere in its
  *       projection. Its rows are individual records the delta builder reconciles one at a time.
  *   <li><b>Single-aggregate SELECT &rarr; {@code AGGREGATE_*}.</b> A SELECT whose single projection
- *       item is one of the recognised scalar aggregates over a plain property. The classifier returns
- *       the final {@code AGGREGATE_*} value, but the aggregate delta path lands in a later track, so
- *       the session bypasses these (uncached) for now.
+ *       item is exactly one of the recognised scalar aggregates over a plain property, with no
+ *       arithmetic applied. An aggregate buried under arithmetic ({@code count(*) + 1}) is not the bare
+ *       scalar the replay path produces and routes to {@code K0_NONE} instead. Bare {@code COUNT(*)
+ *       FROM C} (no WHERE) is hardwired in the planner to an O(1) {@code CountFromClassStep} that the
+ *       aggregate side-tap can never reach, so it also routes to {@code K0_NONE}; a {@code COUNT(*)}
+ *       with a (non-indexed) WHERE does build the aggregation step and stays {@code AGGREGATE_COUNT}.
  *   <li><b>MATCH &rarr; {@link CacheableShape#MATCH_TUPLE_MULTI}.</b> Returned for any MATCH
  *       statement here; the MATCH delta path and the single-alias RECORD-fold (Etap A) land in a
  *       later track, so the session bypasses these for now.
@@ -82,7 +86,7 @@ public final class ShapeClassifier {
       return CacheableShape.K0_NONE;
     }
 
-    var aggregate = singleAggregateShape(select.getProjection());
+    var aggregate = singleAggregateShape(select.getProjection(), select.getWhereClause() != null);
     if (aggregate != null) {
       return aggregate;
     }
@@ -112,8 +116,13 @@ public final class ShapeClassifier {
    * aggregate over a plain property (or {@code COUNT(*)}), otherwise {@code null}. A projection with
    * more than one item, or an aggregate wrapping an expression, is not a clean single-aggregate shape
    * and returns {@code null} so the caller can route it to RECORD or K0_NONE as appropriate.
+   *
+   * <p>{@code hasWhereClause} distinguishes the bare {@code COUNT(*) FROM C} shape (hardwired and
+   * untappable, routed to K0_NONE) from {@code COUNT(*) FROM C WHERE non-indexed-predicate} (which
+   * builds the aggregation step and is tappable, so it stays {@code AGGREGATE_COUNT}).
    */
-  private static CacheableShape singleAggregateShape(SQLProjection projection) {
+  private static CacheableShape singleAggregateShape(SQLProjection projection,
+      boolean hasWhereClause) {
     if (projection == null) {
       return null;
     }
@@ -121,26 +130,82 @@ public final class ShapeClassifier {
     if (items == null || items.size() != 1) {
       return null;
     }
-    var call = topLevelFunctionCall(items.getFirst());
+    var call = rootAggregateCall(items.getFirst());
     if (call == null) {
       return null;
     }
-    return aggregateShapeForCall(call);
+    var shape = aggregateShapeForCall(call);
+    if (shape == CacheableShape.AGGREGATE_COUNT && call.isStar() && !hasWhereClause) {
+      // Bare COUNT(*) FROM C (no WHERE) is hardwired in the planner to a CountFromClassStep before any
+      // AggregateProjectionCalculationStep is built, so the aggregate side-tap can never reach it.
+      // It is already O(1) and transaction-aware, so caching adds nothing. Route it to K0_NONE so the
+      // untappable shape never enters the aggregate replay path. The single-field-indexed
+      // COUNT(*) ... WHERE indexedField = ? shape is also hardwired, but its detection needs index
+      // metadata the AST-only classifier cannot see, so that shape rides the aggregate splice fallback
+      // (the splice finds a CountFromClassStep, not an aggregation step, and falls back uncached).
+      return CacheableShape.K0_NONE;
+    }
+    return shape;
   }
 
   /**
-   * Returns the outermost (closest-to-root in pre-order) {@link SQLFunctionCall} in the projection
-   * item's subtree, or {@code null} if the item carries no function call. For a clean single-aggregate
-   * item such as {@code count(*)} or {@code count(distinct(name))}, this is the aggregate call itself;
-   * the caller then maps its name to a shape and inspects its arguments for the DISTINCT form. A
-   * function call buried under arithmetic (e.g. {@code count(*) + 1}) is also returned, but such a
-   * shape is bypassed (uncached) in this foundation regardless, so the looser match is harmless here.
+   * Returns the aggregate {@link SQLFunctionCall} when the projection item's expression is exactly one
+   * function call with no arithmetic applied, otherwise {@code null}. For a clean single-aggregate item
+   * such as {@code count(*)} or {@code count(distinct(name))}, this is the aggregate call itself; the
+   * caller then maps its name to a shape and inspects its arguments for the DISTINCT form.
+   *
+   * <p>An aggregate buried under arithmetic — {@code count(*) + 1}, {@code sum(price) * 2} — returns
+   * {@code null}: the arithmetic result is not the bare aggregate scalar the side-tap and {@code
+   * AggregateState} replay produce, so caching it as an {@code AGGREGATE_*} shape would replay the wrong
+   * value. Routing it to {@code null} here lets the caller fall through to the {@code
+   * projectionContainsAggregate} branch, which classifies it K0_NONE (deterministically reproducible,
+   * served only under the mutation-version gate). The descent rejects the item the moment it crosses a
+   * math node that applies an operator, so the arithmetic is detected without reading the (package-
+   * private) function-call leaf.
    */
-  private static SQLFunctionCall topLevelFunctionCall(SQLProjectionItem item) {
+  private static SQLFunctionCall rootAggregateCall(SQLProjectionItem item) {
     if (item == null) {
       return null;
     }
-    return firstFunctionCall(item);
+    var expression = item.getExpression();
+    if (expression == null) {
+      return null;
+    }
+    var math = expression.getMathExpression();
+    if (math == null) {
+      return null;
+    }
+    return rootCallWithoutArithmetic(math);
+  }
+
+  /**
+   * Descends a {@link SQLMathExpression}, returning the root {@link SQLFunctionCall} only when no
+   * arithmetic operator is applied anywhere on the path down to it. Any math node carrying a non-empty
+   * operator list (an actual {@code +}/{@code -}/{@code *}/... arithmetic combination) means the item is
+   * an expression over the aggregate, not the aggregate itself, so the method returns {@code null}.
+   * Single-operand wrapper math nodes (grammar artefacts with no operator) are transparently descended.
+   * Once the descent reaches a base expression (a {@link SQLMathExpression} that holds no further child
+   * math expressions), the JJTree subtree is scanned for the function call.
+   */
+  private static SQLFunctionCall rootCallWithoutArithmetic(SQLMathExpression math) {
+    var operators = math.getOperators();
+    if (operators != null && !operators.isEmpty()) {
+      // Arithmetic is applied at this level (e.g. count(*) + 1); this is not a bare aggregate.
+      return null;
+    }
+    var children = math.getChildExpressions();
+    if (children != null && children.size() == 1) {
+      // A single-child math node with no operator is a transparent wrapper; descend into it.
+      return rootCallWithoutArithmetic(children.getFirst());
+    }
+    if (children != null && children.size() > 1) {
+      // More than one operand without an operator should not occur, but if it does it is not a clean
+      // single aggregate; treat it conservatively as non-aggregate.
+      return null;
+    }
+    // Leaf base expression: its subtree holds the function call (if any) directly, with no arithmetic
+    // above it. firstFunctionCall finds count/sum/... and, for COUNT(DISTINCT), the outer count call.
+    return firstFunctionCall(math);
   }
 
   /** Pre-order search for the first {@link SQLFunctionCall} in {@code node}'s subtree. */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifier.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifier.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.sql.parser.Node;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/TxDeltaCursor.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/TxDeltaCursor.java
@@ -1,22 +1,3 @@
-/*
- *
- *
- *  *
- *  *  Licensed under the Apache License, Version 2.0 (the "License");
- *  *  you may not use this file except in compliance with the License.
- *  *  You may obtain a copy of the License at
- *  *
- *  *       http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  *  Unless required by applicable law or agreed to in writing, software
- *  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  *  See the License for the specific language governing permissions and
- *  *  limitations under the License.
- *  *
- *
- *
- */
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java
@@ -1,0 +1,513 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.core.db.record.RecordOperation;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.query.ResultSet;
+import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import java.util.function.Consumer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * End-to-end cache-vs-fresh equivalence for the {@code AGGREGATE_*} cache path (I4 / I10): every
+ * cacheable aggregate scenario runs twice through the live {@code query()} path — once with the cache
+ * off (a fresh uncached execution, the source of truth) and once with it on (forcing a side-tap
+ * populate, then a post-mutation second query served through the replayed {@link AggregateState} view)
+ * — and the two scalars are compared. Comparing against a parallel uncached run rather than a literal
+ * keeps the suite honest as the replay logic evolves.
+ *
+ * <p>The tappable shape is {@code SELECT <agg>(price) FROM C WHERE active = true}: a non-indexed WHERE
+ * forces the planner to build a real {@code AggregateProjectionCalculationStep} the side-tap can splice
+ * above, unlike the hardwired bare/indexed {@code COUNT(*)} forms. Per-kind cases (COUNT / SUM / AVG /
+ * MIN / MAX) cross the four mutation patterns and the D21 collapse case; separate cases pin the
+ * hardwired-COUNT(*) fallback, the {@code count(*) + 1} and {@code count(distinct(prop))} K0_NONE
+ * routings, the contributor-cap overflow, a cache hit on repeat, and the no-exception-leak fallback.
+ *
+ * <p>Run with {@code -ea}: the side-tap's null-RID guard and the buildForAggregate non-null-state
+ * assert are Java {@code assert}s that protect tests, not production.
+ */
+@Category(SequentialTest.class)
+public class AggregateCacheEquivalenceTest extends DbTestBase {
+
+  private static final String CLASS_NAME = "AggRec";
+  private static final String VALUE = "price";
+  private static final String FLAG = "active";
+
+  private boolean previousEnabled;
+
+  @Before
+  public void enableSchema() {
+    previousEnabled = GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.getValueAsBoolean();
+    var cls = session.createClass(CLASS_NAME);
+    cls.createProperty(VALUE, PropertyType.INTEGER);
+    cls.createProperty(FLAG, PropertyType.BOOLEAN);
+  }
+
+  @After
+  public void restoreFlag() {
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(previousEnabled);
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  private FrontendTransactionImpl tx() {
+    return (FrontendTransactionImpl) session.getTransactionInternal();
+  }
+
+  /** A tappable aggregate over the matching (active = true) records. */
+  private static String aggSql(String agg) {
+    return "SELECT " + agg + " FROM " + CLASS_NAME + " WHERE " + FLAG + " = true";
+  }
+
+  /**
+   * Clears every committed record of CLASS_NAME in its own tx with the cache forced off, so the flag-off
+   * and flag-on halves of a pair start from identical committed state and the clearing DELETE never
+   * touches the cache under test.
+   */
+  private void clearClass() {
+    var previous = GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.getValueAsBoolean();
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(false);
+    try {
+      session.begin();
+      session.command("DELETE FROM " + CLASS_NAME);
+      session.commit();
+    } finally {
+      GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(previous);
+    }
+  }
+
+  /** Commits one matching (active=true) record with the given value, returning its persistent RID. */
+  private RID commitMatching(int value) {
+    return commit(value, true);
+  }
+
+  private RID commit(int value, boolean active) {
+    session.begin();
+    var e = session.newEntity(CLASS_NAME);
+    e.setProperty(VALUE, value);
+    e.setProperty(FLAG, active);
+    var rid = ((RecordAbstract) e).getIdentity();
+    session.commit();
+    return rid;
+  }
+
+  /** The single scalar value the aggregate query emits (its lone projection), or null on empty. */
+  private static Object scalar(ResultSet rs) {
+    try (rs) {
+      if (!rs.hasNext()) {
+        return null;
+      }
+      Result row = rs.next();
+      var names = row.getPropertyNames();
+      return row.getProperty(names.iterator().next());
+    }
+  }
+
+  /**
+   * Seeds a fixed committed set of matching records, opens a tx, populates the cache with one aggregate
+   * query, applies {@code mutation} after populate, then captures the second query's scalar. Driven once
+   * per flag state; comparing the two captured scalars is the equivalence test.
+   */
+  private Object runScenario(boolean cacheEnabled, String agg, int[] matchingSeed,
+      Consumer<FrontendTransactionImpl> mutation) {
+    clearClass();
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(false);
+    for (var v : matchingSeed) {
+      commitMatching(v);
+    }
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(cacheEnabled);
+    var sql = aggSql(agg);
+
+    session.begin();
+    scalar(session.query(sql)); // populate (flag on) or plain execution (flag off)
+    mutation.accept(tx());
+    var result = scalar(session.query(sql)); // delta-replayed view (flag on) or fresh (flag off)
+    session.rollback();
+    return result;
+  }
+
+  private void assertEquivalent(String agg, int[] matchingSeed,
+      Consumer<FrontendTransactionImpl> mutation) {
+    var fresh = runScenario(false, agg, matchingSeed, mutation);
+    var cached = runScenario(true, agg, matchingSeed, mutation);
+    assertEquals(
+        "Cached aggregate replay must equal a fresh uncached execution at the same moment for "
+            + agg,
+        fresh, cached);
+  }
+
+  // The four mutation patterns, expressed against the tappable shape. CREATE and DELETE use the
+  // proven addRecordOperation staging; an UPDATE that breaks WHERE flips active=false; a value UPDATE
+  // changes price while staying matched. A loaded-record DELETE/UPDATE uses addRecordOperation because
+  // session.delete(session.load(rid)) on a record committed before the tx throws "not bound to current
+  // session" on the re-query (the addRecordOperation pattern is the proven one from the RECORD suite).
+
+  /** F->T add of a new matching record after populate. */
+  private Consumer<FrontendTransactionImpl> createMatching(int value) {
+    return t -> {
+      var e = session.newEntity(CLASS_NAME);
+      e.setProperty(VALUE, value);
+      e.setProperty(FLAG, true);
+    };
+  }
+
+  /** T->F drop: a WHERE-breaking UPDATE (active=false) on a pre-committed matching record. */
+  private Consumer<FrontendTransactionImpl> breakWhere(RID rid) {
+    return t -> {
+      Entity rec = session.load(rid);
+      rec.setProperty(FLAG, false);
+      t.addRecordOperation((RecordAbstract) rec, RecordOperation.UPDATED);
+    };
+  }
+
+  /** T->T value change: change price while staying matched. */
+  private Consumer<FrontendTransactionImpl> changeValue(RID rid, int newValue) {
+    return t -> {
+      Entity rec = session.load(rid);
+      rec.setProperty(VALUE, newValue);
+      t.addRecordOperation((RecordAbstract) rec, RecordOperation.UPDATED);
+    };
+  }
+
+  /** DELETE of a pre-committed matching record. */
+  private Consumer<FrontendTransactionImpl> deleteRecord(RID rid) {
+    return t -> {
+      Entity rec = session.load(rid);
+      t.addRecordOperation((RecordAbstract) rec, RecordOperation.DELETED);
+    };
+  }
+
+  // ===========================================================================
+  // I4 per-kind equivalence — CREATE / DELETE / WHERE-break UPDATE / value UPDATE
+  // ===========================================================================
+
+  @Test
+  public void countEquivalence_createAfterPopulate() {
+    assertEquivalent("count(*)", new int[] {10, 20, 30}, createMatching(40));
+  }
+
+  @Test
+  public void countEquivalence_deleteAfterPopulate() {
+    var fresh = runWithTarget(false, "count(*)", this::deleteRecord);
+    var cached = runWithTarget(true, "count(*)", this::deleteRecord);
+    assertEquals("COUNT after a DELETE must match fresh", fresh, cached);
+  }
+
+  @Test
+  public void countEquivalence_whereBreakUpdateAfterPopulate() {
+    var fresh = runWithTarget(false, "count(*)", this::breakWhere);
+    var cached = runWithTarget(true, "count(*)", this::breakWhere);
+    assertEquals("COUNT after a WHERE-breaking UPDATE must match fresh", fresh, cached);
+  }
+
+  @Test
+  public void sumEquivalence_createAfterPopulate() {
+    assertEquivalent("sum(" + VALUE + ")", new int[] {10, 20, 30}, createMatching(40));
+  }
+
+  @Test
+  public void sumEquivalence_valueUpdateAfterPopulate() {
+    var fresh = runWithTarget(false, "sum(" + VALUE + ")", rid -> changeValue(rid, 999));
+    var cached = runWithTarget(true, "sum(" + VALUE + ")", rid -> changeValue(rid, 999));
+    assertEquals("SUM after a value UPDATE must match fresh (full re-fold)", fresh, cached);
+  }
+
+  @Test
+  public void sumEquivalence_whereBreakUpdateAfterPopulate() {
+    var fresh = runWithTarget(false, "sum(" + VALUE + ")", this::breakWhere);
+    var cached = runWithTarget(true, "sum(" + VALUE + ")", this::breakWhere);
+    assertEquals("SUM after a WHERE-breaking UPDATE must drop the contributor", fresh, cached);
+  }
+
+  @Test
+  public void avgEquivalence_createAfterPopulate() {
+    assertEquivalent("avg(" + VALUE + ")", new int[] {10, 20, 30}, createMatching(40));
+  }
+
+  @Test
+  public void avgEquivalence_valueUpdateAfterPopulate() {
+    var fresh = runWithTarget(false, "avg(" + VALUE + ")", rid -> changeValue(rid, 100));
+    var cached = runWithTarget(true, "avg(" + VALUE + ")", rid -> changeValue(rid, 100));
+    assertEquals("AVG after a value UPDATE must match fresh (integer truncation)", fresh, cached);
+  }
+
+  @Test
+  public void minEquivalence_deleteAfterPopulate() {
+    var fresh = runWithTarget(false, "min(" + VALUE + ")", this::deleteRecord);
+    var cached = runWithTarget(true, "min(" + VALUE + ")", this::deleteRecord);
+    assertEquals("MIN after a DELETE must match fresh", fresh, cached);
+  }
+
+  @Test
+  public void maxEquivalence_deleteAfterPopulate() {
+    var fresh = runWithTarget(false, "max(" + VALUE + ")", this::deleteRecord);
+    var cached = runWithTarget(true, "max(" + VALUE + ")", this::deleteRecord);
+    assertEquals("MAX after a DELETE must match fresh", fresh, cached);
+  }
+
+  @Test
+  public void maxEquivalence_valueUpdateBelowExtremumAfterPopulate() {
+    // The MAX holder's value drops below a non-holder, forcing the O(n) recompute branch.
+    var fresh = runWithTarget(false, "max(" + VALUE + ")", rid -> changeValue(rid, 1));
+    var cached = runWithTarget(true, "max(" + VALUE + ")", rid -> changeValue(rid, 1));
+    assertEquals("MAX after the holder drops below a non-holder must recompute to match fresh",
+        fresh, cached);
+  }
+
+  /**
+   * Runs a scenario whose mutation targets a specific pre-committed matching record (the highest-value
+   * one, so MIN/MAX transitions are exercised). The target is committed last so it is the MAX holder.
+   */
+  private Object runWithTarget(boolean cacheEnabled, String agg,
+      java.util.function.Function<RID, Consumer<FrontendTransactionImpl>> mutationFor) {
+    clearClass();
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(false);
+    commitMatching(10);
+    commitMatching(20);
+    var target = commitMatching(30); // the extremum holder for MIN/MAX
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(cacheEnabled);
+    var sql = aggSql(agg);
+
+    session.begin();
+    scalar(session.query(sql));
+    mutationFor.apply(target).accept(tx());
+    var result = scalar(session.query(sql));
+    session.rollback();
+    return result;
+  }
+
+  // ===========================================================================
+  // D21 collapse case — pre-populate CREATE of the holder + post-populate WHERE-break
+  // ===========================================================================
+
+  /**
+   * A record created BEFORE the entry is populated (so its op stays typed CREATED but its version is
+   * bumped past populate by a later in-tx UPDATE) whose UPDATE then breaks WHERE must be reconciled by
+   * membership, not op type: the populate-time tap already observed it as a contributor, so the CREATED
+   * op must be read as "drop the existing contributor", not "add a new one". MAX is used so a stale
+   * contributor would visibly change the scalar.
+   */
+  @Test
+  public void collapseCase_prePopulateCreateThenWhereBreak() {
+    var fresh = runCollapse(false);
+    var cached = runCollapse(true);
+    assertEquals("a collapsed CREATE+UPDATE must reconcile by membership, matching fresh", fresh,
+        cached);
+  }
+
+  private Object runCollapse(boolean cacheEnabled) {
+    clearClass();
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(false);
+    commitMatching(10); // a surviving matching record
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(cacheEnabled);
+    var sql = aggSql("max(" + VALUE + ")");
+
+    session.begin();
+    // CREATE a new high matching record BEFORE the first (populating) query, so the populate observes it.
+    var created = session.newEntity(CLASS_NAME);
+    created.setProperty(VALUE, 100);
+    created.setProperty(FLAG, true);
+    scalar(session.query(sql)); // populate; the created row is a contributor (max = 100)
+    // Now break its WHERE in the same tx: the collapsed op stays CREATED but the record no longer matches.
+    created.setProperty(FLAG, false);
+    var result = scalar(session.query(sql)); // must drop it; max back to 10
+    session.rollback();
+    return result;
+  }
+
+  // ===========================================================================
+  // Hardwired COUNT(*) fallback + arithmetic / distinct K0_NONE routings
+  // ===========================================================================
+
+  /**
+   * Bare {@code COUNT(*) FROM C} classifies K0_NONE (hardwired, untappable): the aggregate splice is
+   * never attempted, the K0 version gate serves it, and the scalar still matches a fresh execution. No
+   * splice failure is counted (the shape never reaches the aggregate populate path).
+   */
+  @Test
+  public void bareCountStarServedByK0NoneNotAggregatePath() {
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(true);
+    clearClass();
+    commitMatching(1);
+    commitMatching(2);
+    session.begin();
+    var cache = tx().getQueryResultCache();
+    var sql = "SELECT count(*) FROM " + CLASS_NAME;
+    var first = scalar(session.query(sql));
+    assertEquals("bare COUNT(*) is served and counts no splice failure", 0,
+        cache.getMetrics().getSpliceFailures());
+    var second = scalar(session.query(sql));
+    assertEquals("bare COUNT(*) repeat matches the first read", first, second);
+    assertEquals(2L, first);
+    session.rollback();
+  }
+
+  /**
+   * A single-field-indexed {@code COUNT(*) ... WHERE indexedField = ?} is hardwired to a
+   * CountFromClassStep the side-tap cannot splice above, so the aggregate path falls back uncached and
+   * counts exactly one splice failure, while the scalar still matches a fresh execution.
+   */
+  @Test
+  public void indexedCountStarTakesSpliceFallback() {
+    session.command(
+        "CREATE INDEX " + CLASS_NAME + ".valueIdx ON " + CLASS_NAME + " (" + VALUE + ") NOTUNIQUE");
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(true);
+    clearClass();
+    commit(5, true);
+    commit(5, true);
+    commit(7, true);
+    session.begin();
+    var cache = tx().getQueryResultCache();
+    var sql = "SELECT count(*) FROM " + CLASS_NAME + " WHERE " + VALUE + " = 5";
+    var result = scalar(session.query(sql));
+    assertEquals("the indexed COUNT(*) scalar still matches a fresh execution", 2L, result);
+    assertEquals("the untappable indexed COUNT(*) shape counts one splice failure", 1,
+        cache.getMetrics().getSpliceFailures());
+    session.rollback();
+  }
+
+  /**
+   * {@code count(*) + 1} (aggregate under arithmetic) classifies K0_NONE: the aggregate replay would
+   * return the un-incremented scalar, so the K0 version gate serves it instead, and the cached value
+   * matches a fresh execution exactly.
+   */
+  @Test
+  public void aggregateUnderArithmeticServedByK0None() {
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(true);
+    clearClass();
+    commitMatching(1);
+    commitMatching(2);
+    session.begin();
+    var sql = "SELECT count(*) + 1 AS c FROM " + CLASS_NAME + " WHERE " + FLAG + " = true";
+    var first = scalar(session.query(sql));
+    var second = scalar(session.query(sql));
+    assertEquals("count(*) + 1 repeat matches the first read via the K0 gate", first, second);
+    assertEquals("count(*) + 1 over two matching records is 3", 3L, first);
+    session.rollback();
+  }
+
+  /**
+   * {@code count(distinct(prop))} classifies K0_NONE (the engine has no native distinct-count and
+   * computes it as a row count), so the K0 version gate keeps it correct across a CREATE / a
+   * WHERE-breaking UPDATE / a DELETE: the cached scalar always equals a parallel fresh execution, which
+   * returns the engine's row-count semantics.
+   */
+  @Test
+  public void countDistinctServedByK0NoneMatchesEngineRowCount() {
+    assertEquivalent("count(distinct(" + VALUE + "))", new int[] {10, 20, 30}, createMatching(40));
+    var freshDel = runWithTarget(false, "count(distinct(" + VALUE + "))", this::deleteRecord);
+    var cachedDel = runWithTarget(true, "count(distinct(" + VALUE + "))", this::deleteRecord);
+    assertEquals("count(distinct) after a DELETE matches the engine row-count via the K0 gate",
+        freshDel, cachedDel);
+    var freshBreak = runWithTarget(false, "count(distinct(" + VALUE + "))", this::breakWhere);
+    var cachedBreak = runWithTarget(true, "count(distinct(" + VALUE + "))", this::breakWhere);
+    assertEquals("count(distinct) after a WHERE-breaking UPDATE matches the engine row-count",
+        freshBreak, cachedBreak);
+  }
+
+  // ===========================================================================
+  // Contributor-cap overflow — high-cardinality SUM over a per-row distinct value
+  // ===========================================================================
+
+  /**
+   * A populate that crosses the aggregate contributor cap routes the key non-cacheable: the over-cap
+   * SUM is served once (its scalar still matches a fresh execution), an overflow is counted, no entry is
+   * retained, and a second identical query stays uncached. Uses SUM over a high-cardinality value (each
+   * matching record contributes a distinct value) so the AggregateState contributor collection is what
+   * overflows. With the cap at 2 and three matching records, caching the third contributor overflows.
+   */
+  @Test
+  public void contributorCapOverflowRoutesKeyNonCacheable() {
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(true);
+    var prevCap =
+        GlobalConfiguration.QUERY_TX_RESULT_CACHE_MAX_RECORDS_PER_ENTRY.getValueAsInteger();
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_MAX_RECORDS_PER_ENTRY.setValue(2);
+    try {
+      clearClass();
+      commitMatching(10);
+      commitMatching(20);
+      commitMatching(30);
+      session.begin();
+      var cache = tx().getQueryResultCache();
+      var sql = aggSql("sum(" + VALUE + ")");
+
+      var first = scalar(session.query(sql));
+      assertEquals("the over-cap SUM is still computed correctly", 60, ((Number) first).intValue());
+      assertEquals("crossing the contributor cap counts one overflow", 1,
+          cache.getMetrics().getOverflows());
+      assertEquals("an over-cap aggregate entry is not retained", 0, cache.size());
+
+      var second = scalar(session.query(sql));
+      assertEquals("the re-query returns the same scalar uncached", first, second);
+      assertEquals("an overflowed key does not re-populate the cache", 0, cache.size());
+      session.rollback();
+    } finally {
+      GlobalConfiguration.QUERY_TX_RESULT_CACHE_MAX_RECORDS_PER_ENTRY.setValue(prevCap);
+    }
+  }
+
+  // ===========================================================================
+  // Cache hit on repeat + no-exception-leak
+  // ===========================================================================
+
+  /**
+   * A pure-read repeat of a tappable aggregate is a cache hit: the first query populates (one miss), the
+   * second is served from the replayed view with no intervening mutation (one hit), and both scalars are
+   * equal. This pins that the aggregate path actually caches rather than always re-executing.
+   */
+  @Test
+  public void aggregateHitOnPureReadRepeat() {
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(true);
+    clearClass();
+    commitMatching(10);
+    commitMatching(20);
+    session.begin();
+    var cache = tx().getQueryResultCache();
+    var sql = aggSql("sum(" + VALUE + ")");
+
+    var first = scalar(session.query(sql));
+    assertEquals("first aggregate query is a miss", 1, cache.getMetrics().getMisses());
+    assertEquals("the populate stored an aggregate entry", 1, cache.size());
+    var second = scalar(session.query(sql));
+    assertEquals("a pure-read aggregate repeat is a hit", 1, cache.getMetrics().getHits());
+    assertEquals("the cached scalar equals the first read", first, second);
+    assertEquals(30, ((Number) first).intValue());
+    session.rollback();
+  }
+
+  /**
+   * The whole per-kind matrix exercising the splice, eager drive, and replay must complete without any
+   * exception leaking to the caller. This is the no-leak floor: every aggregate query above returned a
+   * scalar (a thrown exception would have failed the test), and this case re-runs all five kinds in one
+   * transaction to confirm the splice and fallback never throw.
+   */
+  @Test
+  public void allKindsRunWithoutExceptionLeak() {
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(true);
+    clearClass();
+    commitMatching(10);
+    commitMatching(20);
+    session.begin();
+    for (var agg : new String[] {"count(*)", "sum(" + VALUE + ")", "avg(" + VALUE + ")",
+        "min(" + VALUE + ")", "max(" + VALUE + ")"}) {
+      var s = scalar(session.query(aggSql(agg)));
+      assertTrue("every aggregate kind returns a non-null scalar over a non-empty set: " + agg,
+          s != null);
+    }
+    session.rollback();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java
@@ -260,6 +260,34 @@ public class AggregateCacheEquivalenceTest extends DbTestBase {
   }
 
   @Test
+  public void minEquivalence_valueUpdateAfterPopulate() {
+    var fresh = runWithTarget(false, "min(" + VALUE + ")", rid -> changeValue(rid, 999));
+    var cached = runWithTarget(true, "min(" + VALUE + ")", rid -> changeValue(rid, 999));
+    assertEquals("MIN after a value UPDATE must match fresh", fresh, cached);
+  }
+
+  @Test
+  public void minEquivalence_whereBreakUpdateAfterPopulate() {
+    var fresh = runWithTarget(false, "min(" + VALUE + ")", this::breakWhere);
+    var cached = runWithTarget(true, "min(" + VALUE + ")", this::breakWhere);
+    assertEquals("MIN after a WHERE-breaking UPDATE must drop the contributor", fresh, cached);
+  }
+
+  /**
+   * MIN F&rarr;T where a CREATE introduces a value below the current minimum drives the O(1) beats-
+   * extremum branch through the live splice path. The seeded set's min is 10; creating a matching 1
+   * after populate must replay to a new min of 1, matching a fresh execution. Mirrors the MAX collapse/
+   * create coverage so MIN has a live splice-path case beyond DELETE.
+   */
+  @Test
+  public void minEquivalence_createBelowExtremumAfterPopulate() {
+    var fresh = runScenario(false, "min(" + VALUE + ")", new int[] {10, 20, 30}, createMatching(1));
+    var cached = runScenario(true, "min(" + VALUE + ")", new int[] {10, 20, 30}, createMatching(1));
+    assertEquals("MIN after a below-extremum CREATE must replay to the new min, matching fresh",
+        fresh, cached);
+  }
+
+  @Test
   public void maxEquivalence_valueUpdateBelowExtremumAfterPopulate() {
     // The MAX holder's value drops below a non-holder, forcing the O(n) recompute branch.
     var fresh = runWithTarget(false, "max(" + VALUE + ")", rid -> changeValue(rid, 1));
@@ -307,6 +335,44 @@ public class AggregateCacheEquivalenceTest extends DbTestBase {
     var cached = runCollapse(true);
     assertEquals("a collapsed CREATE+UPDATE must reconcile by membership, matching fresh", fresh,
         cached);
+  }
+
+  /**
+   * The SUM analogue of the collapse case driven end-to-end: a record created BEFORE the populating
+   * query (so its op stays typed CREATED) whose value then changes in the same tx must re-fold by
+   * membership, not double-add. Keying on op type would read the collapsed CREATED as a brand-new
+   * contributor and add the changed value on top of the populate-time value, over-counting the sum.
+   * SUM's collapse path is unit-tested in {@code AggregateStateTest} but had no live splice-path
+   * coverage; this drives it through the splice/build/view pipeline and compares against fresh.
+   */
+  @Test
+  public void collapseCase_prePopulateCreateThenValueChangeSum() {
+    var fresh = runCollapseSumValueChange(false);
+    var cached = runCollapseSumValueChange(true);
+    assertEquals(
+        "a collapsed CREATE+value-UPDATE for SUM must re-fold by membership, matching fresh",
+        fresh, cached);
+  }
+
+  private Object runCollapseSumValueChange(boolean cacheEnabled) {
+    clearClass();
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(false);
+    commitMatching(10); // a surviving matching record
+    GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(cacheEnabled);
+    var sql = aggSql("sum(" + VALUE + ")");
+
+    session.begin();
+    // CREATE a new matching record BEFORE the populating query, so the populate observes it (sum = 60).
+    var created = session.newEntity(CLASS_NAME);
+    created.setProperty(VALUE, 50);
+    created.setProperty(FLAG, true);
+    scalar(session.query(sql)); // populate; the created row contributes 50
+    // Change its value in the same tx: the collapsed op stays CREATED but the record is already a
+    // contributor, so the new value must replace the old (re-fold to 10 + 5), not double-add.
+    created.setProperty(VALUE, 5);
+    var result = scalar(session.query(sql)); // must re-fold; sum = 15, not 65
+    session.rollback();
+    return result;
   }
 
   private Object runCollapse(boolean cacheEnabled) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java
@@ -303,6 +303,128 @@ public class AggregateStateTest {
     db.rollback();
   }
 
+  /** Folds a value list through {@code increment} in list order, the deterministic storage scan-order fold. */
+  private static Number scanOrderSumFold(List<? extends Number> values) {
+    Number acc = null;
+    for (var v : values) {
+      acc = acc == null ? v : PropertyTypeInternal.increment(acc, v);
+    }
+    return acc;
+  }
+
+  /**
+   * SUM over Double inputs must fold in observe (== storage scan) order, not in hash-bucket order.
+   * IEEE-754 addition is not associative, so a fold permuted by the backing map's iteration order can
+   * round to a different low-order bit than a fresh scan-order execution. With enough contributors
+   * spanning many magnitudes (a large running total plus many tiny addends), the scan-order fold and a
+   * sorted/permuted fold give measurably different doubles, so this test fails if {@code
+   * contributingValues} ever reverts to an unordered map. The cached scalar must equal the scan-order
+   * {@code increment} fold over the SAME input order bit-for-bit.
+   */
+  @Test
+  public void sumDoubleFoldsInObserveOrderMatchingStorageScanOrder() {
+    db.begin();
+    // 1e16 first (so it dominates the running total), then 64 tiny addends each below the running
+    // total's ULP: in scan order each tiny add rounds away to nothing; a permuted fold that sums the
+    // tiny values together first preserves them, yielding a different double. The order is therefore
+    // load-bearing for the result, not just the type.
+    var values = new java.util.ArrayList<Double>();
+    values.add(1.0e16d);
+    for (var i = 0; i < 64; i++) {
+      values.add(1.0d);
+    }
+    var recs = new java.util.ArrayList<Entity>();
+    for (var v : values) {
+      recs.add(newRec(v));
+    }
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, recs);
+    var expected = scanOrderSumFold(values);
+    assertEquals("SUM double fold must match the scan-order increment fold bit-for-bit", expected,
+        scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * AVG over Double inputs divides a scan-order-folded sum, so the divided result is also order-
+   * sensitive: an out-of-order fold feeds a different sum into {@code computeAverage}. The cached AVG
+   * must equal a fresh scan-order fold divided by the contributor count, pinning that the observe-order
+   * fold reaches the AVG finalisation too.
+   */
+  @Test
+  public void avgDoubleFoldsInObserveOrderMatchingStorageScanOrder() {
+    db.begin();
+    var values = new java.util.ArrayList<Double>();
+    values.add(1.0e16d);
+    for (var i = 0; i < 64; i++) {
+      values.add(1.0d);
+    }
+    var recs = new java.util.ArrayList<Entity>();
+    for (var v : values) {
+      recs.add(newRec(v));
+    }
+    var s = populate(CacheableShape.AGGREGATE_AVG, FIELD, recs);
+    var expectedSum = scanOrderSumFold(values).doubleValue();
+    assertEquals("AVG double must divide the scan-order sum", expectedSum / values.size(),
+        (Double) scalarOf(s), 0.0d);
+    db.rollback();
+  }
+
+  /**
+   * SUM over mixed Integer inputs straddling the {@code Integer} overflow boundary is type-sensitive to
+   * fold order: {@code PropertyTypeInternal.increment} promotes Integer+Integer to Long only when the
+   * partial sum overflows, so whether an intermediate overflows (and thus whether the result type ends
+   * up Integer or Long) depends on the partial-sum order. Folding in observe order must reproduce the
+   * scan-order fold's type AND value exactly; an unordered fold could overflow at a different step and
+   * disagree on both. Inputs chosen so the running scan-order total crosses {@code Integer.MAX_VALUE}
+   * mid-fold.
+   */
+  @Test
+  public void sumMixedIntOverflowFoldsInObserveOrderMatchingStorageScanOrder() {
+    db.begin();
+    // Scan-order partials: 2e9, then +2e9 overflows int (promotes to Long 4e9), then +(-1e9) and
+    // +1 stay Long. A different fold order (e.g. summing the negative early) would keep the partial
+    // in int range longer and could land on a different result type.
+    var values = List.of(2_000_000_000, 2_000_000_000, -1_000_000_000, 1);
+    var recs = new java.util.ArrayList<Entity>();
+    for (var v : values) {
+      recs.add(newRec(v));
+    }
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, recs);
+    var expected = scanOrderSumFold(values);
+    var scalar = scalarOf(s);
+    assertEquals("mixed-int SUM must match the scan-order fold value", expected, scalar);
+    assertEquals("mixed-int SUM must match the scan-order fold type", expected.getClass(),
+        scalar.getClass());
+    db.rollback();
+  }
+
+  /**
+   * The SUM/AVG re-fold is deferred to a single fold per build, not run once per replayed mutation
+   * (the running scalar is never read between mutations). Replaying several SUM-affecting mutations
+   * onto a copy and reading the scalar once must produce the correct final fold; the deferral is
+   * observable through {@code copy()} carrying the dirty flag — the copy folds lazily on its first read
+   * rather than the original having folded eagerly per observe. This pins that intermediate folds are
+   * collapsed without changing the observable result.
+   */
+  @Test
+  public void sumDeferredFoldProducesCorrectFinalScalarAfterManyMutations() {
+    var a = committedRec(10);
+    var b = committedRec(20);
+    var c = committedRec(30);
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(a, b, c));
+    // Three post-populate value changes; with deferral the scalar is folded once, on the read below.
+    a.setProperty(FIELD, 1);
+    s.applyMutation((RecordAbstract) a, RecordOperation.UPDATED, true);
+    b.setProperty(FIELD, 2);
+    s.applyMutation((RecordAbstract) b, RecordOperation.UPDATED, true);
+    c.setProperty(FIELD, 3);
+    s.applyMutation((RecordAbstract) c, RecordOperation.UPDATED, true);
+    var expected = PropertyTypeInternal.increment(PropertyTypeInternal.increment(1, 2), 3);
+    assertEquals("the single deferred fold yields the final scan-order fold", expected,
+        scalarOf(s));
+    db.rollback();
+  }
+
   // ===========================================================================
   // applyMutation transitions, per kind
   // ===========================================================================

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java
@@ -1,0 +1,682 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.command.BasicCommandContext;
+import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.record.RecordOperation;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.record.RecordAbstract;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.ResultInternal;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLSelectStatement;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLWhereClause;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.YouTrackDBSql;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies {@link AggregateState} in isolation: per-kind {@code observe}/{@code applyMutation}
+ * transitions, the SUM/AVG storage-parity fold (D19), AVG integer-truncation and BigDecimal HALF_UP
+ * finalisation, MIN/MAX extremum transitions including the O(n) recompute, COUNT_DISTINCT bucket
+ * lifecycle (D20), the D21 collapse case (a {@code CREATED}-typed op already a contributor dispatched
+ * by membership, not op type), {@code copy} isolation, and the contributor cap overflow callback.
+ *
+ * <p>The replay path it exercises is the same {@link DeltaBuilder#buildForAggregate} drives: seed the
+ * state by observing the pre-mutation records ("populate"), then replay a post-populate mutation and
+ * assert the finalised scalar matches what a fresh aggregate over the post-mutation set returns. Each
+ * test also pins the parity invariant directly against the storage primitive ({@link
+ * PropertyTypeInternal#increment}) where the value, not just the count, is load-bearing.
+ */
+public class AggregateStateTest {
+
+  private static final String CLASS_NAME = "AggRec";
+  private static final String FIELD = "v";
+
+  private YouTrackDBImpl youTrackDB;
+  private DatabaseSessionEmbedded db;
+
+  @Before
+  public void before() {
+    youTrackDB =
+        DbTestBase.createYTDBManagerAndDb(getClass().getSimpleName(), DatabaseType.MEMORY,
+            getClass());
+    db = youTrackDB.open(getClass().getSimpleName(), "admin", DbTestBase.ADMIN_PASSWORD);
+    // Schema-less class: the FIELD property is left undeclared so a test can store Integer / Long /
+    // Double / BigDecimal verbatim under the same name and exercise the cross-subtype fold and
+    // comparison paths the storage functions take. A declared type would coerce every value to it.
+    db.createClass(CLASS_NAME);
+  }
+
+  @After
+  public void after() {
+    db.close();
+    youTrackDB.drop(getClass().getSimpleName());
+    youTrackDB.close();
+  }
+
+  // ===========================================================================
+  // Helpers
+  // ===========================================================================
+
+  private FrontendTransactionImpl tx() {
+    return (FrontendTransactionImpl) db.getTransactionInternal();
+  }
+
+  private CommandContext ctx() {
+    return new BasicCommandContext(db);
+  }
+
+  private static SQLWhereClause parseWhere(String selectSql) {
+    try {
+      var parser = new YouTrackDBSql(new ByteArrayInputStream(selectSql.getBytes()));
+      return ((SQLSelectStatement) parser.parse()).getWhereClause();
+    } catch (Exception e) {
+      throw new AssertionError("Failed to parse: " + selectSql, e);
+    }
+  }
+
+  /** Creates an uncommitted record of CLASS_NAME with FIELD=value and returns it as an Entity. */
+  private Entity newRec(Object value) {
+    var e = db.newEntity(CLASS_NAME);
+    e.setProperty(FIELD, value);
+    return e;
+  }
+
+  /** Creates and commits a record, then reopens a fresh transaction and returns it reloaded. */
+  private Entity committedRec(Object value) {
+    db.begin();
+    var e = db.newEntity(CLASS_NAME);
+    e.setProperty(FIELD, value);
+    var rid = ridOf(e);
+    db.commit();
+    db.begin();
+    return db.load(rid);
+  }
+
+  private static RID ridOf(Entity e) {
+    return ((RecordAbstract) e).getIdentity();
+  }
+
+  /** A result wrapping a record, mirroring what the side-tap forwards into {@code observe}. */
+  private Result resultOf(Entity e) {
+    return new ResultInternal(db, e);
+  }
+
+  private AggregateState state(CacheableShape kind, String propertyName) {
+    return new AggregateState(kind, propertyName, kind.name());
+  }
+
+  /** Observes a list of records into a fresh state, simulating the populate-time side-tap. */
+  private AggregateState populate(CacheableShape kind, String propertyName, List<Entity> records) {
+    var s = state(kind, propertyName);
+    for (var r : records) {
+      s.observe(resultOf(r));
+    }
+    return s;
+  }
+
+  private Object scalarOf(AggregateState s) {
+    return s.toResult(db).getProperty(kindAlias(s));
+  }
+
+  private static String kindAlias(AggregateState s) {
+    return s.getKind().name();
+  }
+
+  // ===========================================================================
+  // observe + toResult, per kind
+  // ===========================================================================
+
+  /** COUNT(*) observes membership only and its scalar is the contributor count as a long. */
+  @Test
+  public void countObserveProducesContributorCount() {
+    db.begin();
+    var s =
+        populate(CacheableShape.AGGREGATE_COUNT, null, List.of(newRec(1), newRec(2), newRec(3)));
+    assertEquals(3L, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * SUM folds each observed value through {@link PropertyTypeInternal#increment} from a verbatim first
+   * seed, so the cached scalar equals the storage primitive applied in the same order.
+   */
+  @Test
+  public void sumObserveMatchesIncrementFold() {
+    db.begin();
+    var s =
+        populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(newRec(10), newRec(20), newRec(5)));
+    // increment(increment(10, 20), 5) is the exact storage fold for SUM.
+    var expected = PropertyTypeInternal.increment(PropertyTypeInternal.increment(10, 20), 5);
+    assertEquals(expected, scalarOf(s));
+    db.rollback();
+  }
+
+  /** SUM over an empty contributor set is 0 (an int), matching {@code SQLFunctionSum.getResult}. */
+  @Test
+  public void sumOverEmptySetIsZeroNotNull() {
+    db.begin();
+    var s = state(CacheableShape.AGGREGATE_SUM, FIELD);
+    assertEquals(0, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * AVG over integer input truncates exactly as {@code computeAverage} (integer division): three
+   * Integer values 10/20/5 sum to Integer 35, divided by 3 is 11, not 11.67.
+   */
+  @Test
+  public void avgIntegerInputTruncates() {
+    db.begin();
+    var s =
+        populate(CacheableShape.AGGREGATE_AVG, FIELD, List.of(newRec(10), newRec(20), newRec(5)));
+    assertEquals(11, scalarOf(s)); // (35 / 3) integer truncation
+    db.rollback();
+  }
+
+  /**
+   * AVG over BigDecimal input rounds HALF_UP: 10 + 20 + 5 = 35 over 3 contributors is 11.666...,
+   * which HALF_UP at the operands' scale yields 12 (scale 0). This pins the BigDecimal finalisation
+   * branch distinct from integer truncation.
+   */
+  @Test
+  public void avgBigDecimalInputRoundsHalfUp() {
+    db.begin();
+    var s =
+        populate(
+            CacheableShape.AGGREGATE_AVG,
+            FIELD,
+            List.of(
+                newRec(new BigDecimal("10")),
+                newRec(new BigDecimal("20")),
+                newRec(new BigDecimal("5"))));
+    // BigDecimal(35).divide(BigDecimal(3), HALF_UP) at scale 0 is 12.
+    assertEquals(new BigDecimal("12"), scalarOf(s));
+    db.rollback();
+  }
+
+  /** MIN over mixed values returns the smallest; MAX returns the largest. */
+  @Test
+  public void minAndMaxObserveExtremum() {
+    db.begin();
+    var recs = List.of(newRec(30), newRec(10), newRec(20));
+    var min = populate(CacheableShape.AGGREGATE_MIN, FIELD, recs);
+    var max = populate(CacheableShape.AGGREGATE_MAX, FIELD, recs);
+    assertEquals(10, scalarOf(min));
+    assertEquals(30, scalarOf(max));
+    db.rollback();
+  }
+
+  /**
+   * COUNT(DISTINCT) buckets by raw Object equality: two equal Integer values share a bucket, a third
+   * distinct value adds one. The scalar is the live bucket count.
+   */
+  @Test
+  public void countDistinctBucketsByValue() {
+    db.begin();
+    var s =
+        populate(
+            CacheableShape.AGGREGATE_COUNT_DISTINCT,
+            FIELD,
+            List.of(newRec(5), newRec(5), newRec(7)));
+    assertEquals(2L, scalarOf(s)); // {5, 7}
+    db.rollback();
+  }
+
+  /**
+   * COUNT(DISTINCT) follows storage's {@code LinkedHashSet<Object>} semantics, so {@code Long(5)} and
+   * {@code Integer(5)} are distinct buckets even though they are numerically equal.
+   */
+  @Test
+  public void countDistinctTreatsCrossSubtypeValuesAsDistinct() {
+    db.begin();
+    var s =
+        populate(
+            CacheableShape.AGGREGATE_COUNT_DISTINCT,
+            FIELD,
+            List.of(newRec(5), newRec(5L)));
+    assertEquals("Long(5) and Integer(5) are distinct buckets", 2L, scalarOf(s));
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // SUM storage parity: mixed input, overflow, precision loss
+  // ===========================================================================
+
+  /**
+   * SUM over mixed Long+Double input promotes to Double exactly as the storage fold does, so the
+   * cached scalar type and value match {@code increment(Long, Double)} bit-for-bit.
+   */
+  @Test
+  public void sumMixedLongDoublePromotesLikeStorage() {
+    db.begin();
+    var s =
+        populate(
+            CacheableShape.AGGREGATE_SUM, FIELD, List.of(newRec(3L), newRec(1.5d)));
+    var expected = PropertyTypeInternal.increment(3L, 1.5d);
+    assertEquals(expected, scalarOf(s));
+    assertTrue("mixed Long+Double promotes to Double", scalarOf(s) instanceof Double);
+    db.rollback();
+  }
+
+  /**
+   * SUM at {@code Long.MAX_VALUE + 1} wraps exactly as the storage fold's Long arithmetic does: the
+   * cache re-fold produces the identical wrapped value by construction (same primitive, same order).
+   */
+  @Test
+  public void sumLongOverflowWrapsLikeStorage() {
+    db.begin();
+    var s =
+        populate(
+            CacheableShape.AGGREGATE_SUM, FIELD, List.of(newRec(Long.MAX_VALUE), newRec(1L)));
+    var expected = PropertyTypeInternal.increment(Long.MAX_VALUE, 1L);
+    assertEquals(expected, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * SUM that promotes a Long to Double at {@code 2^53 + 1} loses precision exactly as storage does:
+   * both paths run the same {@code increment}, so the lossy result is identical by construction.
+   */
+  @Test
+  public void sumLongToDoublePrecisionLossMatchesStorage() {
+    db.begin();
+    long big = (1L << 53) + 1;
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(newRec(big), newRec(1.0d)));
+    var expected = PropertyTypeInternal.increment(big, 1.0d);
+    assertEquals(expected, scalarOf(s));
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // applyMutation transitions, per kind
+  // ===========================================================================
+
+  /**
+   * COUNT F&rarr;T: a post-populate CREATE that matches WHERE adds a contributor, so the scalar grows
+   * by one. The transition is keyed on membership (the new RID is not yet contributing).
+   */
+  @Test
+  public void countApplyMutationFtoTAddsContributor() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_COUNT, null, List.of(newRec(1)));
+    var added = newRec(2);
+    s.applyMutation((RecordAbstract) added, RecordOperation.CREATED, true);
+    assertEquals(2L, scalarOf(s));
+    db.rollback();
+  }
+
+  /** COUNT T&rarr;F: a DELETE of an existing contributor drops it, so the scalar shrinks by one. */
+  @Test
+  public void countApplyMutationTtoFOnDeleteDropsContributor() {
+    var existing = committedRec(1);
+    var s = populate(CacheableShape.AGGREGATE_COUNT, null, List.of(existing));
+    s.applyMutation((RecordAbstract) existing, RecordOperation.DELETED, true);
+    assertEquals(0L, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * COUNT T&rarr;F: an UPDATE that drives a contributor out of WHERE ({@code matchAfter=false}) drops
+   * it even though the op is UPDATED, confirming {@code matchAfter}, not op type, drives the drop.
+   */
+  @Test
+  public void countApplyMutationTtoFOnWhereFailDropsContributor() {
+    var existing = committedRec(5);
+    var s = populate(CacheableShape.AGGREGATE_COUNT, null, List.of(existing));
+    s.applyMutation((RecordAbstract) existing, RecordOperation.UPDATED, false);
+    assertEquals(0L, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * SUM T&rarr;T value change re-folds the whole contributor set: changing one value from 20 to 100
+   * yields the same scalar a fresh fold of {10, 100} produces, via the full re-fold (no subtract).
+   */
+  @Test
+  public void sumApplyMutationTtoTRefolds() {
+    var a = committedRec(10);
+    var b = committedRec(20);
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(a, b));
+    b.setProperty(FIELD, 100);
+    s.applyMutation((RecordAbstract) b, RecordOperation.UPDATED, true);
+    var expected = PropertyTypeInternal.increment(10, 100);
+    assertEquals(expected, scalarOf(s));
+    db.rollback();
+  }
+
+  /** SUM T&rarr;F drop re-folds the remaining set, so removing 20 from {10, 20} leaves 10. */
+  @Test
+  public void sumApplyMutationTtoFRefoldsRemaining() {
+    var a = committedRec(10);
+    var b = committedRec(20);
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(a, b));
+    s.applyMutation((RecordAbstract) b, RecordOperation.DELETED, true);
+    assertEquals(10, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * MAX T&rarr;F drop of the extremum holder triggers the O(n) recompute: removing the 30-holder from
+   * {30, 10, 20} re-derives 20 as the new max by scanning the remaining contributors.
+   */
+  @Test
+  public void maxApplyMutationDropOfExtremumRecomputes() {
+    var top = committedRec(30);
+    var mid = committedRec(20);
+    var low = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_MAX, FIELD, List.of(top, mid, low));
+    assertEquals(30, scalarOf(s));
+    s.applyMutation((RecordAbstract) top, RecordOperation.DELETED, true);
+    assertEquals("dropping the holder recomputes the new max", 20, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * MAX T&rarr;T where the holder's value drops below a non-holder triggers the recompute path: the
+   * 30-holder updated to 5, against {25, 5}, must re-derive 25 (the non-holder) as the new max.
+   */
+  @Test
+  public void maxApplyMutationHolderDropsBelowNonHolderRecomputes() {
+    var holder = committedRec(30);
+    var other = committedRec(25);
+    var s = populate(CacheableShape.AGGREGATE_MAX, FIELD, List.of(holder, other));
+    assertEquals(30, scalarOf(s));
+    holder.setProperty(FIELD, 5);
+    s.applyMutation((RecordAbstract) holder, RecordOperation.UPDATED, true);
+    assertEquals("holder losing extremum direction recomputes from remaining values", 25,
+        scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * MIN F&rarr;T where the new value beats the current extremum updates the scalar in O(1): adding 3
+   * to {10, 20} makes 3 the new min.
+   */
+  @Test
+  public void minApplyMutationNewValueBeatsExtremum() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_MIN, FIELD, List.of(newRec(10), newRec(20)));
+    var added = newRec(3);
+    s.applyMutation((RecordAbstract) added, RecordOperation.CREATED, true);
+    assertEquals(3, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * COUNT(DISTINCT) T&rarr;T key change moves a RID between buckets: changing the only 5-contributor
+   * to 7 empties the 5 bucket and grows the 7 bucket, so {5, 7} becomes {7} and the scalar drops to 1.
+   */
+  @Test
+  public void countDistinctApplyMutationKeyChangeMovesBucket() {
+    var five = committedRec(5);
+    var seven = committedRec(7);
+    var s = populate(CacheableShape.AGGREGATE_COUNT_DISTINCT, FIELD, List.of(five, seven));
+    assertEquals(2L, scalarOf(s));
+    five.setProperty(FIELD, 7);
+    s.applyMutation((RecordAbstract) five, RecordOperation.UPDATED, true);
+    assertEquals("the 5 bucket empties and merges into 7", 1L, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * COUNT(DISTINCT) T&rarr;F drop cleans up the bucket: deleting the only 7-contributor removes the 7
+   * bucket entirely, dropping {5, 7} to {5}.
+   */
+  @Test
+  public void countDistinctApplyMutationDropCleansBucket() {
+    var five = committedRec(5);
+    var seven = committedRec(7);
+    var s = populate(CacheableShape.AGGREGATE_COUNT_DISTINCT, FIELD, List.of(five, seven));
+    s.applyMutation((RecordAbstract) seven, RecordOperation.DELETED, true);
+    assertEquals(1L, scalarOf(s));
+    assertFalse("the emptied 7 bucket is removed",
+        s.getDistinctBuckets().containsKey(7));
+    db.rollback();
+  }
+
+  /** F&rarr;F: a non-contributor that still does not match is a no-op for every kind (SUM here). */
+  @Test
+  public void applyMutationFtoFIsNoOp() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(newRec(10)));
+    var nonMatching = newRec(99);
+    s.applyMutation((RecordAbstract) nonMatching, RecordOperation.CREATED, false);
+    assertEquals("a never-matching create changes nothing", 10, scalarOf(s));
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // D21 collapse safety: membership, not op type
+  // ===========================================================================
+
+  /**
+   * The D21 collapse case: a pre-populate CREATE of a contributor whose post-populate UPDATE drives it
+   * out of WHERE collapses to a {@code CREATED}-typed op. Because the record was already observed at
+   * populate (it is in {@code contributingValues}), {@code was_contributing=true}; with {@code
+   * matchAfter=false} it is a T&rarr;F drop. Keying on op type would misread {@code CREATED} as a new
+   * record and no-op, leaving a stale contributor and a wrong MAX. This pins that membership, not op
+   * type, drives the transition.
+   */
+  @Test
+  public void collapseCreatedOpAlreadyContributingDropsOnWhereFail() {
+    db.begin();
+    var holder = newRec(50); // observed at populate, becomes the MAX holder
+    var other = newRec(20);
+    var s = populate(CacheableShape.AGGREGATE_MAX, FIELD, List.of(holder, other));
+    assertEquals(50, scalarOf(s));
+
+    // The collapsed op is typed CREATED but the record is already a contributor; matchAfter=false
+    // (the post-populate update drove it out of WHERE). Membership dispatch must treat this as T->F.
+    holder.setProperty(FIELD, -1);
+    s.applyMutation((RecordAbstract) holder, RecordOperation.CREATED, false);
+    assertEquals("a CREATED op on an existing contributor that fails WHERE drops it", 20,
+        scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * The collapse case for SUM: a {@code CREATED}-typed op on an already-contributing record whose
+   * value changed must re-fold (T&rarr;T), not double-add. Updating the 10-contributor to 100 against
+   * {10, 5} must yield a fold of {100, 5}, not {10, 5, 100}.
+   */
+  @Test
+  public void collapseCreatedOpAlreadyContributingRefoldsOnValueChange() {
+    db.begin();
+    var a = newRec(10);
+    var b = newRec(5);
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(a, b));
+
+    a.setProperty(FIELD, 100);
+    s.applyMutation((RecordAbstract) a, RecordOperation.CREATED, true);
+    var expected = PropertyTypeInternal.increment(100, 5);
+    assertEquals("a CREATED op on an existing contributor re-folds, never double-adds", expected,
+        scalarOf(s));
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // copy isolation
+  // ===========================================================================
+
+  /**
+   * {@code copy} must produce an independent state: a mutation replayed on the copy must not change
+   * the original's scalar, so the entry's seeded state survives per-view delta builds intact.
+   */
+  @Test
+  public void copyIsolatesMutationsFromOriginal() {
+    db.begin();
+    var original = populate(CacheableShape.AGGREGATE_COUNT, null, List.of(newRec(1), newRec(2)));
+    var copy = original.copy();
+
+    var added = newRec(3);
+    copy.applyMutation((RecordAbstract) added, RecordOperation.CREATED, true);
+
+    assertEquals("the copy reflects the replayed mutation", 3L, scalarOf(copy));
+    assertEquals("the original is untouched by the copy's mutation", 2L, scalarOf(original));
+    db.rollback();
+  }
+
+  /**
+   * COUNT_DISTINCT {@code copy} must deep-copy the per-bucket sets: removing a RID from a bucket on the
+   * copy must not empty the original's bucket, since the buckets are independent mutable containers.
+   */
+  @Test
+  public void copyDeepCopiesDistinctBuckets() {
+    var shared = committedRec(5);
+    var other = committedRec(7);
+    var original =
+        populate(CacheableShape.AGGREGATE_COUNT_DISTINCT, FIELD, List.of(shared, other));
+    var copy = original.copy();
+
+    copy.applyMutation((RecordAbstract) shared, RecordOperation.DELETED, true);
+
+    assertEquals("the copy drops the 5 bucket", 1L, scalarOf(copy));
+    assertEquals("the original keeps both buckets", 2L, scalarOf(original));
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // memory cap overflow
+  // ===========================================================================
+
+  /**
+   * A high-cardinality COUNT(DISTINCT) that crosses the contributor cap must fire the overflow
+   * callback exactly once (the latch), so the cache can route the key non-cacheable. The cap is on the
+   * contributor collection, not the single scalar row.
+   */
+  @Test
+  public void contributorCapFiresOverflowCallbackOnce() {
+    db.begin();
+    var s = state(CacheableShape.AGGREGATE_COUNT_DISTINCT, FIELD);
+    var fired = new AtomicInteger();
+    s.setOverflowGuard(2, fired::incrementAndGet);
+
+    s.observe(resultOf(newRec(1)));
+    s.observe(resultOf(newRec(2)));
+    assertEquals("at the cap, no overflow yet", 0, fired.get());
+    assertFalse(s.isOverflowed());
+
+    s.observe(resultOf(newRec(3))); // crosses the cap of 2
+    assertEquals("crossing the cap fires the callback once", 1, fired.get());
+    assertTrue(s.isOverflowed());
+
+    s.observe(resultOf(newRec(4))); // already overflowed; must not re-fire
+    assertEquals("the overflow callback is one-shot", 1, fired.get());
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // buildForAggregate + view end-to-end
+  // ===========================================================================
+
+  /**
+   * {@link DeltaBuilder#buildForAggregate} copies the entry's seeded state and replays a post-populate
+   * mutation onto the copy, leaving the entry's state untouched. A SUM entry seeded with {10, 20} plus
+   * a post-populate create of 5 (matching WHERE) must replay to 35 while the entry stays at 30.
+   */
+  @Test
+  public void buildForAggregateReplaysOntoCopyLeavingEntryIntact() {
+    db.begin();
+    var a = newRec(10);
+    var b = newRec(20);
+    var seeded = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(a, b));
+    var where = parseWhere("SELECT FROM " + CLASS_NAME + " WHERE " + FIELD + " > 0");
+    var entry =
+        new CachedEntry(
+            CacheableShape.AGGREGATE_SUM,
+            java.util.Set.of(CLASS_NAME),
+            where,
+            null,
+            null,
+            null,
+            null,
+            tx().getMutationVersion());
+    entry.setAggregateState(seeded);
+
+    newRec(5); // post-populate CREATE, matches WHERE
+
+    var delta = DeltaBuilder.buildForAggregate(entry, tx(), ctx());
+
+    assertEquals("the replayed copy reflects the post-populate create", 35,
+        delta.toResult(db).<Object>getProperty(seeded.getAlias()));
+    assertEquals("the entry's seeded state is untouched by the build", 30,
+        seeded.toResult(db).<Object>getProperty(seeded.getAlias()));
+    db.rollback();
+  }
+
+  /**
+   * The aggregate {@link CachedResultSetView} emits the replayed scalar exactly once: {@code hasNext}
+   * is true before the single {@code next}, false after. This is the aggregate-shape contract (one row
+   * per aggregate query) distinct from the record-shape sorted merge.
+   */
+  @Test
+  public void aggregateViewEmitsSingleRowThenDrains() {
+    db.begin();
+    var seeded =
+        populate(CacheableShape.AGGREGATE_COUNT, null, List.of(newRec(1), newRec(2), newRec(3)));
+    var entry =
+        new CachedEntry(
+            CacheableShape.AGGREGATE_COUNT,
+            java.util.Set.of(CLASS_NAME),
+            null,
+            null,
+            null,
+            null,
+            null,
+            tx().getMutationVersion());
+    entry.setAggregateState(seeded);
+
+    var delta = DeltaBuilder.buildForAggregate(entry, tx(), ctx());
+    try (var view = CachedResultSetView.forAggregate(entry, delta, db, tx(), null, ctx())) {
+      assertTrue("the aggregate view has its single row", view.hasNext());
+      var row = view.next();
+      assertEquals(3L, row.<Object>getProperty(seeded.getAlias()));
+      assertFalse("the aggregate view drains after one row", view.hasNext());
+    }
+    db.rollback();
+  }
+
+  /**
+   * The aggregate view pins its entry while iterating and releases the pin on close, exactly like the
+   * record/K0 view, so LRU eviction never truncates an in-flight aggregate consumer.
+   */
+  @Test
+  public void aggregateViewPinsEntryAndReleasesOnClose() {
+    db.begin();
+    var seeded = populate(CacheableShape.AGGREGATE_COUNT, null, List.of(newRec(1)));
+    var entry =
+        new CachedEntry(
+            CacheableShape.AGGREGATE_COUNT,
+            java.util.Set.of(CLASS_NAME),
+            null,
+            null,
+            null,
+            null,
+            null,
+            tx().getMutationVersion());
+    entry.setAggregateState(seeded);
+    var delta = DeltaBuilder.buildForAggregate(entry, tx(), ctx());
+
+    var view = CachedResultSetView.forAggregate(entry, delta, db, tx(), null, ctx());
+    assertEquals("the view pins the entry", 1, entry.getLiveViewCount());
+    view.close();
+    assertEquals("close releases the pin", 0, entry.getLiveViewCount());
+    db.rollback();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java
@@ -572,6 +572,233 @@ public class AggregateStateTest {
     db.rollback();
   }
 
+  // ===========================================================================
+  // Empty-set drain: the last contributor removed by replay, distinct from the
+  // never-seeded empty path. MIN/MAX/AVG must drain to null; COUNT/COUNT_DISTINCT
+  // to 0. Parity with a fresh aggregate over the emptied set (null/0).
+  // ===========================================================================
+
+  /**
+   * MIN drained to empty returns null: deleting the sole contributor leaves {@code recomputeExtremum}
+   * with no values, so {@code currentScalar} is null — the same result a fresh MIN over an empty set
+   * gives ({@code SQLFunctionMin.getResult} returns null). This pins the drain transition (holder
+   * dropped, rescan finds nothing), which is a distinct code path from the never-seeded empty MIN.
+   */
+  @Test
+  public void minDrainsToNullWhenLastContributorDropped() {
+    var only = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_MIN, FIELD, List.of(only));
+    assertEquals(10, scalarOf(s));
+    s.applyMutation((RecordAbstract) only, RecordOperation.DELETED, true);
+    assertEquals("MIN over an emptied set is null, matching SQLFunctionMin", null, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * MAX drained to empty returns null, symmetric with MIN: the extremum-holder drop triggers
+   * {@code recomputeExtremum} over an empty contributor set, leaving {@code currentScalar} null.
+   */
+  @Test
+  public void maxDrainsToNullWhenLastContributorDropped() {
+    var only = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_MAX, FIELD, List.of(only));
+    assertEquals(10, scalarOf(s));
+    s.applyMutation((RecordAbstract) only, RecordOperation.DELETED, true);
+    assertEquals("MAX over an emptied set is null, matching SQLFunctionMax", null, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * AVG drained to empty returns null, never a divide-by-zero: dropping the sole contributor leaves
+   * {@code count==0} with a null accumulator, so {@code computeAverage(null, 0)} returns null rather
+   * than dividing by zero. Pins that the empty drain stays null-not-zero, the contract that keeps the
+   * {@code total==0} integer-division guard load-bearing.
+   */
+  @Test
+  public void avgDrainsToNullNotDivideByZero() {
+    var only = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_AVG, FIELD, List.of(only));
+    assertEquals(10, scalarOf(s));
+    s.applyMutation((RecordAbstract) only, RecordOperation.DELETED, true);
+    assertEquals("AVG over an emptied set is null, never a divide-by-zero", null, scalarOf(s));
+    db.rollback();
+  }
+
+  /** COUNT drained to empty is 0L: deleting the sole contributor drops the count to zero. */
+  @Test
+  public void countDrainsToZeroWhenLastContributorDropped() {
+    var only = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_COUNT, null, List.of(only));
+    assertEquals(1L, scalarOf(s));
+    s.applyMutation((RecordAbstract) only, RecordOperation.DELETED, true);
+    assertEquals("COUNT over an emptied set is 0", 0L, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * COUNT(DISTINCT) drained to empty is 0L: deleting the sole contributor empties its bucket, leaving
+   * no buckets, so the live bucket count is zero.
+   */
+  @Test
+  public void countDistinctDrainsToZeroWhenLastContributorDropped() {
+    var only = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_COUNT_DISTINCT, FIELD, List.of(only));
+    assertEquals(1L, scalarOf(s));
+    s.applyMutation((RecordAbstract) only, RecordOperation.DELETED, true);
+    assertEquals("COUNT(DISTINCT) over an emptied set is 0", 0L, scalarOf(s));
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // Null property value: a matching record whose aggregate property is null does
+  // not contribute. observe skips it; an UPDATE that nulls the value drops it.
+  // Mirrors storage, which skips null values for SUM/AVG/MIN/MAX/DISTINCT.
+  // ===========================================================================
+
+  /**
+   * SUM skips a null-valued matching record at observe: storage's SUM never folds a null, and the cache
+   * mirrors that early-return in {@code observe}, so {10, null, 20} sums to 30 — the null contributes
+   * nothing rather than NPEing the {@code (Number) v} cast in the re-fold.
+   */
+  @Test
+  public void sumSkipsNullPropertyOnObserve() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD,
+        List.of(newRec(10), newRec(null), newRec(20)));
+    assertEquals("a null-valued matching record does not contribute to SUM", 30, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * AVG skips a null-valued matching record at observe: the null is not counted, so AVG over {10, null,
+   * 20} divides 30 by 2 (the two non-null contributors), not by 3. This pins that the null-skip excludes
+   * the record from both the sum and the divisor, matching {@code SQLFunctionAverage}.
+   */
+  @Test
+  public void avgSkipsNullPropertyOnObserve() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_AVG, FIELD,
+        List.of(newRec(10), newRec(null), newRec(20)));
+    assertEquals("a null-valued matching record is excluded from AVG sum and count", 15,
+        scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * SUM drops a contributor when a T&rarr;T UPDATE nulls its property: a record that still matches WHERE
+   * but whose new aggregate value is null flips to non-contributing in {@code applyMutation} (the
+   * null-new-value branch), so {10, 20} with 20 nulled re-folds to 10. A regression here would leave a
+   * stale contributor and a silently wrong scalar.
+   */
+  @Test
+  public void sumDropsContributorWhenUpdateNullsTheProperty() {
+    var a = committedRec(10);
+    var b = committedRec(20);
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(a, b));
+    assertEquals(30, scalarOf(s));
+    b.setProperty(FIELD, null);
+    // Matches WHERE (matchAfter=true) but its new value is null: the null-new-value branch drops it.
+    s.applyMutation((RecordAbstract) b, RecordOperation.UPDATED, true);
+    assertEquals("a matching record whose value becomes null drops out of SUM", 10, scalarOf(s));
+    db.rollback();
+  }
+
+  // ===========================================================================
+  // MIN/MAX comparison across Number subtypes and over non-Number Comparable
+  // values: beatsExtremum runs castComparableNumber only when both operands are
+  // Number, else a raw Comparable.compareTo. Homogeneous Integer input exercises
+  // neither branch, so the cast and the non-Number fallback are unguarded without
+  // the cases below.
+  // ===========================================================================
+
+  /**
+   * MAX compares Integer/Long/Double numerically, not by boxed type: with {5, 10L, 7.5}, the numeric
+   * max is 10L, which {@code beatsExtremum} reaches through {@code castComparableNumber} (the both-
+   * operands-Number branch). A comparison by {@code Number.equals}/hashCode or boxed-reference order
+   * would pick the wrong extremum. Pins the cross-subtype comparison the increment-promotion world
+   * these aggregates live in produces (a MAX over a column mixing Integer and Long).
+   */
+  @Test
+  public void maxComparesAcrossNumberSubtypesNumerically() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_MAX, FIELD,
+        List.of(newRec(5), newRec(10L), newRec(7.5d)));
+    assertEquals("MAX compares Integer/Long/Double numerically, not by boxed type", 10L,
+        scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * MIN compares Integer/Long/Double numerically: with {5, 10L, 7.5}, the numeric min is 5 (Integer),
+   * the cross-subtype mirror of the MAX case, exercising the {@code castComparableNumber} branch in the
+   * MIN direction.
+   */
+  @Test
+  public void minComparesAcrossNumberSubtypesNumerically() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_MIN, FIELD,
+        List.of(newRec(5), newRec(10L), newRec(7.5d)));
+    assertEquals("MIN compares Integer/Long/Double numerically, not by boxed type", 5, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * MIN over non-Number Comparable values (Strings) takes the raw {@code Comparable.compareTo}
+   * fallback, never {@code castComparableNumber}: lexicographic min of {banana, apple, cherry} is
+   * "apple". A {@code MIN(name)} over String ids is a routine shape, and this pins that the non-Number
+   * fallback compares by natural order.
+   */
+  @Test
+  public void minOverStringComparableValues() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_MIN, FIELD,
+        List.of(newRec("banana"), newRec("apple"), newRec("cherry")));
+    assertEquals("apple", scalarOf(s)); // non-Number Comparable path
+    db.rollback();
+  }
+
+  /**
+   * MAX over non-Number Comparable values (Strings) takes the raw {@code Comparable.compareTo}
+   * fallback in the MAX direction: lexicographic max of {banana, apple, cherry} is "cherry".
+   */
+  @Test
+  public void maxOverStringComparableValues() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_MAX, FIELD,
+        List.of(newRec("banana"), newRec("apple"), newRec("cherry")));
+    assertEquals("cherry", scalarOf(s)); // non-Number Comparable path
+    db.rollback();
+  }
+
+  /**
+   * AVG over negative integers truncates toward zero, not floor: Java integer division gives
+   * {@code -35 / 3 == -11}, not -12. The existing positive cases pass under both floor and truncate-
+   * toward-zero (35/3 == 11 either way); a negative input is what distinguishes the implemented rule.
+   */
+  @Test
+  public void avgNegativeIntegerTruncatesTowardZero() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_AVG, FIELD,
+        List.of(newRec(-10), newRec(-20), newRec(-5))); // -35 / 3
+    assertEquals("integer AVG truncates toward zero, not floor", -11, scalarOf(s));
+    db.rollback();
+  }
+
+  /**
+   * AVG over BigDecimal sitting exactly on the HALF_UP round-half boundary rounds up: 5 over 2 is 2.5,
+   * which HALF_UP at scale 0 rounds to 3 (HALF_EVEN would round to 2). The existing 35/3 case rounds to
+   * 12 under both HALF_UP and HALF_EVEN, so only an exact .5 input distinguishes the implemented rule.
+   */
+  @Test
+  public void avgBigDecimalOnExactHalfBoundaryRoundsHalfUp() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_AVG, FIELD,
+        List.of(newRec(new BigDecimal("5")), newRec(new BigDecimal("0"))));
+    // (5 + 0) / 2 = 2.5; HALF_UP at scale 0 is 3, HALF_EVEN would be 2.
+    assertEquals(new BigDecimal("3"), scalarOf(s));
+    db.rollback();
+  }
+
   /** F&rarr;F: a non-contributor that still does not match is a no-op for every kind (SUM here). */
   @Test
   public void applyMutationFtoFIsNoOp() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/FunctionDeterminismEnumerationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/FunctionDeterminismEnumerationTest.java
@@ -1,0 +1,152 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.sql.SQLEngine;
+import com.jetbrains.youtrackdb.internal.core.sql.functions.SQLFunctionFactory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Enumeration-completeness guard for cache-determinism classification (I5). The tx-result cache trusts
+ * {@link NonDeterministicQueryDetector}'s denylist to catch every non-deterministic builtin: a function
+ * whose result varies per call but is missing from the denylist would be silently cached, returning a
+ * stale value on the second {@code query()}. Because the denylist is fail-open, that gap cannot be
+ * detected by the detector itself — only by walking every registered function and asserting each one
+ * has been deliberately classified.
+ *
+ * <p>This test walks all four registered {@link SQLFunctionFactory} implementations
+ * ({@code DefaultSQLFunctionFactory}, {@code DynamicSQLElementFactory}, {@code CustomSQLFunctionFactory}
+ * reflective {@code math_*}, {@code DatabaseFunctionFactory} stored) and requires every advertised
+ * function name to fall into exactly one of two test-maintained classifications: the
+ * {@link #KNOWN_NON_DETERMINISTIC} set (which must equal the detector's denylist) or the
+ * {@link #KNOWN_DETERMINISTIC} set. A newly registered function in neither set fails the build, forcing
+ * its author to classify it — and, when non-deterministic, to add a denylist entry — before it can ship
+ * cacheable. The reflective {@code math_*} family is handled by a prefix rule because the exact member
+ * set is JDK-version dependent: {@code math_random} is non-deterministic, every other {@code math_*} is
+ * a pure numeric function.
+ */
+public class FunctionDeterminismEnumerationTest extends DbTestBase {
+
+  /**
+   * The function names the cache treats as non-deterministic. This MUST mirror
+   * {@link NonDeterministicQueryDetector}'s denylist (plus the special zero-argument {@code date()}
+   * form, whose name is {@code date} but which is deterministic with an argument — see the detector).
+   * Keeping the set here lets the test fail if a registered non-deterministic function lacks coverage,
+   * and the {@link #denylistEntriesAreAllRegistered()} case fails if a denylist name drifts away from
+   * any real registered function (a typo that would silently never match).
+   */
+  private static final Set<String> KNOWN_NON_DETERMINISTIC =
+      Set.of("sysdate", "uuid", "eval", "math_random", "date");
+
+  /**
+   * Registered builtin functions whose result is a pure function of storage + arguments, so caching a
+   * query that calls them is safe. Maintained by hand: a new builtin must be added here (deterministic)
+   * or to {@link #KNOWN_NON_DETERMINISTIC} (and the detector denylist) before it ships. The reflective
+   * {@code math_*} family is intentionally absent — it is classified by the {@code math_} prefix rule in
+   * {@link #classify} because its members are JDK-version dependent.
+   */
+  private static final Set<String> KNOWN_DETERMINISTIC =
+      Set.of(
+          "avg", "coalesce", "count", "decode", "difference", "symmetricdifference", "distance",
+          "distinct", "encode", "first", "format", "traversededge", "traversedelement",
+          "traversedvertex", "if", "assert", "ifnull", "intersect", "last", "list", "map", "max",
+          "min", "interval", "set", "sum", "unionall", "mode", "percentile", "median", "variance",
+          "stddev", "concat", "decimal", "sequence", "abs", "indexkeysize", "strcmpci", "throwcme",
+          "out", "in", "both", "oute", "outv", "ine", "inv", "bothe", "bothv", "shortestpath",
+          "dijkstra", "astar", "detach");
+
+  /**
+   * Classifies a single registered function name as deterministic-or-not for the completeness check.
+   * Returns {@code true} when the name is accounted for (in either curated set, or covered by the
+   * {@code math_} prefix rule); a {@code false} return is a name the author has not yet classified.
+   */
+  private static boolean isClassified(String name) {
+    var lower = name.toLowerCase(Locale.ROOT);
+    if (KNOWN_NON_DETERMINISTIC.contains(lower) || KNOWN_DETERMINISTIC.contains(lower)) {
+      return true;
+    }
+    // Reflective Math.* family: every member except math_random is a pure numeric function. The exact
+    // member set varies by JDK, so it is covered by a prefix rule rather than an enumerated list.
+    return lower.startsWith("math_");
+  }
+
+  private List<SQLFunctionFactory> allFactories() {
+    var factories = new ArrayList<SQLFunctionFactory>();
+    var it = SQLEngine.getFunctionFactories(session);
+    while (it.hasNext()) {
+      factories.add(it.next());
+    }
+    return factories;
+  }
+
+  private Set<String> allRegisteredFunctionNames() {
+    var names = new TreeSet<String>();
+    for (var factory : allFactories()) {
+      for (var name : factory.getFunctionNames(session)) {
+        names.add(name.toLowerCase(Locale.ROOT));
+      }
+    }
+    return names;
+  }
+
+  /**
+   * The ServiceLoader manifest registers exactly four function factories. Pinning the count guards the
+   * enumeration surface: a fifth factory added without updating this test (and the curated sets) would
+   * widen the function set silently, and a removed factory would shrink the determinism guard's reach.
+   */
+  @Test
+  public void exactlyFourFunctionFactoriesAreRegistered() {
+    Assert.assertEquals(
+        "The I5 enumeration must walk all four SQLFunctionFactory implementations; a change to the"
+            + " ServiceLoader manifest must be reflected here",
+        4,
+        allFactories().size());
+  }
+
+  /**
+   * The completeness guard: every registered function across all four factories must be classified. A
+   * new non-deterministic builtin added without a denylist entry — the exact gap the fail-open detector
+   * cannot self-detect — lands here as an unclassified name and fails the build.
+   */
+  @Test
+  public void everyRegisteredFunctionIsClassifiedDeterministicOrNot() {
+    var unclassified = new TreeSet<String>();
+    for (var name : allRegisteredFunctionNames()) {
+      if (!isClassified(name)) {
+        unclassified.add(name);
+      }
+    }
+    Assert.assertTrue(
+        "Unclassified function(s) found: "
+            + unclassified
+            + ". Each must be added to FunctionDeterminismEnumerationTest.KNOWN_DETERMINISTIC, or — if"
+            + " its result varies per call — to KNOWN_NON_DETERMINISTIC AND the"
+            + " NonDeterministicQueryDetector denylist, before it can ship cacheable.",
+        unclassified.isEmpty());
+  }
+
+  /**
+   * Guards the denylist against drift the other direction: every name the cache treats as
+   * non-deterministic must correspond to a function that is actually registered (the {@code math_random}
+   * member is covered by the reflective family). A denylist entry naming no real function is a dead
+   * guard — a typo or a renamed function — that would silently never match and let a non-deterministic
+   * query through.
+   */
+  @Test
+  public void denylistEntriesAreAllRegistered() {
+    var registered = allRegisteredFunctionNames();
+    for (var nonDeterministic : KNOWN_NON_DETERMINISTIC) {
+      Assert.assertTrue(
+          "Denylisted non-deterministic name '"
+              + nonDeterministic
+              + "' matches no registered function; the denylist entry is dead (typo or rename) and"
+              + " would silently never bypass the cache",
+          registered.contains(nonDeterministic));
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryCacheMetricsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/QueryCacheMetricsTest.java
@@ -2,15 +2,36 @@ package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import static org.junit.Assert.assertEquals;
 
+import com.jetbrains.youtrackdb.internal.common.profiler.metrics.TimeRate;
 import org.junit.Test;
 
 /**
  * Verifies the per-transaction tx-result-cache counter holder. Each counter starts at zero, each
  * increment advances only its own counter by one, and repeated increments accumulate. The class is
- * a plain single-threaded holder confined to its owning thread, so no concurrency is exercised here;
- * the increments are wired into the cache lookup/eviction paths in later steps.
+ * a plain single-threaded holder confined to its owning thread, so no concurrency is exercised here.
+ *
+ * <p>The increment methods also bridge to the engine-global {@code QUERY_CACHE_*_RATE} metrics: a
+ * second group of cases injects a recording {@link TimeRate} per counter and asserts each
+ * {@code increment*} records exactly one event into its own global sink and none into the others, so
+ * the global rate is the rolling rate of the same events the per-tx counter measures.
  */
 public class QueryCacheMetricsTest {
+
+  /** A {@link TimeRate} that counts how many times {@code record} was called, for routing assertions. */
+  private static final class RecordingRate implements TimeRate {
+
+    private long recordCount;
+
+    @Override
+    public void record(long value) {
+      recordCount++;
+    }
+
+    @Override
+    public double getRate() {
+      return 0.0;
+    }
+  }
 
   /**
    * A freshly constructed holder reports zero for every counter, so a transaction that never
@@ -72,5 +93,60 @@ public class QueryCacheMetricsTest {
     }
     assertEquals(5L, metrics.getHits());
     assertEquals(3L, metrics.getMisses());
+  }
+
+  /**
+   * Each {@code increment*} call records exactly one event into its own global rate sink and none into
+   * the other four, so the five global rate streams stay independent and each tracks its counter
+   * one-to-one. Injecting recording sinks via the package-visible constructor makes the bridge routing
+   * assertable without standing up an engine or a real metrics registry.
+   */
+  @Test
+  public void eachIncrementRecordsOnlyItsOwnGlobalRate() {
+    var hit = new RecordingRate();
+    var miss = new RecordingRate();
+    var splice = new RecordingRate();
+    var k0 = new RecordingRate();
+    var overflow = new RecordingRate();
+    var metrics = new QueryCacheMetrics(hit, miss, splice, k0, overflow);
+
+    metrics.incrementHits();
+    assertEquals(1L, hit.recordCount);
+    assertEquals(0L, miss.recordCount);
+    assertEquals(0L, splice.recordCount);
+    assertEquals(0L, k0.recordCount);
+    assertEquals(0L, overflow.recordCount);
+
+    metrics.incrementMisses();
+    assertEquals(1L, miss.recordCount);
+
+    metrics.incrementSpliceFailures();
+    assertEquals(1L, splice.recordCount);
+
+    metrics.incrementK0Invalidations();
+    assertEquals(1L, k0.recordCount);
+
+    metrics.incrementOverflows();
+    assertEquals(1L, overflow.recordCount);
+
+    // The hit sink is unaffected by the later increments.
+    assertEquals(1L, hit.recordCount);
+  }
+
+  /**
+   * The global rate sink sees exactly as many events as the per-tx counter advances, confirming the
+   * bridge fires once per increment rather than once per holder.
+   */
+  @Test
+  public void repeatedIncrementsRecordOnePerCounterStep() {
+    var hit = new RecordingRate();
+    var metrics =
+        new QueryCacheMetrics(hit, new RecordingRate(), new RecordingRate(), new RecordingRate(),
+            new RecordingRate());
+    for (var i = 0; i < 4; i++) {
+      metrics.incrementHits();
+    }
+    assertEquals(4L, metrics.getHits());
+    assertEquals(4L, hit.recordCount);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifierTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifierTest.java
@@ -89,12 +89,62 @@ public class ShapeClassifierTest extends DbTestBase {
         ShapeClassifier.classify(parse("select from (select from OUser)")));
   }
 
-  /** {@code COUNT(*)} is the count aggregate shape; the value is final though the delta lands later. */
+  /**
+   * Bare {@code COUNT(*) FROM C} (no WHERE) classifies K0_NONE, not AGGREGATE_COUNT. The planner
+   * hardwires this shape to an O(1) {@code CountFromClassStep} built before any aggregation step
+   * exists, so the aggregate side-tap can never reach it; routing it K0_NONE keeps the untappable shape
+   * out of the aggregate replay path entirely. (It is already O(1) and tx-aware, so caching adds
+   * nothing.)
+   */
   @Test
-  public void countStarClassifiesAsAggregateCount() {
+  public void bareCountStarClassifiesAsK0None() {
+    Assert.assertEquals(
+        "bare COUNT(*) FROM C is hardwired and untappable; it must classify K0_NONE, not"
+            + " AGGREGATE_COUNT",
+        CacheableShape.K0_NONE,
+        ShapeClassifier.classify(parse("select count(*) from OUser")));
+  }
+
+  /**
+   * {@code COUNT(*)} with a (non-indexed) WHERE predicate stays AGGREGATE_COUNT: unlike the bare and
+   * single-field-indexed forms, this shape builds a real {@code AggregateProjectionCalculationStep}, so
+   * the side-tap can observe its contributing records and the aggregate cache path applies. The
+   * classifier cannot see indexes (it runs on the AST alone), so it keeps every WHERE-carrying
+   * {@code COUNT(*)} tappable; the indexed-WHERE residual is caught at the splice fallback instead.
+   */
+  @Test
+  public void countStarWithWhereStaysAggregateCount() {
     Assert.assertEquals(
         CacheableShape.AGGREGATE_COUNT,
-        ShapeClassifier.classify(parse("select count(*) from OUser")));
+        ShapeClassifier.classify(parse("select count(*) from OUser where name = ?")));
+  }
+
+  /**
+   * An aggregate buried under arithmetic ({@code count(*) + 1}) classifies K0_NONE, not
+   * AGGREGATE_COUNT. The cached aggregate replay produces the bare scalar, so caching the arithmetic
+   * result as an AGGREGATE_* shape would replay the wrong value; the K0 version gate serves it safely
+   * instead. This is the tightening that matters now that aggregates actually cache — the earlier
+   * looser match (return the inner call regardless of surrounding arithmetic) was harmless only while
+   * aggregates were uncached.
+   */
+  @Test
+  public void aggregateUnderArithmeticClassifiesAsK0None() {
+    Assert.assertEquals(
+        "count(*) + 1 is an expression over an aggregate, not a bare aggregate; it must classify"
+            + " K0_NONE so the aggregate replay never returns the un-incremented scalar",
+        CacheableShape.K0_NONE,
+        ShapeClassifier.classify(parse("select count(*) + 1 from OUser")));
+  }
+
+  /**
+   * SUM under arithmetic ({@code sum(age) * 2}) likewise classifies K0_NONE, confirming the
+   * arithmetic-rejection rule is not specific to COUNT.
+   */
+  @Test
+  public void sumUnderArithmeticClassifiesAsK0None() {
+    Assert.assertEquals(
+        CacheableShape.K0_NONE,
+        ShapeClassifier.classify(parse("select sum(age) * 2 from OUser")));
   }
 
   /** {@code SUM(prop)} maps to the sum aggregate shape. */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifierTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifierTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor.cache;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLSelectStatement;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLStatement;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.YqlStatementCache;
 import org.junit.Assert;
@@ -156,14 +157,19 @@ public class ShapeClassifierTest extends DbTestBase {
   }
 
   /**
-   * {@code COUNT(DISTINCT(prop))} maps to the count-distinct shape, distinct from a plain count. In
-   * this dialect the DISTINCT keyword inside a function call parses as a nested {@code distinct(...)}
-   * function, which is what the classifier detects.
+   * {@code COUNT(DISTINCT(prop))} classifies K0_NONE, not a distinct-count aggregate shape. The engine
+   * has no native distinct-count and computes {@code count(distinct(prop))} as a plain row count, so the
+   * K0 version gate (re-execute on any mutation) reproduces the engine's result exactly; modelling a
+   * true distinct-count in the aggregate replay would diverge from that native semantics. The DISTINCT
+   * keyword inside a function call parses as a nested {@code distinct(...)} call, which is what the
+   * classifier detects to make this routing decision.
    */
   @Test
-  public void countDistinctClassifiesAsAggregateCountDistinct() {
+  public void countDistinctClassifiesAsK0None() {
     Assert.assertEquals(
-        CacheableShape.AGGREGATE_COUNT_DISTINCT,
+        "count(distinct(prop)) must classify K0_NONE so the K0 version gate keeps it matching the"
+            + " engine's native row-count semantics",
+        CacheableShape.K0_NONE,
         ShapeClassifier.classify(parse("select count(distinct(name)) from OUser")));
   }
 
@@ -184,5 +190,62 @@ public class ShapeClassifierTest extends DbTestBase {
     Assert.assertEquals(
         CacheableShape.RECORD,
         ShapeClassifier.classify(parse("select name.toLowerCase() from OUser")));
+  }
+
+  // ===========================================================================
+  // aggregateMetadata — the side-tap populate path's per-shape facts
+  // ===========================================================================
+
+  private ShapeClassifier.AggregateMetadata metadata(String sql) {
+    return ShapeClassifier.aggregateMetadata((SQLSelectStatement) parse(sql));
+  }
+
+  /**
+   * A value aggregate over a bare property yields metadata carrying that property name and the matching
+   * kind, so the side-tap reads the right field from each contributing record. The alias is the
+   * projection alias the aggregation step emits ({@code sum(age)}).
+   */
+  @Test
+  public void aggregateMetadataForSumCarriesPropertyAndKind() {
+    var md = metadata("select sum(age) from OUser");
+    Assert.assertEquals(CacheableShape.AGGREGATE_SUM, md.kind());
+    Assert.assertEquals("age", md.propertyName());
+    Assert.assertEquals("sum(age)", md.alias());
+  }
+
+  /** MIN/MAX/AVG likewise carry the bare property name they read from each contributing record. */
+  @Test
+  public void aggregateMetadataForMinMaxAvgCarryProperty() {
+    Assert.assertEquals("age", metadata("select min(age) from OUser").propertyName());
+    Assert.assertEquals("age", metadata("select max(age) from OUser").propertyName());
+    Assert.assertEquals("age", metadata("select avg(age) from OUser").propertyName());
+  }
+
+  /**
+   * {@code COUNT(*)} with a WHERE (the tappable count shape) yields metadata with a {@code null} property
+   * name: it observes membership only and reads no value. The kind is AGGREGATE_COUNT.
+   */
+  @Test
+  public void aggregateMetadataForCountStarHasNullProperty() {
+    var md = metadata("select count(*) from OUser where name = ?");
+    Assert.assertEquals(CacheableShape.AGGREGATE_COUNT, md.kind());
+    Assert.assertNull("COUNT(*) reads no per-row value", md.propertyName());
+  }
+
+  /**
+   * {@code count(distinct(prop))} returns null metadata: it classifies K0_NONE and must never reach the
+   * aggregate populate path. A null here is the signal the session uses to bypass the splice entirely.
+   */
+  @Test
+  public void aggregateMetadataForCountDistinctIsNull() {
+    Assert.assertNull(
+        "count(distinct(prop)) is K0_NONE; the aggregate path must not derive metadata for it",
+        metadata("select count(distinct(name)) from OUser"));
+  }
+
+  /** A non-aggregate (plain RECORD) statement yields null metadata. */
+  @Test
+  public void aggregateMetadataForRecordShapeIsNull() {
+    Assert.assertNull(metadata("select from OUser where name = ?"));
   }
 }

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/implementation-plan.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/implementation-plan.md
@@ -384,6 +384,11 @@ Full statements and per-shape test matrices: design.md §"Invariants".
   > tests).
   >
   > **Track file:** `plan/track-1.md` (7 steps, 0 failed)
+  >
+  > **Strategy refresh:** CONTINUE — Track 1's cross-track obligations
+  > (recordPulledRow cap routing, QUERY_CACHE_*_RATE metric wiring,
+  > inFlightLookup liveness, exitCacheCodeUnchecked) are already folded into the
+  > Track 2 and Track 3 entries; no new downstream impact.
 
 - [ ] Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT
   > Adds the `AGGREGATE_*` family on top of Track 1's foundation: the

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/implementation-plan.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/implementation-plan.md
@@ -403,17 +403,21 @@ Full statements and per-shape test matrices: design.md §"Invariants".
   > aggregate branches, splice + fallback in `DatabaseSessionEmbedded`, and the
   > per-aggregate-kind I4 + I5-enumeration tests.
   > **Depends on:** Track 1
-  > **Carried from Track-1 Phase C review:** wire the global
-  > `QUERY_CACHE_*_RATE` metric increments — Track 1 defines and registers
-  > them in `CoreMetrics` but never increments them, and the
-  > "wiring lands in later steps" comment is now stale; finalize them where
-  > this track records cache hits/misses for aggregate shapes. Route every
-  > per-RID/row append through `CachedEntry.recordPulledRow` so the
-  > `maxRecordsPerEntry` cap (enforced only at that point) applies to
-  > aggregate material. If the aggregate splice calls `QueryResultCache.lookup`
-  > outside the `cacheCodeDepth` bracket, the lookup-level `inFlightLookup`
-  > guard becomes reachable and needs end-to-end coverage. Use
-  > `exitCacheCodeUnchecked` for any view-owned cross-thread guard release.
+  > **Carried from Track-1 Phase C review (corrected in Track 2 Phase A):** the
+  > per-tx hit/miss/k0/overflow counters already exist in Track 1's
+  > `QueryResultCache`; what remains is the new `incrementSpliceFailures` counter
+  > plus the global `CoreMetrics.QUERY_CACHE_*_RATE` bridge (registered in Track 1
+  > but never incremented) — finalize the global bridge where this track records
+  > aggregate cache hits/misses. The "route every per-RID append through
+  > `CachedEntry.recordPulledRow`" instruction does NOT apply to aggregates:
+  > `recordPulledRow` bounds the single-scalar `results`, whereas aggregate
+  > material lives in `AggregateState`; cap the `AggregateState` collections
+  > instead and route the key non-cacheable on overflow (see track-2.md Plan of
+  > Work step 1 and Decision Log). If the aggregate splice calls
+  > `QueryResultCache.lookup` outside the `cacheCodeDepth` bracket, the
+  > lookup-level `inFlightLookup` guard becomes reachable and needs end-to-end
+  > coverage. Use `exitCacheCodeUnchecked` for any view-owned cross-thread guard
+  > release.
 
 - [ ] Track 3: MATCH shapes — Etap A composition, partial Etap B, tombstone floor
   > Adds MATCH caching: Etap A (single-alias) folds to RECORD shape via a stored

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/implementation-plan.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/implementation-plan.md
@@ -390,7 +390,7 @@ Full statements and per-shape test matrices: design.md §"Invariants".
   > inFlightLookup liveness, exitCacheCodeUnchecked) are already folded into the
   > Track 2 and Track 3 entries; no new downstream impact.
 
-- [ ] Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT
+- [x] Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT
   > Adds the `AGGREGATE_*` family on top of Track 1's foundation: the
   > `AggregateCacheTapStep` spliced upstream of aggregation to seed per-RID
   > material, the `AggregateState` with `observe`/`applyMutation`/`copy`/`toResult`,
@@ -398,26 +398,61 @@ Full statements and per-shape test matrices: design.md §"Invariants".
   > (SUM/AVG via `PropertyTypeInternal.increment` for storage parity), D20
   > (`COUNT(DISTINCT prop)` via per-value RID buckets), and the D21-collapse
   > membership-based dispatch. Aggregate cache-miss eagerly drives the plan.
-  > **Scope:** ~8 files covering `AggregateState`, `AggregateCacheTapStep`,
-  > `DeltaBuilder` (aggregate path), `ShapeClassifier`/`CachedResultSetView`
-  > aggregate branches, splice + fallback in `DatabaseSessionEmbedded`, and the
-  > per-aggregate-kind I4 + I5-enumeration tests.
-  > **Depends on:** Track 1
-  > **Carried from Track-1 Phase C review (corrected in Track 2 Phase A):** the
-  > per-tx hit/miss/k0/overflow counters already exist in Track 1's
-  > `QueryResultCache`; what remains is the new `incrementSpliceFailures` counter
-  > plus the global `CoreMetrics.QUERY_CACHE_*_RATE` bridge (registered in Track 1
-  > but never incremented) — finalize the global bridge where this track records
-  > aggregate cache hits/misses. The "route every per-RID append through
-  > `CachedEntry.recordPulledRow`" instruction does NOT apply to aggregates:
-  > `recordPulledRow` bounds the single-scalar `results`, whereas aggregate
-  > material lives in `AggregateState`; cap the `AggregateState` collections
-  > instead and route the key non-cacheable on overflow (see track-2.md Plan of
-  > Work step 1 and Decision Log). If the aggregate splice calls
-  > `QueryResultCache.lookup` outside the `cacheCodeDepth` bracket, the
-  > lookup-level `inFlightLookup` guard becomes reachable and needs end-to-end
-  > coverage. Use `exitCacheCodeUnchecked` for any view-owned cross-thread guard
-  > release.
+  >
+  > **Track episode:**
+  > Built the AGGREGATE_* cache path on Track 1's foundation: `AggregateState`
+  > (observe/applyMutation/copy/toResult for all six kinds — SUM/AVG storage
+  > parity via `PropertyTypeInternal.increment`, AVG finalization through
+  > `SQLFunctionAverage.computeAverage`, MIN/MAX extremum-RID transitions,
+  > COUNT_DISTINCT buckets, and a per-state collection cap that routes the key
+  > non-cacheable on overflow), `DeltaBuilder.buildForAggregate`, the
+  > `CachedResultSetView` aggregate path, the `AggregateCacheTapStep` spliced
+  > upstream of `AggregateProjectionCalculationStep`, and the eager-drive plus
+  > uncached fallback in `DatabaseSessionEmbedded`.
+  >
+  > Discoveries with downstream impact:
+  > - `count(distinct(prop))` returns a ROW count in this engine, not a distinct
+  >   count (`SQLFunctionCount` counts every non-null argument; the nested
+  >   `distinct(...)` does not dedup). Routed to K0_NONE so the version gate
+  >   reproduces the engine result exactly; Step 1's distinct-count machinery is
+  >   retained but production-unreached. Phase 4 must reconcile design D20, which
+  >   listed AGGREGATE_COUNT_DISTINCT cacheable.
+  > - Bare and single-field-indexed `COUNT(*)` are hardwired to
+  >   `CountFromClassStep` before any projection step exists: bare `COUNT(*)`
+  >   classifies K0_NONE, indexed `COUNT(*)` rides the splice fallback
+  >   (`incrementSpliceFailures`). Phase 4 must reconcile the design's
+  >   COUNT(*)-cacheable listing.
+  > - The cache package cites design DR/invariant IDs (D7/D8/D11/D18–21,
+  >   I1/I3/I6/I9/I10) in Javadoc, a Track-1 convention. Phase 4 must define these
+  >   in `adr.md` or strip them branch-wide before `_workflow/` is removed.
+  > - `FunctionDeterminismEnumerationTest` walks all four `SQLFunctionFactory`
+  >   implementations and build-fails on any unclassified registered function — a
+  >   build gate any future SQL-function addition trips until the name is
+  >   classified.
+  >
+  > Cross-track impact for Track 3 (MATCH): the `serveThroughCache` gate now
+  > routes RECORD, K0_NONE, and all AGGREGATE_* through separate branches; only
+  > MATCH_TUPLE_MULTI bypasses. Track 3's MATCH branch must follow the same
+  > separate-gate pattern and transfer `viewOwnsGuard` when it builds a
+  > `CachedResultSetView`. The Track-1 cautions carried in correctly: the
+  > `recordPulledRow` cap does not apply to aggregates (the cap targets the
+  > `AggregateState` collections instead), and cross-thread guard release uses
+  > `exitCacheCodeUnchecked`.
+  >
+  > Phase C track-level review (10 dimensional reviewers, one iteration): 19
+  > findings, zero blockers. Six in-scope test-completeness gaps fixed and
+  > verified (Review fix `2a369b1731`): empty-set drain to null/0 across all
+  > kinds, null-property observe/applyMutation skip, MIN/MAX cross-subtype and
+  > non-Number-Comparable comparison, AVG negative-truncation and HALF_UP
+  > boundary, and an evened-out cache-vs-fresh equivalence matrix. One
+  > test-structure finding (an alleged `DbTestBase` double-database setup) was
+  > rejected as a misread — the test extends `Object`. Eleven suggestion-severity
+  > findings were deferred without correctness impact (code-quality polish, two
+  > unreachable null-guard/plan-shape notes, perf micro-optimizations already
+  > logged in the Step 1/3 episodes, test-readability). Two writing-style findings
+  > against immutable episode prose are won't-fix.
+  >
+  > **Track file:** `plan/track-2.md` (3 steps, 0 failed)
 
 - [ ] Track 3: MATCH shapes — Etap A composition, partial Etap B, tombstone floor
   > Adds MATCH caching: Etap A (single-alias) folds to RECORD shape via a stored

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -19,21 +19,62 @@ eagerly drives the plan, unlike RECORD's lazy pull, because a partially-driven
 tap would cache a structurally meaningless scalar.
 
 ## Progress
-- [ ] Review + decomposition
+- [x] Review + decomposition
 - [ ] Step implementation
 - [ ] Track-level code review
 - [ ] Track completion
 
+- [x] 2026-06-11T11:29Z [ctx=info] Review + decomposition complete
+
 ## Surprises & Discoveries
 <!-- Continuous-log. Empty at Phase 1. -->
+
+- **Phase A review (iter 1):** bare and single-field-indexed `COUNT(*)` are
+  hardwired in `SelectExecutionPlanner` to `CountFromClassStep` before any
+  `AggregateProjectionCalculationStep` exists, so the side-tap cannot reach them
+  (A1/R1). The Phase 1 headline validation example `SELECT COUNT(*) FROM C` would
+  have asserted the fallback path, not the cache.
+- **Phase A review (iter 1):** Track 1 over-delivered the `ShapeClassifier`
+  aggregate gates, including the COUNT(DISTINCT) nested-`distinct(...)` parse
+  (R6) — step 5 is verify-and-tighten, not build.
+- **Phase A review, rejected:** the adversarial "splice corrupts the shared
+  cached plan" finding (A2) is a false positive —
+  `YqlExecutionPlanCache.getInternal` returns `result.copy(ctx)`, so the caller
+  always holds a private plan copy.
+- **Phase A review (iter 1):** the ServiceLoader manifest registers four
+  `SQLFunctionFactory` implementations, not three (R5 — `DynamicSQLElementFactory`
+  was omitted from the Phase 1 description).
 
 ## Decision Log
 <!-- Continuous-log. -->
 
 <!-- Reserved for Move 1 — per-track inlined Decision Records. -->
 
+- **Hardwired `COUNT(*)` → not cached (Phase A).** Bare and single-field-indexed
+  `COUNT(*)` are excluded from the aggregate cache (ride the splice fallback or
+  classify K0_NONE). They are already O(1) and tx-aware via `CountFromClassStep`,
+  so caching adds complexity for no benefit and the side-tap cannot tap them.
+  Refines design §AGGREGATE_* shape, which listed `COUNT(*)` as cacheable; flag
+  for Phase 4 design-doc reconciliation.
+- **Aggregate memory cap targets `AggregateState`, not `results` (Phase A).** The
+  carried-from-Track-1 "route per-RID append through `recordPulledRow`"
+  obligation is mis-applied to aggregates; the cap bounds the per-contributor
+  collections instead. Overflow routes the key non-cacheable via the L7 path.
+- **AVG finalizes via `computeAverage` (Phase A).** D19's `increment` covers the
+  SUM accumulation only; AVG needs the contributor `total` and
+  `SQLFunctionAverage.computeAverage`'s type-dispatched division for bit-for-bit
+  parity.
+- **`applyMutation` value-from-record (Phase A).** A T→T value-changing UPDATE
+  reads the new value from the mutated `RecordAbstract`; `boolean matchAfter`
+  carries WHERE-membership only. The existing signature is sufficient (rejects
+  A6.2).
+
 ## Outcomes & Retrospective
 <!-- Continuous-log. -->
+
+- [x] Technical: PASS at iteration 2 (6 findings, 6 accepted)
+- [x] Risk: PASS at iteration 2 (6 findings, 5 accepted; R6 was already implemented in Track 1)
+- [x] Adversarial: PASS at iteration 2 (6 findings, 5 accepted; A2 rejected as a false positive — the plan is copied, not shared)
 
 ## Context and Orientation
 
@@ -53,9 +94,20 @@ Track 1 has shipped the cache infra, `CachedEntry`, `DeltaBuilder` (record path)
 - **`SQLFunctionDistinct.getResult`** uses `LinkedHashSet<Object>` with raw
   `Object.equals`/`hashCode`, so `Long(5)` and `Integer(5)` are distinct;
   `distinctBuckets: Map<Object, Set<RID>>` mirrors that (D20).
-- **Three `SQLFunctionFactory` implementations** (`DefaultSQLFunctionFactory`,
-  `CustomSQLFunctionFactory` reflective `math_*`, `DatabaseFunctionFactory`
-  stored) are the enumeration surface for the I5 completeness test.
+- **Four `SQLFunctionFactory` implementations** (`DefaultSQLFunctionFactory`,
+  `DynamicSQLElementFactory`, `CustomSQLFunctionFactory` reflective `math_*`,
+  `DatabaseFunctionFactory` stored) are the enumeration surface for the I5
+  completeness test. The ServiceLoader manifest registers all four; the Phase 1
+  description named only three (it omitted `DynamicSQLElementFactory`).
+- **Bare and single-field-indexed `COUNT(*)` are hardwired and untappable.**
+  `SelectExecutionPlanner.handleHardwiredOptimizations` short-circuits
+  `SELECT count(*) FROM C` (via `handleHardwiredCountOnClass`) and
+  `SELECT count(*) FROM C WHERE indexedField = ?` (via
+  `handleHardwiredCountOnClassUsingIndex`) to `CountFromClassStep` *before* any
+  `AggregateProjectionCalculationStep` is built, so the side-tap finds nothing to
+  splice. These shapes are already O(1) and tx-aware. `COUNT(*)` over a
+  non-indexed WHERE, and SUM/AVG/MIN/MAX/COUNT(DISTINCT), do build the
+  aggregation step and ARE tappable. See Plan of Work step 5 and Decision Log.
 
 Non-obvious terminology: *side-tap* (a transparent `ExecutionStream` wrapper that
 observes-then-forwards), *eager drive* (forcing the plan to full drain at
@@ -67,7 +119,7 @@ for D21 collapse safety).
 flowchart LR
     Miss["aggregate cache-miss"] --> Plan["createExecutionPlan(ctx, false)"]
     Plan --> Splice["splice AggregateCacheTapStep\nupstream of AggregateProjectionCalculationStep"]
-    Splice --> Drive["plan.start(ctx).next(ctx)\n(blocking full drain)"]
+    Splice --> Drive["plan.start(ctx) + drain\n(blocking full drain)"]
     Drive --> Obs["tap.observe(result)\nper contributing record"]
     Obs --> State["AggregateState\ncontributingValues / Rids / buckets"]
     State --> Entry["CachedEntry (immutable scalar)"]
@@ -85,33 +137,87 @@ CREATE of the extremum holder + post-populate UPDATE breaking WHERE), the splice
 Approximate sequence (decomposer sets final boundaries):
 
 1. **`AggregateState`.** Fields and the `observe`/`applyMutation`/`copy`/`toResult`
-   methods for all six kinds. SUM/AVG via `PropertyTypeInternal.increment` with a
-   full re-fold on T→T/T→F/F→T (no symmetric subtract). MIN/MAX with
-   `extremumRid` RID-identity `was_extremum` and the O(n) recompute only on the
-   two extremum-leaves transitions. COUNT_DISTINCT with `distinctBuckets` +
-   bucket cleanup. All dispatch keys on the `(was_contributing → now_contributing)`
-   transition derived from membership, never `op.type` (D21 collapse safety).
+   methods for all six kinds.
+   - **SUM/AVG storage parity (D19).** `observe` seeds the first contributing
+     value verbatim, then folds each subsequent value via
+     `PropertyTypeInternal.increment` (the primitive `SQLFunctionSum.sum` /
+     `SQLFunctionAverage.sum` use); `applyMutation` does a full re-fold of
+     `contributingValues.values()` on T→T/T→F/F→T (no symmetric subtract). On a
+     T→T value-changing UPDATE the new value is read from the mutated
+     `RecordAbstract` and written into `contributingValues[rid]` before the
+     re-fold; the `boolean matchAfter` flag carries WHERE-membership only. SUM
+     over an empty set is `0`, not null.
+   - **AVG finalization.** AVG additionally tracks the contributor count
+     (`total`) and finalizes through `SQLFunctionAverage.computeAverage`'s
+     type-dispatched division (integer truncation for Integer/Long, BigDecimal
+     `HALF_UP`), not a plain `sum/total`, so the cached scalar matches fresh
+     execution bit-for-bit. `increment` alone (D19) covers only the SUM half.
+   - **MIN/MAX** with `extremumRid` RID-identity `was_extremum` and the O(n)
+     recompute only on the two extremum-leaves transitions.
+   - **COUNT_DISTINCT** with `distinctBuckets` + bucket cleanup.
+   - **Dispatch** keys on the `(was_contributing → now_contributing)` transition
+     derived from membership (`contributingValues.containsKey(rid)` /
+     `contributingRids.contains(rid)`); `status` is consulted only to fold
+     `DELETED` into `now_contributing = false`, never as a stand-in for the
+     before-state (D21 collapse safety — design.md's wording, not the looser
+     "never op.type").
+   - **Memory cap (aggregate-specific).** The carried-from-Track-1
+     `recordPulledRow` cap bounds `results` (one scalar row for an aggregate) and
+     does NOT bound the per-contributor material. Bound the `AggregateState`
+     collections (`contributingValues` / `contributingRids` / `distinctBuckets`)
+     against `maxRecordsPerEntry` instead; on overflow, route the key
+     non-cacheable (the L7 path: remove the entry, add the key to
+     `nonCacheableKeys`). High-cardinality COUNT(DISTINCT)/MIN/MAX is the real
+     OOM vector, not `results`.
 2. **`AggregateCacheTapStep`.** `extends AbstractExecutionStep`; `internalStart`
    calls `prev.start(ctx)` and wraps the stream so `next(ctx)` invokes
    `observe(result)` before forwarding unchanged.
 3. **Splice + fallback in `DatabaseSessionEmbedded`.** Miss path builds the plan
-   via `statement.createExecutionPlan(ctx, false)`, downcasts to
-   `SelectExecutionPlan`, walks `steps`, finds `AggregateProjectionCalculationStep`,
-   rewires its `prev` to the tap. On unexpected shape: close the plan, increment
-   `spliceFailures`, fall back to `statement.execute(...)` returning a plain
-   `LocalResultSet` (no cache), log the step types.
-4. **Eager drive on cache-put.** Force `plan.start(ctx).next(ctx)` so the tap
-   observes every record; hold the single-row scalar on the entry alongside the
-   now-complete `AggregateState`. Wrap in try / put-on-success-only.
-5. **`DeltaBuilder.buildForAggregate` + classify branch.** Copy + replay the
-   populate-version-filtered ops; wire `ShapeClassifier` aggregate gates
-   (single aggregate, no GROUP BY/HAVING, no expression arg, no SKIP/LIMIT;
-   `COUNT(DISTINCT prop)` → AGGREGATE_COUNT_DISTINCT, expression-DISTINCT →
-   K0_NONE). Wire the `CachedResultSetView` aggregate path (`toResult()`,
-   `hasNext` true once).
+   via `statement.createExecutionPlan(ctx, false)` (the returned plan is a
+   per-execution `copy(ctx)` from `YqlExecutionPlanCache.getInternal`, or a fresh
+   `SelectExecutionPlan` on a cache miss — never the shared cached instance, so
+   rewiring `prev` cannot corrupt other callers' plans), downcasts to
+   `SelectExecutionPlan`, walks `steps`, finds
+   `AggregateProjectionCalculationStep`, rewires its `prev` to the tap. The
+   aggregate miss path is a separate branch in the cache shape gate (the existing
+   `serveThroughCache` RECORD/K0 gate), not folded into it, and preserves Track
+   1's two-guard `viewOwnsGuard`/`cacheCodeDepth` contract. On unexpected shape
+   (no `AggregateProjectionCalculationStep` found — e.g. a hardwired
+   `CountFromClassStep`): close the plan, call `incrementSpliceFailures`, fall
+   back to a plain uncached `LocalResultSet` that reproduces the exact uncached
+   behavior, log the step types.
+4. **Eager drive on cache-put.** Drive the plan to full drain via
+   `plan.start(ctx)` then pull the resulting stream to exhaustion (the blocking
+   `AggregateProjectionCalculationStep` produces its single row only after every
+   contributor is observed) so the tap sees every record; hold the single-row
+   scalar on the entry alongside the now-complete `AggregateState`. This is a
+   parallel populate path that cannot reuse Track 1's `populateAndBuildView`, so
+   it independently re-mirrors the three Track-1 populate contracts: stamp
+   `populateMutationVersion` before driving, release the `cacheCodeDepth` guard on
+   every exit (a leaked depth silently disables caching), and close the plan
+   idempotently. Wrap in try / put-on-success-only.
+5. **`DeltaBuilder.buildForAggregate` + classifier tightening.** Copy + replay
+   the populate-version-filtered ops. The `ShapeClassifier` aggregate gates
+   already exist in Track 1 (single aggregate, no GROUP BY/HAVING/SKIP/LIMIT,
+   `count(distinct(prop))` → AGGREGATE_COUNT_DISTINCT, expression-DISTINCT →
+   K0_NONE, including the nested-`distinct(...)` parse) — verify, do not rebuild
+   them. Two tightenings ARE Track 2 work, because aggregates now actually cache:
+   (a) an aggregate buried under arithmetic (`count(*) + 1`) must classify
+   K0_NONE, not AGGREGATE_COUNT — Track 1's `topLevelFunctionCall` returns the
+   inner call and its Javadoc flags this looser match as "harmless here" only
+   while aggregates are uncached; (b) bare/indexed `COUNT(*)` (the hardwired
+   shapes from Context & Orientation) gain no benefit from caching and cannot be
+   tapped, so they either ride the splice fallback or classify K0_NONE — pick one
+   explicitly and test it. Wire the `CachedResultSetView` aggregate path
+   (`toResult()`, `hasNext` true once).
 6. **I4 per-kind + I5 enumeration tests.** Per aggregate kind, the four mutation
-   patterns plus the collapse case. The I5 test walks all three factories and
-   fails the build on an unclassified function.
+   patterns plus the collapse case. I4 cache-hit cases must use a *tappable*
+   shape — not bare `COUNT(*) FROM C` (hardwired, untappable; that test would
+   assert the fallback path and prove nothing). Add a case asserting the hardwired
+   `COUNT(*)` shapes take the fallback, and a memory-cap case that overflows
+   `AggregateState` on a high-cardinality COUNT(DISTINCT) and confirms the key
+   goes non-cacheable. The I5 test walks all four `SQLFunctionFactory`
+   implementations and fails the build on an unclassified function.
 
 Ordering: step 1 is standalone; steps 2-4 form the splice+drive path; step 5
 depends on 1; tests last. Invariants to preserve: aggregate replay matches
@@ -120,28 +226,82 @@ scalar (eager drive); membership dispatch must survive the `addRecordOperation`
 collapse.
 
 ## Concrete Steps
-<!-- Phase A placeholder. -->
+
+1. **AggregateState replay core.** New `AggregateState` (observe / applyMutation /
+   copy / toResult for all six kinds: SUM/AVG storage parity via
+   `PropertyTypeInternal.increment` with first-value seed and full re-fold; AVG
+   `total` + `SQLFunctionAverage.computeAverage` finalization; MIN/MAX
+   `extremumRid` transitions; COUNT_DISTINCT buckets; membership-derived dispatch
+   with D21 collapse safety; aggregate-specific cap on the `AggregateState`
+   collections that routes the key non-cacheable on overflow), plus
+   `DeltaBuilder.buildForAggregate` (copy + replay populate-version-filtered ops),
+   the `CachedResultSetView` aggregate path (`toResult()`, `hasNext` true once),
+   and the `CachedEntry` `aggregateState` field. Unit-tested in isolation:
+   per-kind observe/applyMutation, mixed-input/overflow/precision SUM parity, AVG
+   integer-truncation and BigDecimal `HALF_UP`, the collapse case, cap overflow.
+   *(parallel with Step 2)* — risk: high (performance hot path)  [ ]
+2. **Classifier tightening + global metric bridge.** Tighten `ShapeClassifier` so
+   an aggregate under arithmetic (`count(*) + 1`) classifies K0_NONE (not
+   AGGREGATE_COUNT) and bare / single-field-indexed `COUNT(*)` rides the fallback
+   or classifies K0_NONE (hardwired, untappable); the existing aggregate gates and
+   the COUNT(DISTINCT) nested-`distinct(...)` parse are verified, not rebuilt.
+   Wire the global `CoreMetrics.QUERY_CACHE_*_RATE` increments from the existing
+   per-tx counters. Tested: classifier unit cases for both tightenings, the I5
+   four-factory enumeration completeness test, and a metric-increment assertion.
+   *(parallel with Step 1)* — risk: medium — size: ~3 files; (a) no mergeable
+   low/medium work fits (rest of track is high-tagged or its own integration
+   tests)  [ ]
+3. **Tap + splice + eager drive + fallback.** New `AggregateCacheTapStep extends
+   AbstractExecutionStep`; in `DatabaseSessionEmbedded` the aggregate miss path
+   builds the plan via `createExecutionPlan` (a per-execution copy), splices the
+   tap upstream of `AggregateProjectionCalculationStep` as a separate branch in
+   the cache shape gate (preserving the two-guard `viewOwnsGuard` / `cacheCodeDepth`
+   contract), eager-drives via `plan.start(ctx)` + drain while re-mirroring the
+   three Track-1 populate contracts (stamp `populateMutationVersion` before
+   driving, release the guard on every exit, idempotent close), and falls back to
+   an uncached `LocalResultSet` + `incrementSpliceFailures` on any unexpected
+   shape (e.g. a hardwired `CountFromClassStep`). End-to-end tested: per-kind
+   cache-vs-fresh I4 equivalence over a tappable shape (COUNT/SUM/AVG/MIN/MAX/
+   COUNT_DISTINCT) including the D21 collapse case, bare/indexed COUNT(*) takes the
+   fallback, cap overflow routes the key non-cacheable, no exception leaks.
+   Depends on Steps 1 and 2. — risk: high (architecture / cross-component
+   coordination)  [ ]
 
 ## Episodes
 <!-- Continuous-log. -->
 
 ## Validation and Acceptance
 
-- `SELECT COUNT(*) FROM C` cached, then a matching CREATE / a WHERE-breaking
-  UPDATE / a DELETE between two `query()` calls → the second scalar matches a
-  parallel uncached `query()` (per kind: COUNT, SUM, AVG, MIN, MAX,
-  COUNT_DISTINCT).
+- A *tappable* aggregate (e.g. `SELECT SUM(price) FROM C WHERE active = true`, or
+  `COUNT(*)` over a non-indexed predicate) cached, then a matching CREATE / a
+  WHERE-breaking UPDATE / a DELETE between two `query()` calls → the second scalar
+  matches a parallel uncached `query()` (per kind: COUNT, SUM, AVG, MIN, MAX,
+  COUNT_DISTINCT). The per-kind cache-hit case must NOT use bare
+  `COUNT(*) FROM C`, which is hardwired to `CountFromClassStep` and never reaches
+  the side-tap.
+- Bare `SELECT COUNT(*) FROM C` and indexed `COUNT(*) ... WHERE indexedField = ?`
+  take the uncached fallback (or classify K0_NONE), `incrementSpliceFailures`
+  fires on the fallback branch, and the scalar still matches fresh — caching them
+  is neither attempted nor needed (already O(1)).
+- `count(*) + 1` (aggregate under arithmetic) classifies K0_NONE and is served
+  via the K0 version gate, not the aggregate cache.
 - The D21 collapse case (pre-populate CREATE of the MIN/MAX holder + post-populate
   UPDATE that breaks WHERE; and one that drops the holder's value below a
   non-holder) → cached scalar matches fresh, with no stale contributor.
 - SUM over mixed Long+Double input replays to the same Double fresh execution
-  returns; Long overflow and `2^53+1` precision loss match by construction.
+  returns; Long overflow and `2^53+1` precision loss match by construction. AVG
+  over Integer/Long input truncates exactly as `computeAverage` does (integer
+  division), and BigDecimal AVG rounds `HALF_UP`, matching fresh.
 - `COUNT(DISTINCT prop)` with cross-subtype values (`Long(5)`, `Integer(5)`)
   keeps distinct buckets matching storage; `COUNT(DISTINCT a+b)` routes to K0_NONE.
+- A high-cardinality COUNT(DISTINCT) / MIN / MAX that overflows the
+  `AggregateState` collection cap routes the key non-cacheable (no OOM, no stale
+  cache).
 - A planner shape with no `AggregateProjectionCalculationStep` falls back to an
-  uncached `LocalResultSet` and increments `spliceFailures`; no exception leaks.
+  uncached `LocalResultSet` and `incrementSpliceFailures` fires; no exception
+  leaks.
 - The I5 enumeration test fails the build if a new non-deterministic function in
-  any of the three factories lacks a denylist entry.
+  any of the four factories lacks a denylist entry.
 
 <!-- Phase A placeholder for per-step EARS/Gherkin lines. -->
 
@@ -179,8 +339,14 @@ unexpected plan shape. Eager drive matches the uncached aggregate latency profil
 internals.
 
 **Key signatures:**
-- `AggregateState#observe(Result)`, `#applyMutation(RecordAbstract, byte status, boolean matchAfter)`,
-  `#copy(): AggregateState`, `#toResult(): Result`
+- `AggregateState#observe(Result)`, `#applyMutation(RecordAbstract, byte status, boolean matchAfter)`
+  (the new value for a T→T re-fold is read from the `RecordAbstract`; `matchAfter`
+  carries WHERE-membership only), `#copy(): AggregateState`, `#toResult(): Result`
+- AVG state carries a `total` contributor count and finalizes via
+  `SQLFunctionAverage#computeAverage` (type-dispatched division), not `sum/total`
 - `DeltaBuilder#buildForAggregate(CachedEntry, FrontendTransactionImpl, CommandContext): AggregateState`
 - `AggregateCacheTapStep extends AbstractExecutionStep` — `internalStart(ctx): ExecutionStream`
 - `PropertyTypeInternal#increment(Number current, Number value): Number` (existing, reused)
+- `SQLFunctionAverage#computeAverage(...)` (existing, reused for AVG finalization)
+- `QueryResultCache#incrementSpliceFailures()` (the only new per-tx metric;
+  hit/miss/k0/overflow increments already exist in Track 1)

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -22,13 +22,14 @@ tap would cache a structurally meaningless scalar.
 - [x] Review + decomposition
 - [x] Step implementation
 - [x] Track-level code review
-- [ ] Track completion
+- [x] Track completion
 
 - [x] 2026-06-11T11:29Z [ctx=info] Review + decomposition complete
 - [x] 2026-06-11T18:27Z [ctx=safe] Step 1 complete (commit 4a9c9d0ccf)
 - [x] 2026-06-11T19:00Z [ctx=safe] Step 2 complete (commit d66cd22d57)
 - [x] 2026-06-11T20:32Z [ctx=info] Step 3 complete (commit 3c8849a70c)
 - [x] 2026-06-12T07:57Z [ctx=safe] Track-level code review iteration 1 complete (1/3 iterations)
+- [x] 2026-06-12T08:07Z [ctx=info] Track complete
 
 ## Surprises & Discoveries
 <!-- Continuous-log. Empty at Phase 1. -->

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -269,45 +269,9 @@ collapse.
 
 ## Concrete Steps
 
-1. **AggregateState replay core.** New `AggregateState` (observe / applyMutation /
-   copy / toResult for all six kinds: SUM/AVG storage parity via
-   `PropertyTypeInternal.increment` with first-value seed and full re-fold; AVG
-   `total` + `SQLFunctionAverage.computeAverage` finalization; MIN/MAX
-   `extremumRid` transitions; COUNT_DISTINCT buckets; membership-derived dispatch
-   with D21 collapse safety; aggregate-specific cap on the `AggregateState`
-   collections that routes the key non-cacheable on overflow), plus
-   `DeltaBuilder.buildForAggregate` (copy + replay populate-version-filtered ops),
-   the `CachedResultSetView` aggregate path (`toResult()`, `hasNext` true once),
-   and the `CachedEntry` `aggregateState` field. Unit-tested in isolation:
-   per-kind observe/applyMutation, mixed-input/overflow/precision SUM parity, AVG
-   integer-truncation and BigDecimal `HALF_UP`, the collapse case, cap overflow.
-   *(parallel with Step 2)* — risk: high (performance hot path)  [x] commit: 4a9c9d0ccf
-2. **Classifier tightening + global metric bridge.** Tighten `ShapeClassifier` so
-   an aggregate under arithmetic (`count(*) + 1`) classifies K0_NONE (not
-   AGGREGATE_COUNT) and bare / single-field-indexed `COUNT(*)` rides the fallback
-   or classifies K0_NONE (hardwired, untappable); the existing aggregate gates and
-   the COUNT(DISTINCT) nested-`distinct(...)` parse are verified, not rebuilt.
-   Wire the global `CoreMetrics.QUERY_CACHE_*_RATE` increments from the existing
-   per-tx counters. Tested: classifier unit cases for both tightenings, the I5
-   four-factory enumeration completeness test, and a metric-increment assertion.
-   *(parallel with Step 1)* — risk: medium — size: ~3 files; (a) no mergeable
-   low/medium work fits (rest of track is high-tagged or its own integration
-   tests)  [x] commit: d66cd22d57
-3. **Tap + splice + eager drive + fallback.** New `AggregateCacheTapStep extends
-   AbstractExecutionStep`; in `DatabaseSessionEmbedded` the aggregate miss path
-   builds the plan via `createExecutionPlan` (a per-execution copy), splices the
-   tap upstream of `AggregateProjectionCalculationStep` as a separate branch in
-   the cache shape gate (preserving the two-guard `viewOwnsGuard` / `cacheCodeDepth`
-   contract), eager-drives via `plan.start(ctx)` + drain while re-mirroring the
-   three Track-1 populate contracts (stamp `populateMutationVersion` before
-   driving, release the guard on every exit, idempotent close), and falls back to
-   an uncached `LocalResultSet` + `incrementSpliceFailures` on any unexpected
-   shape (e.g. a hardwired `CountFromClassStep`). End-to-end tested: per-kind
-   cache-vs-fresh I4 equivalence over a tappable shape (COUNT/SUM/AVG/MIN/MAX/
-   COUNT_DISTINCT) including the D21 collapse case, bare/indexed COUNT(*) takes the
-   fallback, cap overflow routes the key non-cacheable, no exception leaks.
-   Depends on Steps 1 and 2. — risk: high (architecture / cross-component
-   coordination)  [x] commit: 3c8849a70c
+1. **AggregateState replay core.** New `AggregateState` (observe / applyMutation / copy / toResult for all six kinds: SUM/AVG storage parity via `PropertyTypeInternal.increment` with first-value seed and full re-fold; AVG `total` + `SQLFunctionAverage.computeAverage` finalization; MIN/MAX `extremumRid` transitions; COUNT_DISTINCT buckets; membership-derived dispatch with D21 collapse safety; aggregate-specific cap on the `AggregateState` collections that routes the key non-cacheable on overflow), plus `DeltaBuilder.buildForAggregate` (copy + replay populate-version-filtered ops), the `CachedResultSetView` aggregate path (`toResult()`, `hasNext` true once), and the `CachedEntry` `aggregateState` field. Unit-tested in isolation: per-kind observe/applyMutation, mixed-input/overflow/precision SUM parity, AVG integer-truncation and BigDecimal `HALF_UP`, the collapse case, cap overflow. *(parallel with Step 2)* — risk: high (performance hot path)  [x] commit: 4a9c9d0ccf
+2. **Classifier tightening + global metric bridge.** Tighten `ShapeClassifier` so an aggregate under arithmetic (`count(*) + 1`) classifies K0_NONE (not AGGREGATE_COUNT) and bare / single-field-indexed `COUNT(*)` rides the fallback or classifies K0_NONE (hardwired, untappable); the existing aggregate gates and the COUNT(DISTINCT) nested-`distinct(...)` parse are verified, not rebuilt. Wire the global `CoreMetrics.QUERY_CACHE_*_RATE` increments from the existing per-tx counters. Tested: classifier unit cases for both tightenings, the I5 four-factory enumeration completeness test, and a metric-increment assertion. *(parallel with Step 1)* — risk: medium — size: ~3 files; (a) no mergeable low/medium work fits (rest of track is high-tagged or its own integration tests)  [x] commit: d66cd22d57
+3. **Tap + splice + eager drive + fallback.** New `AggregateCacheTapStep extends AbstractExecutionStep`; in `DatabaseSessionEmbedded` the aggregate miss path builds the plan via `createExecutionPlan` (a per-execution copy), splices the tap upstream of `AggregateProjectionCalculationStep` as a separate branch in the cache shape gate (preserving the two-guard `viewOwnsGuard` / `cacheCodeDepth` contract), eager-drives via `plan.start(ctx)` + drain while re-mirroring the three Track-1 populate contracts (stamp `populateMutationVersion` before driving, release the guard on every exit, idempotent close), and falls back to an uncached `LocalResultSet` + `incrementSpliceFailures` on any unexpected shape (e.g. a hardwired `CountFromClassStep`). End-to-end tested: per-kind cache-vs-fresh I4 equivalence over a tappable shape (COUNT/SUM/AVG/MIN/MAX/COUNT_DISTINCT) including the D21 collapse case, bare/indexed COUNT(*) takes the fallback, cap overflow routes the key non-cacheable, no exception leaks. Depends on Steps 1 and 2. — risk: high (architecture / cross-component coordination)  [x] commit: 3c8849a70c
 
 ## Episodes
 <!-- Continuous-log. -->

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -28,6 +28,7 @@ tap would cache a structurally meaningless scalar.
 - [x] 2026-06-11T18:27Z [ctx=safe] Step 1 complete (commit 4a9c9d0ccf)
 - [x] 2026-06-11T19:00Z [ctx=safe] Step 2 complete (commit d66cd22d57)
 - [x] 2026-06-11T20:32Z [ctx=info] Step 3 complete (commit 3c8849a70c)
+- [x] 2026-06-12T07:57Z [ctx=safe] Track-level code review iteration 1 complete (1/3 iterations)
 
 ## Surprises & Discoveries
 <!-- Continuous-log. Empty at Phase 1. -->

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -27,6 +27,7 @@ tap would cache a structurally meaningless scalar.
 - [x] 2026-06-11T11:29Z [ctx=info] Review + decomposition complete
 - [x] 2026-06-11T18:27Z [ctx=safe] Step 1 complete (commit 4a9c9d0ccf)
 - [x] 2026-06-11T19:00Z [ctx=safe] Step 2 complete (commit d66cd22d57)
+- [x] 2026-06-11T20:32Z [ctx=info] Step 3 complete (commit 3c8849a70c)
 
 ## Surprises & Discoveries
 <!-- Continuous-log. Empty at Phase 1. -->
@@ -58,6 +59,18 @@ tap would cache a structurally meaningless scalar.
   by the `math_` prefix rule. Any future track that registers a new SQL function or
   factory will break this test until the new name is classified — intended behavior,
   but a build-gating surprise for the unaware. See Episodes §Step 2.
+- **Step 3 (engine semantics):** `count(distinct(prop))` returns a ROW count in this
+  engine, not a distinct count — `SQLFunctionCount` counts every non-null argument and
+  the nested `distinct(...)` does not dedup count's input (a true distinct count needs
+  the subquery form `count(*) FROM (SELECT distinct(prop) ...)`). Resolved by routing
+  `count(distinct(prop))` to K0_NONE so the version gate reproduces the engine result.
+  Phase 4 must reconcile design D20's AGGREGATE_COUNT_DISTINCT cacheable-shape listing.
+  See Episodes §Step 3.
+- **Step 3 (Track 3 forward note):** the `serveThroughCache` shape gate now routes
+  RECORD, K0_NONE, and all AGGREGATE_* through the cache via separate branches; only
+  MATCH_TUPLE_MULTI bypasses. Track 3's MATCH branch must follow the same separate-gate
+  pattern and transfer `viewOwnsGuard` when it builds a `CachedResultSetView`. See
+  Episodes §Step 3.
 
 ## Decision Log
 <!-- Continuous-log. -->
@@ -89,6 +102,14 @@ tap would cache a structurally meaningless scalar.
   so the splice detects the `CountFromClassStep` and increments `spliceFailures`.
   Resolves Plan of Work step 5(b)'s "pick one explicitly and test it." See Episodes
   §Step 2.
+- **`count(distinct(prop))` → K0_NONE (Step 3, user-resolved design decision).** This
+  engine computes `count(distinct(prop))` as a row count, not a distinct count, so
+  caching a true distinct-count (design D20 / AGGREGATE_COUNT_DISTINCT) would violate
+  I10. Resolved by classifying `count(distinct(prop))` K0_NONE: the version gate
+  re-executes on mutation and reproduces the engine's row-count result exactly. This
+  supersedes Step 2's AGGREGATE_COUNT_DISTINCT classification; Step 1's distinct-count
+  `AggregateState` machinery is retained but production-unreached. Phase 4 reconciles
+  design D20. See Episodes §Step 3.
 
 ## Outcomes & Retrospective
 <!-- Continuous-log. -->
@@ -286,7 +307,7 @@ collapse.
    COUNT_DISTINCT) including the D21 collapse case, bare/indexed COUNT(*) takes the
    fallback, cap overflow routes the key non-cacheable, no exception leaks.
    Depends on Steps 1 and 2. — risk: high (architecture / cross-component
-   coordination)  [ ]
+   coordination)  [x] commit: 3c8849a70c
 
 ## Episodes
 <!-- Continuous-log. -->
@@ -383,6 +404,71 @@ appearing where an `AggregateProjectionCalculationStep` was expected. The metric
 lives inside `QueryCacheMetrics` (the increment sites in `QueryResultCache` are
 unchanged), so Step 3's `incrementSpliceFailures` call feeds the global splice-failure
 rate automatically.
+
+### Step 3 — commit 3c8849a70c, 2026-06-11T20:32Z [ctx=info]
+
+**What was done:** Wired the aggregate cache end to end. Added `AggregateCacheTapStep`,
+an observe-then-forward `ExecutionStream` wrapper (non-copyable, spliced
+post-construction). In `DatabaseSessionEmbedded` the aggregate miss path builds a
+per-execution plan copy via `createExecutionPlan`, finds the
+`AggregateProjectionCalculationStep`, splices the tap upstream of it (above a
+pre-aggregate `ProjectionCalculationStep` when present, since that projection strips
+record identity), eager-drives the plan to full drain, builds the entry with a null
+stream/plan/ctx (the scalar is fully computed at populate), and falls back to an
+uncached `LocalResultSet` plus `incrementSpliceFailures` on any unexpected shape. Added
+`QueryResultCache.incrementSpliceFailures()` and `installAggregateOverflowGuard()` (the
+cap is installed before the drive, so an over-cap populate routes the key non-cacheable
+and the later `put` is a no-op), and `ShapeClassifier.AggregateMetadata` +
+`aggregateMetadata()`. The aggregate branch is a separate gate in `serveThroughCache`
+preserving the two-guard `viewOwnsGuard` / `cacheCodeDepth` contract; `buildView` gained
+the aggregate branch (`DeltaBuilder.buildForAggregate` + `CachedResultSetView.forAggregate`).
+173 cache-package tests pass; 19 new end-to-end equivalence tests cover per-kind I4 over
+CREATE / DELETE / WHERE-break / value-UPDATE, the D21 collapse case, both hardwired and
+indexed COUNT(*) fallbacks, count(*)+1 and count(distinct) → K0_NONE, contributor-cap
+overflow, hit-on-repeat, and no-leak.
+
+**What was discovered:** This engine has no native distinct-count — `count(distinct(prop))`
+is computed as a plain row count (5 matching rows holding 2 distinct values returns 5,
+not 2; `SQLFunctionCount.execute` counts every non-null argument and the nested
+`distinct(...)` does not dedup count's input). Caching a true distinct-count would diverge
+from fresh execution, violating I10; the resolved design decision routes
+`count(distinct(prop))` to K0_NONE so the version gate reproduces the engine's row-count
+result exactly. The critical splice-point fix: `AggregateProjectionCalculationStep extends
+ProjectionCalculationStep`, so the pre-aggregate-projection detection excludes the
+aggregation step itself; splicing below the projection would observe null-RID rows and
+trip `AggregateState.observe`'s assert. Five suggestion-severity review findings defer (no
+correctness impact): BC1 (the spliced tap is absent from `SelectExecutionPlan.getSteps()`,
+so prettyPrint/reset/serialize skip it — unreachable: the plan is single-use and `close`
+reaches the tap via the prev-chain), BC2 (`SelectExecutionPlan.close()` derefs `lastStep`
+without a null guard — unreachable: a valid SELECT always chains at least one step), PF1
+(the splice-failure fallback builds the plan twice on the untappable-shape miss path), PF2
+(`aggregateMetadata` re-runs `classify` on an already-classified statement, a second AST
+walk per miss), and PF3 (contributor collections allocate at default capacity, carried
+from Step 1). Track 3 (MATCH) will add its own `serveThroughCache` branch alongside the
+aggregate branch and must transfer `viewOwnsGuard` when it builds a `CachedResultSetView`.
+
+**What changed from the plan:** Step 2's classifier mapping `count(distinct(prop))` →
+AGGREGATE_COUNT_DISTINCT is superseded by the resolved design decision — it now classifies
+K0_NONE, and the Step 2 `ShapeClassifierTest` assertion was updated to match. Step 1's
+COUNT_DISTINCT `AggregateState` machinery and its unit tests are retained but
+production-unreached in v1 (kept for a future engine with a true distinct-count); the I5
+enumeration test is unchanged. The cap-overflow equivalence test uses SUM over a
+high-cardinality value rather than COUNT(DISTINCT). Phase 4 must reconcile design D20
+(which lists AGGREGATE_COUNT_DISTINCT as a cacheable shape) against this routing. No effect
+on Track 3.
+
+**Key files:** `AggregateCacheTapStep.java` (new), `DatabaseSessionEmbedded.java`
+(aggregate miss path: splice + eager drive + fallback), `QueryResultCache.java`
+(`incrementSpliceFailures`, `installAggregateOverflowGuard`), `ShapeClassifier.java`
+(`AggregateMetadata` + `count(distinct)` → K0_NONE), `AggregateCacheEquivalenceTest.java`
+(new, 19 tests), `ShapeClassifierTest.java` (`count(distinct)` → K0_NONE).
+
+**Critical context:** A classify/derive divergence (`aggregateMetadata` returning null on a
+shape the gate accepted) is treated as a splice failure → uncached fallback, not a crash.
+Aggregate entries hold no live stream, so `CachedResultSetView` gets a null plan and the
+plan is closed in `populateAndBuildAggregateView`'s own finally. Track 3's MATCH branch
+must follow the same separate-gate + `viewOwnsGuard`-transfer pattern this step
+established for aggregates.
 
 ## Validation and Acceptance
 

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -26,6 +26,7 @@ tap would cache a structurally meaningless scalar.
 
 - [x] 2026-06-11T11:29Z [ctx=info] Review + decomposition complete
 - [x] 2026-06-11T18:27Z [ctx=safe] Step 1 complete (commit 4a9c9d0ccf)
+- [x] 2026-06-11T19:00Z [ctx=safe] Step 2 complete (commit d66cd22d57)
 
 ## Surprises & Discoveries
 <!-- Continuous-log. Empty at Phase 1. -->
@@ -51,6 +52,12 @@ tap would cache a structurally meaningless scalar.
   ephemeral-identifier rule allows only `adr.md`-defined DR IDs, so Phase 4 must
   define these IDs in `adr.md` (or strip them branch-wide) before merge, otherwise
   every citation dangles once `_workflow/` is removed. See Episodes §Step 1.
+- **Step 2 (I5 guard):** the new `FunctionDeterminismEnumerationTest` walks all four
+  `SQLFunctionFactory` implementations and fails the build whenever a registered SQL
+  function is neither in its curated deterministic/non-deterministic sets nor matched
+  by the `math_` prefix rule. Any future track that registers a new SQL function or
+  factory will break this test until the new name is classified — intended behavior,
+  but a build-gating surprise for the unaware. See Episodes §Step 2.
 
 ## Decision Log
 <!-- Continuous-log. -->
@@ -75,6 +82,13 @@ tap would cache a structurally meaningless scalar.
   reads the new value from the mutated `RecordAbstract`; `boolean matchAfter`
   carries WHERE-membership only. The existing signature is sufficient (rejects
   A6.2).
+- **Hardwired COUNT(*) disposition split (Step 2).** Bare `COUNT(*) FROM C`
+  classifies K0_NONE (statically detectable from the AST, served by the K0 version
+  gate); the single-field-indexed `COUNT(*) ... WHERE indexedField = ?` rides the
+  Step 3 splice fallback, since the AST-only classifier cannot see index metadata,
+  so the splice detects the `CountFromClassStep` and increments `spliceFailures`.
+  Resolves Plan of Work step 5(b)'s "pick one explicitly and test it." See Episodes
+  §Step 2.
 
 ## Outcomes & Retrospective
 <!-- Continuous-log. -->
@@ -257,7 +271,7 @@ collapse.
    four-factory enumeration completeness test, and a metric-increment assertion.
    *(parallel with Step 1)* — risk: medium — size: ~3 files; (a) no mergeable
    low/medium work fits (rest of track is high-tagged or its own integration
-   tests)  [ ]
+   tests)  [x] commit: d66cd22d57
 3. **Tap + splice + eager drive + fallback.** New `AggregateCacheTapStep extends
    AbstractExecutionStep`; in `DatabaseSessionEmbedded` the aggregate miss path
    builds the plan via `createExecutionPlan` (a per-execution copy), splices the
@@ -328,6 +342,47 @@ carries the `sumDirty` flag. Step 3's splice must build the state, call
 `CachedResultSetView.forAggregate(...)`, not the `TxDeltaCursor` constructor.
 `buildForAggregate` asserts a non-null `aggregateState`, so only AGGREGATE_* entries may
 route to it.
+
+### Step 2 — commit d66cd22d57, 2026-06-11T19:00Z [ctx=safe]
+
+**What was done:** Tightened `ShapeClassifier` so two untappable aggregate shapes stay
+out of the now-live aggregate cache path. An aggregate under arithmetic (`count(*) + 1`)
+previously matched AGGREGATE_COUNT through a pre-order function-call search; the descent
+now rejects the subtree as soon as it crosses a math node carrying an operator, so it
+classifies K0_NONE. Bare `COUNT(*) FROM C` (no WHERE), which the planner hardwires to an
+O(1) `CountFromClassStep` the side-tap can never reach, classifies K0_NONE via
+`SQLFunctionCall.isStar()` plus the absent WHERE; `COUNT(*)` with a non-indexed WHERE
+stays AGGREGATE_COUNT and tappable. Bridged the global `QUERY_CACHE_*_RATE` metrics from
+the per-tx counters: each `QueryCacheMetrics` increment now records into the matching
+global `TimeRate` sink (resolved once, NOOP when absent) through two package-visible
+constructors that also enable deterministic tests. Added the I5 enumeration-completeness
+test walking all four `SQLFunctionFactory` implementations. Verified the existing
+aggregate gates and the COUNT(DISTINCT) nested-`distinct(...)` parse without rebuilding
+them. 149 cache-package tests pass.
+
+**What was discovered:** The single-field-indexed `COUNT(*) ... WHERE indexedField = ?`
+residual cannot be detected without index metadata the AST-only classifier lacks, so it
+rides the Step 3 splice fallback rather than classifying K0_NONE; only the statically
+detectable bare `COUNT(*)` classifies K0_NONE. The I5 guard caught real allowlist drift
+on its first run: the average function registers as `avg`, not `average`. The reflective
+`math_*` family is JDK-version-dependent, so the test classifies it by the `math_` prefix
+rule (`math_random` non-deterministic, the rest pure) rather than an enumerated list.
+
+**What changed from the plan:** None. Scope held to the two tightenings, the metric
+bridge, and the I5 / classifier / metric-increment tests. `incrementSpliceFailures` is
+not wired here — it is Step 3's per-tx counter.
+
+**Key files:** `ShapeClassifier.java`, `QueryCacheMetrics.java` (metric bridge plus
+test-seam constructors), `ShapeClassifierTest.java`, `QueryCacheMetricsTest.java`,
+`FunctionDeterminismEnumerationTest.java` (new I5 test).
+
+**Critical context:** The bare-`COUNT(*)` → K0_NONE choice makes the Step 3 splice
+fallback the sole disposition for the single-field-indexed `COUNT(*)` shape, so Step 3's
+fallback branch and its `incrementSpliceFailures` call must handle a `CountFromClassStep`
+appearing where an `AggregateProjectionCalculationStep` was expected. The metric bridge
+lives inside `QueryCacheMetrics` (the increment sites in `QueryResultCache` are
+unchanged), so Step 3's `incrementSpliceFailures` call feeds the global splice-failure
+rate automatically.
 
 ## Validation and Acceptance
 

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -21,7 +21,7 @@ tap would cache a structurally meaningless scalar.
 ## Progress
 - [x] Review + decomposition
 - [x] Step implementation
-- [ ] Track-level code review
+- [x] Track-level code review
 - [ ] Track completion
 
 - [x] 2026-06-11T11:29Z [ctx=info] Review + decomposition complete

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -25,6 +25,7 @@ tap would cache a structurally meaningless scalar.
 - [ ] Track completion
 
 - [x] 2026-06-11T11:29Z [ctx=info] Review + decomposition complete
+- [x] 2026-06-11T18:27Z [ctx=safe] Step 1 complete (commit 4a9c9d0ccf)
 
 ## Surprises & Discoveries
 <!-- Continuous-log. Empty at Phase 1. -->
@@ -44,6 +45,12 @@ tap would cache a structurally meaningless scalar.
 - **Phase A review (iter 1):** the ServiceLoader manifest registers four
   `SQLFunctionFactory` implementations, not three (R5 — `DynamicSQLElementFactory`
   was omitted from the Phase 1 description).
+- **Step 1 (review):** the cache package cites design Decision-Record and invariant
+  IDs (D7/D8/D11/D18/D19/D20/D21, I1/I3/I6/I9/I10) in Javadoc throughout — a
+  Track-1-set, Phase-C-accepted convention, not a Step 1 regression. The
+  ephemeral-identifier rule allows only `adr.md`-defined DR IDs, so Phase 4 must
+  define these IDs in `adr.md` (or strip them branch-wide) before merge, otherwise
+  every citation dangles once `_workflow/` is removed. See Episodes §Step 1.
 
 ## Decision Log
 <!-- Continuous-log. -->
@@ -239,7 +246,7 @@ collapse.
    and the `CachedEntry` `aggregateState` field. Unit-tested in isolation:
    per-kind observe/applyMutation, mixed-input/overflow/precision SUM parity, AVG
    integer-truncation and BigDecimal `HALF_UP`, the collapse case, cap overflow.
-   *(parallel with Step 2)* — risk: high (performance hot path)  [ ]
+   *(parallel with Step 2)* — risk: high (performance hot path)  [x] commit: 4a9c9d0ccf
 2. **Classifier tightening + global metric bridge.** Tighten `ShapeClassifier` so
    an aggregate under arithmetic (`count(*) + 1`) classifies K0_NONE (not
    AGGREGATE_COUNT) and bare / single-field-indexed `COUNT(*)` rides the fallback
@@ -269,6 +276,58 @@ collapse.
 
 ## Episodes
 <!-- Continuous-log. -->
+
+### Step 1 — commit 4a9c9d0ccf, 2026-06-11T18:27Z [ctx=safe]
+
+**What was done:** Implemented the standalone `AggregateState` replay core for the
+aggregate cache shapes: `observe` / `applyMutation` / `copy` / `toResult` across COUNT,
+SUM, AVG, MIN, MAX, and COUNT(DISTINCT). SUM/AVG fold through
+`PropertyTypeInternal.increment` with a verbatim first-value seed; AVG finalizes through
+the storage type-dispatched division (integer truncation, BigDecimal `HALF_UP`); SUM over
+an empty set is `0`. MIN/MAX carry an `extremumRid` with the O(n) recompute fired only on
+the two extremum-leaving transitions; COUNT(DISTINCT) uses raw-`Object` buckets so
+`Long(5)` and `Integer(5)` stay distinct. Dispatch keys on the membership-derived
+(`was_contributing → now_contributing`) transition for D21 collapse safety. Added the
+aggregate-specific contributor cap (bounds the `AggregateState` collections, not
+`results`) with a one-shot overflow callback, plus `DeltaBuilder.buildForAggregate`, the
+`CachedEntry` `aggregateState` slot, and the `CachedResultSetView.forAggregate` view path.
+The step-level review drove one review-fix commit: the SUM/AVG fold now walks an
+insertion-ordered contributor map and runs once lazily (`sumDirty` + `ensureSumFolded`)
+rather than per mutation. 34 unit tests pass.
+
+**What was discovered:** `SQLFunctionAverage.computeAverage` is private, so its
+type-dispatched division is reproduced verbatim rather than called. A second equal-arity
+public `CachedResultSetView` constructor made the K0_NONE null-delta call sites
+ambiguous, so the aggregate view routes through a `forAggregate` static factory instead
+of a constructor overload. Two review suggestions defer to the track-level pass or later
+steps: BC2 — `observe` reads the projected `Result` while `applyMutation` reads the raw
+`Entity`, a value-source coupling the Step 2 classifier gate guards; BC3 — MIN/MAX over
+mixed non-Number `Comparable` values can throw `ClassCastException`, matching storage's
+behavior so cache-vs-fresh parity holds, but untested. PF2 (presize the contributor
+collections) folds into the Step 3 cap wiring. Branch-wide convention, not a Step 1
+regression: the cache package cites design Decision-Record and invariant IDs
+(D7/D8/D11/D18/D19/D20/D21, I1/I3/I6/I9/I10) in Javadoc throughout, set by Track 1 and
+accepted through its Phase C. Phase 4 must define these IDs in `adr.md` (or strip them
+branch-wide) so the citations resolve after `_workflow/` is removed; see Surprises &
+Discoveries.
+
+**What changed from the plan:** None. Scope held to the standalone replay core; the tap,
+splice, eager-drive, and end-to-end I4 equivalence tests stay in Step 3, and the
+classifier tightenings plus metric bridge stay in Step 2.
+
+**Key files:** `AggregateState.java` (new), `DeltaBuilder.java` (`buildForAggregate`),
+`CachedResultSetView.java` (`forAggregate` path), `CachedEntry.java` (`aggregateState`
+slot), `AggregateStateTest.java` (new, 34 tests). Commits `7b3af1d560` (initial) +
+`4a9c9d0ccf` (review fix).
+
+**Critical context:** SUM/AVG folding is now lazy. `getSumAccumulator()`, `getCount()`,
+and the SUM and AVG `scalar()` paths route through `ensureSumFolded()`, and `copy()`
+carries the `sumDirty` flag. Step 3's splice must build the state, call
+`setAggregateState`, install the cap via `setOverflowGuard(maxRecordsPerEntry,
+() -> overflowEntry(key))` mirroring the record-cap wiring, and construct the view via
+`CachedResultSetView.forAggregate(...)`, not the `TxDeltaCursor` constructor.
+`buildForAggregate` asserts a non-null `aggregateState`, so only AGGREGATE_* entries may
+route to it.
 
 ## Validation and Acceptance
 

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -20,7 +20,7 @@ tap would cache a structurally meaningless scalar.
 
 ## Progress
 - [x] Review + decomposition
-- [ ] Step implementation
+- [x] Step implementation
 - [ ] Track-level code review
 - [ ] Track completion
 

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
@@ -350,3 +350,6 @@ internals.
 - `SQLFunctionAverage#computeAverage(...)` (existing, reused for AVG finalization)
 - `QueryResultCache#incrementSpliceFailures()` (the only new per-tx metric;
   hit/miss/k0/overflow increments already exist in Track 1)
+
+## Base commit
+babd8d607687b284687b57ccb882cf838148055b

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/adversarial-gate-verification-iter2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/adversarial-gate-verification-iter2.md
@@ -1,0 +1,135 @@
+<!-- workflow-sha: e9377f7f133f5cd6ec3028936f28be2819e4ae96 -->
+# Adversarial gate verification — Track 2 (Aggregate shapes) — iteration 2
+
+- role: reviewer-adversarial
+- phase: 3A
+- track: "Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT"
+- review_type: adversarial
+- overall: PASS
+- findings: 0
+
+## Manifest
+
+```yaml
+verdicts:
+  - id: A1
+    disposition: accepted-should-fix
+    verdict: VERIFIED
+  - id: A2
+    disposition: rejected
+    verdict: REJECTED
+  - id: A3
+    disposition: accepted-should-fix
+    verdict: VERIFIED
+  - id: A4
+    disposition: accepted-should-fix
+    verdict: VERIFIED
+  - id: A5
+    disposition: accepted-suggestion
+    verdict: VERIFIED
+  - id: A6.1
+    disposition: accepted
+    verdict: VERIFIED
+  - id: A6.2
+    disposition: rejected
+    verdict: REJECTED
+overall: PASS
+new_findings: 0
+source_rechecks:
+  - "YqlExecutionPlanCache.java:66-76,119-139 (static get → getInternal → result.copy(ctx))"
+  - "SelectExecutionPlanner.java:223-262 (cache hit returns plan; fresh SelectExecutionPlan or hardwired result)"
+  - "SelectExecutionPlanner.java:470-475,488-508,553-569 (hardwired count gated isCountStar+isMinimalQuery)"
+```
+
+## Verification certificates
+
+#### Verify A1: hardwired COUNT(*) untappable — downgrade soundness
+- **Fix applied**: Context & Orientation bullet (track L96-104) and Plan of Work
+  step 5(b)/step 6 + Validation now state bare/single-field-indexed `COUNT(*)`
+  ride the splice fallback or classify K0_NONE; headline validation case changed
+  to a tappable shape (`SUM(price) ... WHERE active`, or non-indexed `COUNT(*)`).
+- **Re-check**: `SelectExecutionPlanner.java:470-475` routes through
+  `handleHardwiredCountOnClass` (`:488`, gated `isCountStar` `:505` +
+  `isMinimalQuery` `:508`) and `handleHardwiredCountOnClassUsingIndex` (`:553`,
+  `isCountStar` `:569`); both short-circuit before the aggregation step is built,
+  exactly as A1 claimed. The track's fallback (step 3: no
+  `AggregateProjectionCalculationStep` → close plan, `incrementSpliceFailures`,
+  plain uncached `LocalResultSet`) is a correctness-safe path, so the downgrade
+  to should-fix is sound — no correctness bug, only a vacuous-test risk, which
+  the amended Validation now closes.
+- **Regression check**: Decision Log records the exclusion; Validation asserts the
+  fallback fires and the scalar still matches fresh. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify A2 (REJECTED): splice mutates the shared cached plan
+- **Rejection reason**: `createExecutionPlan` never hands back the cached
+  instance; the cache copies before returning.
+- **Source re-check (priority)**: `YqlExecutionPlanCache.getInternal`
+  (`:119-139`) ends `return result != null ? result.copy(ctx) : null;` with the
+  comment "Copy outside cache". Static `get` (`:66-76`) is a thin delegate to
+  `getInternal`. `SelectExecutionPlanner.createExecutionPlan` (`:235-240`) returns
+  that copy on a hit, or builds a fresh `new SelectExecutionPlan(ctx)` (`:248`)
+  / returns the hardwired `result` (`:261`) on a miss. No path returns the shared
+  cache instance. The iter-1 finding cited `:235-240` of a *different* file
+  (it read the legacy no-copy path); the orchestrator's rejection holds.
+- **Downstream check**: Track step 3 now documents the copy-on-return guarantee
+  inline, so the splice mutates a private plan. No downstream issue.
+- **Verdict**: REJECTED (no action needed)
+
+#### Verify A3: recordPulledRow mis-specified for aggregate cap
+- **Fix applied**: step 1 Memory-cap bullet (L158-165) + Decision Log drop the
+  literal "route per-RID through `recordPulledRow`" and bound the
+  `AggregateState` collections against `maxRecordsPerEntry`, overflow → L7
+  non-cacheable; `results` stays one scalar.
+- **Re-check**: matches the corrected cap target; Validation adds the
+  high-cardinality COUNT(DISTINCT) overflow case.
+- **Regression check**: I10 single-row transparency preserved. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify A4: AVG needs computeAverage + total
+- **Fix applied**: step 1 "AVG finalization" bullet (L144-148) + Key signatures
+  (L300-301) specify `total` tracking and finalization via
+  `SQLFunctionAverage.computeAverage` (type-dispatched division), not `sum/total`.
+- **Re-check**: Validation asserts Integer/Long truncation and BigDecimal
+  HALF_UP match fresh. Matches A4's required parity.
+- **Verdict**: VERIFIED
+
+#### Verify A5: caching bare COUNT(*) duplicates O(1) path
+- **Fix applied**: folded into A1 — Decision Log "Hardwired COUNT(*) → not
+  cached" (L51-56) excludes bare/indexed `COUNT(*)`.
+- **Re-check**: Decision Log records the exclusion and flags design-doc
+  reconciliation for Phase 4. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify A6.1: D21 "never op.type" contradicts the RECORD path
+- **Fix applied**: step 1 Dispatch bullet (L152-157) now reads "status is
+  consulted only to fold DELETED into now_contributing = false, never as a
+  stand-in for the before-state (D21 ... design.md's wording, not the looser
+  'never op.type')".
+- **Re-check**: matches design.md framing; the absolute "never op.type" is gone.
+- **Verdict**: VERIFIED
+
+#### Verify A6.2 (REJECTED): boolean matchAfter can't carry value-changing UPDATE
+- **Rejection reason**: the new value is read from the mutated `RecordAbstract`
+  (the first `applyMutation` arg) and written into `contributingValues[rid]`
+  before the re-fold; `matchAfter` carries WHERE-membership only.
+- **Downstream check**: track step 1 (L139-143), Decision Log (L65-68), and Key
+  signatures (L297-299) all state the value-from-record contract consistently.
+  `applyMutation(RecordAbstract, byte status, boolean matchAfter)` takes the
+  full record, so re-extraction of the summed/extremum property is possible — the
+  signature is sufficient. No downstream issue; the rejection is sound.
+- **Verdict**: REJECTED (no action needed)
+
+## Findings
+
+(none — pure-verdict pass)
+
+## Summary
+
+PASS — all 5 accepted findings VERIFIED (A1, A3, A4, A5, A6.1); both rejections
+(A2, A6.2) confirmed sound against source. The priority A2 re-check reads
+`YqlExecutionPlanCache.getInternal` returning `result.copy(ctx)` (`:138`) with
+static `get` delegating to it (`:76`), and `SelectExecutionPlanner.createExecutionPlan`
+returning that copy or a fresh plan (`:238`/`:248`/`:261`) — the caller never
+holds the shared cached instance, so the splice cannot corrupt other callers.
+No regressions, no new findings.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/adversarial-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/adversarial-iter1.md
@@ -1,0 +1,183 @@
+<!-- workflow-sha: e9377f7f133f5cd6ec3028936f28be2819e4ae96 -->
+# Adversarial review — Track 2 (Aggregate shapes) — iteration 1
+
+- role: reviewer-adversarial
+- phase: 3A
+- track: "Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT"
+- verdict: changes-requested
+- findings: 6
+- blockers: 2
+
+## Manifest
+
+```yaml
+index:
+  - id: A1
+    sev: blocker
+    anchor: "#a1"
+    loc: "track-2.md §Plan of Work step 3; design D10/D19"
+    cert: "Assumption test: every aggregate query exposes an AggregateProjectionCalculationStep to splice"
+    basis: "SelectExecutionPlanner.java:259-262,488-509; CountFromClassStep.java:12-18,56-62; CountFromIndexStep.java"
+  - id: A2
+    sev: blocker
+    anchor: "#a2"
+    loc: "track-2.md §Plan of Work step 3 (rewires prev)"
+    cert: "Violation scenario: splicing prev mutates the shared cached plan"
+    basis: "SelectExecutionPlanner.java:235-240; SQLSelectStatement.java:335-341; AbstractExecutionStep.java:66"
+  - id: A3
+    sev: should-fix
+    anchor: "#a3"
+    loc: "track-2.md carried-from-Track-1 note; §Plan of Work step 4"
+    cert: "Assumption test: recordPulledRow is the right cap point for aggregate material"
+    basis: "CachedEntry.java:268-287,155-159"
+  - id: A4
+    sev: should-fix
+    anchor: "#a4"
+    loc: "track-2.md §Purpose; design D19"
+    cert: "Challenge: D19 — AVG storage parity needs computeAverage, not just increment"
+    basis: "SQLFunctionAverage.java:72-115"
+  - id: A5
+    sev: suggestion
+    anchor: "#a5"
+    loc: "track-2.md §Validation (COUNT(*) case); design D10"
+    cert: "Challenge: D10 — caching bare COUNT(*) duplicates the existing O(1) tx-aware path"
+    basis: "CountFromClassStep.java:56-62,74-81"
+  - id: A6
+    sev: should-fix
+    anchor: "#a6"
+    loc: "track-2.md §Plan of Work step 1 (membership dispatch); design D21"
+    cert: "Assumption test: membership-only dispatch with a boolean matchAfter is sufficient for MIN/MAX/SUM"
+    basis: "DeltaBuilder.java:136-179; FrontendTransactionImpl.java:641-668; CachedEntry.java:159"
+evidence_base:
+  challenges: 3
+  violation_scenarios: 1
+  assumption_tests: 3
+tooling_note: >
+  mcp-steroid steroid_execute_code timed out repeatedly this session (trivial
+  snippets at 300-400s), so all symbol audits fell back to grep + Read. The
+  IDE project ("design.md") is open and matches the working tree, but PSI
+  execution was unavailable. Reference-accuracy caveat: the "no other caller
+  splices prev on a cached plan" and "no existing incremental-aggregate infra"
+  claims rest on grep, not PSI find-usages; a polymorphic or generic call site
+  could be missed. The class-existence and method-body facts (CountFromClassStep,
+  the hardwired-optimization branch, the no-copy cache return, recordPulledRow's
+  body) are direct Reads of the source and are not subject to that caveat.
+```
+
+## Findings
+
+### A1 [blocker]
+**Certificate**: Assumption test — "every aggregate query exposes an `AggregateProjectionCalculationStep` to splice"
+**Target**: Decision D10 (side-tap splice) / Track-2 Plan of Work step 3
+**Challenge**: The splice strategy assumes every cacheable aggregate plan contains an `AggregateProjectionCalculationStep` to rewire. For the single most common aggregate shape — bare `SELECT COUNT(*) FROM C` and `SELECT COUNT(*) FROM C WHERE indexed = ?` — the planner short-circuits to a `CountFromClassStep` / `CountFromIndexStep` **before** any aggregation step is built. `SelectExecutionPlanner.createExecutionPlan` calls `handleHardwiredOptimizations` at line 260 and `return result` at 261 when it fires; `handleHardwiredCountOnClass` (488-509) applies to `COUNT(*)` with no GROUP BY/ORDER BY/SKIP/LIMIT/LET. The resulting plan has no scan, no per-record stream, and no `AggregateProjectionCalculationStep`. The track's step 3 ("walk `steps`, find `AggregateProjectionCalculationStep`, rewire its `prev` to the tap; on unexpected shape, fall back to uncached") therefore *always* falls back for `AGGREGATE_COUNT`, silently disabling the cache for the dominant aggregate — yet the track's headline validation case is exactly `SELECT COUNT(*) FROM C` (§Validation line 1, §Purpose). The test would pass against the fallback path and prove nothing about the tap.
+**Evidence**: `SelectExecutionPlanner.java:259-262` (short-circuit return), `:488-509` (`handleHardwiredCountOnClass` preconditions), `:470-475` (`handleHardwiredOptimizations` also covers the indexed-count case), `CountFromClassStep.java:12-18` (no scan, metadata-only), `:56-62` (`target.count(session)`). No per-RID material is produced for these plans, so even if a tap point existed there is nothing to seed `contributingRids` with.
+**Proposed fix**: Make the plan choose between two delta strategies explicitly. Either (a) route `AGGREGATE_COUNT` (non-DISTINCT) to a count-specific delta that does not depend on the tap — it needs only `contributingRids` membership and `matchAfter`, which can be seeded by a one-time scan or by recognising the hardwired count and re-deriving the contributor set — or (b) declare bare/indexed `COUNT(*)` out of scope for the tap and document that they fall back (see A5, which argues they should not be cached at all). Whichever is chosen, replace the §Validation `COUNT(*)` case with an aggregate kind that actually reaches `AggregateProjectionCalculationStep` (e.g. `SUM`/`MIN`), and add an explicit assertion that the tap was spliced (not the fallback taken) for every kind the track claims to cache.
+
+### A2 [blocker]
+**Certificate**: Violation scenario — "splicing `prev` mutates the shared cached plan"
+**Target**: Track-2 Plan of Work step 3 (rewires `prev`)
+**Challenge**: Step 3 builds the plan via `statement.createExecutionPlan(ctx, false)` and then mutates it in place (rewires `AggregateProjectionCalculationStep.prev` to the tap). `createExecutionPlan(ctx, false)` → `planner.createExecutionPlan(ctx, false, /*useCache=*/true)`, and on a cache hit `SelectExecutionPlanner` returns the cached plan **instance directly with no copy** (`:235-240`, `return (InternalExecutionPlan) plan;`). `AbstractExecutionStep.prev` is a public mutable field (`:66`). So the splice mutates the `SelectExecutionPlan` held in `YqlExecutionPlanCache`, shared by every other caller of the same statement text.
+**Violation construction**:
+1. Start state: `SELECT SUM(price) FROM Product` executed once uncached; its plan is now in `YqlExecutionPlanCache`.
+2. Action: an aggregate cache-miss for the same SQL calls `createExecutionPlan(ctx, false)` → cache hit → the shared plan instance is returned; the track rewires `aggStep.prev = tap`.
+3. Intermediate state: the cached plan's step chain now contains `tap` between the fetch step and the aggregation step.
+4. Violation point: the *next* execution of `SELECT SUM(price) FROM Product` — cache-disabled, profiling, a different session, or a second aggregate miss — retrieves the same mutated instance (`SelectExecutionPlanner.java:236-238`). It re-runs with a stale `tap` whose `observe` writes into a now-dead `AggregateState`, or with a doubly-spliced chain.
+5. Observable consequence: cross-query plan corruption — wrong results or an NPE on a closed tap, intermittent and dependent on cache-eviction timing.
+**Feasibility**: CONSTRUCTIBLE. The cache return path is non-copying and the splice target field is mutated in place; nothing in the track isolates the plan.
+**Evidence**: `SelectExecutionPlanner.java:235-240`; `SQLSelectStatement.java:335-341` (no copy on the path); `AbstractExecutionStep.java:66`.
+**Proposed fix**: Splice into a **non-shared** plan. Use `createExecutionPlanNoCache(ctx, false)` for the aggregate-miss path (it builds a fresh `SelectExecutionPlan` every call, `:344-351`), or deep-`copy()` the plan before mutating. Record the choice in the track's Compatibility note and add a regression test that runs the same aggregate SQL twice (cached then uncached) and asserts the second execution's plan chain is untouched.
+
+### A3 [should-fix]
+**Certificate**: Assumption test — "`recordPulledRow` is the right cap-enforcement point for aggregate material"
+**Target**: Track-2 carried-from-Track-1 note ("route every per-RID/row append through `CachedEntry.recordPulledRow`") + Plan of Work step 4
+**Challenge**: The carried-forward instruction assumes routing aggregate per-RID appends through `recordPulledRow` makes `maxRecordsPerEntry` apply to aggregate material. But `recordPulledRow` appends to `results` (the consumer-visible row list, `:269`) and to `cachedRids` (`:275`), and the aggregate `CachedResultSetView` path returns a single scalar row from `results` (`hasNext` true once, `toResult()`). Pushing every contributing record into `results` would make the aggregate view emit N rows instead of one — a direct I10 transparency violation — and would pollute `cachedRids` with RIDs the RECORD delta semantics do not expect for this shape. The per-contributor growth that the cap should bound lives in `AggregateState` (`contributingRids`, `contributingValues`, `distinctBuckets`), not in `results`.
+**Stress scenario**: `SELECT SUM(price) FROM Product` over 50 000 rows with `maxRecordsPerEntry=10000`. Routed through `recordPulledRow`, `results` reaches 50 000 entries and the view emits 50 000 rows; routed correctly, `results` holds one scalar and the cap must instead watch `distinctBuckets`/`contributingValues` size.
+**Verdict**: BREAKS as literally specified. The cap is meaningful for aggregates but must be enforced against the `AggregateState` collections, with overflow firing the same `onOverflow` eviction callback `CachedEntry` already exposes (`setOverflowGuard`, `:252`).
+**Evidence**: `CachedEntry.java:268-287` (`recordPulledRow` body appends to `results`/`cachedRids` and checks `results.size()`), `:155-159` (`results` is the row list the view reads).
+**Proposed fix**: Drop the literal "route per-RID appends through `recordPulledRow`" for aggregates. Add an aggregate-specific cap: count distinct buckets / contributor entries inside `AggregateState.observe`, and on crossing `maxRecordsPerEntry` invoke the existing `onOverflow` to evict and route the key non-cacheable. Keep `results` at exactly one scalar row. Note this in step 4 and the carried-from-Track-1 paragraph.
+
+### A4 [should-fix]
+**Certificate**: Challenge — D19 (AVG storage parity)
+**Target**: Decision D19 / Track-2 §Purpose ("SUM/AVG fold through the same `PropertyTypeInternal.increment` storage uses")
+**Chosen approach**: Replay SUM and AVG through `PropertyTypeInternal.increment` for bit-for-bit storage parity.
+**Counterargument trace**:
+1. For SUM this is exact: `SQLFunctionSum.sum` is `sum = increment(sum, value)` (`:73`), and `getResult` returns the running sum.
+2. For AVG, `increment` only maintains the running **sum**; the returned scalar is `computeAverage(sum, total)` (`SQLFunctionAverage.java:91-115`), which divides by an integer `total` with per-type semantics — `Integer`/`Long` use **integer division** (`iSum.intValue()/iTotal`, truncating), `Float`/`Double` use FP division, `BigDecimal` uses `divide(..., HALF_UP)`.
+3. An `AggregateState.toResult()` that returns `increment`-folded sum, or that divides with a different rule, diverges from fresh execution: e.g. AVG over `[3, 4]` of `Long` returns `3` (7/2 truncated), not `3.5`.
+**Codebase evidence**: `SQLFunctionAverage.java:72-83` (running sum via `increment` + a separate `total++`), `:91-115` (`computeAverage` type-dispatched divide with integer truncation for Integer/Long).
+**Survival test**: WEAK. D19's storage-parity claim is correct for the running accumulator but the design framing ("SUM/AVG fold through increment") omits that AVG parity additionally requires (a) tracking `total` exactly as `SQLFunctionAverage` does — only non-null values increment it — and (b) reproducing `computeAverage`'s per-type division verbatim in `toResult`.
+**Proposed fix**: In step 1, specify the AVG state as `(runningSum via increment, total count of non-null values)` and require `toResult` to call the same `computeAverage` logic (extract or reuse it) so the truncation and rounding match. Add an AVG I4 case over `Long` inputs whose true mean is fractional, asserting the cached scalar equals the truncated fresh result.
+
+### A5 [suggestion]
+**Certificate**: Challenge — D10 (caching bare COUNT(*))
+**Target**: Decision D10 / §Validation `COUNT(*)` case
+**Chosen approach**: Cache `AGGREGATE_COUNT` including bare `COUNT(*)`.
+**Counterargument trace**:
+1. Bare `SELECT COUNT(*) FROM C` is already O(1) and already transaction-correct without any cache: `CountFromClassStep.produce` reads `target.count(session)` inside `computeInTxInternal` (`:56-62`), so the count already reflects in-tx CREATE/DELETE.
+2. The cache would replace a single metadata read with: a scan (to seed `contributingRids` — see A1, there is no scan in the hardwired plan to tap), an `AggregateState` copy, and a post-populate delta replay.
+3. Outcome: more work, more memory, and a new correctness surface, to re-derive a number the existing step computes correctly in one read.
+**Codebase evidence**: `CountFromClassStep.java:56-62` (live tx-aware count), `:74-81` (`canBeCached()` false precisely because the count is cheap-and-live).
+**Survival test**: WEAK for bare `COUNT(*)`; the decision likely holds for `COUNT` over a `WHERE` that does not reduce to an indexed count (those do reach the aggregation step and gain from caching). The general D10 decision survives, but the specific inclusion of bare/indexed `COUNT(*)` does not add value.
+**Proposed fix**: Either exclude bare and indexed `COUNT(*)` from `AGGREGATE_COUNT` (let the existing O(1) step handle them; classify to K0_NONE or leave uncached) or, if kept for uniformity, state in the track why paying the cache cost over the existing O(1) path is acceptable. This also resolves A1's validation-case problem.
+
+### A6 [should-fix]
+**Certificate**: Assumption test — "membership-only dispatch with a precomputed boolean `matchAfter` is sufficient for MIN/MAX/SUM collapse safety"
+**Target**: Decision D21 / Track-2 Plan of Work step 1 ("dispatch keys on `(was_contributing → now_contributing)` ... never `op.type`")
+**Challenge**: Two sub-claims need tightening.
+1. *"Never `op.type`."* The shipped RECORD path does **not** dispatch on membership alone — it switches on `op.type` (`DeltaBuilder.java:145`) and *combines* it with membership (`cachedRids.contains(rid)`, `:139,:150`) to disambiguate the collapsed pre-populate-CREATE-then-UPDATE case. The collapse logic in `addRecordOperation` keeps `type=CREATED` after an update to a created record (`FrontendTransactionImpl.java:654-661`), so `op.type` is still load-bearing alongside membership. The track's absolute "never `op.type`" framing contradicts the foundation it builds on; the real rule is "membership *and* the collapsed `op.type` together," as the RECORD path already does.
+2. *Membership set identity.* For aggregates the contributor set is the **post-WHERE survivors** observed by the tap, which is a different set from `cachedRids` (all cached rows). `applyMutation(record, status, matchAfter)` is handed only a boolean `matchAfter`; for SUM and MIN/MAX a pass→pass UPDATE that changes the *value* (not the WHERE outcome) still requires re-extracting the new property value from the post-mutation record. A boolean cannot carry that. The transitions that need the value: was-contributing→still-contributing with a changed value (SUM re-fold; MIN/MAX possible extremum move) and fail→pass (new value enters).
+**Code evidence**: `DeltaBuilder.java:136-179` (RECORD combines `op.type` + `cachedRids` membership), `FrontendTransactionImpl.java:641-668` (collapse keeps CREATED, re-stamps version), `CachedEntry.java:159` (`cachedRids` is the full cached-row set, distinct from a post-WHERE contributor set).
+**Verdict**: FRAGILE. The membership idea is sound but underspecified: the dispatch must read both the collapsed `op.type` and membership, and `applyMutation` must take (or internally extract) the post-mutation contributing **value**, not just a boolean.
+**Proposed fix**: Restate step 1's dispatch rule as "membership (`contributingValues.containsKey(rid)`) combined with the collapsed `op.type` and `matchAfter`," matching the RECORD path's proven shape. Specify that `applyMutation` extracts the aggregate's argument property from the post-mutation record for the value-changing transitions (it already takes `RecordAbstract`), and add an I4 case for a pass→pass UPDATE that changes the summed/extremum property without changing WHERE membership.
+
+## Evidence base
+
+### Challenges
+
+#### Challenge: D19 — AVG storage parity needs computeAverage, not just increment
+- **Chosen approach**: replay SUM/AVG through `PropertyTypeInternal.increment` for storage parity.
+- **Best rejected alternative**: n/a (parity primitive is correct for SUM); the challenge is to the *completeness* of the AVG parity claim.
+- **Counterargument trace**: `increment` maintains the running sum only; AVG's scalar is `computeAverage(sum, total)`, which truncates for Integer/Long and rounds HALF_UP for BigDecimal (`SQLFunctionAverage.java:91-115`). A state that returns the folded sum, or divides differently, diverges (Long mean of [3,4] is 3, not 3.5).
+- **Codebase evidence**: `SQLFunctionAverage.java:72-83`, `:91-115`.
+- **Survival test**: WEAK — parity for SUM holds; AVG additionally needs exact `total` tracking and a verbatim `computeAverage` in `toResult`.
+
+#### Challenge: D10 — caching bare COUNT(*) duplicates the existing O(1) tx-aware path
+- **Chosen approach**: cache `AGGREGATE_COUNT` including bare `COUNT(*)`.
+- **Best rejected alternative**: leave bare/indexed `COUNT(*)` to the existing hardwired step (uncached / K0_NONE).
+- **Counterargument trace**: `CountFromClassStep` already returns a live, in-tx count in one metadata read (`:56-62`) and declares itself non-cacheable precisely because the value is cheap and live (`:74-81`). The cache adds scan + state-copy + delta replay to re-derive it.
+- **Codebase evidence**: `CountFromClassStep.java:56-62,74-81`.
+- **Survival test**: WEAK for bare/indexed COUNT(*); the broader D10 decision survives for COUNT over a scanning WHERE.
+
+#### Challenge: D21 — "never op.type" contradicts the RECORD path it builds on
+- **Chosen approach**: aggregate dispatch keys on membership, "never `op.type`."
+- **Best rejected alternative**: the RECORD path's combined `op.type` + membership dispatch.
+- **Counterargument trace**: the collapse keeps `type=CREATED` after CREATE+UPDATE (`FrontendTransactionImpl.java:654-661`); the RECORD `DeltaBuilder` switches on `op.type` and adds `cachedRids` membership to handle that case (`:145,:139,:150`). Membership alone loses the create-vs-update distinction the RECORD path needs `op.type` for.
+- **Codebase evidence**: `DeltaBuilder.java:136-179`, `FrontendTransactionImpl.java:641-668`.
+- **Survival test**: FRAGILE — the rule must be "membership *and* collapsed `op.type`," and `applyMutation` must carry the post-mutation value.
+
+### Violation scenarios
+
+#### Violation scenario: splicing prev mutates the shared cached plan
+- **Invariant claim**: the aggregate-miss splice produces a private, mutable plan it may rewire freely.
+- **Violation construction**: see A2 steps 1-5 — `createExecutionPlan(ctx, false)` returns the `YqlExecutionPlanCache` instance without copy (`SelectExecutionPlanner.java:236-238`); rewiring `AbstractExecutionStep.prev` (`:66`) mutates the shared plan; the next caller of the same SQL sees the spliced/corrupted chain.
+- **Feasibility**: CONSTRUCTIBLE.
+
+### Assumption tests
+
+#### Assumption test: every aggregate query exposes an AggregateProjectionCalculationStep to splice
+- **Claim**: the splice can always find an `AggregateProjectionCalculationStep` to rewire.
+- **Stress scenario**: bare `SELECT COUNT(*) FROM C` and indexed `COUNT(*) WHERE k=?`.
+- **Code evidence**: `SelectExecutionPlanner.java:259-262,470-475,488-509` (hardwired short-circuit to `CountFromClassStep`/`CountFromIndexStep` before any aggregation step), `CountFromClassStep.java:12-18,56-62`.
+- **Verdict**: BREAKS for the dominant COUNT(*) shapes — no tap point, no per-RID material; always falls back.
+
+#### Assumption test: recordPulledRow is the right cap point for aggregate material
+- **Claim**: routing aggregate per-RID appends through `recordPulledRow` enforces `maxRecordsPerEntry` on aggregate material.
+- **Stress scenario**: `SUM` over 50 000 rows with `maxRecordsPerEntry=10000`.
+- **Code evidence**: `CachedEntry.java:268-287` (`recordPulledRow` appends to `results`, checks `results.size()`), `:155-159` (`results` is the single-scalar row list for the aggregate view).
+- **Verdict**: BREAKS — would emit N rows from the aggregate view; cap must target `AggregateState` collections instead.
+
+#### Assumption test: membership-only dispatch with a boolean matchAfter is sufficient for MIN/MAX/SUM
+- **Claim**: `(was_contributing → now_contributing)` membership plus a boolean `matchAfter` covers all aggregate transitions.
+- **Stress scenario**: a pass→pass UPDATE that changes the summed/extremum property without changing WHERE outcome.
+- **Code evidence**: `DeltaBuilder.java:136-179`, `FrontendTransactionImpl.java:654-668`, `CachedEntry.java:159`.
+- **Verdict**: FRAGILE — value-changing transitions need the post-mutation value re-extracted, and the create-vs-update distinction needs the collapsed `op.type`.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/bugs-concurrency-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/bugs-concurrency-iter1.md
@@ -1,0 +1,84 @@
+<!-- MANIFEST
+dimension: bugs-concurrency
+iteration: 1
+high_water_mark: 0
+findings: 2
+index:
+  - id: BC1
+    sev: suggestion
+    anchor: "#bc1-null-rid-corruption-is-assert-only-no-production-fallback"
+    loc: "core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java:551-556"
+    cert: "#c1-null-rid-guard-is-assert-only"
+    basis: "PSI+source: SelectExecutionPlanner chain order, ResultInternal.getIdentity null path"
+  - id: BC2
+    sev: suggestion
+    anchor: "#bc2-eager-drive-does-not-handle-an-aggregation-step-with-non-immediate-projection"
+    loc: "core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java:203-223"
+    cert: "#c2-splice-only-walks-immediate-prev"
+    basis: "source: SelectExecutionPlanner.handleProjections chain order"
+evidence_base: "Planner chain order (SelectExecutionPlanner.handleProjections L755-799), SelectExecutionPlan.start/close prev-chain semantics, ResultInternal.getIdentity null path, QueryResultCache guard/overflow flow, AggregateState fold/dispatch/copy logic, full equivalence + state test suites."
+cert_index:
+  - "#c1-null-rid-guard-is-assert-only"
+  - "#c2-splice-only-walks-immediate-prev"
+flags: []
+-->
+
+## Findings
+
+### BC1 [suggestion] Null-RID corruption is assert-only, no production fallback
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java` (line 551-556)
+
+**Issue**: `observe(Result)` reads `result.getIdentity()` and guards a non-null RID only with a Java `assert` (disabled in production). `ResultInternal.getIdentity()` returns `null` when its `identifiable` is null — exactly the post-projection row a `ProjectionCalculationStep` produces. If the tap ever observes such a row in a `-ea`-off build, `contributingRids.add(null)` / `contributingValues.put(null, value)` silently store under a null key, producing a wrong scalar (e.g. two distinct identity-stripped rows collapse to one contributor) rather than failing loudly or falling back uncached. This violates I10 transparency silently.
+
+**Evidence**: The splice deliberately lands the tap above the pre-aggregate `ProjectionCalculationStep` (DatabaseSessionEmbedded.spliceTap, L210-214) precisely because that projection strips identity. The current planner chain (`SelectExecutionPlanner.handleProjections`, L762-798) puts the pre-aggregate projection as the immediate `prev` of the aggregation step, so today the tap sees identity-carrying records and the assert never trips. The risk is forward-looking: a future planner change that inserts a second identity-affecting step between the splice point and the source, or a plan shape where the immediate `prev` is an identity-stripping step that is not a plain `ProjectionCalculationStep`, would route null-identity rows into `observe` with no production-visible signal.
+
+**Refutation considered**: Confirmed the current chain order in `SelectExecutionPlanner` (Phase 1 pre-aggregate projection chained directly before Phase 2 aggregation, nothing between). So this is not a live bug. Recorded as defense-in-depth: a cheap production-safe path (treat a null RID as a splice failure → uncached fallback, mirroring the existing `incrementSpliceFailures` contract) would convert a silent correctness violation into a benign cache bypass.
+
+**Suggestion**: In `observe`, when `rid == null`, do not mutate the contributor collections; signal the populate as untappable so `populateAndBuildAggregateView` falls back to uncached execution (or at minimum keep the assert and add a comment that a null RID in production is unreconcilable). Optional — the planner-chain analysis shows the path is currently unreachable.
+
+### BC2 [suggestion] Eager-drive does not handle an aggregation step with a non-immediate projection
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java` (line 203-223)
+
+**Issue**: `spliceTap` inspects only `aggregateStep.prev` to decide whether to splice above a pre-aggregate projection. It assumes the identity-stripping projection, when present, is the aggregation step's *immediate* predecessor. If a future plan shape places any step (another projection, a filter, an unwind artifact) between the pre-aggregate projection and the aggregation step, the tap would splice between that intervening step and the aggregation — potentially still below an identity-stripping projection — and feed null-identity rows into `observe` (the BC1 corruption), or splice above a step that does not strip identity and observe rows twice/incorrectly.
+
+**Evidence**: `spliceTap` reads `var prev = aggregateStep.prev;` and only descends one level (L210-214). The correctness of the splice rests entirely on the planner emitting the pre-aggregate projection as the direct `prev`. The current planner (`handleProjections`, L762-785) does exactly that with nothing chained between Phase 1 and Phase 2, so the single-level inspection is sufficient today.
+
+**Refutation considered**: Verified the planner chains Phase 1 (`ProjectionCalculationStep(preAggregateProjection)`) immediately followed by Phase 2 (`AggregateProjectionCalculationStep`) with no intervening `chain(...)` call. The `GuaranteeEmptyCountStep` (L790-794) is chained *after* the aggregation (downstream/next), not between, so it does not affect the upstream splice. No current bug. The single-level assumption is correct against the present planner but is a coupling that would break silently (no test, no assert) if the planner adds an upstream step.
+
+**Suggestion**: Add a brief comment in `spliceTap` documenting the load-bearing assumption ("the pre-aggregate projection, when present, is always the aggregation step's immediate prev per `SelectExecutionPlanner.handleProjections`"), or harden by walking up the prev-chain while each step is identity-stripping. Optional.
+
+## Evidence base
+
+#### C1 null-RID guard is assert-only
+CONFIRMED-as-issue (suggestion): `AggregateState.observe` guards null RID with a Java `assert` only; `ResultInternal.getIdentity()` returns null for an identity-less projection row (verified at ResultInternal.java:708-715); planner chain analysis (SelectExecutionPlanner.handleProjections L762-798) shows the current splice point sees identity-carrying rows, so the assert never trips in practice — the finding is forward-looking hardening, not a live defect.
+
+#### C2 splice only walks immediate prev
+CONFIRMED-as-issue (suggestion): `spliceTap` inspects only `aggregateStep.prev`; the planner (SelectExecutionPlanner.handleProjections L762-785) chains the pre-aggregate projection as the direct predecessor of the aggregation step with nothing between, so single-level inspection is correct against the present planner. Coupling, not a current bug.
+
+#### Refuted / examined-and-cleared claims (full)
+
+- **Cache-code guard leak on eager-drive exception** — REFUTED. If `plan.start()` or the drive loop throws, the assignment `viewOwnsGuard = aggregateResult instanceof CachedResultSetView` (DatabaseSessionEmbedded L809) is never reached, so `viewOwnsGuard` stays false and `serveThroughCache`'s finally (L832-834) calls `tx.exitCacheCode()`. The inner try closes the stream, the outer try closes the plan. No guard leak, no plan leak. Matches the Track-1 "release the guard on every exit" contract the track file requires.
+
+- **`inFlightLookup` reachable outside the `cacheCodeDepth` bracket** (carried Track-1 caution) — REFUTED. The aggregate path calls `cache.lookup` exactly once, inside the same `tx.enterCacheCode()` bracket as the RECORD/K0 path (`serveThroughCache` L782-785). `populateAndBuildAggregateView` does not call `lookup`. The guard stays defense-in-depth as Track 1 left it.
+
+- **SUM/AVG `count` divisor staleness after lazy fold + copy** — REFUTED. Every contributor-changing path (`addContributor`, `removeContributor`, `updateContributor`) sets `sumDirty = true`; `ensureSumFolded` recomputes both `sumAccumulator` and `count` together in `refoldSum`. `copy()` carries `sumDirty` so a copied-then-replayed state folds lazily on first read. `count` can only be read stale if contributingValues changed without setting `sumDirty`, which no path does.
+
+- **AVG divide-by-zero** — REFUTED. `computeAverage` divides only when `sum != null`; `refoldSum` leaves `sumAccumulator == null` exactly when `contributingValues` is empty, in which case `count == 0` too and the null-sum branch returns null before any division. Non-null sum implies count >= 1.
+
+- **`copy()` shares mutable bucket sets with the original** — REFUTED. `copy()` rebuilds each `distinctBuckets` value as `new HashSet<>(e.getValue())` (AggregateState L882-884); `contributingValues`/`contributingRids` are copied via `putAll`/`addAll` into fresh containers. Test `copyDeepCopiesDistinctBuckets` pins this. A replay on the copy cannot disturb the entry's seeded state.
+
+- **D21 collapse double-apply / stale contributor** — REFUTED. `applyMutation` derives `wasContributing` from cache membership and `nowContributing` from `(status != DELETED) && matchAfter`, never from `op.type`. A collapsed pre-populate CREATE already in `contributingValues` is read as a drop/update, not a new add. Tests `collapseCase_prePopulateCreateThenWhereBreak`, `collapseCreatedOpAlreadyContributingDropsOnWhereFail`, and `collapseCreatedOpAlreadyContributingRefoldsOnValueChange` cover it. The populate-version filter in `buildForAggregate` (op.version <= populateMutationVersion skipped) prevents replaying ops already baked into the seed.
+
+- **Tap unreachable by `plan.start()`/`close()` because it is absent from `getSteps()`** — REFUTED. `SelectExecutionPlan.start()` calls `lastStep.start(ctx)` which recurses up the `prev` chain (verified SelectExecutionPlan.java:85-86); `close()` calls `lastStep.close()` which propagates backward via prev with a double-close guard (L76-77, AbstractExecutionStep.close L115-116). The spliced tap is in the prev chain, so both reach it. This matches the BC1 finding the Step-3 episode already deferred.
+
+- **Double-close of the spliced tap (stream.close then plan.close)** — REFUTED. The eager-drive does `stream.close(ctx)` (propagates back through the prev chain including the tap) then `plan.close()` (calls `lastStep.close()` again). `AbstractExecutionStep` has a double-close guard flag (close propagates backward and could cycle, AbstractExecutionStep L101). No double-side-effect.
+
+- **Plan/ctx leak via the entry** — REFUTED. The aggregate entry is built with null stream/plan/ctx (DatabaseSessionEmbedded L161-169); the plan is closed in `populateAndBuildAggregateView`'s own finally. The entry retains only the `AggregateState` (RIDs + detached Number/Object values), not the closed plan or its context.
+
+- **Overflow guard installed but never reset after exception** — REFUTED. `installAggregateOverflowGuard` mutates only the soon-discarded `state`; on any exception path the state is not stored (put is reached only on the success path, and is a no-op once the key is in `nonCacheableKeys`). The overflow latch (`overflowed`) is one-shot per state and irrelevant after the state is discarded. Test `contributorCapOverflowRoutesKeyNonCacheable` confirms the entry is not retained and a repeat stays uncached.
+
+- **`count(*) + 1` mis-routed to RECORD instead of K0_NONE** — REFUTED. `rootAggregateCall` returns null for an aggregate under arithmetic (`rootCallWithoutArithmetic` rejects any math node with a non-empty operator list, ShapeClassifier L1586-1589), so `singleAggregateShape` returns null and `classifySelect` falls to `projectionContainsAggregate` → K0_NONE (ShapeClassifier L166-176). Test `aggregateUnderArithmeticServedByK0None` pins the served value matches fresh.
+
+- **Metric bridge null-registry NPE** — REFUTED. `globalRate` returns `TimeRate.NOOP` when the registry is null (QueryCacheMetrics L1287-1290), and every `increment*` records into a non-null sink. The no-arg constructor resolves the registry from `YouTrackDBEnginesManager`; the package-visible constructors inject sinks directly for deterministic tests.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/code-quality-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/code-quality-iter1.md
@@ -1,0 +1,54 @@
+<!-- MANIFEST
+dimension: code-quality
+iteration: 1
+findings: 3
+evidence_base: { certs: 0 }
+index:
+  - id: CQ1
+    sev: suggestion
+    anchor: "CQ1"
+    loc: "DatabaseSessionEmbedded.java:905-912; ShapeClassifier.java:1439-1446; AggregateState.java:509-515"
+    cert: n/a
+    basis: diff + grep
+  - id: CQ2
+    sev: suggestion
+    anchor: "CQ2"
+    loc: "AggregateState.java:927-940"
+    cert: n/a
+    basis: diff
+  - id: CQ3
+    sev: suggestion
+    anchor: "CQ3"
+    loc: "AggregateState.java:942-972; getContributingValues/getDistinctBuckets"
+    cert: n/a
+    basis: diff
+flags: []
+-->
+
+## Findings
+
+### CQ1 [suggestion] AGGREGATE_* membership enumerated in three places
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java` (`isAggregateShape`, lines ~905-912), `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/ShapeClassifier.java` (`isAggregateKind`, lines ~1439-1446), `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java` (constructor assert, lines ~509-515).
+
+**Issue**: The same six-way disjunction (`shape == AGGREGATE_COUNT || ... || shape == AGGREGATE_COUNT_DISTINCT`) is hand-written three times across three classes. If a future track adds a seventh aggregate shape (or the `COUNT_DISTINCT` member is removed, which Track 3 notes is now production-unreached), each copy must be found and updated independently; missing one silently routes the new shape down the wrong path. This is the classic enumerated-set DRY hazard the `CacheableShape` enum could close.
+
+**Suggestion**: Centralize the predicate once — either a package-visible `CacheableShape.isAggregate()` instance method on the enum, or a single static helper in `ShapeClassifier` that the other two call. The constructor assert in `AggregateState` can then read `assert kind.isAggregate()`. Not blocking: the three copies are currently identical and covered by tests, so there is no live defect — only future-maintenance fragility.
+
+### CQ2 [suggestion] AggregateState.computeAverage silently returns null for unmodeled Number subtypes
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java` (`computeAverage`, lines ~927-940).
+
+**Issue**: The type-dispatch ladder handles `Integer`/`Long`/`Float`/`Double`/`BigDecimal` and falls through to `return null` for anything else. The Javadoc says it reproduces `SQLFunctionAverage.computeAverage` verbatim, and the empty-set case (`sum == null`) legitimately returns null. But a non-null `sum` of an unmodeled subtype (e.g. `Short`, `Byte`, `BigInteger` — whatever `PropertyTypeInternal.increment` can yield from the fold) would also return null, producing a wrong AVG scalar with no signal. Because the value reproduces a private storage method rather than calling it, the two can drift if storage starts producing such a type.
+
+**Suggestion**: If the contract is that `increment` only ever yields the five handled types, make that explicit with an `else throw new IllegalStateException("unexpected AVG accumulator type " + sum.getClass())` on the non-null-but-unmatched branch, so a future divergence fails loudly in a test rather than silently mis-finalizing. Keep the `sum == null -> null` empty-set branch as-is. Low severity: the value aggregates are gated to numeric properties and the equivalence test compares against fresh execution, so a real drift would surface — but only for a type the test happens to exercise.
+
+### CQ3 [suggestion] Package-private test accessors widen the AggregateState surface
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java` (`getContributingValues`, `getDistinctBuckets`, `getContributingRids`, lines ~942-972).
+
+**Issue**: Three accessors return the live internal collections (`Map<RID,Object>`, `Map<Object,Set<RID>>`, `Set<RID>`) rather than copies or unmodifiable views. They are package-private and the comment marks them test/inspection-only, so this is not an encapsulation defect today — the only callers are tests in the same package. The risk is that a future same-package caller mutates the returned collection and corrupts the seeded state, defeating the `copy()` isolation the rest of the class is careful to preserve.
+
+**Suggestion**: Wrap the three returns in `Collections.unmodifiable*` (the tests only read them, so this costs nothing) to make the read-only intent enforced rather than documented. Minor; the cap-overflow and bucket-lifecycle tests that consume these would be unaffected.
+
+## Evidence base

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/performance-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/performance-iter1.md
@@ -1,0 +1,95 @@
+<!-- MANIFEST
+dimension: performance
+prefix: PF
+iteration: 1
+high_water_mark: 0
+findings: 3
+evidence_base: 5
+cert_index: C1,C2,C3,C4,C5
+flags: []
+index:
+  - id: PF1
+    sev: suggestion
+    anchor: "#pf1-minmax-replay-on-extremum-holder-mutation-is-onm-per-build"
+    loc: "AggregateState.java:677-735 (recomputeExtremum), DeltaBuilder.java:1177-1194 (replay loop)"
+    cert: C1
+    basis: "Each replayed mutation touching the extremum holder triggers an O(n) recomputeExtremum; m such ops in one build give O(n*m). MIN/MAX only; SUM/AVG/COUNT/COUNT_DISTINCT are O(1) amortized per op."
+  - id: PF2
+    sev: suggestion
+    anchor: "#pf2-buildforaggregate-rebuilds-full-state-copy--replay-on-every-cache-hit-no-cross-view-share"
+    loc: "DeltaBuilder.java:1163-1197 (buildForAggregate), AggregateState.java:872-886 (copy)"
+    cert: C2
+    basis: "Aggregate hit path does state.copy() (O(n) alloc) + full tx-op-log walk + per-op WHERE re-eval on every view, unlike buildForRecord which caches the (skipSet,injectList) pair per mutationVersion. Documented as intentional; flagged for scale awareness only."
+  - id: PF3
+    sev: suggestion
+    anchor: "#pf3-contributor-collections-allocated-at-default-capacity-carried-from-step-1-pf2pf3"
+    loc: "AggregateState.java:454-499 (field initializers), 873-885 (copy)"
+    cert: C3
+    basis: "contributingValues/contributingRids/distinctBuckets + per-view copy allocate at default capacity, forcing log2(n) rehash/resize cycles when n approaches the 10k cap. Already logged as deferred PF2/PF3 in Step 1/Step 3 episodes."
+-->
+
+# Performance review — Track 2 (Aggregate shapes)
+
+BLUF: No blocker or should-fix performance defects. The hot paths (`observe` at populate, `applyMutation`/`copy` per cache hit) are correctly designed: SUM/AVG fold once lazily via `sumDirty`, COUNT/COUNT_DISTINCT are O(1) per op, and the contributor collections are bounded at 10,000 by the overflow cap. Three suggestion-severity items, all bounded by that cap and two of them already logged as deferred in the track episodes.
+
+## Findings
+
+### PF1 [suggestion] MIN/MAX replay on extremum-holder mutation is O(n·m) per build {#pf1-minmax-replay-on-extremum-holder-mutation-is-onm-per-build}
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java` (lines 677-735, `recomputeExtremum` at 777-787)
+**Also**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/DeltaBuilder.java` (lines 1177-1194, the per-view replay loop)
+
+**Issue**: For `AGGREGATE_MIN` / `AGGREGATE_MAX`, every replayed mutation that drops or moves-away-from-extremum the current holder calls `recomputeExtremum`, an O(n) scan over `contributingValues` (n = contributor count, capped at 10,000). The replay loop in `buildForAggregate` walks all post-populate ops; if `m` of them touch the extremum holder, the build is O(n·m). SUM/AVG sidestep this with the lazy `sumDirty` + single `ensureSumFolded` fold (the Step 1 review fix); COUNT_DISTINCT re-bucketing and COUNT membership are O(1) per op. MIN/MAX is the only shape that retains a per-op O(n) branch inside the replay.
+
+**Evidence**: COST TRACE C1, SCALE CHECK in C1. The pathological case requires repeated mutation of whichever record currently holds the extremum within one transaction — e.g. a tx that repeatedly lowers the running MIN holder below the field, each time forcing a rescan.
+
+**Impact**: Latency on the aggregate cache-hit path for MIN/MAX only. At the n≤10,000 cap and realistic m (tens of post-populate mutations per tx in the target DNQ pattern), worst case is ~10,000 × tens = sub-millisecond, dominated by the WHERE re-eval already in the same loop. MATTERS AT SCALE only if a tx both holds a near-cap MIN/MAX contributor set and mutates the extremum holder repeatedly — not the documented target workload.
+
+**Suggestion**: Leave as-is for v1; the cost is bounded and the worst case is workload-adversarial. If a future D13 measurement flags MIN/MAX hit latency, the deferred D14 `TreeMap` sorted-value index (already named out-of-scope in the track Interfaces section) makes `recomputeExtremum` O(log n). No code change recommended now — record the O(n·m) MIN/MAX shape as the trigger condition for that v2 lever.
+
+### PF2 [suggestion] buildForAggregate rebuilds full state copy + replay on every cache hit (no cross-view share) {#pf2-buildforaggregate-rebuilds-full-state-copy--replay-on-every-cache-hit-no-cross-view-share}
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/DeltaBuilder.java` (lines 1163-1197)
+**Also**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java` (lines 872-886, `copy`)
+
+**Issue**: `buildForAggregate` does a fresh `seeded.copy()` (a new `LinkedHashMap`/`HashSet`/per-bucket `HashSet`, O(n) entries copied) plus a full walk of the transaction's record-operation log plus per-surviving-op WHERE re-eval — on every cache hit. `buildForRecord` (lines 110-118 of the same file) caches its computed `(skipSet, injectList)` pair on the entry keyed by `mutationVersion` and returns a shared immutable cursor when two views hit the entry at the same tx state, skipping the re-walk. The aggregate path deliberately does not (Javadoc: "the aggregate state is not cross-view cached on the entry: a single call produces a fresh copy per view... there is no pause/resume to share").
+
+**Evidence**: COST TRACE C2. The asymmetry is real and intentional, but it means two aggregate `query()` calls at the same `mutationVersion` each pay the full copy + op-log walk, where the RECORD path pays it once.
+
+**Impact**: Per-hit allocation (one `AggregateState.copy()`: 1 `LinkedHashMap` + 1 `HashSet` + k bucket `HashSet`s for COUNT_DISTINCT) and CPU (op-log walk + WHERE re-eval). Bounded by the 10,000 cap. The dominant target pattern is *repeated identical shape within one tx*, so same-version re-hits are exactly the case the RECORD path optimizes and the aggregate path does not. MATTERS AT SCALE for hot aggregate shapes hit many times between two mutations; NEGLIGIBLE for the read-then-mutate-then-read pattern the tests exercise.
+
+**Suggestion**: Keep for v1 — correctness is unaffected and the same-version cross-view cache is a measured optimization, not a default. If D13 shows a hot aggregate shape re-queried many times at a stable `mutationVersion`, mirror `buildForRecord`'s version-tagged pair cache: store the finalized scalar (not the full state) on the entry tagged by `mutationVersion`, and short-circuit when the version matches. Cheaper than the RECORD pair because the aggregate result is a single scalar. Record as a v2 candidate alongside D14.
+
+### PF3 [suggestion] Contributor collections allocated at default capacity (carried from Step 1 PF2/PF3) {#pf3-contributor-collections-allocated-at-default-capacity-carried-from-step-1-pf2pf3}
+
+**File**: `core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateState.java` (lines 454-499 field initializers; 873-885 `copy`)
+
+**Issue**: `contributingRids` (`HashSet`), `contributingValues` (`LinkedHashMap`), and `distinctBuckets` (`HashMap`) are all created at default capacity (16). At populate, `observe` grows them one contributor at a time; near the 10,000 cap that is ~10 rehash/resize cycles per collection. `copy()` likewise builds the destination maps at default capacity and `putAll`s into them, repeating the resize cost per view. The contributor count is unknown at populate (the side-tap discovers it during the drive), so populate-time presizing is not free — but `copy()` knows the source size and could presize.
+
+**Evidence**: COST TRACE C3. This is the same observation already recorded as deferred PF2 (Step 1 episode: "presize the contributor collections... folds into the Step 3 cap wiring") and PF3 (Step 3 episode: "contributor collections allocate at default capacity, carried from Step 1").
+
+**Impact**: GC pressure and CPU from incremental rehashing during populate and per-view copy. O(n) amortized either way; presizing removes the log n resize constant. At n=10,000 the saved work is small relative to the WHERE re-eval and `increment` boxing in the same paths. MATTERS AT SCALE marginally for high-cardinality aggregates copied on every hit.
+
+**Suggestion**: In `copy()`, presize the destination collections from the source sizes: `new LinkedHashMap<>(Math.max(16, contributingValues.size() * 4 / 3 + 1))` and the analogous `HashSet`/`HashMap`. Leave populate-time collections at default (size unknown until the drive completes). One-line-per-collection change, no semantic risk. Consistent with the already-deferred PF2/PF3 — promote to this track only if the copy is confirmed hot by D13; otherwise leave deferred as the episodes recorded.
+
+## Evidence base
+
+#### C1 — MIN/MAX recomputeExtremum O(n) per extremum-holder mutation {#c1}
+
+CONFIRMED-as-issue (suggestion). `recomputeExtremum` (AggregateState.java:777-787) is an O(n) scan over `contributingValues`. It fires from `removeContributor` when the dropped RID `equals(extremumRid)` (line 684-688) and from `updateContributor` when the holder moves away from the extremum direction (line 714-722). Non-holder mutations are O(1) (single `beatsExtremum` compare). Within one `buildForAggregate` replay (DeltaBuilder.java:1177-1194) the loop applies every post-populate op; m holder-touching ops give O(n·m). n is bounded at `maxRecordsPerEntry`=10,000 (GlobalConfiguration.java:978). SUM/AVG are exempt: `addContributor`/`removeContributor`/`updateContributor` only set `sumDirty` (lines 658-660, 681-682, 702-703) and the O(n) fold runs once via `ensureSumFolded` (743-748). SCALE: at 100 records negligible; at 10k cap with tens of holder mutations sub-ms and dominated by the co-located WHERE re-eval; pathological only under adversarial repeated-extremum-holder mutation.
+
+#### C2 — Aggregate hit path: full copy + op-log walk per view, no version-tagged share {#c2}
+
+CONFIRMED-as-issue (suggestion). `buildForAggregate` (DeltaBuilder.java:1163-1197) unconditionally calls `seeded.copy()` then iterates `tx.getRecordOperationsInternal()` (confirmed `Collection<RecordOperation>`, the full tx op list — FrontendTransactionImpl.java:1468) with a per-survivor `whereClause.matchesFilters(record, ctx)`. `copy()` (AggregateState.java:872-886) allocates a fresh `LinkedHashMap`+`HashSet`+per-bucket `HashSet` and copies all n entries. Contrast `buildForRecord` (DeltaBuilder.java:96-101): returns a shared cursor over the entry's cached `(skipSet,injectList)` when `getCachedDeltaVersion() == version`, skipping the walk for same-version re-hits. The aggregate Javadoc states the omission is deliberate (no pause/resume to share). The full op-log walk itself is the accepted v1 cost shared with the RECORD path (DeltaBuilder.java comment: "The remaining full-log walk is the accepted v1 cost"). SCALE: target pattern is hundreds-to-thousands of duplicate-shape queries per request; same-version re-hits of a hot aggregate pay the copy+walk each time where RECORD pays once.
+
+#### C3 — Default-capacity contributor collections {#c3}
+
+CONFIRMED-as-issue (suggestion), already deferred. Fields at AggregateState.java:454 (`new HashSet<>()`), 470 (`new LinkedHashMap<>()`), 499 (`new HashMap<>()`) and the copy destinations (873-885) use default capacity. `observe` grows them incrementally to the 10k cap (~10 resizes). Recorded deferred in Step 1 episode (PF2 "presize the contributor collections") and Step 3 episode (PF3 "contributor collections allocate at default capacity, carried from Step 1"). Populate-time size is unknown until the drive completes (side-tap discovers it), so only `copy()` can presize cheaply.
+
+#### C4 — SUM/AVG fold is correctly lazy (refuted as a finding) {#c4}
+
+Investigated whether SUM/AVG re-fold on every mutation. REFUTED: `addContributor`/`removeContributor`/`updateContributor` set `sumDirty=true` only (AggregateState.java:658-660, 681-682, 702-703); the O(n) `refoldSum` runs once via `ensureSumFolded` on the next scalar read (743-748, 909, 913). A build replaying m mutations does one fold (O(n+m)), not m folds (O(n·m)). The Javadoc at lines 481-488 documents this collapse explicitly. This is the Step 1 review fix and it holds. `refoldSum` does autobox a new `Number` per `PropertyTypeInternal.increment` (line 768) — O(n) boxed allocations per fold — but once per build, not per op, and required for D19 storage-fold parity (no symmetric subtract available). Not a finding.
+
+#### C5 — Eager-drive cost parity and observe-time cost (refuted as a finding) {#c5}
+
+Investigated the aggregate cache-miss eager drive (`populateAndBuildAggregateView`, DatabaseSessionEmbedded.java:97-176) as a possible regression vs uncached. REFUTED: the aggregation step (`AggregateProjectionCalculationStep`) is already blocking — a fresh uncached aggregate query drains every contributor to produce its single row regardless. The eager drive (lines 143-153) adds only the per-row `state.observe(r)` side-call in `ObservingStream.next` (AggregateCacheTapStep.java:334-338): one map/set put + an O(1) overflow check per contributing record. The track Compatibility note ("Eager drive matches the uncached aggregate latency profile") is accurate. The miss path does build the plan once (`createExecutionPlan`) — the deferred Step 3 PF1 notes the untappable-shape fallback builds it twice, but that is the fallback-only path (hardwired COUNT(*)), not the cacheable aggregate path, and is bounded by one extra plan build on a shape that was never going to cache. Not a track-2 finding beyond the already-recorded Step 3 PF1.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/risk-gate-verification-iter2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/risk-gate-verification-iter2.md
@@ -1,0 +1,94 @@
+<!-- role: reviewer-risk | phase: 3A | track: Track 2 — Aggregate shapes | iteration: 2 | gate-verification -->
+# Track 2 Risk Gate Verification — iteration 2
+
+## Manifest
+
+```yaml
+review_type: risk
+track: "Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT"
+phase: 3A
+iteration: 2
+reviewer: reviewer-risk
+kind: gate-verification
+findings: 0
+overall: PASS
+verdicts:
+  - id: R1
+    prior_sev: should-fix
+    disposition: ACCEPTED
+    verdict: VERIFIED
+  - id: R2
+    prior_sev: should-fix
+    disposition: ACCEPTED
+    verdict: VERIFIED
+  - id: R3
+    prior_sev: should-fix
+    disposition: ACCEPTED
+    verdict: VERIFIED
+  - id: R4
+    prior_sev: should-fix
+    disposition: ACCEPTED
+    verdict: VERIFIED
+  - id: R5
+    prior_sev: should-fix
+    disposition: ACCEPTED
+    verdict: VERIFIED
+  - id: R6
+    prior_sev: suggestion
+    disposition: REJECTED
+    verdict: REJECTED
+tooling_note: >
+  Code re-checks (R5 ServiceLoader manifest, R6 ShapeClassifier:177-198 +
+  firstFunctionCall:147-161) used direct Read of the cited file:line —
+  known-location confirmations, not symbol audits. mcp-steroid PSI timed out
+  earlier this session, so no PSI inheritor search was attempted; the R5
+  factory set rests on the manifest file, the canonical registration surface.
+```
+
+#### Verify R1: bare COUNT(*) hardwired, headline test vacuous
+- **Original issue**: `SELECT COUNT(*) FROM C` hardwires to `CountFromClassStep`; side-tap never reached; I4 test asserts fallback while believing it tests the tap.
+- **Fix applied**: Context "hardwired and untappable" bullet (lines 96-104); step 5 (202-205) and step 6 (209-214); Validation (230-240) requires a *tappable* shape, forbids bare `COUNT(*)` for cache-hit, adds a hardwired-rides-fallback case + `incrementSpliceFailures` assertion.
+- **Re-check**: Current state names the hardwired shapes, the tappable set (SUM/AVG/MIN/MAX/COUNT_DISTINCT + non-indexed-WHERE COUNT(*)), and the explicit Decision-Log resolution (lines 51-56). Test framing no longer vacuous.
+- **Regression check**: Checked step 5 vs Validation vs Decision Log — consistent; the "ride fallback OR classify K0_NONE, pick one and test" choice is deferred to decomposer but bounded. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify R2: AVG finalization + SUM empty=0
+- **Original issue**: D19 `increment` covers SUM accumulation only; AVG needs `total` + `computeAverage` type dispatch; SUM empty = 0 not null.
+- **Fix applied**: step 1 "AVG finalization" (144-148), SUM-empty=0 (line 143); Key signatures (300-301, 305) carry `total` + `computeAverage`.
+- **Re-check**: Matches the iter-1 code evidence (`computeAverage:101`, `getResult:89`). Integer truncation + BigDecimal HALF_UP + empty-set 0 all named.
+- **Regression check**: Validation lines 248-249 add the matching parity cases. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify R3: cap targets AggregateState, not results
+- **Original issue**: carried `recordPulledRow` cap bounds `results` (1 scalar), leaving `contributingRids`/`distinctBuckets` uncapped — wrong-collection OOM vector.
+- **Fix applied**: step 1 "Memory cap (aggregate-specific)" (158-165) bounds the AggregateState collections against `maxRecordsPerEntry`, overflow → L7 non-cacheable; Decision Log (57-60).
+- **Re-check**: Obligation now correctly retargeted; L7 one-shot semantics preserved. Validation line 252 adds the overflow case.
+- **Regression check**: No conflict with R4 populate path. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify R4: eager-drive parallel populate path contracts
+- **Original issue**: parallel populate path must re-mirror stamp-before-drive, cacheCodeDepth release, idempotent close.
+- **Fix applied**: step 4 (183-192) names all three contracts explicitly; step 3 (176-178) preserves the two-guard `viewOwnsGuard`/`cacheCodeDepth` contract.
+- **Re-check**: All three contracts present and ordered (stamp before drive). Matches iter-1 trace of `populateAndBuildView`/`serveThroughCache`.
+- **Regression check**: Compatibility note (283-287) consistent. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify R5: four factories, not three
+- **Original issue**: I5 names three; four registered; `DynamicSQLElementFactory` omitted silently.
+- **Fix applied**: Context "Four SQLFunctionFactory implementations" (91-95); step 6 "all four" (213-214); Validation "four factories" (259).
+- **Re-check**: ServiceLoader manifest re-read directly — registers exactly four: `DefaultSQLFunctionFactory`, `DynamicSQLElementFactory`, `DatabaseFunctionFactory`, `CustomSQLFunctionFactory`. Track now matches.
+- **Regression check**: Surprises & Discoveries (42-44) records the correction. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify R6 (REJECTED): COUNT(DISTINCT prop) nested-distinct parse
+- **Rejection reason**: already implemented in Track 1 — `ShapeClassifier.isDistinct` walks into the nested `distinct(...)` call; step 5 is verify-not-build.
+- **Downstream check**: Read `ShapeClassifier:177-198` — `count` routes to `AGGREGATE_COUNT_DISTINCT` iff `isDistinct(call)`; `isDistinct` applies `firstFunctionCall` (pre-order subtree walk, 147-161) to each param and matches a nested `distinct`. The `count(distinct(prop))` shape is recognized. Surprises note (35-37) and step 5 (193-198) accurately record this as Track-1 verify-and-tighten work; the two genuine Track-2 tightenings (arithmetic-buried aggregate → K0_NONE; hardwired COUNT(*)) are correctly separated out. No downstream issue from leaving the parse as Track-1 work.
+- **Verdict**: REJECTED (no action needed)
+
+## Findings
+
+<!-- No new findings surfaced by this verification pass. -->
+
+## Summary
+
+PASS — all five accepted findings (R1–R5) VERIFIED with fixes applied to the amended track-2.md; R6 REJECTED is sound per direct code read. No internal contradictions across the amended Context/Decision Log/Plan of Work/Validation/Key signatures sections. No regressions, no new findings.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/risk-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/risk-iter1.md
@@ -1,0 +1,187 @@
+<!-- role: reviewer-risk | phase: 3A | track: Track 2 — Aggregate shapes | iteration: 1 -->
+# Track 2 Risk Review — iteration 1
+
+## Manifest
+
+```yaml
+review_type: risk
+track: "Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT"
+phase: 3A
+iteration: 1
+reviewer: reviewer-risk
+verdict: changes-requested
+findings: 6
+counts:
+  blocker: 0
+  should-fix: 5
+  suggestion: 1
+evidence_base:
+  exposures: 3
+  assumptions: 5
+  testability: 2
+tooling_note: >
+  mcp-steroid PSI was unreachable this session (steroid_execute_code timed out on
+  every query, including minimal ones, despite the project being open and matching
+  the working tree). Symbol audits fell back to grep + Read. Reference-accuracy
+  caveats are attached to the findings whose verdict depends on a symbol search
+  (R5, R6).
+index:
+  - id: R1
+    sev: should-fix
+    anchor: "R1"
+    loc: "track-2.md Validation lines 130-133; SelectExecutionPlanner.handleHardwiredCountOnClass:488"
+    cert: "Exposure: splice point / aggregate-step presence"
+    basis: "SELECT COUNT(*) FROM C is hardwired to CountFromClassStep — no aggregate step to splice"
+  - id: R2
+    sev: should-fix
+    anchor: "R2"
+    loc: "track-2.md Key signatures line 184; SQLFunctionAverage.computeAverage:101"
+    cert: "Assumption: SUM/AVG storage parity via PropertyTypeInternal.increment"
+    basis: "AVG parity needs computeAverage replication (type-dispatched division), not just increment"
+  - id: R3
+    sev: should-fix
+    anchor: "R3"
+    loc: "track-2.md Interfaces line 163; CachedEntry.java (final, 8-arg ctor, recordPulledRow)"
+    cert: "Exposure: CachedEntry aggregate-state field + cap routing"
+    basis: "CachedEntry has no aggregate field; cap-routing obligation maps to AggregateState, not results"
+  - id: R4
+    sev: should-fix
+    anchor: "R4"
+    loc: "track-2.md Plan of Work step 3-4; DatabaseSessionEmbedded.populateAndBuildView:842"
+    cert: "Exposure: aggregate populate path divergence from RECORD"
+    basis: "Eager-drive splice is a parallel populate path; must re-mirror guard/stream/close contract"
+  - id: R5
+    sev: should-fix
+    anchor: "R5"
+    loc: "track-2.md Context line 56-58, Plan of Work step 6; META-INF/services SQLFunctionFactory"
+    cert: "Assumption: three SQLFunctionFactory implementations are the I5 surface"
+    basis: "Four factories are registered; DynamicSQLElementFactory omitted without stated rationale"
+  - id: R6
+    sev: suggestion
+    anchor: "R6"
+    loc: "track-2.md Plan of Work step 5; SQLProjection / YouTrackDBSql.jj:3835"
+    cert: "Assumption: COUNT(DISTINCT prop) classify is a flat function check"
+    basis: "count(distinct(prop)) is a nested-function AST; classify must walk the nesting"
+```
+
+## Evidence base
+
+### CRITICAL PATH EXPOSURE
+
+#### Exposure: aggregate splice point — is an `AggregateProjectionCalculationStep` present to splice into?
+- **Track claim**: the miss path builds the plan, walks `steps`, finds `AggregateProjectionCalculationStep`, and rewires its `prev` to the tap (Plan of Work step 3). The canonical validation query is `SELECT COUNT(*) FROM C` (Validation lines 130-133).
+- **Critical path trace**:
+  1. `SQLSelectStatement.createExecutionPlan(ctx, false)` @ `SQLSelectStatement.java:335` → `planner.createExecutionPlan(ctx, false, true)`.
+  2. `SelectExecutionPlanner.createExecutionPlan` @ `:223` runs `handleHardwiredOptimizations(result, ctx, enableProfiling)` @ `:260` *before* the projection/aggregate chain is built.
+  3. `handleHardwiredCountOnClass` @ `:488` fires for `COUNT(*)` on a class with no WHERE / no security policy / minimal query, chaining a single `CountFromClassStep` @ `:514` and returning early @ `:261`.
+  4. `handleHardwiredCountOnClassUsingIndex` @ `:553` fires for `COUNT(*) FROM C WHERE field = ?` when a single-field index covers the equality.
+- **Blast radius**: not a crash. The most-cited example (`COUNT(*) FROM C`) and the indexed-`COUNT(*)-WHERE` form produce plans with **no** `AggregateProjectionCalculationStep`, so the splice walk finds nothing and the track's own fallback (close plan, increment `spliceFailures`, uncached `LocalResultSet`) fires. Effect: the headline aggregate never caches, and the per-kind I4 test for `COUNT(*)` would exercise the fallback path, not the side-tap — a silently vacuous test if written against the example as stated.
+- **Existing safeguards**: the fallback path is designed and correct (mirrors `populateAndBuildView`'s `!(original instanceof LocalResultSet)` early-return contract at `DatabaseSessionEmbedded.java:860`). `spliceFailures` maps to the registered `QUERY_CACHE_SPLICE_FAILURE_RATE` metric (`CoreMetrics.java:64`).
+- **Residual risk**: MEDIUM — correctness is safe (fallback), but the track's scope/test framing overstates what caches. SUM/AVG/MIN/MAX/COUNT_DISTINCT and `COUNT(*)` over a non-indexed WHERE do build a real aggregate step; plain `COUNT(*)` and indexed-`COUNT(*)-WHERE` do not.
+
+#### Exposure: `CachedEntry` aggregate-state field and the carried `recordPulledRow` cap obligation
+- **Track claim**: "`CachedEntry` (aggregateState field, if not already added in Track 1)" (Interfaces line 163); carried obligation — "route every per-RID/row append through `CachedEntry.recordPulledRow` so the `maxRecordsPerEntry` cap applies to aggregate material" (plan Track-2 entry).
+- **Critical path trace**:
+  1. `CachedEntry` is `public final` with a single 8-arg constructor (`CachedEntry.java:53,113`) and no aggregate field; every Track-1 call site (`DatabaseSessionEmbedded.populateAndBuildView:873`) passes exactly those 8 args.
+  2. The cap machinery (`recordPulledRow:268`, `setOverflowGuard:252`, `maxRecordsPerEntry:100`) governs `results`/`cachedRids` — record-oriented storage. The aggregate path holds **one** scalar `Result` plus the per-contributor material inside `AggregateState` (`contributingValues`/`contributingRids`/`distinctBuckets`).
+- **Blast radius**: if the aggregate path appends its single scalar through `recordPulledRow`, the `maxRecordsPerEntry` cap (default 10000) never fires for an aggregate, because `results.size()` is 1 regardless of how many contributors the tap observed — the per-contributor growth that actually consumes memory lives in `AggregateState`, uncapped. The carried cap obligation, taken literally, protects the wrong collection.
+- **Existing safeguards**: the cap is the only per-entry memory bound (D8); LRU `maxEntries` bounds entry count but not per-entry aggregate-state size.
+- **Residual risk**: MEDIUM — an unbounded `distinctBuckets`/`contributingRids` on a high-cardinality `COUNT(DISTINCT)` or wide MIN/MAX recompute set is the realistic OOM vector this track introduces, and the Track-1 cap does not reach it without an explicit aggregate-material cap check.
+
+#### Exposure: aggregate populate path diverges from the RECORD populate path
+- **Track claim**: Plan of Work steps 3-4 — build the plan via `createExecutionPlan`, splice the tap, then **eager-drive** `plan.start(ctx).next(ctx)`, holding the scalar + completed `AggregateState` on the entry, "wrap in try / put-on-success-only".
+- **Critical path trace**:
+  1. The Track-1 RECORD path reuses `executeUncached` (`DatabaseSessionEmbedded.java:818`), which calls `statement.execute(...)` → `LocalResultSet` whose constructor calls `plan.start()` (per the comment at `populateAndBuildView:849-850`), then lifts the stream/plan lazily — never drives to completion.
+  2. The aggregate path cannot reuse that: it must construct the plan itself (`createExecutionPlan`), mutate the step chain (splice), and drive to completion at populate. This is a second, parallel populate path that does not flow through `executeUncached`/`populateAndBuildView`.
+  3. The guard contract (`serveThroughCache:774-814`): `enterCacheCode()` brackets the lookup; `viewOwnsGuard = result instanceof CachedResultSetView` transfers the guard to the view, which releases it once on close. The aggregate view eagerly drained at populate, so it never lazily pulls — yet it must still release the guard exactly once on close.
+- **Blast radius**: a populate path that does not faithfully re-mirror Track 1's contract risks (a) a leaked `cacheCodeDepth` bump that bypasses the cache for the rest of the transaction (the exact bug Track-1 Phase C fixed for the fallback branch), (b) a double-closed or never-closed plan/stream, or (c) a populate-version stamp captured after the eager drive instead of before, which would let the delta builder mis-filter post-populate ops.
+- **Existing safeguards**: `IdempotentExecutionStream` (D9) makes a second close a no-op; `CachedEntry.close()` is null-out idempotent (`CachedEntry.java:303`); the `viewOwnsGuard`/finally structure is in place to copy.
+- **Residual risk**: MEDIUM — the contract is documented and copyable, but it is the highest-complexity integration point in the track and the failure modes are silent (leaked depth disables caching invisibly; mis-ordered stamp produces wrong scalars only under specific mutation patterns).
+
+### UNKNOWNS & ASSUMPTIONS
+
+#### Assumption: SUM/AVG replay matches storage bit-for-bit via `PropertyTypeInternal.increment`
+- **Track claim**: "SUM/AVG fold through the same `PropertyTypeInternal.increment` storage uses (D19)" (Purpose; Key signatures line 186 lists only `increment`).
+- **Evidence search**: grep + Read of `SQLFunctionSum.java`, `SQLFunctionAverage.java`, `PropertyTypeInternal.java`.
+- **Code evidence**: `SQLFunctionSum.sum` @ `:73` and `SQLFunctionAverage.sum` @ `:80` both call `PropertyTypeInternal.increment(sum, value)` — SUM half VALIDATED. But `SQLFunctionAverage.getResult` @ `:91` returns `computeAverage(sum, total)` @ `:101`, which is a **separate** primitive doing type-dispatched division: `Integer → iSum.intValue() / iTotal` (integer-truncating), `Long → longValue()/iTotal`, `Float`/`Double` floating division, `BigDecimal → bd.divide(new BigDecimal(iTotal), RoundingMode.HALF_UP)`. AVG also requires tracking `total` (the contributor count), which `increment` does not touch. Separately, `SQLFunctionSum.getResult` @ `:89` returns `0` (Integer) for an empty set, not null.
+- **Verdict**: PARTIALLY VALIDATED — SUM-accumulation parity holds; AVG-finalization parity needs `computeAverage` + `total` replicated, which the track's signature list omits.
+- **Detail**: an `AggregateState.toResult` for AVG that divides without reproducing `computeAverage`'s exact type dispatch (especially Integer truncation and BigDecimal HALF_UP rounding) will diverge from fresh execution on the I4 parity check.
+
+#### Assumption: `COUNT(DISTINCT prop)` is a single function the classifier matches by name
+- **Track claim**: "`COUNT(DISTINCT prop)` → AGGREGATE_COUNT_DISTINCT, expression-DISTINCT → K0_NONE" (Plan of Work step 5); D20 models it on `SQLFunctionDistinct`'s `LinkedHashSet` raw equals.
+- **Evidence search**: grep of `YouTrackDBSql.jj`, `SQLFunctionCount.java`, `SQLFunctionDistinct.java`.
+- **Code evidence**: `SQLFunctionCount` @ `SQLFunctionCount.java:34` is a plain counter with no DISTINCT support. The grammar @ `YouTrackDBSql.jj:3835` parses `DISTINCT` inside a function-arg as `new SQLIdentifier("distinct")` — i.e. `COUNT(DISTINCT prop)` becomes the **nested** call `count(distinct(prop))`. `SQLFunctionDistinct.context` @ `SQLFunctionDistinct.java:37` is a `LinkedHashSet<Object>` with raw `contains` @ `:53` — so the D20 raw-equals model is grounded.
+- **Verdict**: VALIDATED (D20 model) but the classify shape is UNDERSTATED.
+- **Detail**: the classifier must recognise the nested `count(distinct(<plain prop>))` AST shape and distinguish it from `count(distinct(<expression>))` (→ K0_NONE). A flat top-level function-name check is insufficient; the branch walks one level into the count's argument.
+
+#### Assumption: there are three `SQLFunctionFactory` implementations to enumerate for I5
+- **Track claim**: "Three `SQLFunctionFactory` implementations (`DefaultSQLFunctionFactory`, `CustomSQLFunctionFactory` reflective `math_*`, `DatabaseFunctionFactory` stored) are the enumeration surface for the I5 completeness test" (Context lines 56-58); Plan of Work step 6 — "walks all three factories".
+- **Evidence search**: grep of `implements SQLFunctionFactory` across `core/src/main`; Read of `META-INF/services/...SQLFunctionFactory`. (PSI `ClassInheritorsSearch` was attempted but the IDE timed out — see tooling note.)
+- **Code evidence**: the ServiceLoader file registers **four** implementations — `DefaultSQLFunctionFactory`, `DynamicSQLElementFactory`, `DatabaseFunctionFactory`, `CustomSQLFunctionFactory`. `DynamicSQLElementFactory` @ `DynamicSQLElementFactory.java:37` implements `SQLFunctionFactory`; its `getFunctionNames` @ `:51` returns a runtime-populated static `FUNCTIONS` map (`:41`), not a build-time set.
+- **Verdict**: PARTIALLY CONTRADICTED — three named, four registered.
+- **Detail**: `DynamicSQLElementFactory`'s set is runtime-registered, so omitting it from a build-time enumeration test is defensible, but the track states "three" as if complete. The omission is currently silent and reads as an oversight; the D6 fail-open safety net rests on the I5 test being the completeness gate, so the scope of that gate must be explicit. Reference-accuracy caveat: factory enumeration was confirmed via grep + the ServiceLoader manifest, not PSI inheritor search.
+
+#### Assumption: splicing into the per-execution plan does not corrupt the shared plan cache
+- **Track claim**: implicit in Plan of Work step 3 — the miss path mutates `plan.steps` / `step.prev`.
+- **Evidence search**: Read of `SelectExecutionPlanner.createExecutionPlan` and `YqlExecutionPlanCache`.
+- **Code evidence**: the plan-cache hit returns `result.copy(ctx)` (`YqlExecutionPlanCache.java:138`) and `put` stores `internal.copy(ctx)` (`:104`); `copyOn` (`SelectExecutionPlan.java:260`) builds an independent step chain. So `createExecutionPlan(ctx, false)` always hands the caller a fresh per-execution copy.
+- **Verdict**: VALIDATED.
+- **Detail**: the splice mutates a private copy; no shared-cache corruption risk. This is an existing safeguard that lowers what could otherwise be a blocker to a non-issue — recorded so the track does not over-engineer a defensive clone.
+
+#### Assumption: eager-drive at populate matches uncached aggregate latency
+- **Track claim**: "Eager drive matches the uncached aggregate latency profile (every aggregate query blocks to produce its row anyway)" (Compatibility line 172).
+- **Evidence search**: Read of `AggregateProjectionCalculationStep`.
+- **Code evidence**: `executeAggregation` @ `:121-153` is a blocking full drain — `while lastRs.hasNext(ctx) { aggregate(...) }` then finalize — before emitting any row. `internalStart` @ `:104` returns the already-materialized iterator.
+- **Verdict**: VALIDATED — the uncached aggregate already blocks to full drain, so eager-driving at populate adds no new latency class.
+
+### TESTABILITY & COVERAGE
+
+#### Testability: per-kind I4 equivalence + D21 collapse case
+- **Coverage target**: 85% line / 70% branch.
+- **Difficulty assessment**: the I4 matrix (six kinds × four mutation patterns + collapse case) is achievable with the cache-on/cache-off parity harness Track 1 established (`TxResultCacheInvariantsTest`, `DeltaBuilderTest`). The hidden gap is R1: a `COUNT(*) FROM C` I4 test written against the stated example exercises the fallback, not the side-tap, so it would pass while testing nothing of this track's new code. The side-tap path is reached only by SUM/AVG/MIN/MAX/COUNT_DISTINCT and `COUNT(*)` over a non-indexed WHERE.
+- **Existing test infrastructure**: `core/src/test/.../cache/` carries the Track-1 invariant + delta-builder + classifier suites; the parity-harness pattern is reusable.
+- **Feasibility**: ACHIEVABLE, conditioned on the test queries actually routing through the splice (R1) and on AVG/COUNT_DISTINCT finalization parity (R2, R6).
+
+#### Testability: splice-fallback branch and `spliceFailures` increment
+- **Coverage target**: 85% line / 70% branch.
+- **Difficulty assessment**: the fallback branch (no `AggregateProjectionCalculationStep` in the plan) is directly reachable by a plain `COUNT(*) FROM C` (R1 makes this the default, not an edge case), so coverage of the fallback + `spliceFailures`/`QUERY_CACHE_SPLICE_FAILURE_RATE` increment is straightforward. Driving the *unexpected-shape* branch deliberately (a plan that has projections but the aggregate step in an unexpected position) is harder to construct and may need a synthetic plan.
+- **Existing test infrastructure**: `QueryCacheMetricsTest` covers metric increments; the fallback assertion (`no exception leaks`, increments `spliceFailures`) is in the Validation list.
+- **Feasibility**: ACHIEVABLE.
+
+## Findings
+
+### R1 [should-fix]
+**Certificate**: Exposure — aggregate splice point / aggregate-step presence
+**Location**: `track-2.md` Validation lines 130-133 and Purpose lines 5-8; `SelectExecutionPlanner.handleHardwiredCountOnClass` @ `:488`, `handleHardwiredCountOnClassUsingIndex` @ `:553`.
+**Issue**: The track's headline example, `SELECT COUNT(*) FROM C`, never reaches the side-tap. The planner hardwires bare `COUNT(*)` (and indexed `COUNT(*) WHERE field = ?`) to a single `CountFromClassStep` before the aggregate chain is built, so the splice walk finds no `AggregateProjectionCalculationStep` and the fallback (uncached, `spliceFailures++`) fires. Likelihood: certain for these query forms; impact: the most common aggregate silently never caches, and a per-kind I4 test written against the stated `COUNT(*)` example would assert against the fallback path while believing it tests the side-tap (vacuous coverage).
+**Proposed fix**: Update the track's Purpose/Validation to state which aggregate forms reach the side-tap (SUM/AVG/MIN/MAX/COUNT_DISTINCT, and `COUNT(*)` over a *non-indexed* WHERE) versus which hardwire to `CountFromClassStep` and route to the fallback. Either (a) accept that bare/indexed `COUNT(*)` stays uncached and write the I4 `COUNT(*)` test against a non-indexed-WHERE form so it actually exercises the tap, or (b) add an explicit decision to extend caching to the `CountFromClassStep` shape (separate, simpler delta — a metadata count + post-populate created/deleted count adjustment). Add a fallback-path test using bare `COUNT(*)` to cover `spliceFailures`.
+
+### R2 [should-fix]
+**Certificate**: Assumption — SUM/AVG storage parity via `PropertyTypeInternal.increment`
+**Location**: `track-2.md` Purpose lines 15-17, Key signatures line 186 (lists only `increment`); `SQLFunctionAverage.computeAverage` @ `:101`, `getResult` @ `:91`; `SQLFunctionSum.getResult` @ `:89`.
+**Issue**: D19 parity is presented as "fold through `increment`," but AVG finalization is a distinct primitive: `computeAverage(sum, total)` does type-dispatched division (Integer truncation, BigDecimal HALF_UP), and AVG needs the contributor `total` tracked alongside `sum`. SUM's empty-set result is `0` (Integer), not null. Likelihood: high that an `AggregateState.toResult` for AVG re-implements division generically; impact: I4 parity divergence on Integer AVG (truncation), BigDecimal AVG (rounding), and empty-set SUM.
+**Proposed fix**: Add `total` to the AVG state and have `toResult` reproduce `computeAverage`'s exact type dispatch (ideally by calling the same code path or a shared helper), and reproduce SUM's `sum == null ? 0` empty-set result. Note both explicitly in the step that builds `AggregateState` and add I4 cases for Integer-AVG truncation, BigDecimal-AVG rounding, and SUM-of-empty.
+
+### R3 [should-fix]
+**Certificate**: Exposure — `CachedEntry` aggregate-state field + carried cap obligation
+**Location**: `track-2.md` Interfaces line 163, plan Track-2 entry (carried `recordPulledRow` obligation); `CachedEntry.java` (`final`, 8-arg ctor @ `:113`, `recordPulledRow` @ `:268`, `maxRecordsPerEntry` @ `:100`).
+**Issue**: `CachedEntry` is `final` with no aggregate field and a single 8-arg constructor used by Track 1's only call site, so adding `AggregateState` needs a new constructor or a settable field plus a populate-path change. More importantly, the carried "route appends through `recordPulledRow` so `maxRecordsPerEntry` applies" obligation does not bound aggregate memory: an aggregate entry's `results` holds one scalar row, while the per-contributor growth (`contributingRids`, `distinctBuckets`) lives in `AggregateState` and is uncapped. Likelihood: certain the obligation as written misses the aggregate memory vector; impact: unbounded `AggregateState` growth on high-cardinality `COUNT(DISTINCT)` / large MIN/MAX recompute sets — the realistic OOM this track introduces.
+**Proposed fix**: Decide and document how the aggregate path satisfies the memory bound — either apply `maxRecordsPerEntry` to the count of observed contributors inside the tap/`AggregateState` (overflow → evict entry + `nonCacheableKeys`, same one-shot semantics as `recordPulledRow`), or add a separate aggregate-material cap. Specify the `CachedEntry` extension (new constructor vs setter) so the Track-1 call site and the new aggregate populate path stay consistent.
+
+### R4 [should-fix]
+**Certificate**: Exposure — aggregate populate path divergence from RECORD
+**Location**: `track-2.md` Plan of Work steps 3-4; `DatabaseSessionEmbedded.populateAndBuildView` @ `:842`, `serveThroughCache` guard structure @ `:774-814`.
+**Issue**: The aggregate miss path cannot reuse `populateAndBuildView` (which lifts a lazily-driven stream off a `LocalResultSet` built by `executeUncached`). It must build the plan itself, splice, and eager-drive — a parallel populate path that must independently re-mirror three Track-1 contracts: (1) capture `populateMutationVersion` *before* the eager drive; (2) `enterCacheCode`/`viewOwnsGuard`/finally so the guard is released exactly once and `cacheCodeDepth` is never leaked on the fallback branch (the exact class of bug Track-1 Phase C fixed); (3) idempotent stream/plan close via the entry. Likelihood: medium that one of the three is missed; impact: silent failures — a leaked depth disables caching for the rest of the transaction invisibly, a mis-ordered stamp produces wrong scalars only under specific mutation timing.
+**Proposed fix**: In the step that adds the splice + eager drive, call out all three contracts explicitly and structure the aggregate populate path to mirror `populateAndBuildView` / `serveThroughCache` (same stamp-before-drive ordering, same `viewOwnsGuard` transfer + finally release, same `IdempotentExecutionStream`/entry-owns-close wiring). Add a test that asserts `cacheCodeDepth` returns to 0 after both the splice-success and splice-fallback aggregate paths.
+
+### R5 [should-fix]
+**Certificate**: Assumption — three `SQLFunctionFactory` implementations are the I5 surface
+**Location**: `track-2.md` Context lines 56-58, Plan of Work step 6; `META-INF/services/...SQLFunctionFactory`; `DynamicSQLElementFactory` @ `:37,51`.
+**Issue**: The track names three factories as "the enumeration surface" but four are registered (`DefaultSQLFunctionFactory`, `DynamicSQLElementFactory`, `DatabaseFunctionFactory`, `CustomSQLFunctionFactory`). The D6 fail-open denylist relies on the I5 test as its completeness gate, so an unstated omission undercuts that guarantee on its face. `DynamicSQLElementFactory` exposes a runtime-populated `FUNCTIONS` map (not build-time enumerable), which is a legitimate reason to exclude it — but the exclusion must be stated, not silent. Likelihood: medium that the I5 test ships enumerating three and a reviewer reads "three" as complete; impact: a future non-deterministic builtin routed through the omitted factory slips both the denylist (fail-open) and the completeness gate. Reference-accuracy caveat: factory set confirmed via grep + ServiceLoader manifest (PSI inheritor search timed out), so a polymorphic/indirect `SQLFunctionFactory` implementor outside the manifest is not ruled out by this audit.
+**Proposed fix**: In Context/step 6, state the four registered factories and why `DynamicSQLElementFactory` is out of the build-time I5 surface (runtime-registered functions). If any statically-known function reaches the engine through it, fold that factory into the test; otherwise document the runtime-registration boundary as the explicit limit of the I5 gate.
+
+### R6 [suggestion]
+**Certificate**: Assumption — `COUNT(DISTINCT prop)` classify shape
+**Location**: `track-2.md` Plan of Work step 5; `YouTrackDBSql.jj` @ `:3835`; `SQLFunctionCount` @ `:34`, `SQLFunctionDistinct` @ `:37`.
+**Issue**: `COUNT(DISTINCT prop)` parses as the nested call `count(distinct(prop))` (the grammar turns the `DISTINCT` keyword into an inner `distinct(...)` function), not a flat `count` with a modifier. The classify branch that routes `COUNT(DISTINCT prop)` → AGGREGATE_COUNT_DISTINCT and `COUNT(DISTINCT a+b)` → K0_NONE must walk one level into the count's argument and check the inner `distinct`'s argument is a plain property. Likelihood: low that this blocks the track (it is testable), but a flat name check would misclassify. Impact: a missed nesting either fails to cache a cacheable `COUNT(DISTINCT prop)` or wrongly caches an expression form.
+**Proposed fix**: Specify in step 5 that the COUNT_DISTINCT classifier inspects the nested `count(distinct(<arg>))` shape and gates on `<arg>` being a plain property reference; add classifier tests for `count(distinct(prop))` (cacheable) and `count(distinct(a+b))` (K0_NONE).

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/technical-gate-verification-iter2.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/technical-gate-verification-iter2.md
@@ -1,0 +1,91 @@
+<!-- conventions-execution.md §2.5 review-file schema; verdict-producer variant; file-when-handed-a-path mode -->
+<!--REVIEW_MANIFEST_START
+role: reviewer-technical
+phase: 3A
+track: "Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT"
+iteration: 2
+verdict: approved
+findings: 0
+overall: PASS
+verdicts:
+  - id: T1
+    verdict: VERIFIED
+    loc: "track-2.md §Plan of Work step 5"
+  - id: T2
+    verdict: VERIFIED
+    loc: "track-2.md §Plan of Work step 1 'AVG finalization'; §Key signatures"
+  - id: T3
+    verdict: VERIFIED
+    loc: "implementation-plan.md Track-2 carry-over block:406-420"
+  - id: T4
+    verdict: VERIFIED
+    loc: "track-2.md §Plan of Work step 1 'Memory cap'; plan carry-over:411-416"
+  - id: T5
+    verdict: VERIFIED
+    loc: "track-2.md §Plan of Work step 1 SUM/AVG bullet:135-138"
+  - id: T6
+    verdict: VERIFIED
+    loc: "track-2.md §Plan of Work step 3-4:169-192"
+index: []
+evidence_base:
+  premises: 6
+  edge_cases: 0
+  integrations: 0
+  tooling: "Documentation re-read only; orchestrator pre-verified load-bearing code facts against source. No PSI needed (per spawn instructions)."
+REVIEW_MANIFEST_END-->
+
+# Track 2 Technical Gate Verification — Iteration 2
+
+One-line summary: All six iteration-1 technical findings (T1-T6, all ACCEPTED) are correctly resolved in the amended track-2.md and plan carry-over; the edits introduce no internal contradictions or decomposability problems. PASS.
+
+#### Verify T1: firstFunctionCall over-broad
+- **Original issue**: Step 5 overstated classifier work as greenfield; real gap is `count(*) + 1` classifying AGGREGATE_COUNT instead of K0_NONE.
+- **Fix applied**: Step 5 rewritten (track-2.md:193-206).
+- **Re-check**: Step 5 now states the aggregate gates "already exist in Track 1 … verify, do not rebuild them," then names exactly two Track-2 tightenings: (a) `count(*) + 1` must classify K0_NONE (cites the `topLevelFunctionCall` "harmless here" Javadoc), and (b) bare/indexed `COUNT(*)` ride fallback or K0_NONE. Validation line 241 asserts `count(*) + 1` → K0_NONE. Criteria met: greenfield overstatement removed; arithmetic-wrapped gap captured + tested.
+- **Regression check**: Checked step 5 vs Context/Decision-Log COUNT(*) handling — consistent. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify T2: AVG needs computeAverage + total
+- **Original issue**: Step 1 said "SUM/AVG via increment" but AVG needs `int total` and `computeAverage`'s type-dispatched division.
+- **Fix applied**: Step 1 "AVG finalization" bullet (track-2.md:144-148); Decision Log:62-64; Key signatures:300-301,305.
+- **Re-check**: New bullet states AVG tracks `total` and finalizes through `computeAverage` (integer truncation Integer/Long, BigDecimal HALF_UP), "not a plain `sum/total`," explicitly noting `increment` "covers only the SUM half." Key signatures list AVG `total` + `SQLFunctionAverage#computeAverage`. Validation:248-249 asserts integer-truncation and HALF_UP parity. Criteria met.
+- **Regression check**: Checked vs T5 seeding rule — compatible (seed verbatim, fold via increment, finalize via computeAverage). Clean.
+- **Verdict**: VERIFIED
+
+#### Verify T3: metrics carry-over stale
+- **Original issue**: Carry-over implied per-tx hit/miss increments were unwired; they already exist in Track 1.
+- **Fix applied**: Plan Track-2 carry-over block (implementation-plan.md:406-420).
+- **Re-check**: Block now reads "per-tx hit/miss/k0/overflow counters already exist in Track 1's `QueryResultCache`; what remains is the new `incrementSpliceFailures` counter plus the global `CoreMetrics.QUERY_CACHE_*_RATE` bridge … never incremented." Matches T3's proposed reword exactly. `recordPulledRow`/`inFlightLookup`/`exitCacheCodeUnchecked` cautions retained (418-420). Criteria met.
+- **Regression check**: Checked vs Key signatures:306-307 ("only new per-tx metric; hit/miss/k0/overflow increments already exist in Track 1") — consistent. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify T4: recordPulledRow cap mis-specified for aggregates
+- **Original issue**: Carry-over said route aggregate per-RID material through `recordPulledRow`; aggregate material lives in `AggregateState`, not `results`.
+- **Fix applied**: Step 1 "Memory cap (aggregate-specific)" bullet (track-2.md:158-165); Decision Log:57-60; plan carry-over:411-416.
+- **Re-check**: Step 1 bullet states `recordPulledRow` "bounds `results` (one scalar row) and does NOT bound the per-contributor material"; bound `AggregateState` collections (`contributingValues`/`contributingRids`/`distinctBuckets`) against `maxRecordsPerEntry`; overflow routes key non-cacheable via L7 path. Plan carry-over agrees. Validation:252-254 has the high-cardinality overflow case. Criteria met.
+- **Regression check**: Checked vs Interfaces `CachedEntry` field note (278) and I6 cap test (211-213) — consistent. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify T5: seed first value verbatim
+- **Original issue**: Step 1 omitted the verbatim-first-value seeding rule (no typed-zero start).
+- **Fix applied**: Step 1 SUM/AVG storage-parity bullet (track-2.md:135-138).
+- **Re-check**: Bullet states `observe` "seeds the first contributing value verbatim, then folds each subsequent value via `PropertyTypeInternal.increment` (the primitive `SQLFunctionSum.sum`/`SQLFunctionAverage.sum` use)." Matches T5 proposed fix. Criteria met.
+- **Regression check**: Compatible with T2 finalization. Clean.
+- **Verdict**: VERIFIED
+
+#### Verify T6: split serveThroughCache gate; viewOwnsGuard; plan.start not .next
+- **Original issue**: Step 3 didn't state the aggregate branch integration point; step 4 attributed the drain to `.next()` not `plan.start`.
+- **Fix applied**: Steps 3-4 (track-2.md:169-192).
+- **Re-check**: Step 3 now states the aggregate miss path "is a separate branch in the cache shape gate … not folded into it, and preserves Track 1's two-guard `viewOwnsGuard`/`cacheCodeDepth` contract." Step 4 attributes the full drain to `plan.start(ctx)` ("the blocking `AggregateProjectionCalculationStep` produces its single row only after every contributor is observed"), re-mirrors stamp-version/guard-release/idempotent-close. The mermaid label (116) still reads `plan.start(ctx).next(ctx)`; step-4 prose is the authoritative correction and is correct. Criteria met.
+- **Regression check**: Step 3 fallback sets viewOwnsGuard correctly per the existing populate fallback. Clean.
+- **Verdict**: VERIFIED
+
+## Findings
+
+(No new findings.)
+
+## Cross-section consistency check
+Plan of Work, Validation, Decision Log, and Interfaces/Key-signatures now agree across all six edits: AVG `total`+`computeAverage`, verbatim-first-value, AggregateState-targeted cap, `incrementSpliceFailures` as the sole new per-tx metric, and the separate-branch/eager-drive integration. No contradictions or decomposability regressions introduced. The mermaid `.next(ctx)` label is the lone stale artifact; the load-bearing step-4 prose corrects it, so it is not blocking.
+
+## Summary
+PASS

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/technical-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/technical-iter1.md
@@ -1,0 +1,192 @@
+<!-- conventions-execution.md §2.5 review-file schema; file-when-handed-a-path mode -->
+<!--REVIEW_MANIFEST_START
+role: reviewer-technical
+phase: 3A
+track: "Track 2: Aggregate shapes — side-tap, storage-parity replay, COUNT_DISTINCT"
+iteration: 1
+verdict: changes-requested
+findings: 6
+index:
+  - id: T1
+    sev: should-fix
+    anchor: "T1"
+    loc: "track-2.md §Plan of Work step 5 / §Purpose; ShapeClassifier.java:116-162"
+    cert: "Premise: ShapeClassifier already classifies aggregate shapes"
+    basis: read
+  - id: T2
+    sev: should-fix
+    anchor: "T2"
+    loc: "track-2.md §Plan of Work steps 1-5; SQLFunctionAverage.java:91-115"
+    cert: "Premise: AVG via PropertyTypeInternal.increment (D19)"
+    basis: read
+  - id: T3
+    sev: should-fix
+    anchor: "T3"
+    loc: "track-2.md §Carried-from-Track-1 note; CoreMetrics.java:39-46, QueryResultCache.java:107-142, QueryCacheMetrics.java"
+    cert: "Premise: QUERY_CACHE_*_RATE metrics defined but never incremented"
+    basis: read
+  - id: T4
+    sev: should-fix
+    anchor: "T4"
+    loc: "track-2.md §Carried-from-Track-1 note + §Interfaces; CachedEntry.java:258-287"
+    cert: "Edge case: maxRecordsPerEntry cap routing for aggregate material"
+    basis: read
+  - id: T5
+    sev: suggestion
+    anchor: "T5"
+    loc: "track-2.md §Context line 'first value stored as-is'; SQLFunctionSum.java:66-76"
+    cert: "Premise: SUM seeds first value verbatim, not via increment"
+    basis: read
+  - id: T6
+    sev: suggestion
+    anchor: "T6"
+    loc: "track-2.md §Plan of Work step 3-4; DatabaseSessionEmbedded.java:842-885"
+    cert: "Integration: aggregate miss path vs populateAndBuildView stream-lift contract"
+    basis: read
+evidence_base:
+  premises: 9
+  edge_cases: 2
+  integrations: 2
+  tooling: "mcp-steroid execute_code non-functional this session (every call incl. trivial ping timed out at the ~60s MCP HTTP cap despite list_projects/list_windows succeeding and indexingInProgress=false). Fell back to find + Read per the prompt's unreachable-IDE clause. All class-existence premises confirmed via unambiguous single-match find (non-worktree path, package matches reconstructed FQN); reference-accuracy caveat applies to caller/usage claims (T3, T6)."
+REVIEW_MANIFEST_END-->
+
+# Track 2 Technical Review — Iteration 1
+
+One-line summary: Track is feasible against the as-built Track 1 foundation; all named classes and the D19/D20/D21 primitives resolve, but three should-fix items correct stale carry-over instructions and an over-broad classifier slot that becomes load-bearing once aggregates cache, plus two AVG/SUM parity nuances the Plan of Work understates.
+
+## Findings
+
+### T1 [should-fix]
+**Certificate**: Premise — ShapeClassifier already classifies aggregate shapes
+**Location**: track-2.md §Plan of Work step 5 ("Wire `ShapeClassifier` aggregate gates (single aggregate, no GROUP BY/HAVING, no expression arg, no SKIP/LIMIT; `COUNT(DISTINCT prop)` → AGGREGATE_COUNT_DISTINCT, expression-DISTINCT → K0_NONE)"); `ShapeClassifier.java:67-198`.
+**Issue**: Track 1 already implemented every aggregate classifier gate this step describes. `classifySelect` routes SKIP/LIMIT and GROUP BY/LET/UNWIND/subquery to K0_NONE (lines 71-83), `singleAggregateShape` returns the `AGGREGATE_*` shape for a single recognised aggregate (lines 116-129), `aggregateShapeForCall` maps `count(distinct(...))` → `AGGREGATE_COUNT_DISTINCT` and SUM/AVG/MIN/MAX directly (lines 170-185), and `projectionContainsAggregate` falls a mixed/expression aggregate to K0_NONE (lines 93-95). The Plan of Work overstates the classifier work as if it is greenfield; the decomposer should not re-implement it. The genuine remaining classifier gap is the over-broad `firstFunctionCall` match (see below), not the gates listed.
+
+Sub-issue (the real classifier work): `topLevelFunctionCall`/`firstFunctionCall` (lines 139-162) return the *first* function call in the subtree even when buried under arithmetic — the Javadoc at lines 131-137 explicitly admits `count(*) + 1` is returned and notes "such a shape is bypassed (uncached) in this foundation regardless, so the looser match is harmless here." Track 2 wires the AGGREGATE_* path, so that looseness stops being harmless: `SELECT count(*) + 1 FROM C` would now classify as `AGGREGATE_COUNT` and cache a scalar that is not what the projection returns. The classifier must additionally verify the aggregate call is the *root* of the single projection item (not nested under arithmetic) before returning an `AGGREGATE_*` shape, routing `count(*) + 1` to K0_NONE.
+**Proposed fix**: Trim Plan of Work step 5 to state the classifier gates already exist (Track 1) and that the only classifier change is tightening `singleAggregateShape` to reject an aggregate that is not the top-level node of the projection item's expression (so expression-wrapped aggregates fall to K0_NONE). Add an I4 test for `count(*) + 1` / `sum(a) * 2` asserting K0_NONE (cache-on ≡ cache-off).
+
+### T2 [should-fix]
+**Certificate**: Premise — AVG via PropertyTypeInternal.increment (D19)
+**Location**: track-2.md §Purpose ("SUM/AVG fold through the same `PropertyTypeInternal.increment`"), §Plan of Work step 1 ("SUM/AVG via `PropertyTypeInternal.increment`"); `SQLFunctionAverage.java:39-115`.
+**Issue**: AVG storage parity needs more than `increment`. `SQLFunctionAverage` keeps two pieces of state — `Number sum` *and* `int total` — and `computeAverage` (lines 101-115) does **type-dependent division**: `Integer`/`Long` sums use integer division (`iSum.intValue() / iTotal`, `iSum.longValue() / iTotal`), `Float`/`Double` use floating division, `BigDecimal` uses `divide(…, HALF_UP)`. An `AggregateState` that only re-folds the running `sum` through `increment` and divides by a count will diverge from storage whenever the input is integral (e.g. AVG over Long column truncates toward zero in storage but a naive `sum.doubleValue()/n` would not). The Plan of Work step 1 mentions `total` for MIN/MAX recompute but not for AVG, and does not call out the integer-division and HALF_UP-rounding semantics that bit-for-bit parity (D19) requires.
+**Proposed fix**: In Plan of Work step 1, state that `AggregateState` for AVG must hold both `sum` (folded via `increment`, first value seeded verbatim per T5) and an `int total`, and must reproduce `SQLFunctionAverage.computeAverage` exactly — including integer division for Integer/Long sums and `BigDecimal.divide(total, RoundingMode.HALF_UP)`. Add an I4 case: AVG over an all-Long column with a non-evenly-divisible total, asserting the cached scalar equals the truncating-division fresh result.
+
+### T3 [should-fix]
+**Certificate**: Premise — QUERY_CACHE_*_RATE metrics defined but never incremented
+**Location**: track-2.md §"Carried from Track-1 Phase C review" ("Track 1 defines and registers them in `CoreMetrics` but never increments them, and the 'wiring lands in later steps' comment is now stale"); `CoreMetrics.java:39-46`, `QueryCacheMetrics.java`, `QueryResultCache.java:107-142`.
+**Issue**: The carry-over instruction is partly stale and conflates two metric layers. There are two distinct surfaces: (a) the **per-tx** `QueryCacheMetrics` holder (`incrementHits/Misses/SpliceFailures/K0Invalidations/Overflows`), and (b) the **global** `CoreMetrics.QUERY_CACHE_HIT_RATE` / aggregate-rate `MetricDefinition`s. Contrary to the note, the per-tx counters ARE already incremented in Track 1: `QueryResultCache.lookup` calls `incrementMisses` (line 123), `incrementK0Invalidations` (132), `incrementHits` (139), and eviction calls `incrementOverflows` (180, 206). What is genuinely unwired is (i) the bridge from per-tx counters to the global `CoreMetrics.QUERY_CACHE_*_RATE` rates (the "increment/record wiring lands in later steps" comment at `CoreMetrics.java:40-41`), and (ii) `incrementSpliceFailures` — which has no call site because no splice exists yet (genuinely Track 2 work, tied to step 3's fallback). The carry-over as written would send the implementer hunting for missing hit/miss increments that already exist.
+**Proposed fix**: Reword the carry-over note to: per-tx hit/miss/k0/overflow increments already exist in Track 1's `QueryResultCache`; Track 2 owns (1) calling `incrementSpliceFailures()` on the aggregate-splice fallback path, and (2) bridging the per-tx `QueryCacheMetrics` counters to the global `CoreMetrics.QUERY_CACHE_*_RATE` rates where the tx records its outcome (decide the recording site — likely tx-end or per-lookup). Keep the `recordPulledRow` / `inFlightLookup` / `exitCacheCodeUnchecked` cautions unchanged; they are accurate.
+
+### T4 [should-fix]
+**Certificate**: Edge case — maxRecordsPerEntry cap routing for aggregate material
+**Location**: track-2.md §"Carried from Track-1 Phase C review" ("Route every per-RID/row append through `CachedEntry.recordPulledRow` so the `maxRecordsPerEntry` cap … applies to aggregate material"); `CachedEntry.java:155-157, 252-287`.
+**Issue**: `recordPulledRow` (lines 268-287) appends to `results` (`List<Result>`) and `cachedRids`, then checks `results.size() > maxRecordsPerEntry`. Aggregate material is **not** rows in `results` — it is `contributingValues` / `contributingRids` / `distinctBuckets` on the new `AggregateState`. Routing aggregate per-RID material through `recordPulledRow` would (a) pollute `results`/`cachedRids` with per-contributor entries that the aggregate view never replays (its view returns a single `toResult()` row), and (b) size-bound on the wrong collection if `AggregateState` keeps its own structures. The carry-over instruction, taken literally, is unsound for the aggregate shape. The cap intent (bound per-entry memory for the contributing-RID material the tap accumulates) is valid, but the mechanism must be an aggregate-specific cap on the `AggregateState` structures, not `recordPulledRow`.
+**Proposed fix**: Add a Decision-Log note or amend Plan of Work step 4: the `maxRecordsPerEntry` cap for aggregate entries is enforced on the size of `AggregateState`'s contributing structures (`contributingRids` / `distinctBuckets` total), not by funnelling contributors through `recordPulledRow`. On overflow, fire the same `onOverflow` callback the RECORD path uses (evict + route key non-cacheable) so the bound and the non-cacheable routing stay uniform. Keep `recordPulledRow` for the single scalar row only (or document that the aggregate view's lone `toResult()` row is the one `results` entry). Reword the carry-over so it does not say "route every per-RID append through `recordPulledRow`" for aggregates.
+
+### T5 [suggestion]
+**Certificate**: Premise — SUM seeds first value verbatim, not via increment
+**Location**: track-2.md §Context line 48-52, §Plan of Work step 1; `SQLFunctionSum.java:66-76`, `SQLFunctionAverage.java:72-83`.
+**Issue**: Both `SQLFunctionSum.sum` and `SQLFunctionAverage.sum` store the **first** non-null value verbatim (`sum = value`) and only call `PropertyTypeInternal.increment(sum, value)` from the second value onward. This matters for bit-for-bit parity: if `AggregateState.observe` folds the first value through `increment(seed, value)` against a typed zero seed, the result type can differ from storage (e.g. `increment(Integer 0, Long 5)` promotes to Long, but storage keeps the first value's own type until a wider value arrives). The Plan of Work says "SUM/AVG via `PropertyTypeInternal.increment`" without noting the verbatim-first-value rule. Minor because the track already commits to "the identical primitive," but the seeding asymmetry is the subtle part most likely to be missed.
+**Proposed fix**: Add one sentence to Plan of Work step 1: `AggregateState` SUM/AVG must seed the first observed value verbatim (matching `SQLFunctionSum.sum`'s `sum == null` branch) and fold subsequent values through `increment`, never starting from a typed zero. Cover with the existing mixed-input I4 case plus a single-value SUM over a non-default-typed column.
+
+### T6 [suggestion]
+**Certificate**: Integration — aggregate miss path vs populateAndBuildView stream-lift contract
+**Location**: track-2.md §Plan of Work steps 3-4, §Compatibility; `DatabaseSessionEmbedded.java:733-885`.
+**Issue (reference-accuracy caveat: caller analysis via Read, not PSI — IDE execute_code was non-functional this session)**: Track 1's miss path (`populateAndBuildView`, lines 842-885) lifts the live stream off a `LocalResultSet` produced by `statement.execute(...)` and stores it for lazy pull. The aggregate path described in steps 3-4 diverges fundamentally: it builds the plan via `statement.createExecutionPlan(ctx, false)`, splices the tap, eagerly drives, and caches a scalar + `AggregateState` — there is no `LocalResultSet` to lift a stream from, and the entry holds no live stream (the `CachedEntry` constructor at `CachedEntry.java:113-131` accepts `@Nullable ExecutionStream stream`, so a null-stream aggregate entry is structurally allowed). The track does not state *where* in `serveThroughCache` the aggregate branch attaches. Currently line 791 (`shape != RECORD && shape != K0_NONE`) routes all AGGREGATE_* to `executeUncached`; Track 2 must split that gate so AGGREGATE_* shapes go to a new aggregate populate path instead of bypassing, while preserving the two-guard bracket (`enterCacheCode` / `viewOwnsGuard` / `exitCacheCode` finally at lines 774-814) and the `viewOwnsGuard = result instanceof CachedResultSetView` ownership transfer. The eager-drive note ("`plan.start(ctx).next(ctx)`") is correct in effect because `AggregateProjectionCalculationStep` is blocking (`executeAggregation` at lines 121-153 drains all upstream during `start`, so the tap observes every contributor before the single result row is produced) — but the track should state that `plan.start(ctx)` itself triggers the full drain, not the subsequent `.next()`.
+**Proposed fix**: In Plan of Work step 3, specify the integration point precisely: split the `serveThroughCache` shape gate (currently `DatabaseSessionEmbedded.java:791`) so AGGREGATE_* shapes route to the new aggregate-populate method (not `executeUncached`), and confirm the new path returns a `CachedResultSetView` so the existing `viewOwnsGuard` transfer and the two-guard finally remain correct. On splice fallback, return the plain `LocalResultSet` AND release the guard the same way the existing populate fallback does (`viewOwnsGuard` stays false → `exitCacheCode` in finally). In step 4, clarify that the blocking aggregate step drains during `plan.start(ctx)`, so the tap sees all contributors there; `.next()` only retrieves the already-computed scalar row.
+
+## Evidence base
+
+#### Premise: AggregateProjectionCalculationStep exists and is the splice point
+- **Track claim**: "`AggregateProjectionCalculationStep` (`internal/core/sql/executor/`, ≈121-137) runs the blocking aggregation loop … The side-tap splices immediately upstream of it."
+- **Search performed**: `find -name AggregateProjectionCalculationStep.java` (PSI execute_code non-functional this session); Read of the file.
+- **Code location**: `core/src/main/java/.../sql/executor/AggregateProjectionCalculationStep.java:58, 121-153`
+- **Actual behavior**: `public class AggregateProjectionCalculationStep extends ProjectionCalculationStep` (NOT `extends AbstractExecutionStep` directly, but `ProjectionCalculationStep extends AbstractExecutionStep`, confirmed `ProjectionCalculationStep.java:43`). `executeAggregation` (121-153) calls `prev.start(ctx)` then drains `while (lastRs.hasNext(ctx))` — a blocking step. `prev` is the inherited public field on `AbstractExecutionStep` (`AbstractExecutionStep.java:66`, `setPrevious` at 85-86), so rewiring its `prev` to a tap is mechanically valid.
+- **Verdict**: CONFIRMED
+- **Detail**: Splice feasible; the cited "≈121-137" maps to the `executeAggregation` body. The blocking-drain semantics underpin the eager-drive correctness (T6).
+
+#### Premise: AggregateCacheTapStep extends AbstractExecutionStep (new)
+- **Track claim**: "`AggregateCacheTapStep extends AbstractExecutionStep` — `internalStart(ctx): ExecutionStream`."
+- **Search performed**: `find -name AggregateCacheTapStep.java` → no match (expected, new); Read of `AbstractExecutionStep.java`.
+- **Code location**: NOT FOUND (planned by this track); `AbstractExecutionStep.java:59, 130-149`
+- **Actual behavior**: `public abstract class AbstractExecutionStep implements ExecutionStepInternal`; concrete steps implement `internalStart(CommandContext): ExecutionStream` (abstract; `start()` wraps it with profiling at 130-149). A tap wrapping `prev.start(ctx)` and forwarding-after-observe is a standard decorator over the upstream `ExecutionStream`.
+- **Verdict**: CONFIRMED (planned by this track)
+- **Detail**: Key signature `internalStart(ctx): ExecutionStream` correct.
+
+#### Premise: AggregateState (new)
+- **Track claim**: New class with `observe`/`applyMutation(RecordAbstract, byte status, boolean matchAfter)`/`copy`/`toResult`.
+- **Search performed**: `find -name AggregateState.java` → no match (expected, new).
+- **Code location**: NOT FOUND (planned by this track)
+- **Actual behavior**: n/a; the `applyMutation` parameter types are validated against the real `RecordOperation` below.
+- **Verdict**: CONFIRMED (planned by this track)
+
+#### Premise: PropertyTypeInternal.increment(Number, Number): Number exists
+- **Track claim**: "`PropertyTypeInternal#increment(Number current, Number value): Number` (existing, reused)."
+- **Search performed**: grep + Read of `PropertyTypeInternal.java`.
+- **Code location**: `core/src/main/java/.../metadata/schema/PropertyTypeInternal.java:1782`
+- **Actual behavior**: `public static Number increment(final Number a, final Number b)`; throws `IllegalArgumentException` on null arg; switch over types with documented overflow-promotion (Integer+Integer overflow → Long), BigDecimal widening, etc.
+- **Verdict**: CONFIRMED
+- **Detail**: Signature exact. Used by `SQLFunctionSum.sum` (line 73) and `SQLFunctionAverage.sum` (line 80) — the storage path the track must mirror.
+
+#### Premise: SUM/AVG fold semantics (D19)
+- **Track claim**: "`AggregateState.observe` calls the identical primitive so cache replay matches storage."
+- **Search performed**: Read `SQLFunctionSum.java`, `SQLFunctionAverage.java`.
+- **Code location**: `SQLFunctionSum.java:66-76`, `SQLFunctionAverage.java:72-115`
+- **Actual behavior**: First non-null value stored verbatim (`sum == null → sum = value`); subsequent via `increment`. AVG additionally keeps `int total` and `computeAverage` does type-dependent division (integer division for Integer/Long, HALF_UP for BigDecimal).
+- **Verdict**: PARTIAL
+- **Detail**: Produced T2 (AVG total + integer-division parity) and T5 (verbatim-first-value seeding). The "identical primitive" claim is necessary but not sufficient.
+
+#### Premise: COUNT(DISTINCT prop) parses as count(distinct(prop)); SQLFunctionDistinct uses raw-equals Set (D20)
+- **Track claim**: "`SQLFunctionDistinct.getResult` uses `LinkedHashSet<Object>` with raw `Object.equals`/`hashCode` … `distinctBuckets: Map<Object, Set<RID>>` mirrors that (D20)."
+- **Search performed**: Read `SQLFunctionDistinct.java`; grep YouTrackDBSql.jj for DISTINCT (lines 3318, 3835); Read `ShapeClassifier.isDistinct` (188-198).
+- **Code location**: `SQLFunctionDistinct.java:37, 51-59`; `ShapeClassifier.java:177-198`
+- **Actual behavior**: `private final Set<Object> context = new LinkedHashSet<Object>()`; `execute` adds via `!context.contains(value)` — raw `Object.equals`/`hashCode`, so `Long(5)` ≠ `Integer(5)`. Grammar turns bare `<DISTINCT>` into a `SQLFunctionCall` named "distinct" (line 3835), so `COUNT(DISTINCT prop)` is the nested call `count(distinct(prop))`, which `ShapeClassifier.isDistinct` already detects.
+- **Verdict**: CONFIRMED
+- **Detail**: D20's raw-equals bucket model matches storage. Note `SQLFunctionDistinct` is the collection `distinct()`; for `COUNT(DISTINCT)` the count counts the distinct-filtered stream — the track's per-value RID-bucket model is the right replay primitive.
+
+#### Premise: RecordOperation carries version + byte type + RecordAbstract record (D5/D21)
+- **Track claim**: `applyMutation(RecordAbstract record, byte status, boolean matchAfter)`; membership-based dispatch over collapsed ops; `op.version` filter.
+- **Search performed**: grep `import RecordOperation` in FrontendTransactionImpl + DeltaBuilder; Read both `tx.RecordOperation` and `db.record.RecordOperation`.
+- **Code location**: `core/src/main/java/.../db/record/RecordOperation.java:29-54` (the active class); `tx/RecordOperation.java` (an unrelated 2-arg record, NOT used by the cache).
+- **Actual behavior**: `db.record.RecordOperation` is `final class` with `public byte type` (DELETED=1/UPDATED=2/CREATED=3), `public final RecordAbstract record`, `public long version` (Javadoc: "version > populateMutationVersion to skip changes a cached entry already observed"). `FrontendTransactionImpl` and `DeltaBuilder` both import this one; `getRecordOperationsInternal(): Collection<RecordOperation>`.
+- **Verdict**: CONFIRMED
+- **Detail**: `applyMutation(RecordAbstract, byte status, …)` parameter types match exactly (record is RecordAbstract, status is byte). The collapse/membership-dispatch premise holds: `addRecordOperation` collapses CREATE+UPDATE and re-stamps `version`, so deriving before-state from `contributingValues.containsKey(rid)` rather than `op.type` (which may read CREATED post-collapse) is the correct D21 safety. Two `RecordOperation` classes exist — a name-collision trap; the cache uses `db.record.*`, not `tx.*`.
+
+#### Premise: ShapeClassifier already classifies all aggregate shapes
+- **Track claim**: Plan of Work step 5 "wire `ShapeClassifier` aggregate gates."
+- **Search performed**: Read `ShapeClassifier.java` in full.
+- **Code location**: `ShapeClassifier.java:67-198`
+- **Actual behavior**: `classifySelect` already routes SKIP/LIMIT, GROUP BY/LET/UNWIND/subquery → K0_NONE; `singleAggregateShape` + `aggregateShapeForCall` already return AGGREGATE_COUNT/SUM/AVG/MIN/MAX/COUNT_DISTINCT; `projectionContainsAggregate` routes mixed/expression aggregates → K0_NONE. `CacheableShape` enum already declares all AGGREGATE_* constants.
+- **Verdict**: WRONG (track overstates the work as greenfield)
+- **Detail**: Produced T1. Remaining classifier work is narrow: tighten `firstFunctionCall`'s admitted over-broad match so an aggregate buried under arithmetic (`count(*) + 1`) falls to K0_NONE rather than caching a wrong scalar.
+
+#### Premise: CachedEntry has no aggregateState field; constructor accepts null stream/plan
+- **Track claim**: §Interfaces "`CachedEntry` (aggregateState field, if not already added in Track 1)."
+- **Search performed**: grep + Read `CachedEntry.java:55-131, 252-287`.
+- **Code location**: `CachedEntry.java:55-131`
+- **Actual behavior**: Fields are shape/results/cachedRids/effectiveFromClasses/whereClause/orderBy/populateMutationVersion/stream/plan/ctx — no `aggregateState`. Constructor (113-131) takes `@Nullable ExecutionStream stream`, `@Nullable InternalExecutionPlan plan`, `@Nullable CommandContext ctx` — a null-stream aggregate entry is structurally allowed. `recordPulledRow` (268-287) appends to `results`/`cachedRids` and enforces the cap there.
+- **Verdict**: CONFIRMED (aggregateState is this track's addition)
+- **Detail**: Produced T4 (cap-routing mismatch) and informs T6 (null-stream aggregate entry is allowed).
+
+#### Edge case: maxRecordsPerEntry overflow for aggregate contributing material
+- **Trigger**: An aggregate over a large class accumulates more contributing RIDs/values than `maxRecordsPerEntry`.
+- **Code path trace**:
+  1. `CachedEntry.recordPulledRow(r)` @ `CachedEntry.java:268` — appends to `results`, checks `results.size() > maxRecordsPerEntry`.
+  2. Aggregate material lives in `AggregateState.contributingValues/Rids/buckets`, not `results` — so routing it through `recordPulledRow` mis-sizes and pollutes `results`/`cachedRids`.
+- **Outcome**: Cap silently ineffective (or wrong-collection eviction) for aggregate material if the carry-over is followed literally.
+- **Track coverage**: no — the carry-over assumes RECORD-shaped `results`.
+
+#### Edge case: aggregate splice fallback leaks the cache-code guard
+- **Trigger**: Planner emits a shape with no `AggregateProjectionCalculationStep`; the track falls back to uncached `LocalResultSet`.
+- **Code path trace**:
+  1. `serveThroughCache` @ `DatabaseSessionEmbedded.java:774` — `enterCacheCode()` bumps depth.
+  2. Aggregate populate path (new) must set `viewOwnsGuard = false` on fallback (no `CachedResultSetView`), so the finally at 805-813 calls `exitCacheCode()` exactly once.
+  3. If the new path forgets the ownership rule, the depth bump leaks for the rest of the tx (cache disabled).
+- **Outcome**: Correct iff the new path mirrors the existing populate fallback's `viewOwnsGuard = result instanceof CachedResultSetView` (line 803).
+- **Track coverage**: partial — fallback is described (step 3) but the guard-release contract is not stated. Folded into T6.
+
+#### Integration: serveThroughCache shape gate
+- **Plan claim**: Steps 3-4 build the plan via `createExecutionPlan`, splice, eager-drive; fallback to `LocalResultSet`.
+- **Actual entry point**: `DatabaseSessionEmbedded.serveThroughCache:733-815`; shape gate at line 791 currently bypasses all non-RECORD/non-K0_NONE shapes to `executeUncached`. `populateAndBuildView:842-885` is the RECORD/K0_NONE populate path (lifts stream off `LocalResultSet`).
+- **Caller analysis (reference-accuracy caveat — Read, not PSI)**: `serveThroughCache` is the shared entry for both `query()` overloads; `createExecutionPlan(ctx, boolean)` confirmed at `SQLSelectStatement.java:335` and `SQLStatement.java:111`; `LocalResultSet.getInternalExecutionPlan()/getStream()/setStream()` confirmed at `LocalResultSet.java:65-79`.
+- **Breaking change risk**: Low for existing callers (aggregates currently bypass; the change only redirects a currently-uncached branch). Risk is internal: the new aggregate branch must preserve the two-guard bracket and `viewOwnsGuard` transfer.
+- **Verdict**: MATCHES (with the integration-point specificity gap in T6)

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-behavior-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-behavior-iter1.md
@@ -1,0 +1,70 @@
+<!-- MANIFEST
+dimension: test-behavior
+prefix: TB
+findings: 1
+high_water_mark: 1
+evidence_base: true
+cert_index: true
+index:
+  - id: TB1
+    sev: suggestion
+    anchor: "#tb1-no-leak-floor-test-asserts-only-non-null-not-the-scalar"
+    loc: "AggregateCacheEquivalenceTest.java:499 allKindsRunWithoutExceptionLeak"
+    cert: C1
+    basis: "FALSIFIABILITY CHECK — a wrong-but-non-null scalar passes; mitigated by per-kind value-pinned siblings"
+flags: []
+-->
+
+# Track 2 test-behavior review (iter 1)
+
+## Findings
+
+### TB1 [suggestion] No-leak floor test asserts only non-null, not the scalar
+
+**File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java`, method `allKindsRunWithoutExceptionLeak` (line 499)
+
+**Issue**: The only per-kind assertion in this case is `assertTrue("...returns a non-null scalar...", s != null)`. This is an existence-only assertion: a regression that made the SUM fold, the AVG finalisation, or a MIN/MAX recompute return a wrong-but-non-null scalar would not fail this test.
+
+**Evidence (FALSIFIABILITY CHECK)**: If `AggregateState.refoldSum` were mutated to double-add a contributor (return `60` instead of `30` for `sum(price)` over `{10,20}`), `allKindsRunWithoutExceptionLeak` would still pass — `60 != null`. The mutation is caught only by the sibling cases (`aggregateHitOnPureReadRepeat` pins `30`; `sumEquivalence_valueUpdateAfterPopulate` pins fresh-vs-cached over distinct values), not by this case.
+
+**Why this is a suggestion, not a defect**: the case's stated scope (Javadoc lines 492-497) is the no-exception-leak floor — every aggregate kind also has a dedicated value-pinning equivalence test in the same class, so the shallow assertion is a deliberate narrowing, not a coverage gap. The behavior it claims to verify (no exception leaks across all five kinds in one tx) is genuinely verified: a thrown exception fails the test.
+
+**Suggested fix** (optional — folds a free value check onto the existing loop):
+```java
+for (var agg : new String[] {"count(*)", "sum(" + VALUE + ")", "avg(" + VALUE + ")",
+    "min(" + VALUE + ")", "max(" + VALUE + ")"}) {
+  var cached = scalar(session.query(aggSql(agg)));
+  GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(false);
+  var fresh = scalar(session.query(aggSql(agg)));
+  GlobalConfiguration.QUERY_TX_RESULT_CACHE_ENABLED.setValue(true);
+  assertEquals("every kind's cached scalar matches fresh, no leak: " + agg, fresh, cached);
+}
+```
+
+## Evidence base
+
+#### C1 — TB1 confirmed-as-issue (suggestion)
+
+`allKindsRunWithoutExceptionLeak` asserts `s != null` only; a wrong-but-non-null scalar survives the mutation. Confirmed by FALSIFIABILITY CHECK against a hypothetical double-add in `refoldSum`. Held at suggestion because every kind is value-pinned in a dedicated sibling case and the Javadoc scopes this case to the no-leak floor.
+
+---
+
+The following candidate concerns were examined and **refuted** — recorded here so a re-review does not re-raise them.
+
+**REFUTED — create-after-populate cases are vacuous (the F→T add path is never exercised).** Hypothesis: `createMatching` (line 160) creates a record via `session.newEntity` but never calls `addRecordOperation` or `save()` (unlike `breakWhere` / `changeValue` / `deleteRecord`, which stage the op explicitly), so the new contributor would be invisible to both the delta build (`DeltaBuilder.buildForAggregate` iterates `tx.getRecordOperationsInternal()`, line 243) and the fresh scan — making `assertEquivalent` pass with both sides returning the stale seed count and never testing the F→T transition. **Refutation**: ran an instrumented probe of the exact `count(*) FROM AggRec WHERE active = true` create-after-populate scenario. Result: `first=3 second(cached)=4`. The unsaved `newEntity` IS picked up by the populating scan and the cached second query's replay correctly reflects the new contributor, so the F→T add delta path is genuinely exercised. The `addRecordOperation` calls live inside the `save`/`newInstance` registration path (`DatabaseSessionEmbedded` lines 1481/1501) reached by the query/commit machinery. Concern dropped.
+
+**REFUTED — differential-only equivalence cases give false confidence.** Hypothesis: cases using `assertEquivalent` / `runWithTarget` (SUM/AVG value-update, MIN/MAX delete, where-break) compare only fresh-vs-cached with no absolute-value anchor, so a bug shared by both paths passes. **Refutation**: the flag-off run is a genuine uncached `query()` (`runScenario` line 128 forces `QUERY_TX_RESULT_CACHE_ENABLED=false` before the second query) — the source of truth is real execution, not a literal the test author could mis-transcribe. A cached-replay bug that diverges from uncached execution is caught. The only residual blind spot (a bug in the seed setup shared by both halves) is closed by the seed values being distinct enough that a fold error changes the number: `{10,20,30}` with the 30-holder updated to 999 gives fresh `1029` vs a double-add `1059`. Differential testing against an independent oracle is the correct design here, and the Javadoc (lines 28-29) justifies it explicitly. Concern dropped.
+
+**REFUTED — metrics-bridge routing test is vacuous.** Hypothesis: `QueryCacheMetricsTest.eachIncrementRecordsOnlyItsOwnGlobalRate` injects a `RecordingRate` that overrides only `record(long value)`, while production `QueryCacheMetrics.incrementHits` calls the no-arg `hitRate.record()`; if `record()` did not delegate, `recordCount` would stay 0 and the routing asserts would be checking 0-against-0 — vacuously green. **Refutation**: `TimeRate.record()` is a default method delegating to `record(1)` (`TimeRate.java:16-17`), which dispatches to the overridden `record(long)`. The case asserts `1L` for the incremented sink (line 115) — that assertion fails if delegation breaks — and `0L` for the other four, so each increment's routing is genuinely falsifiable. Concern dropped.
+
+**REFUTED — AggregateStateTest scan-order tests only pin the value (a type-regression to unordered map slips through on Double inputs).** Hypothesis: the IEEE-754 non-associativity tests could pass on type alone. **Refutation**: `sumMixedIntOverflowFoldsInObserveOrderMatchingStorageScanOrder` (line 382) asserts BOTH `expected` value AND `expected.getClass()` against the scalar (lines 395-397), and `sumDoubleFoldsInObserveOrderMatchingStorageScanOrder` (line 325) constructs inputs (`1e16` + 64 ones) where a permuted fold rounds to a measurably different double — so a revert of `contributingValues` from `LinkedHashMap` to `HashMap` fails the value assertion, not merely the type. These are among the strongest tests in the track. Concern dropped.
+
+## Coverage
+
+Examined all five changed test files against their production counterparts:
+
+- `AggregateStateTest.java` (34 cases) vs `AggregateState.java` — per-kind observe/applyMutation, SUM/AVG storage-parity fold (value + type pinned against `PropertyTypeInternal.increment`), AVG integer-truncation and BigDecimal HALF_UP, MIN/MAX O(n) recompute on both extremum-leaving transitions, COUNT_DISTINCT bucket lifecycle, the D21 collapse case (CREATED-typed op on an existing contributor dispatched by membership), `copy` deep-isolation, contributor-cap one-shot overflow. Strong, precise, falsifiable.
+- `AggregateCacheEquivalenceTest.java` (19 cases) vs `DatabaseSessionEmbedded` splice + `DeltaBuilder.buildForAggregate` + `CachedResultSetView.forAggregate` — per-kind I4 differential against uncached execution, D21 collapse, hardwired/indexed COUNT(*) fallback with `spliceFailures` assertion, `count(*)+1` and `count(distinct)` K0_NONE routing, contributor-cap overflow with `overflows`/`size()` assertions, hit-on-repeat with `hits`/`misses` assertions. One suggestion (TB1).
+- `ShapeClassifierTest.java` vs `ShapeClassifier` — both Track 2 tightenings (arithmetic→K0_NONE for COUNT and SUM, bare COUNT(*)→K0_NONE), `aggregateMetadata` per-shape facts including null for K0_NONE shapes. Precise enum and field assertions.
+- `FunctionDeterminismEnumerationTest.java` (3 cases) vs `NonDeterministicQueryDetector` denylist — four-factory enumeration completeness, factory-count pin, bidirectional denylist-drift guard. Genuinely build-gating.
+- `QueryCacheMetricsTest.java` (5 cases) vs `QueryCacheMetrics` — per-counter independence, accumulation, and the global-rate bridge routing (one-per-increment, own-sink-only). Falsifiable via the injected recording sinks.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-completeness-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-completeness-iter1.md
@@ -1,0 +1,190 @@
+<!-- MANIFEST
+dimension: test-completeness
+iteration: 1
+high_water_mark: 0
+findings: 5
+evidence_base: 7
+cert_index: C1,C2,C3,C4,C5,C6,C7
+flags: []
+index:
+  - id: TC1
+    sev: should-fix
+    anchor: "#tc1-empty-set-drain-untested-for-min-max-avg-count-count_distinct"
+    loc: "AggregateState.java:777-787,903-919; AggregateStateTest.java"
+    cert: C1
+    basis: "branch-read + production-parity read"
+  - id: TC2
+    sev: should-fix
+    anchor: "#tc2-null-property-value-paths-in-observe-and-applymutation-untested"
+    loc: "AggregateState.java:562-568,602-610; AggregateStateTest.java"
+    cert: C2
+    basis: "branch-read"
+  - id: TC3
+    sev: should-fix
+    anchor: "#tc3-min-max-non-number-comparable-and-cross-subtype-comparison-untested"
+    loc: "AggregateState.java:810-838; AggregateStateTest.java"
+    cert: C3
+    basis: "branch-read + Step-1 episode BC3"
+  - id: TC4
+    sev: suggestion
+    anchor: "#tc4-avg-negative-and-rounding-boundary-values-not-exercised"
+    loc: "AggregateState.java:927-940; AggregateStateTest.java"
+    cert: C4
+    basis: "production-parity read"
+  - id: TC5
+    sev: suggestion
+    anchor: "#tc5-min-distinct-count_distinct-equivalence-and-collapse-coverage-thinner-than-sum-max"
+    loc: "AggregateCacheEquivalenceTest.java"
+    cert: C5
+    basis: "test-matrix audit"
+-->
+
+## Findings
+
+### TC1 [should-fix] Empty-set drain untested for MIN/MAX/AVG/COUNT/COUNT_DISTINCT
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java`, `.../AggregateCacheEquivalenceTest.java`
+- **Production code**: `AggregateState.java` — `recomputeExtremum` (777-787), `scalar()` (903-919), `computeAverage` (927-940); `SQLFunctionMin/Max/Average.getResult` return `null` over empty input.
+- **Missing scenario**: A mutation that drains the *entire* contributing set to empty (the last contributor dropped via DELETE or WHERE-break), then the scalar is read. SUM-empty-after-seed is covered (`sumOverEmptySetIsZeroNotNull`, but that is the *seed* path, not the *drain* path). No test drains MIN/MAX to empty (exercising `recomputeExtremum` setting `currentScalar=null`), drains AVG to empty (`computeAverage(null, 0)` → null, and the would-be `total==0` integer-division-by-zero guard), or drains COUNT/COUNT_DISTINCT to zero through `applyMutation`.
+- **Why it matters**: The "0 contributors remaining" state is a distinct boundary from "0 contributors seeded". `recomputeExtremum` over an empty `contributingValues` leaves `currentScalar` null — fresh MIN/MAX over an empty post-mutation set also returns null, so parity should hold, but the transition into that state (holder dropped → rescan finds nothing) is its own code path with no coverage. For AVG, the divide-by-zero is only avoided because `sumAccumulator` is null when `count==0`; if a future refactor ever folds an empty set to a non-null zero accumulator, `computeAverage` divides by `total==0` and throws `ArithmeticException` — there is no regression test pinning that the empty drain stays null-not-zero. `AggregateCacheEquivalenceTest` never empties a tappable shape end-to-end either (every `runWithTarget` scenario keeps ≥2 of 3 records).
+- **Evidence**: Input-domain table row "contributing set size after replay = 0" — Currently Tested? NO for MIN/MAX/AVG/COUNT/COUNT_DISTINCT (only SUM seed-empty at `AggregateStateTest.java` `sumOverEmptySetIsZeroNotNull`).
+- **Refutation considered**: C1 — confirmed the drain path is reachable (DELETE-all-matching in one tx then re-query is a normal user pattern) and that production returns null/0 over empty, so parity is the assertable contract. Not covered indirectly: the equivalence suite's mutation helpers all leave survivors.
+- **Suggested test**:
+  ```java
+  @Test
+  public void minDrainsToNullWhenLastContributorDropped() {
+    db.begin();
+    var only = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_MIN, FIELD, List.of(only));
+    s.applyMutation((RecordAbstract) only, RecordOperation.DELETED, true);
+    assertNull("MIN over an emptied set is null, matching SQLFunctionMin", scalarOf(s));
+    db.rollback();
+  }
+
+  @Test
+  public void avgDrainsToNullNotDivideByZero() {
+    db.begin();
+    var only = committedRec(10);
+    var s = populate(CacheableShape.AGGREGATE_AVG, FIELD, List.of(only));
+    s.applyMutation((RecordAbstract) only, RecordOperation.DELETED, true);
+    assertNull("AVG over an emptied set is null, never a divide-by-zero", scalarOf(s));
+    db.rollback();
+  }
+  // plus an AggregateCacheEquivalenceTest case that DELETEs every matching
+  // record after populate (min/max/avg/sum/count) and asserts the cached
+  // scalar equals the fresh empty-set result.
+  ```
+
+### TC2 [should-fix] Null-property-value paths in observe and applyMutation untested
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java`
+- **Production code**: `AggregateState.observe` null-skip (562-568) and `applyMutation` null-new-value → `nowContributing=false` (602-610).
+- **Missing scenario**: A contributing record whose *aggregate property* is null. Storage's SUM/AVG/MIN/MAX/DISTINCT skip null values entirely; `AggregateState` mirrors this with two branches — `observe` returns early on a null property, and `applyMutation` flips a WHERE-matching record to non-contributing when its new value is null. Neither branch has a unit test. Every test record sets a non-null `FIELD`/`price`.
+- **Why it matters**: This is the difference between "record matches WHERE" and "record contributes to the aggregate". A value aggregate over a class where some matching rows have a null property is a routine production shape (`SUM(price) WHERE active=true` where `price` is sometimes unset). If the null-skip in `observe` regressed, the seeded scalar would mis-fold (NPE in `refoldSum`'s `(Number) v` cast, or a null in a distinct bucket). If the `applyMutation` null branch regressed, a T→T UPDATE that nulls the property would leave a stale contributor instead of dropping it — a silent wrong scalar. The `(Number) v` cast at `refoldSum` (762-763) would throw on a null that slipped through, so the skip is load-bearing.
+- **Evidence**: Input-domain table rows "observed property value = null" and "post-mutation property value = null" — Currently Tested? NO.
+- **Refutation considered**: C2 — confirmed both branches are reachable on a schema-less or nullable-property class (the equivalence suite even declares `price` as a nullable `INTEGER` property). Not covered by the F→F no-op test (`applyMutationFtoFIsNoOp` uses a non-matching value, not a null property on a matching record).
+- **Suggested test**:
+  ```java
+  @Test
+  public void sumSkipsNullPropertyOnObserve() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD,
+        List.of(newRec(10), newRec(null), newRec(20)));
+    assertEquals("a null-valued matching record does not contribute", 30, scalarOf(s));
+    db.rollback();
+  }
+
+  @Test
+  public void sumDropsContributorWhenUpdateNullsTheProperty() {
+    var a = committedRec(10);
+    var b = committedRec(20);
+    var s = populate(CacheableShape.AGGREGATE_SUM, FIELD, List.of(a, b));
+    b.setProperty(FIELD, null);
+    s.applyMutation((RecordAbstract) b, RecordOperation.UPDATED, true); // matches WHERE, value null
+    assertEquals("a matching record whose value becomes null drops out", 10, scalarOf(s));
+    db.rollback();
+  }
+  ```
+
+### TC3 [should-fix] MIN/MAX non-Number Comparable and cross-subtype comparison untested
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java`
+- **Production code**: `AggregateState.beatsExtremum` / `staysInExtremumDirection` (810-838) — the `castComparableNumber` path runs only when both operands are `Number`; otherwise it falls through to a raw `Comparable.compareTo`.
+- **Missing scenario**: MIN/MAX over (a) cross-`Number`-subtype values that force the `castComparableNumber` branch (e.g. an `Integer` extremum challenged by a `Long`, or `Long` vs `Double`), and (b) non-Number `Comparable` values (String dates, `String` ids). Every MIN/MAX test uses homogeneous `Integer` values, so the `castComparableNumber` cast and the non-Number `compareTo` fallback are both unexercised. Step 1's own episode flags this as BC3 ("MIN/MAX over mixed non-Number Comparable values can throw ClassCastException ... untested").
+- **Why it matters**: `beatsExtremum` is the comparison primitive behind every MIN/MAX transition. With homogeneous `Integer` input the `castComparableNumber` branch is dead in tests, so an off-by-one in the cast (wrong operand order, wrong sign for MIN vs MAX) would not surface. A `MAX(score)` where `score` is sometimes `Integer` and sometimes `Long` (the `increment`-promotion world these aggregates live in) is exactly the cross-subtype case D19 cares about; the cache must compare numerically (`Integer(5) < Long(10)`), and there is no test that would fail if it compared by `Number.equals`/hashCode or by boxed-reference order instead.
+- **Evidence**: Input-domain table rows "MIN/MAX operand types = mixed Integer/Long/Double" and "= non-Number Comparable" — Currently Tested? NO (all MIN/MAX cases use `Integer`). Cross-subtype is tested for COUNT_DISTINCT (`countDistinctTreatsCrossSubtypeValuesAsDistinct`) but never for the MIN/MAX comparison direction.
+- **Refutation considered**: C3 — confirmed `SQLFunctionMin/Max` run `castComparableNumber` for the numeric case and a raw `compareTo` otherwise, so the cache must reproduce both. Not covered by `minAndMaxObserveExtremum` (homogeneous Integer) or the equivalence suite (declared INTEGER property coerces everything to one subtype, so even end-to-end the cross-subtype path is unreachable through the equivalence harness).
+- **Suggested test**:
+  ```java
+  @Test
+  public void maxComparesAcrossNumberSubtypesNumerically() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_MAX, FIELD,
+        List.of(newRec(5), newRec(10L), newRec(7.5d)));
+    assertEquals("MAX compares Integer/Long/Double numerically, not by boxed type",
+        10L, scalarOf(s));
+    db.rollback();
+  }
+
+  @Test
+  public void minOverStringComparableValues() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_MIN, FIELD,
+        List.of(newRec("banana"), newRec("apple"), newRec("cherry")));
+    assertEquals("apple", scalarOf(s)); // non-Number Comparable path
+    db.rollback();
+  }
+  ```
+
+### TC4 [suggestion] AVG negative and rounding-boundary values not exercised
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java`
+- **Production code**: `AggregateState.computeAverage` (927-940) — integer truncation (toward zero for negatives) and BigDecimal `HALF_UP`.
+- **Missing scenario**: AVG over negative integers (where Java integer division truncates toward zero, not floor — `-35/3 == -11`, not `-12`) and a BigDecimal AVG sitting exactly on the `HALF_UP` round-half boundary (e.g. sum `5` over `2` → `2.5` → `3` at scale 0). The existing `avgIntegerInputTruncates` (35/3) and `avgBigDecimalInputRoundsHalfUp` (35/3) use only positive, non-half-boundary inputs.
+- **Why it matters**: Truncation direction and the exact half-up rounding rule are the two places AVG most easily diverges from a "plain sum/count" implementation. The current cases pass for both `floor` and `truncate-toward-zero` (both give 11 for 35/3) and for both `HALF_UP` and `HALF_EVEN` (35/3=11.67 rounds to 12 either way). A negative case and an exact-half case are the inputs that actually distinguish the implemented rule. Lower severity because `computeAverage` is copied verbatim from production, so cache-vs-fresh parity holds by construction; the value is guarding against a future independent edit of the cache copy drifting from storage.
+- **Evidence**: Input-domain table rows "AVG sign = negative" and "BigDecimal AVG on exact .5 boundary" — Currently Tested? NO.
+- **Refutation considered**: C4 — verified production `computeAverage` is reproduced character-for-character, so this is a guard-rail gap, not a current-behavior bug; hence suggestion, not should-fix.
+- **Suggested test**:
+  ```java
+  @Test
+  public void avgNegativeIntegerTruncatesTowardZero() {
+    db.begin();
+    var s = populate(CacheableShape.AGGREGATE_AVG, FIELD,
+        List.of(newRec(-10), newRec(-20), newRec(-5))); // -35 / 3
+    assertEquals("integer AVG truncates toward zero, not floor", -11, scalarOf(s));
+    db.rollback();
+  }
+  ```
+
+### TC5 [suggestion] MIN / DISTINCT / COUNT_DISTINCT equivalence and collapse coverage thinner than SUM/MAX
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java`
+- **Production code**: per-kind `applyMutation` paths in `AggregateState.java`.
+- **Missing scenario**: The end-to-end equivalence matrix is uneven across kinds. SUM gets CREATE + value-UPDATE + WHERE-break; MAX gets DELETE + value-UPDATE-below-extremum; AVG gets CREATE + value-UPDATE; but **MIN gets only DELETE** (no CREATE-below-extremum, no value-UPDATE, no WHERE-break), **COUNT gets no value-UPDATE** (COUNT ignores value, so this is acceptable), and the **D21 collapse case is exercised only for MAX** end-to-end — SUM's collapse (re-fold-not-double-add) is unit-tested in `AggregateStateTest` but never driven through the live splice path. The MIN F→T-beats-extremum transition (`minApplyMutationNewValueBeatsExtremum`) is unit-tested but never end-to-end.
+- **Why it matters**: The unit tests cover each `applyMutation` branch in isolation, but the end-to-end suite is what proves the *splice + eager-drive + buildForAggregate + view* pipeline wires the right metadata (alias, propertyName) and reconciles correctly for each kind. A kind-specific wiring bug (e.g. MIN reading the wrong property, or the collapse membership-dispatch only working when the live tx produces the op type SUM happens to hit) would slip through because MIN/SUM-collapse have no live coverage. Lower severity because the unit layer is thorough and the pipeline is kind-agnostic by construction, so the marginal bug surface is small.
+- **Evidence**: Test-matrix audit — per-kind × mutation-pattern grid is fully populated only for SUM and MAX; MIN end-to-end = {DELETE}, SUM-collapse end-to-end = {none}.
+- **Refutation considered**: C5 — the pipeline (splice/drive/build/view) is shape-keyed but not value-kind-keyed, so most kind-specific risk is in `AggregateState` which the unit suite covers well; this is defense-in-depth, hence suggestion.
+- **Suggested test**: add a `minEquivalence_createBelowExtremumAfterPopulate` and a `sumEquivalence_collapseCreateThenValueChange` mirroring the existing MAX collapse case, so each value kind has at least one live splice-path equivalence assertion per non-trivial transition.
+
+## Evidence base
+
+#### C1 — empty-set drain boundary
+CONFIRMED-as-gap. `AggregateState.recomputeExtremum` (777-787) sets `currentScalar=null` when `contributingValues` is empty; `scalar()` (903-919) returns `currentScalar` for MIN/MAX (null), `computeAverage(null,0)` for AVG (null via the final `return null`), `(long) size` for COUNT/COUNT_DISTINCT (0). `SQLFunctionAverage.getResult` (verified at `SQLFunctionAverage.java:91-115`) returns `computeAverage(null, 0)` → null over empty; MIN/MAX (`SQLFunctionMin.java:43-98`) return null over empty. So fresh-execution parity over an emptied set is null/0, which is assertable. The drain *transition* (last contributor removed by replay) is exercised by no test; `sumOverEmptySetIsZeroNotNull` covers only the never-seeded path. Reachable: DELETE-all-matching then re-query in one tx.
+
+#### C2 — null property value
+CONFIRMED-as-gap. `observe` (562-568) early-returns on a null property; `applyMutation` (602-610) flips `nowContributing=false` when `readValue` returns null. `refoldSum` casts `(Number) v` (762-763) so a null that bypassed the skip would NPE/CCE. No test sets a null aggregate property. The equivalence-suite `price` is a nullable `INTEGER` property, so the path is reachable through the live API.
+
+#### C3 — MIN/MAX comparison subtypes
+CONFIRMED-as-gap. `beatsExtremum`/`staysInExtremumDirection` (810-838) run `PropertyTypeInternal.castComparableNumber` only when both operands are `Number`, else raw `compareTo`. `SQLFunctionMin.execute` (verified `SQLFunctionMin.java:64-72`) runs the same `castComparableNumber` for the numeric case. All MIN/MAX tests use homogeneous `Integer`, so neither the cast branch nor the non-Number fallback executes. Step 1 episode independently recorded this as deferred finding BC3.
+
+#### C4 — AVG sign/rounding boundary
+CONFIRMED-as-low-value. `AggregateState.computeAverage` (927-940) is a verbatim copy of `SQLFunctionAverage.computeAverage` (`SQLFunctionAverage.java:101-115`), so cache-vs-fresh parity holds by construction today. The gap is a guard against future drift of the copy, and the existing positive/non-half inputs do not distinguish truncate-toward-zero from floor, nor HALF_UP from HALF_EVEN. Suggestion severity.
+
+#### C5 — per-kind matrix evenness
+CONFIRMED-as-low-value. Audited `AggregateCacheEquivalenceTest`: SUM = {create, valueUpdate, whereBreak}; MAX = {delete, valueUpdateBelowExtremum}; AVG = {create, valueUpdate}; MIN = {delete}; COUNT = {create, delete, whereBreak}; collapse end-to-end = {MAX only}. The populate/splice/build/view pipeline is shape-keyed (`isAggregateShape`) not value-kind-keyed, so kind-specific live risk is confined to `AggregateState`, which `AggregateStateTest` covers per-branch. Defense-in-depth, suggestion severity.
+
+#### C6 — tooling basis
+mcp-steroid reachable; open project `design.md` rooted at the working tree (`steroid_list_projects`). Production-code reads (`SQLFunctionAverage`, `SQLFunctionMin`, `PropertyTypeInternal.increment` signature) done by direct Read against the working tree, which matches the open project root. No find-usages/override claims underpin any finding, so the grep-vs-PSI reference-accuracy caveat does not bind here — every finding rests on branch reads of code present in the diff plus the three named production methods.
+
+#### C7 — diff completeness
+Full cumulative track diff (~3681 lines) paged in four reads (offsets 1/700/1400/2100/2800), covering all five test files end-to-end plus the production context (`AggregateState`, `AggregateCacheTapStep`, `DeltaBuilder.buildForAggregate`, `ShapeClassifier`, `DatabaseSessionEmbedded`, `CachedResultSetView`, `QueryCacheMetrics`, `QueryResultCache`, `CachedEntry`). No finding is formed from a truncated read.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-concurrency-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-concurrency-iter1.md
@@ -1,0 +1,99 @@
+<!-- MANIFEST
+dimension: test-concurrency
+iteration: 1
+high_water_mark: 0
+findings: 0
+verdict: pass
+evidence_base: present
+cert_index: present
+flags: none
+index: []
+-->
+
+## Findings
+
+No concurrency-testing findings. Track 2 adds no genuinely multi-threaded
+production behavior, so no concurrent test is owed. The basis for that
+conclusion is in the Evidence base below.
+
+## Evidence base
+
+The track concern handed down from Track 1 was specific: *if the aggregate
+splice calls `QueryResultCache.lookup` outside the `cacheCodeDepth` bracket,
+the lookup-level `inFlightLookup` guard becomes reachable and needs end-to-end
+coverage; cross-thread guard release must use `exitCacheCodeUnchecked`.* Both
+halves were checked against the as-built code and both refuted as live concerns
+for this track.
+
+#### C1 — Does the aggregate path reach `cache.lookup` outside the `cacheCodeDepth` bracket?
+
+CONTRACT: the lookup-level `inFlightLookup` guard is defense-in-depth and needs
+coverage only if a Track-2 path calls `lookup` outside the tx-level
+`cacheCodeDepth` bracket.
+
+TEST TRACE / production trace:
+`DatabaseSessionEmbedded.serveThroughCache` (line 741) enters the bracket with
+`tx.enterCacheCode()` at line 782, performs the single `cache.lookup(key, ...)`
+at line 785 (inside the bracket), then on an aggregate miss calls
+`populateAndBuildAggregateView` at line 808 — still inside the bracket, with the
+`finally` at line 832 releasing the guard when no view took ownership. The
+aggregate populate method (`populateAndBuildAggregateView`, line 941) builds a
+per-execution plan copy, splices the tap, eager-drives the plan, puts the entry,
+and calls `buildView`. It never calls `cache.lookup`. Grep over the whole track
+diff confirms `lookup` appears only at the one in-bracket call site; the
+aggregate path adds none.
+
+VERDICT: the `inFlightLookup` guard is NOT newly reachable in Track 2. The
+precondition for owing it coverage ("lookup called outside the bracket") does
+not hold. CONFIRMED that no new test is owed.
+
+#### C2 — Does Track 2 introduce a new cross-thread guard release?
+
+CONTRACT: any view-owned cross-thread guard release must use
+`exitCacheCodeUnchecked`, and such a path would need coverage.
+
+TEST RACE CHECK / production trace: the `viewOwnsGuard` transfer in the
+aggregate branch (line 809) is byte-for-byte the RECORD pattern — a built
+`CachedResultSetView` owns the guard and releases it on close/exhaustion; an
+uncached fallback leaves `viewOwnsGuard` false so the synchronous `finally`
+releases it. `exitCacheCodeUnchecked` appears zero times in the track diff. No
+new thread, executor, `CompletableFuture`, or `submit/execute` call is
+introduced (grep confirms: the only `Runnable` is the synchronous
+`onOverflow` overflow callback, invoked inline from `AggregateState.observe` on
+the owning thread; the only `Executor` token is absent). The sole cross-thread
+path in the subsystem — tx-end `clear()` via `exitCacheCodeUnchecked`, already
+present and covered in Track 1 — is unchanged by this track.
+
+VERDICT: no new cross-thread release path. CONFIRMED that no new test is owed.
+
+#### C3 — Is the new production state genuinely single-threaded?
+
+PREMISE P1: `AggregateState` (contributingValues/Rids, distinctBuckets,
+sumAccumulator, currentScalar) is shared mutable state protected by NO lock —
+its Javadoc states "Single-transaction state observed only by the owning thread;
+no field is synchronised."
+PREMISE P2: `AggregateCacheTapStep` and its inner `ObservingStream` claim no
+thread-safety and carry the same single-thread Javadoc; they run on the
+plan-driving thread.
+PREMISE P3: expected access pattern — all aggregate observe/applyMutation/copy/
+toResult calls run under `FrontendTransactionImpl.assertOnOwningThread()`
+(plan-slim "Single-thread tx model"; Track-1 invariant I2). The copy-per-view
+discipline (`buildForAggregate` copies the seeded state before replay) means the
+entry's seeded state is never mutated after populate, so even the
+populate-thread vs view-thread distinction reduces to one logical owner.
+
+This matches the plan constraint exactly: "All cache mutation paths run under
+`assertOnOwningThread()`; only tx-end `clear()` is cross-thread ... No locking is
+added." The aggregate replay logic is single-threaded by construction;
+suggesting a contention or interleaving test for it would contradict the design
+contract and the reviewer guideline against inventing concurrent tests for
+single-threaded code.
+
+VERDICT: single-threaded replay logic. No concurrency test is appropriate.
+
+Tooling note: traces above rest on call-site enumeration of `cache.lookup`,
+`exitCacheCodeUnchecked`, and thread-spawning APIs within the track diff plus the
+as-built `DatabaseSessionEmbedded.serveThroughCache`. The reachability claims
+(lookup never called from the aggregate path; no new cross-thread release) are
+diff-scoped and grep-confirmed against the changed files; they do not depend on
+enumerating polymorphic implementers, so the grep basis is sufficient here.

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-structure-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/test-structure-iter1.md
@@ -1,0 +1,51 @@
+<!-- MANIFEST
+dimension: test-structure
+prefix: TS
+findings: 3
+high_water_mark: 0
+evidence_base: { certs: 0 }
+flags: []
+index:
+  - id: TS1
+    sev: should-fix
+    anchor: "TS1"
+    loc: "core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java:2202"
+    cert: n/a
+    basis: "AggregateStateTest extends DbTestBase, overrides the lifecycle with its own @Before/@After, and shadows the protected youTrackDB field — every method spins up two databases."
+  - id: TS2
+    sev: suggestion
+    anchor: "TS2"
+    loc: "core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java:1763"
+    cert: n/a
+    basis: "Three near-parallel scenario drivers (runScenario / runWithTarget / runCollapse) plus an assertEquivalent helper used by only some cases; most cases inline the fresh-vs-cached compare, so the equivalence pattern is expressed inconsistently."
+  - id: TS3
+    sev: suggestion
+    anchor: "TS3"
+    loc: "core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java:1688"
+    cert: n/a
+    basis: "@Before enableSchema() reads/saves the cache flag and creates schema; @After restoreFlag() restores it — the method names describe only half of what each does."
+-->
+
+## Findings
+
+### TS1 [should-fix] AggregateStateTest runs a dual lifecycle and shadows DbTestBase.youTrackDB
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateStateTest.java`, class declaration (line ~2202) plus `@Before before()` / `@After after()` and the `private YouTrackDBImpl youTrackDB` field.
+- **Issue**: `AggregateStateTest extends DbTestBase` but supplies its own `@Before before()` and `@After after()` and its own `db` / `youTrackDB` fields. JUnit 4 runs *both* the superclass `@Before` (`DbTestBase.beforeTest()`, which creates `this.databaseName`, a pool, and the inherited `session`) and the subclass `before()` (which creates a second database named `getClass().getSimpleName()` via `createYTDBManagerAndDb` and opens its own `db`). The test only ever uses `db`; the inherited database, pool, and `session` are created and torn down unused on every one of the 34 methods. Worse, the subclass field `private YouTrackDBImpl youTrackDB` **shadows** the `protected YouTrackDBImpl youTrackDB` in `DbTestBase` (confirmed: `DbTestBase.java:35`), so the two lifecycles operate on two different manager instances that happen to share a field name. A future reader cannot tell from the class body that a whole second database is being stood up by the parent, and any later change that makes the subclass touch the inherited `session` or `youTrackDB` would silently bind to the wrong instance.
+
+  This is isolation-correct today only because surefire runs with `<parallel>classes</parallel>` (core/pom.xml:304) — methods within the class are sequential, so the class-named database is not contended. It is the *clarity* and *fragility* that fail the bar: the test reads as a self-contained fixture while a hidden parallel fixture runs alongside it.
+- **Suggestion**: Pick one fixture model. Either (a) drop the custom `before()`/`after()` and use the inherited `DbTestBase` lifecycle plus the inherited `session` (rename local `db` usages to `session`, which is already a `DatabaseSessionEmbedded`), eliminating the second database entirely; or (b) if a hand-rolled manager is genuinely needed, do **not** extend `DbTestBase` — extend nothing and own the full lifecycle, so no parent `@Before` fires and no field is shadowed. Option (a) is the smaller change and matches every sibling test in this package (`AggregateCacheEquivalenceTest`, `ShapeClassifierTest`, `FunctionDeterminismEnumerationTest` all use the inherited `session`).
+
+### TS2 [suggestion] AggregateCacheEquivalenceTest expresses the same equivalence pattern three different ways
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java`, helpers `runScenario` (line ~1763), `runWithTarget` (line ~1913), `runCollapse` (line ~1950), and `assertEquivalent` (line ~1781).
+- **Issue**: The class has three near-identical scenario drivers that each `clearClass()`, seed committed records, toggle the cache flag, run a populating query, apply a mutation, run a second query, and roll back. `assertEquivalent` wraps `runScenario` and emits the fresh-vs-cached `assertEquals`, but only four cases call it (`countEquivalence_createAfterPopulate`, the `sum`/`avg` create cases, `countDistinctServedByK0NoneMatchesEngineRowCount`). The majority of cases call `runWithTarget` twice (once for `false`, once for `true`) and inline their own `assertEquals`, repeating the fresh-vs-cached comparison boilerplate at every call site. The result is that the central invariant of the suite — "cached scalar equals a fresh uncached scalar at the same moment" — is sometimes a one-line helper call and sometimes six lines of hand-rolled compare, so a reader must re-derive the pattern per test and the failure messages drift ("must match fresh", "must drop the contributor", "must recompute to match fresh").
+- **Suggestion**: Add a target-aware `assertEquivalentWithTarget(String agg, Function<RID, Consumer<...>> mutationFor)` mirroring `assertEquivalent`, and route the `runWithTarget`-based cases through it. That collapses each two-line `fresh`/`cached` capture plus `assertEquals` into a single call and gives every equivalence case a uniform failure message, leaving only the genuinely structural cases (`runCollapse`, the K0/fallback metric assertions) to spell out their own logic.
+
+### TS3 [suggestion] AggregateCacheEquivalenceTest fixture method names describe only half their work
+
+- **File**: `core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/cache/AggregateCacheEquivalenceTest.java`, `@Before enableSchema()` (line ~1688) and `@After restoreFlag()` (line ~1696).
+- **Issue**: `enableSchema()` both saves the current `QUERY_TX_RESULT_CACHE_ENABLED` value into `previousEnabled` *and* creates the test class/properties; `restoreFlag()` restores that saved value. The names cover only one half each: `enableSchema` does not mention that it captures the cache-flag baseline (the load-bearing half that pairs with `@After`), and the schema-creation half it *is* named for is unrelated to flag handling. A reader scanning for where the global flag is saved/restored will not find it under these names, and the `@Before`/`@After` pairing reads as mismatched.
+- **Suggestion**: Rename to reflect both responsibilities, e.g. `@Before setUpClassAndCaptureFlag()` / `@After restoreCacheFlag()`, or split the flag capture/restore into clearly named statements with a one-line comment ("save the global cache flag so per-test toggles can be undone"). Pure naming/comment change; no behavior impact.
+
+## Evidence base

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/workflow-consistency-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/workflow-consistency-iter1.md
@@ -1,0 +1,19 @@
+<!-- MANIFEST
+dimension: workflow-consistency
+prefix: WC
+findings: 0
+high_water_mark: 0
+evidence_base: { certs: 0 }
+cert_index: []
+flags: []
+index: []
+-->
+# Workflow consistency review — Track 2 (iter 1)
+
+## Findings
+
+(none)
+
+## Evidence base
+
+(evidence-trail-exempt: no refutation or certificate phase to persist)

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/workflow-context-budget-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/workflow-context-budget-iter1.md
@@ -1,0 +1,18 @@
+<!-- MANIFEST
+dimension: workflow-context-budget
+target: docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+iteration: 1
+findings: 0
+evidence_base: { certs: 0 }
+cert_index: []
+flags: { evidence_trail_exempt: true, exempt_reason: "no refutation or certificate phase to persist" }
+index: []
+-->
+
+# Workflow context-budget review — Track 2
+
+## Findings
+
+None.
+
+## Evidence base

--- a/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/workflow-writing-style-iter1.md
+++ b/docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2/reviews/workflow-writing-style-iter1.md
@@ -1,0 +1,64 @@
+<!-- MANIFEST
+reviewer: review-workflow-writing-style
+target: docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md
+range: babd8d607687b284687b57ccb882cf838148055b..HEAD
+findings: 2
+high_water_mark: 0
+evidence_base: "## Evidence base"
+cert_index:
+  - C1
+  - C2
+flags: []
+index:
+  - id: WS1
+    sev: should-fix
+    anchor: "### WS1 "
+    loc: "docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md:297-311"
+    cert: C1
+    basis: judgment
+  - id: WS2
+    sev: should-fix
+    anchor: "### WS2 "
+    loc: "docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md:394-412"
+    cert: C2
+    basis: judgment
+-->
+
+## Findings
+
+### WS1 [should-fix] Two em dashes in the Step 1 "What was discovered" paragraph
+
+- File: `docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md` (line 297-311)
+- Axis: em-dash overuse
+- Cost: two em dashes in one blank-line-bounded paragraph; the house-style cap is one per paragraph (`house-style.md § Em-dash discipline`).
+- Issue: The Step 1 `**What was discovered:**` paragraph (lines 297-311) carries two em dashes, both in the inline deferral list: `steps: BC2 — observe reads the projected Result ...; BC3 — MIN/MAX over mixed non-Number ...`. `§ Em-dash discipline` allows at most one em dash per paragraph and the mechanical check counts per blank-line-bounded paragraph.
+- Suggestion: Replace the `BC<N> —` separators with colons, which reads as the definition-list form the content actually is:
+
+  ```
+  Two review suggestions defer to the track-level pass or later
+  steps: BC2: `observe` reads the projected `Result` while `applyMutation` reads the raw
+  `Entity`, a value-source coupling the Step 2 classifier gate guards; BC3: MIN/MAX over
+  mixed non-Number `Comparable` values can throw `ClassCastException`, ...
+  ```
+
+### WS2 [should-fix] Three em dashes in the Step 3 "What was discovered" paragraph
+
+- File: `docs/adr/YTDB-820-tx-result-cache/_workflow/plan/track-2.md` (line 394-412)
+- Axis: em-dash overuse
+- Cost: three em dashes in one blank-line-bounded paragraph; the cap is one per paragraph, and `§ Em-dash discipline` also bans the multi-clause em-dash cadence (`house-style.md § Em-dash discipline`).
+- Issue: The Step 3 `**What was discovered:**` paragraph (lines 394-412) carries three em dashes: line 394 `no native distinct-count — count(distinct(prop)) is computed ...`, line 405 `skip it — unreachable: the plan is single-use ...`, and line 407 `without a null guard — unreachable: a valid SELECT ...`. Two of the three (`skip it —`, `null guard —`) introduce an `unreachable:` justification, where a colon does the same work.
+- Suggestion: Keep the first em dash (line 394, the one allowed per paragraph) and convert the two `— unreachable:` joins to colons: `... so prettyPrint/reset/serialize skip it (unreachable: the plan is single-use ...)` and `... without a null guard (unreachable: a valid SELECT always chains at least one step)`. Parenthesizing the BC1/BC2 asides also tightens the long enumeration.
+
+## Evidence base
+
+#### C1 — em-dash count, Step 1 "What was discovered" paragraph (lines 297-311)
+Refuted-in-full check (finding survives): counted em dashes in the blank-line-bounded paragraph spanning lines 297-311 (blanks at 296 and 312). Em dashes at line 302 (`BC2 —`) and line 303 (`BC3 —`) → 2 per paragraph, over the cap of 1. The heading-line em dash (line 279, `### Step 1 —`) is a separate paragraph and does not count. Confirmed via `grep '—'` on the Episodes range cross-referenced against blank-line offsets.
+
+#### C2 — em-dash count, Step 3 "What was discovered" paragraph (lines 394-412)
+Refuted-in-full check (finding survives): counted em dashes in the blank-line-bounded paragraph spanning lines 394-412 (blanks at 393 and 413). Em dashes at line 394 (`distinct-count —`), line 405 (`skip it —`), line 407 (`null guard —`) → 3 per paragraph, over the cap of 1; also matches the banned multi-clause cadence. The heading-line em dash (line 372) and the line-415 em dash (`What changed from the plan` paragraph, one per paragraph, fine) are separate paragraphs. Confirmed via `grep '—'` cross-referenced against blank-line offsets.
+
+#### Survived checks (one line each)
+- Banned vocabulary Tier 1-4: confirmed clean across in-range prose (lines 21-120, 276-435) — zero hits on the full Tier 1/2/3 regex sweep.
+- Banned sentence patterns (negative parallelism, throat-clearing, signposting, closing phrases): confirmed clean — zero hits on the `it's not X / not just / at its core / let's break / in conclusion` sweep. The "returns a ROW count ..., not a distinct count" (line 64) and "returns 5, not 2" (line 395) contrasts state load-bearing factual results, not performative "not X, it's Y" depth-performance; not findings.
+- Banned analysis patterns (copula avoidance, hedge stacking, filler phrases `in order to` / `due to the fact that`): confirmed clean — zero hits.
+- Section length: episode `## Episodes` structured-field blocks are template-bound-exempt per `house-style.md § Structural rules` "Section length cap exception" category (1); not evaluated for length per the task scope.


### PR DESCRIPTION
> This is a workflow review surface, not a merge target. The feature PR is #1077.

## Purpose / Big Picture

Track 2 adds aggregate-query caching on top of the foundation: the `AggregateState` replay core, tightened aggregate classification with a metric bridge, and the aggregate cache splice with its eager-drive and fallback paths.

---

Satellite review PR for **Track 2** of `YTDB-820-tx-result-cache` (feature PR #1077). The diff is this track's commits only (`bb982a5abe..7dd9bfff0e`). This PR is closed, never merged, after author approval; the code already lives in the feature branch. See YTDB-1025 for the satellite-review model.
