### PR TITLE
Add workflow-gate salience to the slate orchestrator surface

### DIFF
--- a/.pi/extensions/slate/design-principles.md
+++ b/.pi/extensions/slate/design-principles.md
@@ -157,12 +157,13 @@ The orchestrator's knowledge of these principles is two-tier, following the
 project's load-on-demand guidance (AGENTS.md):
 
 - **Tier 1 — always loaded.** The doctrine in `mode.ts` is the operational
-  distillation of P1–P10 plus the review discipline defined in
-  `review-rules.md`, appended to the system prompt every turn while
-  orchestrator mode is on. It costs a few hundred tokens and covers
-  everything routine dispatching needs.
+  distillation of P1–P10, the review discipline defined in
+  `review-rules.md`, and a pointer to the repository's track-based
+  workflow gates (`docs/dev-workflow/track-development.md`), appended to
+  the system prompt every turn while orchestrator mode is on. It costs a
+  few hundred tokens and covers everything routine dispatching needs.
 - **Tier 2 — on demand.** This document. The doctrine carries a short
-  pointer to it (doctrine rule 9); the orchestrator reads it only when
+  pointer to it (doctrine rule 10); the orchestrator reads it only when
   reasoning about the architecture itself — explaining slate, modifying
   the extension, or making a non-obvious routing/compaction decision.
 

--- a/.pi/extensions/slate/mode.ts
+++ b/.pi/extensions/slate/mode.ts
@@ -40,11 +40,16 @@ threads execute. Rules:
 6. After every episode, update your strategy. Episodes marked STATUS: FAILED
    require adaptation, not blind retry.
 7. Keep your own messages strategic: goals, task routing, synthesis.
-8. Every non-trivial change gets reviewed before it is declared done.
+8. Repository changes — including .pi/ tooling, extensions, and docs —
+   follow the track-based workflow (docs/dev-workflow/track-development.md).
+   Before the FIRST dispatch that modifies files, confirm the
+   pre-implementation gates ran (adversarial review, umbrella draft PR,
+   user-approved scope) or name the lighter tier that applies per that doc.
+9. Every non-trivial change gets reviewed before it is declared done.
    Before dispatching review threads, read
    .pi/extensions/slate/review-rules.md (skip the read if it is already
    in your context) and follow it.
-9. The design principles behind this architecture are documented in
+10. The design principles behind this architecture are documented in
    .pi/extensions/slate/design-principles.md. Read that file only when you
    must reason about slate itself (explaining it, changing the extension,
    or an unusual routing/compaction decision) — never for routine

--- a/.pi/extensions/slate/tools.ts
+++ b/.pi/extensions/slate/tools.ts
@@ -22,6 +22,7 @@ export function registerSlateTools(pi: ExtensionAPI, store: SlateStore, getManag
 			"Threads are serial; to parallelize, dispatch to DIFFERENT threads in one message.",
 			"`model` (\"provider/id\") and `tools` apply only when creating a new thread.",
 			"An episode header of STATUS: FAILED means the action failed — read it and adapt.",
+			"Tasks that modify repository files require the track workflow's pre-implementation gates to have run first.",
 		].join(" "),
 		promptSnippet: "Dispatch one bounded action to a persistent worker thread; returns a compressed episode",
 		promptGuidelines: [

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -9,6 +9,8 @@ automatically by the slate extension). Hands-on command references live in
 
 All changes follow the track-based flow — full protocol in `docs/dev-workflow/track-development.md`:
 
+This flow covers **all files in the repository**, including `.pi/` tooling and slate extension code — not only Java/product sources. There is no "harness tooling" exemption: editing an extension, prompt, or doc is a repository change and takes the same gates.
+
 1. **Research first** — interactive code exploration before implementation; a research log is
    opened lazily when complexity triggers fire (non-trivial decisions, surprises, risky
    invariants, session boundaries — see the protocol doc).


### PR DESCRIPTION
#### Motivation:

