### PR TITLE
YTDB-1157: YTDB-1153: Avoid heavy API on Gremlin hot paths

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraphQueryBuilder.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraphQueryBuilder.java
@@ -66,8 +66,7 @@ public class YTDBGraphQueryBuilder {
             list.stream()
                 .map(s -> (String) s)
                 .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toSet())
-        );
+                .collect(Collectors.toSet()));
       } else if (StringUtils.isBlank((String) value)) {
         requestedClasses.add(Set.of());
       } else {
@@ -85,8 +84,7 @@ public class YTDBGraphQueryBuilder {
             predicateStr,
             false,
             false,
-            null
-        ));
+            null));
         return ConditionType.PREDICATE;
       } else {
         final var predicateStr = formatPredicate(biPredicate);
@@ -98,8 +96,7 @@ public class YTDBGraphQueryBuilder {
               predicateStr,
               requiresAdditionalNotNull(biPredicate),
               true,
-              value
-          ));
+              value));
           return ConditionType.PREDICATE;
         }
       }
@@ -129,13 +126,10 @@ public class YTDBGraphQueryBuilder {
             innerClasses -> innerClasses.stream()
                 .filter(hierarchyAnalyzer::classExists) // ignoring non-existent classes
                 .filter(name ->
-                    // considering only classes who don't have parents also requested (union semantics)
-                    innerClasses.stream().noneMatch(
-                        maybeParent -> hierarchyAnalyzer.isSuperClassOf(maybeParent, name)
-                    )
-                )
-                .collect(Collectors.toSet())
-        )
+                // considering only classes who don't have parents also requested (union semantics)
+                innerClasses.stream().noneMatch(
+                    maybeParent -> hierarchyAnalyzer.isSuperClassOf(maybeParent, name)))
+                .collect(Collectors.toSet()))
 
         // 2. Apply "intersection" to the resulting sets.
         // Set A intersected with set B will
@@ -143,21 +137,16 @@ public class YTDBGraphQueryBuilder {
         // and B. For instance, [dolphin,bird,insect] intersected with [mammal,ant] will produce
         // [dolphin,ant]
         .reduce(
-            (classesOne, classesTwo) ->
-                classesOne.stream().flatMap(c1 ->
-                        classesTwo.stream().flatMap(c2 ->
-                            hierarchyAnalyzer.selectChild(c1, c2).stream()
-                        )
-                    )
-                    .collect(Collectors.toSet())
-        )
+            (classesOne, classesTwo) -> classesOne.stream()
+                .flatMap(c1 -> classesTwo.stream()
+                    .flatMap(c2 -> hierarchyAnalyzer.selectChild(c1, c2).stream()))
+                .collect(Collectors.toSet()))
         .orElseGet(() -> Set.of(hierarchyRoot))
         .stream()
         .toList();
   }
 
