### PR TITLE
Workflow: user-performed merge; single-track peer review on the umbrella PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,8 @@ Guidance: docs/dev-workflow/track-development.md -->
 #### Tracks:
 <!-- Multi-track changes only — display index; the source of truth is the marker commits
 (`git log --oneline --grep '^Track [0-9]* complete:'`). Write "N/A (single-track)" otherwise.
-Branch-life only: this table is stripped from the description before the squash-merge. -->
+Branch-life only: this table is stripped from the description before the PR is flipped ready
+for review. -->
 
 | # | Track | Scope | Status | Satellite PR |
 |---|-------|-------|--------|--------------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,6 @@
 | [Fine-Grained Security](security.md) | Predicate-based security policies, per-role filtering, ALTER/REVOKE lifecycle |
 | [Development Workflow](workflow-book/chapters/01-workflow-at-a-glance.md) | Contributor onboarding book for the YouTrackDB development workflow — phases, tiers, tracks, and reviews — in 16 chapters. Start at Chapter 1. |
 | [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, user design review, adversarial review, umbrella draft PR, per-track code review and mandatory user review gate, marker commits |
-| [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs for multi-track changes (single-track peer review runs on the umbrella PR) — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
+| [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs for multi-track changes (single-track and trivial peer review runs on the umbrella PR) — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,6 @@
 | [Fine-Grained Security](security.md) | Predicate-based security policies, per-role filtering, ALTER/REVOKE lifecycle |
 | [Development Workflow](workflow-book/chapters/01-workflow-at-a-glance.md) | Contributor onboarding book for the YouTrackDB development workflow — phases, tiers, tracks, and reviews — in 16 chapters. Start at Chapter 1. |
 | [Track-Based Development](dev-workflow/track-development.md) | Mandatory baseline flow for all changes — research, user design review, adversarial review, umbrella draft PR, per-track code review and mandatory user review gate, marker commits |
-| [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
+| [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs for multi-track changes (single-track peer review runs on the umbrella PR) — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -32,13 +32,15 @@ This flow covers **all files in the repository**, including `.pi/` tooling and s
    marker commit the agent asks whether to open a draft satellite PR for review by separate
    peer reviewers; mechanics in `docs/dev-workflow/satellite-pr.md`. Satellites are
    review-only: always draft, never merged. Once opened, the track blocks the next one until
-   the peer review is complete or the user explicitly waives completion.
+   the peer review is complete or the user explicitly waives completion. Satellites are
+   multi-track only — for single-track changes the optional peer review runs on the umbrella
+   PR after the ready-for-review flip.
 
 Single-track changes skip the split and markers; trivial changes (typos, doc-only, mechanical
 renames) collapse the design review into consent to the planned-changes paragraph and may also
 skip the full adversarial review — see the protocol doc's scaling table. The mandatory user
 review gate applies at every tier: for single-track and trivial changes it gates the
-squash-merge.
+ready-for-review flip.
 
 ## Test Policy
 
@@ -100,11 +102,15 @@ dispatch a build there while another build or test run is in progress.
 - Target branch: `develop` (exception: satellite review PRs target their pinned `track-NN-base`
   branch)
 - **1 PR = 1 squashed commit** — all branch commits are squashed on merge
+- **Merge is user-performed** — the agent never merges the umbrella PR. Its final act is
+  flipping the PR to ready-for-review after the pre-flip checklist (see
+  `docs/dev-workflow/track-development.md`); the user may wait for CI and/or peer review, ask
+  the agent to fix failures or observations, and squash-merges themselves.
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made. Satellite review PRs are exempt — they carry a track-summary body instead (see the satellite bullet below).
 - **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
 - **Planned changes & Tracks sections**: The PR template includes "Planned changes" and "Tracks" sections, mandatory for non-trivial changes. The umbrella draft PR's description is kept in sync as work proceeds — see `docs/dev-workflow/track-development.md`.
-- **Satellite review PRs** are draft-only review vehicles for individual tracks: they are never merged and never marked ready for review — see `docs/dev-workflow/satellite-pr.md`.
+- **Satellite review PRs** are draft-only review vehicles for individual tracks: they are never merged and never marked ready for review — see `docs/dev-workflow/satellite-pr.md`. Single-track changes create no satellite — their peer review runs on the umbrella PR.
 
 ### Rebase Conflict Resolution
 - When a rebase produces conflicts in prose-heavy files (e.g., `AGENTS.md` or `docs/adr/**`), re-read every resolved file end-to-end before continuing — three-way prose merges can splice text that parses but contradicts itself.

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -33,8 +33,8 @@ This flow covers **all files in the repository**, including `.pi/` tooling and s
    peer reviewers; mechanics in `docs/dev-workflow/satellite-pr.md`. Satellites are
    review-only: always draft, never merged. Once opened, the track blocks the next one until
    the peer review is complete or the user explicitly waives completion. Satellites are
-   multi-track only — for single-track changes the optional peer review runs on the umbrella
-   PR after the ready-for-review flip.
+   multi-track only — for single-track and trivial changes the optional peer review runs on
+   the umbrella PR after the ready-for-review flip.
 
 Single-track changes skip the split and markers; trivial changes (typos, doc-only, mechanical
 renames) collapse the design review into consent to the planned-changes paragraph and may also
@@ -102,15 +102,14 @@ dispatch a build there while another build or test run is in progress.
 - Target branch: `develop` (exception: satellite review PRs target their pinned `track-NN-base`
   branch)
 - **1 PR = 1 squashed commit** — all branch commits are squashed on merge
-- **Merge is user-performed** — the agent never merges the umbrella PR. Its final act is
-  flipping the PR to ready-for-review after the pre-flip checklist (see
-  `docs/dev-workflow/track-development.md`); the user may wait for CI and/or peer review, ask
-  the agent to fix failures or observations, and squash-merges themselves.
+- **Merge is user-performed** — the agent never merges the umbrella PR; it flips the PR to
+  ready-for-review after the pre-flip checklist and hands it to the user — see
+  `docs/dev-workflow/track-development.md` § Ready-for-review flip, merge & cleanup.
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made. Satellite review PRs are exempt — they carry a track-summary body instead (see the satellite bullet below).
 - **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
 - **Planned changes & Tracks sections**: The PR template includes "Planned changes" and "Tracks" sections, mandatory for non-trivial changes. The umbrella draft PR's description is kept in sync as work proceeds — see `docs/dev-workflow/track-development.md`.
-- **Satellite review PRs** are draft-only review vehicles for individual tracks: they are never merged and never marked ready for review — see `docs/dev-workflow/satellite-pr.md`. Single-track changes create no satellite — their peer review runs on the umbrella PR.
+- **Satellite review PRs** are draft-only review vehicles for individual tracks (multi-track changes only — see workflow step 6 above): they are never merged and never marked ready for review — see `docs/dev-workflow/satellite-pr.md`.
 
 ### Rebase Conflict Resolution
 - When a rebase produces conflicts in prose-heavy files (e.g., `AGENTS.md` or `docs/adr/**`), re-read every resolved file end-to-end before continuing — three-way prose merges can splice text that parses but contradicts itself.

--- a/docs/dev-workflow/satellite-pr.md
+++ b/docs/dev-workflow/satellite-pr.md
@@ -3,11 +3,14 @@
 ## Purpose & invariants
 
 A satellite PR is a review vehicle for ONE track's diff, aimed at separate peer reviewers.
-Satellites exist for MULTI-TRACK changes only; for single-track changes the umbrella PR itself
-hosts the optional peer review after the agent flips it ready for review — the same observation
-loop (below), run on the umbrella PR. The primary user review happens in-session as a mandatory
-per-track gate (see `docs/dev-workflow/track-development.md`) and is never replaced by a
-satellite. Two invariants:
+Satellites exist for MULTI-TRACK changes only; for single-track and trivial changes the
+umbrella PR itself hosts the optional peer review after the agent flips it ready for review.
+There the observation loop (below) applies only in part: observations are read and fixed as
+normal commits under the same completion signal, but the satellite-only mechanics — head
+force-update, next-track blocking — do not apply; the post-flip duties live in
+`docs/dev-workflow/track-development.md` § Ready-for-review flip, merge & cleanup. The primary
+user review happens in-session as a mandatory per-track gate (see the same doc) and is never
+replaced by a satellite. Two invariants:
 
 - It is **never merged**.
 - It is **never marked "ready for review"** — it stays DRAFT for its whole life.
@@ -60,7 +63,9 @@ decide (keep waiting vs waive completion). Peer-fix commits land after the track
 approval: on a non-final track they fall inside the next track's commit range and are covered by
 that track's mandatory user review; commits after the last user-approved gate (e.g., final-track
 peer fixes) are presented to the user by the pre-flip checklist (see
-`docs/dev-workflow/track-development.md` § Ready-for-review flip, merge & cleanup).
+`docs/dev-workflow/track-development.md` § Ready-for-review flip, merge & cleanup). On a
+single-track or trivial change's umbrella PR, post-flip peer fixes are instead presented as
+they land (same section).
 
 Caveat: if later tracks have started (i.e., the user waived completion), the updated head
 pollutes the satellite's diff with later-track commits. Mitigations: GitHub's "changes since
@@ -76,6 +81,8 @@ with `--force-with-lease`.
 
 The umbrella PR's merge is user-performed. Closing every satellite PR and deleting every
 `track-NN-base` / `track-NN-head` branch is an agent duty, executed when the user reports the
-merge or a later session detects it. Discover leftovers with `gh pr list --state open --draft`,
-filtering for `[Track NN]` titles, plus a branch scan for the `<branch>/track-NN-base` /
-`<branch>/track-NN-head` name pattern.
+merge or a later session detects it. First confirm the umbrella PR is actually MERGED
+(`gh pr view --json state,mergedAt`) — never run cleanup while the umbrella is open: a paused
+in-flight branch keeps its satellites. Discover leftovers with
+`gh pr list --state open --draft`, filtering for `[Track NN]` titles, plus a branch scan for
+the `<branch>/track-NN-base` / `<branch>/track-NN-head` name pattern.

--- a/docs/dev-workflow/satellite-pr.md
+++ b/docs/dev-workflow/satellite-pr.md
@@ -2,9 +2,12 @@
 
 ## Purpose & invariants
 
-A satellite PR is a review vehicle for ONE track's diff, aimed at separate peer reviewers. The
-primary user review happens in-session as a mandatory per-track gate (see
-`docs/dev-workflow/track-development.md`) and is never replaced by a satellite. Two invariants:
+A satellite PR is a review vehicle for ONE track's diff, aimed at separate peer reviewers.
+Satellites exist for MULTI-TRACK changes only; for single-track changes the umbrella PR itself
+hosts the optional peer review after the agent flips it ready for review — the same observation
+loop (below), run on the umbrella PR. The primary user review happens in-session as a mandatory
+per-track gate (see `docs/dev-workflow/track-development.md`) and is never replaced by a
+satellite. Two invariants:
 
 - It is **never merged**.
 - It is **never marked "ready for review"** — it stays DRAFT for its whole life.
@@ -56,8 +59,8 @@ or states the review is done; if the signal is ambiguous or absent, the agent as
 decide (keep waiting vs waive completion). Peer-fix commits land after the track's user
 approval: on a non-final track they fall inside the next track's commit range and are covered by
 that track's mandatory user review; commits after the last user-approved gate (e.g., final-track
-peer fixes) are covered by the pre-merge user review (see
-`docs/dev-workflow/track-development.md` § Merge & cleanup).
+peer fixes) are presented to the user by the pre-flip checklist (see
+`docs/dev-workflow/track-development.md` § Ready-for-review flip, merge & cleanup).
 
 Caveat: if later tracks have started (i.e., the user waived completion), the updated head
 pollutes the satellite's diff with later-track commits. Mitigations: GitHub's "changes since
@@ -71,5 +74,8 @@ with `--force-with-lease`.
 
 ## Cleanup
 
-When the umbrella PR merges: close every satellite PR and delete every `track-NN-base` /
-`track-NN-head` branch.
+The umbrella PR's merge is user-performed. Closing every satellite PR and deleting every
+`track-NN-base` / `track-NN-head` branch is an agent duty, executed when the user reports the
+merge or a later session detects it. Discover leftovers with `gh pr list --state open --draft`,
+filtering for `[Track NN]` titles, plus a branch scan for the `<branch>/track-NN-base` /
+`<branch>/track-NN-head` name pattern.

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -7,7 +7,7 @@ This is the mandatory flow for ALL changes in this repository:
 Research → (lazy) research log → user design review → adversarial review → umbrella draft PR →
 user approves track split → per-track loop (implement → track code review → fixes → mandatory
 user review → marker commit → optional satellite peer-review PR) → ready-for-review flip →
-user-performed squash-merge + cleanup.
+user-performed squash-merge → cleanup.
 
 The flow scales with change size:
 
@@ -15,7 +15,7 @@ The flow scales with change size:
 | --- | --- |
 | Multi-track change | Full flow as described above. |
 | Single-track change | No track split, no marker commits. Everything else applies. Optional peer review runs on the umbrella PR itself — no satellite (see § Ready-for-review flip, merge & cleanup). |
-| Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Planned-changes section is a 2–3-sentence paragraph; the design review collapses into user consent to it. Micro adversarial review, or skip it with explicit user consent. |
+| Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Planned-changes section is a 2–3-sentence paragraph; the design review collapses into user consent to it. Micro adversarial review, or skip it with explicit user consent. Optional peer review as for single-track changes — on the umbrella PR. |
 
 The mandatory user review gate applies at EVERY tier. For single-track and trivial changes the
 whole branch diff is the track, so the user review sits after the agent code review and before
@@ -211,16 +211,16 @@ Per-track sequence:
    if reality diverged from it.
 7. Ask the user whether to open a satellite review PR (see `docs/dev-workflow/satellite-pr.md`) —
    a peer-review vehicle for separate reviewers, not the primary user review (that already
-   happened in step 4). (This ask is multi-track only — for single-track changes the peer-review
-   ask happens at the ready-for-review flip and the review runs on the umbrella PR itself.)
-   Once a satellite is open, the track's review loop stays open: process peer observations and do NOT start the next track until the peer review is complete
-   (completion signal defined in that doc) or the user explicitly waives completion. Record the
-   peer-review state (open / completed / waived) in the track's Tracks table row — same
-   mechanism as sticky answers — so a new session knows whether the loop is still open. Sticky
-   answers are allowed: the user may reply "yes/no for all remaining tracks". Record the sticky
-   answer as a one-line note under the Tracks table for cross-session durability and stop
-   asking. Sticky answers apply only to this satellite ask — the step-4 user review stays
-   mandatory for every track.
+   happened in step 4). (This ask is multi-track only — for single-track and trivial changes the
+   peer-review ask happens at the flip; see § Ready-for-review flip, merge & cleanup.) Once a
+   satellite is open, the track's review loop stays open: process peer observations and do NOT
+   start the next track until the peer review is complete (completion signal defined in that
+   doc) or the user explicitly waives completion. Record the peer-review state (open /
+   completed / waived) in the track's Tracks table row — same mechanism as sticky answers — so
+   a new session knows whether the loop is still open. Sticky answers are allowed: the user
+   may reply "yes/no for all remaining tracks". Record the sticky answer as a one-line note
+   under the Tracks table for cross-session durability and stop asking. Sticky answers apply
+   only to this satellite ask — the step-4 user review stays mandatory for every track.
 
 ## Marker commits (source of truth for track boundaries)
 
