### PR TITLE
[ci-fix] Freeze GranularTicker time on stop() under a lifecycle lock

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTicker.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTicker.java
@@ -27,8 +27,22 @@ import java.util.concurrent.TimeUnit;
 ///   [#approximateCurrentTimeMillis()].
 ///
 /// Because the refresh task is the only writer, `snapshot = nextSnapshot(...)` never races
-/// with itself and no further serialization is needed. Readers observe an atomic, monotonic
-/// `(nanoTime, nanoTimeDifference)` pair via the volatile store on `snapshot`.
+/// with itself and no further writer-vs-writer serialization is needed. Readers observe an
+/// atomic, monotonic `(nanoTime, nanoTimeDifference)` pair via the volatile store on
+/// `snapshot`.
+///
+/// ### Lifecycle freeze
+///
+/// [#stop()] must guarantee that no refresh publishes a newer snapshot after it returns —
+/// callers rely on the approximate time staying frozen once the ticker is stopped.
+/// Cancelling the [ScheduledFuture] with `cancel(false)` neither interrupts an
+/// already-running refresh nor waits for it, and an in-flight refresh can be descheduled by
+/// the OS between its early `stopped` check and the volatile publish. To close that window
+/// the publish and the `stopped` flag are serialized on [#lifecycleLock]: `stop()` sets the
+/// flag under the lock, and `refresh()` re-checks the flag and publishes under the same lock.
+/// Once `stop()` returns, every subsequent refresh either has already published (before
+/// `stop()` acquired the lock) or observes `stopped == true` under the lock and publishes
+/// nothing. Readers never take this lock.
 ///
 /// Callers such as `Stopwatch.timed()`, `YTDBQueryMetricsStep` and
 /// `FrontendTransactionImpl.notifyMetricsListener` compute deltas across two reader
