### PR TITLE
Add track-based development workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,20 @@ If this PR is related to an issue, prefix the title with the issue number (e.g.,
 Explain WHY this change was made — the problem, context, and trade-offs.
 Not a restatement of the diff. This section is **MANDATORY**.
 
+#### Planned changes:
+<!-- MANDATORY for non-trivial changes. Written when the draft PR is created (before
+implementation); updated as reality diverges. High design level using the main domain
+entities from the code — no file paths, no method signatures. Include the subsections that
+apply: Current state · What changes (contract/behavior) · How (design level) ·
+Key decisions (chosen vs rejected alternatives) · Out of scope · Risks & accepted
+trade-offs · Verification approach. For trivial changes a 2–3 sentence paragraph suffices.
+Guidance: docs/dev-workflow/track-development.md -->
+
+#### Tracks:
+<!-- Multi-track changes only — display index; the source of truth is the marker commits
+(`git log --oneline --grep '^Track [0-9]* complete:'`). Write "N/A (single-track)" otherwise.
+Branch-life only: this table is stripped from the description before the squash-merge. -->
+
+| # | Track | Scope | Status | Satellite PR |
+|---|-------|-------|--------|--------------|
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,30 @@ Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless) 
 
 For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDBC and legacy JMH benchmarks, and the per-test JVM properties (`bufferSize`, `createDefaultUsers`, `checksumMode`, `directMemory.trackMode`): see `.claude/docs/testing-details.md`.
 
+## Development Workflow (Track-Based)
+
+All changes follow the track-based flow — full protocol in `docs/dev-workflow/track-development.md`:
+
+1. **Research first** — interactive code exploration before implementation; a research log is
+   opened lazily when complexity triggers fire (non-trivial decisions, surprises, risky
+   invariants, session boundaries — see the protocol doc).
+2. **Adversarial review** — mandatory before implementation for every change; a fresh-context
+   reviewer attacks the research log (or the draft plan when no log exists); scaled down to a
+   micro-review for trivial changes.
+3. **Umbrella draft PR** — created before implementation starts, with a design-level
+   description (Planned changes + Tracks sections per the PR template). The user approves the
+   proposed track split before coding begins.
+4. **Track-based implementation (mandatory)** — multi-file changes are split into tracks
+   (independently reviewable units, ~12–25 files); development is linear on one branch; each
+   track ends with a mandatory agent code review of the track diff, then an empty marker
+   commit `Track NN complete: <short name>` (the durable track-boundary record).
+5. **Satellite review PRs (optional, user-gated)** — after each track the agent asks whether
+   to open a draft satellite PR for human review of that track's diff; mechanics in
+   `docs/dev-workflow/satellite-pr.md`. Satellites are review-only: always draft, never merged.
+
+Single-track changes skip the split and markers; trivial changes (typos, doc-only, mechanical
+renames) may also skip the full adversarial review — see the protocol doc's scaling table.
+
 ## Git Conventions
 
 ### Branches
@@ -128,11 +152,14 @@ For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDB
 - **No merge commits** (enforced by CI - `block-merge-commits.yml`)
 - PR title auto-prefixed with YTDB issue number from branch name
 - **Multiple issues**: when a PR addresses several issues, list them all in the title, comma-separated and wrapped in square brackets: `[YTDB-123, YTDB-456] <summary>`.
-- Target branch: `develop`
+- Target branch: `develop` (exception: satellite review PRs target their pinned `track-NN-base`
+  branch)
 - **1 PR = 1 squashed commit** — all branch commits are squashed on merge
-- **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made.
+- **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made. Satellite review PRs are exempt — they carry a track-summary body instead (see the satellite bullet below).
 - **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
+- **Planned changes & Tracks sections**: The PR template includes "Planned changes" and "Tracks" sections, mandatory for non-trivial changes. The umbrella draft PR is created before implementation starts and its description is kept in sync as work proceeds — see `docs/dev-workflow/track-development.md`.
+- **Satellite review PRs** are draft-only review vehicles for individual tracks: they are never merged and never marked ready for review — see `docs/dev-workflow/satellite-pr.md`.
 
 ### Rebase Conflict Resolution
 - When a rebase produces conflicts in prose-heavy files (e.g., `AGENTS.md` or `docs/adr/**`), re-read each resolved section end-to-end before continuing. Three-way merges on prose-heavy files can yield text that parses but no longer makes sense: half of a procedure from one side spliced to half from the other, rules that contradict themselves across paragraphs, cross-references to sections that no longer exist, threshold tables drifted from the prose that cites them. Tests catch broken code; nothing catches broken prose except a reader.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,5 @@
 | [Object-Oriented Data Modeling](object-oriented.md) | Inheritance, polymorphic queries, property types, schema evolution |
 | [Fine-Grained Security](security.md) | Predicate-based security policies, per-role filtering, ALTER/REVOKE lifecycle |
 | [Development Workflow](workflow-book/chapters/01-workflow-at-a-glance.md) | Contributor onboarding book for the YouTrackDB development workflow — phases, tiers, tracks, and reviews — in 16 chapters. Start at Chapter 1. |