@@ -258,24 +258,27 @@ update automatically since their refs moved.
 ## Ready-for-review flip, merge & cleanup
 
 The umbrella PR is the ONLY PR ever merged (squash, per repo conventions), and the merge is
-performed BY THE USER — the agent never merges it. The agent's final act is flipping the PR to
-ready-for-review, gated by this pre-flip checklist:
+performed BY THE USER — the agent never merges it. Flipping the PR to ready-for-review is the
+agent's last act before handing the PR to the user; post-flip fix work and post-merge cleanup
+stay agent duties (below). The flip is gated by this pre-flip checklist:
 
 - Re-read the whole PR description end-to-end to confirm it still tells one consistent story.
 - Every opened satellite's peer review is completed or explicitly user-waived — flipping never
   discards a pending review.
 - All commits landed since the last user-approved gate (e.g., final-track peer-review fixes)
   are presented to the user.
-- Strip the Tracks table (and any sticky-answer note under it) from the description. Track
-  numbers are ephemeral branch-life identifiers: after the squash-merge the marker commits are
-  gone and the satellites are closed, so track references would dangle in develop's history.
-  The rest of the description — Motivation, Planned changes — stays: it becomes the
-  squash-commit body.
+- Strip the whole Tracks section from the description, whatever its form — the table for
+  multi-track changes or the "N/A (single-track)" placeholder — plus any sticky-answer note
+  under it. Track numbers are ephemeral branch-life identifiers: after the squash-merge the
+  marker commits are gone and the satellites are closed, so track references would dangle in
+  develop's history. The rest of the description — Motivation, Planned changes — stays: it
+  becomes the squash-commit body.
 
