### PR TITLE
Show total session expenses (orchestrator + workers) in slate status line

### DIFF
--- a/.pi/extensions/slate/episodes.ts
+++ b/.pi/extensions/slate/episodes.ts
@@ -94,6 +94,7 @@ export interface CompressedEpisode {
 	text: string; // full episode markdown (header + body) as returned to the orchestrator
 	file: string;
 	compressor: string; // model used, or "(uncompressed fallback)"
+	costUsd: number; // USD cost of the compression LLM call (0 on fallback)
 }
 
 function lastAssistantText(messages: unknown[]): string {
@@ -119,6 +120,7 @@ export async function compressEpisode(opts: CompressEpisodeOptions): Promise<Com
 
 	let body: string | undefined;
 	let compressor = "(uncompressed fallback)";
+	let costUsd = 0;
 
 	try {
 		const model = await resolveCompressorModel(ctx, opts.configuredModel, opts.workerModel);
@@ -151,6 +153,7 @@ export async function compressEpisode(opts: CompressEpisodeOptions): Promise<Com
 						signal: opts.signal,
 					},
 				);
+				costUsd = response.usage?.cost?.total ?? 0;
 				const text = response.content
 					.filter((c: { type: string }): c is { type: "text"; text: string } => c.type === "text")
 					.map((c: { text: string }) => c.text)
@@ -192,5 +195,5 @@ export async function compressEpisode(opts: CompressEpisodeOptions): Promise<Com
 
 	const text = `${header}${body}\n`;
 	writeFileSync(file, text, "utf8");
-	return { text, file, compressor };
+	return { text, file, compressor, costUsd };
 }

--- a/.pi/extensions/slate/handoff.ts
+++ b/.pi/extensions/slate/handoff.ts
@@ -20,7 +20,7 @@
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { SlateConfig, SlateSnapshot, SlateStore } from "./state.ts";
+import { orchestratorCostUsd, type SlateConfig, type SlateSnapshot, type SlateStore } from "./state.ts";
 
 const DEFAULT_PAUSE_THRESHOLD_PERCENT = 40;
 /** A pending-handoff file older than this cannot belong to an in-flight handoff. */
@@ -173,7 +173,15 @@ export function registerSlateHandoff(
 			brief,
 			// The successor starts unpaused and in orchestrator mode regardless of
 			// the current (paused) state.
-			snapshot: { ...store.snapshot(), paused: false, orchestratorMode: true },
+			snapshot: {
+				...store.snapshot(),
+				paused: false,
+				orchestratorMode: true,
+				// The successor's own branch sum starts at zero, so bank the parent's
+				// billed orchestrator spend (plus anything already carried) — the
+				// displayed total must survive repeated handoffs.
+				carriedCostUsd: store.carriedCostUsd + orchestratorCostUsd(ctx),
+			},
 		};
 		const file = pendingFile(ctx.cwd);
 		mkdirSync(dirname(file), { recursive: true });

--- a/.pi/extensions/slate/mode.ts
+++ b/.pi/extensions/slate/mode.ts
@@ -15,7 +15,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { SlateHandoffHooks } from "./handoff.ts";
 import { DEFAULT_ORCHESTRATOR_PROMPT_DOCS, loadPromptDocs } from "./prompt-docs.ts";
-import type { SlateConfig, SlateStore } from "./state.ts";
+import { orchestratorCostUsd, type SlateConfig, type SlateStore } from "./state.ts";
 
 const ORCHESTRATOR_TOOLS = ["read", "grep", "find", "ls", "thread", "threads", "episode"];
 
@@ -75,10 +75,18 @@ export function registerSlateMode(
 			uiCtx.ui.setStatus("slate", undefined);
 			return;
 		}
