### PR TITLE
YTDB-1195: Make QueryMetricsStep.close() idempotent

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/monitoring/YTDBQueryMetricsStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/common/profiler/monitoring/YTDBQueryMetricsStep.java
@@ -56,6 +56,7 @@ public class YTDBQueryMetricsStep<S> extends AbstractStep<S, S> implements AutoC
   private final Ticker ticker;
   private final boolean isLightweight;
   private boolean hasStarted = false;
+  private boolean closed = false;
   private long startMillis;
   private long nano;
   private long endNano;
@@ -128,9 +129,10 @@ public class YTDBQueryMetricsStep<S> extends AbstractStep<S, S> implements AutoC
 
   @Override
   public void close() throws Exception {
-    if (!hasStarted) {
+    if (!hasStarted || closed) {
       return;
     }
+    closed = true;
 
     final var duration = isLightweight ? endNano - nano : nano;
     try {
@@ -168,6 +170,19 @@ public class YTDBQueryMetricsStep<S> extends AbstractStep<S, S> implements AutoC
       LogManager.instance().error(this,
           "Error in QueryMetricsListener callback", e);
     }
+  }
+
+  @Override
+  public void reset() {
+    // Re-arm the base AbstractStep iterator first: super.reset() clears the exhausted state
+    // so this step can be iterated again. Only then clear the monitoring state, so a re-run
+    // starts fresh with new timing measurements and fires queryFinished exactly once.
+    super.reset();
+    this.hasStarted = false;
+    this.closed = false;
+    this.startMillis = 0;
+    this.nano = 0;
+    this.endNano = 0;
   }
 
   private void queryHasStarted() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/gremlin/gremlintest/scenarios/YTDBQueryMetricsStrategyTest.java
@@ -21,6 +21,7 @@ import com.jetbrains.youtrackdb.internal.core.sql.executor.FetchFromIndexStep;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
 import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
 import org.apache.tinkerpop.gremlin.process.traversal.DT;
@@ -326,6 +327,82 @@ public class YTDBQueryMetricsStrategyTest extends YTDBAbstractGremlinTest {
     assertThat(listener.executionPlan)
         .as("a by-id lookup runs no query, so no plan is captured")
         .isNull();
+  }
+
+  // YTDB-1195: queryFinished should fire exactly once even when a traversal is
+  // exhausted via iteration and then explicitly closed.
+  @Test
+  @LoadGraphWith(MODERN)
+  public void queryFinishedFiresOnceWhenTraversalExhaustedThenClosed() throws Exception {
+    final var invocationCount = new AtomicInteger(0);
+    QueryMetricsListener countingListener = (queryDetails, startedAtMillis, executionTimeNanos) -> {
+      invocationCount.incrementAndGet();
+    };
+
+    ((YTDBTransaction) g.tx())
+        .withQueryMonitoringMode(QueryMonitoringMode.LIGHTWEIGHT)
+        .withQueryListener(countingListener);
+
+    g.tx().open();
+
+    var q = g.V().hasLabel("person");
+    // Iterate to full exhaustion
+    while (q.hasNext()) {
+      q.next();
+    }
+    // Then explicitly close (this should be idempotent and not fire queryFinished again)
+    q.close();
+
+    g.tx().commit();
+
+    assertThat(invocationCount.get())
+        .as("queryFinished should fire exactly once despite explicit close after exhaustion")
+        .isEqualTo(1);
+  }
+
+  // YTDB-1195: After reset(), a re-executed traversal should fire queryFinished again.
+  // This tests that reset() properly clears the closed flag so re-execution isn't suppressed.
+  @Test
+  @LoadGraphWith(MODERN)
+  public void queryFinishedFiresAgainAfterResetAndReExecution() throws Exception {
+    final var invocationCount = new AtomicInteger(0);
+    QueryMetricsListener countingListener = (queryDetails, startedAtMillis, executionTimeNanos) -> {
+      invocationCount.incrementAndGet();
+    };
+
+    ((YTDBTransaction) g.tx())
+        .withQueryMonitoringMode(QueryMonitoringMode.LIGHTWEIGHT)
+        .withQueryListener(countingListener);
+
+    g.tx().open();
+
+    final var traversal = g.V().hasLabel("person");
+    final var admin = traversal.asAdmin();
+
+    // First execution: iterate to exhaustion and close
+    while (traversal.hasNext()) {
+      traversal.next();
+    }
+    traversal.close();
+
+    assertThat(invocationCount.get())
+        .as("queryFinished should fire once for the first execution")
+        .isEqualTo(1);
+
+    // Reset the traversal to re-arm it for re-execution
+    admin.reset();
+
+    // Second execution: iterate to exhaustion and close
+    while (traversal.hasNext()) {
+      traversal.next();
+    }
+    traversal.close();
+
+    g.tx().commit();
+
+    assertThat(invocationCount.get())
+        .as("queryFinished should fire twice total (once per execution after reset)")
+        .isEqualTo(2);
   }
 
   // A non-graph-rooted root traversal (g.inject) has no YTDBGraphStep at its root, so


### PR DESCRIPTION
#### Motivation:

When query monitoring is enabled (`withQueryMonitoringMode` + `withQueryListener`), a single logical Gremlin query reported `queryFinished` twice for the common exhaust-then-close access pattern. TinkerPop auto-closes a traversal when its iterator is exhausted, and well-behaved clients (e.g. DNQ) also call `traversal.close()` explicitly in teardown — so `close()` ran twice. `close()` was guarded only by `hasStarted`, with no once-only guard, so every close fired the listener. This inflated any per-query metric/count/timing and forced downstream consumers (DNQ full-scan logging, XD-1281) to add a client-side dedup workaround. The bug was data-dependent (non-exhausting terminal ops like `count()` fired once; fully-iterated queries fired twice), making it easy to miss.

#### Planned changes:

Current state · `QueryMetricsStep.close()` fires the metrics listener on every invocation, guarded only by `hasStarted`.
What changes · `close()` becomes idempotent: the listener fires at most once per execution regardless of how many times the step is closed. A reset-and-re-executed monitored traversal fires exactly once per execution.
How · Add a `closed` guard set before the listener callback (so a throwing callback cannot double-fire), and override the step's `reset()` to clear all per-run lifecycle state (started/closed flags and timing) so re-execution after `reset()` is measured fresh.
Key decisions · Fixed at the single listener call site (`close()`) rather than in the client, since that is the sole invocation point and both close paths converge there. The `reset()` override was added to avoid a latent regression where the once-only guard would otherwise permanently suppress metrics on a reused traversal.
Out of scope · No change to listener API, monitoring modes, or non-Gremlin query paths.
Risks & accepted trade-offs · Thread-safety unchanged — the step is thread-confined (embedded via ThreadLocal transaction; remote via single-threaded session executor), so a plain boolean guard is adequate.
Verification approach · Added regression tests: exactly-once on exhaust-then-explicit-close, and once-per-run across reset+re-execution. `YTDBQueryMetricsStrategyTest` passes 17/17 via the `YTDBProcessTest` suite.

#### Tracks:

N/A (single-track)