-Single-track changes: at the flip the agent asks whether the user wants a peer review. If yes,
-peers review the ready umbrella PR directly — no satellite branches or PR are created; the
-observation loop of `docs/dev-workflow/satellite-pr.md` applies, run on the umbrella PR (fixes
-land as normal commits; no branch re-pinning is needed since the PR head is the working branch).
+Single-track and trivial changes: at the flip the agent asks whether the user wants a peer
+review. If yes, peers review the ready umbrella PR directly — no satellite branches or PR are
+created; the observation loop of `docs/dev-workflow/satellite-pr.md` applies, run on the
+umbrella PR (fixes land as normal commits; no branch re-pinning is needed since the PR head is
+the working branch).
 
 After the flip: the user may wait for CI green and/or peer-review completion and ask the agent
 to fix test failures or peer observations. The agent lands fixes as normal commits, keeps the
@@ -293,6 +296,7 @@ Richer internal planning and execution machinery — whatever agent tooling is i
 layered on top of this baseline, provided it satisfies the mandatory gates: a user design
 review before adversarial review, pre-implementation adversarial review, an umbrella draft PR
 before coding starts, a code review per track, a mandatory user review per track, marker
-commits at track boundaries, the per-track satellite-PR ask, and a user-performed merge (the
-agent never merges the umbrella PR). This document defines the baseline that applies
+commits at track boundaries, the per-track satellite-PR ask for multi-track changes (the
+flip-time peer-review ask for single-track and trivial changes), and a user-performed merge
+(the agent never merges the umbrella PR). This document defines the baseline that applies
 regardless of the tooling.

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -6,19 +6,20 @@ This is the mandatory flow for ALL changes in this repository:
 
 Research → (lazy) research log → user design review → adversarial review → umbrella draft PR →
 user approves track split → per-track loop (implement → track code review → fixes → mandatory
-user review → marker commit → optional satellite peer-review PR) → squash-merge + cleanup.
+user review → marker commit → optional satellite peer-review PR) → ready-for-review flip →
+user-performed squash-merge + cleanup.
 
 The flow scales with change size:
 
 | Change size | What applies |
 | --- | --- |
 | Multi-track change | Full flow as described above. |