@@ -50,6 +64,11 @@ public class GranularTicker implements Ticker, AutoCloseable {
   private final long recalibrationInterval;
   private volatile boolean started;
   private volatile boolean stopped;
+
+  /// Serializes the snapshot publish in [#refresh()] against the `stopped` write in
+  /// [#stop()] so the approximate time is guaranteed frozen once `stop()` returns. See the
+  /// "Lifecycle freeze" section of the class Javadoc. Readers never acquire this lock.
+  private final Object lifecycleLock = new Object();
 
   /// Combined `(nanoTime, nanoTimeDifference)` snapshot. `nanoTime` is the most recently
   /// sampled [System#nanoTime()]. `nanoTimeDifference` is the offset between
@@ -100,7 +119,17 @@ public class GranularTicker implements Ticker, AutoCloseable {
     // Sample currentTimeMillis only on recalibration fires. On non-recalibration fires the
     // previous snapshot's nanoTimeDifference is reused, so the syscall is skipped entirely.
     final long wallMillis = recalibrate ? System.currentTimeMillis() : 0L;
-    snapshot = nextSnapshot(snapshot, freshNano, wallMillis, recalibrate);
+    // Publish under the lifecycle lock and re-check stopped. stop() takes the same lock to
+    // set the flag, so this refresh either published before stop() acquired the lock or, if
+    // it was descheduled past stop() between the early check above and here, now sees
+    // stopped == true and publishes nothing. Either way the time is frozen once stop()
+    // returns. The top-of-method check stays as a fast path that skips nanoTime sampling.
+    synchronized (lifecycleLock) {
+      if (stopped) {
+        return;
+      }
+      snapshot = nextSnapshot(snapshot, freshNano, wallMillis, recalibrate);
+    }
   }
 
   /// Builds the next snapshot while enforcing monotonicity of both accessors. Package-private
@@ -158,7 +187,12 @@ public class GranularTicker implements Ticker, AutoCloseable {
 
   @Override
   public void stop() {
-    stopped = true;
+    // Set the flag under the lock so any refresh that has already entered its publish block
+    // completes first; after this returns every later refresh observes stopped == true under
+    // the lock and publishes nothing, freezing the approximate time.
+    synchronized (lifecycleLock) {
+      stopped = true;
+    }
     var f = refreshFuture;
     if (f != null) {
       f.cancel(false);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/common/profiler/GranularTickerTest.java
@@ -125,6 +125,107 @@ public class GranularTickerTest {
     }
   }
 
+  /**
+   * Regression test for the stop()-vs-refresh publish race. A refresh task that has already
+   * passed the early {@code stopped} check (and sampled its fresh nanoTime) can be descheduled
+   * by the OS before it publishes its snapshot. If it then resumes after stop() has set the
+   * flag, it must observe the flag under the lifecycle lock and publish nothing, so
+   * approximateNanoTime() stays frozen. This is the race that flaked
+   * {@link #startThenStopFreezesTime()} on Windows CI (~15.6 ms timer quantum plus contention).
+   *
+   * <p>The race is reproduced deterministically rather than by timing: the test thread holds
+   * the lifecycle lock to pin an in-flight refresh at its publish point, sets {@code stopped}
+   * exactly as stop() does (under the lock), then releases the lock and lets the refresh
+   * resume. Without the under-lock re-check the refresh would publish a newer nanoTime and
+   * unfreeze the ticker.
+   */
+  @Test
+  public void inFlightRefreshAfterStopDoesNotUnfreezeTime() throws Exception {
+    List<Runnable> capturedTasks = new ArrayList<>();
+    // Fake scheduler that only captures the refresh runnable so the test can drive it on its
+    // own thread instead of relying on real fixed-rate scheduling.
+    ScheduledExecutorService fakeScheduler = new DelegatingScheduledExecutorService(
+        Executors.newSingleThreadScheduledExecutor()) {
+      @Override
+      public ScheduledFuture<?> scheduleAtFixedRate(
+          Runnable command, long initialDelay, long period, TimeUnit unit) {
+        capturedTasks.add(command);
+        return NO_OP_FUTURE;
+      }
+    };
+    try {
+      // One-hour granularity so the only fire is the one the test drives manually.
+      var ticker = new GranularTicker(
+          TimeUnit.HOURS.toNanos(1), TimeUnit.HOURS.toNanos(1), fakeScheduler);
+      ticker.start();
+      assertThat(capturedTasks).hasSize(1);
+      var refresh = capturedTasks.get(0);
+
+      // This single driven fire is a recalibration fire: recalibrationInterval ==
+      // max(1, 1h / 1h) == 1, so a leaked publish would recompute nanoTimeDifference and move
+      // BOTH accessors. Capture the frozen value of each, plus the snapshot reference itself,
+      // so the assertions below prove no publish occurred rather than inferring it from a
+      // value that the nextSnapshot clamp could coincidentally preserve.
+      var frozenNano = ticker.approximateNanoTime();
+      var frozenMillis = ticker.approximateCurrentTimeMillis();
+
+      Field lockField = GranularTicker.class.getDeclaredField("lifecycleLock");
+      lockField.setAccessible(true);
+      var lifecycleLock = lockField.get(ticker);
+      Field stoppedField = GranularTicker.class.getDeclaredField("stopped");
+      stoppedField.setAccessible(true);
+      Field snapshotField = GranularTicker.class.getDeclaredField("snapshot");
+      snapshotField.setAccessible(true);
+      var frozenSnapshot = snapshotField.get(ticker);
+
+      var refreshThread = new Thread(refresh, "in-flight-refresh");
+      // Daemon so a leaked thread (if the fix ever regresses and the refresh never unblocks)
+      // cannot outlive the suite and wedge the forked JVM.
+      refreshThread.setDaemon(true);
+      synchronized (lifecycleLock) {
+        // Pin the in-flight refresh at its publish point: it passes the early stopped check
+        // (stopped is still false) and samples a fresh nanoTime, then blocks acquiring the
+        // lifecycle lock the test thread holds. BLOCKED is unambiguous here because
+        // lifecycleLock is the only monitor on refresh()'s pre-publish path — if the refresh
+        // ever terminated or blocked elsewhere instead, the bailouts below fail the test
+        // loudly rather than letting it hang or pass vacuously.
+        refreshThread.start();
+        final var deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        Thread.State state;
+        while ((state = refreshThread.getState()) != Thread.State.BLOCKED) {
+          assertThat(state)
+              .as("refresh must block on lifecycleLock, not terminate before publishing")
+              .isNotEqualTo(Thread.State.TERMINATED);
+          assertThat(System.nanoTime())
+              .as("refresh did not reach the publish lock within the deadline; state=" + state)
+              .isLessThan(deadlineNanos);
+          Thread.onSpinWait();
+        }
+        // Set stopped under the lock, exactly as stop() does, while the refresh is pinned.
+        stoppedField.setBoolean(ticker, true);
+      }
+      // Release the lock; the pinned refresh resumes, re-checks stopped under the lock, and
+      // must publish nothing.
+      refreshThread.join(TimeUnit.SECONDS.toMillis(5));
+      assertThat(refreshThread.isAlive())
+          .as("the pinned refresh must finish after the lock is released")
+          .isFalse();
+
+      // Object identity: a refresh that published would store a new Snapshot instance.
+      assertThat(snapshotField.get(ticker))
+          .as("an in-flight refresh resuming after stop must publish no new snapshot")
+          .isSameAs(frozenSnapshot);
+      assertThat(ticker.approximateNanoTime())
+          .as("an in-flight refresh resuming after stop must not unfreeze approximateNanoTime")
+          .isEqualTo(frozenNano);
+      assertThat(ticker.approximateCurrentTimeMillis())
+          .as("a recalibration refresh resuming after stop must not unfreeze wall-clock millis")
+          .isEqualTo(frozenMillis);
+    } finally {
+      fakeScheduler.shutdownNow();
+    }
+  }
+
   /** close() delegates to stop(), behaving identically. */
   @Test
   public void closeAfterStartCancelsFutures() throws Exception {


### PR DESCRIPTION
## Motivation

`GranularTickerTest.startThenStopFreezesTime` flaked on Windows CI (JDK 25): `approximateNanoTime()` advanced ~7 ms after `stop()` ([failed run](https://github.com/JetBrains/youtrackdb/actions/runs/28292606898)). The ticker contract is that the approximate time stays frozen once it is stopped — callers such as `Stopwatch.timed()`, `YTDBQueryMetricsStep`, and `FrontendTransactionImpl.notifyMetricsListener` rely on it.

`stop()` set the `stopped` flag and called `cancel(false)` on the refresh future, but `cancel(false)` neither interrupts a running refresh nor waits for it. `refresh()` checked `stopped` at method entry, sampled `System.nanoTime()`, then published the snapshot. A refresh that had already passed the entry check could be descheduled by the OS (Windows ~15.6 ms timer quantum plus CI contention) between that check and the volatile publish; resuming after `stop()` returned, it published a fresh snapshot and unfroze the approximate time.

## Fix

Serialize the publish against the `stopped` write on a new `lifecycleLock`:

- `stop()` sets `stopped` under the lock, so any refresh already inside its publish block completes first.
- `refresh()` re-checks `stopped` and publishes the snapshot under the same lock.

Once `stop()` returns, every later refresh either already published (before `stop()` took the lock) or observes `stopped == true` under the lock and publishes nothing. The entry-level `stopped` check stays as a fast path that skips `nanoTime` sampling, and readers still take no lock.

## Testing

Adds `inFlightRefreshAfterStopDoesNotUnfreezeTime`, a deterministic regression test for the publish race. Instead of relying on timing, it holds `lifecycleLock` to pin an in-flight refresh at its publish point, sets `stopped` exactly as `stop()` does, then releases the lock and lets the refresh resume. It then asserts the `snapshot` reference is unchanged (object identity) and that neither `approximateNanoTime()` nor `approximateCurrentTimeMillis()` advances — proving no publish occurred rather than inferring it from a value the `nextSnapshot` monotonicity clamp could coincidentally preserve. A fake scheduler captures the refresh runnable so the test drives the single (recalibration) fire on its own thread.
