### PR TITLE
Slate orchestrator auto-pause and handoff at context budget

### DIFF
--- a/.pi/extensions/handoff-guard.ts
+++ b/.pi/extensions/handoff-guard.ts
@@ -20,6 +20,12 @@
  * /handoff [focus...] — starts a fresh session. The kickoff message comes from
  * `.pi/handoff.md` when present (project-specific resumption instructions),
  * else a generic fallback; the optional [focus...] argument is appended.
+ *
+ * Slate awareness: when the slate extension's orchestrator mode is active
+ * (detected via the active tool set), the in-band notice and /handoff are
+ * deferred to slate's own pause/handoff flow (/slate handoff), which also
+ * carries thread/episode state into the new session. The snapshot file is
+ * still written.
  */
 
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -31,6 +37,12 @@ import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 const THRESHOLD_PERCENT = 40;
 const CTX_DIR = join(tmpdir(), "pi-context");
 const CTX_FILE = join(CTX_DIR, `${process.pid}.json`);
+
+/** Slate orchestrator mode restricts tools to read-only + slate's `thread` family. */
+function slateOrchestratorActive(pi: ExtensionAPI): boolean {
+	const tools = pi.getActiveTools();
+	return tools.includes("thread") && !tools.includes("bash") && !tools.includes("edit");
+}
 
 export default function (pi: ExtensionAPI) {
 	let warned = false;
@@ -62,7 +74,8 @@ export default function (pi: ExtensionAPI) {
 		const snap = writeSnapshot(ctx);
 		if (snap.percent == null) return;
 		const pct = Math.round(snap.percent);
-		if (snap.overThreshold && !warned) {
+		// Slate's auto-pause owns the over-budget response in orchestrator mode.
+		if (snap.overThreshold && !warned && !slateOrchestratorActive(pi)) {
 			warned = true;
 			ctx.ui.notify(
 				`Context at ${pct}% (threshold ${THRESHOLD_PERCENT}%). ` +
@@ -102,6 +115,13 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("handoff", {
 		description: "Fresh session that resumes work from persisted state (context hygiene)",
 		handler: async (args, ctx) => {
+			if (slateOrchestratorActive(pi)) {
+				ctx.ui.notify(
+					"Slate orchestrator mode is active — use /slate handoff instead (it carries thread/episode state into the new session).",
+					"warning",
+				);
+				return;
+			}
 			await ctx.waitForIdle();
 			const focus = args?.trim();
 			const template = join(ctx.cwd, CONFIG_DIR_NAME, "handoff.md");

--- a/.pi/extensions/slate/handoff.ts
+++ b/.pi/extensions/slate/handoff.ts
@@ -1,0 +1,192 @@
+/**
+ * Auto-pause + handoff: context-budget discipline for the orchestrator.
+ *
+ * Monitoring: after every turn, when orchestrator mode is on and context usage
+ * crosses pauseThresholdPercent (default 40), the store is paused — the thread
+ * tool then rejects NEW dispatches (in-flight ones finish) — and the
+ * orchestrator is steered to produce a handoff brief for the user.
+ *
+ * /slate handoff [focus] → startHandoff(): captures the orchestrator's last
+ * assistant message as the brief, writes .pi/slate/pending-handoff.json
+ * (state snapshot + brief + parent session), and opens a fresh session.
+ *
+ * Adoption: session replacement tears down this extension instance, so
+ * in-memory state cannot cross over; and the fresh session's own file has no
+ * slate-state entries for restore() to find (they live in the parent's file).
+ * The pending file bridges the gap: the NEW instance's session_start handler
+ * adopts the snapshot when the fresh session's parentSession header matches.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { SlateConfig, SlateSnapshot, SlateStore } from "./state.ts";
+
+const DEFAULT_PAUSE_THRESHOLD_PERCENT = 40;
+/** A pending-handoff file older than this cannot belong to an in-flight handoff. */
+const PENDING_MAX_AGE_MS = 15 * 60 * 1000;
+const BRIEF_MAX_CHARS = 6000;
+
+interface PendingHandoff {
+	parentSession: string | undefined; // undefined = in-memory session; adoption then never matches
+	createdAt: number;
+	brief: string;
+	snapshot: SlateSnapshot;
+}
+
+export interface SlateHandoffHooks {
+	startHandoff(ctx: ExtensionCommandContext, focus?: string): Promise<void>;
+}
+
+function pendingFile(cwd: string): string {
+	return join(cwd, ".pi/slate/pending-handoff.json");
+}
+
+/** Last assistant message text on the current branch (the handoff brief). */
+function lastAssistantText(ctx: ExtensionCommandContext): string {
+	let text = "";
+	for (const entry of ctx.sessionManager.getBranch()) {
+		const e = entry as {
+			type: string;
+			message?: { role?: string; content?: string | Array<{ type: string; text?: string }> };
+		};
+		if (e.type !== "message" || e.message?.role !== "assistant") continue;
+		const content = e.message.content;
+		const t = (typeof content === "string"
+			? content
+			: (content ?? [])
+					.filter((c) => c.type === "text")
+					.map((c) => c.text ?? "")
+					.join("\n")
+		).trim();
+		if (t) text = t;
+	}
+	return text.length > BRIEF_MAX_CHARS ? `${text.slice(0, BRIEF_MAX_CHARS)}\n[... brief truncated]` : text;
+}
+
+function buildKickoff(cwd: string, brief: string, focus?: string): string {
+	const template = join(cwd, ".pi/slate-handoff.md");
+	const base = existsSync(template)
+		? readFileSync(template, "utf8").trim()
+		: [
+				"Slate orchestrator handoff (context hygiene; the previous orchestrator exceeded its context budget).",
+				"Orchestrator mode and all worker threads/episodes from the previous session are already restored:",
+				"use `threads` to list them and `episode` to fetch details. Continue the work.",
+			].join("\n");
+	const parts = [base];
+	if (brief) parts.push("", "## Handoff brief from the previous orchestrator", "", brief);
+	if (focus) parts.push("", `Immediate focus: ${focus}`);
+	return parts.join("\n");
+}
+
+export function registerSlateHandoff(
+	pi: ExtensionAPI,
+	store: SlateStore,
+	getConfig: () => SlateConfig,
+): SlateHandoffHooks {
+	const checkBudget = (ctx: ExtensionContext) => {
+		if (!store.orchestratorMode || store.paused) return;
+		const percent = ctx.getContextUsage()?.percent;
+		if (percent == null) return;
+		const threshold = getConfig().pauseThresholdPercent ?? DEFAULT_PAUSE_THRESHOLD_PERCENT;
+		if (percent < threshold) return;
+
+		store.paused = true;
+		store.save();
+		const pct = Math.round(percent);
+		if (ctx.hasUI) {
+			ctx.ui.notify(
+				`slate: context at ${pct}% (budget ${threshold}%) — paused. Run /slate handoff [focus] to continue in a fresh session.`,
+				"warning",
+			);
+		}
+		pi.sendMessage(
+			{
+				customType: "slate-pause",
+				content: [
+					`[slate] Context is at ${pct}% — over the ${threshold}% budget. Slate auto-paused: the thread tool now REJECTS new dispatches.`,
+					"Finish nothing new. Reply to the user with:",
+					"(1) a concise HANDOFF BRIEF — overall goal, per-thread state with episode ids, immediate next actions;",
+					"(2) instructions: run /slate handoff [optional focus] to continue in a fresh session where all threads and episodes are restored automatically;",
+					"alternatively, start a new pi session manually, run /slate on, and have the new orchestrator read the episode files under .pi/slate/episodes/.",
+				].join("\n"),
+				display: true,
+			},
+			{ deliverAs: "steer", triggerTurn: true },
+		);
+	};
+
+	pi.on("turn_end", async (_event, ctx) => checkBudget(ctx));
+	pi.on("agent_end", async (_event, ctx) => checkBudget(ctx));
+
+	// Adopt a pending handoff into a fresh session. Registered AFTER index.ts's
+	// restore handler (so a branch that already carries slate state wins) and
+	// BEFORE mode.ts's (so its tool restriction sees the adopted mode).
+	pi.on("session_start", async (_event, ctx) => {
+		if (store.threads.size > 0 || store.orchestratorMode) return; // state already restored on this branch
+		const file = pendingFile(ctx.cwd);
+		try {
+			if (!existsSync(file)) return;
+			const pending = JSON.parse(readFileSync(file, "utf8")) as PendingHandoff;
+			const age = Date.now() - (pending.createdAt ?? 0);
+			const stale = age >= PENDING_MAX_AGE_MS;
+			const matches = !!pending.parentSession && pending.parentSession === ctx.sessionManager.getHeader()?.parentSession;
+			if (!matches || stale) {
+				// Never adopt into an unrelated session; reap the file only once it
+				// can no longer belong to an in-flight handoff.
+				if (stale) rmSync(file, { force: true });
+				return;
+			}
+			store.adoptSnapshot(pending.snapshot, ctx);
+			store.paused = false;
+			store.save();
+			rmSync(file, { force: true });
+			if (ctx.hasUI) {
+				const t = store.threads.size;
+				const e = store.episodes.size;
+				ctx.ui.notify(
+					`slate: handoff state restored (${t} thread${t === 1 ? "" : "s"}, ${e} episode${e === 1 ? "" : "s"}).`,
+					"info",
+				);
+			}
+		} catch {
+			/* a broken pending file must never break session start */
+		}
+	});
+
+	const startHandoff = async (ctx: ExtensionCommandContext, focus?: string): Promise<void> => {
+		await ctx.waitForIdle();
+
+		const brief = lastAssistantText(ctx);
+		const parentSession = ctx.sessionManager.getSessionFile();
+		const pending: PendingHandoff = {
+			parentSession,
+			createdAt: Date.now(),
+			brief,
+			// The successor starts unpaused and in orchestrator mode regardless of
+			// the current (paused) state.
+			snapshot: { ...store.snapshot(), paused: false, orchestratorMode: true },
+		};
+		const file = pendingFile(ctx.cwd);
+		mkdirSync(dirname(file), { recursive: true });
+		writeFileSync(file, `${JSON.stringify(pending, null, 2)}\n`, "utf8");
+
+		const kickoff = buildKickoff(ctx.cwd, brief, focus);
+		const { cancelled } = await ctx.newSession({
+			parentSession,
+			withSession: async (fresh) => {
+				await fresh.sendUserMessage(kickoff);
+			},
+		});
+		if (cancelled) {
+			// Left behind, the pending file could be adopted by an unintended fork
+			// or session sharing this parent within the 15-min window.
+			rmSync(file, { force: true });
+			store.paused = false;
+			store.save();
+			if (ctx.hasUI) ctx.ui.notify("slate: handoff cancelled — pause cleared, pending state removed.", "warning");
+		}
+	};
+
+	return { startHandoff };
+}

--- a/.pi/extensions/slate/handoff.ts
+++ b/.pi/extensions/slate/handoff.ts
@@ -52,9 +52,12 @@ function lastAssistantText(ctx: ExtensionCommandContext): string {
 		};
 		if (e.type !== "message" || e.message?.role !== "assistant") continue;
 		const content = e.message.content;
+		// Entries come from JSON on disk; content may not match the declared
+		// shape. Skip anything that is neither string nor block array.
+		if (typeof content !== "string" && !Array.isArray(content)) continue;
 		const t = (typeof content === "string"
 			? content
-			: (content ?? [])
+			: content
 					.filter((c) => c.type === "text")
 					.map((c) => c.text ?? "")
 					.join("\n")
@@ -88,7 +91,12 @@ export function registerSlateHandoff(
 		if (!store.orchestratorMode || store.paused) return;
 		const percent = ctx.getContextUsage()?.percent;
 		if (percent == null) return;
-		const threshold = getConfig().pauseThresholdPercent ?? DEFAULT_PAUSE_THRESHOLD_PERCENT;
+		// .pi/slate.json is user-edited: accept only finite (0, 100] thresholds.
+		const configured = getConfig().pauseThresholdPercent;
+		const threshold =
+			typeof configured === "number" && Number.isFinite(configured) && configured > 0 && configured <= 100
+				? configured
+				: DEFAULT_PAUSE_THRESHOLD_PERCENT;
 		if (percent < threshold) return;
 
 		store.paused = true;
@@ -172,19 +180,45 @@ export function registerSlateHandoff(
 		writeFileSync(file, `${JSON.stringify(pending, null, 2)}\n`, "utf8");
 
 		const kickoff = buildKickoff(ctx.cwd, brief, focus);
-		const { cancelled } = await ctx.newSession({
-			parentSession,
-			withSession: async (fresh) => {
-				await fresh.sendUserMessage(kickoff);
-			},
-		});
-		if (cancelled) {
-			// Left behind, the pending file could be adopted by an unintended fork
-			// or session sharing this parent within the 15-min window.
-			rmSync(file, { force: true });
-			store.paused = false;
-			store.save();
-			if (ctx.hasUI) ctx.ui.notify("slate: handoff cancelled — pause cleared, pending state removed.", "warning");
+		// catch, NOT finally: on success the NEW session's adoption handler has
+		// already consumed and deleted the pending file (session_start fires
+		// inside newSession) — cleaning up there would be wrong.
+		try {
+			const { cancelled } = await ctx.newSession({
+				parentSession,
+				withSession: async (fresh) => {
+					await fresh.sendUserMessage(kickoff);
+				},
+			});
+			if (cancelled) {
+				// Left behind, the pending file could be adopted by an unintended fork
+				// or session sharing this parent within the 15-min window.
+				rmSync(file, { force: true });
+				store.paused = false;
+				store.save();
+				if (ctx.hasUI) ctx.ui.notify("slate: handoff cancelled — pause cleared, pending state removed.", "warning");
+			}
+		} catch (error) {
+			try {
+				rmSync(file, { force: true });
+			} catch {
+				/* ignore */
+			}
+			// Best-effort: if the replacement partially happened, the old pi/ctx
+			// are stale and these calls themselves throw.
+			try {
+				store.paused = false;
+				store.save();
+				if (ctx.hasUI) {
+					ctx.ui.notify(
+						`slate: handoff failed — ${error instanceof Error ? error.message : String(error)}. Pause cleared; pending state removed.`,
+						"error",
+					);
+				}
+			} catch {
+				/* stale pi/ctx after partial replacement */
+			}
+			throw error;
 		}
 	};
 

--- a/.pi/extensions/slate/index.ts
+++ b/.pi/extensions/slate/index.ts
@@ -13,14 +13,17 @@
  *   episodes.ts — episode compression (Sonnet-default, D5)
  *   threads.ts  — ThreadManager: queueing, dispatch lifecycle
  *   tools.ts    — thread / threads / episode tools
+ *   handoff.ts  — context-budget auto-pause + fresh-session handoff
  *
  * Optional config at .pi/slate.json:
- *   { "episodeModel": "provider/id", "workerTools": [...], "maxConcurrent": 4 }
+ *   { "episodeModel": "provider/id", "workerTools": [...], "maxConcurrent": 4,
+ *     "pauseThresholdPercent": 40 }
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerSlateHandoff } from "./handoff.ts";
 import { registerSlateMode } from "./mode.ts";
 import { SlateStore, type SlateConfig } from "./state.ts";
 import { ThreadManager } from "./threads.ts";
@@ -52,7 +55,11 @@ export default function (pi: ExtensionAPI) {
 		manager.disposeAll();
 	});
 
-	// Registered AFTER the session_start handler above so that mode restoration
-	// (which re-applies tool restrictions) runs after store.restore().
-	registerSlateMode(pi, store);
+	// session_start ordering (registration order): restore → adopt pending
+	// handoff → re-apply mode tools. registerSlateHandoff must therefore sit
+	// between the restore handler above and registerSlateMode below.
+	// getConfig reads the CURRENT `manager` (reassigned on session_start).
+	const handoff = registerSlateHandoff(pi, store, () => manager.getConfig());
+
+	registerSlateMode(pi, store, handoff);
 }

--- a/.pi/extensions/slate/mode.ts
+++ b/.pi/extensions/slate/mode.ts
@@ -7,9 +7,13 @@
  *   - the thread-weaving doctrine is appended to the system prompt each turn;
  *   - a widget above the editor shows live thread status;
  *   - the mode persists in slate state and is re-applied on session restore.
+ *
+ * `/slate handoff [focus]` / `/slate resume` interact with the auto-pause
+ * machinery in handoff.ts (context budget → paused → fresh-session handoff).
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { SlateHandoffHooks } from "./handoff.ts";
 import type { SlateStore } from "./state.ts";
 
 const ORCHESTRATOR_TOOLS = ["read", "grep", "find", "ls", "thread", "threads", "episode"];
@@ -36,7 +40,16 @@ threads execute. Rules:
    require adaptation, not blind retry.
 7. Keep your own messages strategic: goals, task routing, synthesis.`;
 
-export function registerSlateMode(pi: ExtensionAPI, store: SlateStore): void {
+const PAUSED_ADDENDUM = `
+
+# PAUSED — context budget exceeded
+
+Slate is paused for handoff: thread dispatches are REJECTED. Do not start new
+work. Reply with a concise handoff brief (overall goal, per-thread state with
+episode ids, immediate next actions) and direct the user to run
+/slate handoff [optional focus].`;
+
+export function registerSlateMode(pi: ExtensionAPI, store: SlateStore, hooks: SlateHandoffHooks): void {
 	let savedTools: string[] | undefined;
 	let uiCtx: ExtensionContext | undefined;
 
@@ -51,6 +64,7 @@ export function registerSlateMode(pi: ExtensionAPI, store: SlateStore): void {
 		const threads = [...store.threads.values()];
 		const lines = [
 			`slate ⋅ orchestrator mode ⋅ ${threads.length} thread${threads.length === 1 ? "" : "s"}`,
+			...(store.paused ? ["  ⛔ PAUSED (context budget) — run /slate handoff"] : []),
 			...threads.map(
 				(t) =>
 					`  ${t.status === "running" ? "⏳" : "·"} ${t.id} ${t.name} [${t.status}] ${t.episodeIds.length} episode${t.episodeIds.length === 1 ? "" : "s"}`,
@@ -67,6 +81,7 @@ export function registerSlateMode(pi: ExtensionAPI, store: SlateStore): void {
 			pi.setActiveTools(savedTools ?? [...pi.getAllTools().map((t) => t.name)]);
 			savedTools = undefined;
 		}
+		if (!on) store.paused = false; // a pause is meaningless outside orchestrator mode
 		store.orchestratorMode = on;
 		if (persist) store.save();
 		updateWidget();
@@ -76,10 +91,26 @@ export function registerSlateMode(pi: ExtensionAPI, store: SlateStore): void {
 	store.onDidChange = updateWidget;
 
 	pi.registerCommand("slate", {
-		description: "Toggle Slate orchestrator mode (on/off; no arg toggles)",
+		description: "Slate orchestrator mode: on | off | handoff [focus] | resume (no arg toggles)",
 		handler: async (args, ctx) => {
 			uiCtx = ctx;
-			const arg = args?.trim().toLowerCase();
+			const trimmed = args?.trim() ?? "";
+			const [verb, ...rest] = trimmed.split(/\s+/);
+			const arg = verb?.toLowerCase();
+			if (arg === "handoff") {
+				if (!store.orchestratorMode) {
+					if (ctx.hasUI) ctx.ui.notify("slate: orchestrator mode is not active — nothing to hand off.", "warning");
+					return;
+				}
+				await hooks.startHandoff(ctx, rest.join(" ") || undefined);
+				return;
+			}
+			if (arg === "resume") {
+				store.paused = false;
+				store.save();
+				if (ctx.hasUI) ctx.ui.notify("slate: pause cleared — dispatches allowed again.", "info");
+				return;
+			}
 			const target = arg === "on" ? true : arg === "off" ? false : !store.orchestratorMode;
 			setMode(target, true);
 			if (ctx.hasUI) {
@@ -95,13 +126,15 @@ export function registerSlateMode(pi: ExtensionAPI, store: SlateStore): void {
 
 	pi.on("before_agent_start", async (event) => {
 		if (!store.orchestratorMode) return;
-		return { systemPrompt: event.systemPrompt + DOCTRINE };
+		const doctrine = store.paused ? DOCTRINE + PAUSED_ADDENDUM : DOCTRINE;
+		return { systemPrompt: event.systemPrompt + doctrine };
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
 		uiCtx = ctx;
-		// store.restore() ran in index.ts before this handler is invoked in
-		// registration order; re-apply the persisted mode to the fresh runtime.
+		// store.restore() (index.ts) and pending-handoff adoption (handoff.ts)
+		// ran before this handler in registration order; re-apply the persisted
+		// mode to the fresh runtime.
 		if (store.orchestratorMode) {
 			const active = pi.getActiveTools();
 			const alreadyRestricted =

--- a/.pi/extensions/slate/state.ts
+++ b/.pi/extensions/slate/state.ts
@@ -36,18 +36,22 @@ export interface SlateSnapshot {
 	threads: ThreadRecord[];
 	episodes: EpisodeRecord[];
 	orchestratorMode: boolean;
+	paused: boolean;
 }
 
 export interface SlateConfig {
 	episodeModel?: string; // "provider/id" for the episode compressor (D5)
 	workerTools?: string[];
 	maxConcurrent?: number;
+	pauseThresholdPercent?: number; // orchestrator context budget for auto-pause (default 40)
 }
 
 export class SlateStore {
 	threads = new Map<string, ThreadRecord>();
 	episodes = new Map<string, EpisodeRecord>();
 	orchestratorMode = false;
+	/** When true (context budget exceeded) ThreadManager rejects NEW dispatches. */
+	paused = false;
 	/** Invoked after every save/restore; used by mode.ts to refresh the widget. */
 	onDidChange?: () => void;
 
@@ -67,6 +71,7 @@ export class SlateStore {
 			threads: [...this.threads.values()].map((t) => ({ ...t, status: "idle" as const })),
 			episodes: [...this.episodes.values()],
 			orchestratorMode: this.orchestratorMode,
+			paused: this.paused,
 		};
 	}
 
@@ -75,7 +80,7 @@ export class SlateStore {
 		this.onDidChange?.();
 	}
 
-	/** Rebuild from the last slate-state entry on the current branch; drop records whose files vanished. */
+	/** Rebuild from the last slate-state entry on the current branch. */
 	restore(ctx: ExtensionContext): void {
 		let latest: SlateSnapshot | undefined;
 		for (const entry of ctx.sessionManager.getBranch()) {
@@ -84,12 +89,23 @@ export class SlateStore {
 				latest = e.data as SlateSnapshot;
 			}
 		}
+		this.adoptSnapshot(latest, ctx);
+	}
+
+	/**
+	 * Replace all state with a snapshot (undefined clears), dropping records
+	 * whose files vanished. Shared by restore() and the cross-session handoff
+	 * adoption in handoff.ts.
+	 */
+	adoptSnapshot(latest: SlateSnapshot | undefined, ctx: ExtensionContext): void {
 		this.threads.clear();
 		this.episodes.clear();
 		this.orchestratorMode = false;
+		this.paused = false;
 		if (!latest) return;
 
 		this.orchestratorMode = latest.orchestratorMode ?? false;
+		this.paused = latest.paused ?? false;
 		const dropped: string[] = [];
 		for (const t of latest.threads ?? []) {
 			if (t.sessionFile && !existsSync(t.sessionFile)) {

--- a/.pi/extensions/slate/threads.ts
+++ b/.pi/extensions/slate/threads.ts
@@ -96,6 +96,15 @@ export class ThreadManager {
 		signal: AbortSignal | undefined,
 		onProgress?: (p: DispatchProgress) => void,
 	): Promise<DispatchResult> {
+		// Pause blocks only NEW dispatches — in-flight ones already hold their
+		// queue slot and are allowed to finish (their episodes still get written).
+		if (this.store.paused) {
+			throw new Error(
+				"Slate is paused for handoff: the context budget was exceeded and new dispatches are rejected. " +
+					"Reply to the user with a handoff brief (overall goal, per-thread state with episode ids, immediate next actions) " +
+					"and ask them to run /slate handoff [focus] to continue in a fresh session.",
+			);
+		}
 		const thread = this.resolveThread(opts);
 
 		// Per-thread FIFO: chain onto the previous dispatch for this thread.
@@ -207,10 +216,10 @@ export class ThreadManager {
 
 			unsubscribe = session.subscribe((event: { type: string; [k: string]: unknown }) => {
 				if (event.type === "tool_execution_start") {
-					lines.push(`→ ${(event as { toolName: string }).toolName}`);
+					lines.push(`→ ${(event as unknown as { toolName: string }).toolName}`);
 					emit(false);
 				} else if (event.type === "message_end") {
-					const msg = (event as { message: { role: string; content?: Array<{ type: string; text?: string }>; usage?: { input?: number; output?: number; totalTokens?: number; cost?: { total?: number } }; stopReason?: string; errorMessage?: string } }).message;
+					const msg = (event as unknown as { message: { role: string; content?: Array<{ type: string; text?: string }>; usage?: { input?: number; output?: number; totalTokens?: number; cost?: { total?: number } }; stopReason?: string; errorMessage?: string } }).message;
 					if (msg.role !== "assistant") return;
 					usage.turns++;
 					usage.input += msg.usage?.input ?? 0;

--- a/.pi/extensions/slate/tools.ts
+++ b/.pi/extensions/slate/tools.ts
@@ -100,7 +100,7 @@ export function registerSlateTools(pi: ExtensionAPI, store: SlateStore, getManag
 		async execute() {
 			const threads = [...store.threads.values()];
 			if (threads.length === 0) {
-				return { content: [{ type: "text", text: "No threads yet. Use the thread tool to create one." }], details: {} };
+				return { content: [{ type: "text", text: "No threads yet. Use the thread tool to create one." }], details: { count: 0 } };
 			}
 			const lines = threads.map((t) => {
 				const episodes = t.episodeIds.length > 0 ? t.episodeIds.join(", ") : "(none)";


### PR DESCRIPTION
#### Motivation:

Long slate orchestration sessions accumulate context until the orchestrator's strategic quality degrades, and there was no mechanism to stop it from dispatching new work or to continue in a fresh session without losing thread/episode state.

This PR auto-pauses the orchestrator at 40% context usage (configurable via `pauseThresholdPercent` in `.pi/slate.json`): the `thread` tool rejects new dispatches, the orchestrator is steered to reply with a handoff brief and direct the user to `/slate handoff [focus]`, and that command starts a fresh session that adopts all threads and episodes — worker sessions resume from their on-disk `.jsonl` files. Slate state entries live on the parent session's branch and do not survive a session replacement, so the carryover uses `.pi/slate/pending-handoff.json`, consumed on the new session's start and guarded by parent-session provenance plus a 15-minute staleness window. The generic `handoff-guard` extension now defers to slate when orchestrator mode is active (`/handoff` redirects to `/slate handoff`), so the two extensions never issue conflicting guidance.

Also fixes three pre-existing strict-mode type errors found by the first-ever typecheck of the extensions (verified with `tsc --strict` against the pi SDK type definitions; changes are pi tooling only — no Java modules touched, so the Maven test suite does not apply).
