### PR TITLE
YTDB-1197: Fix ORDER BY null placement for index scans

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
@@ -247,8 +247,20 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
   }
 
   /**
-   * Full index scan (no key condition). First fetches null-key entries (if the index
-   * stores them), then streams all entries in ASC or DESC order.
+   * Full index scan (no key condition). Concatenates the null-key entries (if the index stores
+   * them) with the sorted B-tree entries, placing the null group so that it matches the
+   * in-memory sort's "null = smallest" semantic (see {@link
+   * com.jetbrains.youtrackdb.internal.core.sql.parser.SQLOrderByItem#compare}):
+   *
+   * <pre>
+   *  ASC  -> null keys first, then ascending B-tree entries
+   *  DESC -> descending B-tree entries first, then null keys last
+   * </pre>
+   *
+   * <p>Null keys are physically stored in a separate bucket outside the sorted B-tree, so their
+   * position in the emitted sequence is decided purely by where the null stream is concatenated.
+   * The old code always prepended the null stream, which put nulls first for DESC too and
+   * diverged from the in-memory path (YTDB-1197).
    */
   private static List<Stream<RawPair<Object, RID>>> processFlatIteration(
       DatabaseSessionEmbedded session, Index index, boolean isOrderAsc) {
@@ -256,17 +268,31 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     Set<Stream<RawPair<Object, RID>>> acquiredStreams =
         Collections.newSetFromMap(new IdentityHashMap<>());
 
-    var stream = fetchNullKeys(session, index);
-    if (stream != null) {
-      acquiredStreams.add(stream);
-      streams.add(stream);
-    }
+    var nullStream = fetchNullKeys(session, index);
+    var mainStream = isOrderAsc ? index.stream(session) : index.descStream(session);
 
-    stream = isOrderAsc ? index.stream(session) : index.descStream(session);
-    if (acquiredStreams.add(stream)) {
-      streams.add(stream);
+    if (isOrderAsc) {
+      addStreamIfNew(nullStream, streams, acquiredStreams);
+      addStreamIfNew(mainStream, streams, acquiredStreams);
+    } else {
+      addStreamIfNew(mainStream, streams, acquiredStreams);
+      addStreamIfNew(nullStream, streams, acquiredStreams);
     }
     return streams;
+  }
+
+  /**
+   * Appends {@code stream} to {@code streams} unless it is {@code null} or an identity-duplicate
+   * of a stream already added. The {@code acquiredStreams} identity set guards against adding
+   * (and later double-closing) the same stream instance twice.
+   */
+  private static void addStreamIfNew(
+      @Nullable Stream<RawPair<Object, RID>> stream,
+      List<Stream<RawPair<Object, RID>>> streams,
+      Set<Stream<RawPair<Object, RID>>> acquiredStreams) {
+    if (stream != null && acquiredStreams.add(stream)) {
+      streams.add(stream);
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
@@ -268,8 +268,23 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     Set<Stream<RawPair<Object, RID>>> acquiredStreams =
         Collections.newSetFromMap(new IdentityHashMap<>());
 
-    var nullStream = fetchNullKeys(session, index);
-    var mainStream = isOrderAsc ? index.stream(session) : index.descStream(session);
+    // Acquire both streams before wiring them into the result list. The caller closes these streams
+    // only once they are returned in `streams` (via the ExecutionStreamProducer in internalStart);
+    // if the second acquisition throws, the list is discarded and the first, already-open stream
+    // leaks. So close whatever was opened, then rethrow. Only the two acquisitions can throw; the
+    // addStreamIfNew calls below are plain list/set inserts, so the try wraps exactly them.
+    Stream<RawPair<Object, RID>> nullStream = null;
+    Stream<RawPair<Object, RID>> mainStream = null;
+    try {
+      nullStream = fetchNullKeys(session, index);
+      mainStream = isOrderAsc ? index.stream(session) : index.descStream(session);
+    } catch (RuntimeException e) {
+      // mainStream is still null when its own acquisition throws, so at most one stream is open
+      // here: no double close is possible even when both would be the same instance.
+      closeSuppressing(nullStream, e);
+      closeSuppressing(mainStream, e);
+      throw e;
+    }
 
     if (isOrderAsc) {
       addStreamIfNew(nullStream, streams, acquiredStreams);
@@ -279,6 +294,21 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       addStreamIfNew(nullStream, streams, acquiredStreams);
     }
     return streams;
+  }
+
+  /**
+   * Closes {@code stream} if it is non-null, attaching any failure from {@code close()} to {@code
+   * primary} as a suppressed exception so the original acquisition failure stays the thrown one.
+   */
+  private static void closeSuppressing(
+      @Nullable Stream<RawPair<Object, RID>> stream, RuntimeException primary) {
+    if (stream != null) {
+      try {
+        stream.close();
+      } catch (RuntimeException e) {
+        primary.addSuppressed(e);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
@@ -260,7 +260,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * <p>Null keys are physically stored in a separate bucket outside the sorted B-tree, so their
    * position in the emitted sequence is decided purely by where the null stream is concatenated.
    * The old code always prepended the null stream, which put nulls first for DESC too and
-   * diverged from the in-memory path (YTDB-1197).
+   * diverged from the in-memory path.
    */
   private static List<Stream<RawPair<Object, RID>>> processFlatIteration(
       DatabaseSessionEmbedded session, Index index, boolean isOrderAsc) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStep.java
@@ -278,9 +278,12 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
     try {
       nullStream = fetchNullKeys(session, index);
       mainStream = isOrderAsc ? index.stream(session) : index.descStream(session);
-    } catch (RuntimeException e) {
-      // mainStream is still null when its own acquisition throws, so at most one stream is open
-      // here: no double close is possible even when both would be the same instance.
+    } catch (RuntimeException | Error e) {
+      // Guard both unchecked hierarchies, not just RuntimeException: if the main-stream setup trips
+      // an `assert` under -ea it throws AssertionError (an Error), which must still close the
+      // already-open null stream instead of leaking it. mainStream is still null when its own
+      // acquisition throws, so at most one stream is open here: no double close is possible even
+      // when both would be the same instance.
       closeSuppressing(nullStream, e);
       closeSuppressing(mainStream, e);
       throw e;
@@ -301,13 +304,25 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
    * primary} as a suppressed exception so the original acquisition failure stays the thrown one.
    */
   private static void closeSuppressing(
-      @Nullable Stream<RawPair<Object, RID>> stream, RuntimeException primary) {
+      @Nullable Stream<RawPair<Object, RID>> stream, Throwable primary) {
     if (stream != null) {
       try {
         stream.close();
-      } catch (RuntimeException e) {
+      } catch (RuntimeException | Error e) {
         primary.addSuppressed(e);
       }
+    }
+  }
+
+  /**
+   * Closes every stream in {@code streams}, attaching each {@code close()} failure to {@code
+   * primary} as a suppressed exception. Releases the streams a multi-acquisition method already
+   * acquired when a later acquisition throws.
+   */
+  private static void closeAllSuppressing(
+      List<Stream<RawPair<Object, RID>>> streams, Throwable primary) {
+    for (var stream : streams) {
+      closeSuppressing(stream, primary);
     }
   }
 
@@ -355,8 +370,39 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
       SQLBooleanExpression condition,
       boolean isOrderAsc,
       CommandContext ctx) {
-    var session = ctx.getDatabaseSession();
     List<Stream<RawPair<Object, RID>>> streams = new ArrayList<>();
+    // Acquire streams into `streams` across all range combinations. If a later acquisition throws
+    // partway through, the streams already acquired would leak: the caller closes streams only once
+    // this method returns them, and on a throw the partial list is discarded. So close whatever was
+    // acquired, then rethrow. This is the same acquire-then-maybe-throw hazard processFlatIteration
+    // guards against.
+    try {
+      collectRangeStreams(
+          streams, index, fromKey, fromKeyIncluded, toKey, toKeyIncluded, condition, isOrderAsc,
+          ctx);
+    } catch (RuntimeException | Error e) {
+      closeAllSuppressing(streams, e);
+      throw e;
+    }
+    return streams;
+  }
+
+  /**
+   * Runs the range lookups for {@link #multipleRange}, appending each acquired stream to {@code
+   * streams}. Split out so {@code multipleRange} can close the partially-filled list if any
+   * acquisition here throws.
+   */
+  private static void collectRangeStreams(
+      List<Stream<RawPair<Object, RID>>> streams,
+      Index index,
+      SQLCollection fromKey,
+      boolean fromKeyIncluded,
+      SQLCollection toKey,
+      boolean toKeyIncluded,
+      SQLBooleanExpression condition,
+      boolean isOrderAsc,
+      CommandContext ctx) {
+    var session = ctx.getDatabaseSession();
     Set<Stream<RawPair<Object, RID>>> acquiredStreams =
         Collections.newSetFromMap(new IdentityHashMap<>());
     // Expand multi-valued key expressions (from IN or subqueries) into all combinations.
@@ -416,16 +462,12 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
                       // correctly in this
                       // case
                       stream = getStreamForNullKey(session, index);
-                      if (acquiredStreams.add(stream)) {
-                        streams.add(stream);
-                      }
+                      addStreamIfNew(stream, streams, acquiredStreams);
                     } else {
                       stream =
                           index.streamEntriesBetween(session,
                               from, fromKeyIncluded, to, toKeyIncluded, isOrderAsc);
-                      if (acquiredStreams.add(stream)) {
-                        streams.add(stream);
-                      }
+                      addStreamIfNew(stream, streams, acquiredStreams);
                     }
                   });
         }
@@ -452,9 +494,7 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
         // manage null value explicitly, as the index API does not seem to work correctly in this
         // case
         stream = getStreamForNullKey(session, index);
-        if (acquiredStreams.add(stream)) {
-          streams.add(stream);
-        }
+        addStreamIfNew(stream, streams, acquiredStreams);
       } else {
         if (from instanceof Collection<?> fromColl) {
           var toColl = (Collection<?>) to;
@@ -474,20 +514,15 @@ public class FetchFromIndexStep extends AbstractExecutionStep {
             stream = index.streamEntriesBetween(session, fromVal, fromKeyIncluded, toVal,
                 toKeyIncluded,
                 isOrderAsc);
-            if (acquiredStreams.add(stream)) {
-              streams.add(stream);
-            }
+            addStreamIfNew(stream, streams, acquiredStreams);
           }
         } else {
           stream = index.streamEntriesBetween(session, from, fromKeyIncluded, to, toKeyIncluded,
               isOrderAsc);
-          if (acquiredStreams.add(stream)) {
-            streams.add(stream);
-          }
+          addStreamIfNew(stream, streams, acquiredStreams);
         }
       }
     }