-  @Nullable
-  public YTDBGraphBaseQuery build(DatabaseSessionEmbedded session) {
+  @Nullable public YTDBGraphBaseQuery build(DatabaseSessionEmbedded session) {
     var schema = session.getMetadata().getImmutableSchemaSnapshot();
     assert schema != null;
 
@@ -204,8 +193,7 @@ public class YTDBGraphQueryBuilder {
       final var sqlName = param.withValue ? "param" + i : null;
       appendCondition(
           where,
-          param.name, sqlName, param.predicateStr, param.requiresNotNull
-      );
+          param.name, sqlName, param.predicateStr, param.requiresNotNull);
       if (param.withValue) {
         parameters.put(sqlName, param.value);
       }
@@ -242,8 +230,7 @@ public class YTDBGraphQueryBuilder {
       String name,
       @Nullable String sqlParamName,
       String predicateStr,
-      boolean addNotNullCondition
-  ) {
+      boolean addNotNullCondition) {
     if (T.id.getAccessor().equalsIgnoreCase(name)) {
       builder.append(" @rid ").append(predicateStr);
     } else if (addNotNullCondition) {
@@ -258,8 +245,7 @@ public class YTDBGraphQueryBuilder {
     }
   }
 
-  @Nullable
-  private static String formatPredicate(BiPredicate<?, ?> predicate) {
+  @Nullable private static String formatPredicate(BiPredicate<?, ?> predicate) {
     if (predicate instanceof Compare compare) {
       return switch (compare) {
         case Compare.eq -> "=";
@@ -294,21 +280,15 @@ public class YTDBGraphQueryBuilder {
       String predicateStr,
       boolean requiresNotNull,
       boolean withValue,
-      Object value
-  ) {
+      Object value) {
 
   }
 
   private static boolean isLabelKey(String key) {
-    try {
-      if (key == null || key.isEmpty()) {
-        return false;
-      }
-
-      return T.fromString(key) == T.label;
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
+    // Compare directly against the label token's accessor ("~label") instead of T.fromString(key):
+    // fromString throws IllegalArgumentException for every non-token key (the common case on hot
+    // paths), and exception construction is expensive. equals() handles null/empty safely.
+    return T.label.getAccessor().equals(key);
   }
 
   private static class HierarchyAnalyzer {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/traversal/step/filter/YTDBHasLabelStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/traversal/step/filter/YTDBHasLabelStep.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrackdb.internal.core.gremlin.traversal.step.filter;
 
 import com.jetbrains.youtrackdb.api.gremlin.embedded.YTDBElement;
 import com.jetbrains.youtrackdb.internal.core.gremlin.YTDBElementImpl;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -23,8 +24,7 @@ public class YTDBHasLabelStep<S extends YTDBElement> extends FilterStep<S> {
   public YTDBHasLabelStep(
       final Traversal.Admin<?, ?> traversal,
       List<P<? super String>> predicates,
-      boolean polymorphic
-  ) {
+      boolean polymorphic) {
     super(traversal);
     this.predicates = predicates;
     this.polymorphic = polymorphic;
@@ -51,8 +51,10 @@ public class YTDBHasLabelStep<S extends YTDBElement> extends FilterStep<S> {
 
     if (traverser.get() instanceof YTDBElementImpl ytdbElement) {
 
-      final var entity = ytdbElement.getRawEntity();
-      final var schemaClass = entity.getSchemaClass();
+      final var entity = (EntityImpl) ytdbElement.getRawEntity();
+      // Use the lightweight immutable schema snapshot rather than getSchemaClass(), which resolves
+      // the class against the live schema on every call. Both yield the same class for label tests.
+      final var schemaClass = entity.getImmutableSchemaClass(entity.getSession());
       if (schemaClass == null) {
         // this shouldn't ever happen, I suppose
         return false;


### PR DESCRIPTION
#### Motivation:

Benchmarking the Hub APIs surfaced two performance-heavy calls sitting on Gremlin query hot paths:

1. `YTDBGraphQueryBuilder#isLabelKey` detected non-label keys by calling TinkerPop's `T.fromString` and catching the `IllegalArgumentException` it throws for unknown tokens. That exception is thrown for every ordinary property key — the common case on the hot path — and constructing it (stack trace capture) is expensive. It is now a direct comparison against the label token's accessor (`"~label"`), which is allocation-free and null/empty-safe. This also matches how `YTDBGraphStepStrategy` already detects the label token.

2. `YTDBHasLabelStep#filter` resolved each traverser's class via `Entity#getSchemaClass`, which looks the class up against the live schema on every element. It now uses the lightweight immutable-snapshot lookup `EntityImpl#getImmutableSchemaClass`, passing the entity's own session. Both yield the same class for label tests, so behavior is preserved.

Both changes are behavior-preserving; the existing Gremlin test coverage (`GraphQueryTest`, `YTDBHasLabelProcessTest`) exercises both paths and passes. A full `./mvnw clean package` is green (all modules, 0 test failures/errors).

Note: `YTDBGraphQueryBuilder` also carries Spotless reformatting of pre-existing drift that ratchet had been skipping until the file was touched — no behavioral change in those hunks.