### PR TITLE
Fix Hetzner runner autoscaler for datacenter removal

### DIFF
--- a/.github/workflows/testflows-orchestrator.pkr.hcl
+++ b/.github/workflows/testflows-orchestrator.pkr.hcl
@@ -91,7 +91,10 @@ build {
       # 4. Create virtual environment for testflows
       "python3 -m venv /opt/testflows-runners",
       "/opt/testflows-runners/bin/pip install --upgrade pip",
-      "/opt/testflows-runners/bin/pip install testflows.github.hetzner.runners",
+      # Floor pinned to the build that migrated off the removed Hetzner `datacenter`
+      # server field (removed after 2026-07-01) to `server.location`; older builds
+      # crash every scale cycle on the current API. Newer builds still flow in.
+      "/opt/testflows-runners/bin/pip install 'testflows.github.hetzner.runners>=1.10.260702'",
 
       # 5. Create symlink for easy access
       "ln -sf /opt/testflows-runners/bin/github-hetzner-runners /usr/local/bin/github-hetzner-runners",

--- a/.github/workflows/testflows-orchestrator/github-hetzner-runners-wrapper
+++ b/.github/workflows/testflows-orchestrator/github-hetzner-runners-wrapper
@@ -6,6 +6,6 @@ exec /usr/local/bin/github-hetzner-runners \
      --github-repository "${GITHUB_REPOSITORY}" \
      --hetzner-token "${HCLOUD_TOKEN}" \
      --max-runners 36 \
-     --recycle 0 \
+     --recycle off \
      --scripts /etc/github-hetzner-runners/scripts
 


### PR DESCRIPTION
#### Motivation

On 2026-07-03 the self-hosted `Linux x86 - JDK 21/25` CI legs queued forever while every GitHub-hosted leg (macOS, Windows, `ubuntu-24.04-arm`) passed. The `github-hetzner-runners` autoscaler on the orchestrator VM was crashing on every scale cycle with `AttributeError: 'NoneType' object has no attribute 'location'`, so no `type-cpx42` runner ever registered.

Root cause is external: Hetzner removed the `datacenter` field from server API responses after its ["phasing out datacenters" deprecation](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters), whose removal date was **2026-07-01**. The pinned autoscaler (hcloud 2.3.0 + testflows 1.10.260127) dereferences `server.datacenter.location.name` in ~12 places, which now returns `None` for every server.

The upstream fix is `testflows.github.hetzner.runners==1.10.260702.1164359` (built 2026-07-02, one day after removal): it migrated to `server.location` and requires `hcloud==2.22.0`. The live orchestrator VM was upgraded in place and is healthy again (10 runners online, backlog draining).

This PR keeps the checked-in image definition consistent so a snapshot rebuild does not regress:

- **Wrapper**: the new build's CLI rejects `--recycle 0` (it now takes `on|off` — `error: argument -r/--recycle: invalid value 0`), which would fail argparse and prevent the service from starting. Changed to `--recycle off`, its intended "no recycle" meaning.
- **Packer**: floor-pinned the `pip install` to `>=1.10.260702` so a rebuild cannot resolve a pre-fix build. Newer builds still flow in.

#### Trade-offs

`--recycle off` preserves the prior behavior (fresh server per job, deleted on completion). No functional change beyond adapting to the new flag grammar. The pin is a floor, not an exact version, so future testflows fixes are not blocked.

#### Testing

Verified against production: after upgrading hcloud → 2.22.0 and testflows → 1.10.260702 and setting `--recycle off`, the service starts clean, enumerates servers without the `location` crash, and provisions runners that register and pick up jobs. All 5 backlogged runs moved to `in_progress`.