### PR TITLE
YTDB-1176: Short-circuit contradictory WHERE equalities to EmptyStep

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -9,6 +9,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.id.RecordIdInternal;
 import com.jetbrains.youtrackdb.internal.core.index.Index;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -992,12 +993,13 @@ public class SelectExecutionPlanner {
    * early-calculable literals. The result set is guaranteed empty without scanning.
    */
   static boolean isUnsatisfiableWhere(
-      @Nullable List<SQLAndBlock> flattenedWhereClause, CommandContext ctx) {
+      @Nullable List<SQLAndBlock> flattenedWhereClause, CommandContext ctx,
+      @Nullable SchemaClass clazz) {
     if (flattenedWhereClause == null || flattenedWhereClause.isEmpty()) {
       return false;
     }
     for (var block : flattenedWhereClause) {
-      if (!isUnsatisfiableAndBlock(block, ctx)) {
+      if (!isUnsatisfiableAndBlock(block, ctx, clazz)) {
         return false;
       }
     }
@@ -1005,28 +1007,34 @@ public class SelectExecutionPlanner {
   }
 
   /**
-   * Detects that one AND block can never match. Two independent reasons make a block empty:
+   * Detects that one AND block can never match. A block is provably empty when any of these holds
+   * on the same property:
    *
    * <ul>
    *   <li>an equality against the SQL {@code null} literal ({@code field = null}) — always false,
    *       so a single such condition empties the block;
-   *   <li>contradictory equality literals on the same property ({@code field = 'a' AND field =
-   *       'b'}) — the property would have to hold two different values at once; and
-   *   <li>a non-null equality and an {@code IS NULL} on the same property ({@code field = 'a' AND
-   *       field IS NULL}) — the property would have to be both a value and null.
+   *   <li>contradictory equality values ({@code field = 'a' AND field = 'b'}) — the property would
+   *       have to hold two different values at once; and
+   *   <li>a non-null equality and an {@code IS NULL} ({@code field = 'a' AND field IS NULL}) — the
+   *       property would have to be both a value and null.
    * </ul>
    *
-   * <p>Non-literal equalities (parameters, per-row expressions) are ignored — they cannot be
-   * resolved at plan time. The property may sit on either side of the operator, so both
+   * <p>The value operand of an equality is resolved at plan time when it is a literal or a bound
+   * parameter — both of which the engine can evaluate up front; a per-row expression cannot be
+   * resolved and is ignored. The property may sit on either side of the operator, so both
    * {@code field = 'a'} and {@code 'a' = field} are recognised.
    *
-   * <p>Two literals count as contradictory only when the engine's own equality
-   * ({@link QueryOperatorEquals#equals}) reports them unequal. That is the same comparison the
-   * runtime filter applies, so numeric and cross-type coercion is honoured: {@code field = 1 AND
-   * field = 1.0} stays satisfiable rather than being misread as empty. Using strict
-   * {@link Objects#equals} here would drop rows for such queries.
+   * <p>Two equality values are contradictory only when they stay distinct after coercion to the
+   * property's declared type, compared with the engine's own type-aware equality. The runtime
+   * filter coerces each literal to the stored value's type, so {@code n = '5' AND n = '05'} on an
+   * INTEGER property is satisfiable — both coerce to {@code 5} — and must not be read as empty.
+   * Comparing the raw literals ({@code Objects.equals}, or the untyped equality) would drop that
+   * row. When the property type is unknown — a schemaless field, or {@code clazz} did not resolve —
+   * the coercion cannot be reproduced, so the equality-contradiction check is skipped; the
+   * type-independent {@code = null} and {@code IS NULL} contradictions still apply.
    */
-  static boolean isUnsatisfiableAndBlock(SQLAndBlock block, CommandContext ctx) {
+  static boolean isUnsatisfiableAndBlock(
+      SQLAndBlock block, CommandContext ctx, @Nullable SchemaClass clazz) {
     Map<String, List<Object>> literalEqualities = new HashMap<>();
     Set<String> nullRequiredProperties = new HashSet<>();
     for (var expr : block.getSubBlocks()) {
@@ -1071,28 +1079,68 @@ public class SelectExecutionPlanner {
       literalEqualities.computeIfAbsent(property, k -> new ArrayList<>()).add(value);
     }
     var session = ctx.getDatabaseSession();
-    for (var values : literalEqualities.values()) {
+    for (var entry : literalEqualities.entrySet()) {
+      var values = entry.getValue();
       if (values.size() < 2) {
+        continue;
+      }
+      // The runtime filter coerces each literal to the property's stored type, so two values only
+      // prove the block empty when they stay distinct under that same coercion. Without the
+      // declared type (schemaless field, or the class did not resolve) the coercion is unknown, so
+      // the contradiction cannot be proven and the block is left to normal planning.
+      var type = propertyType(clazz, entry.getKey());
+      if (type == null) {
         continue;
       }
       var first = values.getFirst();
       for (var i = 1; i < values.size(); i++) {
-        // Compare with the engine's coercing equality, not Objects.equals: the runtime filter
-        // treats e.g. 1 and 1.0 as equal, so only a value the filter also rejects proves the
-        // block empty. Objects.equals would falsely flag mixed-type-but-equal literals.
-        if (!QueryOperatorEquals.equals(session, first, values.get(i))) {
+        if (literalsProvablyDistinct(session, first, values.get(i), type)) {
           return true;
         }
       }
     }
-    // A property required to be null (IS NULL) cannot also equal a non-null literal. The literal
-    // map never holds null values, because `= null` is rejected above, so any overlap contradicts.
+    // A property forced null by IS NULL cannot also satisfy an equality on the same property: a
+    // non-null value contradicts IS NULL, and an equality whose value is null (a `= null` literal
+    // returns above; a parameter bound to null reaches the map) matches no row on its own. Either
+    // way, a property in both maps empties the block.
     for (var nullProperty : nullRequiredProperties) {
       if (literalEqualities.containsKey(nullProperty)) {
         return true;
       }
     }
     return false;
+  }
+
+  /**
+   * The declared type of {@code property} on {@code clazz}, or {@code null} when the class is
+   * unresolved, the property is not declared (schemaless), or the property has no type.
+   */
+  @Nullable private static PropertyTypeInternal propertyType(
+      @Nullable SchemaClass clazz, String property) {
+    if (clazz == null) {
+      return null;
+    }
+    var declared = clazz.getProperty(property);
+    if (declared == null) {
+      return null;
+    }
+    return PropertyTypeInternal.convertFromPublicType(declared.getType());
+  }
+
+  /**
+   * True when {@code a} and {@code b} stay unequal after coercion to {@code type}, so no stored
+   * value of that type can equal both. Uses the engine's type-aware equality so the plan-time test
+   * matches the runtime filter. A literal that cannot be coerced to {@code type} matches no row at
+   * runtime, but coercing it here can throw; that case is treated as "not provably distinct" so a
+   * query that used to run is never turned into a plan-time failure.
+   */
+  private static boolean literalsProvablyDistinct(
+      @Nullable DatabaseSessionEmbedded session, Object a, Object b, PropertyTypeInternal type) {
+    try {
+      return !QueryOperatorEquals.equals(session, a, b, type);
+    } catch (RuntimeException ignore) {
+      return false;
+    }
   }
 
   /**
@@ -2214,7 +2262,8 @@ public class SelectExecutionPlanner {
       CommandContext ctx,
       boolean profilingEnabled) {
     var identifier = from.getItem().getIdentifier();
-    if (isUnsatisfiableWhere(info.flattenedWhereClause, ctx)) {
+    var targetClass = getSchemaFromContext(ctx).getClass(identifier.getStringValue());
+    if (isUnsatisfiableWhere(info.flattenedWhereClause, ctx, targetClass)) {
       plan.chain(new EmptyStep(ctx, profilingEnabled));
       // The predicate is provably empty. Clear the WHERE so handleWhere() does not append a dead
       // FilterStep over the already-empty stream, matching how the index paths consume the WHERE.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -985,6 +985,63 @@ public class SelectExecutionPlanner {
   }
 
   /**
+   * Returns {@code true} when every OR branch in the flattened WHERE is provably unsatisfiable
+   * at plan time — e.g. {@code field = 'a' AND field = 'b'} on the same property with different
+   * early-calculable literals. The result set is guaranteed empty without scanning.
+   */
+  static boolean isUnsatisfiableWhere(
+      @Nullable List<SQLAndBlock> flattenedWhereClause, CommandContext ctx) {
+    if (flattenedWhereClause == null || flattenedWhereClause.isEmpty()) {
+      return false;
+    }
+    for (var block : flattenedWhereClause) {
+      if (!isUnsatisfiableAndBlock(block, ctx)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Detects contradictory equality literals on the same property inside one AND block.
+   * Non-literal equalities (parameters, per-row expressions) are ignored — they cannot be
+   * resolved at plan time.
+   */
+  static boolean isUnsatisfiableAndBlock(SQLAndBlock block, CommandContext ctx) {
+    Map<String, List<Object>> literalEqualities = new HashMap<>();
+    for (var expr : block.getSubBlocks()) {
+      if (!(expr instanceof SQLBinaryCondition cond)) {
+        continue;
+      }
+      if (!(cond.getOperator() instanceof SQLEqualsOperator)) {
+        continue;
+      }
+      var property = cond.getRelatedIndexPropertyName();
+      if (property == null) {
+        continue;
+      }
+      var right = cond.getRight();
+      if (right == null || !right.isEarlyCalculated(ctx)) {
+        continue;
+      }
+      Object value = right.execute((Result) null, ctx);
+      literalEqualities.computeIfAbsent(property, k -> new ArrayList<>()).add(value);
+    }
+    for (var values : literalEqualities.values()) {
+      if (values.size() < 2) {
+        continue;
+      }
+      var first = values.getFirst();
+      for (var i = 1; i < values.size(); i++) {
+        if (!Objects.equals(first, values.get(i))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * Adds synthetic projection items for ORDER BY expressions that are not already
    * present in the user's SELECT list.
    *
@@ -2103,6 +2160,10 @@ public class SelectExecutionPlanner {
       CommandContext ctx,
       boolean profilingEnabled) {
     var identifier = from.getItem().getIdentifier();
+    if (isUnsatisfiableWhere(info.flattenedWhereClause, ctx)) {
+      plan.chain(new EmptyStep(ctx, profilingEnabled));
+      return;
+    }
     if (handleClassAsTargetWithIndexedFunction(
         plan, identifier, info, ctx, profilingEnabled)) {
       plan.chain(new FilterByClassStep(identifier, ctx, profilingEnabled));

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -994,7 +994,7 @@ public class SelectExecutionPlanner {
    */
   static boolean isUnsatisfiableWhere(
       @Nullable List<SQLAndBlock> flattenedWhereClause, CommandContext ctx,
-      @Nullable SchemaClass clazz) {
+      SchemaClass clazz) {
     if (flattenedWhereClause == null || flattenedWhereClause.isEmpty()) {
       return false;
     }
@@ -1031,12 +1031,12 @@ public class SelectExecutionPlanner {
    * and must not be read as empty; likewise it applies the property's collate, so on a
    * case-insensitive STRING property {@code name = 'A' AND name = 'a'} is satisfiable and must not
    * be read as empty. Comparing the raw literals ({@code Objects.equals}, or the untyped equality)
-   * would drop those rows. When the property type is unknown — a schemaless field, or {@code clazz}
-   * did not resolve — the coercion cannot be reproduced, so the equality-contradiction check is
+   * would drop those rows. When the property type is unknown — a schemaless field whose property
+   * is not declared — the coercion cannot be reproduced, so the equality-contradiction check is
    * skipped; the type-independent {@code = null} and {@code IS NULL} contradictions still apply.
    */
   static boolean isUnsatisfiableAndBlock(
-      SQLAndBlock block, CommandContext ctx, @Nullable SchemaClass clazz) {
+      SQLAndBlock block, CommandContext ctx, SchemaClass clazz) {
     Map<String, List<Object>> literalEqualities = new HashMap<>();
     Set<String> nullRequiredProperties = new HashSet<>();
     for (var expr : block.getSubBlocks()) {
@@ -1099,10 +1099,10 @@ public class SelectExecutionPlanner {
       }
       // The runtime filter coerces each literal to the property's stored type and applies the
       // property's collate before comparing, so two values only prove the block empty when they
-      // stay distinct under that same coercion and collation. Without a declared type (schemaless
-      // field, or the class did not resolve) the coercion is unknown, so the contradiction cannot
-      // be proven and the block is left to normal planning.
-      var declared = clazz == null ? null : clazz.getProperty(entry.getKey());
+      // stay distinct under that same coercion and collation. Without a declared type — a
+      // schemaless field whose property is not declared — the coercion is unknown, so the
+      // contradiction cannot be proven and the block is left to normal planning.
+      var declared = clazz.getProperty(entry.getKey());
       if (declared == null) {
         continue;
       }
@@ -2280,7 +2280,13 @@ public class SelectExecutionPlanner {
       boolean profilingEnabled) {
     var identifier = from.getItem().getIdentifier();
     var targetClass = getSchemaFromContext(ctx).getClass(identifier.getStringValue());
-    if (isUnsatisfiableWhere(info.flattenedWhereClause, ctx, targetClass)) {
+    // Only short-circuit when the class resolves. A target whose name is not in the schema is left
+    // to the downstream handlers, which reject it (throwing "Class not found") — so a missing class
+    // errors consistently regardless of the WHERE, instead of a provably-empty predicate
+    // (e.g. `field = null`) silently turning that error into an empty result set. Resolved classes
+    // still short-circuit, including schemaless fields (class resolves, property undeclared).
+    if (targetClass != null
+        && isUnsatisfiableWhere(info.flattenedWhereClause, ctx, targetClass)) {
       plan.chain(new EmptyStep(ctx, profilingEnabled));
       // The predicate is provably empty. Clear the WHERE so handleWhere() does not append a dead
       // FilterStep over the already-empty stream, matching how the index paths consume the WHERE.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -15,6 +15,7 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyTyp
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Schema;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
+import com.jetbrains.youtrackdb.internal.core.sql.operator.QueryOperatorEquals;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.AggregateProjectionSplit;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLAndBlock;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBaseExpression;
@@ -1006,6 +1007,12 @@ public class SelectExecutionPlanner {
    * Detects contradictory equality literals on the same property inside one AND block.
    * Non-literal equalities (parameters, per-row expressions) are ignored — they cannot be
    * resolved at plan time.
+   *
+   * <p>Two literals count as contradictory only when the engine's own equality
+   * ({@link QueryOperatorEquals#equals}) reports them unequal. That is the same comparison the
+   * runtime filter applies, so numeric and cross-type coercion is honoured: {@code field = 1 AND
+   * field = 1.0} stays satisfiable rather than being misread as empty. Using strict
+   * {@link Objects#equals} here would drop rows for such queries.
    */
   static boolean isUnsatisfiableAndBlock(SQLAndBlock block, CommandContext ctx) {
     Map<String, List<Object>> literalEqualities = new HashMap<>();
@@ -1027,13 +1034,17 @@ public class SelectExecutionPlanner {
       Object value = right.execute((Result) null, ctx);
       literalEqualities.computeIfAbsent(property, k -> new ArrayList<>()).add(value);
     }
+    var session = ctx.getDatabaseSession();
     for (var values : literalEqualities.values()) {
       if (values.size() < 2) {
         continue;
       }
       var first = values.getFirst();
       for (var i = 1; i < values.size(); i++) {
-        if (!Objects.equals(first, values.get(i))) {
+        // Compare with the engine's coercing equality, not Objects.equals: the runtime filter
+        // treats e.g. 1 and 1.0 as equal, so only a value the filter also rejects proves the
+        // block empty. Objects.equals would falsely flag mixed-type-but-equal literals.
+        if (!QueryOperatorEquals.equals(session, first, values.get(i))) {
           return true;
         }
       }
@@ -2162,6 +2173,10 @@ public class SelectExecutionPlanner {
     var identifier = from.getItem().getIdentifier();
     if (isUnsatisfiableWhere(info.flattenedWhereClause, ctx)) {
       plan.chain(new EmptyStep(ctx, profilingEnabled));
+      // The predicate is provably empty. Clear the WHERE so handleWhere() does not append a dead
+      // FilterStep over the already-empty stream, matching how the index paths consume the WHERE.
+      info.whereClause = null;
+      info.flattenedWhereClause = null;
       return;
     }
     if (handleClassAsTargetWithIndexedFunction(

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -3293,10 +3293,17 @@ public class SelectExecutionPlanner {
         //try to mere first condition with the rest of the conditions too
         var resultingExpressions = new ArrayList<SQLBooleanExpression>(2);
 
+        // The merge collapses two equalities on the same property into one index key. Pass the
+        // property collate so values that are equal only under it (e.g. 'A' and 'a' on a
+        // case-insensitive property) still merge and keep using the index instead of dropping to a
+        // full scan.
+        var mergeProperty = clazz.getProperty(indexPropertyName);
+        var mergeCollate = mergeProperty == null ? null : mergeProperty.getCollate();
+
         var firstExpression = expressions.getFirst();
         var expressionToMerge = expressions.get(1);
 
-        var mergedExpression = firstExpression.mergeUsingAnd(expressionToMerge, ctx);
+        var mergedExpression = firstExpression.mergeUsingAnd(expressionToMerge, ctx, mergeCollate);
         if (mergedExpression != null) {
           expressionToMerge = mergedExpression;
         } else {
@@ -3306,7 +3313,8 @@ public class SelectExecutionPlanner {
         if (expressions.size() > 2) {
           for (var i = 2; i < expressions.size(); i++) {
             var nextBlockToMerge = expressions.get(i);
-            expressionToMerge = expressionToMerge.mergeUsingAnd(nextBlockToMerge, ctx);
+            expressionToMerge =
+                expressionToMerge.mergeUsingAnd(nextBlockToMerge, ctx, mergeCollate);
 
             //unable to merge expressions
             if (expressionToMerge == null) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -31,6 +31,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIdentifier;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIndexIdentifier;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLInputParameter;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLInteger;
+import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLIsNullCondition;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLLetClause;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLLetItem;
 import com.jetbrains.youtrackdb.internal.core.sql.parser.SQLMetadataIdentifier;
@@ -1004,9 +1005,20 @@ public class SelectExecutionPlanner {
   }
 
   /**
-   * Detects contradictory equality literals on the same property inside one AND block.
-   * Non-literal equalities (parameters, per-row expressions) are ignored — they cannot be
-   * resolved at plan time.
+   * Detects that one AND block can never match. Two independent reasons make a block empty:
+   *
+   * <ul>
+   *   <li>an equality against the SQL {@code null} literal ({@code field = null}) — always false,
+   *       so a single such condition empties the block;
+   *   <li>contradictory equality literals on the same property ({@code field = 'a' AND field =
+   *       'b'}) — the property would have to hold two different values at once; and
+   *   <li>a non-null equality and an {@code IS NULL} on the same property ({@code field = 'a' AND
+   *       field IS NULL}) — the property would have to be both a value and null.
+   * </ul>
+   *
+   * <p>Non-literal equalities (parameters, per-row expressions) are ignored — they cannot be
+   * resolved at plan time. The property may sit on either side of the operator, so both
+   * {@code field = 'a'} and {@code 'a' = field} are recognised.
    *
    * <p>Two literals count as contradictory only when the engine's own equality
    * ({@link QueryOperatorEquals#equals}) reports them unequal. That is the same comparison the
@@ -1016,22 +1028,46 @@ public class SelectExecutionPlanner {
    */
   static boolean isUnsatisfiableAndBlock(SQLAndBlock block, CommandContext ctx) {
     Map<String, List<Object>> literalEqualities = new HashMap<>();
+    Set<String> nullRequiredProperties = new HashSet<>();
     for (var expr : block.getSubBlocks()) {
+      // `field IS NULL` forces the property to be null; record it and cross-check against non-null
+      // equalities on the same property after the loop.
+      if (expr instanceof SQLIsNullCondition isNull) {
+        var target = isNull.getExpression();
+        if (target != null && target.isBaseIdentifier()) {
+          nullRequiredProperties.add(target.getDefaultAlias().getStringValue());
+        }
+        continue;
+      }
       if (!(expr instanceof SQLBinaryCondition cond)) {
         continue;
+      }
+      // `X = null` is always false, so one such condition makes the whole AND block empty.
+      if (cond.isEqualityWithNullLiteral()) {
+        return true;
       }
       if (!(cond.getOperator() instanceof SQLEqualsOperator)) {
         continue;
       }
-      var property = cond.getRelatedIndexPropertyName();
-      if (property == null) {
-        continue;
-      }
+      // The property can be on either side of '='; the literal is whatever the other side is,
+      // provided it resolves at plan time. Skip conditions with no bare property (e.g. field =
+      // field) or a non-literal operand.
+      var left = cond.getLeft();
       var right = cond.getRight();
-      if (right == null || !right.isEarlyCalculated(ctx)) {
+      String property;
+      SQLExpression valueExpr;
+      if (left != null && left.isBaseIdentifier() && right != null
+          && right.isEarlyCalculated(ctx)) {
+        property = left.getDefaultAlias().getStringValue();
+        valueExpr = right;
+      } else if (right != null && right.isBaseIdentifier()
+          && left != null && left.isEarlyCalculated(ctx)) {
+        property = right.getDefaultAlias().getStringValue();
+        valueExpr = left;
+      } else {
         continue;
       }
-      Object value = right.execute((Result) null, ctx);
+      Object value = valueExpr.execute((Result) null, ctx);
       literalEqualities.computeIfAbsent(property, k -> new ArrayList<>()).add(value);
     }
     var session = ctx.getDatabaseSession();
@@ -1047,6 +1083,13 @@ public class SelectExecutionPlanner {
         if (!QueryOperatorEquals.equals(session, first, values.get(i))) {
           return true;
         }
+      }
+    }
+    // A property required to be null (IS NULL) cannot also equal a non-null literal. The literal
+    // map never holds null values, because `= null` is rejected above, so any overlap contradicts.
+    for (var nullProperty : nullRequiredProperties) {
+      if (literalEqualities.containsKey(nullProperty)) {
+        return true;
       }
     }
     return false;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectExecutionPlanner.java
@@ -12,8 +12,8 @@ import com.jetbrains.youtrackdb.internal.core.index.Index;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaInternal;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Collate;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
-import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Schema;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.sql.operator.QueryOperatorEquals;
@@ -1025,13 +1025,15 @@ public class SelectExecutionPlanner {
    * {@code field = 'a'} and {@code 'a' = field} are recognised.
    *
    * <p>Two equality values are contradictory only when they stay distinct after coercion to the
-   * property's declared type, compared with the engine's own type-aware equality. The runtime
-   * filter coerces each literal to the stored value's type, so {@code n = '5' AND n = '05'} on an
-   * INTEGER property is satisfiable — both coerce to {@code 5} — and must not be read as empty.
-   * Comparing the raw literals ({@code Objects.equals}, or the untyped equality) would drop that
-   * row. When the property type is unknown — a schemaless field, or {@code clazz} did not resolve —
-   * the coercion cannot be reproduced, so the equality-contradiction check is skipped; the
-   * type-independent {@code = null} and {@code IS NULL} contradictions still apply.
+   * property's declared type and application of its collate, compared with the engine's own
+   * type-aware equality. The runtime filter coerces each literal to the stored value's type, so
+   * {@code n = '5' AND n = '05'} on an INTEGER property is satisfiable — both coerce to {@code 5} —
+   * and must not be read as empty; likewise it applies the property's collate, so on a
+   * case-insensitive STRING property {@code name = 'A' AND name = 'a'} is satisfiable and must not
+   * be read as empty. Comparing the raw literals ({@code Objects.equals}, or the untyped equality)
+   * would drop those rows. When the property type is unknown — a schemaless field, or {@code clazz}
+   * did not resolve — the coercion cannot be reproduced, so the equality-contradiction check is
+   * skipped; the type-independent {@code = null} and {@code IS NULL} contradictions still apply.
    */
   static boolean isUnsatisfiableAndBlock(
       SQLAndBlock block, CommandContext ctx, @Nullable SchemaClass clazz) {
@@ -1075,7 +1077,18 @@ public class SelectExecutionPlanner {
       } else {
         continue;
       }
-      Object value = valueExpr.execute((Result) null, ctx);
+      // Resolve the value operand up front. A bound parameter that is unbound or bound to null
+      // resolves to null and is recorded as an always-false `field = null` equality (matching the
+      // runtime filter). A constant fold that throws when evaluated at plan time (e.g. `1 / 0`)
+      // must not abort planning: on an empty or non-matching scan the runtime filter never
+      // evaluates it, so leave the operand to normal planning rather than turning a query that
+      // used to run into a plan-time failure.
+      Object value;
+      try {
+        value = valueExpr.execute((Result) null, ctx);
+      } catch (RuntimeException ignore) {
+        continue;
+      }
       literalEqualities.computeIfAbsent(property, k -> new ArrayList<>()).add(value);
     }
     var session = ctx.getDatabaseSession();
@@ -1084,17 +1097,23 @@ public class SelectExecutionPlanner {
       if (values.size() < 2) {
         continue;
       }
-      // The runtime filter coerces each literal to the property's stored type, so two values only
-      // prove the block empty when they stay distinct under that same coercion. Without the
-      // declared type (schemaless field, or the class did not resolve) the coercion is unknown, so
-      // the contradiction cannot be proven and the block is left to normal planning.
-      var type = propertyType(clazz, entry.getKey());
+      // The runtime filter coerces each literal to the property's stored type and applies the
+      // property's collate before comparing, so two values only prove the block empty when they
+      // stay distinct under that same coercion and collation. Without a declared type (schemaless
+      // field, or the class did not resolve) the coercion is unknown, so the contradiction cannot
+      // be proven and the block is left to normal planning.
+      var declared = clazz == null ? null : clazz.getProperty(entry.getKey());
+      if (declared == null) {
+        continue;
+      }
+      var type = PropertyTypeInternal.convertFromPublicType(declared.getType());
       if (type == null) {
         continue;
       }
+      var collate = declared.getCollate();
       var first = values.getFirst();
       for (var i = 1; i < values.size(); i++) {
-        if (literalsProvablyDistinct(session, first, values.get(i), type)) {
+        if (literalsProvablyDistinct(session, first, values.get(i), type, collate)) {
           return true;
         }
       }
@@ -1112,31 +1131,29 @@ public class SelectExecutionPlanner {
   }
 
   /**
-   * The declared type of {@code property} on {@code clazz}, or {@code null} when the class is
-   * unresolved, the property is not declared (schemaless), or the property has no type.
-   */
-  @Nullable private static PropertyTypeInternal propertyType(
-      @Nullable SchemaClass clazz, String property) {
-    if (clazz == null) {
-      return null;
-    }
-    var declared = clazz.getProperty(property);
-    if (declared == null) {
-      return null;
-    }
-    return PropertyTypeInternal.convertFromPublicType(declared.getType());
-  }
-
-  /**
-   * True when {@code a} and {@code b} stay unequal after coercion to {@code type}, so no stored
-   * value of that type can equal both. Uses the engine's type-aware equality so the plan-time test
-   * matches the runtime filter. A literal that cannot be coerced to {@code type} matches no row at
-   * runtime, but coercing it here can throw; that case is treated as "not provably distinct" so a
-   * query that used to run is never turned into a plan-time failure.
+   * True when {@code a} and {@code b} stay unequal after coercion to {@code type} and application
+   * of {@code collate}, so no stored value of that type can equal both. Mirrors the runtime filter
+   * ({@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCondition#evaluate}): the
+   * property's collate is applied to each operand before the engine's type-aware equality, so a
+   * case-insensitive property treats {@code 'A'} and {@code 'a'} as equal (satisfiable) rather than
+   * distinct. A literal that cannot be coerced to {@code type}, or a collate that rejects the
+   * value, matches no row at runtime, but doing that work here can throw; that case is treated as
+   * "not provably distinct" so a query that used to run is never turned into a plan-time failure.
    */
   private static boolean literalsProvablyDistinct(
-      @Nullable DatabaseSessionEmbedded session, Object a, Object b, PropertyTypeInternal type) {
+      @Nullable DatabaseSessionEmbedded session, Object a, Object b, PropertyTypeInternal type,
+      @Nullable Collate collate) {
     try {
+      if (collate != null) {
+        // Guard nulls: `equals(x, null)` is already false, and not every Collate implementation is
+        // null-safe in transform().
+        if (a != null) {
+          a = collate.transform(a);
+        }
+        if (b != null) {
+          b = collate.transform(b);
+        }
+      }
       return !QueryOperatorEquals.equals(session, a, b, type);
     } catch (RuntimeException ignore) {
       return false;
@@ -2297,10 +2314,11 @@ public class SelectExecutionPlanner {
       orderByRidAsc = false;
     }
     var className = identifier.getStringValue();
-    Schema schema = getSchemaFromContext(ctx);
 
     AbstractExecutionStep fetcher;
-    if (schema.getClass(className) != null) {
+    // Reuse the class resolved at the top of the method for the empty-WHERE check instead of
+    // looking it up again.
+    if (targetClass != null) {
       fetcher =
           new FetchFromClassExecutionStep(
               className, null, info, ctx, orderByRidAsc, profilingEnabled);

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCompareOperator.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCompareOperator.java
@@ -231,7 +231,8 @@ public interface SQLBinaryCompareOperator {
         if (result <= 0) {
           yield new MergeResult(this, currentRight);
         }
-        yield new MergeResult(otherOperator, otherOperator);
+        // Keep the other LE bound; its right operand is the value, not the operator.
+        yield new MergeResult(otherOperator, otherRight);
       }
 
       case SQLLtOperator lessThan -> {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
@@ -769,8 +769,11 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
       if (resultOperand != null) {
         var result = new SQLBinaryCondition(-1);
         result.left = left.copy();
-        result.operator = operator.copy();
-        result.right = new SQLValueExpression(resultOperand);
+        // Unwrap the MergeResult: the merged condition uses the operator and right value the merge
+        // produced, not the current operator with the whole record as its value. mergeWithOperator
+        // can also change the operator (e.g. GE + NE -> GT), so both fields must come from it.
+        result.operator = resultOperand.operator().copy();
+        result.right = new SQLValueExpression(resultOperand.mergedRightOperand());
 
         return result;
       }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
@@ -368,6 +368,17 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
     return right;
   }
 
+  /**
+   * True when this is an equality against the SQL {@code null} literal ({@code field = null} or
+   * {@code null = field}). Such a condition is always false — {@code equals(x, null)} never holds,
+   * even for a null-valued field ({@code IS NULL} is the way to match null) — so any AND block that
+   * contains it is unsatisfiable.
+   */
+  public boolean isEqualityWithNullLiteral() {
+    return operator instanceof SQLEqualsOperator
+        && ((left != null && left.isNull) || (right != null && right.isNull));
+  }
+
   public void setLeft(SQLExpression left) {
     this.left = left;
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBinaryCondition.java
@@ -8,6 +8,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Collate;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
@@ -758,6 +759,13 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
   @Override
   public SQLBooleanExpression mergeUsingAnd(SQLBooleanExpression other,
       @Nonnull CommandContext ctx) {
+    return mergeUsingAnd(other, ctx, null);
+  }
+
+  @Nullable
+  @Override
+  public SQLBooleanExpression mergeUsingAnd(SQLBooleanExpression other,
+      @Nonnull CommandContext ctx, @Nullable Collate collate) {
     if (other instanceof SQLBinaryCondition otherCondition) {
       if (!left.isBaseIdentifier() && !right.isEarlyCalculated(ctx)) {
         return null;
@@ -771,6 +779,27 @@ public final class SQLBinaryCondition extends SQLBooleanExpression {
 
       var otherRightValue = otherCondition.right.execute((Result) null, ctx);
       var rightValue = right.execute((Result) null, ctx);
+
+      // Apply the property collate to both equality operands so values that are equal only under the
+      // collate (e.g. 'A' and 'a' on a case-insensitive property) merge into one index lookup rather
+      // than leaving two conditions that no index key can express, which drops the plan to a full
+      // scan. Only equality operands are collated: a range merge keeps its raw bound so the ordering
+      // that picks the tighter bound is unchanged. transform() may reject a value, so a failure
+      // leaves the raw operands and the merge simply may not collapse them.
+      if (collate != null
+          && operator instanceof SQLEqualsOperator
+          && otherCondition.operator instanceof SQLEqualsOperator) {
+        try {
+          if (rightValue != null) {
+            rightValue = collate.transform(rightValue);
+          }
+          if (otherRightValue != null) {
+            otherRightValue = collate.transform(otherRightValue);
+          }
+        } catch (RuntimeException ignore) {
+          // leave the raw values untouched
+        }
+      }
 
       var resultOperand = operator.mergeWithOperator(ctx.getDatabaseSession(),
           otherCondition.operator,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBooleanExpression.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/parser/SQLBooleanExpression.java
@@ -6,6 +6,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Collate;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.sql.executor.IndexSearchInfo;
@@ -375,6 +376,17 @@ public abstract class SQLBooleanExpression extends SimpleNode {
   @Nullable
   public abstract SQLBooleanExpression mergeUsingAnd(SQLBooleanExpression other,
       @Nonnull CommandContext ctx);
+
+  /// As {@link #mergeUsingAnd(SQLBooleanExpression, CommandContext)}, but with the collate of the
+  /// property under test. It lets equality operands that are equal only under that collate (e.g.
+  /// `name = 'A'` and `name = 'a'` on a case-insensitive property) merge into one index lookup
+  /// instead of falling back to a full scan. The default ignores the collate and delegates to the
+  /// two-argument form; only conditions that compare operand values override this.
+  @Nullable
+  public SQLBooleanExpression mergeUsingAnd(SQLBooleanExpression other, @Nonnull CommandContext ctx,
+      @Nullable Collate collate) {
+    return mergeUsingAnd(other, ctx);
+  }
 
   @Nullable
   public IndexCandidate findIndex(IndexFinder info, CommandContext ctx) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -1,0 +1,109 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for plan-time detection of contradictory WHERE equalities on the same field.
+ *
+ * <p>{@code WHERE indexed = 'x' AND indexed = 'y'} must short-circuit to {@link EmptyStep}
+ * instead of falling back to a full class scan when the predicate is provably empty.
+ */
+public class ContradictoryWherePlannerTest extends TestUtilsFixture {
+
+  private String className;
+
+  @Before
+  public void setUpSchema() {
+    var clazz = createClassInstance();
+    className = clazz.getName();
+    clazz.createProperty("indexed", PropertyType.STRING);
+    clazz.createIndex(
+        className + ".indexed", SchemaClass.INDEX_TYPE.NOTUNIQUE, "indexed");
+
+    session.begin();
+    for (var i = 0; i < 10; i++) {
+      session.newInstance(className).setProperty("indexed", "v" + i);
+    }
+    session.commit();
+  }
+
+  /**
+   * Contradictory literal equalities on an indexed field must emit {@link EmptyStep} and return
+   * zero rows without scanning the class.
+   */
+  @Test
+  public void contradictoryIndexedEqualities_shortCircuitsToEmptyStep() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed = 'v2'")) {
+      var plan = rs.getExecutionPlan();
+      var firstStep = plan.getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for contradictory predicate, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse("contradictory predicate must return no rows", rs.hasNext());
+    }
+  }
+
+  /**
+   * A single indexed equality must still use the index lookup path.
+   */
+  @Test
+  public void singleIndexedEquality_usesIndexLookup() {
+    try (var rs = session.query("SELECT FROM " + className + " WHERE indexed = 'v1'")) {
+      var plan = rs.getExecutionPlan();
+      var firstStep = plan.getSteps().getFirst();
+      assertTrue(
+          "expected FetchFromIndexStep for singleton equality, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof FetchFromIndexStep);
+      assertTrue(rs.hasNext());
+      assertEquals("v1", rs.next().getProperty("indexed"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Redundant equalities with the same literal must not be classified as unsatisfiable at plan
+   * time (no {@link EmptyStep} short-circuit).
+   */
+  @Test
+  public void duplicateIndexedEquality_sameLiteral_doesNotShortCircuit() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed = 'v1'")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertFalse(
+          "duplicate same-value equalities must not use EmptyStep",
+          firstStep instanceof EmptyStep);
+    }
+  }
+
+  /**
+   * OR with one unsatisfiable branch and one satisfiable branch must still return matches from the
+   * satisfiable branch.
+   */
+  @Test
+  public void orWithOneContradictoryBranch_stillReturnsMatches() {
+    try (var rs =
+        session.query(
+            "SELECT FROM "
+                + className
+                + " WHERE (indexed = 'v1' AND indexed = 'v2') OR indexed = 'v0'")) {
+      assertFalse(
+          "OR with a satisfiable branch must not short-circuit to empty",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertTrue(rs.hasNext());
+      assertEquals("v0", rs.next().getProperty("indexed"));
+      assertFalse(rs.hasNext());
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,18 +73,24 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
   }
 
   /**
-   * Redundant equalities with the same literal must not be classified as unsatisfiable at plan
-   * time (no {@link EmptyStep} short-circuit).
+   * Redundant equalities with the same literal are satisfiable, so the detector must not flag them:
+   * the plan keeps the index lookup instead of short-circuiting to {@link EmptyStep}.
+   *
+   * <p>This asserts only that no short-circuit happens. Whether the index path then returns the
+   * matching row is a separate, pre-existing defect: two equalities on the same single-column index
+   * build a broken multi-key lookup that returns zero rows. That bug is outside this change (the
+   * planner never reaches it for the contradictory case, which now emits {@link EmptyStep}).
    */
   @Test
-  public void duplicateIndexedEquality_sameLiteral_doesNotShortCircuit() {
+  public void duplicateIndexedEquality_sameLiteral_isNotShortCircuited() {
     try (var rs =
         session.query(
             "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed = 'v1'")) {
       var firstStep = rs.getExecutionPlan().getSteps().getFirst();
-      assertFalse(
-          "duplicate same-value equalities must not use EmptyStep",
-          firstStep instanceof EmptyStep);
+      assertTrue(
+          "duplicate same-value equalities must keep the index lookup, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof FetchFromIndexStep);
     }
   }
 
@@ -103,6 +110,120 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
           rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
       assertTrue(rs.hasNext());
       assertEquals("v0", rs.next().getProperty("indexed"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Two equalities with the same numeric value but different literal types
+   * ({@code num = 1 AND num = 1.0}) are satisfiable, because the runtime filter coerces numbers.
+   * The planner must not treat them as contradictory: it must not short-circuit to
+   * {@link EmptyStep} and must return the {@code num = 1} row. Guards against a plan-time comparison
+   * that uses strict {@code Objects.equals} instead of the engine's coercing equality — that would
+   * emit {@link EmptyStep} here and drop the row.
+   *
+   * <p>The field is deliberately left non-indexed so the query runs through a full scan plus filter.
+   * That keeps the assertion focused on the coercion fix and clear of the separate index-path defect
+   * (repeated equality on an indexed field returns zero rows), which is out of scope here.
+   */
+  @Test
+  public void numericCoercion_sameValueDifferentType_isNotContradictory() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("num", PropertyType.INTEGER);
+    session.begin();
+    session.newInstance(cn).setProperty("num", 1);
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE num = 1 AND num = 1.0")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertFalse(
+          "num = 1 AND num = 1.0 is satisfiable under numeric coercion, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertTrue("expected the num=1 record to be returned", rs.hasNext());
+      assertEquals(1, (int) rs.next().getProperty("num"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Three distinct equality literals on the same field ({@code = 'v1' AND = 'v2' AND = 'v3'}) are
+   * contradictory and must short-circuit to {@link EmptyStep}. Exercises the multi-value branch of
+   * the detector (more than one comparison against the first value).
+   */
+  @Test
+  public void threeDistinctValues_shortCircuitsToEmptyStep() {
+    try (var rs =
+        session.query(
+            "SELECT FROM "
+                + className
+                + " WHERE indexed = 'v1' AND indexed = 'v2' AND indexed = 'v3'")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for three distinct equalities, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Contradiction detection is not gated on the field being indexed: a contradictory predicate on a
+   * non-indexed field must also short-circuit to {@link EmptyStep} instead of a full class scan.
+   */
+  @Test
+  public void contradictionOnNonIndexedField_shortCircuitsToEmptyStep() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("plain", PropertyType.STRING);
+    session.begin();
+    session.newInstance(cn).setProperty("plain", "x");
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE plain = 'a' AND plain = 'b'")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for contradiction on a non-indexed field, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Contradictory equalities supplied through bound named parameters must also short-circuit to
+   * {@link EmptyStep}: parameters are known at plan time, so the detector resolves them the same way
+   * as inline literals.
+   */
+  @Test
+  public void contradictoryBoundParameters_shortCircuitsToEmptyStep() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = :a AND indexed = :b",
+            Map.of("a", "v1", "b", "v2"))) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for contradictory bound parameters, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * {@code count(*)} over a contradictory predicate must still return exactly one row holding zero:
+   * the short-circuit feeds an empty stream to the aggregate, which is the same input the old
+   * full-scan-plus-filter path produced. Guards against the short-circuit swallowing the aggregate
+   * row.
+   */
+  @Test
+  public void countStarOverContradiction_returnsSingleZeroRow() {
+    try (var rs =
+        session.query(
+            "SELECT count(*) FROM " + className + " WHERE indexed = 'v1' AND indexed = 'v2'")) {
+      assertTrue("count(*) with no matches must still return one row", rs.hasNext());
+      assertEquals(0L, (Object) rs.next().getProperty("count(*)"));
       assertFalse(rs.hasNext());
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -74,15 +74,13 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
 
   /**
    * Redundant equalities with the same literal are satisfiable, so the detector must not flag them:
-   * the plan keeps the index lookup instead of short-circuiting to {@link EmptyStep}.
-   *
-   * <p>This asserts only that no short-circuit happens. Whether the index path then returns the
-   * matching row is a separate, pre-existing defect: two equalities on the same single-column index
-   * build a broken multi-key lookup that returns zero rows. That bug is outside this change (the
-   * planner never reaches it for the contradictory case, which now emits {@link EmptyStep}).
+   * the plan keeps the index lookup and returns the single matching row rather than short-circuiting
+   * to {@link EmptyStep}. Returning the row also depends on the same-field merge fix in
+   * {@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCondition#mergeUsingAnd}; see
+   * {@link RepeatedEqualityOnIndexTest} for the broader merge cases.
    */
   @Test
-  public void duplicateIndexedEquality_sameLiteral_isNotShortCircuited() {
+  public void duplicateIndexedEquality_sameLiteral_usesIndexAndReturnsRow() {
     try (var rs =
         session.query(
             "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed = 'v1'")) {
@@ -91,6 +89,9 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
           "duplicate same-value equalities must keep the index lookup, got "
               + firstStep.getClass().getSimpleName(),
           firstStep instanceof FetchFromIndexStep);
+      assertTrue(rs.hasNext());
+      assertEquals("v1", rs.next().getProperty("indexed"));
+      assertFalse(rs.hasNext());
     }
   }
 
@@ -122,9 +123,9 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
    * that uses strict {@code Objects.equals} instead of the engine's coercing equality — that would
    * emit {@link EmptyStep} here and drop the row.
    *
-   * <p>The field is deliberately left non-indexed so the query runs through a full scan plus filter.
-   * That keeps the assertion focused on the coercion fix and clear of the separate index-path defect
-   * (repeated equality on an indexed field returns zero rows), which is out of scope here.
+   * <p>The field is left non-indexed so the query runs through a full scan plus filter, keeping the
+   * assertion focused on the coercion fix in the detector. The indexed same-field merge path is
+   * covered separately by {@link RepeatedEqualityOnIndexTest}.
    */
   @Test
   public void numericCoercion_sameValueDifferentType_isNotContradictory() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrackdb.internal.core.sql.executor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -358,17 +359,112 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
   }
 
   /**
-   * Two {@code IS NULL} conditions on the same field are satisfiable (the field is simply null), so
-   * the detector must not treat them as contradictory: no {@link EmptyStep} short-circuit.
+   * Two {@code IS NULL} conditions on the same field are satisfiable — the field is simply null —
+   * so the detector must not treat them as contradictory. With a null-valued row present the plan
+   * must stay non-empty and return that row, proving the "satisfiable" claim against real data
+   * rather than only at plan-shape level.
    */
   @Test
-  public void doubleIsNullSameField_isNotContradictory() {
-    try (var rs =
-        session.query(
-            "SELECT FROM " + className + " WHERE indexed IS NULL AND indexed IS NULL")) {
+  public void doubleIsNullSameField_returnsNullRow() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("p", PropertyType.STRING);
+    session.begin();
+    session.newInstance(cn).setProperty("p", "x");
+    session.newInstance(cn); // second row leaves p null
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE p IS NULL AND p IS NULL")) {
       assertFalse(
           "two IS NULL on the same field must not short-circuit to empty",
           rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertTrue("the null-valued row must be returned", rs.hasNext());
+      assertNull("IS NULL must match the row whose property is null", rs.next().getProperty("p"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * {@code field = null} is always false even when a null-valued row exists: {@code = null} matches
+   * nothing, {@code IS NULL} is the null test. With one null row and one valued row present,
+   * {@code p = null} must short-circuit to {@link EmptyStep} and return nothing, while
+   * {@code p IS NULL} returns the null row. Proves the short-circuit matches runtime semantics on
+   * real null data, not only the plan shape.
+   */
+  @Test
+  public void equalityAgainstNull_isEmptyEvenWhenNullRowExists() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("p", PropertyType.STRING);
+    session.begin();
+    session.newInstance(cn).setProperty("p", "x");
+    session.newInstance(cn); // null-valued row
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE p = null")) {
+      assertTrue(
+          "p = null must short-circuit to EmptyStep",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertFalse("p = null must match no row, even the null one", rs.hasNext());
+    }
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE p IS NULL")) {
+      assertTrue("p IS NULL must match the null-valued row", rs.hasNext());
+      assertNull(rs.next().getProperty("p"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Two equalities against numeric string literals with the same value but different text
+   * ({@code num = '5' AND num = '05'}) are satisfiable on an INTEGER property: the runtime coerces
+   * each literal to the field type, so both become {@code 5}. The detector must coerce to the
+   * declared type before comparing; a raw string comparison ('5' vs '05') would wrongly short
+   * circuit to {@link EmptyStep} and drop the matching row.
+   */
+  @Test
+  public void numericStringLiterals_sameCoercedValue_isNotContradictory() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("num", PropertyType.INTEGER);
+    session.begin();
+    session.newInstance(cn).setProperty("num", 5);
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE num = '5' AND num = '05'")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertFalse(
+          "num = '5' AND num = '05' coerces to 5 = 5 and is satisfiable, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertTrue("expected the num=5 record to be returned", rs.hasNext());
+      assertEquals(5, (int) rs.next().getProperty("num"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * The contradiction check needs the declared type to reproduce the runtime coercion. On a
+   * schemaless field the type is unknown, so {@code n = '5' AND n = '05'} must not be flagged
+   * contradictory: the stored INTEGER {@code 5} matches both literals, and the row must be returned
+   * rather than dropped by a raw string comparison.
+   */
+  @Test
+  public void numericStringLiterals_schemalessField_isNotContradictory() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    session.begin();
+    session.newInstance(cn).setProperty("n", 5); // no declared property: schemaless
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE n = '5' AND n = '05'")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertFalse(
+          "a schemaless field must not be flagged contradictory, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertTrue("expected the schemaless n=5 record to be returned", rs.hasNext());
+      assertEquals(5, (int) rs.next().getProperty("n"));
+      assertFalse(rs.hasNext());
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -9,6 +9,7 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyTyp
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -370,6 +371,30 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
   }
 
   /**
+   * The IS NULL / equality cross-check must also fire when the equality's value is a parameter bound
+   * to {@code null}. {@code indexed IS NULL AND indexed = :p} with {@code :p = null} records a
+   * {@code field = null} equality in the value map, which combined with {@code IS NULL} still cannot
+   * match: IS NULL forces the field null, and {@code = null} matches nothing. This covers the
+   * null-parameter arm of the cross-check that the inline {@code = null} literal
+   * ({@link #equalityAndIsNullSameField_shortCircuitsToEmptyStep}) never reaches, because the
+   * literal form short-circuits earlier via {@code isEqualityWithNullLiteral}, before the value map
+   * is built.
+   */
+  @Test
+  public void isNullPlusNullBoundParameter_shortCircuitsToEmptyStep() {
+    var params = new HashMap<String, Object>();
+    params.put("p", null);
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed IS NULL AND indexed = :p", params)) {
+      assertTrue(
+          "IS NULL plus a null-bound parameter on the same field must short-circuit to EmptyStep",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
    * Two {@code IS NULL} conditions on the same field are satisfiable — the field is simply null —
    * so the detector must not treat them as contradictory. With a null-valued row present the plan
    * must stay non-empty and return that row, proving the "satisfiable" claim against real data
@@ -501,10 +526,13 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
   }
 
   /**
-   * The collate carve-out must also hold when the ci property is indexed: the index lowercases its
-   * keys, so {@code name = 'A' AND name = 'a'} is satisfiable and must keep the index lookup rather
-   * than short-circuiting. Exercises the collate fix through the same-field merge on a collated
-   * index.
+   * The collate carve-out must also hold when the ci property is indexed: {@code name = 'A' AND
+   * name = 'a'} is satisfiable — the values are equal under the collate — and must keep the index
+   * lookup. The same-field merge
+   * ({@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCondition#mergeUsingAnd})
+   * applies the property collate to the two equality operands, so both reduce to {@code 'a'} and
+   * fold into a single index key. Asserts {@link FetchFromIndexStep} so a regression that dropped
+   * the collated merge back to a full scan, while still returning the row, would fail the test.
    */
   @Test
   public void caseInsensitiveCollation_indexed_sameValueDifferentCase_returnsRow() {
@@ -516,7 +544,16 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
     session.newInstance(cn).setProperty("name", "a");
     session.commit();
 
-    assertSatisfiableReturns(cn, "name = 'A' AND name = 'a'", "name", "a");
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE name = 'A' AND name = 'a'")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "ci-collated 'A'/'a' must keep the index lookup, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof FetchFromIndexStep);
+      assertTrue("expected the collated row to be returned", rs.hasNext());
+      assertEquals("a", rs.next().getProperty("name"));
+      assertFalse(rs.hasNext());
+    }
   }
 
   /**
@@ -711,6 +748,32 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
   }
 
   /**
+   * Two non-null equality literals that cannot be coerced to the declared type
+   * ({@code num = 'abc' AND num = 'def'} on an INTEGER field) make the type-aware comparison in
+   * {@code literalsProvablyDistinct} throw while coercing. That failure must be swallowed and read
+   * as "not provably distinct", so the block falls through to normal planning instead of aborting
+   * the plan or short-circuiting to {@link EmptyStep}. Exercises the coercion-throws catch that the
+   * satisfiable coercion cases, where coercion succeeds, never reach. The class is empty, so the
+   * runtime filter never evaluates the uncoercible operands either: the query plans and runs to zero
+   * rows without throwing.
+   */
+  @Test
+  public void uncoercibleEqualityLiterals_coercionThrows_fallsThroughWithoutShortCircuit() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("num", PropertyType.INTEGER); // non-indexed: full scan + filter
+    // No rows seeded: the empty scan keeps the runtime filter from evaluating 'abc' / 'def' too.
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE num = 'abc' AND num = 'def'")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertFalse(
+          "an uncoercible-literal contradiction candidate must not short-circuit, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse("empty class must yield no rows and no exception", rs.hasNext());
+    }
+  }
+
+  /**
    * Operands the detector cannot resolve to a plan-time literal must fall through to normal
    * planning, not be read as contradictions. {@code indexed = indexed} (a field on both sides) is
    * always true, so combined with {@code indexed = 'v2'} the query must return the v2 row rather
@@ -735,6 +798,36 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
       assertFalse(
           "field = otherField must not be read as a contradiction",
           rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+    }
+  }
+
+  /**
+   * The detector groups equality candidates by property, so equalities on two different fields never
+   * contradict each other: {@code a = 'x' AND b = 'y'} is satisfiable and must plan normally and
+   * return the matching row. Guards against a future change that mis-keys the value map and
+   * cross-fires across properties.
+   */
+  @Test
+  public void distinctFieldsEachSatisfiable_doesNotShortCircuit() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("a", PropertyType.STRING);
+    clazz.createProperty("b", PropertyType.STRING);
+    session.begin();
+    var e = session.newInstance(cn);
+    e.setProperty("a", "x");
+    e.setProperty("b", "y");
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE a = 'x' AND b = 'y'")) {
+      assertFalse(
+          "equalities on distinct fields must not short-circuit to empty",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertTrue("the matching row must be returned", rs.hasNext());
+      var row = rs.next();
+      assertEquals("x", row.getProperty("a"));
+      assertEquals("y", row.getProperty("b"));
+      assertFalse(rs.hasNext());
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.math.BigDecimal;
+import java.util.Date;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +31,9 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
     clazz.createIndex(
         className + ".indexed", SchemaClass.INDEX_TYPE.NOTUNIQUE, "indexed");
 
+    // Seed 10 rows (indexed = v0..v9) so a failed short-circuit would fall back to a scan that
+    // returns rows, rather than a vacuously-empty class that would pass an EmptyStep assertion for
+    // the wrong reason.
     session.begin();
     for (var i = 0; i < 10; i++) {
       session.newInstance(className).setProperty("indexed", "v" + i);
@@ -37,22 +42,51 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
   }
 
   /**
+   * Assert that {@code SELECT FROM <className> WHERE <where>} short-circuits to {@link EmptyStep}
+   * and returns no rows. Factors out the plan-shape-plus-empty assertion repeated across the
+   * contradiction cases.
+   */
+  private void assertShortCircuitsToEmpty(String where) {
+    assertShortCircuitsToEmpty(className, where);
+  }
+
+  /** As {@link #assertShortCircuitsToEmpty(String)} but against an arbitrary class. */
+  private void assertShortCircuitsToEmpty(String clazz, String where) {
+    try (var rs = session.query("SELECT FROM " + clazz + " WHERE " + where)) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for '" + where + "', got " + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse("'" + where + "' must return no rows", rs.hasNext());
+    }
+  }
+
+  /**
+   * Assert that {@code SELECT FROM <clazz> WHERE <where>} is satisfiable — it must not short-circuit
+   * to {@link EmptyStep} — and returns exactly one row whose {@code prop} equals {@code expected}.
+   * Used by the coercion carve-out cases, where a regression to raw {@code Objects.equals} would
+   * wrongly emit {@link EmptyStep} and drop the row.
+   */
+  private void assertSatisfiableReturns(String clazz, String where, String prop, Object expected) {
+    try (var rs = session.query("SELECT FROM " + clazz + " WHERE " + where)) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertFalse(
+          "'" + where + "' is satisfiable and must not short-circuit, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertTrue("'" + where + "' must return the matching row", rs.hasNext());
+      assertEquals(expected, rs.next().getProperty(prop));
+      assertFalse("'" + where + "' must return exactly one row", rs.hasNext());
+    }
+  }
+
+  /**
    * Contradictory literal equalities on an indexed field must emit {@link EmptyStep} and return
    * zero rows without scanning the class.
    */
   @Test
   public void contradictoryIndexedEqualities_shortCircuitsToEmptyStep() {
-    try (var rs =
-        session.query(
-            "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed = 'v2'")) {
-      var plan = rs.getExecutionPlan();
-      var firstStep = plan.getSteps().getFirst();
-      assertTrue(
-          "expected EmptyStep for contradictory predicate, got "
-              + firstStep.getClass().getSimpleName(),
-          firstStep instanceof EmptyStep);
-      assertFalse("contradictory predicate must return no rows", rs.hasNext());
-    }
+    assertShortCircuitsToEmpty("indexed = 'v1' AND indexed = 'v2'");
   }
 
   /**
@@ -156,18 +190,7 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
    */
   @Test
   public void threeDistinctValues_shortCircuitsToEmptyStep() {
-    try (var rs =
-        session.query(
-            "SELECT FROM "
-                + className
-                + " WHERE indexed = 'v1' AND indexed = 'v2' AND indexed = 'v3'")) {
-      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
-      assertTrue(
-          "expected EmptyStep for three distinct equalities, got "
-              + firstStep.getClass().getSimpleName(),
-          firstStep instanceof EmptyStep);
-      assertFalse(rs.hasNext());
-    }
+    assertShortCircuitsToEmpty("indexed = 'v1' AND indexed = 'v2' AND indexed = 'v3'");
   }
 
   /**
@@ -224,6 +247,12 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
     try (var rs =
         session.query(
             "SELECT count(*) FROM " + className + " WHERE indexed = 'v1' AND indexed = 'v2'")) {
+      // The aggregate sits above the source, so EmptyStep is not the first step; assert it is
+      // present in the chain so a regression that counted via a full scan + filter (same 0L result)
+      // would not pass silently.
+      assertTrue(
+          "count(*) over a contradiction must short-circuit to EmptyStep",
+          rs.getExecutionPlan().getSteps().stream().anyMatch(s -> s instanceof EmptyStep));
       assertTrue("count(*) with no matches must still return one row", rs.hasNext());
       assertEquals(0L, (Object) rs.next().getProperty("count(*)"));
       assertFalse(rs.hasNext());
@@ -309,16 +338,7 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
    */
   @Test
   public void leftLiteralContradiction_shortCircuitsToEmptyStep() {
-    try (var rs =
-        session.query(
-            "SELECT FROM " + className + " WHERE 'v1' = indexed AND 'v2' = indexed")) {
-      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
-      assertTrue(
-          "expected EmptyStep for left-literal contradiction, got "
-              + firstStep.getClass().getSimpleName(),
-          firstStep instanceof EmptyStep);
-      assertFalse(rs.hasNext());
-    }
+    assertShortCircuitsToEmpty("'v1' = indexed AND 'v2' = indexed");
   }
 
   /**
@@ -346,16 +366,7 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
    */
   @Test
   public void equalityAndIsNullSameField_shortCircuitsToEmptyStep() {
-    try (var rs =
-        session.query(
-            "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed IS NULL")) {
-      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
-      assertTrue(
-          "expected EmptyStep for '= literal AND IS NULL', got "
-              + firstStep.getClass().getSimpleName(),
-          firstStep instanceof EmptyStep);
-      assertFalse(rs.hasNext());
-    }
+    assertShortCircuitsToEmpty("indexed = 'v1' AND indexed IS NULL");
   }
 
   /**
@@ -465,6 +476,265 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
       assertTrue("expected the schemaless n=5 record to be returned", rs.hasNext());
       assertEquals(5, (int) rs.next().getProperty("n"));
       assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * On a case-insensitive (ci) STRING property the runtime filter lowercases both operands before
+   * comparing, so {@code name = 'A' AND name = 'a'} both reduce to 'a' and match the stored row —
+   * the predicate is satisfiable. The detector must apply the property's collate the same way;
+   * without it 'A' and 'a' look distinct and the block is wrongly emptied, silently dropping the
+   * row. Both operand orders are covered on a non-indexed field so the query runs through the
+   * filter.
+   */
+  @Test
+  public void caseInsensitiveCollation_sameValueDifferentCase_isNotContradictory() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("name", PropertyType.STRING).setCollate("ci");
+    session.begin();
+    session.newInstance(cn).setProperty("name", "a");
+    session.commit();
+
+    assertSatisfiableReturns(cn, "name = 'A' AND name = 'a'", "name", "a");
+    assertSatisfiableReturns(cn, "'A' = name AND 'a' = name", "name", "a");
+  }
+
+  /**
+   * The collate carve-out must also hold when the ci property is indexed: the index lowercases its
+   * keys, so {@code name = 'A' AND name = 'a'} is satisfiable and must keep the index lookup rather
+   * than short-circuiting. Exercises the collate fix through the same-field merge on a collated
+   * index.
+   */
+  @Test
+  public void caseInsensitiveCollation_indexed_sameValueDifferentCase_returnsRow() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("name", PropertyType.STRING).setCollate("ci");
+    clazz.createIndex(cn + ".name", SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    session.begin();
+    session.newInstance(cn).setProperty("name", "a");
+    session.commit();
+
+    assertSatisfiableReturns(cn, "name = 'A' AND name = 'a'", "name", "a");
+  }
+
+  /**
+   * Genuinely distinct values on a ci property are still contradictory: {@code name = 'a' AND
+   * name = 'b'} lowercase to 'a' and 'b', which differ, so the block is provably empty and must
+   * short-circuit. Confirms the collate fix did not disable detection for real contradictions.
+   */
+  @Test
+  public void caseInsensitiveCollation_distinctValues_shortCircuitsToEmptyStep() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("name", PropertyType.STRING).setCollate("ci");
+    session.begin();
+    session.newInstance(cn).setProperty("name", "a");
+    session.commit();
+
+    assertShortCircuitsToEmpty(cn, "name = 'a' AND name = 'b'");
+    // Case variants of two distinct values remain distinct after lowercasing.
+    assertShortCircuitsToEmpty(cn, "name = 'A' AND name = 'B'");
+  }
+
+  /**
+   * BOOLEAN coercion: {@code flag = true AND flag = false} is contradictory (EmptyStep), while
+   * {@code flag = true AND flag = 'true'} is satisfiable because the string literal coerces to
+   * {@code Boolean.TRUE}. Guards the non-INTEGER coercion branch the INTEGER cases never reach.
+   */
+  @Test
+  public void booleanCoercion_contradictionShortCircuits_stringFormIsSatisfiable() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("flag", PropertyType.BOOLEAN);
+    session.begin();
+    session.newInstance(cn).setProperty("flag", true);
+    session.commit();
+
+    assertShortCircuitsToEmpty(cn, "flag = true AND flag = false");
+    assertSatisfiableReturns(cn, "flag = true AND flag = 'true'", "flag", true);
+  }
+
+  /**
+   * LONG coercion: distinct values beyond the int range short-circuit (also confirming the check
+   * does not truncate to int), while an Integer/String literal pair for the same value
+   * ({@code n = 5 AND n = '5'}) stays satisfiable.
+   */
+  @Test
+  public void longCoercion_distinctShortCircuits_mixedLiteralSatisfiable() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("n", PropertyType.LONG);
+    session.begin();
+    session.newInstance(cn).setProperty("n", 5L);
+    session.commit();
+
+    assertShortCircuitsToEmpty(cn, "n = 3000000000 AND n = 3000000001");
+    assertSatisfiableReturns(cn, "n = 5 AND n = '5'", "n", 5L);
+  }
+
+  /**
+   * DOUBLE coercion: {@code d = 5.0 AND d = 6.0} is contradictory, while {@code d = 5 AND d = 5.0}
+   * coerces the integer literal to 5.0 and stays satisfiable.
+   */
+  @Test
+  public void doubleCoercion_distinctShortCircuits_intFormSatisfiable() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("d", PropertyType.DOUBLE);
+    session.begin();
+    session.newInstance(cn).setProperty("d", 5.0);
+    session.commit();
+
+    assertShortCircuitsToEmpty(cn, "d = 5.0 AND d = 6.0");
+    assertSatisfiableReturns(cn, "d = 5 AND d = 5.0", "d", 5.0);
+  }
+
+  /**
+   * DECIMAL coercion: {@code dec = 5 AND dec = 6} is contradictory, while {@code dec = 5 AND
+   * dec = '5'} coerces both to the same BigDecimal and stays satisfiable.
+   */
+  @Test
+  public void decimalCoercion_distinctShortCircuits_stringFormSatisfiable() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("dec", PropertyType.DECIMAL);
+    session.begin();
+    session.newInstance(cn).setProperty("dec", new BigDecimal("5"));
+    session.commit();
+
+    assertShortCircuitsToEmpty(cn, "dec = 5 AND dec = 6");
+    assertSatisfiableReturns(cn, "dec = 5 AND dec = '5'", "dec", new BigDecimal("5"));
+  }
+
+  /**
+   * DATETIME coercion via bound parameters: two distinct instants short-circuit, while the same
+   * instant supplied twice (as separate Date objects) stays satisfiable. Uses parameters so the
+   * detector resolves real Date values, exercising the DATE/DATETIME branch of the coercion path
+   * without depending on date-literal syntax.
+   */
+  @Test
+  public void dateTimeCoercion_distinctShortCircuits_sameInstantSatisfiable() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("ts", PropertyType.DATETIME);
+    var instant = new Date(1_600_000_000_000L);
+    session.begin();
+    session.newInstance(cn).setProperty("ts", instant);
+    session.commit();
+
+    try (var rs =
+        session.query(
+            "SELECT FROM " + cn + " WHERE ts = :a AND ts = :b",
+            Map.of("a", instant, "b", new Date(1_700_000_000_000L)))) {
+      assertTrue(
+          "distinct instants must short-circuit to EmptyStep",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+    try (var rs =
+        session.query(
+            "SELECT FROM " + cn + " WHERE ts = :a AND ts = :b",
+            Map.of("a", instant, "b", new Date(1_600_000_000_000L)))) {
+      assertFalse(
+          "the same instant must not short-circuit",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertTrue("the matching row must be returned", rs.hasNext());
+    }
+  }
+
+  /**
+   * GROUP BY over a contradiction returns zero groups — the opposite cardinality from bare
+   * {@code count(*)}, which returns one zero row. The empty stream from the short-circuit must feed
+   * the grouping so no group is emitted.
+   */
+  @Test
+  public void groupByOverContradiction_returnsNoGroups() {
+    try (var rs =
+        session.query(
+            "SELECT indexed, count(*) FROM " + className
+                + " WHERE indexed = 'v1' AND indexed = 'v2' GROUP BY indexed")) {
+      assertTrue(
+          "GROUP BY over a contradiction must short-circuit to EmptyStep",
+          rs.getExecutionPlan().getSteps().stream().anyMatch(s -> s instanceof EmptyStep));
+      assertFalse("GROUP BY over an empty stream must emit no groups", rs.hasNext());
+    }
+  }
+
+  /** DISTINCT over a contradiction returns no rows. */
+  @Test
+  public void distinctOverContradiction_returnsNoRows() {
+    try (var rs =
+        session.query(
+            "SELECT DISTINCT indexed FROM " + className
+                + " WHERE indexed = 'v1' AND indexed = 'v2'")) {
+      assertTrue(
+          rs.getExecutionPlan().getSteps().stream().anyMatch(s -> s instanceof EmptyStep));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /** ORDER BY with LIMIT/SKIP composes with the empty stream without error and yields no rows. */
+  @Test
+  public void orderByLimitOverContradiction_returnsNoRows() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className
+                + " WHERE indexed = 'v1' AND indexed = 'v2' ORDER BY indexed LIMIT 5 SKIP 3")) {
+      assertTrue(
+          rs.getExecutionPlan().getSteps().stream().anyMatch(s -> s instanceof EmptyStep));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * A constant-fold value operand that throws when evaluated ({@code num = 1/0}) must not abort
+   * planning. On an empty class the runtime filter never evaluates the operand, so before the
+   * short-circuit the query returned no rows; the plan-time detector must preserve that by catching
+   * the evaluation failure and falling through, rather than throwing {@code ArithmeticException}
+   * out of the planner. Both the contradiction-candidate form and the single-equality form (which
+   * still evaluates the operand while populating the value map) are covered.
+   */
+  @Test
+  public void throwingEarlyCalcOperand_doesNotAbortPlanning() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("num", PropertyType.INTEGER);
+    // No rows seeded: mirrors the empty / no-row-scanned case that surfaced the regression.
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE num = 1/0 AND num = 2/0")) {
+      assertFalse("empty class must yield no rows and no exception", rs.hasNext());
+    }
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE num = 1/0")) {
+      assertFalse("empty class must yield no rows and no exception", rs.hasNext());
+    }
+  }
+
+  /**
+   * Operands the detector cannot resolve to a plan-time literal must fall through to normal
+   * planning, not be read as contradictions. {@code indexed = indexed} (a field on both sides) is
+   * always true, so combined with {@code indexed = 'v2'} the query must return the v2 row rather
+   * than short-circuiting; {@code indexed = other} (another identifier) must likewise not
+   * short-circuit.
+   */
+  @Test
+  public void nonResolvableOperand_fallsThroughWithoutShortCircuit() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = indexed AND indexed = 'v2'")) {
+      assertFalse(
+          "field = field must not be read as a contradiction",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertTrue(rs.hasNext());
+      assertEquals("v2", rs.next().getProperty("indexed"));
+      assertFalse(rs.hasNext());
+    }
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = other AND indexed = 'v2'")) {
+      assertFalse(
+          "field = otherField must not be read as a contradiction",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -3,8 +3,10 @@ package com.jetbrains.youtrackdb.internal.core.sql.executor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.jetbrains.youtrackdb.internal.core.exception.CommandExecutionException;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import java.math.BigDecimal;
@@ -313,6 +315,45 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
           rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
       assertFalse(rs.hasNext());
     }
+  }
+
+  /**
+   * A target class that does not resolve must error the same way whatever the WHERE looks like. A
+   * provably-empty predicate ({@code field = null}) must not turn the class-not-found error into a
+   * silent empty result. Before the {@code targetClass != null} guard in
+   * {@link SelectExecutionPlanner}, {@code SELECT FROM <missing> WHERE f = null} short-circuited to
+   * {@link EmptyStep} and returned zero rows, while the same query with no WHERE threw. This pins
+   * the throw for both shapes so a typo'd class name never hides behind an empty predicate.
+   */
+  @Test
+  public void unsatisfiableWhereOnMissingClass_throwsClassNotFound() {
+    var missingClass = "NoSuchClassForContradictionTest";
+    // Baseline: a missing class with no WHERE throws "Class not found".
+    var noWhere =
+        assertThrows(
+            CommandExecutionException.class,
+            () -> {
+              try (var rs = session.query("SELECT FROM " + missingClass)) {
+                rs.hasNext();
+              }
+            });
+    assertTrue(
+        "expected a class-not-found error, got: " + noWhere.getMessage(),
+        noWhere.getMessage().contains("Class not found"));
+    // Regression: the contradictory `= null` predicate must throw the same error, not swallow it
+    // into an empty result via EmptyStep.
+    var contradictoryWhere =
+        assertThrows(
+            CommandExecutionException.class,
+            () -> {
+              try (var rs =
+                  session.query("SELECT FROM " + missingClass + " WHERE indexed = null")) {
+                rs.hasNext();
+              }
+            });
+    assertTrue(
+        "expected a class-not-found error, got: " + contradictoryWhere.getMessage(),
+        contradictoryWhere.getMessage().contains("Class not found"));
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/ContradictoryWherePlannerTest.java
@@ -228,4 +228,147 @@ public class ContradictoryWherePlannerTest extends TestUtilsFixture {
       assertFalse(rs.hasNext());
     }
   }
+
+  /**
+   * The coercion carve-out must also hold when the field is indexed: {@code num = 1 AND num = 1.0}
+   * on an indexed INTEGER field is satisfiable, so it must keep the index lookup and return the
+   * {@code num = 1} row rather than short-circuiting to {@link EmptyStep}. Covers the intersection
+   * of the coercion detector and the same-field index merge, which the non-indexed
+   * {@link #numericCoercion_sameValueDifferentType_isNotContradictory} case does not exercise.
+   */
+  @Test
+  public void indexedNumericCoercion_sameValueDifferentType_returnsRow() {
+    var clazz = createClassInstance();
+    var cn = clazz.getName();
+    clazz.createProperty("num", PropertyType.INTEGER);
+    clazz.createIndex(cn + ".num", SchemaClass.INDEX_TYPE.NOTUNIQUE, "num");
+    session.begin();
+    session.newInstance(cn).setProperty("num", 1);
+    session.commit();
+
+    try (var rs = session.query("SELECT FROM " + cn + " WHERE num = 1 AND num = 1.0")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "num = 1 AND num = 1.0 must keep the index lookup, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof FetchFromIndexStep);
+      assertTrue("expected the num=1 record to be returned", rs.hasNext());
+      assertEquals(1, (int) rs.next().getProperty("num"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * An equality against the {@code null} literal is always false ({@code = null} matches nothing at
+   * runtime, {@code IS NULL} is the null test), so a block containing it is unsatisfiable. Both
+   * {@code indexed = 'v1' AND indexed = null} and a lone {@code indexed = null} must short-circuit
+   * to {@link EmptyStep} and return no rows.
+   */
+  @Test
+  public void nullLiteralEquality_shortCircuitsToEmptyStep() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed = null")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for equality against null, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+    try (var rs = session.query("SELECT FROM " + className + " WHERE indexed = null")) {
+      assertTrue(
+          "lone equality against null must short-circuit to EmptyStep",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * A block emptied only by a {@code = null} equality must not empty the whole WHERE when another
+   * OR branch is satisfiable: {@code indexed = null OR indexed = 'v0'} must still return {@code v0}.
+   */
+  @Test
+  public void nullEqualityInOneBranch_stillReturnsOtherBranch() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = null OR indexed = 'v0'")) {
+      assertFalse(
+          "OR with a satisfiable branch must not short-circuit to empty",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertTrue(rs.hasNext());
+      assertEquals("v0", rs.next().getProperty("indexed"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * The property may sit on the left of the literal: {@code 'v1' = indexed AND 'v2' = indexed} is
+   * contradictory and must short-circuit to {@link EmptyStep}, the same as the right-hand form.
+   */
+  @Test
+  public void leftLiteralContradiction_shortCircuitsToEmptyStep() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE 'v1' = indexed AND 'v2' = indexed")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for left-literal contradiction, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Left-literal equalities with the same value are satisfiable and must not be flagged: the query
+   * must not short-circuit to {@link EmptyStep} and must return the matching row. Guards the
+   * left-hand detection path against over-flagging.
+   */
+  @Test
+  public void leftLiteralSameValue_isNotContradictory() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE 'v1' = indexed AND 'v1' = indexed")) {
+      assertFalse(
+          "duplicate left-literal equalities must not short-circuit to empty",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+      assertTrue(rs.hasNext());
+      assertEquals("v1", rs.next().getProperty("indexed"));
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * A non-null equality and an {@code IS NULL} on the same field cannot both hold — the field would
+   * have to be a value and null at once — so the predicate must short-circuit to {@link EmptyStep}.
+   */
+  @Test
+  public void equalityAndIsNullSameField_shortCircuitsToEmptyStep() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed = 'v1' AND indexed IS NULL")) {
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected EmptyStep for '= literal AND IS NULL', got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof EmptyStep);
+      assertFalse(rs.hasNext());
+    }
+  }
+
+  /**
+   * Two {@code IS NULL} conditions on the same field are satisfiable (the field is simply null), so
+   * the detector must not treat them as contradictory: no {@link EmptyStep} short-circuit.
+   */
+  @Test
+  public void doubleIsNullSameField_isNotContradictory() {
+    try (var rs =
+        session.query(
+            "SELECT FROM " + className + " WHERE indexed IS NULL AND indexed IS NULL")) {
+      assertFalse(
+          "two IS NULL on the same field must not short-circuit to empty",
+          rs.getExecutionPlan().getSteps().getFirst() instanceof EmptyStep);
+    }
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
@@ -39,6 +40,13 @@ public class RepeatedEqualityOnIndexTest extends TestUtilsFixture {
   private Set<Integer> queryValues(String where) {
     var seen = new HashSet<Integer>();
     try (var rs = session.query("SELECT FROM " + className + " WHERE " + where)) {
+      // The merge must produce a real index lookup, not a full scan; otherwise a regression that
+      // silently falls back to a scan would still return the right values and hide itself.
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected FetchFromIndexStep for '" + where + "', got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof FetchFromIndexStep);
       while (rs.hasNext()) {
         seen.add(rs.next().getProperty("n"));
       }
@@ -46,7 +54,7 @@ public class RepeatedEqualityOnIndexTest extends TestUtilsFixture {
     return seen;
   }
 
-  /** Duplicate equality on an indexed field must return the matching row, not an empty result. */
+  /** Duplicate equality on an indexed field must return the matching row through the index. */
   @Test
   public void duplicateEquality_returnsMatchingRow() {
     assertEquals(Set.of(5), queryValues("n = 5 AND n = 5"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
@@ -73,4 +73,26 @@ public class RepeatedEqualityOnIndexTest extends TestUtilsFixture {
     assertEquals(new HashSet<>(List.of(0, 1, 2, 3, 4)), queryValues("n <= 4 AND n <= 7"));
     assertEquals(new HashSet<>(List.of(0, 1, 2, 3, 4)), queryValues("n <= 7 AND n <= 4"));
   }
+
+  /**
+   * Two lower bounds with different operators merge to the tighter one and take the merge result's
+   * operator, not the first condition's ({@code n > 3 AND n >= 5} becomes {@code n >= 5}, not
+   * {@code n > 5}). Pins {@code mergeUsingAnd} reading the operator from the merge result: keeping
+   * the original {@code >} would wrongly drop {@code n = 5}. The same-operator bound tests above
+   * never change the operator, so they cannot catch that half of the fix.
+   */
+  @Test
+  public void lowerBounds_differentOperators_takeMergedOperator() {
+    assertEquals(new HashSet<>(List.of(5, 6, 7, 8, 9)), queryValues("n > 3 AND n >= 5"));
+  }
+
+  /**
+   * Two upper bounds with different operators merge to the tighter one and take the merge result's
+   * operator ({@code n < 8 AND n <= 5} becomes {@code n <= 5}, not {@code n < 5}); keeping the
+   * original {@code <} would wrongly drop {@code n = 5}.
+   */
+  @Test
+  public void upperBounds_differentOperators_takeMergedOperator() {
+    assertEquals(new HashSet<>(List.of(0, 1, 2, 3, 4, 5)), queryValues("n < 8 AND n <= 5"));
+  }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
@@ -1,0 +1,68 @@
+package com.jetbrains.youtrackdb.internal.core.sql.executor;
+
+import static org.junit.Assert.assertEquals;
+
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Regression tests for merging two conditions on the same indexed field into one index lookup.
+ *
+ * <p>{@link com.jetbrains.youtrackdb.internal.core.sql.parser.SQLBinaryCondition#mergeUsingAnd}
+ * used to store the whole {@code MergeResult} record as the merged condition's right operand, so
+ * the index searched for a key equal to that record and matched nothing — a satisfiable query
+ * silently returned zero rows. These tests pin the corrected behaviour for the cases that actually
+ * merge: duplicate equalities and two bounds in the same direction.
+ */
+public class RepeatedEqualityOnIndexTest extends TestUtilsFixture {
+
+  private String className;
+
+  @Before
+  public void setUpSchema() {
+    var clazz = createClassInstance();
+    className = clazz.getName();
+    clazz.createProperty("n", PropertyType.INTEGER);
+    clazz.createIndex(className + ".n", SchemaClass.INDEX_TYPE.NOTUNIQUE, "n");
+    session.begin();
+    for (var i = 0; i < 10; i++) {
+      session.newInstance(className).setProperty("n", i);
+    }
+    session.commit();
+  }
+
+  private Set<Integer> queryValues(String where) {
+    var seen = new HashSet<Integer>();
+    try (var rs = session.query("SELECT FROM " + className + " WHERE " + where)) {
+      while (rs.hasNext()) {
+        seen.add(rs.next().getProperty("n"));
+      }
+    }
+    return seen;
+  }
+
+  /** Duplicate equality on an indexed field must return the matching row, not an empty result. */
+  @Test
+  public void duplicateEquality_returnsMatchingRow() {
+    assertEquals(Set.of(5), queryValues("n = 5 AND n = 5"));
+  }
+
+  /** Two lower bounds merge to the tighter one; both operand orders must give the same rows. */
+  @Test
+  public void lowerBounds_mergeToTighter() {
+    assertEquals(new HashSet<>(List.of(5, 6, 7, 8, 9)), queryValues("n >= 2 AND n >= 5"));
+    assertEquals(new HashSet<>(List.of(5, 6, 7, 8, 9)), queryValues("n >= 5 AND n >= 2"));
+  }
+
+  /** Two upper bounds merge to the tighter one; both operand orders must give the same rows. */
+  @Test
+  public void upperBounds_mergeToTighter() {
+    assertEquals(new HashSet<>(List.of(0, 1, 2, 3, 4)), queryValues("n <= 4 AND n <= 7"));
+    assertEquals(new HashSet<>(List.of(0, 1, 2, 3, 4)), queryValues("n <= 7 AND n <= 4"));
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
@@ -131,6 +131,12 @@ public class RepeatedEqualityOnIndexTest extends TestUtilsFixture {
   @Test
   public void emptyRange_returnsNoRows() {
     try (var rs = session.query("SELECT FROM " + className + " WHERE n >= 5 AND n <= 4")) {
+      // The bounds stay a real index range scan, not a silent full-scan fallback.
+      var firstStep = rs.getExecutionPlan().getSteps().getFirst();
+      assertTrue(
+          "expected FetchFromIndexStep for an empty range, got "
+              + firstStep.getClass().getSimpleName(),
+          firstStep instanceof FetchFromIndexStep);
       assertFalse("an empty range must return no rows", rs.hasNext());
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/RepeatedEqualityOnIndexTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.sql.executor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -94,5 +95,43 @@ public class RepeatedEqualityOnIndexTest extends TestUtilsFixture {
   @Test
   public void upperBounds_differentOperators_takeMergedOperator() {
     assertEquals(new HashSet<>(List.of(0, 1, 2, 3, 4, 5)), queryValues("n < 8 AND n <= 5"));
+  }
+
+  /**
+   * A bound merged with a {@code !=} on the boundary changes the operator: {@code n >= 5 AND n != 5}
+   * becomes {@code n > 5} and {@code n <= 4 AND n != 4} becomes {@code n < 4}. This is the {@code GE
+   * + NE -> GT} (and {@code LE + NE -> LT}) case the merge fix's comment names as its motivating
+   * example; the range-bound tests above never exercise the {@code !=} branch, so without this the
+   * operator-from-merge-result half of the fix is only partly pinned.
+   */
+  @Test
+  public void boundMergedWithNotEqualOnBoundary_takesMergedOperator() {
+    assertEquals(new HashSet<>(List.of(6, 7, 8, 9)), queryValues("n >= 5 AND n != 5"));
+    assertEquals(new HashSet<>(List.of(0, 1, 2, 3)), queryValues("n <= 4 AND n != 4"));
+  }
+
+  /**
+   * Equal same-operator bounds merge to a single bound: {@code n <= 5 AND n <= 5} keeps {@code <= 5}
+   * and {@code n >= 5 AND n >= 5} keeps {@code >= 5}. Exercises the {@code result == 0} branch of the
+   * bound merge — the boundary where an off-by-one between {@code <=} and {@code <} would flip which
+   * operand survives; the distinct-bound tests above never hit it.
+   */
+  @Test
+  public void equalBounds_keepSingleBound() {
+    assertEquals(new HashSet<>(List.of(0, 1, 2, 3, 4, 5)), queryValues("n <= 5 AND n <= 5"));
+    assertEquals(new HashSet<>(List.of(5, 6, 7, 8, 9)), queryValues("n >= 5 AND n >= 5"));
+  }
+
+  /**
+   * An empty range ({@code n >= 5 AND n <= 4}) does not merge — the lower and upper bounds are kept
+   * as a range with no satisfying value — and must return zero rows rather than the wrong rows.
+   * Pins that "returns nothing" here is the correct answer, not the silent-zero-rows symptom the
+   * merge fix removed.
+   */
+  @Test
+  public void emptyRange_returnsNoRows() {
+    try (var rs = session.query("SELECT FROM " + className + " WHERE n >= 5 AND n <= 4")) {
+      assertFalse("an empty range must return no rows", rs.hasNext());
+    }
   }
 }


### PR DESCRIPTION
#### PR Title:

YTDB-1176: Short-circuit contradictory WHERE equalities to EmptyStep

#### Motivation

`SELECT FROM A WHERE indexed = 'x' AND indexed = 'y'` ignored the index on `indexed` and fell back to a full class scan (`FetchFromClassExecutionStep`). The two-value predicate is contradictory and returns zero rows, yet the engine scanned every record. A single `WHERE indexed = 'x'` uses the index; repeating the same property under `AND` regressed the plan to a full scan. Several related same-field predicates that are also provably empty share this problem.

#### Changes

The planner already flattens the WHERE clause into disjunctive normal form — a list of AND-blocks, one per OR-branch (`info.flattenedWhereClause`). This PR adds a plan-time check over that structure and short-circuits a provably empty predicate to `EmptyStep`.

An AND-block is treated as empty when any of these holds on the same property:

- **Contradictory equality values** — `field = 'a' AND field = 'b'`: the property would have to hold two different values at once. Both values are coerced to the property's declared type and transformed with its collate, then compared with the engine's own equality (`QueryOperatorEquals.equals`). That mirrors the runtime filter (`SQLBinaryCondition.evaluate`), which coerces each literal to the stored value's type and applies the property's collate. So `field = 1 AND field = 1.0` stays satisfiable, `n = '5' AND n = '05'` on an INTEGER property stays satisfiable (both coerce to `5`), and `name = 'A' AND name = 'a'` on a case-insensitive (`ci`) property stays satisfiable (both lowercase to `a`) rather than being misread as empty. When the property's type is unknown — a schemaless field, or the class does not resolve — the runtime coercion cannot be reproduced, so the equality check is skipped and normal planning runs.
- **Equality against the `null` literal** — `field = null` (or `null = field`): always false, since `equals(x, null)` never holds (`IS NULL` is the null test). One such condition empties the block. Type-independent.
- **Equality plus `IS NULL`** — `field = 'a' AND field IS NULL`: the property would have to be a non-null value and null at once. Type-independent.

The property may sit on either side of `=`, so both `field = 'a'` and `'a' = field` are recognised; the value operand is resolved when it is a literal or a bound parameter. Resolving the operand is guarded: a constant fold that throws (e.g. `num = 1/0`) is left to normal planning instead of aborting the plan, matching the behaviour where the runtime filter never evaluates the operand on an empty or non-matching scan. The whole WHERE is short-circuited only when *every* OR-branch is empty; a single equality still uses the index, and an `OR` with a satisfiable branch is untouched.

The check runs at the top of `handleClassAsTarget`, before the indexed-function / index / sort-only / full-scan cascade. It resolves the target class from the schema once (reused for the full-scan fetcher instead of a second lookup) to read property types and collate. When it fires, the planner chains `EmptyStep`, clears the WHERE so no redundant `FilterStep` is appended over the already-empty stream, and returns.

#### Three pre-existing same-field merge issues fixed along the way

While writing the tests I hit three problems in how two conditions on the same field get merged into one index lookup (`SQLBinaryCondition.mergeUsingAnd`), all older than this branch. I fixed all three here so the new tests get the behaviour I'd expect. If any is by design, I can pull that part out — please double-check my reading.

1. **Merged condition kept the whole `MergeResult` as its value.** `mergeUsingAnd` stored the entire `MergeResult` record in the merged condition's right operand and kept the original operator, instead of unwrapping `resultOperand.mergedRightOperand()` / `resultOperand.operator()`. `SQLValueExpression` stores the object verbatim, so the index searched for a key equal to a `MergeResult` and matched nothing — satisfiable queries like `f = v AND f = v` and `n >= 2 AND n >= 5` returned zero rows once the index was chosen. Plain ranges (`n > a AND n < b`) are unaffected, because that combination does not merge.
2. **`mergeLEOperator` used the operator object as the merged value.** One branch yielded `new MergeResult(otherOperator, otherOperator)` where every sibling branch uses `otherRight`, breaking `f <= a AND f <= b` when the first bound was the looser one (`n <= 7 AND n <= 4` returned zero rows). Changed to `otherRight` to match the siblings.
3. **The merge ignored the property collate, so a collated duplicate fell back to a full scan.** On a case-insensitive (`ci`) property, `name = 'A' AND name = 'a'` is satisfiable — the two values are equal under the collate — but the merge compared the literals raw (`doCompare`), saw `'A'` ≠ `'a'`, and refused to fold them into one index key. With no index key the planner dropped to a full class scan; the post-fetch filter still applied the collate and returned the row, so results were correct while the index was silently skipped. The contradiction check above already keeps this pair out of `EmptyStep` (it applies the collate), and the merge now also receives the property's collate and transforms both equality operands with it before comparing, so the pair collapses to a single index lookup. Only equality operands are collated: range merges keep their raw bounds, and runtime comparison (`doCompare`) and the non-comparison operators (`LIKE`, `IN`, `CONTAINSKEY`, `CONTAINSVALUE`) are unchanged. The collate reaches `SQLBinaryCondition` through a new three-argument `mergeUsingAnd` overload whose default ignores it, so no other expression type changes behaviour.

#### Testing

- `ContradictoryWherePlannerTest` — contradictory equalities short-circuit to `EmptyStep`; single equality still uses the index; duplicate same-value equality returns its row; numeric coercion (`num = 1 AND num = 1.0`) stays satisfiable off and on an index; string literals that coerce to the same typed value (`num = '5' AND num = '05'`) stay satisfiable, on a declared and a schemaless field; the coercion carve-out beyond INTEGER (BOOLEAN, LONG, DOUBLE, DECIMAL, DATETIME) — distinct values short-circuit, mixed literal forms of the same value stay satisfiable; case-insensitive collation (`name = 'A' AND name = 'a'`) stays satisfiable on a declared field and, when indexed, keeps the index lookup (asserts `FetchFromIndexStep`), while genuinely distinct values still short-circuit; `= null` (paired and lone) short-circuits even when a null-valued row exists, while `IS NULL` returns that row; `IS NULL` + equality short-circuits; two `IS NULL` return the null row; the left-literal form (`'a' = field`); `OR` with a satisfiable branch is not short-circuited; `count(*)` over a contradiction returns a single zero row through `EmptyStep`; `GROUP BY` returns no groups, `DISTINCT` and `ORDER BY` with `LIMIT`/`SKIP` compose with the empty stream; a throwing constant fold (`num = 1/0`) does not abort planning; an uncoercible-literal pair (`num = 'abc' AND num = 'def'` on an INTEGER field) whose type-aware comparison throws falls through to normal planning without a plan-time failure; equalities on two distinct fields (`a = 'x' AND b = 'y'`) do not short-circuit; the `IS NULL` / equality cross-check also fires for a parameter bound to null (`indexed IS NULL AND indexed = :p`); non-resolvable operands (`field = field`, `field = otherField`) fall through; contradiction via bound parameters and on a non-indexed field.
- `RepeatedEqualityOnIndexTest` — duplicate equality and same-direction bounds (both operand orders) return the correct rows through the index (asserts `FetchFromIndexStep`, not a silent full-scan fallback); operator-changing bound merges (`n > 3 AND n >= 5` → `n >= 5`, `n < 8 AND n <= 5` → `n <= 5`, and the `!=` cases `n >= 5 AND n != 5` → `n > 5`, `n <= 4 AND n != 4` → `n < 4`); equal same-operator bounds keep a single bound; an empty range (`n >= 5 AND n <= 4`) returns no rows and stays an index range scan (asserts `FetchFromIndexStep`), not a silent full-scan fallback.
- Regression: `SelectStatementExecutionTest`, `SelectExecutionPlannerBranchTest`, `IndexSearchDescriptorCostTest`, and the collate / index-finder suites (`CollateEqualsTest`, `CompositeCollateTest`, `StatementIndexFinderTest`, `IndexFinderTest`, `IndexCandidatesTest`, `FetchFromIndexStepTest`, `AnalyzeIndexStatementExecutionTest`) all green.
