### PR TITLE
YTDB-1178: Diagnose back-reference loss in commit path

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -5195,9 +5195,13 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
                   + " has missing opposite link bag " + oppositeLinkBagPropertyName
                   + " on " + oppositeEntity.getIdentity();
           throw new LinksConsistencyException(this,
-              "Cannot remove link " + propertyName + " for " + entity
-                  + " from opposite entity " + oppositeEntity
-                  + " because required property does not exist");
+              describeMissingBackReference(
+                  "Cannot remove link " + propertyName + " for " + entity.getIdentity()
+                      + " from opposite entity " + oppositeEntity.getIdentity()
+                      + " because required opposite link bag property "
+                      + oppositeLinkBagPropertyName + " does not exist",
+                  entity, propertyName, oppositeEntity, oppositeLinkBagPropertyName,
+                  null, diff));
         }
         linkBag = new LinkBag(this);
         oppositeEntity.setPropertyInternal(oppositeLinkBagPropertyName, linkBag);
@@ -5219,9 +5223,18 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
                 : "New entity " + entity.getIdentity()
                     + " not found in opposite link bag " + oppositeLinkBagPropertyName
                     + " on " + oppositeEntity.getIdentity();
-            throw new LinksConsistencyException(this, "Cannot remove link " + rid
-                + " from opposite entity because it does not exist in opposite link bag : "
-                + oppositeLinkBagPropertyName);
+            // This violation is rare and so far reproduces only under heavy concurrency on
+            // weak-memory-model (ARM) hardware (LocalPaginatedStorageRestoreFromWALIT). The
+            // base phrase is preserved verbatim for log-grep continuity; the appended
+            // diagnostics capture the exact state so the next occurrence can be root-caused
+            // straight from CI logs without a reproduction.
+            throw new LinksConsistencyException(this,
+                describeMissingBackReference(
+                    "Cannot remove link " + rid
+                        + " from opposite entity because it does not exist in opposite link"
+                        + " bag : " + oppositeLinkBagPropertyName,
+                    entity, propertyName, oppositeEntity, oppositeLinkBagPropertyName,
+                    linkBag, diff));
           }
         }
       }
@@ -5229,6 +5242,104 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
       if (linkBag.isEmpty()) {
         oppositeEntity.removePropertyInternal(oppositeLinkBagPropertyName);
       }