+| [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, adversarial review, umbrella draft PR, per-track code review, marker commits |
+| [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track review PRs — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |

--- a/docs/dev-workflow/satellite-pr.md
+++ b/docs/dev-workflow/satellite-pr.md
@@ -1,0 +1,62 @@
+# Satellite Review PRs
+
+## Purpose & invariants
+
+A satellite PR is a review vehicle for ONE track's diff. Two invariants:
+
+- It is **never merged**.
+- It is **never marked "ready for review"** — it stays DRAFT for its whole life.
+
+Why draft matters: every PR-gate workflow in this repo (maven-pipeline including the coverage and
+test-count gates, pr-title-prefix, block-merge-commits) skips drafts, so satellites incur zero CI
+cost. Additionally, the test-count gate's baseline is hardcoded to origin/develop and would
+misfire on a non-develop base if the PR ever left draft.
+
+## When
+
+Optional per track and user-gated: after a track's review fixes and marker commit land, the agent
+asks whether to create one. Sticky answers ("yes/no for all remaining tracks") are honored and
+recorded under the umbrella PR's Tracks table.
+
+## Creation
+
+Two pinned branches per track:
+
+- Base `<branch>/track-NN-base` — at the PREVIOUS track's marker commit (for track 01: the
+  merge-base with develop).
+- Head `<branch>/track-NN-head` — at THIS track's marker commit.
+
+Push both, then:
+
+```bash
+gh pr create --draft \
+  --base <branch>/track-NN-base \
+  --head <branch>/track-NN-head \
+  --title "[Track NN] <name> (review only — do not merge)" \
+  --body <track summary>
+```
+
+The body is the track summary: scope, key decisions relevant to this track, and suggested review
+focus. Link the satellite in the umbrella PR's Tracks table.
+
+## Observation loop
+
+The reviewer leaves observations in the satellite PR. The agent reads them (`gh pr view
+--comments` / review threads), fixes them as NORMAL commits on the working branch (never on the
+satellite branches), then force-updates `<branch>/track-NN-head` to the current working-branch
+HEAD with `--force-with-lease`.
+
+Caveat: if later tracks have started, the updated head pollutes the satellite's diff with
+later-track commits. Mitigations: GitHub's "changes since your last review" view shows only the
+fix commits, and observations should be resolved promptly — preferably before the next track
+completes.
+
+## Rebase re-pinning
+
+After a working-branch rebase, recompute both branches from the (moved) marker commits and push
+with `--force-with-lease`.
+
+## Cleanup
+
+When the umbrella PR merges: close every satellite PR and delete every `track-NN-base` /
+`track-NN-head` branch.

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -1,0 +1,215 @@
+# Track-Based Development Workflow
+
+## Overview
+
+This is the mandatory flow for ALL changes in this repository:
+
+Research → (lazy) research log → adversarial review → umbrella draft PR → user approves track
+split → per-track loop (implement → track code review → fixes → marker commit → optional satellite
+PR) → squash-merge + cleanup.
+
+The flow scales with change size:
+
+| Change size | What applies |
+| --- | --- |
+| Multi-track change | Full flow as described above. |
+| Single-track change | No track split, no marker commits. Everything else applies. |
+| Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Micro adversarial review, or skip it with explicit user consent. Planned-changes section is a 2–3-sentence paragraph. |
+
+## Research phase (lightweight)
+
+Research is interactive exploration before any implementation: read real source code, trace call
+chains, and clarify aims and constraints with the user. There is no design document, no
+implementation plan, and no mandatory artifacts. The phase ends when the initial design of the
+change is understood.
+
+## Research log (lazy-triggered)
+
+Start research WITHOUT a log. Open one the moment any trigger below fires, then backfill the
+decisions already made — backfilling is cheap while they are still in context.
+
+| # | Trigger |
+| --- | --- |
+| 1 | Second non-trivial decision (a choice where a plausible alternative was rejected for a reason). |
+| 2 | First surprise — the codebase behaves differently than assumed. |
+| 3 | First risky invariant identified — concurrency, durability/WAL/recovery, transactional semantics, public API or behavioral change. |
+| 4 | Research will cross a session boundary. |
+| 5 | The change is multi-track. |
+| 6 | The user requests it. |
+
+### Log format
+
+Four sections:
+
+- **Initial request** — verbatim, written once.
+- **Decision Log** — append-only. Each entry is at most 4 lines: the decision, why, and the
+  alternatives rejected. Each entry MUST be self-sufficient in one sentence; optional evidence
+  citations go in as deep links.
+- **Surprises & Discoveries**
+- **Open Questions**
+
+### Persistence
+
+During research the log lives as an untracked file `research-log.md` at the repo root. At
+umbrella-PR creation its content is folded into the PR description — Key decisions, Risks, and
+Open questions feed the corresponding Planned-changes subsections — and the file is deleted.
+Decisions made after PR creation are appended to the PR description directly.
+
+### Under-trigger guardrail
+
+When shaping the PR description without a log, state this explicitly (e.g. "no log kept — one
+trivial decision, no surprises") so the user can override and request one.
+
+## Adversarial review (mandatory, pre-implementation)
+
+Adversarial review runs after research converges, BEFORE the PR description is finalized and
+implementation starts, for EVERY change. The rationale, briefly: critique activates latent
+knowledge that constructive planning does not (generator/critic asymmetry), and a fresh-context
+reviewer has no anchoring on the author's rationale.
+
+The reviewer must be a fresh context (sub-agent or fresh session) that did not author the
+decisions.
+
+Input is keyed on log existence:
+
+- Log exists → the adversary attacks the log (plus its cited evidence).
+- No log → the adversary attacks the draft Planned-changes statement.
+- Trivial tier → micro-review with one bounded question ("what breaks / what am I not seeing?"),
+  or skipped with explicit user consent.
+
+Charter scaling: for single-track changes, limit the mandate to correctness, hidden coupling, and
+missed alternatives — style and speculative scope creep are out of bounds.
+
+Licensed null verdict: "no substantive findings" is an acceptable, respected outcome — the review
+prompt must say so.
+
+Triage each finding with the user. Three outcomes:
+
+- **Strengthen** — enrich the alternatives-rejected rationale of the attacked decision.
+- **Reverse** — change the decision now, while it is still cheap.
+- **Accept-as-risk** — record it in Open Questions / Risks.
+
+One round by default; run a second round only if any decision was actually reversed. Append a
+verdict line to the log (or straight to the PR description if there is no log):
+
+```
+Adversarial review: passed, N accepted risks — YYYY-MM-DD
+```
+
+## Umbrella draft PR
+
+Created once the initial design is understood, before implementation:
+
+```bash
+gh pr create --draft --base develop
+```
+
+The description follows `.github/pull_request_template.md`: Motivation (why), "Planned changes"
+(detailed but high-level), and "Tracks" (a display table).
+
+### Planned-changes rules
+
+Write at a high design level using the MAIN DOMAIN ENTITIES from the code — real class and
+component names. Hard guards: no file paths, no method signatures. If a sentence would change when
+a method is renamed, it is too deep.
+
+Subsections activate when their content exists:
+
+- **Current state** — the before-picture per affected area.
+- **What changes** — the externally observable contract/behavior: API surface, semantics,
+  defaults, on-disk format, compatibility, concurrency guarantees.
+- **How** — design-level description.
+- **Key decisions** — chosen vs rejected; preempts "why not X?" review comments.
+- **Out of scope** — explicit non-goals.
+- **Risks & accepted trade-offs** — including the adversarial review verdict line.
+- **Verification approach** — 1–2 lines.
+
+"Deep enough" test: a reviewer who knows the codebase but not this change can (1) predict which
+subsystems the diff touches, (2) evaluate each track's diff against a stated intent, and
+(3) answer "why not alternative X" without asking.
+
+Note: the description becomes the squash-commit body on develop — it is the permanent
+git-archaeology record for the change.
+
+The user approves the proposed track split (and the description) before implementation starts.
+Mid-flight changes to the split are re-presented to the user.
+
+## Track loop
+
+A track is one PR in a stacked-diff series: it builds on the tracks before it, stands alone as
+an independently reviewable unit, and carries as much of the change as one reviewable diff
+holds.
+
+Sizing (soft bounds): a track of ≤~12 in-scope files folds into a neighbor; >~20–25 in-scope
+files is a split candidate.
+
+All development is linear on the single working branch; each track is a contiguous commit range.
+Track numbering is append-only: completed tracks never renumber, a replanned remainder gets new
+numbers, and abandoned planned tracks are struck through in the Tracks table — their numbers are
+never reused.
+
+Per-track sequence:
+
+1. Implement the track (normal commit/test/push discipline per AGENTS.md).
+2. MANDATORY agent code review of the cumulative track diff `git diff <prev-marker>..HEAD` —
+   correctness, test coverage, style, API surface, documentation sync.
+3. Fix findings as normal commits.
+4. Land the marker commit.
+5. Update the umbrella PR Tracks table row (status, satellite link); revise Planned changes only
+   if reality diverged from it.
+6. Ask the user whether to open a satellite review PR (see `docs/dev-workflow/satellite-pr.md`). Sticky
+   answers are allowed: the user may reply "yes/no for all remaining tracks". Record the sticky
+   answer as a one-line note under the Tracks table for cross-session durability and stop asking.
+
+## Marker commits (source of truth for track boundaries)
+
+Format — an empty commit with a zero-padded two-digit track number:
+
+```bash
+git commit --allow-empty -m "Track NN complete: <short name>"
+# e.g.  Track 03 complete: wal-refactor
+```
+
+List all boundaries offline:
+
+```bash
+git log --oneline --grep '^Track [0-9]* complete:'
+```
+
+Track N's diff is `marker(N-1)..marker(N)`; track 01's base is the merge-base with develop.
+
+Properties:
+
+- **Rebase-resilient** — markers are in the history being rebased, so they move with it.
+- **Zero cleanup** — the squash-merge into develop erases them.
+- The umbrella PR Tracks table is a display-only index (names, scope lines, satellite links —
+  never SHAs).
+
+Single-track changes land no markers — the whole branch diff is the track.
+
+## Rebase protocol
+
+After any rebase of the working branch: the markers moved automatically. Re-pin all satellite
+base/head branches from the moved markers and push with `--force-with-lease`. Open satellite PRs
+update automatically since their refs moved.
+
+## Merge & cleanup
+
+The umbrella PR is the ONLY PR ever merged (squash, per repo conventions). Before merge:
+
+- Re-read the whole PR description end-to-end to confirm it still tells one consistent story.
+- Strip the Tracks table (and any sticky-answer note under it) from the description. Track
+  numbers are ephemeral branch-life identifiers: after the squash-merge the marker commits are
+  gone and the satellites are closed, so track references would dangle in develop's history.
+  The rest of the description — Motivation, Planned changes — stays: it becomes the
+  squash-commit body.
+
+At merge: close all satellite PRs and delete all satellite review branches.
+
+## Layering richer workflows on top
+
+Richer internal planning and execution machinery — whatever agent tooling is in use — may be
+layered on top of this baseline, provided it satisfies the mandatory gates: pre-implementation
+adversarial review, an umbrella draft PR before coding starts, a code review per track, marker
+commits at track boundaries, and the per-track satellite-PR ask. This document defines the
+baseline that applies regardless of the tooling.


### PR DESCRIPTION
#### Motivation:
Large changes are currently reviewed as one monolithic branch diff, which makes thorough review impractical and loses the reasoning behind design decisions. Review feedback also has no dedicated channel scoped to a coherent slice of the work. This change introduces a mandatory track-based development flow so every non-trivial change is reviewable in track-sized diffs, with decision quality raised before implementation and the PR description serving as the durable design record (it becomes the squash-commit body).

#### Planned changes:
**Current state**: AGENTS.md prescribes commit/PR conventions but no development flow; changes are reviewed only as the full branch diff.

**What changes**: all changes follow a track-based flow — a lightweight research phase (research log opened lazily on complexity triggers) → a mandatory fresh-context adversarial review of the decisions → an umbrella draft PR created before implementation (new "Planned changes" and "Tracks" PR-template sections) → per-track implementation on a single linear branch, each track closed by a mandatory agent code review and an empty marker commit (`Track NN complete: <short name>`) recording the boundary → an optional, user-gated draft satellite PR per track (pinned `track-NN-base`/`track-NN-head` branches) as the reviewer's channel. Satellite observations are fixed on the working branch and the satellite head is updated.

**Key decisions**: marker commits chosen over tags/branches/PR-description SHAs as the boundary record — the only rebase-resilient option, and squash-merge erases them with zero cleanup; satellite PRs stay draft forever — all CI gates skip drafts, and the test-count gate's develop-hardcoded baseline would misfire on non-develop bases; the flow is fully decoupled from `.claude/workflow/` (planned for sunset) — protocol docs are self-contained under `docs/dev-workflow/`.

**Out of scope**: wiring the Claude workflow to comply (it is being sunset); CI enforcement of the new conventions.

**Verification approach**: docs-only change; cross-file consistency audit (marker format, satellite branch naming, invariants, cross-references) and docs/README.md link check passed.

#### Tracks:
N/A (single-track)
