### PR TITLE
Fix two flaky storage tests

### DIFF
--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/FrequencySketchTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/chm/FrequencySketchTest.java
@@ -158,11 +158,12 @@ public class FrequencySketchTest {
   // ---- reset (aging) triggered by sampleSize ----
 
   /**
-   * After exactly {@code sampleSize = 10 * capacity} distinct increments the sketch halves all
-   * counters (the {@code reset()} aging step). We verify that a key incremented to frequency 15
-   * drops to approximately 7–8 after a reset. The exact post-reset value is
-   * {@code (15 >> 1) = 7} for a fully-saturated counter. This exercises the {@code reset()}
-   * private method that {@code increment()} calls when {@code ++size == sampleSize}.
+   * After roughly {@code sampleSize = 10 * capacity} distinct increments the sketch halves all
+   * counters (the {@code reset()} aging step). We saturate one key to frequency 15, drive the
+   * sketch to the reset, and stop the instant the reset fires. Its counter must then read exactly
+   * {@code (15 >> 1) = 7}: the read happens before any later increment can collide with the
+   * halved counter and inflate it. This exercises the {@code reset()} private method that
+   * {@code increment()} calls when {@code ++size == sampleSize}.
    */
   @Test
   public void testResetHalvesCountersAfterSampleWindow() {
@@ -183,23 +184,36 @@ public class FrequencySketchTest {
     }
     Assert.assertEquals("frequency must be 15 before reset", 15, sketch.frequency(targetHash));
 
-    // Now drive 'size' up to sampleSize (40) by incrementing a high-entropy set of distinct
-    // keys. We need size to reach 40 from 15, so 25 more increments of sufficiently-distinct
-    // keys (each adds 1 to size if at least one counter was not already at 15).
-    for (int i = 0; i < 30; i++) {
-      // Use large spread keys unlikely to hash to the same slot as targetHash.
-      sketch.increment(i * 100_003 + 37);
+    // Drive 'size' toward sampleSize (40) with high-entropy distinct keys until the aging reset()
+    // fires, then stop the instant it does. The saturated key's four counters are pinned at the
+    // maximum of 15, so any filler key that collides in one of those slots hits an
+    // already-saturated counter where incrementAt is a no-op; frequency(targetHash) therefore
+    // stays exactly 15 until reset() halves every counter in one pass.
+    //
+    // Reading at the exact reset boundary is what keeps this deterministic. The table has only a
+    // handful of slots, so a filler key incremented AFTER the reset can collide with targetHash's
+    // now-halved counters and push them back up. An earlier version of this test kept incrementing
+    // past the reset and so observed post-reset values of 8-9 instead of 7 under unlucky
+    // per-instance hash seeds. 'safetyBound' only guards against a pathological seed in which
+    // filler keys never advance 'size'; about 25 increments are needed in practice.
+    final int safetyBound = 10_000;
+    int filler = 0;
+    while (sketch.frequency(targetHash) == 15 && filler < safetyBound) {
+      // Large, well-spread keys so each one advances 'size' toward the reset threshold.
+      sketch.increment(filler * 100_003 + 37);
+      filler++;
     }
+    Assert.assertTrue(
+        "aging reset() did not fire within " + safetyBound + " filler increments",
+        filler < safetyBound);
 
-    // After reset(), the targetHash counter was halved: floor(15/2) = 7.
+    // reset() halves each counter, so the saturated key drops from 15 to floor(15/2) = 7. Because
+    // we stopped reading at the moment of the reset, no later collision could inflate it, so the
+    // post-reset frequency is deterministically 7.
     final int freqAfterReset = sketch.frequency(targetHash);
-    Assert.assertTrue(
-        "After reset(), frequency of the saturated key must be ≤ 8 (halved from 15), was "
-            + freqAfterReset,
-        freqAfterReset <= 8);
-    Assert.assertTrue(
-        "After reset(), frequency of the saturated key must be ≥ 1 (not zeroed), was "
-            + freqAfterReset,
-        freqAfterReset >= 1);
+    Assert.assertEquals(
+        "After reset(), the saturated key's frequency must be exactly floor(15/2) = 7",
+        7,
+        freqAfterReset);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/index/sbtree/singlevalue/v3/BTreeTestIT.java
@@ -864,6 +864,20 @@ public class BTreeTestIT {
       Random random,
       boolean keyInclusive,
       boolean ascSortOrder, AtomicOperation atomicOperation) {
+    // Deterministic boundary probe for the out-of-range fromKey case that originally crashed this
+    // test (a perturbed fromKey sorting past keyValues.lastKey()). Appending '\uffff' yields a key
+    // that sorts after every stored key, so "major" iteration from it must be empty in either
+    // order and the oracle must agree. Pinning it here keeps the regression from slipping back
+    // under an unlucky random seed.
+    final var pastLastKey = keyValues.lastKey() + "\uffff";
+    try (var stream =
+        singleValueTree.iterateEntriesMajor(
+            pastLastKey, keyInclusive, ascSortOrder, atomicOperation)) {
+      Assert.assertFalse(stream.iterator().hasNext());
+    }
+    Assert.assertFalse(
+        keyValues.tailMap(pastLastKey, keyInclusive).entrySet().iterator().hasNext());
+
     var keys = new String[keyValues.size()];
     var index = 0;
 
@@ -890,12 +904,17 @@ public class BTreeTestIT {
         if (ascSortOrder) {
           iterator = keyValues.tailMap(fromKey, keyInclusive).entrySet().iterator();
         } else {
+          // "Major" iteration returns every key >= fromKey, here in descending order. Build the
+          // oracle from tailMap(fromKey).descendingMap() rather than
+          // descendingMap().subMap(lastKey, ..., fromKey, ...): perturbKey can nudge fromKey
+          // lexicographically ABOVE keyValues.lastKey(). It drops the second-to-last char and
+          // shifts the last, so a longer key becomes a shorter one that can outrank the max — e.g.
+          // perturbKey("9949", -1) yields "998", which sorts after a last key of "995". A two-bound
+          // subMap throws IllegalArgumentException("fromKey > toKey") for such an out-of-range
+          // fromKey; tailMap clamps to the empty result instead — exactly what the B-tree itself
+          // returns for a fromKey past the last entry — and mirrors the ascending branch above.
           iterator =
-              keyValues
-                  .descendingMap()
-                  .subMap(keyValues.lastKey(), true, fromKey, keyInclusive)
-                  .entrySet()
-                  .iterator();
+              keyValues.tailMap(fromKey, keyInclusive).descendingMap().entrySet().iterator();
         }
 
         while (iterator.hasNext()) {


### PR DESCRIPTION
#### Motivation:

CI run [28166090811](https://github.com/JetBrains/youtrackdb/actions/runs/28166090811) on `develop` (commit `cc5288fd56`) failed on two tests. Both are seed-dependent flakes caused by assumptions in the **test** code; the production storage code is correct in both cases.

**`FrequencySketchTest#testResetHalvesCountersAfterSampleWindow` (Windows / JDK 21)** — asserted `frequency ≤ 8` after the aging `reset()` and saw 9. The test saturated a key to frequency 15, then ran a fixed 30-iteration filler loop to drive the reset. The `reset()` fires partway through the loop, and the remaining increments collide with the saturated key's now-halved counters (the sketch table has only four slots), pushing the reading above the guessed `≤ 8` bound under some per-instance hash seeds.

**`BTreeTestIT#testIterateEntriesMajor` (Small Cache IT)** — threw `IllegalArgumentException: fromKey > toKey` from inside `java.util.TreeMap`, i.e. the test's reference oracle. The descending oracle used `descendingMap().subMap(lastKey, true, fromKey, …)`. `perturbKey` drops a key's second-to-last char, so it can yield a `fromKey` sorting lexicographically above `lastKey()` (e.g. `perturbKey("9949",-1)="998" > "995"`); the two-bound `subMap` rejects that. The B-tree returns an empty result for an out-of-range `fromKey`, so only the oracle was wrong.

#### Changes

- **`FrequencySketchTest`** — the filler loop now stops the instant `reset()` fires (detected by the key's frequency dropping from 15) and asserts the post-reset value is exactly `7` (`floor(15/2)`). Reading at the reset boundary leaves no room for a later collision to inflate the counter, so the result is deterministic for any seed. Bounded-loop safety guard added; Javadoc/comments updated.
- **`BTreeTestIT`** — the descending oracle now uses `tailMap(fromKey, keyInclusive).descendingMap()`: identical to the old `subMap` for in-range bounds, but clamps to empty (never throws) for an out-of-range `fromKey`, matching the B-tree. Added a deterministic boundary probe (queries a key past the maximum on every run) so the regression cannot recur under an unlucky seed.

Both changes are test-only — no production code is modified.

#### Test plan

- [x] `FrequencySketchTest` — 8/8 pass.
- [x] `BTreeTestIT#testIterateEntriesMajor` (including the new boundary probe) passes under the exact CI profile (`small-cache-it`, `keysCount=10000`), BUILD SUCCESS.
- [x] `./mvnw -pl core spotless:check` clean.
- [x] Dimensional code + test-quality review (5 agents, opus): 0 blockers; all actionable findings applied and re-confirmed.