-| Single-track change | No track split, no marker commits. Everything else applies. |
+| Single-track change | No track split, no marker commits. Everything else applies. Optional peer review runs on the umbrella PR itself — no satellite (see § Ready-for-review flip, merge & cleanup). |
 | Trivial change (typo, doc-only, mechanical rename, obvious one-file fix) | No split. Planned-changes section is a 2–3-sentence paragraph; the design review collapses into user consent to it. Micro adversarial review, or skip it with explicit user consent. |
 
 The mandatory user review gate applies at EVERY tier. For single-track and trivial changes the
 whole branch diff is the track, so the user review sits after the agent code review and before
-the squash-merge.
+the ready-for-review flip.
 
 ## Research phase (lightweight)
 
@@ -210,8 +211,9 @@ Per-track sequence:
    if reality diverged from it.
 7. Ask the user whether to open a satellite review PR (see `docs/dev-workflow/satellite-pr.md`) —
    a peer-review vehicle for separate reviewers, not the primary user review (that already
-   happened in step 4). Once a satellite is open, the track's review loop stays open: process
-   peer observations and do NOT start the next track until the peer review is complete
+   happened in step 4). (This ask is multi-track only — for single-track changes the peer-review
+   ask happens at the ready-for-review flip and the review runs on the umbrella PR itself.)
+   Once a satellite is open, the track's review loop stays open: process peer observations and do NOT start the next track until the peer review is complete
    (completion signal defined in that doc) or the user explicitly waives completion. Record the
    peer-review state (open / completed / waived) in the track's Tracks table row — same
    mechanism as sticky answers — so a new session knows whether the loop is still open. Sticky
