### PR TITLE
Add mandatory per-track user review gate to the track-based workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,6 @@
 | [Fine-Grained Security](security.md) | Predicate-based security policies, per-role filtering, ALTER/REVOKE lifecycle |
 | [Development Workflow](workflow-book/chapters/01-workflow-at-a-glance.md) | Contributor onboarding book for the YouTrackDB development workflow — phases, tiers, tracks, and reviews — in 16 chapters. Start at Chapter 1. |
 | [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, adversarial review, umbrella draft PR, per-track code review, marker commits |
-| [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track review PRs — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
+| [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 | [Object-Oriented Data Modeling](object-oriented.md) | Inheritance, polymorphic queries, property types, schema evolution |
 | [Fine-Grained Security](security.md) | Predicate-based security policies, per-role filtering, ALTER/REVOKE lifecycle |
 | [Development Workflow](workflow-book/chapters/01-workflow-at-a-glance.md) | Contributor onboarding book for the YouTrackDB development workflow — phases, tiers, tracks, and reviews — in 16 chapters. Start at Chapter 1. |
-| [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, adversarial review, umbrella draft PR, per-track code review, marker commits |
+| [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, adversarial review, umbrella draft PR, per-track code review and mandatory user review gate, marker commits |
 | [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -22,19 +22,19 @@ This flow covers **all files in the repository**, including `.pi/` tooling and s
    proposed track split before coding begins.
 4. **Track-based implementation (mandatory)** — multi-file changes are split into tracks
    (independently reviewable units, ~12–25 files); development is linear on one branch; each
-   track ends with a mandatory agent code review of the track diff, then a mandatory USER
-   review — the orchestrator presents the track summary and diff and waits for explicit user
-   approval — then an empty marker commit `Track NN complete: <short name>` (the durable
-   track-boundary record).
+   track ends with a mandatory agent code review of the track diff, then a mandatory user
+   review — the orchestrator waits for explicit user approval — then an empty marker commit
+   `Track NN complete: <short name>` (the durable track-boundary record).
 5. **Satellite review PRs (optional, user-gated)** — after each track's user approval and
    marker commit the agent asks whether to open a draft satellite PR for review by separate
-   PEER reviewers (not the primary user review, which is in-session and mandatory); mechanics
-   in `docs/dev-workflow/satellite-pr.md`. Satellites are review-only: always draft, never
-   merged. Once opened, the track blocks the next one until the peer review completes or the
-   user explicitly waives completion.
+   peer reviewers; mechanics in `docs/dev-workflow/satellite-pr.md`. Satellites are
+   review-only: always draft, never merged. Once opened, the track blocks the next one until
+   the peer review is complete or the user explicitly waives completion.
 
 Single-track changes skip the split and markers; trivial changes (typos, doc-only, mechanical
-renames) may also skip the full adversarial review — see the protocol doc's scaling table.
+renames) may also skip the full adversarial review — see the protocol doc's scaling table. The
+mandatory user review gate applies at every tier: for single-track and trivial changes it gates
+the squash-merge.
 
 ## Test Policy
 

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -22,11 +22,16 @@ This flow covers **all files in the repository**, including `.pi/` tooling and s
    proposed track split before coding begins.
 4. **Track-based implementation (mandatory)** — multi-file changes are split into tracks
    (independently reviewable units, ~12–25 files); development is linear on one branch; each
-   track ends with a mandatory agent code review of the track diff, then an empty marker
-   commit `Track NN complete: <short name>` (the durable track-boundary record).
-5. **Satellite review PRs (optional, user-gated)** — after each track the agent asks whether
-   to open a draft satellite PR for human review of that track's diff; mechanics in
-   `docs/dev-workflow/satellite-pr.md`. Satellites are review-only: always draft, never merged.
+   track ends with a mandatory agent code review of the track diff, then a mandatory USER
+   review — the orchestrator presents the track summary and diff and waits for explicit user
+   approval — then an empty marker commit `Track NN complete: <short name>` (the durable
+   track-boundary record).
+5. **Satellite review PRs (optional, user-gated)** — after each track's user approval and
+   marker commit the agent asks whether to open a draft satellite PR for review by separate
+   PEER reviewers (not the primary user review, which is in-session and mandatory); mechanics
+   in `docs/dev-workflow/satellite-pr.md`. Satellites are review-only: always draft, never
+   merged. Once opened, the track blocks the next one until the peer review completes or the
+   user explicitly waives completion.
 
 Single-track changes skip the split and markers; trivial changes (typos, doc-only, mechanical
 renames) may also skip the full adversarial review — see the protocol doc's scaling table.

--- a/docs/dev-workflow/satellite-pr.md
+++ b/docs/dev-workflow/satellite-pr.md
@@ -2,7 +2,9 @@
 
 ## Purpose & invariants
 
-A satellite PR is a review vehicle for ONE track's diff. Two invariants:
+A satellite PR is a review vehicle for ONE track's diff, aimed at SEPARATE PEER REVIEWERS. The
+primary user review happens in-session as a mandatory per-track gate (see
+`docs/dev-workflow/track-development.md`) and is never replaced by a satellite. Two invariants:
 
 - It is **never merged**.
 - It is **never marked "ready for review"** — it stays DRAFT for its whole life.
@@ -14,9 +16,10 @@ misfire on a non-develop base if the PR ever left draft.
 
 ## When
 
-Optional per track and user-gated: after a track's review fixes and marker commit land, the agent
-asks whether to create one. Sticky answers ("yes/no for all remaining tracks") are honored and
-recorded under the umbrella PR's Tracks table.
+Optional per track and user-gated: after a track's user-review approval and marker commit land,
+the agent asks whether to create one. Sticky answers ("yes/no for all remaining tracks") are
+honored and recorded under the umbrella PR's Tracks table — they never waive the mandatory
+in-session user review.
 
 ## Creation
 
@@ -46,10 +49,15 @@ The reviewer leaves observations in the satellite PR. The agent reads them (`gh 
 satellite branches), then force-updates `<branch>/track-NN-head` to the current working-branch
 HEAD with `--force-with-lease`.
 
-Caveat: if later tracks have started, the updated head pollutes the satellite's diff with
-later-track commits. Mitigations: GitHub's "changes since your last review" view shows only the
-fix commits, and observations should be resolved promptly — preferably before the next track
-completes.
+Once a satellite is open, the track's review loop stays open: the next track does NOT start
+until the peer review completes or the user explicitly waives completion. Peer-fix commits land
+after the track's user approval, so they are covered by the pre-merge user review of post-gate
+commits (see `docs/dev-workflow/track-development.md` § Merge & cleanup).
+
+Caveat: if later tracks have started (i.e., the user waived completion), the updated head
+pollutes the satellite's diff with later-track commits. Mitigations: GitHub's "changes since
+your last review" view shows only the fix commits, and observations should be resolved promptly
+— preferably before the next track completes.
 
 ## Rebase re-pinning
 

--- a/docs/dev-workflow/satellite-pr.md
+++ b/docs/dev-workflow/satellite-pr.md
@@ -2,7 +2,7 @@
 
 ## Purpose & invariants
 
-A satellite PR is a review vehicle for ONE track's diff, aimed at SEPARATE PEER REVIEWERS. The
+A satellite PR is a review vehicle for ONE track's diff, aimed at separate peer reviewers. The
 primary user review happens in-session as a mandatory per-track gate (see
 `docs/dev-workflow/track-development.md`) and is never replaced by a satellite. Two invariants:
 
@@ -16,10 +16,10 @@ misfire on a non-develop base if the PR ever left draft.
 
 ## When
 
-Optional per track and user-gated: after a track's user-review approval and marker commit land,
-the agent asks whether to create one. Sticky answers ("yes/no for all remaining tracks") are
-honored and recorded under the umbrella PR's Tracks table — they never waive the mandatory
-in-session user review.
+Optional per track and user-gated: after a track's user approval and marker commit land, the
+agent asks whether to create one. Sticky answers ("yes/no for all remaining tracks") are honored
+and recorded under the umbrella PR's Tracks table; the mandatory in-session user review still
+applies to every track.
 
 ## Creation
 
@@ -50,9 +50,14 @@ satellite branches), then force-updates `<branch>/track-NN-head` to the current 
 HEAD with `--force-with-lease`.
 
 Once a satellite is open, the track's review loop stays open: the next track does NOT start
-until the peer review completes or the user explicitly waives completion. Peer-fix commits land
-after the track's user approval, so they are covered by the pre-merge user review of post-gate
-commits (see `docs/dev-workflow/track-development.md` § Merge & cleanup).
+until the peer review is complete or the user explicitly waives completion. Peer review is
+complete when all review observations/threads are resolved AND the reviewer explicitly approves
+or states the review is done; if the signal is ambiguous or absent, the agent asks the user to
+decide (keep waiting vs waive completion). Peer-fix commits land after the track's user
+approval: on a non-final track they fall inside the next track's commit range and are covered by
+that track's mandatory user review; commits after the last user-approved gate (e.g., final-track
+peer fixes) are covered by the pre-merge user review (see
+`docs/dev-workflow/track-development.md` § Merge & cleanup).
 
 Caveat: if later tracks have started (i.e., the user waived completion), the updated head
 pollutes the satellite's diff with later-track commits. Mitigations: GitHub's "changes since

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -6,7 +6,7 @@ This is the mandatory flow for ALL changes in this repository:
 
 Research → (lazy) research log → adversarial review → umbrella draft PR → user approves track
 split → per-track loop (implement → track code review → fixes → mandatory user review → marker
-commit → optional satellite PR (peer review)) → squash-merge + cleanup.
+commit → optional satellite peer-review PR) → squash-merge + cleanup.
 
 The flow scales with change size:
 
@@ -160,18 +160,21 @@ Per-track sequence:
 3. Fix findings as normal commits.
 4. MANDATORY user review: present the track summary and the track diff to the user, then loop on
    user feedback — landing fixes as normal commits — until the user explicitly approves. The
-   orchestrator WAITS for that approval; the marker commit certifies a fully user-reviewed track.
+   agent waits for that approval; the marker commit certifies a fully user-reviewed track.
 5. Land the marker commit.
 6. Update the umbrella PR Tracks table row (status, satellite link); revise Planned changes only
    if reality diverged from it.
 7. Ask the user whether to open a satellite review PR (see `docs/dev-workflow/satellite-pr.md`) —
-   a peer-review vehicle for SEPARATE reviewers, not the primary user review (that already
+   a peer-review vehicle for separate reviewers, not the primary user review (that already
    happened in step 4). Once a satellite is open, the track's review loop stays open: process
-   peer observations and do NOT start the next track until the peer review completes or the user
-   explicitly says to proceed without completing it. Sticky answers are allowed: the user may
-   reply "yes/no for all remaining tracks". Record the sticky answer as a one-line note under the
-   Tracks table for cross-session durability and stop asking. Sticky answers never waive the
-   mandatory in-session user review in step 4.
+   peer observations and do NOT start the next track until the peer review is complete
+   (completion signal defined in that doc) or the user explicitly waives completion. Record the
+   peer-review state (open / completed / waived) in the track's Tracks table row — same
+   mechanism as sticky answers — so a new session knows whether the loop is still open. Sticky
+   answers are allowed: the user may reply "yes/no for all remaining tracks". Record the sticky
+   answer as a one-line note under the Tracks table for cross-session durability and stop
+   asking. Sticky answers apply only to this satellite ask — the step-4 user review stays
+   mandatory for every track.
 
 ## Marker commits (source of truth for track boundaries)
 
@@ -212,6 +215,8 @@ The umbrella PR is the ONLY PR ever merged (squash, per repo conventions). Befor
 - Re-read the whole PR description end-to-end to confirm it still tells one consistent story.
 - Any commits landed after the last user-approved gate (e.g., late peer-review fixes on the
   final track) get a user review.
+- Every opened satellite's peer review is completed or explicitly user-waived — closing
+  satellites at merge never discards a pending review.
 - Strip the Tracks table (and any sticky-answer note under it) from the description. Track
   numbers are ephemeral branch-life identifiers: after the squash-merge the marker commits are
   gone and the satellites are closed, so track references would dangle in develop's history.

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -197,8 +197,9 @@ Properties:
 
 - **Rebase-resilient** — markers are in the history being rebased, so they move with it.
 - **Zero cleanup** — the squash-merge into develop erases them.
-- The umbrella PR Tracks table is a display-only index (names, scope lines, satellite links —
-  never SHAs).
+- The umbrella PR Tracks table is a display-only index (names, scope lines, statuses,
+  peer-review state, satellite links — never SHAs); it is never the source of truth for track
+  boundaries.
 
 Single-track changes land no markers — the whole branch diff is the track.
 

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -5,8 +5,8 @@
 This is the mandatory flow for ALL changes in this repository:
 
 Research → (lazy) research log → adversarial review → umbrella draft PR → user approves track
-split → per-track loop (implement → track code review → fixes → marker commit → optional satellite
-PR) → squash-merge + cleanup.
+split → per-track loop (implement → track code review → fixes → mandatory user review → marker
+commit → optional satellite PR (peer review)) → squash-merge + cleanup.
 
 The flow scales with change size:
 
@@ -15,6 +15,10 @@ The flow scales with change size:
 | Multi-track change | Full flow as described above. |
 | Single-track change | No track split, no marker commits. Everything else applies. |
 | Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Micro adversarial review, or skip it with explicit user consent. Planned-changes section is a 2–3-sentence paragraph. |
+
+The mandatory user review gate applies at EVERY tier. For single-track and trivial changes the
+whole branch diff is the track, so the user review sits after the agent code review and before
+the squash-merge.
 
 ## Research phase (lightweight)
 
@@ -154,12 +158,20 @@ Per-track sequence:
 2. MANDATORY agent code review of the cumulative track diff `git diff <prev-marker>..HEAD` —
    correctness, test coverage, style, API surface, documentation sync.
 3. Fix findings as normal commits.
-4. Land the marker commit.
-5. Update the umbrella PR Tracks table row (status, satellite link); revise Planned changes only
+4. MANDATORY user review: present the track summary and the track diff to the user, then loop on
+   user feedback — landing fixes as normal commits — until the user explicitly approves. The
+   orchestrator WAITS for that approval; the marker commit certifies a fully user-reviewed track.
+5. Land the marker commit.
+6. Update the umbrella PR Tracks table row (status, satellite link); revise Planned changes only
    if reality diverged from it.
-6. Ask the user whether to open a satellite review PR (see `docs/dev-workflow/satellite-pr.md`). Sticky
-   answers are allowed: the user may reply "yes/no for all remaining tracks". Record the sticky
-   answer as a one-line note under the Tracks table for cross-session durability and stop asking.
+7. Ask the user whether to open a satellite review PR (see `docs/dev-workflow/satellite-pr.md`) —
+   a peer-review vehicle for SEPARATE reviewers, not the primary user review (that already
+   happened in step 4). Once a satellite is open, the track's review loop stays open: process
+   peer observations and do NOT start the next track until the peer review completes or the user
+   explicitly says to proceed without completing it. Sticky answers are allowed: the user may
+   reply "yes/no for all remaining tracks". Record the sticky answer as a one-line note under the
+   Tracks table for cross-session durability and stop asking. Sticky answers never waive the
+   mandatory in-session user review in step 4.
 
 ## Marker commits (source of truth for track boundaries)
 
@@ -198,6 +210,8 @@ update automatically since their refs moved.
 The umbrella PR is the ONLY PR ever merged (squash, per repo conventions). Before merge:
 
 - Re-read the whole PR description end-to-end to confirm it still tells one consistent story.
+- Any commits landed after the last user-approved gate (e.g., late peer-review fixes on the
+  final track) get a user review.
 - Strip the Tracks table (and any sticky-answer note under it) from the description. Track
   numbers are ephemeral branch-life identifiers: after the squash-merge the marker commits are
   gone and the satellites are closed, so track references would dangle in develop's history.
@@ -210,6 +224,6 @@ At merge: close all satellite PRs and delete all satellite review branches.
 
 Richer internal planning and execution machinery — whatever agent tooling is in use — may be
 layered on top of this baseline, provided it satisfies the mandatory gates: pre-implementation
-adversarial review, an umbrella draft PR before coding starts, a code review per track, marker
-commits at track boundaries, and the per-track satellite-PR ask. This document defines the
-baseline that applies regardless of the tooling.
+adversarial review, an umbrella draft PR before coding starts, a code review per track, a
+mandatory user review per track, marker commits at track boundaries, and the per-track
+satellite-PR ask. This document defines the baseline that applies regardless of the tooling.


### PR DESCRIPTION
#### Motivation:

In the current track-based workflow the user's review of a finished track is not a mandatory gate — the optional satellite PR is framed as the only human-review vehicle, so a track can be sealed with only the agent code review. This change makes user review a mandatory per-track gate and re-scopes satellite PRs as review vehicles for separate peer reviewers.

#### Planned changes:

- **Current state**: per-track sequence is implement → agent code review → fixes → marker commit → umbrella update → optional satellite ask; satellite PRs are described as the vehicle for human review of a track's diff.
- **What changes**: a mandatory user review gate is inserted after the agent code review and its fixes, before the marker commit — the orchestrator presents the track summary/diff and loops on user feedback until explicit approval. The gate is tier-universal: single-track and trivial changes (whole branch diff = the track) gate before squash-merge. Satellite PRs stay optional and user-gated but are re-scoped for separate peer reviewers; once a satellite is opened, the track's review loop stays open until the peer review completes or the user explicitly waives completion. Sticky satellite answers never waive the mandatory user review. The merge protocol additionally requires user review of any commits landed after the last user-approved gate. Decisions added during review: the peer-review completion signal is defined as all observations/threads resolved plus explicit reviewer sign-off (ambiguous or absent signal → ask the user); a merge precondition requires every opened satellite's peer review to be completed or explicitly user-waived before the squash-merge; and satellite peer-review state (open/completed/waived) is durably recorded in the umbrella Tracks table row.
- **Key decisions**: user gate sits before the marker commit so the marker seals a fully user-reviewed track (alternative — gating after the marker — rejected: marker would no longer certify review completion). Satellite peer review made blocking-by-default once opened (alternative — fire-and-forget satellites — rejected per user direction).
- **Out of scope**: docs/workflow-book/ (pre-existing drift from the baseline workflow docs; accepted risk).
- **Risks & accepted trade-offs**: Adversarial review: passed, 1 accepted risk — 2026-07-13. Accepted risk: workflow-book drift widens slightly (book already omits markers/satellites).
- **Verification approach**: doc-only change; end-to-end consistency re-read of all four edited docs.
