### PR TITLE
Raise test-linux timeout and drop unstable test-macos leg

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -90,6 +90,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.should_run == 'true'
     runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 600
     strategy:
       fail-fast: false
       matrix:
@@ -239,78 +240,8 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  test-macos:
-    name: macOS arm - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
-    needs: check-changes
-    if: needs.check-changes.outputs.should_run == 'true'
-    # GitHub-hosted Apple Silicon runner. The docker-images profile is
-    # intentionally omitted — it builds linux/amd64 and linux/arm64
-    # images, which don't belong on a macOS runner.
-    #
-    # Non-blocking during soak period: this job is excluded from the
-    # needs: of merge-to-main (so a macOS failure does not block the
-    # develop→main promotion), deploy (so it does not block artifact
-    # publishing), and notify-fixed (so "build fixed" still fires when
-    # Linux/Windows/merge recover). notify-failure still observes macOS
-    # so the team sees regressions, and the CI Fix Agent is
-    # auto-dispatched on macOS failures too so the agent can attempt a
-    # fix. Promote to blocking once the leg is proven stable on develop.
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '21', '25' ]
-        distribution: [ 'temurin' ]
-    steps:
-      - name: Checkout Source Code
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'develop' }}
-          fetch-depth: 0
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: ${{ matrix.distribution }}
-          architecture: aarch64
-          cache: 'maven'
-          overwrite-settings: false
-
-      - name: Run Maven Test
-        id: tests
-        run: ./mvnw -s .github/workflows/settings.xml clean verify -B -Dmaven.test.failure.ignore=true -P ci-integration-tests
-        env:
-          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
-          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/macos@v2
-        if: always()
-        with:
-          files: |
-            **/target/surefire-reports/TEST-*.xml
-            **/target/failsafe-reports/TEST-*.xml
-          action_fail: true
-          large_files: true
-          comment_mode: off
-          compare_to_earlier_commit: false
-          check_name: Integration Tests Results (macOS arm, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
-      - name: Upload Test Diagnostics
-        uses: actions/upload-artifact@v7
-        if: "!cancelled()"
-        with:
-          name: test-diagnostics-integration-macos-jdk${{ matrix.java }}-${{ matrix.distribution }}
-          path: |
-            **/target/deadlock-report.txt
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-          retention-days: 7
-          if-no-files-found: ignore
-
   merge-to-main:
     name: Merge develop into main
-    # test-macos intentionally excluded: non-blocking during soak period.
     needs: [ test-linux, test-windows ]
     if: success() && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -357,7 +288,6 @@ jobs:
   # ------------------------------------------------------------------
   deploy:
     name: Deploy Artifacts
-    # test-macos intentionally excluded: non-blocking during soak period.
     needs: [ test-linux, test-windows ]
     if: success() && github.event_name != 'schedule'
     runs-on: ubuntu-latest
@@ -475,14 +405,13 @@ jobs:
 
   notify-failure:
     name: Notify build failure on Zulip
-    needs: [ test-linux, test-windows, test-macos, merge-to-main, deploy ]
+    needs: [ test-linux, test-windows, merge-to-main, deploy ]
     if: >-
       always() &&
       github.event_name != 'workflow_dispatch' &&
       (
         needs.test-linux.result == 'failure' ||
         needs.test-windows.result == 'failure' ||
-        needs.test-macos.result == 'failure' ||
         needs.merge-to-main.result == 'failure' ||
         needs.deploy.result == 'failure'
       )
@@ -491,8 +420,7 @@ jobs:
       - name: Dispatch CI Fix Agent
         if: >-
           needs.test-linux.result == 'failure' ||
-          needs.test-windows.result == 'failure' ||
-          needs.test-macos.result == 'failure'
+          needs.test-windows.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.CI_FIX_AGENT_TOKEN }}
         run: |
@@ -547,8 +475,6 @@ jobs:
 
   notify-fixed:
     name: Notify build fixed on Zulip
-    # test-macos intentionally excluded during soak: a "fixed" signal should
-    # fire when Linux/Windows/merge recover even if macOS is still flaky.
     # deploy IS included so a deploy failure suppresses the "fixed" signal —
     # we must never report "build fixed" while artifact publishing is broken
     # (a deploy-only failure already triggers notify-failure). deploy is


### PR DESCRIPTION
#### Motivation:

Two changes to `maven-integration-tests-pipeline.yml`:

- **Raise the `test-linux` timeout to 600 minutes.** The job had no explicit `timeout-minutes`, so it inherited the default 360-minute ceiling, which the Linux integration leg has been hitting and failing on. 600 gives it the headroom it needs.

- **Remove the `test-macos` job.** The macOS runs are GitHub-hosted VM builds — slow and unstable, producing frequent false failures. The leg was already kept non-blocking during a soak period and has not proven stable, so it is dropped along with its references in `merge-to-main`, `deploy`, `notify-failure`, and `notify-fixed`.