-    return streams;
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
@@ -388,6 +388,49 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
   }
 
   /**
+   * ASC full scan whose main-stream acquisition fails with an {@link AssertionError} — the exact
+   * shape an {@code assert} throws under {@code -ea} while the index scan is being set up. Even
+   * though an AssertionError is an {@link Error} and not a {@link RuntimeException}, the
+   * already-open null-key stream must STILL be closed before the error propagates, and the
+   * AssertionError itself must escape unwrapped.
+   *
+   * <p>This pins the {@code | Error} half of the {@code catch (RuntimeException | Error e)} guard in
+   * {@code processFlatIteration}: the sibling leak tests only inject a {@link RuntimeException}, so
+   * narrowing that clause to {@code catch (RuntimeException e)} would let an -ea AssertionError skip
+   * the close-and-rethrow path and leak the null stream while every RuntimeException test kept
+   * passing. Injecting an Error here is the only assertion that fails under that narrowing.
+   */
+  @Test
+  public void fullScanAscClosesNullStreamWhenMainStreamAcquisitionThrowsError() {
+    var fixture = createIndexedClass();
+    // Borrow a real NOTUNIQUE definition — it does not ignore nulls, so fetchNullKeys runs.
+    var definition = getIndex(fixture.indexName).getDefinition();
+    var ctx = newContext();
+
+    // A null-key stream whose close() we can observe.
+    var nullStreamClosed = new AtomicBoolean(false);
+    Stream<RID> nullRids = Stream.<RID>empty().onClose(() -> nullStreamClosed.set(true));
+
+    // Index that yields the null-key stream but fails the main (non-null) scan with an Error
+    // (AssertionError), not a RuntimeException — mirrors an -ea assertion tripping during setup.
+    var failingIndex = mock(Index.class);
+    when(failingIndex.getDefinition()).thenReturn(definition);
+    when(failingIndex.getName()).thenReturn(fixture.indexName);
+    when(failingIndex.getRids(any(), nullable(Object.class))).thenReturn(nullRids);
+    var mainStreamFailure = new AssertionError("index scan assertion failed");
+    when(failingIndex.stream(any())).thenThrow(mainStreamFailure);
+
+    var desc = new IndexSearchDescriptor(failingIndex);
+
+    assertThatThrownBy(() -> FetchFromIndexStep.init(desc, true, ctx))
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("index scan assertion failed");
+    assertThat(nullStreamClosed)
+        .as("null-key stream must be closed even when the failure is an Error, not leaked")
+        .isTrue();
+  }
+
+  /**
    * Drives a full scan whose main-stream acquisition throws and asserts the already-open null-key
    * stream is closed and the original failure propagates unwrapped. Stubs whichever main-scan
    * method the direction uses: {@code stream} for ASC, {@code descStream} for DESC.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
@@ -314,7 +314,7 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
    * A full ASCENDING scan over an index that stores null keys emits the null-key group BEFORE the
    * ascending non-null keys. This is the "null = smallest" placement that {@link
    * com.jetbrains.youtrackdb.internal.core.sql.parser.SQLOrderByItem#compare} produces for ASC, and
-   * it must match whether or not the index accelerates the sort (YTDB-1197). Two null records are
+   * it must match whether or not the index accelerates the sort. Two null records are
    * seeded so the assertion also proves the multi-value (NOTUNIQUE) null bucket yields every RID.
    */
   @Test
