### PR TITLE
Run light test build on the ARM CI runner

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -99,12 +99,20 @@ jobs:
         arch: [ 'x86', 'arm' ]
         include:
           - arch: x86
+            # Powerful self-hosted Hetzner runner: full job — integration tests
+            # (clean verify) plus the multi-arch Docker image build.
             runs_on: [ self-hosted, type-cpx42, image-x86-system-ubuntu-24.04, in-nbg1-fsn1-hel1 ]
+            maven_goals: 'clean verify'
             mvn_opts: '-Dmaven.test.failure.ignore=true -P ci-integration-tests -P docker-images -Ddocker.platforms=linux/amd64'
             java_arch: x64
           - arch: arm
-            # GitHub-hosted runner — Hetzner ARM capacity is scarce.
+            # GitHub-hosted runner — Hetzner ARM capacity is scarce. This runner
+            # is weak, like windows-latest, so it runs the light test build: clean
+            # package with unit tests only, no failsafe integration-test/verify
+            # phase. The Docker image build is bound to the package phase, so it
+            # still produces the arm64 image without running integration tests.
             runs_on: ubuntu-24.04-arm
+            maven_goals: 'clean package'
             mvn_opts: '-Dmaven.test.failure.ignore=true -P ci-integration-tests -P docker-images -Ddocker.platforms=linux/arm64/v8'
             java_arch: aarch64
     steps:
@@ -124,7 +132,7 @@ jobs:
 
       - name: Run Maven Test
         id: tests
-        run: ./mvnw -s .github/workflows/settings.xml clean verify -B ${{ matrix.mvn_opts }}
+        run: ./mvnw -s .github/workflows/settings.xml ${{ matrix.maven_goals }} -B ${{ matrix.mvn_opts }}
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}


### PR DESCRIPTION
#### Motivation

The ARM leg of the integration-tests pipeline runs on a GitHub-hosted `ubuntu-24.04-arm` runner because Hetzner ARM capacity is scarce. That runner is weak, like `windows-latest`, but it was running the same full job as the powerful self-hosted x86 runner: `clean verify` with the failsafe integration tests plus a multi-arch Docker build. On a weak runner that is slow and prone to OOM, while the integration tests already run on the x86 leg.

This moves the Maven goal into the build matrix so the ARM leg matches the light Windows build: `clean package` with unit tests only, skipping the failsafe `integration-test`/`verify` phase. The arm64 Docker image is still produced because `docker:build` binds to the `package` phase (`server/pom.xml`). The self-hosted x86 runner keeps the full `clean verify` run, so the Linux integration tests still execute on every pipeline run.

Effective ARM command:

```
./mvnw -s .github/workflows/settings.xml clean package -B -Dmaven.test.failure.ignore=true -P ci-integration-tests -P docker-images -Ddocker.platforms=linux/arm64/v8
```