### PR TITLE
Add mandatory user design review gate before adversarial review in dev workflow

### DIFF
--- a/.pi/extensions/slate/mode.ts
+++ b/.pi/extensions/slate/mode.ts
@@ -43,8 +43,9 @@ threads execute. Rules:
 8. Repository changes — including .pi/ tooling, extensions, and docs —
    follow the track-based workflow (docs/dev-workflow/track-development.md).
    Before the FIRST dispatch that modifies files, confirm the
-   pre-implementation gates ran (adversarial review, umbrella draft PR,
-   user-approved scope) or name the lighter tier that applies per that doc.
+   pre-implementation gates ran (user design review, adversarial review,
+   umbrella draft PR, user-approved scope) or name the lighter tier that
+   applies per that doc.
 9. Every non-trivial change gets reviewed before it is declared done.
    Before dispatching review threads, read
    .pi/extensions/slate/review-rules.md (skip the read if it is already

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 | [Object-Oriented Data Modeling](object-oriented.md) | Inheritance, polymorphic queries, property types, schema evolution |
 | [Fine-Grained Security](security.md) | Predicate-based security policies, per-role filtering, ALTER/REVOKE lifecycle |
 | [Development Workflow](workflow-book/chapters/01-workflow-at-a-glance.md) | Contributor onboarding book for the YouTrackDB development workflow — phases, tiers, tracks, and reviews — in 16 chapters. Start at Chapter 1. |
-| [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, adversarial review, umbrella draft PR, per-track code review and mandatory user review gate, marker commits |
+| [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, user design review, adversarial review, umbrella draft PR, per-track code review and mandatory user review gate, marker commits |
 | [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -14,14 +14,12 @@ This flow covers **all files in the repository**, including `.pi/` tooling and s
 1. **Research first** — interactive code exploration before implementation; a research log is
    opened lazily when complexity triggers fire (non-trivial decisions, surprises, risky
    invariants, session boundaries — see the protocol doc).
-2. **User design review (mandatory, pre-adversarial)** — research ends with a user review loop:
-   the agent presents the design (approach, key decisions with rejected alternatives, risks,
-   open questions — from the research log or the draft Planned-changes statement) and loops on
-   user feedback until explicit approval, recorded as a
-   `Design review: user-approved — YYYY-MM-DD` verdict line.
+2. **User design review** — mandatory before adversarial review: the agent presents the design
+   to the user and loops on feedback until explicit approval, recorded as a durable verdict
+   line — see the protocol doc.
 3. **Adversarial review** — mandatory before implementation for every change; a fresh-context
-   reviewer attacks the user-approved design — the research log (or the draft plan when no log
-   exists); scaled down to a micro-review for trivial changes.
+   reviewer attacks the user-approved design — the research log (or the draft Planned-changes
+   statement when no log exists); scaled down to a micro-review for trivial changes.
 4. **Umbrella draft PR** — created before implementation starts, with a design-level
    description (Planned changes + Tracks sections per the PR template). The user approves the
    proposed track split before coding begins.

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -14,27 +14,33 @@ This flow covers **all files in the repository**, including `.pi/` tooling and s
 1. **Research first** — interactive code exploration before implementation; a research log is
    opened lazily when complexity triggers fire (non-trivial decisions, surprises, risky
    invariants, session boundaries — see the protocol doc).
-2. **Adversarial review** — mandatory before implementation for every change; a fresh-context
-   reviewer attacks the research log (or the draft plan when no log exists); scaled down to a
-   micro-review for trivial changes.
-3. **Umbrella draft PR** — created before implementation starts, with a design-level
+2. **User design review (mandatory, pre-adversarial)** — research ends with a user review loop:
+   the agent presents the design (approach, key decisions with rejected alternatives, risks,
+   open questions — from the research log or the draft Planned-changes statement) and loops on
+   user feedback until explicit approval, recorded as a
+   `Design review: user-approved — YYYY-MM-DD` verdict line.
+3. **Adversarial review** — mandatory before implementation for every change; a fresh-context
+   reviewer attacks the user-approved design — the research log (or the draft plan when no log
+   exists); scaled down to a micro-review for trivial changes.
+4. **Umbrella draft PR** — created before implementation starts, with a design-level
    description (Planned changes + Tracks sections per the PR template). The user approves the
    proposed track split before coding begins.
-4. **Track-based implementation (mandatory)** — multi-file changes are split into tracks
+5. **Track-based implementation (mandatory)** — multi-file changes are split into tracks
    (independently reviewable units, ~12–25 files); development is linear on one branch; each
    track ends with a mandatory agent code review of the track diff, then a mandatory user
    review — the orchestrator waits for explicit user approval — then an empty marker commit
    `Track NN complete: <short name>` (the durable track-boundary record).
-5. **Satellite review PRs (optional, user-gated)** — after each track's user approval and
+6. **Satellite review PRs (optional, user-gated)** — after each track's user approval and
    marker commit the agent asks whether to open a draft satellite PR for review by separate
    peer reviewers; mechanics in `docs/dev-workflow/satellite-pr.md`. Satellites are
    review-only: always draft, never merged. Once opened, the track blocks the next one until
    the peer review is complete or the user explicitly waives completion.
 
 Single-track changes skip the split and markers; trivial changes (typos, doc-only, mechanical
-renames) may also skip the full adversarial review — see the protocol doc's scaling table. The
-mandatory user review gate applies at every tier: for single-track and trivial changes it gates
-the squash-merge.
+renames) collapse the design review into consent to the planned-changes paragraph and may also
+skip the full adversarial review — see the protocol doc's scaling table. The mandatory user
+review gate applies at every tier: for single-track and trivial changes it gates the
+squash-merge.
 
 ## Test Policy
 

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -4,9 +4,9 @@
 
 This is the mandatory flow for ALL changes in this repository:
 
-Research → (lazy) research log → adversarial review → umbrella draft PR → user approves track
-split → per-track loop (implement → track code review → fixes → mandatory user review → marker
-commit → optional satellite peer-review PR) → squash-merge + cleanup.
+Research → (lazy) research log → user design review → adversarial review → umbrella draft PR →
+user approves track split → per-track loop (implement → track code review → fixes → mandatory
+user review → marker commit → optional satellite peer-review PR) → squash-merge + cleanup.
 
 The flow scales with change size:
 
@@ -14,7 +14,7 @@ The flow scales with change size:
 | --- | --- |
 | Multi-track change | Full flow as described above. |
 | Single-track change | No track split, no marker commits. Everything else applies. |
-| Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Micro adversarial review, or skip it with explicit user consent. Planned-changes section is a 2–3-sentence paragraph. |
+| Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Design review collapses into user consent to the 2–3-sentence planned-changes paragraph. Micro adversarial review, or skip it with explicit user consent. |
 
 The mandatory user review gate applies at EVERY tier. For single-track and trivial changes the
 whole branch diff is the track, so the user review sits after the agent code review and before
@@ -25,7 +25,7 @@ the squash-merge.
 Research is interactive exploration before any implementation: read real source code, trace call
 chains, and clarify aims and constraints with the user. There is no design document, no
 implementation plan, and no mandatory artifacts. The phase ends when the initial design of the
-change is understood.
+change is understood and has passed the user design review (see below).
 
 ## Research log (lazy-triggered)
 
@@ -56,7 +56,8 @@ Four sections:
 
 During research the log lives as an untracked file `research-log.md` at the repo root. At
 umbrella-PR creation its content is folded into the PR description — Key decisions, Risks, and
-Open questions feed the corresponding Planned-changes subsections — and the file is deleted.
+Open questions feed the corresponding Planned-changes subsections, and the design review and
+adversarial review verdict lines land in Risks & accepted trade-offs — and the file is deleted.
 Decisions made after PR creation are appended to the PR description directly.
 
 ### Under-trigger guardrail
@@ -64,12 +65,41 @@ Decisions made after PR creation are appended to the PR description directly.
 When shaping the PR description without a log, state this explicitly (e.g. "no log kept — one
 trivial decision, no surprises") so the user can override and request one.
 
+## User design review (mandatory, pre-adversarial)
+
+When research converges, the agent presents the design to the user: the proposed approach, key
+decisions with the alternatives rejected, risks, and open questions. The presentation input is
+keyed on log existence, the same way as the adversarial review's: log exists → present from the
+log; no log → present the draft Planned-changes statement. The agent then loops on user
+feedback — revising the design (and log) — until the user explicitly approves. Only after that
+approval does the adversarial review run.
+
+Rationale: the user owns the design direction. Reviewing with the user first means the
+adversarial review attacks a stabilized, user-endorsed design instead of one the user may still
+redirect — adversarial rounds are not spent on designs that would change anyway. The loop
+mechanics mirror the track loop's mandatory user review (present → feedback → explicit
+approval); the position relative to machine review is deliberately inverted — here the user
+reviews first.
+
+Durable record — append a verdict line to the log:
+
+```
+Design review: user-approved — YYYY-MM-DD
+```
+
+With no log, append the line to the draft Planned-changes statement instead; it travels into
+the PR description at umbrella-PR creation.
+
+Tier scaling: at the trivial tier the design review collapses into the user's consent to the
+2–3-sentence planned-changes paragraph. For trivial and single-track changes that consent may
+be batched with the PR-description approval into a single ask.
+
 ## Adversarial review (mandatory, pre-implementation)
 
-Adversarial review runs after research converges, BEFORE the PR description is finalized and
-implementation starts, for EVERY change. The rationale, briefly: critique activates latent
-knowledge that constructive planning does not (generator/critic asymmetry), and a fresh-context
-reviewer has no anchoring on the author's rationale.
+Adversarial review runs after the user design review approves the design, BEFORE the PR
+description is finalized and implementation starts, for EVERY change. The rationale, briefly:
+critique activates latent knowledge that constructive planning does not (generator/critic
+asymmetry), and a fresh-context reviewer has no anchoring on the author's rationale.
 
 The reviewer must be a fresh context (sub-agent or fresh session) that did not author the
 decisions.
@@ -93,8 +123,12 @@ Triage each finding with the user. Three outcomes:
 - **Reverse** — change the decision now, while it is still cheap.
 - **Accept-as-risk** — record it in Open Questions / Risks.
 
+Triage runs with the user, so a Reverse outcome is itself user-endorsed; after any reversal,
+refresh the design-review verdict line (new date) before the second adversarial round.
+
 One round by default; run a second round only if any decision was actually reversed. Append a
-verdict line to the log (or straight to the PR description if there is no log):
+verdict line to the log (or to the draft Planned-changes statement if there is no log; it
+travels into the PR description at umbrella-PR creation):
 
 ```
 Adversarial review: passed, N accepted risks — YYYY-MM-DD
@@ -102,7 +136,8 @@ Adversarial review: passed, N accepted risks — YYYY-MM-DD
 
 ## Umbrella draft PR
 
-Created once the initial design is understood, before implementation:
+Created once the design has passed the user design review and the adversarial review, before
+implementation:
 
 ```bash
 gh pr create --draft --base develop
@@ -125,7 +160,8 @@ Subsections activate when their content exists:
 - **How** — design-level description.
 - **Key decisions** — chosen vs rejected; preempts "why not X?" review comments.
 - **Out of scope** — explicit non-goals.
-- **Risks & accepted trade-offs** — including the adversarial review verdict line.
+- **Risks & accepted trade-offs** — including the design review and adversarial review verdict
+  lines.
 - **Verification approach** — 1–2 lines.
 
 "Deep enough" test: a reviewer who knows the codebase but not this change can (1) predict which
@@ -229,7 +265,8 @@ At merge: close all satellite PRs and delete all satellite review branches.
 ## Layering richer workflows on top
 
 Richer internal planning and execution machinery — whatever agent tooling is in use — may be
-layered on top of this baseline, provided it satisfies the mandatory gates: pre-implementation
-adversarial review, an umbrella draft PR before coding starts, a code review per track, a
-mandatory user review per track, marker commits at track boundaries, and the per-track
-satellite-PR ask. This document defines the baseline that applies regardless of the tooling.
+layered on top of this baseline, provided it satisfies the mandatory gates: a user design
+review before adversarial review, pre-implementation adversarial review, an umbrella draft PR
+before coding starts, a code review per track, a mandatory user review per track, marker
+commits at track boundaries, and the per-track satellite-PR ask. This document defines the
+baseline that applies regardless of the tooling.

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -14,7 +14,7 @@ The flow scales with change size:
 | --- | --- |
 | Multi-track change | Full flow as described above. |
 | Single-track change | No track split, no marker commits. Everything else applies. |
-| Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Design review collapses into user consent to the 2–3-sentence planned-changes paragraph. Micro adversarial review, or skip it with explicit user consent. |
+| Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Planned-changes section is a 2–3-sentence paragraph; the design review collapses into user consent to it. Micro adversarial review, or skip it with explicit user consent. |
 
 The mandatory user review gate applies at EVERY tier. For single-track and trivial changes the
 whole branch diff is the track, so the user review sits after the agent code review and before
@@ -88,18 +88,25 @@ Design review: user-approved — YYYY-MM-DD
 ```
 
 With no log, append the line to the draft Planned-changes statement instead; it travels into
-the PR description at umbrella-PR creation.
+the PR description at umbrella-PR creation. (Crossing a session boundary before umbrella-PR
+creation is research-log trigger #4 — open a log then; it becomes the verdict line's home.)
+The verdict line is written at every tier; at the trivial tier it is appended after the
+planned-changes paragraph, which stands in for the Risks & accepted trade-offs subsection.
 
 Tier scaling: at the trivial tier the design review collapses into the user's consent to the
-2–3-sentence planned-changes paragraph. For trivial and single-track changes that consent may
-be batched with the PR-description approval into a single ask.
+2–3-sentence planned-changes paragraph. For trivial and single-track changes the ask may be
+batched: the agent presents the design together with the draft PR description in ONE
+pre-adversarial ask, and the user's single approval covers both. Umbrella-PR creation still
+follows the adversarial review; the description is re-presented only if adversarial triage
+changed it.
 
 ## Adversarial review (mandatory, pre-implementation)
 
-Adversarial review runs after the user design review approves the design, BEFORE the PR
-description is finalized and implementation starts, for EVERY change. The rationale, briefly:
-critique activates latent knowledge that constructive planning does not (generator/critic
-asymmetry), and a fresh-context reviewer has no anchoring on the author's rationale.
+Adversarial review runs after the user approves the design in the user design review, BEFORE
+the PR description is finalized and implementation starts, for EVERY change. The rationale,
+briefly: critique activates latent knowledge that constructive planning does not
+(generator/critic asymmetry), and a fresh-context reviewer has no anchoring on the author's
+rationale.
 
 The reviewer must be a fresh context (sub-agent or fresh session) that did not author the
 decisions.
@@ -124,7 +131,8 @@ Triage each finding with the user. Three outcomes:
 - **Accept-as-risk** — record it in Open Questions / Risks.
 
 Triage runs with the user, so a Reverse outcome is itself user-endorsed; after any reversal,
-refresh the design-review verdict line (new date) before the second adversarial round.
+refresh the design-review verdict line (new date) before any further adversarial round (a
+round-2 reversal refreshes the line before the change is declared reviewed).
 
 One round by default; run a second round only if any decision was actually reversed. Append a
 verdict line to the log (or to the draft Planned-changes statement if there is no log; it


### PR DESCRIPTION
## Motivation

The baseline development workflow ran adversarial review directly after research, so the first structured user contact with the design happened only at umbrella-PR approval. The user owns the design direction: reviewing the design with the user before machine review avoids spending adversarial rounds on designs the user would redirect, and gives the adversary a stabilized, user-endorsed target to attack.

## Planned changes

**Current state** — the pre-implementation gate order is research → (lazy) research log → adversarial review → umbrella draft PR → user approves track split. The user's first design gate is the track-split approval at PR creation.

**What changes** — a mandatory user design review loop now ends the research phase: the agent presents the design (approach, key decisions with rejected alternatives, risks, open questions — from the research log when one exists, otherwise the draft Planned-changes statement) and loops on user feedback until explicit approval; only then does adversarial review run. Durable record: a `Design review: user-approved — YYYY-MM-DD` verdict line in the research log (no log → the draft Planned-changes statement), folded into the PR description alongside the adversarial verdict line. The verdict line is written at every tier; at the trivial tier it is appended after the planned-changes paragraph. Tier scaling: trivial changes collapse the review into user consent to the 2–3-sentence planned-changes paragraph; for trivial and single-track changes the ask may be batched: the design and the draft PR description are presented in one pre-adversarial ask and a single approval covers both; umbrella-PR creation still follows the adversarial review, and the description is re-presented only if adversarial triage changed it. Adversarial triage reversals remain user-endorsed (triage runs with the user); after any reversal the design-review verdict line is refreshed before any further adversarial round.

**How** — amend the baseline protocol (new "User design review" gate section, reordered overview flow line, adjusted research-phase ending, adversarial-review ordering, umbrella-PR trigger, research-log persistence/fold rules, scaling table, layering-clause gates list), the orchestrator guidelines phase list, the slate orchestrator prompt's pre-implementation gates list, and the docs index summary.

**Key decisions** — user review placed BEFORE adversarial review (rejected: adversary-first, the previous order — wastes adversarial rounds when the user redirects the design; the anchoring concern is accepted because adversarial findings are still triaged with the user). Both verdict lines get an explicit fold destination in "Risks & accepted trade-offs" (also fixes a pre-existing gap: the adversarial verdict's no-log path pointed at a PR description that does not exist yet at verdict time).

**Out of scope** — `.claude/workflow/**` and `docs/workflow-book/**`: the richer layered workflow is sunset and not kept in sync with the baseline.

**Risks & accepted trade-offs**
- `.claude/workflow` predates the new gate and is not updated (accepted risk — sunset workflow).
- Design review: user-approved — 2026-07-13
- Adversarial review: passed, 1 accepted risk — 2026-07-13

**Verification approach** — docs plus one prompt-string edit; agent doc review (consistency, completeness) plus the mandatory user review; no test impact.

*(No research log kept — decisions captured directly in this description.)*