-		uiCtx.ui.setStatus("slate", "slate: orchestrator");
+		// Orchestrator's own spend: summed over ALL entries (billed reality —
+		// abandoned branches still cost money), plus spend carried across handoffs.
+		const orchestratorCost = orchestratorCostUsd(uiCtx);
+		const total = orchestratorCost + store.workerCostUsd + store.carriedCostUsd;
+		// Keep the line short in the common no-handoff case.
+		const carried = store.carriedCostUsd > 0 ? ` + carried $${store.carriedCostUsd.toFixed(4)}` : "";
+		const costLine = `total $${total.toFixed(4)} (me $${orchestratorCost.toFixed(4)} + workers $${store.workerCostUsd.toFixed(4)}${carried})`;
+		uiCtx.ui.setStatus("slate", `slate: orchestrator ⋅ ${costLine}`);
 		const threads = [...store.threads.values()];
 		const lines = [
 			`slate ⋅ orchestrator mode ⋅ ${threads.length} thread${threads.length === 1 ? "" : "s"}`,
+			`  ${costLine}`,
 			...(store.paused ? ["  ⛔ PAUSED (context budget) — run /slate handoff"] : []),
 			...threads.map(
 				(t) =>
@@ -151,6 +159,12 @@ export function registerSlateMode(
 		const parts = [DOCTRINE, ...docs.map((d) => `\n\n${d}`)];
 		if (store.paused) parts.push(PAUSED_ADDENDUM);
 		return { systemPrompt: event.systemPrompt + parts.join("") };
+	});
+
+	// Refresh the orchestrator's own cost after each of its settled runs.
+	pi.on("agent_settled", async (_event, ctx) => {
+		uiCtx = ctx;
+		updateWidget();
 	});
 
 	pi.on("session_start", async (_event, ctx) => {

--- a/.pi/extensions/slate/state.ts
+++ b/.pi/extensions/slate/state.ts
@@ -176,8 +176,10 @@ export class SlateStore {
 export function orchestratorCostUsd(ctx: ExtensionContext): number {
 	let cost = 0;
 	for (const entry of ctx.sessionManager.getEntries()) {
-		if (entry.type === "message" && entry.message.role === "assistant") {
-			cost += entry.message.usage?.cost?.total ?? 0;
+		// Loose cast + optional chaining: tolerate malformed/legacy entries.
+		const e = entry as { type: string; message?: { role?: string; usage?: { cost?: { total?: number } } } };
+		if (e.type === "message" && e.message?.role === "assistant") {
+			cost += e.message.usage?.cost?.total ?? 0;
 		}
 	}
 	return cost;

--- a/.pi/extensions/slate/state.ts
+++ b/.pi/extensions/slate/state.ts
@@ -37,6 +37,8 @@ export interface SlateSnapshot {
 	episodes: EpisodeRecord[];
 	orchestratorMode: boolean;
 	paused: boolean;
+	workerCostUsd: number;
+	carriedCostUsd: number; // orchestrator spend banked from ancestor sessions at handoff
 }
 
 export interface SlateConfig {
@@ -54,6 +56,14 @@ export class SlateStore {
 	orchestratorMode = false;
 	/** When true (context budget exceeded) ThreadManager rejects NEW dispatches. */
 	paused = false;
+	/**
+	 * Cumulative USD spend of worker threads this session. Includes the episode
+	 * compressor's LLM calls, so the "workers" figure shown in the widget covers
+	 * compression spend too.
+	 */
+	workerCostUsd = 0;
+	/** Orchestrator spend inherited from ancestor sessions across handoffs. */
+	carriedCostUsd = 0;
 	/** Invoked after every save/restore; used by mode.ts to refresh the widget. */
 	onDidChange?: () => void;
 
@@ -74,6 +84,8 @@ export class SlateStore {
 			episodes: [...this.episodes.values()],
 			orchestratorMode: this.orchestratorMode,
 			paused: this.paused,
+			workerCostUsd: this.workerCostUsd,
+			carriedCostUsd: this.carriedCostUsd,
 		};
 	}
 
@@ -92,6 +104,20 @@ export class SlateStore {
 			}
 		}
 		this.adoptSnapshot(latest, ctx);
+		// Cost counters are NOT branch-scoped like the records above: money never
+		// un-spends, and dispatches on now-abandoned branches were still billed.
+		// Take the MAX over ALL slate-state entries (both counters are monotonic
+		// within a session file) so a branch switch cannot roll them back.
+		for (const entry of ctx.sessionManager.getEntries()) {
+			const e = entry as {
+				type: string;
+				customType?: string;
+				data?: { workerCostUsd?: number; carriedCostUsd?: number };
+			};
+			if (e.type !== "custom" || e.customType !== "slate-state") continue;
+			this.workerCostUsd = Math.max(this.workerCostUsd, e.data?.workerCostUsd ?? 0);
+			this.carriedCostUsd = Math.max(this.carriedCostUsd, e.data?.carriedCostUsd ?? 0);
+		}
 	}
 
 	/**
@@ -104,10 +130,15 @@ export class SlateStore {
 		this.episodes.clear();
 		this.orchestratorMode = false;
 		this.paused = false;
+		this.workerCostUsd = 0;
+		this.carriedCostUsd = 0;
 		if (!latest) return;
 
 		this.orchestratorMode = latest.orchestratorMode ?? false;
 		this.paused = latest.paused ?? false;
+		// ?? 0: old snapshots lack the cost fields.
+		this.workerCostUsd = latest.workerCostUsd ?? 0;
+		this.carriedCostUsd = latest.carriedCostUsd ?? 0;
 		const dropped: string[] = [];
 		for (const t of latest.threads ?? []) {
 			if (t.sessionFile && !existsSync(t.sessionFile)) {
@@ -133,4 +164,21 @@ export class SlateStore {
 		}
 		this.onDidChange?.();
 	}
+}
+
+/**
+ * Orchestrator spend recorded in the session file: billed LINEAGE spend —
+ * summed over ALL entries including abandoned branches (forked/cloned sessions
+ * thus inherit parent-file spend as their own). EXCLUDES pi-internal LLM calls
+ * stored as non-message entries (compaction, branch summarization).
+ * Shared by the widget (mode.ts) and handoff carry (handoff.ts).
+ */
+export function orchestratorCostUsd(ctx: ExtensionContext): number {
+	let cost = 0;
+	for (const entry of ctx.sessionManager.getEntries()) {
+		if (entry.type === "message" && entry.message.role === "assistant") {
+			cost += entry.message.usage?.cost?.total ?? 0;
+		}
+	}
+	return cost;
 }

--- a/.pi/extensions/slate/threads.ts
+++ b/.pi/extensions/slate/threads.ts
@@ -288,6 +288,9 @@ export class ThreadManager {
 		thread.episodeIds.push(episodeId);
 		thread.status = "idle";
 		thread.updatedAt = Date.now();
+		// Accumulate session-wide worker spend (worker turns + episode compressor)
+		// BEFORE save so it persists with the snapshot.
+		this.store.workerCostUsd += usage.cost + compressed.costUsd;
 		this.store.save();
 
 		emit(true, status);


### PR DESCRIPTION
#### Motivation:

pi's built-in footer shows only the orchestrator's own LLM spend. In slate orchestrator mode most spend happens in worker threads and episode compression, so the real cost of a session was invisible. The slate status line and widget now show total session expenses alongside pi's built-in display.

#### Planned changes:

**Current state**: the slate status line showed only the mode name; worker dispatch cost was visible only in per-episode headers; nothing aggregated or persisted totals.

**What changes**: in orchestrator mode the status line and widget show total spend = orchestrator + worker threads (including episode compressor) + spend carried from handoff predecessors, with a "carried" term rendered only after a handoff. Totals survive restart, resume, branch switching, and `/slate handoff`. Old snapshots without the new fields load as zero.

**How**: a running worker-spend counter is persisted in the slate state snapshot and incremented once per dispatch. Orchestrator spend is recomputed from session entries across all branches — billed lineage spend, immune to branch switching and message edits. A handoff banks the parent's orchestrator spend into a carried baseline for the successor session. The display refreshes on state changes and when the agent settles.

**Key decisions**:
1. Running persisted total instead of per-episode cost fields — money spent stays counted even when episodes are dropped.
2. Summing all session entries instead of the current branch — matches billed reality; the branch-scoped sum was rejected after adversarial review.
3. Restore takes the MAX over all persisted snapshots — counters never roll back on branch switch + resume.
4. Episode-compressor spend is counted under "workers" (documented in code).
5. Handoff carries orchestrator spend forward as an explicit baseline.

**Out of scope**: reconciling in-flight worker spend from worker session files after a crash; counting pi-internal compaction/summarization LLM calls.

**Risks & accepted trade-offs**:
- A crash/reload mid-dispatch loses that dispatch's spend from the counter (accepted; the worker session file retains ground truth).
- pi-internal compaction/branch-summary LLM calls are not counted (small, bounded).
- Sessions resumed from pre-feature snapshots show zero worker spend.
- Forked sessions inherit lineage spend as their own (documented as lineage semantics).
- The monotonic-restore guard exists only on the restore path; noted for future adoption-logic changes.

Adversarial review round 1: passed, 3 should-fix findings fixed and gate-verified — 2026-07-13
Adversarial review round 2: passed, findings accepted as risks (1 justified should-fix) — 2026-07-13

No research log kept — decisions backfilled into this description.

**Verification approach**: TypeScript extension with no test harness in this repo; verified via `node --experimental-strip-types --check` on all edited files, type-shape tracing against the installed pi `.d.ts` files, one code review, a verification gate, and two adversarial design-review rounds. No Java modules touched, so the standard test/coverage gates do not apply.

#### Tracks:

N/A (single-track)