In a prior session (slate total-cost status line, #1213) the slate orchestrator edited `.pi/extensions/` files without running the repository's mandatory pre-implementation workflow gates — adversarial review, research log, and an umbrella draft PR before coding. Root-cause analysis found three compounding failures:

1. **Categorization.** The always-injected orchestrator guidelines open with "All changes follow the track-based flow," but that phrasing was read narrowly: extension/tooling edits were treated as "harness tooling, not repository changes." The sentence that closes the loophole explicitly — the flow is mandatory for ALL changes in this repository — lives only in the on-demand `track-development.md`, which the misclassification meant was never loaded.
2. **Salience.** The always-injected slate doctrine's only review rule is post-implementation; satisfying it produced a false "process complete" signal. Nothing at the actual decision point — the first file-modifying dispatch — asked whether the pre-implementation gates had run.
3. **No structural cue.** The thread tool dispatches file-modifying tasks regardless of workflow phase.

This change raises the salience of the pre-implementation gates at the orchestrator's decision point and closes the categorization loophole by naming `.pi/` tooling explicitly on the always-loaded surfaces. It deliberately does not add hard enforcement (see Out of scope).

#### Planned changes:

**Current state.** The always-injected slate orchestrator doctrine carries operating rules of which only the review rule is workflow-related, and it fires post-implementation. The thread tool contract describes dispatch mechanics but says nothing about workflow phase. The orchestrator guidelines' Development Workflow section says "all changes" without enumerating which files count.

**What changes.** Three always-loaded / decision-point surfaces gain a pre-implementation-gate reminder:
- The orchestrator doctrine gains one new rule, inserted before the existing review rule, stating that repository changes — explicitly including `.pi/` tooling, extensions, and docs — follow the track-based workflow, and that before the first file-modifying dispatch the orchestrator must confirm the pre-implementation gates (adversarial review, umbrella draft PR, user-approved scope) or name the lighter tier that applies per the workflow doc.
- The thread tool contract gains a one-line nudge that file-modifying tasks require the pre-implementation gates to have run.
- The orchestrator guidelines' Development Workflow section states explicitly that the flow covers ALL files in the repository, including `.pi/` tooling and extension code.

**How.** Pure prompt/doc content. The doctrine addition is kept minimal (about five lines) to protect the always-loaded context budget. Inserting the new doctrine rule shifts the trailing rule numbers; the slate design-principles doc is kept in sync — its §6 always-loaded-vs-on-demand description now names the workflow-gate pointer, and its rule-number pointer shifts from 9 to 10. The §5 P1–P10 principle table is unchanged, because the new rule is a project-workflow overlay, not a design principle.

**Key decisions.**
- Salient reminders over hard enforcement (chosen). Rejected: gating dispatches on a mutating/non-mutating classification of task text — unreliable and would lower slate's expressivity, contrary to its design principles.
- The escape hatch points at the workflow doc's tiering rather than asserting a "trivial" bypass, because even the trivial tier keeps a lightweight umbrella PR — it does not waive the PR/approval gates.
- The new rule is a project-workflow overlay, not a slate design principle (P1–P10), so it is not added to the design-principles §5 principle-mapping table.

**Out of scope.** Hard enforcement / mechanically blocking dispatches until gates are recorded.

**Risks & accepted trade-offs.** Salient reminders can still be ignored; that residual risk is accepted as the deliberate trade-off against the expressivity cost of hard gating. The ~4-line doctrine addition is a small, justified context-budget cost.

Adversarial review: passed, 0 accepted risks (2 low-severity findings folded into this description and the wording) — 2026-07-13. No research log kept — single design stream, one non-trivial decision (doctrine renumbering), no surprises.

**Verification approach.** `node --experimental-strip-types --check` on the two edited TS files; non-code review perspectives (consistency/cross-references, instruction completeness, context budget) on the diff.

#### Tracks:

N/A (single-track)
