### PR TITLE
Workflow: finalize PR title and description before the ready-for-review flip

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,8 @@ Not a restatement of the diff. This section is **MANDATORY**.
 
 #### Planned changes:
 <!-- MANDATORY for non-trivial changes. Written when the draft PR is created (before
-implementation); updated as reality diverges. High design level using the main domain
+implementation); updated as reality diverges; brought to the final, as-implemented state
+before the PR is flipped ready for review. High design level using the main domain
 entities from the code — no file paths, no method signatures. Include the subsections that
 apply: Current state · What changes (contract/behavior) · How (design level) ·
 Key decisions (chosen vs rejected alternatives) · Out of scope · Risks & accepted

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -102,11 +102,12 @@ dispatch a build there while another build or test run is in progress.
 - Target branch: `develop` (exception: satellite review PRs target their pinned `track-NN-base`
   branch)
 - **1 PR = 1 squashed commit** — all branch commits are squashed on merge
-- **Merge is user-performed** — the agent never merges the umbrella PR; it flips the PR to
-  ready-for-review after the pre-flip checklist and hands it to the user — see
+- **Merge is user-performed** — the agent never merges the umbrella PR; it runs the pre-flip
+  checklist — which includes updating the PR title and description to the final state of the
+  change — then flips the PR to ready-for-review and hands it to the user — see
   `docs/dev-workflow/track-development.md` § Ready-for-review flip, merge & cleanup.
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made. Satellite review PRs are exempt — they carry a track-summary body instead (see the satellite bullet below).
-- **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes.
+- **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes. The pre-flip checklist ends with a final-state update of the title and description — a backstop, not a substitute, for per-push sync.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
 - **Planned changes & Tracks sections**: The PR template includes "Planned changes" and "Tracks" sections, mandatory for non-trivial changes. The umbrella draft PR's description is kept in sync as work proceeds — see `docs/dev-workflow/track-development.md`.
 - **Satellite review PRs** are draft-only review vehicles for individual tracks (multi-track changes only — see workflow step 6 above): they are never merged and never marked ready for review — see `docs/dev-workflow/satellite-pr.md`.

--- a/docs/agents/orchestrator-guidelines.md
+++ b/docs/agents/orchestrator-guidelines.md
@@ -103,11 +103,10 @@ dispatch a build there while another build or test run is in progress.
   branch)
 - **1 PR = 1 squashed commit** — all branch commits are squashed on merge
 - **Merge is user-performed** — the agent never merges the umbrella PR; it runs the pre-flip
-  checklist — which includes updating the PR title and description to the final state of the
-  change — then flips the PR to ready-for-review and hands it to the user — see
+  checklist, then flips the PR to ready-for-review and hands it to the user — see
   `docs/dev-workflow/track-development.md` § Ready-for-review flip, merge & cleanup.
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made. Satellite review PRs are exempt — they carry a track-summary body instead (see the satellite bullet below).
-- **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes. The pre-flip checklist ends with a final-state update of the title and description — a backstop, not a substitute, for per-push sync.
+- **Keep the PR title and description in sync with follow-up commits.** The squashed commit message is built from the PR title and description, not from individual commit messages — update them with every push so the merge commit reflects all changes. The pre-flip checklist includes a final-state update of the title and description — a backstop, not a substitute, for per-push sync.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
 - **Planned changes & Tracks sections**: The PR template includes "Planned changes" and "Tracks" sections, mandatory for non-trivial changes. The umbrella draft PR's description is kept in sync as work proceeds — see `docs/dev-workflow/track-development.md`.
 - **Satellite review PRs** are draft-only review vehicles for individual tracks (multi-track changes only — see workflow step 6 above): they are never merged and never marked ready for review — see `docs/dev-workflow/satellite-pr.md`.

--- a/docs/dev-workflow/track-development.md
+++ b/docs/dev-workflow/track-development.md
@@ -260,9 +260,8 @@ update automatically since their refs moved.
 The umbrella PR is the ONLY PR ever merged (squash, per repo conventions), and the merge is
 performed BY THE USER — the agent never merges it. Flipping the PR to ready-for-review is the
 agent's last act before handing the PR to the user; post-flip fix work and post-merge cleanup
-stay agent duties (below). The flip is gated by this pre-flip checklist:
+stay agent duties (below). The flip is gated by this pre-flip checklist, executed in order:
 
-- Re-read the whole PR description end-to-end to confirm it still tells one consistent story.
 - Every opened satellite's peer review is completed or explicitly user-waived — flipping never
   discards a pending review.
 - All commits landed since the last user-approved gate (e.g., final-track peer-review fixes)
@@ -273,6 +272,13 @@ stay agent duties (below). The flip is gated by this pre-flip checklist:
   marker commits are gone and the satellites are closed, so track references would dangle in
   develop's history. The rest of the description — Motivation, Planned changes — stays: it
   becomes the squash-commit body.
+- Update the PR title and description to the final state of the change: the title names what
+  was actually delivered — preserving the issue prefix or multi-issue bracket list and any gate
+  markers such as `[no-test-number-check]` — and the description, including the Planned changes
+  section, describes the change as implemented, folding in everything added, dropped, or
+  reshaped since the draft PR was opened.
+- Last, re-read the whole PR description end-to-end to confirm the as-flipped text tells one
+  consistent story.
 
 Single-track and trivial changes: at the flip the agent asks whether the user wants a peer
 review. If yes, peers review the ready umbrella PR directly — no satellite branches or PR are


### PR DESCRIPTION
#### Motivation:

The squash-merge builds the permanent commit body on develop from the umbrella PR's title and description. Today the pre-flip checklist only re-reads the description for consistency — nothing forces the title and description to be brought up to the final, as-implemented state before the flip, so a description that still tells the planned story (or a title missing delivered scope) can become the permanent git-archaeology record. The checklist also validates the description before the Tracks section is stripped, so the text that actually gets merged is never re-validated.

#### Planned changes:

The pre-flip checklist in the track-development workflow doc is now executed in order and extended: the satellite-review and commit-presentation gates come first, then the Tracks-section strip, then a new step — update the PR title and description to the final state of the change (the title names what was actually delivered while preserving the issue prefix / multi-issue bracket list and gate markers such as `[no-test-number-check]`; the description, including the Planned changes section, describes the change as implemented, folding in everything added, dropped, or reshaped since the draft PR was opened) — and the end-to-end consistency re-read moves to the last position so the as-flipped text is what gets validated. The orchestrator guidelines are synced: the user-performed-merge bullet now says the agent runs the pre-flip checklist and then flips, and the title/description-sync bullet notes the checklist includes a final-state update of the title and description — a backstop, not a substitute, for per-push sync. The PR template's Planned-changes comment now says the section is brought to the final, as-implemented state before the PR is flipped ready for review.

Out of scope: the legacy skill workflow docs (CLAUDE.md, .claude/workflow) and the historical workflow-book content — they describe a workflow that never flips PRs and stay untouched.

Design review: user-approved — 2026-07-14
Adversarial review: passed, 1 accepted risk — 2026-07-14