@@ -253,22 +255,37 @@ After any rebase of the working branch: the markers moved automatically. Re-pin 
 base/head branches from the moved markers and push with `--force-with-lease`. Open satellite PRs
 update automatically since their refs moved.
 
-## Merge & cleanup
+## Ready-for-review flip, merge & cleanup
 
-The umbrella PR is the ONLY PR ever merged (squash, per repo conventions). Before merge:
+The umbrella PR is the ONLY PR ever merged (squash, per repo conventions), and the merge is
+performed BY THE USER — the agent never merges it. The agent's final act is flipping the PR to
+ready-for-review, gated by this pre-flip checklist:
 
 - Re-read the whole PR description end-to-end to confirm it still tells one consistent story.
-- Any commits landed after the last user-approved gate (e.g., late peer-review fixes on the
-  final track) get a user review.
-- Every opened satellite's peer review is completed or explicitly user-waived — closing
-  satellites at merge never discards a pending review.
+- Every opened satellite's peer review is completed or explicitly user-waived — flipping never
+  discards a pending review.
+- All commits landed since the last user-approved gate (e.g., final-track peer-review fixes)
+  are presented to the user.
 - Strip the Tracks table (and any sticky-answer note under it) from the description. Track
   numbers are ephemeral branch-life identifiers: after the squash-merge the marker commits are
   gone and the satellites are closed, so track references would dangle in develop's history.
   The rest of the description — Motivation, Planned changes — stays: it becomes the
   squash-commit body.
 