@@ -334,7 +334,7 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
 
   /**
    * A full DESCENDING scan places the null-key group LAST, mirroring the in-memory sort's DESC
-   * behavior (nulls last). This pins the YTDB-1197 fix: {@code processFlatIteration} used to
+   * behavior (nulls last). This pins the fix: {@code processFlatIteration} used to
    * prepend the null stream unconditionally, so DESC emitted nulls first and diverged from the
    * in-memory path. Two null records verify the descending scan still surfaces every RID stored
    * under the null key (the BTreeMultiValueIndexEngine null bucket).

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
@@ -310,6 +310,57 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
     assertThat(keys(results)).containsExactly(10, 20);
   }
 
+  /**
+   * A full ASCENDING scan over an index that stores null keys emits the null-key group BEFORE the
+   * ascending non-null keys. This is the "null = smallest" placement that {@link
+   * com.jetbrains.youtrackdb.internal.core.sql.parser.SQLOrderByItem#compare} produces for ASC, and
+   * it must match whether or not the index accelerates the sort (YTDB-1197). Two null records are
+   * seeded so the assertion also proves the multi-value (NOTUNIQUE) null bucket yields every RID.
+   */
+  @Test
+  public void fullScanAscendingEmitsNullKeyEntriesFirst() {
+    var fixture = createIndexedClass();
+    var index = getIndex(fixture.indexName);
+    seed(fixture.className, 10, 20);
+    seedNull(fixture.className, 2);
+    var ctx = newContext();
+    var step = new FetchFromIndexStep(new IndexSearchDescriptor(index), true, ctx, false);
+
+    var results = startAndDrain(step, ctx);
+
+    // ASC: null group first, then ascending keys.
+    assertThat(keys(results)).containsExactly(null, null, 10, 20);
+  }
+
+  /**
+   * A full DESCENDING scan places the null-key group LAST, mirroring the in-memory sort's DESC
+   * behavior (nulls last). This pins the YTDB-1197 fix: {@code processFlatIteration} used to
+   * prepend the null stream unconditionally, so DESC emitted nulls first and diverged from the
+   * in-memory path. Two null records verify the descending scan still surfaces every RID stored
+   * under the null key (the BTreeMultiValueIndexEngine null bucket).
+   */
+  @Test
+  public void fullScanDescendingEmitsNullKeyEntriesLast() {
+    var fixture = createIndexedClass();
+    var index = getIndex(fixture.indexName);
+    seed(fixture.className, 10, 20);
+    var nullRids = seedNullReturningRids(fixture.className, 2);
+    var ctx = newContext();
+    var step = new FetchFromIndexStep(new IndexSearchDescriptor(index), false, ctx, false);
+
+    var results = startAndDrain(step, ctx);
+
+    // DESC: descending keys first, then the null group last.
+    assertThat(keys(results)).containsExactly(20, 10, null, null);
+    // The null bucket must surface every RID that was stored under the null key.
+    var emittedNullRids =
+        results.stream()
+            .filter(r -> r.getProperty("key") == null)
+            .map(r -> r.<RID>getProperty("rid"))
+            .toList();
+    assertThat(emittedNullRids).containsExactlyInAnyOrderElementsOf(nullRids);
+  }
+
   // =========================================================================
   // processAndBlock / multipleRange: operator coverage on a single-field index
   // =========================================================================
@@ -1027,6 +1078,25 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
         session.newEntity(className);
       }
       session.commit();