+    }
+  }
+
+  /**
+   * Builds a diagnostic message for a back-reference consistency violation detected in
+   * {@link #updateOppositeLinks}. The violation means the opposite entity is missing the
+   * back-reference for the source link we are removing — either the back-reference bag
+   * exists but does not hold that entry, or the bag property is absent entirely
+   * ({@code oppositeLinkBag == null}). Either case should never happen, because each
+   * back-reference bag has a single writer. It has so far reproduced only rarely and only
+   * under heavy concurrency on weak-memory-model (ARM) hardware, so this method records the
+   * exact state at the point of failure: the source and opposite record identities and
+   * versions, the source's forward links, and the back-reference bag's type, size, pointer,
+   * and contents. With that state in the CI log the loss can be classified (whole bag lost
+   * vs. one entry lost vs. wrong bag type) without a local reproduction.
+   *
+   * <p>Every field is read inside {@link #appendDiagnosticField} so a failure while
+   * gathering diagnostics can never throw and mask the original consistency error. Reading
+   * {@code sourceForwardLinks} can force lazy deserialization of the source record, which is
+   * benign and idempotent on this already-failing path.
+   *
+   * @param baseMessage the human-readable violation summary, kept verbatim at the start so
+   *     existing log searches still match
+   * @param oppositeLinkBag the opposite entity's back-reference bag, or {@code null} when
+   *     the bag property is absent entirely
+   */
+  static String describeMissingBackReference(
+      String baseMessage,
+      EntityImpl sourceEntity,
+      String sourcePropertyName,
+      EntityImpl oppositeEntity,
+      String oppositeLinkBagPropertyName,
+      @Nullable LinkBag oppositeLinkBag,
+      int diff) {
+    var sb = new StringBuilder(256);
+    sb.append(baseMessage).append(" [diag");
+    appendDiagnosticField(sb, "sourceProperty", () -> sourcePropertyName);
+    appendDiagnosticField(sb, "source", () -> describeEntityState(sourceEntity));
+    appendDiagnosticField(
+        sb, "sourceForwardLinks",
+        () -> String.valueOf(sourceEntity.getPropertyInternal(sourcePropertyName, false)));
+    appendDiagnosticField(sb, "oppositeBagProperty", () -> oppositeLinkBagPropertyName);
+    appendDiagnosticField(sb, "opposite", () -> describeEntityState(oppositeEntity));
+    if (oppositeLinkBag == null) {
+      sb.append(" bag=absent");
+    } else {
+      appendDiagnosticField(sb, "bagType",
+          () -> oppositeLinkBag.isEmbedded() ? "embedded" : "btree");
+      appendDiagnosticField(sb, "bagSize", () -> Integer.toString(oppositeLinkBag.size()));
+      appendDiagnosticField(sb, "bagPointer", () -> String.valueOf(oppositeLinkBag.getPointer()));
+      appendDiagnosticField(sb, "bagContents", () -> dumpLinkBagContents(oppositeLinkBag));
+    }
+    appendDiagnosticField(sb, "diff", () -> Integer.toString(diff));
+    return sb.append(']').toString();
+  }
+
+  /** Renders identity, version, new-ness, and dirty state of a record for diagnostics. */
+  private static String describeEntityState(EntityImpl entity) {
+    var identity = entity.getIdentity();
+    return identity + " v" + entity.getVersion() + (identity.isNew() ? " NEW" : "")
+        + " dirty=" + entity.isDirty();
+  }
+
+  /**
+   * Lists the primary RIDs held by a back-reference bag, capped so a pathologically large
+   * bag cannot produce an unbounded log line. The dropped count is reported when the cap is
+   * hit so the reader still knows the true size.
+   */
+  private static String dumpLinkBagContents(LinkBag bag) {
+    final var max = 64;
+    var sb = new StringBuilder().append('[');
+    var i = 0;
+    for (var pair : bag) {
+      if (i >= max) {
+        sb.append(",...(").append(bag.size() - max).append(" more)");
+        break;
+      }
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(pair.primaryRid());
+      i++;
+    }
+    return sb.append(']').toString();
+  }
+
+  /**
+   * Appends {@code name=value} to the diagnostic buffer, substituting an error marker if
+   * the value supplier throws. This keeps diagnostic gathering total: a corrupt bag or an
+   * unloadable record degrades one field rather than masking the original error.
+   */
+  private static void appendDiagnosticField(
+      StringBuilder sb, String name, Supplier<Object> valueSupplier) {
+    sb.append(' ').append(name).append('=');
+    try {
+      sb.append(valueSupplier.get());
+    } catch (Throwable t) {
+      sb.append("<error:").append(t.getClass().getSimpleName()).append('>');
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbeddedBackReferenceDiagnosticsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbeddedBackReferenceDiagnosticsTest.java
@@ -1,0 +1,243 @@
+package com.jetbrains.youtrackdb.internal.core.db;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrackdb.internal.core.storage.ridbag.BTreeBasedLinkBag;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DatabaseSessionEmbedded#describeMissingBackReference}, the diagnostic
+ * builder used when commit-time back-reference maintenance ({@code updateOppositeLinks}) finds an
+ * opposite link bag that does not contain a link it is about to remove.
+ *
+ * <p>The underlying consistency violation is rare and reproduces only under heavy concurrency on
+ * weak-memory-model (ARM) hardware (see {@code LocalPaginatedStorageRestoreFromWALIT}), so it
+ * cannot be triggered deterministically. These tests instead exercise the diagnostic builder
+ * directly with constructed entities and bags to verify that: (1) the message carries the state a
+ * future investigator needs (source/opposite identity and version, the source's forward links, and
+ * the bag's type, size, pointer, and contents); (2) the original violation summary is preserved
+ * verbatim as the message prefix for log-grep continuity; and (3) gathering diagnostics is total —
+ * a null or failing input degrades a single named field instead of throwing and masking the real
+ * error. The bag-type (embedded/btree), new-entity, and cap-boundary branches are each pinned.
+ */
+public class DatabaseSessionEmbeddedBackReferenceDiagnosticsTest extends DbTestBase {
+
+  /** Creates a persisted, schemaless entity carrying one marker property so it gets a real RID. */
+  private EntityImpl newPersistentEntity(String marker) {
+    session.begin();
+    var entity = (EntityImpl) session.newEntity();
+    entity.setProperty("marker", marker);
+    session.commit();
+    return entity;
+  }
+
+  /**
+   * A populated embedded bag that is missing the source link: the message must keep the base
+   * summary as its exact prefix and then append the source/opposite state fields (full shape,
+   * including version and dirty flag), the source forward-links field, the opposite bag-property
+   * name, the bag type/size/pointer, and the bag contents and diff. This is the dominant signal —
+   * it tells the investigator whether the bag lost only this one entry (other RIDs still present)
+   * or something larger. Assertions pin whole fields, not scattered fragments, so a regression
+   * that drops a sub-field or mislabels one is caught.
+   */
+  @Test
+  public void diagnosticsCapturePopulatedBagState() {
+    var source = newPersistentEntity("source");
+    var opposite = newPersistentEntity("opposite");
+
+    session.begin();
+    var bag = new LinkBag(session);
+    var present1 = new RecordId(12, 100);
+    var present2 = new RecordId(12, 101);
+    bag.add(present1);
+    bag.add(present2);
+
+    var base = "Cannot remove link " + source.getIdentity()
+        + " from opposite entity because it does not exist in opposite link bag : #linkMap";
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        base, source, "linkMap", opposite, "#linkMap", bag, -1);
+    // Source/opposite are committed and untouched in this tx, so they render v<n> dirty=false.
+    var expectedSourceField =
+        "source=" + source.getIdentity() + " v" + source.getVersion() + " dirty=false";
+    var expectedOppositeField =
+        "opposite=" + opposite.getIdentity() + " v" + opposite.getVersion() + " dirty=false";
+    session.rollback();
+
+    // Base summary is the verbatim prefix, with the diagnostic block appended after it.
+    assertTrue(message, message.startsWith(base + " [diag"));
+    assertTrue(message, message.endsWith("]"));
+    assertTrue(message, message.contains("sourceProperty=linkMap"));
+    assertTrue(message, message.contains(expectedSourceField));
+    assertTrue(message, message.contains("sourceForwardLinks="));
+    assertTrue(message, message.contains("oppositeBagProperty=#linkMap"));
+    assertTrue(message, message.contains(expectedOppositeField));
+    assertTrue(message, message.contains("bagType=embedded"));
+    assertTrue(message, message.contains("bagSize=2"));
+    assertTrue(message, message.contains("bagPointer="));
+    // The RIDs the bag actually holds, as a unit — distinguishes "one entry lost" from "whole bag
+    // lost"; embedded-bag iteration is RID-ascending so the order is deterministic.
+    assertTrue(message, message.contains("bagContents=[" + present1 + "," + present2 + "]"));
+    assertTrue(message, message.contains("diff=-1"));
+  }
+
+  /**
+   * An empty bag is the "whole bag lost" signal. The message must report {@code bagSize=0} and an
+   * empty contents list rather than omitting the bag fields.
+   */
+  @Test
+  public void diagnosticsReportEmptyBag() {
+    var source = newPersistentEntity("source");
+    var opposite = newPersistentEntity("opposite");
+
+    session.begin();
+    var bag = new LinkBag(session);
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkMap", opposite, "#linkMap", bag, -1);
+    session.rollback();
+
+    assertTrue(message, message.contains("bagType=embedded"));
+    assertTrue(message, message.contains("bagSize=0"));
+    assertTrue(message, message.contains("bagContents=[]"));
+  }
+
+  /**
+   * When the opposite back-reference bag property is absent entirely (the {@code linkBag == null}
+   * branch of {@code updateOppositeLinks}), the message must say {@code bag=absent} and omit the
+   * bag size/type fields. No transaction is opened because no bag is constructed.
+   */
+  @Test
+  public void diagnosticsReportAbsentBag() {
+    var source = newPersistentEntity("source");
+    var opposite = newPersistentEntity("opposite");
+
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkMap", opposite, "#linkMap", null, -1);
+
+    assertTrue(message, message.contains("bag=absent"));
+    assertFalse(message, message.contains("bagSize="));
+  }
+
+  /**
+   * A B-tree-backed bag must render {@code bagType=btree} and take the
+   * {@code BTreeBasedLinkBag.getCollectionPointer()} arm of {@code getPointer()}. The delegate is
+   * injected directly (no {@code GlobalConfiguration} mutation, so this test stays parallel-safe)
+   * to exercise the non-embedded branch the embedded-bag tests cannot reach.
+   */
+  @Test
+  public void diagnosticsReportBtreeBagType() {
+    var source = newPersistentEntity("source");
+    var opposite = newPersistentEntity("opposite");
+
+    session.begin();
+    var bag = new LinkBag(session, new BTreeBasedLinkBag(session, Integer.MAX_VALUE));
+    assertFalse("delegate must be the B-tree implementation", bag.isEmbedded());
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkMap", opposite, "#linkMap", bag, -1);
+    session.rollback();
+
+    assertTrue(message, message.contains("bagType=btree"));
+    // getPointer() returns the collection pointer (null before persistence) for a btree bag.
+    assertTrue(message, message.contains("bagPointer="));
+  }
+
+  /**
+   * The contents dump is capped so a pathologically large bag cannot produce an unbounded log
+   * line; the dropped count is reported and the true size is still shown. Sixty-five entries
+   * exceeds the cap of 64 by one, so the dump shows "(1 more)".
+   */
+  @Test
+  public void diagnosticsCapLargeBagContents() {
+    var source = newPersistentEntity("source");
+    var opposite = newPersistentEntity("opposite");
+
+    session.begin();
+    var bag = new LinkBag(session);
+    for (var i = 0; i < 65; i++) {
+      bag.add(new RecordId(13, i));
+    }
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkMap", opposite, "#linkMap", bag, -1);
+    session.rollback();
+
+    assertTrue(message, message.contains("bagSize=65"));
+    // Cap of 64 leaves exactly one entry undumped.
+    assertTrue(message, message.contains("(1 more)"));
+  }
+
+  /**
+   * The other side of the cap boundary: a bag of exactly 64 entries must dump all of them with no
+   * truncation marker. Together with {@link #diagnosticsCapLargeBagContents} this pins the
+   * {@code i >= max} comparison from both sides so an off-by-one (e.g. {@code >} vs {@code >=}) is
+   * caught.
+   */
+  @Test
+  public void diagnosticsDumpExactlyAtCapEmitsNoMoreSuffix() {
+    var source = newPersistentEntity("source");
+    var opposite = newPersistentEntity("opposite");
+
+    session.begin();
+    var bag = new LinkBag(session);
+    for (var i = 0; i < 64; i++) {
+      bag.add(new RecordId(13, i));
+    }
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkMap", opposite, "#linkMap", bag, -1);
+    session.rollback();
+
+    assertTrue(message, message.contains("bagSize=64"));
+    assertFalse(message, message.contains(" more)"));
+  }
+
+  /**
+   * A not-yet-persisted source entity must render the {@code NEW} marker and its version, since
+   * whether the lost link involved a brand-new record is exactly the kind of state an investigator
+   * needs. Exercises the {@code identity.isNew()} true branch of {@code describeEntityState}.
+   */
+  @Test
+  public void diagnosticsMarkNewSourceEntity() {
+    var opposite = newPersistentEntity("opposite");
+
+    session.begin();
+    var newSource = (EntityImpl) session.newEntity();
+    var newId = newSource.getIdentity();
+    assertTrue("precondition: source identity is new", newId.isNew());
+    var bag = new LinkBag(session);
+    bag.add(new RecordId(16, 1));
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", newSource, "linkMap", opposite, "#linkMap", bag, -1);
+    session.rollback();
+
+    assertTrue(message, message.contains("source=" + newId + " v"));
+    assertTrue(message, message.contains(" NEW"));
+  }
+
+  /**
+   * Diagnostic gathering must be total: a failure while reading one field (here a null opposite
+   * entity, which makes the state reader throw a {@link NullPointerException}) is replaced by an
+   * error marker that names the exception class, so the original consistency exception is never
+   * masked and the investigator still sees why the field failed. Fields after the failing one must
+   * still be gathered.
+   */
+  @Test
+  public void diagnosticsAreDefensiveWhenAFieldThrows() {
+    var source = newPersistentEntity("source");
+
+    session.begin();
+    var bag = new LinkBag(session);
+    bag.add(new RecordId(14, 1));
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkMap", null, "#linkMap", bag, -1);
+    session.rollback();
+
+    // The opposite-entity field failed and degraded to a marker naming the exception class.
+    assertTrue(message, message.contains("opposite=<error:NullPointerException>"));
+    // Fields after the failing one are still gathered.
+    assertTrue(message, message.contains("bagType=embedded"));
+    assertTrue(message, message.contains("diff=-1"));
+  }
+}


### PR DESCRIPTION
#### Motivation:

`LocalPaginatedStorageRestoreFromWALIT.testSimpleRestore` failed on the **Linux arm – JDK 25** leg of [run 27026777420](https://github.com/JetBrains/youtrackdb/actions/runs/27026777420) (commit `9b49b201`). It passed on x86, macOS, and Windows, and on the ARM re-run — a flaky, ARM-only failure.

De-interleaving the concurrent-thread CI output, the test failed at `future.get()` with:

```
LinksConsistencyException: Cannot remove link #25:424 from opposite entity
because it does not exist in opposite link bag : #linkMap
```

thrown in commit pre-processing by `DatabaseSessionEmbedded.updateOppositeLinks`. Deleting a **persistent** `TestOne` decrements a target `TestTwo`'s `#linkMap` back-reference bag, but the source RID is missing from it. Assertions are enabled and the `assert !isNew()` guard did not fire, so the entity is persistent and the back-reference was genuinely lost in an earlier committed transaction. Each back-reference bag has a single writer per thread, so this is real loss — the same family as the prior, incomplete fix #936. (The `... is not opened` lines in the same log region are collateral from the seven abandoned writer threads after the test already failed.)

The bug is real but rare, did not reproduce on x86 in a 368 s run, and a prior six-file fix did not fully resolve it. Fixing it blind is risky and unverifiable here; catching the exception in the test would mask a genuine consistency bug that the final `DatabaseCompare` cannot detect (both copies share the loss); quarantining fixes nothing. So this PR makes the failure **diagnosable** instead.

#### What this changes

Diagnostic enrichment only — no behavior change, no fix, no mask. The exception still propagates, so the test still fails when the bug recurs.

- `DatabaseSessionEmbedded.updateOppositeLinks`: both `LinksConsistencyException` throw sites now build their message via a new `describeMissingBackReference` helper. It records the source and opposite **identity + version + dirty/new state**, the source's **forward links**, and the back-reference bag's **type (embedded/btree), size, pointer, and contents** (capped at 64 entries). With that state in the CI log, the next ARM occurrence can be classified (whole bag lost vs. one entry lost vs. wrong bag type) without a local reproduction.
- Gathering is per-field in `try/catch`, so a diagnostic failure can never mask the original error; it runs only on the throw path, so the success path keeps **zero overhead**. The original message phrase is preserved as the message prefix for log-grep continuity.
- New `DatabaseSessionEmbeddedBackReferenceDiagnosticsTest` (8 cases) exercises every branch of the builder directly (the concurrency bug itself is not deterministically reproducible).

#### Test plan

- [x] `./mvnw -pl core test -Dtest=DatabaseSessionEmbeddedBackReferenceDiagnosticsTest` — 8/8 pass
- [x] `./mvnw -pl core spotless:check` — clean
- [x] Full `core` unit suite — green
- [x] 6-dimension code + test review (code-quality, bugs/concurrency, performance, test-behavior/completeness/structure), PSI-backed — zero blockers, zero should-fix after one fix round

#### Follow-up

The underlying back-reference-loss bug in `updateOppositeLinks` remains open; these diagnostics give the next occurrence a place to land. The root-cause fix is tracked in [YTDB-1178](https://youtrack.jetbrains.com/issue/YTDB-1178).