-At merge: close all satellite PRs and delete all satellite review branches.
+Single-track changes: at the flip the agent asks whether the user wants a peer review. If yes,
+peers review the ready umbrella PR directly — no satellite branches or PR are created; the
+observation loop of `docs/dev-workflow/satellite-pr.md` applies, run on the umbrella PR (fixes
+land as normal commits; no branch re-pinning is needed since the PR head is the working branch).
+
+After the flip: the user may wait for CI green and/or peer-review completion and ask the agent
+to fix test failures or peer observations. The agent lands fixes as normal commits, keeps the
+description in sync, and presents agent-landed commits to the user as they land. Commits pushed
+directly by reviewers are visible in the PR UI; the agent reconciles the description with them
+on its next task. The user's merge act is the final approval.
+
+At merge: close all satellite PRs and delete all satellite review branches — an agent duty,
+executed when the user reports the merge or a later session detects it (the leftover discovery
+procedure lives in `docs/dev-workflow/satellite-pr.md` § Cleanup).
 
 ## Layering richer workflows on top
 
@@ -276,5 +293,6 @@ Richer internal planning and execution machinery — whatever agent tooling is i
 layered on top of this baseline, provided it satisfies the mandatory gates: a user design
 review before adversarial review, pre-implementation adversarial review, an umbrella draft PR
 before coding starts, a code review per track, a mandatory user review per track, marker
-commits at track boundaries, and the per-track satellite-PR ask. This document defines the
-baseline that applies regardless of the tooling.
+commits at track boundaries, the per-track satellite-PR ask, and a user-performed merge (the
+agent never merges the umbrella PR). This document defines the baseline that applies
+regardless of the tooling.


### PR DESCRIPTION
#### Motivation:

The agent auto-merging the umbrella PR removes the user's chance to wait for CI results or peer-review completion before landing. Creating satellite branches for a single-track change duplicates the umbrella PR's own diff for no benefit.

#### Planned changes:

**Current state:** the agent squash-merges the umbrella PR itself after the final user review; satellite PRs are the per-track peer-review vehicle at every tier, including single-track changes.

**What changes:** merging the umbrella PR becomes a user action at every tier. The agent's last act before handing the PR to the user is flipping it to ready-for-review, after a pre-flip checklist: description re-read end-to-end, the whole Tracks section stripped (table or single-track placeholder), every satellite peer review completed or user-waived, and all commits since the last user-approved gate presented to the user. The user may wait for CI green and/or peer-review completion, ask the agent to fix test failures or peer observations, then squash-merges themselves. For single-track and trivial changes the umbrella PR itself hosts the optional peer review — no satellite branches or PR are created; the satellite observation loop applies on the umbrella PR, minus the satellite-only mechanics. Satellites remain per-track vehicles for multi-track changes only.

**Key decisions:**

1. Late-commit coverage: any commit landed after the last user-approved gate is presented to the user — pre-flip commits before flipping, post-flip agent-landed commits as they land; the user's merge act is the final approval. Reviewer-pushed commits on the ready PR are visible in the PR UI; the agent reconciles the description on its next task. Rejected alternative: keeping an agent-run pre-merge user review — impossible once the merge is user-performed.
2. Post-merge cleanup stays an agent duty, run only after confirming the umbrella PR actually merged; leftover satellites/branches are discoverable via `gh pr list --draft` on `[Track NN]` titles and the `track-NN-base`/`track-NN-head` branch pattern.
3. CI running on the flipped umbrella PR is intended — the user waits on it; the satellites' draft-only zero-CI rationale is unchanged.

**Out of scope:** the `.claude/workflow` layer and the generated workflow-book — they encode "the user flips to ready manually", contradicting the new baseline; accepted as obsolete-layer risk since that layer is being sunset (adversarial findings WC1/WC2).

**Risks & accepted trade-offs:**

Design review: user-approved — 2026-07-13
Adversarial review: passed, 2 accepted risks — 2026-07-13

**Verification approach:** doc-only change; end-to-end consistency re-read of every touched doc; no tests.