+    } catch (Exception e) {
+      session.rollback();
+      throw e;
+    }
+  }
+
+  /**
+   * Like {@link #seedNull(String, int)} but returns the RIDs of the created null records, so a test
+   * can assert the null-key stream surfaces exactly those RIDs.
+   */
+  private List<RID> seedNullReturningRids(String className, int count) {
+    session.begin();
+    try {
+      var entities = new ArrayList<EntityImpl>();
+      for (var i = 0; i < count; i++) {
+        entities.add((EntityImpl) session.newEntity(className));
+      }
+      session.commit();
+      return entities.stream().<RID>map(EntityImpl::getIdentity).toList();
     } catch (Exception e) {
       session.rollback();
       throw e;

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
@@ -3,10 +3,13 @@ package com.jetbrains.youtrackdb.internal.core.sql.executor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.jetbrains.youtrackdb.internal.common.util.RawPair;
 import com.jetbrains.youtrackdb.internal.core.command.CommandContext;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
@@ -363,15 +366,33 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
   }
 
   /**
-   * A full scan opens the null-key stream first, then the main B-tree stream. If opening the main
-   * stream throws, the already-open null stream must be closed before the exception propagates —
-   * otherwise it leaks, because the caller only closes streams that {@code init()} actually returns
-   * and on a throw the partial list is discarded. The index is mocked so its main scan fails while
-   * its null-key scan still yields a stream; the test asserts the original failure propagates
-   * unwrapped and the null stream was closed.
+   * ASC full scan: the null-key stream is acquired first, then the main scan via {@code
+   * index.stream}. If that main acquisition throws, the already-open null stream must be closed
+   * before the exception propagates — otherwise it leaks, because the caller only closes streams
+   * that {@code init()} actually returns and on a throw the partial list is discarded.
    */
   @Test
-  public void fullScanClosesNullStreamWhenMainStreamAcquisitionThrows() {
+  public void fullScanAscClosesNullStreamWhenMainStreamAcquisitionThrows() {
+    assertMainStreamAcquisitionFailureClosesNullStream(true);
+  }
+
+  /**
+   * DESC full scan: same leak guarantee as the ASC case, but the main scan is acquired via {@code
+   * index.descStream}. Both acquisitions sit inside the same guarded block, so this pins the DESC
+   * acquisition method too — a regression that wrapped only {@code stream()} would leak on DESC and
+   * the ASC test alone would not catch it.
+   */
+  @Test
+  public void fullScanDescClosesNullStreamWhenMainStreamAcquisitionThrows() {
+    assertMainStreamAcquisitionFailureClosesNullStream(false);
+  }
+
+  /**
+   * Drives a full scan whose main-stream acquisition throws and asserts the already-open null-key
+   * stream is closed and the original failure propagates unwrapped. Stubs whichever main-scan
+   * method the direction uses: {@code stream} for ASC, {@code descStream} for DESC.
+   */
+  private void assertMainStreamAcquisitionFailureClosesNullStream(boolean isOrderAsc) {
     var fixture = createIndexedClass();
     // Borrow a real NOTUNIQUE definition — it does not ignore nulls, so fetchNullKeys runs.
     var definition = getIndex(fixture.indexName).getDefinition();
@@ -386,15 +407,100 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
     when(failingIndex.getDefinition()).thenReturn(definition);
     when(failingIndex.getName()).thenReturn(fixture.indexName);
     when(failingIndex.getRids(any(), nullable(Object.class))).thenReturn(nullRids);
+    var mainStreamFailure = new IllegalStateException("index scan failed");
+    if (isOrderAsc) {
+      when(failingIndex.stream(any())).thenThrow(mainStreamFailure);
+    } else {
+      when(failingIndex.descStream(any())).thenThrow(mainStreamFailure);
+    }
+
+    var desc = new IndexSearchDescriptor(failingIndex);
+
+    assertThatThrownBy(() -> FetchFromIndexStep.init(desc, isOrderAsc, ctx))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("index scan failed");
+    assertThat(nullStreamClosed).as("null-key stream must be closed, not leaked").isTrue();
+  }
+
+  /**
+   * When the main-stream acquisition throws AND closing the already-open null stream itself throws,
+   * the ORIGINAL acquisition failure must stay the propagated exception and the close failure must
+   * be attached to it as a suppressed exception. Pins {@code closeSuppressing}'s contract: it wraps
+   * {@code close()} in try/catch precisely because a real B-tree stream close can fail, and that
+   * failure must not mask the root cause.
+   */
+  @Test
+  public void fullScanKeepsOriginalFailureWhenNullStreamCloseAlsoThrows() {
+    var fixture = createIndexedClass();
+    var definition = getIndex(fixture.indexName).getDefinition();
+    var ctx = newContext();
+
+    // A null-key stream whose own close() throws.
+    var closeFailure = new IllegalStateException("null stream close failed");
+    Stream<RID> nullRids =
+        Stream.<RID>empty()
+            .onClose(
+                () -> {
+                  throw closeFailure;
+                });
+
+    var failingIndex = mock(Index.class);
+    when(failingIndex.getDefinition()).thenReturn(definition);
+    when(failingIndex.getName()).thenReturn(fixture.indexName);
+    when(failingIndex.getRids(any(), nullable(Object.class))).thenReturn(nullRids);
     when(failingIndex.stream(any())).thenThrow(new IllegalStateException("index scan failed"));
 
     var desc = new IndexSearchDescriptor(failingIndex);
 
-    // ASC full scan: null stream acquired, then the main stream throws.
     assertThatThrownBy(() -> FetchFromIndexStep.init(desc, true, ctx))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("index scan failed");
-    assertThat(nullStreamClosed).as("null-key stream must be closed, not leaked").isTrue();
+        .hasMessage("index scan failed") // original acquisition failure stays the thrown one
+        .satisfies(t -> assertThat(t.getSuppressed()).contains(closeFailure));
+  }
+
+  /**
+   * A range scan that expands to several key ranges (here {@code WHERE key IN [10, 30]}, two
+   * ranges) acquires one stream per range. If a later range acquisition throws, the streams already
+   * acquired for earlier ranges must be closed before the exception propagates — the same leak the
+   * full-scan path guards against. The index is mocked so the first {@code streamEntriesBetween}
+   * yields an observable stream and the second throws; the test asserts the first stream was closed
+   * and the original failure propagates unwrapped.
+   */
+  @Test
+  public void multipleRangeClosesEarlierStreamsWhenLaterRangeAcquisitionThrows() {
+    var fixture = createIndexedClass();
+    var definition = getIndex(fixture.indexName).getDefinition();
+    var ctx = newContext();
+
+    // First range yields a stream whose close() we can observe; second range acquisition throws.
+    var firstStreamClosed = new AtomicBoolean(false);
+    Stream<RawPair<Object, RID>> firstStream =
+        Stream.<RawPair<Object, RID>>empty().onClose(() -> firstStreamClosed.set(true));
+
+    var failingIndex = mock(Index.class);
+    when(failingIndex.getDefinition()).thenReturn(definition);
+    when(failingIndex.getName()).thenReturn(fixture.indexName);
+    doReturn(firstStream)
+        .doThrow(new IllegalStateException("range scan failed"))
+        .when(failingIndex)
+        .streamEntriesBetween(any(), any(), anyBoolean(), any(), anyBoolean(), anyBoolean());
+
+    var inCondition = new SQLInCondition(-1);
+    inCondition.setLeft(fieldExpr("key"));
+    inCondition.setRightMathExpression(valueMathExpr(List.of(10, 30)));
+    var desc = new IndexSearchDescriptor(failingIndex, andBlockOf(inCondition));
+
+    // multipleRange reads the active transaction, so the range path needs one open (the full-scan
+    // path does not); rolled back afterward since nothing is committed.
+    session.begin();
+    try {
+      assertThatThrownBy(() -> FetchFromIndexStep.init(desc, true, ctx))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("range scan failed");
+      assertThat(firstStreamClosed).as("earlier range stream must be closed, not leaked").isTrue();
+    } finally {
+      session.rollback();
+    }
   }
 
   // =========================================================================
@@ -1108,16 +1214,9 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
    * index stores them under the {@code null} key if the index does not ignore nulls.
    */
   private void seedNull(String className, int count) {
-    session.begin();
-    try {
-      for (var i = 0; i < count; i++) {
-        session.newEntity(className);
-      }
-      session.commit();
-    } catch (Exception e) {
-      session.rollback();
-      throw e;
-    }
+    // Delegates to seedNullReturningRids so the transaction/seeding logic lives in one place; the
+    // returned RIDs are irrelevant when the caller only needs the null-keyed records to exist.
+    seedNullReturningRids(className, count);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/FetchFromIndexStepTest.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 import org.junit.Test;
 
 /**
@@ -359,6 +360,41 @@ public class FetchFromIndexStepTest extends TestUtilsFixture {
             .map(r -> r.<RID>getProperty("rid"))
             .toList();
     assertThat(emittedNullRids).containsExactlyInAnyOrderElementsOf(nullRids);
+  }
+
+  /**
+   * A full scan opens the null-key stream first, then the main B-tree stream. If opening the main
+   * stream throws, the already-open null stream must be closed before the exception propagates —
+   * otherwise it leaks, because the caller only closes streams that {@code init()} actually returns
+   * and on a throw the partial list is discarded. The index is mocked so its main scan fails while
+   * its null-key scan still yields a stream; the test asserts the original failure propagates
+   * unwrapped and the null stream was closed.
+   */
+  @Test
+  public void fullScanClosesNullStreamWhenMainStreamAcquisitionThrows() {
+    var fixture = createIndexedClass();
+    // Borrow a real NOTUNIQUE definition — it does not ignore nulls, so fetchNullKeys runs.
+    var definition = getIndex(fixture.indexName).getDefinition();
+    var ctx = newContext();
+
+    // A null-key stream whose close() we can observe.
+    var nullStreamClosed = new AtomicBoolean(false);
+    Stream<RID> nullRids = Stream.<RID>empty().onClose(() -> nullStreamClosed.set(true));
+
+    // Index that yields the null-key stream but fails when the main (non-null) scan is opened.
+    var failingIndex = mock(Index.class);
+    when(failingIndex.getDefinition()).thenReturn(definition);
+    when(failingIndex.getName()).thenReturn(fixture.indexName);
+    when(failingIndex.getRids(any(), nullable(Object.class))).thenReturn(nullRids);
+    when(failingIndex.stream(any())).thenThrow(new IllegalStateException("index scan failed"));
+
+    var desc = new IndexSearchDescriptor(failingIndex);
+
+    // ASC full scan: null stream acquired, then the main stream throws.
+    assertThatThrownBy(() -> FetchFromIndexStep.init(desc, true, ctx))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("index scan failed");
+    assertThat(nullStreamClosed).as("null-key stream must be closed, not leaked").isTrue();
   }
 
   // =========================================================================

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -6974,12 +6974,16 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.commit();
   }
 
-  // ── ORDER BY null placement: index-accelerated vs in-memory (YTDB-1197) ──
+  // ── ORDER BY null placement: index-accelerated vs in-memory ──
   //
-  // One explicit test per scenario. Each asserts (a) whether the index optimization is used — an
-  // index-accelerated sort has a FetchFromIndexStep and no OrderByStep, an in-memory sort has an
-  // OrderByStep and no FetchFromIndexStep (checked inside orderedNamesAndAssertPlan) — and (b) the
-  // exact null placement. Every scenario pins the same order literal per direction, so ASC and
+  // The in-memory sort treats null as the smallest value: nulls first for ASC, nulls last for DESC.
+  // An index-accelerated sort must produce the same placement even though it never runs a
+  // comparator — null keys live in a separate bucket outside the sorted B-tree, so the code decides
+  // their position purely by where it concatenates the null stream. One explicit test per scenario.
+  // Each asserts (a) whether the index optimization is used — an index-accelerated sort has a
+  // FetchFromIndexStep and no OrderByStep, an in-memory sort has an OrderByStep and no
+  // FetchFromIndexStep (checked by orderedNamesIndexAccelerated / orderedNamesInMemory) — and (b)
+  // the exact null placement. Every scenario pins the same order literal per direction, so ASC and
   // DESC placement is identical across the index-accelerated and in-memory paths by construction.
 
   /**
@@ -6993,15 +6997,15 @@ public class SelectStatementExecutionTest extends DbTestBase {
     createIndexedNameClass(className, INDEX_TYPE.NOTUNIQUE);
     seedNames(className, Arrays.asList("b", "a", "c", null, null));
 
-    var ordered = orderedNamesAndAssertPlan(className, "ASC", true);
+    var ordered = orderedNamesIndexAccelerated(className, "ASC");
 
     Assert.assertEquals(Arrays.asList(null, null, "a", "b", "c"), ordered);
   }
 
   /**
    * DESC over a NOTUNIQUE (multi-value) indexed field: index-accelerated, and the null-keyed rows
-   * come LAST. This is the placement the bug got wrong — the index path used to emit nulls first
-   * for DESC (YTDB-1197).
+   * come LAST. This is the placement the bug got wrong — the index path used to prepend the null
+   * stream unconditionally, so it emitted nulls first for DESC too instead of last.
    */
   @Test
   public void testOrderByDescUsesNotUniqueIndexNullsLast() {
@@ -7009,7 +7013,7 @@ public class SelectStatementExecutionTest extends DbTestBase {
     createIndexedNameClass(className, INDEX_TYPE.NOTUNIQUE);
     seedNames(className, Arrays.asList("b", "a", "c", null, null));
 
-    var ordered = orderedNamesAndAssertPlan(className, "DESC", true);
+    var ordered = orderedNamesIndexAccelerated(className, "DESC");
 
     Assert.assertEquals(Arrays.asList("c", "b", "a", null, null), ordered);
   }
@@ -7025,14 +7029,14 @@ public class SelectStatementExecutionTest extends DbTestBase {
     createIndexedNameClass(className, INDEX_TYPE.UNIQUE);
     seedNames(className, Arrays.asList("b", "a", "c", null));
 
-    var ordered = orderedNamesAndAssertPlan(className, "ASC", true);
+    var ordered = orderedNamesIndexAccelerated(className, "ASC");
 
     Assert.assertEquals(Arrays.asList(null, "a", "b", "c"), ordered);
   }
 
   /**
    * DESC over a UNIQUE (single-value) indexed field: index-accelerated, single null key emitted
-   * LAST — the DESC placement fixed in YTDB-1197.
+   * LAST — the same DESC placement the in-memory sort produces.
    */
   @Test
   public void testOrderByDescUsesUniqueIndexNullsLast() {
@@ -7040,7 +7044,7 @@ public class SelectStatementExecutionTest extends DbTestBase {
     createIndexedNameClass(className, INDEX_TYPE.UNIQUE);
     seedNames(className, Arrays.asList("b", "a", "c", null));
 
-    var ordered = orderedNamesAndAssertPlan(className, "DESC", true);
+    var ordered = orderedNamesIndexAccelerated(className, "DESC");
 
     Assert.assertEquals(Arrays.asList("c", "b", "a", null), ordered);
   }
@@ -7055,14 +7059,14 @@ public class SelectStatementExecutionTest extends DbTestBase {
     createPlainNameClass(className);
     seedNames(className, Arrays.asList("b", "a", "c", null, null));
 
-    var ordered = orderedNamesAndAssertPlan(className, "ASC", false);
+    var ordered = orderedNamesInMemory(className, "ASC");
 
     Assert.assertEquals(Arrays.asList(null, null, "a", "b", "c"), ordered);
   }
 
   /**
    * DESC with no index: in-memory sort (OrderByStep, no FetchFromIndexStep), nulls last. Reference
-   * behavior the index-accelerated DESC path must match (YTDB-1197).
+   * behavior the index-accelerated DESC path must match.
    */
   @Test
   public void testOrderByDescInMemoryNullsLast() {
@@ -7070,7 +7074,7 @@ public class SelectStatementExecutionTest extends DbTestBase {
     createPlainNameClass(className);
     seedNames(className, Arrays.asList("b", "a", "c", null, null));
 
-    var ordered = orderedNamesAndAssertPlan(className, "DESC", false);
+    var ordered = orderedNamesInMemory(className, "DESC");
 
     Assert.assertEquals(Arrays.asList("c", "b", "a", null, null), ordered);
   }
@@ -7106,36 +7110,57 @@ public class SelectStatementExecutionTest extends DbTestBase {
   }
 
   /**
-   * Runs {@code SELECT name FROM <className> ORDER BY name <direction>} and returns the emitted
-   * {@code name} values in result order (nulls included). Asserts the execution plan shape matches
-   * {@code expectIndexAcceleratedSort}: an index-accelerated sort must contain a {@link
-   * FetchFromIndexStep} and no {@link OrderByStep}; an in-memory sort must contain an {@link
-   * OrderByStep} and no {@link FetchFromIndexStep}.
+   * Runs {@code SELECT name FROM <className> ORDER BY name <direction>}, asserts the planner
+   * satisfied the sort from the index — the plan contains a {@link FetchFromIndexStep} and adds no
+   * in-memory {@link OrderByStep} — and returns the emitted {@code name} values in result order
+   * (nulls included). Use this for a class that has an index on {@code name}.
    */
-  private List<Object> orderedNamesAndAssertPlan(
-      String className, String direction, boolean expectIndexAcceleratedSort) {
+  private List<Object> orderedNamesIndexAccelerated(String className, String direction) {
     session.begin();
     try {
       var result = session.query("SELECT name FROM " + className + " ORDER BY name " + direction);
       var plan = result.getExecutionPlan();
       var fetchFromIndex =
           plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count();
-      var orderBy =
-          plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count();
+      var orderBy = plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count();
       var rendered = plan.prettyPrint(0, 2);
-      if (expectIndexAcceleratedSort) {
-        Assert.assertTrue(
-            "expected an index-accelerated sort (FetchFromIndexStep), plan was:\n" + rendered,
-            fetchFromIndex >= 1);
-        Assert.assertEquals(
-            "index-accelerated sort must not add an in-memory OrderByStep, plan was:\n" + rendered,
-            0, orderBy);
-      } else {
-        Assert.assertEquals(
-            "expected an in-memory sort (no index), plan was:\n" + rendered, 0, fetchFromIndex);
-        Assert.assertEquals(
-            "in-memory sort must add an OrderByStep, plan was:\n" + rendered, 1, orderBy);
+      Assert.assertTrue(
+          "expected an index-accelerated sort (FetchFromIndexStep), plan was:\n" + rendered,
+          fetchFromIndex >= 1);
+      Assert.assertEquals(
+          "index-accelerated sort must not add an in-memory OrderByStep, plan was:\n" + rendered,
+          0, orderBy);
+      var names = new ArrayList<>();
+      while (result.hasNext()) {
+        names.add(result.next().<Object>getProperty("name"));
       }
+      result.close();
+      return names;
+    } finally {
+      session.commit();
+    }
+  }
+
+  /**
+   * Runs {@code SELECT name FROM <className> ORDER BY name <direction>}, asserts the sort ran in
+   * memory — the plan contains an {@link OrderByStep} and no {@link FetchFromIndexStep} — and
+   * returns the emitted {@code name} values in result order (nulls included). Use this for a class
+   * with no index on {@code name}, so its result is the reference the index-accelerated path must
+   * match.
+   */
+  private List<Object> orderedNamesInMemory(String className, String direction) {
+    session.begin();
+    try {
+      var result = session.query("SELECT name FROM " + className + " ORDER BY name " + direction);
+      var plan = result.getExecutionPlan();
+      var fetchFromIndex =
+          plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count();
+      var orderBy = plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count();
+      var rendered = plan.prettyPrint(0, 2);
+      Assert.assertEquals(
+          "expected an in-memory sort (no index), plan was:\n" + rendered, 0, fetchFromIndex);
+      Assert.assertEquals(
+          "in-memory sort must add an OrderByStep, plan was:\n" + rendered, 1, orderBy);
       var names = new ArrayList<>();
       while (result.hasNext()) {
         names.add(result.next().<Object>getProperty("name"));

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -6974,6 +6974,134 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.commit();
   }
 
+  /**
+   * ORDER BY null placement must be identical whether a NOTUNIQUE (multi-value) index accelerates
+   * the sort or the rows are sorted in memory, for both ASC and DESC. The indexed class routes
+   * through handleClassWithIndexForSortOnly -> FetchFromIndexValuesStep (a FetchFromIndexStep with
+   * no OrderByStep); the non-indexed class falls back to an in-memory OrderByStep. Both must place
+   * nulls first for ASC and last for DESC (YTDB-1197 — the index path used to emit nulls first for
+   * DESC too).
+   */
+  @Test
+  public void testOrderByNullPlacementConsistentForNotUniqueIndex() {
+    var indexed = "testNullPlacementIdxNotUnique";
+    var inMemory = "testNullPlacementNoIdxNotUnique";
+    var idxCls = session.getMetadata().getSchema().createClass(indexed);
+    idxCls.createProperty("name", PropertyType.STRING);
+    idxCls.createIndex(indexed + ".name", INDEX_TYPE.NOTUNIQUE, "name");
+    session.getMetadata().getSchema().createClass(inMemory)
+        .createProperty("name", PropertyType.STRING);
+
+    // Two nulls exercise the multi-value null bucket; unsorted non-null values prove the sort runs.
+    var names = Arrays.asList("b", "a", "c", null, null);
+    seedNames(indexed, names);
+    seedNames(inMemory, names);
+
+    // ASC: nulls first, then ascending values — this path already agreed before the fix.
+    var idxAsc = orderedNamesAndAssertPlan(indexed, "ASC", true);
+    var memAsc = orderedNamesAndAssertPlan(inMemory, "ASC", false);
+    Assert.assertEquals(Arrays.asList(null, null, "a", "b", "c"), idxAsc);
+    Assert.assertEquals(memAsc, idxAsc);
+
+    // DESC: descending values, then nulls last — the placement the bug diverged on.
+    var idxDesc = orderedNamesAndAssertPlan(indexed, "DESC", true);
+    var memDesc = orderedNamesAndAssertPlan(inMemory, "DESC", false);
+    Assert.assertEquals(Arrays.asList("c", "b", "a", null, null), idxDesc);
+    Assert.assertEquals(memDesc, idxDesc);
+  }
+
+  /**
+   * Same null-placement invariant as {@link #testOrderByNullPlacementConsistentForNotUniqueIndex}
+   * but for a UNIQUE (single-value) index. Nulls are not ignored by default
+   * (INDEX_IGNORE_NULL_VALUES_DEFAULT = false), so a UNIQUE index stores a single null key; the
+   * index-accelerated scan must return that null row and place it consistently with the in-memory
+   * sort for both ASC (nulls first) and DESC (nulls last).
+   */
+  @Test
+  public void testOrderByNullPlacementConsistentForUniqueIndex() {
+    var indexed = "testNullPlacementIdxUnique";
+    var inMemory = "testNullPlacementNoIdxUnique";
+    var idxCls = session.getMetadata().getSchema().createClass(indexed);
+    idxCls.createProperty("name", PropertyType.STRING);
+    idxCls.createIndex(indexed + ".name", INDEX_TYPE.UNIQUE, "name");
+    session.getMetadata().getSchema().createClass(inMemory)
+        .createProperty("name", PropertyType.STRING);
+
+    // UNIQUE allows a single null key, so seed exactly one null.
+    var names = Arrays.asList("b", "a", "c", null);
+    seedNames(indexed, names);
+    seedNames(inMemory, names);
+
+    var idxAsc = orderedNamesAndAssertPlan(indexed, "ASC", true);
+    var memAsc = orderedNamesAndAssertPlan(inMemory, "ASC", false);
+    Assert.assertEquals(Arrays.asList(null, "a", "b", "c"), idxAsc);
+    Assert.assertEquals(memAsc, idxAsc);
+
+    var idxDesc = orderedNamesAndAssertPlan(indexed, "DESC", true);
+    var memDesc = orderedNamesAndAssertPlan(inMemory, "DESC", false);
+    Assert.assertEquals(Arrays.asList("c", "b", "a", null), idxDesc);
+    Assert.assertEquals(memDesc, idxDesc);
+  }
+
+  /**
+   * Inserts one record per entry in {@code names}; a {@code null} entry creates a record that does
+   * not set the {@code name} property, so an index that does not ignore nulls stores it under the
+   * null key. Each record is committed separately, matching the seeding style of the other
+   * index-ordering tests in this class.
+   */
+  private void seedNames(String className, List<String> names) {
+    for (var name : names) {
+      session.begin();
+      var doc = (EntityImpl) session.newEntity(className);
+      if (name != null) {
+        doc.setProperty("name", name);
+      }
+      session.commit();
+    }
+  }
+
+  /**
+   * Runs {@code SELECT name FROM <className> ORDER BY name <direction>} and returns the emitted
+   * {@code name} values in result order (nulls included). Asserts the execution plan shape matches
+   * {@code expectIndexAcceleratedSort}: an index-accelerated sort must contain a {@link
+   * FetchFromIndexStep} and no {@link OrderByStep}; an in-memory sort must contain an {@link
+   * OrderByStep} and no {@link FetchFromIndexStep}.
+   */
+  private List<Object> orderedNamesAndAssertPlan(
+      String className, String direction, boolean expectIndexAcceleratedSort) {
+    session.begin();
+    try {
+      var result = session.query("SELECT name FROM " + className + " ORDER BY name " + direction);
+      var plan = result.getExecutionPlan();
+      var fetchFromIndex =
+          plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count();
+      var orderBy =
+          plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count();
+      var rendered = plan.prettyPrint(0, 2);
+      if (expectIndexAcceleratedSort) {
+        Assert.assertTrue(
+            "expected an index-accelerated sort (FetchFromIndexStep), plan was:\n" + rendered,
+            fetchFromIndex >= 1);
+        Assert.assertEquals(
+            "index-accelerated sort must not add an in-memory OrderByStep, plan was:\n" + rendered,
+            0, orderBy);
+      } else {
+        Assert.assertEquals(
+            "expected an in-memory sort (no index), plan was:\n" + rendered, 0, fetchFromIndex);
+        Assert.assertEquals(
+            "in-memory sort must add an OrderByStep, plan was:\n" + rendered, 1, orderBy);
+      }
+      var names = new ArrayList<>();
+      while (result.hasNext()) {
+        names.add(result.next().<Object>getProperty("name"));
+      }
+      result.close();
+      return names;
+    } finally {
+      session.commit();
+    }
+  }
+
   // ── CASE + MIN/MAX aggregate tests ──
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -6974,73 +6974,118 @@ public class SelectStatementExecutionTest extends DbTestBase {
     session.commit();
   }
 
+  // ── ORDER BY null placement: index-accelerated vs in-memory (YTDB-1197) ──
+  //
+  // One explicit test per scenario. Each asserts (a) whether the index optimization is used — an
+  // index-accelerated sort has a FetchFromIndexStep and no OrderByStep, an in-memory sort has an
+  // OrderByStep and no FetchFromIndexStep (checked inside orderedNamesAndAssertPlan) — and (b) the
+  // exact null placement. Every scenario pins the same order literal per direction, so ASC and
+  // DESC placement is identical across the index-accelerated and in-memory paths by construction.
+
   /**
-   * ORDER BY null placement must be identical whether a NOTUNIQUE (multi-value) index accelerates
-   * the sort or the rows are sorted in memory, for both ASC and DESC. The indexed class routes
-   * through handleClassWithIndexForSortOnly -> FetchFromIndexValuesStep (a FetchFromIndexStep with
-   * no OrderByStep); the non-indexed class falls back to an in-memory OrderByStep. Both must place
-   * nulls first for ASC and last for DESC (YTDB-1197 — the index path used to emit nulls first for
-   * DESC too).
+   * ASC over a NOTUNIQUE (multi-value) indexed field: the planner satisfies ORDER BY from the index
+   * (FetchFromIndexValuesStep, no OrderByStep) and emits the two null-keyed rows first, then the
+   * ascending values.
    */
   @Test
-  public void testOrderByNullPlacementConsistentForNotUniqueIndex() {
-    var indexed = "testNullPlacementIdxNotUnique";
-    var inMemory = "testNullPlacementNoIdxNotUnique";
-    var idxCls = session.getMetadata().getSchema().createClass(indexed);
-    idxCls.createProperty("name", PropertyType.STRING);
-    idxCls.createIndex(indexed + ".name", INDEX_TYPE.NOTUNIQUE, "name");
-    session.getMetadata().getSchema().createClass(inMemory)
-        .createProperty("name", PropertyType.STRING);
+  public void testOrderByAscUsesNotUniqueIndexNullsFirst() {
+    var className = "testOrderByAscIdxNotUnique";
+    createIndexedNameClass(className, INDEX_TYPE.NOTUNIQUE);
+    seedNames(className, Arrays.asList("b", "a", "c", null, null));
 
-    // Two nulls exercise the multi-value null bucket; unsorted non-null values prove the sort runs.
-    var names = Arrays.asList("b", "a", "c", null, null);
-    seedNames(indexed, names);
-    seedNames(inMemory, names);
+    var ordered = orderedNamesAndAssertPlan(className, "ASC", true);
 
-    // ASC: nulls first, then ascending values — this path already agreed before the fix.
-    var idxAsc = orderedNamesAndAssertPlan(indexed, "ASC", true);
-    var memAsc = orderedNamesAndAssertPlan(inMemory, "ASC", false);
-    Assert.assertEquals(Arrays.asList(null, null, "a", "b", "c"), idxAsc);
-    Assert.assertEquals(memAsc, idxAsc);
-
-    // DESC: descending values, then nulls last — the placement the bug diverged on.
-    var idxDesc = orderedNamesAndAssertPlan(indexed, "DESC", true);
-    var memDesc = orderedNamesAndAssertPlan(inMemory, "DESC", false);
-    Assert.assertEquals(Arrays.asList("c", "b", "a", null, null), idxDesc);
-    Assert.assertEquals(memDesc, idxDesc);
+    Assert.assertEquals(Arrays.asList(null, null, "a", "b", "c"), ordered);
   }
 
   /**
-   * Same null-placement invariant as {@link #testOrderByNullPlacementConsistentForNotUniqueIndex}
-   * but for a UNIQUE (single-value) index. Nulls are not ignored by default
-   * (INDEX_IGNORE_NULL_VALUES_DEFAULT = false), so a UNIQUE index stores a single null key; the
-   * index-accelerated scan must return that null row and place it consistently with the in-memory
-   * sort for both ASC (nulls first) and DESC (nulls last).
+   * DESC over a NOTUNIQUE (multi-value) indexed field: index-accelerated, and the null-keyed rows
+   * come LAST. This is the placement the bug got wrong — the index path used to emit nulls first
+   * for DESC (YTDB-1197).
    */
   @Test
-  public void testOrderByNullPlacementConsistentForUniqueIndex() {
-    var indexed = "testNullPlacementIdxUnique";
-    var inMemory = "testNullPlacementNoIdxUnique";
-    var idxCls = session.getMetadata().getSchema().createClass(indexed);
-    idxCls.createProperty("name", PropertyType.STRING);
-    idxCls.createIndex(indexed + ".name", INDEX_TYPE.UNIQUE, "name");
-    session.getMetadata().getSchema().createClass(inMemory)
+  public void testOrderByDescUsesNotUniqueIndexNullsLast() {
+    var className = "testOrderByDescIdxNotUnique";
+    createIndexedNameClass(className, INDEX_TYPE.NOTUNIQUE);
+    seedNames(className, Arrays.asList("b", "a", "c", null, null));
+
+    var ordered = orderedNamesAndAssertPlan(className, "DESC", true);
+
+    Assert.assertEquals(Arrays.asList("c", "b", "a", null, null), ordered);
+  }
+
+  /**
+   * ASC over a UNIQUE (single-value) indexed field: index-accelerated. Nulls are not ignored by
+   * default (INDEX_IGNORE_NULL_VALUES_DEFAULT = false), so the single null key is stored and
+   * emitted first.
+   */
+  @Test
+  public void testOrderByAscUsesUniqueIndexNullsFirst() {
+    var className = "testOrderByAscIdxUnique";
+    createIndexedNameClass(className, INDEX_TYPE.UNIQUE);
+    seedNames(className, Arrays.asList("b", "a", "c", null));
+
+    var ordered = orderedNamesAndAssertPlan(className, "ASC", true);
+
+    Assert.assertEquals(Arrays.asList(null, "a", "b", "c"), ordered);
+  }
+
+  /**
+   * DESC over a UNIQUE (single-value) indexed field: index-accelerated, single null key emitted
+   * LAST — the DESC placement fixed in YTDB-1197.
+   */
+  @Test
+  public void testOrderByDescUsesUniqueIndexNullsLast() {
+    var className = "testOrderByDescIdxUnique";
+    createIndexedNameClass(className, INDEX_TYPE.UNIQUE);
+    seedNames(className, Arrays.asList("b", "a", "c", null));
+
+    var ordered = orderedNamesAndAssertPlan(className, "DESC", true);
+
+    Assert.assertEquals(Arrays.asList("c", "b", "a", null), ordered);
+  }
+
+  /**
+   * ASC with no index: the sort runs in memory (OrderByStep, no FetchFromIndexStep) and nulls come
+   * first. Reference behavior the index-accelerated ASC path must match.
+   */
+  @Test
+  public void testOrderByAscInMemoryNullsFirst() {
+    var className = "testOrderByAscNoIdx";
+    createPlainNameClass(className);
+    seedNames(className, Arrays.asList("b", "a", "c", null, null));
+
+    var ordered = orderedNamesAndAssertPlan(className, "ASC", false);
+
+    Assert.assertEquals(Arrays.asList(null, null, "a", "b", "c"), ordered);
+  }
+
+  /**
+   * DESC with no index: in-memory sort (OrderByStep, no FetchFromIndexStep), nulls last. Reference
+   * behavior the index-accelerated DESC path must match (YTDB-1197).
+   */
+  @Test
+  public void testOrderByDescInMemoryNullsLast() {
+    var className = "testOrderByDescNoIdx";
+    createPlainNameClass(className);
+    seedNames(className, Arrays.asList("b", "a", "c", null, null));
+
+    var ordered = orderedNamesAndAssertPlan(className, "DESC", false);
+
+    Assert.assertEquals(Arrays.asList("c", "b", "a", null, null), ordered);
+  }
+
+  /** Creates a class with a STRING {@code name} property and an index of {@code type} on it. */
+  private void createIndexedNameClass(String className, INDEX_TYPE type) {
+    var cls = session.getMetadata().getSchema().createClass(className);
+    cls.createProperty("name", PropertyType.STRING);
+    cls.createIndex(className + ".name", type, "name");
+  }
+
+  /** Creates a class with a STRING {@code name} property and no index (forces an in-memory sort). */
+  private void createPlainNameClass(String className) {
+    session.getMetadata().getSchema().createClass(className)
         .createProperty("name", PropertyType.STRING);
-
-    // UNIQUE allows a single null key, so seed exactly one null.
-    var names = Arrays.asList("b", "a", "c", null);
-    seedNames(indexed, names);
-    seedNames(inMemory, names);
-
-    var idxAsc = orderedNamesAndAssertPlan(indexed, "ASC", true);
-    var memAsc = orderedNamesAndAssertPlan(inMemory, "ASC", false);
-    Assert.assertEquals(Arrays.asList(null, "a", "b", "c"), idxAsc);
-    Assert.assertEquals(memAsc, idxAsc);
-
-    var idxDesc = orderedNamesAndAssertPlan(indexed, "DESC", true);
-    var memDesc = orderedNamesAndAssertPlan(inMemory, "DESC", false);
-    Assert.assertEquals(Arrays.asList("c", "b", "a", null), idxDesc);
-    Assert.assertEquals(memDesc, idxDesc);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/sql/executor/SelectStatementExecutionTest.java
@@ -7086,7 +7086,9 @@ public class SelectStatementExecutionTest extends DbTestBase {
     cls.createIndex(className + ".name", type, "name");
   }
 
-  /** Creates a class with a STRING {@code name} property and no index (forces an in-memory sort). */
+  /**
+   * Creates a class with a STRING {@code name} property and no index, forcing an in-memory sort.
+   */
   private void createPlainNameClass(String className) {
     session.getMetadata().getSchema().createClass(className)
         .createProperty("name", PropertyType.STRING);
@@ -7116,29 +7118,15 @@ public class SelectStatementExecutionTest extends DbTestBase {
    * (nulls included). Use this for a class that has an index on {@code name}.
    */
   private List<Object> orderedNamesIndexAccelerated(String className, String direction) {
-    session.begin();
-    try {
-      var result = session.query("SELECT name FROM " + className + " ORDER BY name " + direction);
-      var plan = result.getExecutionPlan();
-      var fetchFromIndex =
-          plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count();
-      var orderBy = plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count();
-      var rendered = plan.prettyPrint(0, 2);
-      Assert.assertTrue(
-          "expected an index-accelerated sort (FetchFromIndexStep), plan was:\n" + rendered,
-          fetchFromIndex >= 1);
-      Assert.assertEquals(
-          "index-accelerated sort must not add an in-memory OrderByStep, plan was:\n" + rendered,
-          0, orderBy);
-      var names = new ArrayList<>();
-      while (result.hasNext()) {
-        names.add(result.next().<Object>getProperty("name"));
-      }
-      result.close();
-      return names;
-    } finally {
-      session.commit();
-    }
+    var run = runOrderByQuery(className, direction);
+    Assert.assertTrue(
+        "expected an index-accelerated sort (FetchFromIndexStep), plan was:\n" + run.renderedPlan(),
+        run.fetchFromIndexSteps() >= 1);
+    Assert.assertEquals(
+        "index-accelerated sort must not add an in-memory OrderByStep, plan was:\n"
+            + run.renderedPlan(),
+        0, run.orderBySteps());
+    return run.names();
   }
 
   /**
@@ -7149,27 +7137,46 @@ public class SelectStatementExecutionTest extends DbTestBase {
    * match.
    */
   private List<Object> orderedNamesInMemory(String className, String direction) {
+    var run = runOrderByQuery(className, direction);
+    Assert.assertEquals(
+        "expected an in-memory sort (no index), plan was:\n" + run.renderedPlan(), 0,
+        run.fetchFromIndexSteps());
+    Assert.assertEquals(
+        "in-memory sort must add an OrderByStep, plan was:\n" + run.renderedPlan(), 1,
+        run.orderBySteps());
+    return run.names();
+  }
+
+  /**
+   * Runs {@code SELECT name FROM <className> ORDER BY name <direction>} and returns the plan-step
+   * counts, the rendered plan (for assertion messages), and the emitted {@code name} values in
+   * result order (nulls included). The {@code ResultSet} is closed and the transaction committed
+   * unconditionally, so a failed assertion in a caller cannot leak either. The wrappers {@link
+   * #orderedNamesIndexAccelerated} / {@link #orderedNamesInMemory} add the plan-shape assertion
+   * that tells an index-accelerated sort apart from an in-memory one.
+   */
+  private OrderByRun runOrderByQuery(String className, String direction) {
     session.begin();
-    try {
-      var result = session.query("SELECT name FROM " + className + " ORDER BY name " + direction);
+    try (var result =
+        session.query("SELECT name FROM " + className + " ORDER BY name " + direction)) {
       var plan = result.getExecutionPlan();
       var fetchFromIndex =
           plan.getSteps().stream().filter(step -> step instanceof FetchFromIndexStep).count();
       var orderBy = plan.getSteps().stream().filter(step -> step instanceof OrderByStep).count();
       var rendered = plan.prettyPrint(0, 2);
-      Assert.assertEquals(
-          "expected an in-memory sort (no index), plan was:\n" + rendered, 0, fetchFromIndex);
-      Assert.assertEquals(
-          "in-memory sort must add an OrderByStep, plan was:\n" + rendered, 1, orderBy);
       var names = new ArrayList<>();
       while (result.hasNext()) {
         names.add(result.next().<Object>getProperty("name"));
       }
-      result.close();
-      return names;
+      return new OrderByRun(fetchFromIndex, orderBy, rendered, names);
     } finally {
       session.commit();
     }
+  }
+
+  /** Plan-step counts, rendered plan, and emitted names from one ORDER BY query run. */
+  private record OrderByRun(
+      long fetchFromIndexSteps, long orderBySteps, String renderedPlan, List<Object> names) {
   }
 
   // ── CASE + MIN/MAX aggregate tests ──


### PR DESCRIPTION
#### PR Title:

YTDB-1197: Fix ORDER BY null placement for index scans

#### Motivation:

A full index scan that satisfies `ORDER BY` from the index placed `null` keys in the wrong spot for descending sorts. YouTrackDB's in-memory `ORDER BY` treats `null` as the smallest value — nulls first for `ASC`, nulls last for `DESC` (see `SQLOrderByItem.compare`). The index-accelerated path always prepended the null-key group, so a `DESC` scan emitted nulls first instead of last. The same query over the same data then returned a different row order depending on whether an index happened to accelerate the sort. That divergence is a correctness bug: plan choice must not change results.

The fix also closes a latent resource leak on the same path. The step opened the null-key stream before the main B-tree stream; if opening the main stream threw, the already-open null stream leaked, because the caller closes streams only once the step returns them and on a throw the partial list is discarded.

#### Planned changes:

**What changes (behavior):** A full-scan `ORDER BY` served from an index now places the null-key group to match the in-memory sort — nulls first for `ASC`, nulls last for `DESC`. Result order no longer depends on whether the sort is index-accelerated.

**How (design level):** Null keys live in a separate bucket outside the sorted B-tree, so their position in the emitted sequence is decided purely by where the null stream is concatenated relative to the sorted stream. The full-scan step now concatenates null-first for `ASC` and null-last for `DESC` instead of always prepending.

**Robustness:** The full-scan step acquires both streams inside a guarded block and closes whatever was opened if the second acquisition throws, so the null-key stream can no longer leak. The catch is scoped to the two acquisitions (the only operations that can throw) and catches `RuntimeException | Error` (deliberately, so it also closes streams on an -ea `AssertionError`); any failure from `close()` is attached as a suppressed exception so the original acquisition failure is the one that propagates.

**Also fixed:** The sibling range/equality path (`multipleRange`) acquired streams in the same acquire-then-maybe-throw shape and could leak the same way. It was refactored into a guarded wrapper that delegates to an extracted `collectRangeStreams`, and gained the same close-on-failure leak guard, so it can no longer leak either.

**Verification:** Unit tests on the full-scan step assert null placement for `ASC` and `DESC` (including that the multi-value null bucket surfaces every RID), and that the null stream is closed when the main-stream acquisition throws. End-to-end SQL tests assert, per direction, both the execution-plan shape — index-accelerated has a `FetchFromIndexStep` and no `OrderByStep`, in-memory has an `OrderByStep` and no `FetchFromIndexStep` — and the exact null placement, pinning the index-accelerated and in-memory paths to identical output.

#### Tracks:

N/A (single-track)
