### PR TITLE
Add pi project settings: opus-4-8, xhigh thinking, hide thinking blocks

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,3 @@
+{
+  "defaultThinkingLevel": "xhigh"
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,5 @@
 {
-  "defaultThinkingLevel": "xhigh"
+  "defaultModel": "claude-opus-4-8",
+  "defaultThinkingLevel": "xhigh",
+  "hideThinkingBlock": true
 }


### PR DESCRIPTION
## Summary

Adds a project-level `.pi/settings.json` for the pi coding agent with:

- `defaultModel: claude-opus-4-8` (ships with a 1M-token context window)
- `defaultThinkingLevel: xhigh`
- `hideThinkingBlock: true` — hides the agent's thinking blocks in output

## Notes

These settings apply when pi is launched from this project directory (after trusting the project).