### PR TITLE
[YTDB-1178] Fix optimistic-read mixed-state race in storage page reads

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -311,6 +311,15 @@ public enum GlobalConfiguration {
       Boolean.class,
       false),
 
+  STORAGE_OPTIMISTIC_READ_NULL_RECHECK_REPORT_INTERVAL_SECS(
+      "youtrackdb.storage.optimisticRead.nullRecheckReportIntervalSecs",
+      "Minimum interval in seconds between reports of the optimistic-read null-recheck"
+          + " anomaly detector. On a disagreement (the pinned re-check finds an entry that a"
+          + " validated optimistic lookup missed) at most one ERROR is logged per interval"
+          + " per storage component.",
+      Integer.class,
+      60),
+
   STORAGE_COLLECTION_GC_MIN_THRESHOLD(
       "youtrackdb.storage.collection.gc.minThreshold",
       "Minimum number of dead records in a collection before the records GC is considered."

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded.java
@@ -5282,7 +5282,13 @@ public class DatabaseSessionEmbedded extends ListenerManger<SessionListener>
     appendDiagnosticField(sb, "source", () -> describeEntityState(sourceEntity));
     appendDiagnosticField(
         sb, "sourceForwardLinks",
-        () -> String.valueOf(sourceEntity.getPropertyInternal(sourcePropertyName, false)));
+        // Objects.toString forces the Object rendering: getPropertyInternal's unbounded
+        // generic return type <RET> would make an unqualified String.valueOf(...) call
+        // resolve to the char[] overload (javac infers RET := char[] as the most specific
+        // applicable type), inserting a checkcast that throws ClassCastException for every
+        // non-char[] value and an NPE for null — destroying exactly the source-side
+        // evidence this diagnostic exists to capture.
+        () -> Objects.toString(sourceEntity.getPropertyInternal(sourcePropertyName, false)));
     appendDiagnosticField(sb, "oppositeBagProperty", () -> oppositeLinkBagPropertyName);
     appendDiagnosticField(sb, "opposite", () -> describeEntityState(oppositeEntity));
     if (oppositeLinkBag == null) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpoch.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpoch.java
@@ -1,0 +1,97 @@
+package com.jetbrains.youtrackdb.internal.core.storage.cache;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Per-storage epoch bracketing the commit-time page-apply phase of atomic operations.
+ *
+ * <p>Optimistic multi-page reads validate each page individually via {@link
+ * com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame} stamps, but per-page
+ * stamps are a purely <em>temporal</em> check: they prove each page was not modified while
+ * it was being read, not that the set of pages formed a mutually consistent snapshot. A
+ * committing transaction applies its page changes to the read cache one page at a time
+ * (in hash order, see {@code AtomicOperationBinaryTracking.commitChanges}), so a reader
+ * overlapping that apply window can observe a mix of pre- and post-commit pages with every
+ * individual stamp still valid — e.g., a B-tree leaf already shrunk by a split while its
+ * new right sibling is not yet visible, producing a false "key absent" result.
+ *
+ * <p>This class closes that gap with two monotonic counters:
+ *
+ * <ul>
+ *   <li>{@code applyEnterSeq} — incremented immediately <em>before</em> a committing
+ *       operation starts mutating shared cache state (file deletion/creation/truncation
+ *       and the per-page apply loop);
+ *   <li>{@code applyExitSeq} — incremented immediately <em>after</em> that section
+ *       completes (in a {@code finally} block, so an escaping exception cannot leave the
+ *       epoch permanently "in apply" and shut down optimistic reads).
+ * </ul>
+ *
+ * <p>Two independent counters are used instead of a single odd/even parity word because
+ * apply phases of <em>different</em> components may run concurrently within one storage:
+ * with parity, a second writer entering while the first is still applying would flip the
+ * bit back to "idle" and mask the overlap. With separate counters the idle condition is
+ * {@code enterSeq == exitSeq}, which holds only when no apply phase is in flight.
+ *
+ * <p>Reader protocol (see {@link OptimisticReadScope}):
+ *
+ * <ol>
+ *   <li>At {@link OptimisticReadScope#reset()}, capture {@code exitSeq} first, then
+ *       {@code enterSeq}. Reading exit before enter is deliberate: if the two captured
+ *       values are equal, every apply that had entered by the time {@code enterSeq} was
+ *       read had already exited <em>before</em> the capture started, so no apply phase
+ *       was in flight at capture time.
+ *   <li>After the per-frame stamp validation loop in
+ *       {@link OptimisticReadScope#validateOrThrow()}, re-read {@code enterSeq}. The read
+ *       is valid only if {@code enterAtCapture == exitAtCapture} (no apply in flight at
+ *       capture) and {@code enterSeq() == enterAtCapture} (no apply entered since).
+ * </ol>
+ *
+ * <p>Memory ordering: all accesses go through {@link AtomicLong}, i.e., volatile
+ * reads/writes. The writer's {@code enterApplyPhase()} volatile increment happens-before
+ * any page mutation it performs, and every mutation happens-before its
+ * {@code exitApplyPhase()} increment; a reader that observes {@code enter == exit} with an
+ * unchanged {@code enterSeq} therefore observed either none or all of any committed
+ * apply's effects — never a partial mix.
+ *
+ * <p>Ownership: one instance per storage, owned by
+ * {@code AtomicOperationsManager}. Deliberately <em>not</em> placed on {@code ReadCache}:
+ * on the disk engine a single read cache is shared by all storages of the engine, and an
+ * engine-global epoch would let commits in one database spuriously invalidate optimistic
+ * reads in another.
+ */
+public final class ApplyPhaseEpoch {
+
+  private final AtomicLong applyEnterSeq = new AtomicLong();
+  private final AtomicLong applyExitSeq = new AtomicLong();
+
+  /**
+   * Marks the start of a commit-time apply phase. Must be paired with exactly one
+   * {@link #exitApplyPhase()} call in a {@code finally} block.
+   */
+  public void enterApplyPhase() {
+    applyEnterSeq.incrementAndGet();
+  }
+
+  /**
+   * Marks the end of a commit-time apply phase. Called from a {@code finally} block so
+   * that an exception escaping the apply section cannot leave the epoch permanently in
+   * the "apply in flight" state (which would disable optimistic reads for good).
+   */
+  public void exitApplyPhase() {
+    applyExitSeq.incrementAndGet();
+  }
+
+  /**
+   * Returns the current enter sequence (volatile read).
+   */
+  public long enterSeq() {
+    return applyEnterSeq.get();
+  }
+
+  /**
+   * Returns the current exit sequence (volatile read).
+   */
+  public long exitSeq() {
+    return applyExitSeq.get();
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
@@ -5,9 +5,20 @@ import java.util.Arrays;
 
 /**
  * Tracks page frames and their optimistic stamps accumulated during a multi-page read
- * operation (e.g., B-tree traversal). Validation happens both per-page (to catch stale
- * pointers early) and at the end of the operation (to ensure all pages form a consistent
- * snapshot).
+ * operation (e.g., B-tree traversal). Validation is two-layered:
+ *
+ * <ul>
+ *   <li><b>Per-page stamps</b> — a purely <em>temporal</em> check: each stamp proves the
+ *       individual page was not modified between being read and being validated. Stamps
+ *       alone do NOT guarantee that the pages form a mutually consistent snapshot: a
+ *       committing transaction applies its changes page-by-page, so a reader overlapping
+ *       that apply window can see a mix of pre- and post-commit pages while every stamp
+ *       stays valid.
+ *   <li><b>Apply-phase epoch</b> — the cross-page consistency guarantee. {@link #reset()}
+ *       captures the storage's {@link ApplyPhaseEpoch} counters and
+ *       {@link #validateOrThrow()} re-checks them after the stamp loop; the read fails if
+ *       any commit-time apply phase overlapped the read window.
+ * </ul>
  *
  * <p>Stored in {@code AtomicOperation} and reused across optimistic read attempts within
  * the same transaction. {@link #reset()} is called before each attempt.
@@ -18,11 +29,43 @@ public final class OptimisticReadScope {
 
   private static final int INITIAL_CAPACITY = 8;
 
+  // Per-storage apply-phase epoch shared with all writers of the same storage.
+  private final ApplyPhaseEpoch applyPhaseEpoch;
+
   private PageFrame[] frames;
   private long[] stamps;
   private int count;
 
+  // Epoch counters captured by reset(); compared against the live epoch in
+  // validateOrThrow() to detect an overlapping commit-time apply phase.
+  private long enterSeqAtCapture;
+  private long exitSeqAtCapture;
+
+  // Nesting-detection state (-ea builds only). attemptActive is flipped exclusively
+  // by enterAttempt()/exitAttempt(), which are invoked from assert statements in
+  // StorageComponent.executeOptimisticStorageRead — with assertions disabled neither
+  // runs and both fields stay false, so production builds pay only the dead branch
+  // in reset(). A nested executeOptimisticStorageRead call inside an optimistic
+  // lambda would wipe the outer scope's stamps via reset(), silently voiding the
+  // outer validation; this state machine surfaces that as an AssertionError.
+  private boolean attemptActive;
+  private boolean nestedResetDetected;
+
+  /**
+   * Convenience constructor for standalone use (tests, tooling) where no epoch is shared
+   * with concurrent writers: allocates a private {@link ApplyPhaseEpoch} that no writer
+   * ever bumps, so epoch validation trivially passes and only per-page stamp validation
+   * applies. Production code must pass the storage-wide epoch owned by
+   * {@code AtomicOperationsManager} (via {@code AtomicOperationBinaryTracking}), otherwise
+   * commit-time apply phases would be invisible to this scope.
+   */
   public OptimisticReadScope() {
+    this(new ApplyPhaseEpoch());
+  }
+
+  public OptimisticReadScope(ApplyPhaseEpoch applyPhaseEpoch) {
+    assert applyPhaseEpoch != null : "ApplyPhaseEpoch must not be null";
+    this.applyPhaseEpoch = applyPhaseEpoch;
     this.frames = new PageFrame[INITIAL_CAPACITY];
     this.stamps = new long[INITIAL_CAPACITY];
     this.count = 0;
@@ -45,14 +88,27 @@ public final class OptimisticReadScope {
   }
 
   /**
-   * Validates all accumulated stamps. Throws {@link OptimisticReadFailedException} if any
-   * stamp is invalid (page was evicted or modified).
+   * Validates all accumulated stamps, then the apply-phase epoch. Throws
+   * {@link OptimisticReadFailedException} if any stamp is invalid (page was evicted or
+   * modified) or if a commit-time apply phase overlapped the read window (the pages may
+   * individually be intact yet form an inconsistent mix of pre- and post-commit state).
    */
   public void validateOrThrow() {
     for (int i = 0; i < count; i++) {
       if (!frames[i].validate(stamps[i])) {
         throw OptimisticReadFailedException.INSTANCE;
       }
+    }
+    // The epoch check MUST stay after the stamp loop. PageFrame.validate() performs a
+    // volatile read of the StampedLock state, and ApplyPhaseEpoch.enterSeq() is a
+    // volatile read as well; the JMM forbids reordering two volatile reads, so keeping
+    // program order (stamps first, epoch second) guarantees the epoch re-read cannot be
+    // hoisted before the stamp validation. Validity requires both that no apply phase
+    // was in flight at capture time (enter == exit at capture) and that none entered
+    // since (live enterSeq unchanged).
+    if (enterSeqAtCapture != exitSeqAtCapture
+        || applyPhaseEpoch.enterSeq() != enterSeqAtCapture) {
+      throw OptimisticReadFailedException.INSTANCE;
     }
   }
 
@@ -72,13 +128,68 @@ public final class OptimisticReadScope {
   }
 
   /**
-   * Resets the scope for reuse. Nulls frame references up to the current count to avoid
-   * preventing garbage collection of evicted PageFrames.
+   * Resets the scope for reuse and captures the apply-phase epoch for the upcoming read
+   * attempt. Nulls frame references up to the current count to avoid preventing garbage
+   * collection of evicted PageFrames.
+   *
+   * <p>Contract: this method must never throw — it is invoked outside the try/fallback
+   * block of {@code StorageComponent.executeOptimisticStorageRead}, so an exception here
+   * would escape past the pinned fallback instead of triggering it.
    */
   public void reset() {
+    // Nesting detection (-ea builds only): attemptActive can be true here only when a
+    // surrounding executeOptimisticStorageRead is still in flight — i.e., this reset
+    // belongs to a nested attempt that is about to wipe the outer scope's stamps.
+    // Record the violation; the outer exitAttempt() assert will surface it.
+    if (attemptActive) {
+      nestedResetDetected = true;
+    }
+
+    // Capture the epoch. Exit is read BEFORE enter deliberately: if the two values are
+    // equal, every apply phase that had entered by the time enterSeq was read had
+    // already exited before the capture began, so no apply was in flight at capture
+    // time. (Enter-first could not distinguish that from an apply spanning the capture.)
+    exitSeqAtCapture = applyPhaseEpoch.exitSeq();
+    enterSeqAtCapture = applyPhaseEpoch.enterSeq();
+
     // Null out frame references to prevent GC retention
     Arrays.fill(frames, 0, count, null);
     count = 0;
+  }
+
+  /**
+   * Marks the start of an optimistic read attempt. Called only via {@code assert} from
+   * {@code StorageComponent.executeOptimisticStorageRead} (zero cost with assertions
+   * disabled). Returns {@code false} — failing the assert — if an attempt is already in
+   * flight, i.e., a nested executeOptimisticStorageRead call was made from inside an
+   * optimistic lambda.
+   */
+  public boolean enterAttempt() {
+    if (attemptActive) {
+      // Nested attempt: also latch the violation so the OUTER exitAttempt() fails.
+      // The AssertionError raised here (inside the outer optimistic lambda) is
+      // swallowed by the outer fallback catch, so the latch is what actually
+      // surfaces the bug to the caller.
+      nestedResetDetected = true;
+      return false;
+    }
+    attemptActive = true;
+    return true;
+  }
+
+  /**
+   * Marks the end of an optimistic read attempt (successful or falling back). Called only
+   * via {@code assert} from {@code StorageComponent.executeOptimisticStorageRead}.
+   * Returns {@code false} — failing the assert — if the attempt was not well-formed:
+   * either it was never entered, or a nested reset was detected while it was in flight.
+   * Clears the detection state so a subsequent pinned fallback that legitimately starts
+   * a fresh optimistic read does not trip a stale flag.
+   */
+  public boolean exitAttempt() {
+    final boolean wellFormed = attemptActive && !nestedResetDetected;
+    attemptActive = false;
+    nestedResetDetected = false;
+    return wellFormed;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
@@ -99,13 +99,15 @@ public final class OptimisticReadScope {
         throw OptimisticReadFailedException.INSTANCE;
       }
     }
-    // The epoch check MUST stay after the stamp loop. PageFrame.validate() performs a
-    // volatile read of the StampedLock state, and ApplyPhaseEpoch.enterSeq() is a
-    // volatile read as well; the JMM forbids reordering two volatile reads, so keeping
-    // program order (stamps first, epoch second) guarantees the epoch re-read cannot be
-    // hoisted before the stamp validation. Validity requires both that no apply phase
-    // was in flight at capture time (enter == exit at capture) and that none entered
-    // since (live enterSeq unchanged).
+    // Epoch check placement: the essential requirement is only that this check runs
+    // AFTER all page reads of the attempt — which holds structurally, because the
+    // caller invokes validateOrThrow() once the optimistic lambda has finished reading.
+    // Both PageFrame.validate() (StampedLock state read behind an acquire fence) and
+    // ApplyPhaseEpoch.enterSeq() (volatile read) are synchronization actions whose
+    // mutual order matches program order, so running the epoch check after the stamp
+    // loop is the natural, conservative placement — not a load-bearing constraint.
+    // Validity requires both that no apply phase was in flight at capture time
+    // (enter == exit at capture) and that none entered since (live enterSeq unchanged).
     if (enterSeqAtCapture != exitSeqAtCapture
         || applyPhaseEpoch.enterSeq() != enterSeqAtCapture) {
       throw OptimisticReadFailedException.INSTANCE;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -1134,8 +1134,8 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
       // bracketed — they do not mutate shared cache pages (snapshot-index entries are
       // SI-filtered on read).
       //
-      // The bracket is gated on the commit actually having shared-cache mutations
-      // (CN-11): zero-change commits — read-only atomic operations, pure metadata ops —
+      // The bracket is gated on the commit actually having shared-cache mutations:
+      // zero-change commits — read-only atomic operations, pure metadata ops —
       // perform no readCache calls in the section below, so bumping the epoch for them
       // would only spuriously invalidate every concurrently overlapping optimistic
       // read in the storage.
@@ -1328,7 +1328,7 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     var pageIndexes = fileChanges.pageChangesMap.keySet().toLongArray();
     final var reordered = hook.orderPageApplications(fileId, pageIndexes.clone());
     if (reordered != null) {
-      // Enforce the "complete permutation" contract (CS-1/CQ-2/CN-13): an unknown
+      // Enforce the "complete permutation" contract: an unknown
       // index would apply nothing for a real page, a duplicate would double-apply,
       // and an omission would silently drop a WAL-committed page's changes from the
       // cache — all of which would silently weaken the tests using this seam.

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -157,6 +157,12 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   // the hot path this class is designed to support.
   private final OptimisticReadScope optimisticReadScope;
 
+  // TEST-ONLY seam for the commit-time page-apply loop (see PageApplyHook). Always null
+  // in production — the apply loop takes the unmodified fast path on null. Volatile
+  // because tests install the hook on the test thread while commitChanges may run on a
+  // separate writer thread.
+  @Nullable private volatile PageApplyHook pageApplyHook;
+
   // Per-storage apply-phase epoch, owned by AtomicOperationsManager and shared by all
   // atomic operations of the same storage. Bumped around the cache-apply section of
   // commitChanges so concurrent optimistic readers can detect overlap with a partially
@@ -1167,68 +1173,32 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
           // and updateDirtyPagesTable (Track 4) skips them regardless.
           final var fileStartLSN = nonDurable ? null : startLSN;
 
-          final Iterator<Long2ObjectMap.Entry<CacheEntryChanges>> filePageChangesIterator =
-              fileChanges.pageChangesMap.long2ObjectEntrySet().iterator();
-          while (filePageChangesIterator.hasNext()) {
-            final var filePageChangesEntry =
-                filePageChangesIterator.next();
+          // Snapshot the test hook once per file so a concurrent (test-side) uninstall
+          // cannot switch paths mid-file. Null in production — the fast path below is
+          // byte-for-byte the pre-seam loop.
+          final var hook = pageApplyHook;
+          if (hook == null) {
+            final Iterator<Long2ObjectMap.Entry<CacheEntryChanges>> filePageChangesIterator =
+                fileChanges.pageChangesMap.long2ObjectEntrySet().iterator();
+            while (filePageChangesIterator.hasNext()) {
+              final var filePageChangesEntry =
+                  filePageChangesIterator.next();
 
-            if (filePageChangesEntry.getValue().changes.hasChanges()) {
-              final var pageIndex = filePageChangesEntry.getLongKey();
-              final var filePageChanges = filePageChangesEntry.getValue();
-
-              final var cacheEntry =
-                  readCache.loadOrAddForWrite(
-                      fileId, pageIndex, writeCache, filePageChanges.verifyCheckSum, fileStartLSN);
-              // loadOrAddForWrite is total on both engines at this point:
-              //   - Disk engine (LockFreeReadCache + WOWCache): WriteCache.loadOrAdd gap-fills
-              //     intermediate pages and returns a usable entry for the requested pageIndex.
-              //   - In-memory engine (DirectMemoryOnlyDiskCache): allocatePageForWrite eagerly
-              //     installs the page in MemoryFile during the TX, so the commit-time
-              //     loadOrAddForWrite reads the page back via MemoryFile.loadPage.
-              // Of the four sibling loadOrAddForWrite sites, this one is the only reachable
-              // site on the in-memory engine (the AbstractStorage WAL-replay branches and
-              // DiskStorage incremental-backup restore are disk-only because
-              // MemoryWriteAheadLog is a no-op). So an assertion is not sufficient here:
-              // any future extension or test caller that bypasses allocatePageForWrite on
-              // the in-memory engine would surface a null return only in -ea test builds.
-              // Throw unconditionally so the violation is visible in production builds too.
-              if (cacheEntry == null) {
-                throw new IllegalStateException(
-                    "readCache.loadOrAddForWrite returned null in commitChanges for fileId="
-                        + fileId + " pageIndex=" + pageIndex
-                        + " isNew=" + filePageChanges.isNew
-                        + " (in-memory engine: eager-install in allocatePageForWrite must"
-                        + " have run; disk engine: WriteCache.loadOrAdd is total);"
-                        + " WriteCache.loadOrAdd totality contract violated");
+              if (filePageChangesEntry.getValue().changes.hasChanges()) {
+                applyPageChangesToCache(
+                    fileId,
+                    filePageChangesEntry.getLongKey(),
+                    filePageChangesEntry.getValue(),
+                    nonDurable,
+                    fileStartLSN,
+                    txEndLsn);
+              } else {
+                filePageChangesIterator.remove();
               }
-
-              try {
-                final var durablePage = new DurablePage(cacheEntry);
-
-                durablePage.restoreChanges(filePageChanges.changes);
-
-                // Non-durable pages have no WAL records, so endLSN and changeLSN
-                // are not meaningful. The dirty-pages-table skip in
-                // updateDirtyPagesTable (Track 4) ensures these pages
-                // don't block WAL truncation.
-                if (!nonDurable) {
-                  // flushPendingOperations sets changeLSN for all durable pages.
-                  // The WAL phase above throws StorageException if changeLSN is
-                  // null for a durable page with changes — this assert is a
-                  // defense-in-depth double-check.
-                  assert filePageChanges.getChangeLSN() != null
-                      : "Durable page must have changeLSN set for page "
-                          + cacheEntry.getPageIndex();
-                  cacheEntry.setEndLSN(txEndLsn);
-                  durablePage.setLsn(filePageChanges.getChangeLSN());
-                }
-              } finally {
-                readCache.releaseFromWrite(cacheEntry, writeCache, true);
-              }
-            } else {
-              filePageChangesIterator.remove();
             }
+          } else {
+            applyPageChangesWithHook(hook, fileId, fileChanges, nonDurable, fileStartLSN,
+                txEndLsn);
           }
         }
       } finally {
@@ -1238,6 +1208,155 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
       return txEndLsn;
     } finally {
       active = false;
+    }
+  }
+
+  /**
+   * Applies one page's accumulated binary changes to the shared read cache. Extracted
+   * from the commitChanges apply loop so the production iterator path and the test-only
+   * hook-ordered path ({@link #applyPageChangesWithHook}) share the exact same per-page
+   * logic. Must only be called inside the apply-phase epoch bracket.
+   */
+  private void applyPageChangesToCache(
+      final long fileId,
+      final long pageIndex,
+      final CacheEntryChanges filePageChanges,
+      final boolean nonDurable,
+      @Nullable final LogSequenceNumber fileStartLSN,
+      @Nullable final LogSequenceNumber txEndLsn) throws IOException {
+    final var cacheEntry =
+        readCache.loadOrAddForWrite(
+            fileId, pageIndex, writeCache, filePageChanges.verifyCheckSum, fileStartLSN);
+    // loadOrAddForWrite is total on both engines at this point:
+    //   - Disk engine (LockFreeReadCache + WOWCache): WriteCache.loadOrAdd gap-fills
+    //     intermediate pages and returns a usable entry for the requested pageIndex.
+    //   - In-memory engine (DirectMemoryOnlyDiskCache): allocatePageForWrite eagerly
+    //     installs the page in MemoryFile during the TX, so the commit-time
+    //     loadOrAddForWrite reads the page back via MemoryFile.loadPage.
+    // Of the four sibling loadOrAddForWrite sites, this one is the only reachable
+    // site on the in-memory engine (the AbstractStorage WAL-replay branches and
+    // DiskStorage incremental-backup restore are disk-only because
+    // MemoryWriteAheadLog is a no-op). So an assertion is not sufficient here:
+    // any future extension or test caller that bypasses allocatePageForWrite on
+    // the in-memory engine would surface a null return only in -ea test builds.
+    // Throw unconditionally so the violation is visible in production builds too.
+    if (cacheEntry == null) {
+      throw new IllegalStateException(
+          "readCache.loadOrAddForWrite returned null in commitChanges for fileId="
+              + fileId + " pageIndex=" + pageIndex
+              + " isNew=" + filePageChanges.isNew
+              + " (in-memory engine: eager-install in allocatePageForWrite must"
+              + " have run; disk engine: WriteCache.loadOrAdd is total);"
+              + " WriteCache.loadOrAdd totality contract violated");
+    }
+
+    try {
+      final var durablePage = new DurablePage(cacheEntry);
+
+      durablePage.restoreChanges(filePageChanges.changes);
+
+      // Non-durable pages have no WAL records, so endLSN and changeLSN
+      // are not meaningful. The dirty-pages-table skip in
+      // updateDirtyPagesTable (Track 4) ensures these pages
+      // don't block WAL truncation.
+      if (!nonDurable) {
+        // flushPendingOperations sets changeLSN for all durable pages.
+        // The WAL phase above throws StorageException if changeLSN is
+        // null for a durable page with changes — this assert is a
+        // defense-in-depth double-check.
+        assert filePageChanges.getChangeLSN() != null
+            : "Durable page must have changeLSN set for page "
+                + cacheEntry.getPageIndex();
+        cacheEntry.setEndLSN(txEndLsn);
+        durablePage.setLsn(filePageChanges.getChangeLSN());
+      }
+    } finally {
+      readCache.releaseFromWrite(cacheEntry, writeCache, true);
+    }
+  }
+
+  /**
+   * TEST-ONLY variant of the per-file page-apply loop, active only when a
+   * {@link PageApplyHook} is installed. Applies the file's changed pages in the order
+   * chosen by {@link PageApplyHook#orderPageApplications} (default: the map's native
+   * order) and invokes {@link PageApplyHook#beforePageApply} before each application.
+   * Runs inside the apply-phase epoch bracket, so a hook that throws still triggers the
+   * bracket's finally-exit (the epoch can never be left permanently "in apply").
+   */
+  private void applyPageChangesWithHook(
+      final PageApplyHook hook,
+      final long fileId,
+      final FileChanges fileChanges,
+      final boolean nonDurable,
+      @Nullable final LogSequenceNumber fileStartLSN,
+      @Nullable final LogSequenceNumber txEndLsn) throws IOException {
+    var pageIndexes = fileChanges.pageChangesMap.keySet().toLongArray();
+    final var reordered = hook.orderPageApplications(fileId, pageIndexes.clone());
+    if (reordered != null) {
+      pageIndexes = reordered;
+    }
+
+    for (final var pageIndex : pageIndexes) {
+      final var filePageChanges = fileChanges.pageChangesMap.get(pageIndex);
+      if (filePageChanges == null) {
+        throw new IllegalStateException(
+            "PageApplyHook.orderPageApplications returned unknown page index " + pageIndex
+                + " for file " + fileId);
+      }
+
+      if (filePageChanges.changes.hasChanges()) {
+        hook.beforePageApply(fileId, pageIndex);
+        applyPageChangesToCache(fileId, pageIndex, filePageChanges, nonDurable, fileStartLSN,
+            txEndLsn);
+      } else {
+        fileChanges.pageChangesMap.remove(pageIndex);
+      }
+    }
+  }
+
+  /**
+   * Installs the TEST-ONLY page-apply hook (see {@link PageApplyHook}). Must never be
+   * called from production code — the hook exists solely so tests can deterministically
+   * order and pause the commit-time page-apply loop inside the apply-phase epoch bracket.
+   */
+  void setPageApplyHook(@Nullable final PageApplyHook hook) {
+    this.pageApplyHook = hook;
+  }
+
+  /**
+   * TEST-ONLY seam into the commit-time page-apply loop of {@link #commitChanges}
+   * (YTDB-1178). The page-apply order is normally fastutil hash order, which makes
+   * mixed-state races (a reader overlapping a partially applied commit) practically
+   * impossible to reproduce deterministically. This hook lets a test (a) dictate the
+   * order in which a file's changed pages are applied and (b) block at a barrier between
+   * two page applications — while the writer is inside the apply-phase epoch bracket and
+   * still holds its component exclusive locks — so a concurrent reader can be run
+   * deterministically against the mixed state.
+   *
+   * <p>Production impact: a single null check per file in the apply loop; the hook field
+   * is always null outside tests.
+   */
+  interface PageApplyHook {
+
+    /**
+     * Returns the order in which the given changed pages of {@code fileId} should be
+     * applied, or {@code null} to keep the default (map iteration) order. The returned
+     * array must be a permutation of {@code pageIndexes} — unknown indexes fail the
+     * commit with {@link IllegalStateException}; omitted pages would silently not be
+     * applied, so tests must return all of them.
+     */
+    @Nullable default long[] orderPageApplications(final long fileId, final long[] pageIndexes) {
+      return null;
+    }
+
+    /**
+     * Called immediately before the changes for {@code (fileId, pageIndex)} are applied
+     * to the shared read cache. May block (e.g., on a barrier) to pause the writer
+     * mid-apply between two page applications. Runs inside the apply-phase epoch
+     * bracket; a thrown exception aborts the commit but still passes through the
+     * bracket's finally-exit.
+     */
+    default void beforePageApply(final long fileId, final long pageIndex) {
     }
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -1133,7 +1133,16 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
       // epoch. The WAL phase and snapshot-buffer flushes above are deliberately NOT
       // bracketed — they do not mutate shared cache pages (snapshot-index entries are
       // SI-filtered on read).
-      applyPhaseEpoch.enterApplyPhase();
+      //
+      // The bracket is gated on the commit actually having shared-cache mutations
+      // (CN-11): zero-change commits — read-only atomic operations, pure metadata ops —
+      // perform no readCache calls in the section below, so bumping the epoch for them
+      // would only spuriously invalidate every concurrently overlapping optimistic
+      // read in the storage.
+      final var mutatesSharedCache = commitMutatesSharedCache();
+      if (mutatesSharedCache) {
+        applyPhaseEpoch.enterApplyPhase();
+      }
       try {
         deletedFilesIterator = deletedFiles.longIterator();
         while (deletedFilesIterator.hasNext()) {
@@ -1202,7 +1211,9 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
           }
         }
       } finally {
-        applyPhaseEpoch.exitApplyPhase();
+        if (mutatesSharedCache) {
+          applyPhaseEpoch.exitApplyPhase();
+        }
       }
 
       return txEndLsn;
@@ -1276,6 +1287,30 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   }
 
   /**
+   * Returns whether this commit will mutate shared read-cache state in the apply
+   * section: any file deletion, any new/truncated file, or any page with accumulated
+   * changes. Zero-change commits (read-only atomic operations) return {@code false}
+   * and skip the apply-phase epoch bracket entirely.
+   */
+  private boolean commitMutatesSharedCache() {
+    if (!deletedFiles.isEmpty()) {
+      return true;
+    }
+    for (final var fileChangesEntry : fileChanges.long2ObjectEntrySet()) {
+      final var changes = fileChangesEntry.getValue();
+      if (changes.isNew || changes.truncate) {
+        return true;
+      }
+      for (final var pageEntry : changes.pageChangesMap.long2ObjectEntrySet()) {
+        if (pageEntry.getValue().changes.hasChanges()) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * TEST-ONLY variant of the per-file page-apply loop, active only when a
    * {@link PageApplyHook} is installed. Applies the file's changed pages in the order
    * chosen by {@link PageApplyHook#orderPageApplications} (default: the map's native
@@ -1293,16 +1328,39 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     var pageIndexes = fileChanges.pageChangesMap.keySet().toLongArray();
     final var reordered = hook.orderPageApplications(fileId, pageIndexes.clone());
     if (reordered != null) {
+      // Enforce the "complete permutation" contract (CS-1/CQ-2/CN-13): an unknown
+      // index would apply nothing for a real page, a duplicate would double-apply,
+      // and an omission would silently drop a WAL-committed page's changes from the
+      // cache — all of which would silently weaken the tests using this seam.
+      final var expected = new LongOpenHashSet(pageIndexes);
+      final var seen = new LongOpenHashSet(reordered.length);
+      for (final var pageIndex : reordered) {
+        if (!expected.contains(pageIndex)) {
+          throw new IllegalStateException(
+              "PageApplyHook.orderPageApplications returned unknown page index " + pageIndex
+                  + " for file " + fileId);
+        }
+        if (!seen.add(pageIndex)) {
+          throw new IllegalStateException(
+              "PageApplyHook.orderPageApplications returned duplicate page index " + pageIndex
+                  + " for file " + fileId);
+        }
+      }
+      if (reordered.length != pageIndexes.length) {
+        throw new IllegalStateException(
+            "PageApplyHook.orderPageApplications returned an incomplete permutation for file "
+                + fileId + ": expected " + pageIndexes.length + " pages, got "
+                + reordered.length);
+      }
       pageIndexes = reordered;
     }
 
     for (final var pageIndex : pageIndexes) {
       final var filePageChanges = fileChanges.pageChangesMap.get(pageIndex);
-      if (filePageChanges == null) {
-        throw new IllegalStateException(
-            "PageApplyHook.orderPageApplications returned unknown page index " + pageIndex
-                + " for file " + fileId);
-      }
+      // The permutation validation above (and keySet origin on the default path)
+      // guarantees every index resolves; this is a defensive invariant only.
+      assert filePageChanges != null
+          : "page changes vanished for page index " + pageIndex + " in file " + fileId;
 
       if (filePageChanges.changes.hasChanges()) {
         hook.beforePageApply(fileId, pageIndex);
@@ -1341,9 +1399,10 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     /**
      * Returns the order in which the given changed pages of {@code fileId} should be
      * applied, or {@code null} to keep the default (map iteration) order. The returned
-     * array must be a permutation of {@code pageIndexes} — unknown indexes fail the
-     * commit with {@link IllegalStateException}; omitted pages would silently not be
-     * applied, so tests must return all of them.
+     * array must be a COMPLETE permutation of {@code pageIndexes}: unknown indexes,
+     * duplicates, and omissions all fail the commit with
+     * {@link IllegalStateException} (an omission would otherwise silently drop a
+     * WAL-committed page's changes from the cache).
      */
     @Nullable default long[] orderPageApplications(final long fileId, final long[] pageIndexes) {
       return null;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -26,6 +26,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.index.engine.HistogramDeltaHolder;
 import com.jetbrains.youtrackdb.internal.core.index.engine.IndexCountDeltaHolder;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.AbstractWriteCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntryImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
@@ -154,8 +155,21 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   // Optimistic read scope — reused across optimistic read attempts within
   // the same atomic operation. Eagerly allocated since optimistic reads are
   // the hot path this class is designed to support.
-  private final OptimisticReadScope optimisticReadScope = new OptimisticReadScope();
+  private final OptimisticReadScope optimisticReadScope;
 
+  // Per-storage apply-phase epoch, owned by AtomicOperationsManager and shared by all
+  // atomic operations of the same storage. Bumped around the cache-apply section of
+  // commitChanges so concurrent optimistic readers can detect overlap with a partially
+  // applied commit (per-page stamps alone cannot — they are a temporal check only).
+  private final ApplyPhaseEpoch applyPhaseEpoch;
+
+  /**
+   * Convenience constructor for standalone use (tests, tooling) where no epoch is shared
+   * with concurrent optimistic readers: allocates a private {@link ApplyPhaseEpoch}.
+   * Production code must use the primary constructor with the storage-wide epoch owned by
+   * {@link AtomicOperationsManager} — a private epoch would make commit-time applies
+   * invisible to optimistic readers of other operations on the same storage.
+   */
   AtomicOperationBinaryTracking(
       final ReadCache readCache,
       final WriteCache writeCache,
@@ -168,6 +182,24 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
       @Nonnull ConcurrentSkipListMap<EdgeSnapshotKey, LinkBagValue> sharedEdgeSnapshotIndex,
       @Nonnull ConcurrentSkipListMap<EdgeVisibilityKey, EdgeSnapshotKey> sharedEdgeVisibilityIndex,
       @Nonnull AtomicLong edgeSnapshotIndexSize) {
+    this(readCache, writeCache, writeAheadLog, storageId, snapshot, sharedSnapshotIndex,
+        sharedVisibilityIndex, snapshotIndexSize, sharedEdgeSnapshotIndex,
+        sharedEdgeVisibilityIndex, edgeSnapshotIndexSize, new ApplyPhaseEpoch());
+  }
+
+  AtomicOperationBinaryTracking(
+      final ReadCache readCache,
+      final WriteCache writeCache,
+      @Nullable final WriteAheadLog writeAheadLog,
+      final int storageId,
+      @Nonnull AtomicOperationsSnapshot snapshot,
+      @Nonnull ConcurrentSkipListMap<SnapshotKey, PositionEntry> sharedSnapshotIndex,
+      @Nonnull ConcurrentSkipListMap<VisibilityKey, SnapshotKey> sharedVisibilityIndex,
+      @Nonnull AtomicLong snapshotIndexSize,
+      @Nonnull ConcurrentSkipListMap<EdgeSnapshotKey, LinkBagValue> sharedEdgeSnapshotIndex,
+      @Nonnull ConcurrentSkipListMap<EdgeVisibilityKey, EdgeSnapshotKey> sharedEdgeVisibilityIndex,
+      @Nonnull AtomicLong edgeSnapshotIndexSize,
+      @Nonnull ApplyPhaseEpoch applyPhaseEpoch) {
     this.snapshot = snapshot;
     newFileNamesId.defaultReturnValue(-1);
     deletedFileNameIdMap.defaultReturnValue(-1);
@@ -182,6 +214,8 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     this.sharedEdgeSnapshotIndex = sharedEdgeSnapshotIndex;
     this.sharedEdgeVisibilityIndex = sharedEdgeVisibilityIndex;
     this.edgeSnapshotIndexSize = edgeSnapshotIndexSize;
+    this.applyPhaseEpoch = applyPhaseEpoch;
+    this.optimisticReadScope = new OptimisticReadScope(applyPhaseEpoch);
     this.active = true;
   }
 
@@ -1079,107 +1113,126 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
         flushEdgeSnapshotBuffers();
       }
 
-      deletedFilesIterator = deletedFiles.longIterator();
-      while (deletedFilesIterator.hasNext()) {
-        var deletedFileId = deletedFilesIterator.nextLong();
-        readCache.deleteFile(deletedFileId, writeCache);
-      }
-
-      for (final var fileChangesEntry : fileChanges.long2ObjectEntrySet()) {
-        final var fileChanges = fileChangesEntry.getValue();
-        final var fileId = fileChangesEntry.getLongKey();
-        final boolean nonDurable = nonDurableFlags.get(fileId);
-
-        if (fileChanges.isNew) {
-          // On the in-memory engine, addFile already eagerly registered this fileId with
-          // readCache so that fresh-booked-file pages could take the eager-install branch
-          // in allocatePageForWrite (see AtomicOperationBinaryTracking.addFile). A second
-          // readCache.addFile call would throw "File with id ... already exists" from
-          // DirectMemoryOnlyDiskCache.addFile.
-          if (!fileChanges.eagerlyInstalledInCache) {
-            readCache.addFile(
-                fileChanges.fileName,
-                newFileNamesId.getLong(fileChanges.fileName),
-                writeCache,
-                nonDurable);
-          }
-        } else if (fileChanges.truncate) {
-          LogManager.instance()
-              .warn(
-                  this,
-                  "You performing truncate operation which is considered unsafe because can not be"
-                      + " rolled back, as result data can be incorrectly restored after crash, this"
-                      + " operation is not recommended to be used");
-          readCache.truncateFile(fileId, writeCache);
+      // Apply-phase epoch bracket: exactly ONE enter/exit pair spanning the entire
+      // shared-cache mutation section — the readCache.deleteFile loop plus the whole
+      // per-file apply loop (addFile/truncateFile/loadOrAddForWrite/releaseFromWrite).
+      // Pages are applied one at a time in hash order, so a concurrent optimistic
+      // reader overlapping this section could see a mix of pre- and post-commit pages
+      // with every per-page stamp still valid; the epoch lets it detect the overlap
+      // and fall back to the pinned path. The exit MUST be in a finally block: an
+      // exception escaping this section must not leave the epoch permanently "in
+      // apply", which would disable optimistic reads for the storage's lifetime.
+      // Rolled-back operations never reach commitChanges (see the gate in
+      // AtomicOperationsManager.endAtomicOperation), so rollback does not bump the
+      // epoch. The WAL phase and snapshot-buffer flushes above are deliberately NOT
+      // bracketed — they do not mutate shared cache pages (snapshot-index entries are
+      // SI-filtered on read).
+      applyPhaseEpoch.enterApplyPhase();
+      try {
+        deletedFilesIterator = deletedFiles.longIterator();
+        while (deletedFilesIterator.hasNext()) {
+          var deletedFileId = deletedFilesIterator.nextLong();
+          readCache.deleteFile(deletedFileId, writeCache);
         }
 
-        // Non-durable files use null startLSN — no WAL dependency exists,
-        // and updateDirtyPagesTable (Track 4) skips them regardless.
-        final var fileStartLSN = nonDurable ? null : startLSN;
+        for (final var fileChangesEntry : fileChanges.long2ObjectEntrySet()) {
+          final var fileChanges = fileChangesEntry.getValue();
+          final var fileId = fileChangesEntry.getLongKey();
+          final boolean nonDurable = nonDurableFlags.get(fileId);
 
-        final Iterator<Long2ObjectMap.Entry<CacheEntryChanges>> filePageChangesIterator =
-            fileChanges.pageChangesMap.long2ObjectEntrySet().iterator();
-        while (filePageChangesIterator.hasNext()) {
-          final var filePageChangesEntry =
-              filePageChangesIterator.next();
-
-          if (filePageChangesEntry.getValue().changes.hasChanges()) {
-            final var pageIndex = filePageChangesEntry.getLongKey();
-            final var filePageChanges = filePageChangesEntry.getValue();
-
-            final var cacheEntry =
-                readCache.loadOrAddForWrite(
-                    fileId, pageIndex, writeCache, filePageChanges.verifyCheckSum, fileStartLSN);
-            // loadOrAddForWrite is total on both engines at this point:
-            //   - Disk engine (LockFreeReadCache + WOWCache): WriteCache.loadOrAdd gap-fills
-            //     intermediate pages and returns a usable entry for the requested pageIndex.
-            //   - In-memory engine (DirectMemoryOnlyDiskCache): allocatePageForWrite eagerly
-            //     installs the page in MemoryFile during the TX, so the commit-time
-            //     loadOrAddForWrite reads the page back via MemoryFile.loadPage.
-            // Of the four sibling loadOrAddForWrite sites, this one is the only reachable
-            // site on the in-memory engine (the AbstractStorage WAL-replay branches and
-            // DiskStorage incremental-backup restore are disk-only because
-            // MemoryWriteAheadLog is a no-op). So an assertion is not sufficient here:
-            // any future extension or test caller that bypasses allocatePageForWrite on
-            // the in-memory engine would surface a null return only in -ea test builds.
-            // Throw unconditionally so the violation is visible in production builds too.
-            if (cacheEntry == null) {
-              throw new IllegalStateException(
-                  "readCache.loadOrAddForWrite returned null in commitChanges for fileId="
-                      + fileId + " pageIndex=" + pageIndex
-                      + " isNew=" + filePageChanges.isNew
-                      + " (in-memory engine: eager-install in allocatePageForWrite must"
-                      + " have run; disk engine: WriteCache.loadOrAdd is total);"
-                      + " WriteCache.loadOrAdd totality contract violated");
+          if (fileChanges.isNew) {
+            // On the in-memory engine, addFile already eagerly registered this fileId with
+            // readCache so that fresh-booked-file pages could take the eager-install branch
+            // in allocatePageForWrite (see AtomicOperationBinaryTracking.addFile). A second
+            // readCache.addFile call would throw "File with id ... already exists" from
+            // DirectMemoryOnlyDiskCache.addFile.
+            if (!fileChanges.eagerlyInstalledInCache) {
+              readCache.addFile(
+                  fileChanges.fileName,
+                  newFileNamesId.getLong(fileChanges.fileName),
+                  writeCache,
+                  nonDurable);
             }
+          } else if (fileChanges.truncate) {
+            LogManager.instance()
+                .warn(
+                    this,
+                    "You performing truncate operation which is considered unsafe because can not"
+                        + " be rolled back, as result data can be incorrectly restored after"
+                        + " crash, this operation is not recommended to be used");
+            readCache.truncateFile(fileId, writeCache);
+          }
 
-            try {
-              final var durablePage = new DurablePage(cacheEntry);
+          // Non-durable files use null startLSN — no WAL dependency exists,
+          // and updateDirtyPagesTable (Track 4) skips them regardless.
+          final var fileStartLSN = nonDurable ? null : startLSN;
 
-              durablePage.restoreChanges(filePageChanges.changes);
+          final Iterator<Long2ObjectMap.Entry<CacheEntryChanges>> filePageChangesIterator =
+              fileChanges.pageChangesMap.long2ObjectEntrySet().iterator();
+          while (filePageChangesIterator.hasNext()) {
+            final var filePageChangesEntry =
+                filePageChangesIterator.next();
 
-              // Non-durable pages have no WAL records, so endLSN and changeLSN
-              // are not meaningful. The dirty-pages-table skip in
-              // updateDirtyPagesTable (Track 4) ensures these pages
-              // don't block WAL truncation.
-              if (!nonDurable) {
-                // flushPendingOperations sets changeLSN for all durable pages.
-                // The WAL phase above throws StorageException if changeLSN is
-                // null for a durable page with changes — this assert is a
-                // defense-in-depth double-check.
-                assert filePageChanges.getChangeLSN() != null
-                    : "Durable page must have changeLSN set for page "
-                        + cacheEntry.getPageIndex();
-                cacheEntry.setEndLSN(txEndLsn);
-                durablePage.setLsn(filePageChanges.getChangeLSN());
+            if (filePageChangesEntry.getValue().changes.hasChanges()) {
+              final var pageIndex = filePageChangesEntry.getLongKey();
+              final var filePageChanges = filePageChangesEntry.getValue();
+
+              final var cacheEntry =
+                  readCache.loadOrAddForWrite(
+                      fileId, pageIndex, writeCache, filePageChanges.verifyCheckSum, fileStartLSN);
+              // loadOrAddForWrite is total on both engines at this point:
+              //   - Disk engine (LockFreeReadCache + WOWCache): WriteCache.loadOrAdd gap-fills
+              //     intermediate pages and returns a usable entry for the requested pageIndex.
+              //   - In-memory engine (DirectMemoryOnlyDiskCache): allocatePageForWrite eagerly
+              //     installs the page in MemoryFile during the TX, so the commit-time
+              //     loadOrAddForWrite reads the page back via MemoryFile.loadPage.
+              // Of the four sibling loadOrAddForWrite sites, this one is the only reachable
+              // site on the in-memory engine (the AbstractStorage WAL-replay branches and
+              // DiskStorage incremental-backup restore are disk-only because
+              // MemoryWriteAheadLog is a no-op). So an assertion is not sufficient here:
+              // any future extension or test caller that bypasses allocatePageForWrite on
+              // the in-memory engine would surface a null return only in -ea test builds.
+              // Throw unconditionally so the violation is visible in production builds too.
+              if (cacheEntry == null) {
+                throw new IllegalStateException(
+                    "readCache.loadOrAddForWrite returned null in commitChanges for fileId="
+                        + fileId + " pageIndex=" + pageIndex
+                        + " isNew=" + filePageChanges.isNew
+                        + " (in-memory engine: eager-install in allocatePageForWrite must"
+                        + " have run; disk engine: WriteCache.loadOrAdd is total);"
+                        + " WriteCache.loadOrAdd totality contract violated");
               }
-            } finally {
-              readCache.releaseFromWrite(cacheEntry, writeCache, true);
+
+              try {
+                final var durablePage = new DurablePage(cacheEntry);
+
+                durablePage.restoreChanges(filePageChanges.changes);
+
+                // Non-durable pages have no WAL records, so endLSN and changeLSN
+                // are not meaningful. The dirty-pages-table skip in
+                // updateDirtyPagesTable (Track 4) ensures these pages
+                // don't block WAL truncation.
+                if (!nonDurable) {
+                  // flushPendingOperations sets changeLSN for all durable pages.
+                  // The WAL phase above throws StorageException if changeLSN is
+                  // null for a durable page with changes — this assert is a
+                  // defense-in-depth double-check.
+                  assert filePageChanges.getChangeLSN() != null
+                      : "Durable page must have changeLSN set for page "
+                          + cacheEntry.getPageIndex();
+                  cacheEntry.setEndLSN(txEndLsn);
+                  durablePage.setLsn(filePageChanges.getChangeLSN());
+                }
+              } finally {
+                readCache.releaseFromWrite(cacheEntry, writeCache, true);
+              }
+            } else {
+              filePageChangesIterator.remove();
             }
-          } else {
-            filePageChangesIterator.remove();
           }
         }
+      } finally {
+        applyPhaseEpoch.exitApplyPhase();
       }
 
       return txEndLsn;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -28,6 +28,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.BaseException;
 import com.jetbrains.youtrackdb.internal.core.exception.CommonStorageComponentException;
 import com.jetbrains.youtrackdb.internal.core.exception.CoreException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
@@ -67,6 +68,14 @@ public class AtomicOperationsManager {
   private final OperationsFreezer writeOperationsFreezer = new OperationsFreezer();
   private final AtomicOperationsTable atomicOperationsTable;
 
+  // Apply-phase epoch shared by all atomic operations of this storage. Owned here (one
+  // manager per storage) rather than by ReadCache, because on the disk engine a single
+  // read cache is shared by all storages of the engine — an engine-global epoch would
+  // let commits in one database spuriously invalidate optimistic reads in another.
+  // Writers bump it around the cache-apply section of commitChanges; readers capture
+  // and validate it via OptimisticReadScope.
+  private final ApplyPhaseEpoch applyPhaseEpoch = new ApplyPhaseEpoch();
+
   public AtomicOperationsManager(
       AbstractStorage storage, AtomicOperationsTable atomicOperationsTable) {
     this.storage = storage;
@@ -100,7 +109,7 @@ public class AtomicOperationsManager {
         snapshot, storage.getSharedSnapshotIndex(), storage.getVisibilityIndex(),
         storage.getSnapshotIndexSize(),
         storage.getSharedEdgeSnapshotIndex(), storage.getEdgeVisibilityIndex(),
-        storage.getEdgeSnapshotIndexSize());
+        storage.getEdgeSnapshotIndexSize(), applyPhaseEpoch);
   }
 
   public void startToApplyOperations(AtomicOperation atomicOperation) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -76,6 +76,18 @@ public class AtomicOperationsManager {
   // and validate it via OptimisticReadScope.
   private final ApplyPhaseEpoch applyPhaseEpoch = new ApplyPhaseEpoch();
 
+  /**
+   * TEST-ONLY accessor for this storage's apply-phase epoch, exposed package-private for
+   * the test bridge in the same test package (used by the YTDB-1178 mixed-apply-state
+   * regression tests to make baseline-relative assertions on the epoch counters).
+   * Production code must not call this — writers bump the epoch only through
+   * {@code AtomicOperationBinaryTracking.commitChanges} and readers observe it only
+   * through {@code OptimisticReadScope}.
+   */
+  ApplyPhaseEpoch getApplyPhaseEpoch() {
+    return applyPhaseEpoch;
+  }
+
   public AtomicOperationsManager(
       AbstractStorage storage, AtomicOperationsTable atomicOperationsTable) {
     this.storage = storage;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -35,7 +35,13 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Base class for all storage-backed data structures that participate in the page cache lifecycle.
@@ -685,6 +691,147 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     } finally {
       if (!attemptClosedByFallback) {
         assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+      }
+    }
+  }
+
+  // Rate limiter state for the null-recheck disagreement WARN: nanoTime of the last
+  // emitted message, 0 = never emitted. Per component instance, CAS-updated so
+  // concurrent readers emit at most ~one message per interval.
+  private final AtomicLong lastNullRecheckWarnNanos = new AtomicLong();
+
+  private static final long NULL_RECHECK_WARN_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
+
+  /**
+   * Variant of {@link #executeOptimisticStorageRead(AtomicOperation, OptimisticReadFunction,
+   * PinnedReadFunction)} for point lookups whose NULL result is load-bearing — the
+   * belt-and-braces hardening for the apply-phase epoch (YTDB-1178). The historical failure
+   * mode this guards against is a <em>false null</em>: an optimistic B-tree descent composing
+   * a per-page-valid but mutually inconsistent view and concluding "absent" for a present
+   * key. The epoch closes that race; this re-check is an independent second line of defense
+   * plus a live detector for any unmodeled anomaly.
+   *
+   * <p>Decision rules:
+   *
+   * <ul>
+   *   <li>The re-check triggers ONLY when the optimistic attempt completed cleanly (per-page
+   *       stamps AND epoch both validated) and {@code recheckTrigger} accepts the result
+   *       (typically: the lookup came back null). It NEVER triggers after the pinned fallback
+   *       ran — the fallback's result is already authoritative, and re-checking it would make
+   *       every legitimate miss pay the pinned cost twice more.
+   *   <li>On trigger, the pinned lambda runs once under the component shared lock. A non-null
+   *       pinned result that differs from the optimistic one is a disagreement: a rate-limited
+   *       WARN is emitted and the pinned result is returned. If the pinned result is null too,
+   *       the null is confirmed and returned silently.
+   * </ul>
+   *
+   * @param recheckTrigger    evaluated on the validated optimistic result; return true to
+   *                          request the pinned re-check (e.g. {@code Objects::isNull}, or a
+   *                          flag captured from an inner lookup when the composed result can
+   *                          mask the load-bearing null)
+   * @param lookupDescription lazily built key coordinates for the disagreement WARN
+   */
+  @Nullable protected <T> T executeOptimisticStorageReadWithNullRecheck(
+      @Nonnull final AtomicOperation atomicOperation,
+      final OptimisticReadFunction<T> optimistic,
+      final PinnedReadFunction<T> pinned,
+      final Predicate<T> recheckTrigger,
+      final Supplier<String> lookupDescription) throws IOException {
+    assert atomicOperation != null;
+
+    final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
+    scope.reset();
+    // See the nesting-guard comments in executeOptimisticStorageRead.
+    assert scope.enterAttempt() : "Nested optimistic read attempt on " + getLockName();
+
+    final T result;
+    var attemptClosedByFallback = false;
+    try {
+      result = optimistic.apply();
+      scope.validateOrThrow();
+
+      recordOptimisticAccesses(scope);
+    } catch (final RuntimeException | AssertionError e) {
+      // Same fallback semantics as executeOptimisticStorageRead — and deliberately NO
+      // re-check on this path: the pinned result below is already authoritative.
+      attemptClosedByFallback = true;
+      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+
+      acquireSharedLock();
+      try {
+        return pinned.apply();
+      } finally {
+        releaseSharedLock();
+      }
+    } finally {
+      if (!attemptClosedByFallback) {
+        assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+      }
+    }
+
+    // Reaching here means the optimistic attempt completed cleanly (the catch above either
+    // returned or threw). The trigger and the re-check run OUTSIDE the try/catch so that a
+    // pinned-path failure cannot be misrouted into a second fallback.
+    if (!recheckTrigger.test(result)) {
+      return result;
+    }
+
+    final T pinnedResult;
+    acquireSharedLock();
+    try {
+      pinnedResult = pinned.apply();
+    } finally {
+      releaseSharedLock();
+    }
+
+    if (pinnedResult != null && !Objects.equals(pinnedResult, result)) {
+      warnOptimisticNullRecheckDisagreement(lookupDescription);
+      return pinnedResult;
+    }
+    // Agreement (typically both null): confirm silently. When the pinned result is null but
+    // the composed optimistic result was not (e.g. a snapshot-index hit), the optimistic
+    // value is still a valid concurrent-snapshot answer and is preferred.
+    return pinnedResult != null ? pinnedResult : result;
+  }
+
+  /**
+   * Emits the rate-limited disagreement WARN for the validated-null re-check. Protected so
+   * unit tests can override it to capture emissions; the rate limiter itself lives in
+   * {@link #tryAcquireNullRecheckWarnSlot(long)} and is tested directly.
+   */
+  protected void warnOptimisticNullRecheckDisagreement(
+      final Supplier<String> lookupDescription) {
+    if (!tryAcquireNullRecheckWarnSlot(System.nanoTime())) {
+      return;
+    }
+    LogManager.instance()
+        .warn(
+            this,
+            "Optimistic point lookup in component '%s' reported a miss, but the pinned"
+                + " re-check found an entry (%s). This is usually benign — a concurrent commit"
+                + " may have inserted the entry between the optimistic attempt and the re-check"
+                + " — but it may also indicate an unmodeled optimistic-read anomaly worth"
+                + " reporting. At most one such message is logged per minute per component.",
+            getName(),
+            lookupDescription.get());
+  }
+
+  /**
+   * Rate limiter for the disagreement WARN: returns true if the caller won the right to log
+   * at {@code nowNanos} (at most one win per {@link #NULL_RECHECK_WARN_INTERVAL_NANOS}).
+   * CAS-based so concurrent winners are unique. Package-private for direct unit testing
+   * with controlled timestamps.
+   */
+  boolean tryAcquireNullRecheckWarnSlot(final long nowNanos) {
+    while (true) {
+      final long last = lastNullRecheckWarnNanos.get();
+      // 0 is the "never logged" sentinel; a genuine nanoTime of exactly 0 would merely
+      // allow one extra message, which is harmless.
+      if (last != 0 && nowNanos - last < NULL_RECHECK_WARN_INTERVAL_NANOS) {
+        return false;
+      }
+      if (lastNullRecheckWarnNanos.compareAndSet(last, nowNanos)) {
+        return true;
       }
     }
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -600,6 +600,13 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     // placed inside the try could never surface. See OptimisticReadScope#enterAttempt.
     assert scope.enterAttempt() : "Nested optimistic read attempt on " + getLockName();
 
+    // Tracks whether the fallback catch below already closed the attempt. The attempt
+    // must be closed exactly once on EVERY exit path — including throwables the catch
+    // does not handle (a checked IOException from the optimistic lambda, or a VM error)
+    // — otherwise attemptActive stays latched and every subsequent optimistic read on
+    // this AtomicOperation fails with a spurious "Nested optimistic read attempt"
+    // AssertionError under -ea (CN-10/BG-1).
+    var attemptClosedByFallback = false;
     try {
       final T result = optimistic.apply();
       scope.validateOrThrow();
@@ -608,10 +615,6 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // policy's frequency sketch stays accurate.
       recordOptimisticAccesses(scope);
 
-      // Well-formedness check on both exits (here and at the top of the catch below):
-      // fails if a nested reset was detected while this attempt was in flight.
-      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
-
       return result;
     } catch (final RuntimeException | AssertionError e) {
       // Catch RuntimeException and AssertionError because speculative reads from
@@ -619,13 +622,16 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // and assertion failures (e.g., position-consistency checks seeing stale data)
       // before stamp validation has a chance to detect the inconsistency.
       // All such errors are safe to swallow here — the pinned fallback path will
-      // produce the correct result.
+      // produce the correct result. Checked exceptions and other Errors are NOT
+      // caught — they propagate to the caller (and the finally below still closes
+      // the attempt).
 
       // Close the attempt before the pinned fallback runs: the fallback may itself
       // legitimately start fresh optimistic reads (e.g., via helper methods), which
       // must not trip a stale nesting flag. If a nested reset was detected during the
       // failed attempt, this assert surfaces it (the nested AssertionError itself was
       // swallowed by this catch).
+      attemptClosedByFallback = true;
       assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
 
       acquireSharedLock();
@@ -633,6 +639,13 @@ public abstract class StorageComponent extends SharedResourceAbstract {
         return pinned.apply();
       } finally {
         releaseSharedLock();
+      }
+    } finally {
+      // Close the attempt on all remaining exit paths: normal return, and any
+      // throwable the catch above does not handle. Skipped when the fallback already
+      // closed it (exitAttempt is not idempotent — a second call reports ill-formed).
+      if (!attemptClosedByFallback) {
+        assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
       }
     }
   }
@@ -652,15 +665,15 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     // See the nesting-guard comments in the T-returning overload above.
     assert scope.enterAttempt() : "Nested optimistic read attempt on " + getLockName();
 
+    var attemptClosedByFallback = false;
     try {
       optimistic.run();
       scope.validateOrThrow();
 
       recordOptimisticAccesses(scope);
-
-      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
     } catch (final RuntimeException | AssertionError e) {
       // See comment in the T-returning overload above.
+      attemptClosedByFallback = true;
       assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
 
       acquireSharedLock();
@@ -668,6 +681,10 @@ public abstract class StorageComponent extends SharedResourceAbstract {
         pinned.run();
       } finally {
         releaseSharedLock();
+      }
+    } finally {
+      if (!attemptClosedByFallback) {
+        assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
       }
     }
   }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -605,7 +605,7 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     // does not handle (a checked IOException from the optimistic lambda, or a VM error)
     // — otherwise attemptActive stays latched and every subsequent optimistic read on
     // this AtomicOperation fails with a spurious "Nested optimistic read attempt"
-    // AssertionError under -ea (CN-10/BG-1).
+    // AssertionError under -ea.
     var attemptClosedByFallback = false;
     try {
       final T result = optimistic.apply();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -20,6 +20,7 @@
 
 package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base;
 
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.common.concur.resource.SharedResourceAbstract;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.function.TxConsumer;
@@ -700,8 +701,6 @@ public abstract class StorageComponent extends SharedResourceAbstract {
   // concurrent readers emit at most ~one message per interval.
   private final AtomicLong lastNullRecheckErrorNanos = new AtomicLong();
 
-  private static final long NULL_RECHECK_ERROR_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
-
   /**
    * Variant of {@link #executeOptimisticStorageRead(AtomicOperation, OptimisticReadFunction,
    * PinnedReadFunction)} for point lookups whose NULL result is load-bearing — the
@@ -823,7 +822,9 @@ public abstract class StorageComponent extends SharedResourceAbstract {
                 + " returned — but this indicates a possible optimistic-read/epoch anomaly:"
                 + " visibility is resolved against a fixed operation snapshot, so a"
                 + " concurrently committed insert cannot explain the miss. Please report this"
-                + " occurrence. At most one such message is logged per minute per component.",
+                + " occurrence. At most one such message is logged per configured interval per"
+                + " component (youtrackdb.storage.optimisticRead.nullRecheckReportIntervalSecs,"
+                + " default 60s).",
             // The explicit null Throwable pins the single
             // error(requester, message, exception, Object...) overload — unlike warn, error
             // has no (requester, dbName, message, ...) sibling that two String arguments
@@ -835,22 +836,46 @@ public abstract class StorageComponent extends SharedResourceAbstract {
 
   /**
    * Rate limiter for the disagreement ERROR: returns true if the caller won the right to
-   * log at {@code nowNanos} (at most one win per
-   * {@link #NULL_RECHECK_ERROR_INTERVAL_NANOS}). CAS-based so concurrent winners are
-   * unique. Package-private for direct unit testing with controlled timestamps.
+   * log at {@code nowNanos} (at most one win per configured interval, see
+   * {@link GlobalConfiguration#STORAGE_OPTIMISTIC_READ_NULL_RECHECK_REPORT_INTERVAL_SECS}).
+   * CAS-based so concurrent winners are unique. Package-private for direct unit testing
+   * with controlled timestamps.
    */
   boolean tryAcquireNullRecheckErrorSlot(final long nowNanos) {
+    final long intervalNanos = nullRecheckErrorIntervalNanos();
     while (true) {
       final long last = lastNullRecheckErrorNanos.get();
       // 0 is the "never logged" sentinel; a genuine nanoTime of exactly 0 would merely
       // allow one extra message, which is harmless.
-      if (last != 0 && nowNanos - last < NULL_RECHECK_ERROR_INTERVAL_NANOS) {
+      if (last != 0 && nowNanos - last < intervalNanos) {
         return false;
       }
       if (lastNullRecheckErrorNanos.compareAndSet(last, nowNanos)) {
         return true;
       }
     }
+  }
+
+  /**
+   * Resolves the null-recheck report rate-limit interval in nanoseconds. Components read
+   * configuration through the storage's per-database {@code ContextConfiguration} — the
+   * dominant idiom at this layer (cf. {@code StaleTransactionMonitor}) — falling back to
+   * the {@link GlobalConfiguration} default when no context configuration is available
+   * (unit-test component doubles built around mock storages; production components exist
+   * only for open storages, which always carry one). Resolved lazily on each limiter
+   * check: the check runs only on the rare disagreement path, so the map lookup is
+   * negligible and component construction stays free of configuration-lifecycle ordering
+   * concerns.
+   */
+  private long nullRecheckErrorIntervalNanos() {
+    final var contextConfiguration = storage.getContextConfiguration();
+    final int intervalSecs =
+        contextConfiguration != null
+            ? contextConfiguration.getValueAsInteger(
+                GlobalConfiguration.STORAGE_OPTIMISTIC_READ_NULL_RECHECK_REPORT_INTERVAL_SECS)
+            : GlobalConfiguration.STORAGE_OPTIMISTIC_READ_NULL_RECHECK_REPORT_INTERVAL_SECS
+                .getValueAsInteger();
+    return TimeUnit.SECONDS.toNanos(intervalSecs);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -593,6 +593,12 @@ public abstract class StorageComponent extends SharedResourceAbstract {
 
     final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
     scope.reset();
+    // -ea-only guard against nested optimistic read attempts: a nested
+    // executeOptimisticStorageRead call from inside an optimistic lambda would wipe the
+    // outer scope's stamps via reset(), silently voiding the outer validation. Kept
+    // OUTSIDE the try below — the fallback catch swallows AssertionError, so an assert
+    // placed inside the try could never surface. See OptimisticReadScope#enterAttempt.
+    assert scope.enterAttempt() : "Nested optimistic read attempt on " + getLockName();
 
     try {
       final T result = optimistic.apply();
@@ -602,6 +608,10 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // policy's frequency sketch stays accurate.
       recordOptimisticAccesses(scope);
 
+      // Well-formedness check on both exits (here and at the top of the catch below):
+      // fails if a nested reset was detected while this attempt was in flight.
+      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+
       return result;
     } catch (final RuntimeException | AssertionError e) {
       // Catch RuntimeException and AssertionError because speculative reads from
@@ -610,6 +620,14 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // before stamp validation has a chance to detect the inconsistency.
       // All such errors are safe to swallow here — the pinned fallback path will
       // produce the correct result.
+
+      // Close the attempt before the pinned fallback runs: the fallback may itself
+      // legitimately start fresh optimistic reads (e.g., via helper methods), which
+      // must not trip a stale nesting flag. If a nested reset was detected during the
+      // failed attempt, this assert surfaces it (the nested AssertionError itself was
+      // swallowed by this catch).
+      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+
       acquireSharedLock();
       try {
         return pinned.apply();
@@ -631,14 +649,20 @@ public abstract class StorageComponent extends SharedResourceAbstract {
 
     final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
     scope.reset();
+    // See the nesting-guard comments in the T-returning overload above.
+    assert scope.enterAttempt() : "Nested optimistic read attempt on " + getLockName();
 
     try {
       optimistic.run();
       scope.validateOrThrow();
 
       recordOptimisticAccesses(scope);
+
+      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
     } catch (final RuntimeException | AssertionError e) {
       // See comment in the T-returning overload above.
+      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+
       acquireSharedLock();
       try {
         pinned.run();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -695,12 +695,12 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     }
   }
 
-  // Rate limiter state for the null-recheck disagreement WARN: nanoTime of the last
+  // Rate limiter state for the null-recheck disagreement ERROR: nanoTime of the last
   // emitted message, 0 = never emitted. Per component instance, CAS-updated so
   // concurrent readers emit at most ~one message per interval.
-  private final AtomicLong lastNullRecheckWarnNanos = new AtomicLong();
+  private final AtomicLong lastNullRecheckErrorNanos = new AtomicLong();
 
-  private static final long NULL_RECHECK_WARN_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
+  private static final long NULL_RECHECK_ERROR_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
 
   /**
    * Variant of {@link #executeOptimisticStorageRead(AtomicOperation, OptimisticReadFunction,
@@ -721,15 +721,18 @@ public abstract class StorageComponent extends SharedResourceAbstract {
    *       every legitimate miss pay the pinned cost twice more.
    *   <li>On trigger, the pinned lambda runs once under the component shared lock. A non-null
    *       pinned result that differs from the optimistic one is a disagreement: a rate-limited
-   *       WARN is emitted and the pinned result is returned. If the pinned result is null too,
+   *       ERROR is emitted and the pinned result is returned. If the pinned result is null too,
    *       the null is confirmed and returned silently.
+   *   <li>The trigger fires only on the load-bearing NULL by design: stale validated
+   *       NON-null results are guaranteed consistent by the apply-phase epoch, and
+   *       re-verifying them would double the pinned cost of every successful lookup.
    * </ul>
    *
    * @param recheckTrigger    evaluated on the validated optimistic result; return true to
    *                          request the pinned re-check (e.g. {@code Objects::isNull}, or a
    *                          flag captured from an inner lookup when the composed result can
    *                          mask the load-bearing null)
-   * @param lookupDescription lazily built key coordinates for the disagreement WARN
+   * @param lookupDescription lazily built key coordinates for the disagreement report
    */
   @Nullable protected <T> T executeOptimisticStorageReadWithNullRecheck(
       @Nonnull final AtomicOperation atomicOperation,
@@ -785,56 +788,66 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     }
 
     if (pinnedResult != null && !Objects.equals(pinnedResult, result)) {
-      warnOptimisticNullRecheckDisagreement(lookupDescription);
+      errorOptimisticNullRecheckDisagreement(lookupDescription);
       return pinnedResult;
     }
-    // Agreement (typically both null): confirm silently. When the pinned result is null but
-    // the composed optimistic result was not (e.g. a snapshot-index hit), the optimistic
-    // value is still a valid concurrent-snapshot answer and is preferred.
+    // Agreement (typically both null): confirm silently. The reverse-direction
+    // disagreement — optimistic non-null, pinned null — is DELIBERATELY silent: that is
+    // the snapshot-hit shape (the composed optimistic value came from the in-memory
+    // snapshot index while the tree had nothing). The pinned run saw the same or newer
+    // state, and the optimistic value is the SI-correct answer for this operation's
+    // snapshot, so it is preferred and no anomaly is reported.
     return pinnedResult != null ? pinnedResult : result;
   }
 
   /**
-   * Emits the rate-limited disagreement WARN for the validated-null re-check. Protected so
+   * Emits the rate-limited disagreement ERROR for the validated-null re-check. Protected so
    * unit tests can override it to capture emissions; the rate limiter itself lives in
-   * {@link #tryAcquireNullRecheckWarnSlot(long)} and is tested directly.
+   * {@link #tryAcquireNullRecheckErrorSlot(long)} and is tested directly.
+   *
+   * <p>ERROR (not WARN) because for the production wiring the miss cannot be explained by
+   * benign timing: visibility is resolved against a fixed snapshot captured at operation
+   * construction, so a concurrently committed insert would be filtered out anyway — a
+   * disagreement here indicates a genuine optimistic-read anomaly.
    */
-  protected void warnOptimisticNullRecheckDisagreement(
+  protected void errorOptimisticNullRecheckDisagreement(
       final Supplier<String> lookupDescription) {
-    if (!tryAcquireNullRecheckWarnSlot(System.nanoTime())) {
+    if (!tryAcquireNullRecheckErrorSlot(System.nanoTime())) {
       return;
     }
     LogManager.instance()
-        .warn(
+        .error(
             this,
-            "Optimistic point lookup in component '%s' reported a miss, but the pinned"
-                + " re-check found an entry (%s). This is usually benign — a concurrent commit"
-                + " may have inserted the entry between the optimistic attempt and the re-check"
-                + " — but it may also indicate an unmodeled optimistic-read anomaly worth"
-                + " reporting. At most one such message is logged per minute per component.",
-            // The Object cast pins the warn(requester, message, Object...) overload: with
-            // two String arguments javac would otherwise select the
-            // warn(requester, dbName, message, Object...) overload, shifting the whole
-            // message into the dbName slot and breaking the %s formatting.
-            (Object) getName(),
+            "Pinned re-check in component '%s' found an entry that the validated optimistic"
+                + " lookup missed (%s). The lookup self-healed — the pinned result was"
+                + " returned — but this indicates a possible optimistic-read/epoch anomaly:"
+                + " visibility is resolved against a fixed operation snapshot, so a"
+                + " concurrently committed insert cannot explain the miss. Please report this"
+                + " occurrence. At most one such message is logged per minute per component.",
+            // The explicit null Throwable pins the single
+            // error(requester, message, exception, Object...) overload — unlike warn, error
+            // has no (requester, dbName, message, ...) sibling that two String arguments
+            // could silently select.
+            null,
+            getName(),
             lookupDescription.get());
   }
 
   /**
-   * Rate limiter for the disagreement WARN: returns true if the caller won the right to log
-   * at {@code nowNanos} (at most one win per {@link #NULL_RECHECK_WARN_INTERVAL_NANOS}).
-   * CAS-based so concurrent winners are unique. Package-private for direct unit testing
-   * with controlled timestamps.
+   * Rate limiter for the disagreement ERROR: returns true if the caller won the right to
+   * log at {@code nowNanos} (at most one win per
+   * {@link #NULL_RECHECK_ERROR_INTERVAL_NANOS}). CAS-based so concurrent winners are
+   * unique. Package-private for direct unit testing with controlled timestamps.
    */
-  boolean tryAcquireNullRecheckWarnSlot(final long nowNanos) {
+  boolean tryAcquireNullRecheckErrorSlot(final long nowNanos) {
     while (true) {
-      final long last = lastNullRecheckWarnNanos.get();
+      final long last = lastNullRecheckErrorNanos.get();
       // 0 is the "never logged" sentinel; a genuine nanoTime of exactly 0 would merely
       // allow one extra message, which is harmless.
-      if (last != 0 && nowNanos - last < NULL_RECHECK_WARN_INTERVAL_NANOS) {
+      if (last != 0 && nowNanos - last < NULL_RECHECK_ERROR_INTERVAL_NANOS) {
         return false;
       }
-      if (lastNullRecheckWarnNanos.compareAndSet(last, nowNanos)) {
+      if (lastNullRecheckErrorNanos.compareAndSet(last, nowNanos)) {
         return true;
       }
     }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -812,7 +812,11 @@ public abstract class StorageComponent extends SharedResourceAbstract {
                 + " may have inserted the entry between the optimistic attempt and the re-check"
                 + " — but it may also indicate an unmodeled optimistic-read anomaly worth"
                 + " reporting. At most one such message is logged per minute per component.",
-            getName(),
+            // The Object cast pins the warn(requester, message, Object...) overload: with
+            // two String arguments javac would otherwise select the
+            // warn(requester, dbName, message, Object...) overload, shifting the whole
+            // message into the dbName slot and breaking the %s formatting.
+            (Object) getName(),
             lookupDescription.get());
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTree.java
@@ -170,7 +170,7 @@ public final class SharedLinkBagBTree extends StorageComponent {
   }
 
   /**
-   * Key coordinates for the null-recheck disagreement WARN.
+   * Key coordinates for the null-recheck disagreement report.
    */
   private String lookupDescription(
       final long ridBagId, final int targetCollection, final long targetPosition) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTree.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTree.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.stream.Stream;
@@ -148,18 +149,33 @@ public final class SharedLinkBagBTree extends StorageComponent {
       final int targetCollection,
       final long targetPosition) {
     try {
-      return executeOptimisticStorageRead(
+      // Belt-and-braces hardening (YTDB-1178): a validated optimistic NULL is re-checked
+      // once via the pinned path — the false-null is exactly the failure mode of the
+      // historical mixed-apply-state race, and upstream LinkBag.remove turns it into
+      // LinksConsistencyException while LinkBag.add silently overwrites the counter.
+      return executeOptimisticStorageReadWithNullRecheck(
           atomicOperation,
           () -> findCurrentEntryOptimistic(
               atomicOperation, ridBagId, targetCollection, targetPosition),
           () -> findCurrentEntryInternal(atomicOperation, ridBagId, targetCollection,
-              targetPosition));
+              targetPosition),
+          Objects::isNull,
+          () -> lookupDescription(ridBagId, targetCollection, targetPosition));
     } catch (final IOException e) {
       throw BaseException.wrapException(
           new StorageException(storage.getName(),
               "Error during prefix lookup in rid bag btree [" + getName() + "]"),
           e, storage.getName());
     }
+  }
+
+  /**
+   * Key coordinates for the null-recheck disagreement WARN.
+   */
+  private String lookupDescription(
+      final long ridBagId, final int targetCollection, final long targetPosition) {
+    return "ridBagId=" + ridBagId + ", targetCollection=" + targetCollection
+        + ", targetPosition=" + targetPosition;
   }
 
   /**
@@ -409,12 +425,19 @@ public final class SharedLinkBagBTree extends StorageComponent {
       final int targetCollection,
       final long targetPosition) {
     try {
-      return executeOptimisticStorageRead(
+      // Belt-and-braces hardening (YTDB-1178), keyed on the INNER tree-lookup null (the
+      // holder written by the optimistic lambda) rather than the composed result: a stale
+      // snapshot-index entry could otherwise mask a false tree-null. See
+      // executeOptimisticStorageReadWithNullRecheck for the decision rules.
+      final var treeLookupNull = new boolean[1];
+      return executeOptimisticStorageReadWithNullRecheck(
           atomicOperation,
           () -> findVisibleEntryOptimistic(
-              atomicOperation, ridBagId, targetCollection, targetPosition),
+              atomicOperation, ridBagId, targetCollection, targetPosition, treeLookupNull),
           () -> findVisibleEntryInternal(atomicOperation, ridBagId, targetCollection,
-              targetPosition));
+              targetPosition),
+          result -> treeLookupNull[0],
+          () -> lookupDescription(ridBagId, targetCollection, targetPosition));
     } catch (final IOException e) {
       throw BaseException.wrapException(
           new StorageException(storage.getName(),
@@ -428,14 +451,21 @@ public final class SharedLinkBagBTree extends StorageComponent {
    * for the prefix lookup, then performs in-memory visibility resolution.
    * The visibility resolution (resolveVisibleEntry / findVisibleSnapshotEntry)
    * operates on in-memory data structures, so no additional page I/O is needed.
+   *
+   * @param treeLookupNullOut single-element holder set to true when the inner tree lookup
+   *                          returned null — the trigger signal for the validated-null
+   *                          re-check in {@link #findVisibleEntry} (the composed result may
+   *                          still be non-null via the snapshot index)
    */
   @Nullable private RawPair<EdgeKey, LinkBagValue> findVisibleEntryOptimistic(
       final AtomicOperation atomicOperation,
       final long ridBagId,
       final int targetCollection,
-      final long targetPosition) {
+      final long targetPosition,
+      final boolean[] treeLookupNullOut) {
     final var current = findCurrentEntryOptimistic(
         atomicOperation, ridBagId, targetCollection, targetPosition);
+    treeLookupNullOut[0] = current == null;
     if (current == null) {
       final long currentOperationTs = atomicOperation.getCommitTsUnsafe();
       final var snapshot = atomicOperation.getAtomicOperationsSnapshot();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbeddedBackReferenceDiagnosticsTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbeddedBackReferenceDiagnosticsTest.java
@@ -51,6 +51,10 @@ public class DatabaseSessionEmbeddedBackReferenceDiagnosticsTest extends DbTestB
     var opposite = newPersistentEntity("opposite");
 
     session.begin();
+    // Reload the committed source in the active transaction so its properties are
+    // readable: the forward-links field must actually render (as null here — the property
+    // is absent) instead of degrading to an error marker.
+    source = session.load(source.getIdentity());
     var bag = new LinkBag(session);
     var present1 = new RecordId(12, 100);
     var present2 = new RecordId(12, 101);
@@ -73,7 +77,12 @@ public class DatabaseSessionEmbeddedBackReferenceDiagnosticsTest extends DbTestB
     assertTrue(message, message.endsWith("]"));
     assertTrue(message, message.contains("sourceProperty=linkMap"));
     assertTrue(message, message.contains(expectedSourceField));
-    assertTrue(message, message.contains("sourceForwardLinks="));
+    // The source has no 'linkMap' property, so the forward-links field renders the null
+    // gracefully. (The historical String.valueOf(char[]) overload trap turned this into
+    // <error:NullPointerException>, destroying the source-side evidence.)
+    assertTrue(message, message.contains("sourceForwardLinks=null"));
+    assertFalse("no diagnostic field may degrade to an error marker: " + message,
+        message.contains("<error:"));
     assertTrue(message, message.contains("oppositeBagProperty=#linkMap"));
     assertTrue(message, message.contains(expectedOppositeField));
     assertTrue(message, message.contains("bagType=embedded"));
@@ -191,6 +200,69 @@ public class DatabaseSessionEmbeddedBackReferenceDiagnosticsTest extends DbTestB
 
     assertTrue(message, message.contains("bagSize=64"));
     assertFalse(message, message.contains(" more)"));
+  }
+
+  /**
+   * The source's forward links are the other half of the evidence: for a linkMap property
+   * the rendered value must show the ACTUAL map content — the key and the target rid — not
+   * an error marker. This pins the fix for the {@code String.valueOf(char[])} overload
+   * trap: {@code getPropertyInternal}'s unbounded generic return let javac resolve the
+   * render call to the char[] overload, so every non-char[] property value threw
+   * ClassCastException and the field degraded to {@code <error:ClassCastException>}.
+   */
+  @Test
+  public void diagnosticsRenderSourceForwardLinksContentForLinkMap() {
+    var opposite = newPersistentEntity("opposite");
+    var targetRid = new RecordId(15, 7);
+
+    session.begin();
+    var source = (EntityImpl) session.newEntity();
+    source.getOrCreateLinkMap("linkMap").put("edgeKey", targetRid);
+    var bag = new LinkBag(session);
+    bag.add(new RecordId(15, 8));
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkMap", opposite, "#linkMap", bag, -1);
+    session.rollback();
+
+    // The rendered forward-links value carries the real map content: key and target rid.
+    assertTrue(message, message.contains("sourceForwardLinks="));
+    assertTrue("rendered value must contain the map key: " + message,
+        message.contains("edgeKey"));
+    assertTrue("rendered value must contain the target rid: " + message,
+        message.contains(targetRid.toString()));
+    assertFalse("no diagnostic field may degrade to an error marker: " + message,
+        message.contains("<error:"));
+  }
+
+  /**
+   * Same content pin for a second property shape (linkList): the rendered forward-links
+   * value must contain every target rid. Before the overload-trap fix this field threw
+   * ClassCastException for list values exactly as for maps.
+   */
+  @Test
+  public void diagnosticsRenderSourceForwardLinksContentForLinkList() {
+    var opposite = newPersistentEntity("opposite");
+    var ridA = new RecordId(15, 8);
+    var ridB = new RecordId(15, 9);
+
+    session.begin();
+    var source = (EntityImpl) session.newEntity();
+    var linkList = source.getOrCreateLinkList("linkList");
+    linkList.add(ridA);
+    linkList.add(ridB);
+    var bag = new LinkBag(session);
+    bag.add(new RecordId(15, 10));
+    var message = DatabaseSessionEmbedded.describeMissingBackReference(
+        "base", source, "linkList", opposite, "#linkList", bag, -1);
+    session.rollback();
+
+    assertTrue(message, message.contains("sourceForwardLinks="));
+    assertTrue("rendered value must contain the first rid: " + message,
+        message.contains(ridA.toString()));
+    assertTrue("rendered value must contain the second rid: " + message,
+        message.contains(ridB.toString()));
+    assertFalse("no diagnostic field may degrade to an error marker: " + message,
+        message.contains("<error:"));
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpochTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpochTest.java
@@ -1,0 +1,201 @@
+package com.jetbrains.youtrackdb.internal.core.storage.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link ApplyPhaseEpoch} reader/writer protocol (YTDB-1178): writers
+ * bracket the commit-time page-apply section with enterApplyPhase()/exitApplyPhase();
+ * readers capture both counters in {@link OptimisticReadScope#reset()} and re-check them
+ * in {@link OptimisticReadScope#validateOrThrow()}. A reader must fail whenever any apply
+ * phase overlaps its read window — including the parity-defeating interleaving where two
+ * writers' apply phases overlap each other.
+ */
+public class ApplyPhaseEpochTest {
+
+  @Test
+  public void testCountersStartAtZeroAndIncrementIndependently() {
+    // Fresh epoch is quiescent (0/0); enter and exit bump their own counters only.
+    var epoch = new ApplyPhaseEpoch();
+    assertEquals(0, epoch.enterSeq());
+    assertEquals(0, epoch.exitSeq());
+
+    epoch.enterApplyPhase();
+    assertEquals(1, epoch.enterSeq());
+    assertEquals(0, epoch.exitSeq());
+
+    epoch.exitApplyPhase();
+    assertEquals(1, epoch.enterSeq());
+    assertEquals(1, epoch.exitSeq());
+  }
+
+  @Test
+  public void testQuiescentCapturePassesValidation() {
+    // A read whose window overlaps no apply phase must pass the epoch check — both on a
+    // fresh epoch and after previous apply phases have fully completed.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+
+    scope.reset();
+    scope.validateOrThrow(); // fresh epoch: passes
+
+    // A completed apply BEFORE the capture must not affect the next read.
+    epoch.enterApplyPhase();
+    epoch.exitApplyPhase();
+    scope.reset();
+    scope.validateOrThrow(); // quiescent again: passes
+  }
+
+  @Test
+  public void testApplyInFlightAtCaptureFailsValidation() {
+    // A writer already inside the apply bracket when the reader captures (enter != exit
+    // at capture time) must fail validation — the reader could see partially applied
+    // pages with all stamps still valid.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+
+    epoch.enterApplyPhase();
+    scope.reset(); // capture sees enter=1, exit=0
+    expectValidateFails(scope);
+    epoch.exitApplyPhase();
+  }
+
+  @Test
+  public void testApplyEnteredAfterCaptureFailsValidation() {
+    // Epoch quiescent at capture, but a writer enters the apply phase before the reader
+    // validates: the live enterSeq no longer matches the captured value → fail.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+
+    scope.reset(); // capture sees enter=0, exit=0
+    epoch.enterApplyPhase();
+    expectValidateFails(scope);
+    epoch.exitApplyPhase();
+  }
+
+  @Test
+  public void testApplyCompletedWithinReadWindowFailsValidation() {
+    // A full apply phase (enter AND exit) between capture and validation must still
+    // fail: the reader may have read some pages before and some after the apply.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+
+    scope.reset();
+    epoch.enterApplyPhase();
+    epoch.exitApplyPhase();
+    expectValidateFails(scope); // enterSeq moved from 0 to 1 since capture
+  }
+
+  @Test
+  public void testResetNeverThrowsAndRecapturesFreshValues() {
+    // reset() is called outside the try/fallback block of
+    // StorageComponent.executeOptimisticStorageRead, so it must never throw — even while
+    // an apply phase is in flight. After the apply completes, a fresh reset() must
+    // re-capture and let validation pass again.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+
+    epoch.enterApplyPhase();
+    scope.reset(); // in-flight apply: must not throw, only latch the doomed capture
+    expectValidateFails(scope);
+
+    epoch.exitApplyPhase();
+    scope.reset(); // re-captures enter=1, exit=1 → quiescent
+    scope.validateOrThrow();
+  }
+
+  @Test
+  public void testConcurrentOverlappingAppliesNeverLetOverlappingReaderPass()
+      throws Exception {
+    // Two writer threads with overlapping apply phases: A enters, B enters, A exits,
+    // B exits. This is the interleaving that defeats a single odd/even parity bit —
+    // after A's exit a parity scheme would report "idle" while B is still mid-apply.
+    // The two-counter scheme must keep failing an overlapping reader until BOTH writers
+    // have exited. The interleaving is made deterministic with latches.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+
+    var aEntered = new CountDownLatch(1);
+    var bEntered = new CountDownLatch(1);
+    var aMayExit = new CountDownLatch(1);
+    var bMayExit = new CountDownLatch(1);
+    var aExited = new CountDownLatch(1);
+    var error = new AtomicReference<Throwable>();
+
+    var writerA = new Thread(() -> {
+      try {
+        epoch.enterApplyPhase();
+        aEntered.countDown();
+        await(aMayExit);
+        epoch.exitApplyPhase();
+        aExited.countDown();
+      } catch (Throwable t) {
+        error.set(t);
+      }
+    });
+    var writerB = new Thread(() -> {
+      try {
+        await(aEntered); // enforce: A enters first
+        epoch.enterApplyPhase();
+        bEntered.countDown();
+        await(bMayExit);
+        epoch.exitApplyPhase();
+      } catch (Throwable t) {
+        error.set(t);
+      }
+    });
+    writerA.start();
+    writerB.start();
+
+    try {
+      await(bEntered);
+
+      // Both applies in flight (enter=2, exit=0): reader must fail.
+      scope.reset();
+      expectValidateFails(scope);
+
+      // A exits while B is still applying (enter=2, exit=1) — the parity trap.
+      aMayExit.countDown();
+      await(aExited);
+      scope.reset();
+      expectValidateFails(scope);
+    } finally {
+      // Always release the writers so a failing assertion cannot hang the test.
+      aMayExit.countDown();
+      bMayExit.countDown();
+    }
+
+    writerA.join(TimeUnit.SECONDS.toMillis(10));
+    writerB.join(TimeUnit.SECONDS.toMillis(10));
+    assertNull("Writer thread failed: " + error.get(), error.get());
+
+    // Both writers exited (enter=2, exit=2): a fresh capture passes.
+    scope.reset();
+    scope.validateOrThrow();
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      assertTrue("Timed out waiting on latch", latch.await(10, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void expectValidateFails(OptimisticReadScope scope) {
+    try {
+      scope.validateOrThrow();
+      fail("Expected OptimisticReadFailedException — an apply phase overlapped the read");
+    } catch (OptimisticReadFailedException expected) {
+      // expected — epoch check detected the overlapping apply phase
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScopeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScopeTest.java
@@ -17,8 +17,10 @@ import org.junit.Test;
 /**
  * Tests for OptimisticReadScope — the multi-page stamp tracker used by optimistic reads.
  * Covers: record/validate happy path, validateOrThrow on invalid stamp, validateLastOrThrow,
- * reset clears state, grow on overflow, empty scope validates, and cross-thread stamp
- * invalidation via PageFrame exclusive lock (review finding R2).
+ * reset clears state, grow on overflow, empty scope validates, cross-thread stamp
+ * invalidation via PageFrame exclusive lock (review finding R2), and the interplay of
+ * per-page stamps with the apply-phase epoch check (YTDB-1178) — see
+ * {@link ApplyPhaseEpochTest} for the pure epoch protocol.
  */
 public class OptimisticReadScopeTest {
 
@@ -230,6 +232,65 @@ public class OptimisticReadScopeTest {
     frame1.releaseExclusiveLock(writeStamp);
 
     scope.validateOrThrow();
+  }
+
+  // --- Apply-phase epoch integration (YTDB-1178) ---
+
+  @Test
+  public void testEpochOverlapFailsEvenWhenAllStampsValid() {
+    // Per-page stamps are a temporal-only check. A commit apply phase overlapping the
+    // read window must fail validateOrThrow() even though every recorded stamp is still
+    // valid — the pages could be a mix of pre- and post-commit state.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+    var frame = pool.acquire(true, Intention.TEST);
+
+    scope.reset(); // capture the quiescent epoch
+    scope.record(frame, frame.tryOptimisticRead());
+
+    // A writer enters the apply phase mid-read; the frame's stamp is untouched.
+    epoch.enterApplyPhase();
+    try {
+      scope.validateOrThrow();
+      fail("Expected OptimisticReadFailedException — apply phase overlapped the read");
+    } catch (OptimisticReadFailedException expected) {
+      // expected — the epoch check caught the overlap the stamps cannot see
+    } finally {
+      epoch.exitApplyPhase();
+    }
+
+    releaseFrame(frame);
+  }
+
+  @Test
+  public void testValidateLastOrThrowIsStampOnly() {
+    // validateLastOrThrow() is a mid-traversal early check and deliberately stays
+    // stamp-only — the epoch is checked exactly once per attempt, in validateOrThrow().
+    // With an apply phase in flight, validateLastOrThrow must still pass for a valid
+    // stamp while validateOrThrow on the same scope must fail.
+    var epoch = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope(epoch);
+    var frame = pool.acquire(true, Intention.TEST);
+
+    scope.reset();
+    scope.record(frame, frame.tryOptimisticRead());
+
+    epoch.enterApplyPhase();
+    try {
+      // Stamp-only check: passes even though an apply phase is in flight.
+      scope.validateLastOrThrow();
+
+      try {
+        scope.validateOrThrow();
+        fail("Expected OptimisticReadFailedException from the epoch check");
+      } catch (OptimisticReadFailedException expected) {
+        // expected — only validateOrThrow performs the epoch check
+      }
+    } finally {
+      epoch.exitApplyPhase();
+    }
+
+    releaseFrame(frame);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationTestBridge.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationTestBridge.java
@@ -1,0 +1,84 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations;
+
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
+import javax.annotation.Nullable;
+
+/**
+ * Test-only bridge exposing the package-private apply-phase seams of the
+ * {@code atomicoperations} package to tests living in other packages (YTDB-1178).
+ *
+ * <p>Two seams are re-exported:
+ *
+ * <ul>
+ *   <li>{@link AtomicOperationBinaryTracking.PageApplyHook} installation on a live
+ *       atomic operation, so an integration test can dictate the commit-time page-apply
+ *       order and pause the writer mid-apply inside the epoch bracket;
+ *   <li>the per-storage {@link ApplyPhaseEpoch} owned by {@link AtomicOperationsManager},
+ *       so a test can make baseline-relative assertions on the epoch counters (never
+ *       absolute ones — any read-only operation also brackets its own empty apply
+ *       phase).
+ * </ul>
+ */
+public final class AtomicOperationTestBridge {
+
+  private AtomicOperationTestBridge() {
+  }
+
+  /**
+   * Public mirror of the package-private
+   * {@link AtomicOperationBinaryTracking.PageApplyHook} test seam. See that interface
+   * for the full contract.
+   */
+  public interface TestPageApplyHook {
+
+    /**
+     * Returns the order in which the given changed pages of {@code fileId} should be
+     * applied, or {@code null} to keep the default order. The returned array must be a
+     * permutation of {@code pageIndexes}.
+     */
+    @Nullable default long[] orderPageApplications(final long fileId, final long[] pageIndexes) {
+      return null;
+    }
+
+    /**
+     * Called immediately before the changes for {@code (fileId, pageIndex)} are applied
+     * to the shared read cache. May block to pause the writer mid-apply.
+     */
+    default void beforePageApply(final long fileId, final long pageIndex) {
+    }
+  }
+
+  /**
+   * Installs (or clears, with {@code null}) a page-apply hook on the given atomic
+   * operation. The operation must be an {@link AtomicOperationBinaryTracking} instance
+   * (the only production implementation, produced by
+   * {@link AtomicOperationsManager#startAtomicOperation()}).
+   */
+  public static void installPageApplyHook(
+      final AtomicOperation operation, @Nullable final TestPageApplyHook hook) {
+    final var tracking = (AtomicOperationBinaryTracking) operation;
+    if (hook == null) {
+      tracking.setPageApplyHook(null);
+      return;
+    }
+    tracking.setPageApplyHook(new AtomicOperationBinaryTracking.PageApplyHook() {
+      @Override
+      public long[] orderPageApplications(final long fileId, final long[] pageIndexes) {
+        return hook.orderPageApplications(fileId, pageIndexes);
+      }
+
+      @Override
+      public void beforePageApply(final long fileId, final long pageIndex) {
+        hook.beforePageApply(fileId, pageIndex);
+      }
+    });
+  }
+
+  /**
+   * Returns the apply-phase epoch of the given manager's storage. Tests must only make
+   * baseline-relative assertions on the returned counters.
+   */
+  public static ApplyPhaseEpoch applyPhaseEpoch(final AtomicOperationsManager manager) {
+    return manager.getApplyPhaseEpoch();
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationTestBridge.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationTestBridge.java
@@ -15,8 +15,8 @@ import javax.annotation.Nullable;
  *       order and pause the writer mid-apply inside the epoch bracket;
  *   <li>the per-storage {@link ApplyPhaseEpoch} owned by {@link AtomicOperationsManager},
  *       so a test can make baseline-relative assertions on the epoch counters (never
- *       absolute ones — any read-only operation also brackets its own empty apply
- *       phase).
+ *       absolute ones — any commit that mutates shared cache state bumps the epoch,
+ *       and storages are shared across tests).
  * </ul>
  */
 public final class AtomicOperationTestBridge {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
@@ -1,0 +1,384 @@
+package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationBinaryTracking.PageApplyHook;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsTable.AtomicOperationsSnapshot;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurablePage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.LogSequenceNumber;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.TestPageOperation;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WALRecordsFactory;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WriteAheadLog;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.common.WriteableWALRecord;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the TEST-ONLY {@link PageApplyHook} seam in
+ * {@link AtomicOperationBinaryTracking#commitChanges} and for the apply-phase epoch
+ * bracket around the page-apply loop (YTDB-1178).
+ *
+ * <p>The seam exists because the production page-apply order is fastutil hash order,
+ * which makes the mixed-state race (a reader overlapping a partially applied commit)
+ * practically impossible to reproduce. These tests verify that:
+ *
+ * <ul>
+ *   <li>the hook can dictate and observe the page-apply order;
+ *   <li>a reader overlapping a writer paused mid-apply (between two page applications,
+ *       inside the epoch bracket) deterministically fails epoch validation;
+ *   <li>the epoch bracket is exactly one enter/exit pair per commit, with the exit in a
+ *       finally block that runs even when the hook throws.
+ * </ul>
+ */
+public class CommitChangesPageApplyHookTest {
+
+  private static final int STORAGE_ID = 1;
+  private static final int PAGE_SIZE = DurablePage.MAX_PAGE_SIZE_BYTES;
+
+  private ReadCache readCache;
+  private WriteCache writeCache;
+  private WriteAheadLog wal;
+  private AtomicInteger lsnCounter;
+  private AtomicLong fileIdCounter;
+  private ApplyPhaseEpoch epoch;
+
+  // Order in which pages hit readCache.loadOrAddForWrite — the authoritative signal of
+  // apply order. Synchronized because the writer may run on a separate thread.
+  private List<Long> appliedPageOrder;
+
+  @Before
+  public void setUp() throws IOException {
+    readCache = mock(ReadCache.class);
+    writeCache = mock(WriteCache.class);
+    when(writeCache.getStorageName()).thenReturn("test-storage");
+    wal = mock(WriteAheadLog.class);
+    lsnCounter = new AtomicInteger(1);
+    fileIdCounter = new AtomicLong(100);
+    epoch = new ApplyPhaseEpoch();
+    appliedPageOrder = Collections.synchronizedList(new ArrayList<>());
+
+    WALRecordsFactory.INSTANCE.registerNewRecord(
+        TestPageOperation.TEST_RECORD_ID, TestPageOperation.class);
+
+    when(wal.log(any(WriteableWALRecord.class))).thenAnswer(invocation -> {
+      var record = invocation.getArgument(0, WriteableWALRecord.class);
+      var lsn = new LogSequenceNumber(0, lsnCounter.getAndIncrement());
+      record.setLsn(lsn);
+      return lsn;
+    });
+    when(wal.logAtomicOperationStartRecord(anyBoolean(), anyLong()))
+        .thenAnswer(invocation -> new LogSequenceNumber(0, lsnCounter.getAndIncrement()));
+    when(wal.end()).thenAnswer(inv -> new LogSequenceNumber(0, lsnCounter.get()));
+
+    // loadOrAddForWrite is the first cache touch of each page application: record the
+    // order and return a pre-built mock entry. Mock entries are created lazily on
+    // whichever thread runs commitChanges — creating plain Mockito mocks off the test
+    // thread is safe, and per-invocation stubbing is avoided by building the entry with
+    // a self-contained answer.
+    when(readCache.loadOrAddForWrite(anyLong(), anyLong(), any(), anyBoolean(), any()))
+        .thenAnswer(invocation -> {
+          final long fileId = invocation.getArgument(0);
+          final long pageIndex = invocation.getArgument(1);
+          appliedPageOrder.add(pageIndex);
+          return newCacheEntry(fileId, (int) pageIndex);
+        });
+  }
+
+  private static CacheEntry newCacheEntry(long fileId, int pageIndex) {
+    var buffer = ByteBuffer.allocateDirect(PAGE_SIZE).order(ByteOrder.nativeOrder());
+    var cachePointer = mock(CachePointer.class);
+    when(cachePointer.getBuffer()).thenReturn(buffer);
+
+    var cacheEntry = mock(CacheEntry.class);
+    when(cacheEntry.getPageIndex()).thenReturn(pageIndex);
+    when(cacheEntry.getFileId()).thenReturn(fileId);
+    when(cacheEntry.getCachePointer()).thenReturn(cachePointer);
+    return cacheEntry;
+  }
+
+  private AtomicOperationBinaryTracking createOperation() {
+    var snapshot = new AtomicOperationsSnapshot(0, 100, new LongOpenHashSet(), 100);
+    var op = new AtomicOperationBinaryTracking(
+        readCache, writeCache, wal, STORAGE_ID,
+        snapshot,
+        new ConcurrentSkipListMap<>(),
+        new ConcurrentSkipListMap<>(),
+        new AtomicLong(),
+        new ConcurrentSkipListMap<>(),
+        new ConcurrentSkipListMap<>(),
+        new AtomicLong(),
+        epoch);
+    op.startToApplyOperations(42);
+    return op;
+  }
+
+  private static long composeFileId(long internalId, int storageId) {
+    return internalId | ((long) storageId << 32);
+  }
+
+  /**
+   * Creates a new durable file with {@code pageCount} changed pages (indexes 0..n-1),
+   * registers a logical PageOperation per page, and flushes so every page carries a
+   * changeLSN — the precondition for reaching the commit-time apply loop.
+   */
+  private long setupNewFileWithPages(
+      AtomicOperationBinaryTracking op, String fileName, int pageCount) throws IOException {
+    long internalId = fileIdCounter.getAndIncrement();
+    long fullFileId = composeFileId(internalId, STORAGE_ID);
+    when(writeCache.bookFileId(fileName)).thenReturn(fullFileId);
+    long fileId = op.addFile(fileName);
+
+    for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+      var page = op.allocatePageForWrite(fileId, pageIndex);
+      page.getChanges().setByteValue(null, (byte) 1, 100);
+      page.setInitialLSN(new LogSequenceNumber(-1, -1));
+      op.registerPageOperation(fileId, pageIndex,
+          new TestPageOperation(
+              pageIndex, fileId, 0, new LogSequenceNumber(0, 0), pageIndex));
+    }
+    op.flushPendingOperations();
+    return fileId;
+  }
+
+  @Test
+  public void testHookControlsAndObservesApplyOrder() throws IOException {
+    // The hook dictates a reversed apply order (page 1 before page 0) and observes each
+    // application via beforePageApply. Both the hook's observations and the cache-level
+    // loadOrAddForWrite order must match the requested order — proving the seam really
+    // controls the order pages become visible in the shared cache.
+    var op = createOperation();
+    setupNewFileWithPages(op, "ordered.dat", 2);
+
+    var observedOrder = Collections.synchronizedList(new ArrayList<Long>());
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public long[] orderPageApplications(long fileId, long[] pageIndexes) {
+        Assert.assertEquals(2, pageIndexes.length);
+        return new long[] {1, 0};
+      }
+
+      @Override
+      public void beforePageApply(long fileId, long pageIndex) {
+        observedOrder.add(pageIndex);
+      }
+    });
+
+    var txEndLsn = op.commitChanges(42L, wal);
+    Assert.assertNotNull(txEndLsn);
+
+    Assert.assertEquals(List.of(1L, 0L), observedOrder);
+    Assert.assertEquals(List.of(1L, 0L), appliedPageOrder);
+    // Exactly one epoch bracket for the whole commit, even with multiple pages.
+    Assert.assertEquals(1, epoch.enterSeq());
+    Assert.assertEquals(1, epoch.exitSeq());
+  }
+
+  @Test
+  public void testHookObservesDefaultOrderWhenOrderingReturnsNull() throws IOException {
+    // orderPageApplications returning null keeps the default order; beforePageApply must
+    // still observe every changed page exactly once (the default order itself is hash
+    // order and deliberately not asserted).
+    var op = createOperation();
+    setupNewFileWithPages(op, "default-order.dat", 2);
+
+    var observed = Collections.synchronizedList(new ArrayList<Long>());
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public void beforePageApply(long fileId, long pageIndex) {
+        observed.add(pageIndex);
+      }
+    });
+
+    Assert.assertNotNull(op.commitChanges(42L, wal));
+
+    var sorted = new ArrayList<>(observed);
+    Collections.sort(sorted);
+    Assert.assertEquals(List.of(0L, 1L), sorted);
+    Assert.assertEquals(observed, appliedPageOrder);
+  }
+
+  @Test
+  public void testReaderFailsDeterministicallyWhileWriterPausedMidApply()
+      throws Exception {
+    // THE seam test (AR-10): a writer thread commits two pages and is paused by the hook
+    // barrier BETWEEN the two page applications — inside the epoch bracket, page 0
+    // already visible in the cache, page 1 not yet (the mixed state). An overlapping
+    // reader capturing the epoch at that moment must deterministically fail
+    // validateOrThrow(), because enterSeq != exitSeq at capture. After the writer
+    // resumes and finishes, a fresh capture must pass.
+    var op = createOperation();
+    setupNewFileWithPages(op, "mid-apply.dat", 2);
+
+    var midApplyReached = new CountDownLatch(1);
+    var resume = new CountDownLatch(1);
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public long[] orderPageApplications(long fileId, long[] pageIndexes) {
+        return new long[] {0, 1}; // deterministic order: pause before the SECOND page
+      }
+
+      @Override
+      public void beforePageApply(long fileId, long pageIndex) {
+        if (pageIndex == 1) {
+          midApplyReached.countDown();
+          try {
+            if (!resume.await(10, TimeUnit.SECONDS)) {
+              throw new IllegalStateException("Timed out waiting for resume signal");
+            }
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+          }
+        }
+      }
+    });
+
+    var writerError = new AtomicReference<Throwable>();
+    var txEndLsn = new AtomicReference<LogSequenceNumber>();
+    var writer = new Thread(() -> {
+      try {
+        txEndLsn.set(op.commitChanges(42L, wal));
+      } catch (Throwable t) {
+        writerError.set(t);
+      }
+    });
+    writer.start();
+
+    try {
+      Assert.assertTrue(
+          "Writer never reached the mid-apply barrier",
+          midApplyReached.await(10, TimeUnit.SECONDS));
+
+      // Writer is paused mid-apply: page 0 applied, page 1 pending, bracket open.
+      Assert.assertEquals(List.of(0L), appliedPageOrder);
+      Assert.assertEquals(1, epoch.enterSeq());
+      Assert.assertEquals(0, epoch.exitSeq());
+
+      // Overlapping reader (a different operation sharing the storage epoch): capture
+      // now → validation must fail deterministically.
+      var readerScope = new OptimisticReadScope(epoch);
+      readerScope.reset();
+      try {
+        readerScope.validateOrThrow();
+        Assert.fail("Reader overlapping a mid-apply writer must fail epoch validation");
+      } catch (OptimisticReadFailedException expected) {
+        // expected — apply phase in flight at capture time
+      }
+    } finally {
+      resume.countDown();
+    }
+
+    writer.join(TimeUnit.SECONDS.toMillis(10));
+    Assert.assertFalse("Writer thread did not finish", writer.isAlive());
+    Assert.assertNull("Writer failed: " + writerError.get(), writerError.get());
+    Assert.assertNotNull(txEndLsn.get());
+
+    // Commit finished: both pages applied, bracket closed, fresh reader passes.
+    Assert.assertEquals(List.of(0L, 1L), appliedPageOrder);
+    Assert.assertEquals(1, epoch.enterSeq());
+    Assert.assertEquals(1, epoch.exitSeq());
+    var readerScope = new OptimisticReadScope(epoch);
+    readerScope.reset();
+    readerScope.validateOrThrow();
+  }
+
+  @Test
+  public void testEpochExitsInFinallyWhenHookThrows() throws IOException {
+    // A hook that throws mid-apply aborts the commit, but the epoch exit sits in a
+    // finally block: the bracket must still close (enterSeq == exitSeq afterwards), so
+    // optimistic reads are not permanently disabled by the failed commit.
+    var op = createOperation();
+    setupNewFileWithPages(op, "hook-throws.dat", 2);
+
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public void beforePageApply(long fileId, long pageIndex) {
+        throw new IllegalStateException("test hook failure");
+      }
+    });
+
+    try {
+      op.commitChanges(42L, wal);
+      Assert.fail("Expected the hook's IllegalStateException to abort the commit");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals("test hook failure", e.getMessage());
+    }
+
+    // Bracket balanced despite the exception — a fresh reader capture passes.
+    Assert.assertEquals(1, epoch.enterSeq());
+    Assert.assertEquals(1, epoch.exitSeq());
+    var readerScope = new OptimisticReadScope(epoch);
+    readerScope.reset();
+    readerScope.validateOrThrow();
+  }
+
+  @Test
+  public void testHookReturningUnknownPageIndexFailsCommitWithBalancedEpoch()
+      throws IOException {
+    // A hook ordering that references a page index not present in the change set must
+    // fail loudly (it would otherwise silently skip real pages), and the epoch bracket
+    // must still close via the finally.
+    var op = createOperation();
+    setupNewFileWithPages(op, "unknown-page.dat", 2);
+
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public long[] orderPageApplications(long fileId, long[] pageIndexes) {
+        return new long[] {99};
+      }
+    });
+
+    try {
+      op.commitChanges(42L, wal);
+      Assert.fail("Expected IllegalStateException for unknown page index");
+    } catch (IllegalStateException e) {
+      Assert.assertTrue(
+          "Message should mention the unknown page index: " + e.getMessage(),
+          e.getMessage().contains("unknown page index 99"));
+    }
+
+    Assert.assertEquals(1, epoch.enterSeq());
+    Assert.assertEquals(1, epoch.exitSeq());
+  }
+
+  @Test
+  public void testCommitWithoutHookBumpsEpochExactlyOnce() throws IOException {
+    // The production path (no hook installed) must also bracket the apply section with
+    // exactly one enter/exit pair per commit — one pair for the whole commit, not one
+    // per page or per file.
+    var op = createOperation();
+    setupNewFileWithPages(op, "no-hook-a.dat", 2);
+    setupNewFileWithPages(op, "no-hook-b.dat", 1);
+
+    Assert.assertNotNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(3, appliedPageOrder.size());
+    Assert.assertEquals(1, epoch.enterSeq());
+    Assert.assertEquals(1, epoch.exitSeq());
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
@@ -367,6 +367,80 @@ public class CommitChangesPageApplyHookTest {
   }
 
   @Test
+  public void testZeroChangeCommitDoesNotBumpEpoch() throws IOException {
+    // CN-11/CQ-1/CS-2 regression: a commit with nothing to apply (read-only atomic
+    // operation — no deleted files, no new/truncated files, no page changes) performs
+    // no shared-cache mutation, so it must NOT enter the epoch bracket. Before the
+    // gating fix, every commit bumped the epoch, spuriously invalidating all
+    // concurrently overlapping optimistic reads in the storage.
+    var op = createOperation();
+
+    // Pure no-op commit: returns null (no WAL unit was ever started either).
+    Assert.assertNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(0, epoch.enterSeq());
+    Assert.assertEquals(0, epoch.exitSeq());
+  }
+
+  @Test
+  public void testHookReturningDuplicatePageIndexFailsCommitWithBalancedEpoch()
+      throws IOException {
+    // CS-1/CQ-2/CN-13: a duplicate in the hook-returned order would double-apply a
+    // page. The permutation validation must fail the commit loudly, and the epoch
+    // bracket must still close via the finally.
+    var op = createOperation();
+    setupNewFileWithPages(op, "duplicate-page.dat", 2);
+
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public long[] orderPageApplications(long fileId, long[] pageIndexes) {
+        return new long[] {0, 0};
+      }
+    });
+
+    try {
+      op.commitChanges(42L, wal);
+      Assert.fail("Expected IllegalStateException for duplicate page index");
+    } catch (IllegalStateException e) {
+      Assert.assertTrue(
+          "Message should mention the duplicate page index: " + e.getMessage(),
+          e.getMessage().contains("duplicate page index 0"));
+    }
+
+    Assert.assertEquals(1, epoch.enterSeq());
+    Assert.assertEquals(1, epoch.exitSeq());
+  }
+
+  @Test
+  public void testHookOmittingPagesFailsCommitWithBalancedEpoch() throws IOException {
+    // CS-1/CQ-2/CN-13: an omission in the hook-returned order would silently drop a
+    // WAL-committed page's changes from the cache. The permutation validation must
+    // fail the commit loudly (incomplete permutation), and the epoch bracket must
+    // still close via the finally.
+    var op = createOperation();
+    setupNewFileWithPages(op, "omitted-page.dat", 2);
+
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public long[] orderPageApplications(long fileId, long[] pageIndexes) {
+        return new long[] {0}; // omits page 1
+      }
+    });
+
+    try {
+      op.commitChanges(42L, wal);
+      Assert.fail("Expected IllegalStateException for incomplete permutation");
+    } catch (IllegalStateException e) {
+      Assert.assertTrue(
+          "Message should mention the incomplete permutation: " + e.getMessage(),
+          e.getMessage().contains("incomplete permutation"));
+    }
+
+    Assert.assertEquals(1, epoch.enterSeq());
+    Assert.assertEquals(1, epoch.exitSeq());
+  }
+
+  @Test
   public void testCommitWithoutHookBumpsEpochExactlyOnce() throws IOException {
     // The production path (no hook installed) must also bracket the apply section with
     // exactly one enter/exit pair per commit — one pair for the whole commit, not one

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
@@ -225,7 +225,7 @@ public class CommitChangesPageApplyHookTest {
   @Test
   public void testReaderFailsDeterministicallyWhileWriterPausedMidApply()
       throws Exception {
-    // THE seam test (AR-10): a writer thread commits two pages and is paused by the hook
+    // THE seam test: a writer thread commits two pages and is paused by the hook
     // barrier BETWEEN the two page applications — inside the epoch bracket, page 0
     // already visible in the cache, page 1 not yet (the mixed state). An overlapping
     // reader capturing the epoch at that moment must deterministically fail
@@ -368,7 +368,7 @@ public class CommitChangesPageApplyHookTest {
 
   @Test
   public void testZeroChangeCommitDoesNotBumpEpoch() throws IOException {
-    // CN-11/CQ-1/CS-2 regression: a commit with nothing to apply (read-only atomic
+    // Regression guard: a commit with nothing to apply (read-only atomic
     // operation — no deleted files, no new/truncated files, no page changes) performs
     // no shared-cache mutation, so it must NOT enter the epoch bracket. Before the
     // gating fix, every commit bumped the epoch, spuriously invalidating all
@@ -385,7 +385,7 @@ public class CommitChangesPageApplyHookTest {
   @Test
   public void testHookReturningDuplicatePageIndexFailsCommitWithBalancedEpoch()
       throws IOException {
-    // CS-1/CQ-2/CN-13: a duplicate in the hook-returned order would double-apply a
+    // A duplicate in the hook-returned order would double-apply a
     // page. The permutation validation must fail the commit loudly, and the epoch
     // bracket must still close via the finally.
     var op = createOperation();
@@ -413,7 +413,7 @@ public class CommitChangesPageApplyHookTest {
 
   @Test
   public void testHookOmittingPagesFailsCommitWithBalancedEpoch() throws IOException {
-    // CS-1/CQ-2/CN-13: an omission in the hook-returned order would silently drop a
+    // An omission in the hook-returned order would silently drop a
     // WAL-committed page's changes from the cache. The permutation validation must
     // fail the commit loudly (incomplete permutation), and the epoch bracket must
     // still close via the finally.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -54,7 +54,7 @@ public class StorageComponentOptimisticReadTest {
   private ReadCache mockReadCache;
   private AtomicOperation mockAtomicOp;
   private OptimisticReadScope scope;
-  private WarnCapturingStorageComponent component;
+  private ErrorCapturingStorageComponent component;
 
   @Before
   public void setUp() {
@@ -74,7 +74,7 @@ public class StorageComponentOptimisticReadTest {
     mockAtomicOp = mock(AtomicOperation.class);
     when(mockAtomicOp.getOptimisticReadScope()).thenReturn(scope);
 
-    component = new WarnCapturingStorageComponent(mockStorage);
+    component = new ErrorCapturingStorageComponent(mockStorage);
   }
 
   @After
@@ -699,7 +699,7 @@ public class StorageComponentOptimisticReadTest {
   public void testValidatedNullTriggersExactlyOnePinnedRecheckAndStaysSilent()
       throws IOException {
     // A cleanly validated optimistic NULL triggers exactly one pinned re-check; when the
-    // pinned run confirms the miss (agreement), the null is returned silently — no WARN.
+    // pinned run confirms the miss (agreement), the null is returned silently — no report.
     final int[] pinnedRuns = {0};
 
     String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
@@ -714,13 +714,13 @@ public class StorageComponentOptimisticReadTest {
 
     assertNull(result);
     assertEquals(1, pinnedRuns[0]);
-    assertEquals(0, component.nullRecheckWarnCount);
+    assertEquals(0, component.nullRecheckErrorCount);
   }
 
   @Test
-  public void testNullRecheckDisagreementReturnsPinnedResultAndWarns() throws IOException {
+  public void testNullRecheckDisagreementReturnsPinnedResultAndReportsError() throws IOException {
     // Disagreement: validated optimistic null, but the pinned re-check finds an entry.
-    // The pinned result is authoritative and returned; exactly one WARN is emitted with
+    // The pinned result is authoritative and returned; exactly one rate-limited ERROR is emitted with
     // the lookup coordinates.
     final int[] pinnedRuns = {0};
 
@@ -736,8 +736,8 @@ public class StorageComponentOptimisticReadTest {
 
     assertEquals("pinned-found", result);
     assertEquals(1, pinnedRuns[0]);
-    assertEquals(1, component.nullRecheckWarnCount);
-    assertEquals("key=42", component.lastNullRecheckWarnDescription);
+    assertEquals(1, component.nullRecheckErrorCount);
+    assertEquals("key=42", component.lastNullRecheckErrorDescription);
   }
 
   @Test
@@ -763,7 +763,7 @@ public class StorageComponentOptimisticReadTest {
 
     assertEquals("optimistic-hit", result);
     assertEquals(0, pinnedRuns[0]);
-    assertEquals(0, component.nullRecheckWarnCount);
+    assertEquals(0, component.nullRecheckErrorCount);
     releaseFrame(frame);
   }
 
@@ -789,14 +789,14 @@ public class StorageComponentOptimisticReadTest {
 
     assertNull(result);
     assertEquals(1, pinnedRuns[0]);
-    assertEquals(0, component.nullRecheckWarnCount);
+    assertEquals(0, component.nullRecheckErrorCount);
   }
 
   @Test
-  public void testEqualNonNullResultsDoNotWarn() throws IOException {
+  public void testEqualNonNullResultsDoNotReport() throws IOException {
     // findVisibleEntry shape: the trigger can fire even when the composed optimistic
     // result is non-null (inner tree-null with a snapshot-index hit). An equal pinned
-    // result is agreement, not disagreement — no WARN.
+    // result is agreement, not disagreement — no report.
     String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
         mockAtomicOp,
         () -> List.of("same"),
@@ -805,13 +805,37 @@ public class StorageComponentOptimisticReadTest {
         () -> "key=42").get(0);
 
     assertEquals("same", result);
-    assertEquals(0, component.nullRecheckWarnCount);
+    assertEquals(0, component.nullRecheckErrorCount);
   }
 
   @Test
-  public void testProductionWarnEmissionIsRateLimited() throws IOException {
+  public void testPinnedNullOptimisticNonNullReturnsOptimisticSilently() throws IOException {
+    // Reverse-direction disagreement: the trigger fires on a non-null composed optimistic
+    // result (the findVisibleEntry snapshot-hit shape) and the pinned re-check returns
+    // null. The optimistic value is the SI-correct answer for this operation's snapshot
+    // and must be returned; this direction is deliberately silent — exactly one pinned
+    // run, no disagreement signal, no emission.
+    final int[] pinnedRuns = {0};
+
+    String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
+        mockAtomicOp,
+        () -> "optimistic-snapshot-hit",
+        () -> {
+          pinnedRuns[0]++;
+          return null;
+        },
+        r -> true,
+        () -> "key=42");
+
+    assertEquals("optimistic-snapshot-hit", result);
+    assertEquals(1, pinnedRuns[0]);
+    assertEquals(0, component.nullRecheckErrorCount);
+  }
+
+  @Test
+  public void testProductionErrorEmissionIsRateLimited() throws IOException {
     // Uses a component WITHOUT the capturing override so the PRODUCTION emission body of
-    // warnOptimisticNullRecheckDisagreement runs end-to-end: the first disagreement
+    // errorOptimisticNullRecheckDisagreement runs end-to-end: the first disagreement
     // passes the rate limiter and logs through LogManager (building the lazy
     // description); an immediate second disagreement takes the limiter's suppression
     // return. Both lookups must still return the authoritative pinned result.
@@ -828,20 +852,20 @@ public class StorageComponentOptimisticReadTest {
   }
 
   @Test
-  public void testNullRecheckWarnRateLimiterSuppressesRepeats() {
-    // The rate limiter allows at most one WARN per minute per component; tested with
+  public void testNullRecheckErrorRateLimiterSuppressesRepeats() {
+    // The rate limiter allows at most one ERROR per minute per component; tested with
     // controlled timestamps against the package-private seam.
     long t0 = 1L;
     assertTrue("first emission must be allowed",
-        component.tryAcquireNullRecheckWarnSlot(t0));
+        component.tryAcquireNullRecheckErrorSlot(t0));
     assertFalse("immediate repeat must be suppressed",
-        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.MILLISECONDS.toNanos(1)));
+        component.tryAcquireNullRecheckErrorSlot(t0 + TimeUnit.MILLISECONDS.toNanos(1)));
     assertFalse("repeat within the interval must be suppressed",
-        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.SECONDS.toNanos(59)));
+        component.tryAcquireNullRecheckErrorSlot(t0 + TimeUnit.SECONDS.toNanos(59)));
     assertTrue("emission after the interval must be allowed",
-        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.SECONDS.toNanos(61)));
+        component.tryAcquireNullRecheckErrorSlot(t0 + TimeUnit.SECONDS.toNanos(61)));
     assertFalse("the fresh emission must restart the interval",
-        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.SECONDS.toNanos(62)));
+        component.tryAcquireNullRecheckErrorSlot(t0 + TimeUnit.SECONDS.toNanos(62)));
   }
 
   @Test
@@ -938,26 +962,26 @@ public class StorageComponentOptimisticReadTest {
   }
 
   /**
-   * Test subclass whose WARN override replaces the LogManager sink so tests can assert
+   * Test subclass whose report override replaces the LogManager sink so tests can assert
    * emission counts and descriptions; the production emission body is exercised
    * separately through the plain {@link TestStorageComponent} in
-   * {@link #testProductionWarnEmissionIsRateLimited()}, and the rate limiter through its
+   * {@link #testProductionErrorEmissionIsRateLimited()}, and the rate limiter through its
    * package-private seam.
    */
-  private static class WarnCapturingStorageComponent extends TestStorageComponent {
+  private static class ErrorCapturingStorageComponent extends TestStorageComponent {
 
-    int nullRecheckWarnCount;
-    String lastNullRecheckWarnDescription;
+    int nullRecheckErrorCount;
+    String lastNullRecheckErrorDescription;
 
-    WarnCapturingStorageComponent(AbstractStorage storage) {
+    ErrorCapturingStorageComponent(AbstractStorage storage) {
       super(storage);
     }
 
     @Override
-    protected void warnOptimisticNullRecheckDisagreement(
+    protected void errorOptimisticNullRecheckDisagreement(
         Supplier<String> lookupDescription) {
-      nullRecheckWarnCount++;
-      lastNullRecheckWarnDescription = lookupDescription.get();
+      nullRecheckErrorCount++;
+      lastNullRecheckErrorDescription = lookupDescription.get();
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -54,7 +54,7 @@ public class StorageComponentOptimisticReadTest {
   private ReadCache mockReadCache;
   private AtomicOperation mockAtomicOp;
   private OptimisticReadScope scope;
-  private TestStorageComponent component;
+  private WarnCapturingStorageComponent component;
 
   @Before
   public void setUp() {
@@ -74,7 +74,7 @@ public class StorageComponentOptimisticReadTest {
     mockAtomicOp = mock(AtomicOperation.class);
     when(mockAtomicOp.getOptimisticReadScope()).thenReturn(scope);
 
-    component = new TestStorageComponent(mockStorage);
+    component = new WarnCapturingStorageComponent(mockStorage);
   }
 
   @After
@@ -809,6 +809,25 @@ public class StorageComponentOptimisticReadTest {
   }
 
   @Test
+  public void testProductionWarnEmissionIsRateLimited() throws IOException {
+    // Uses a component WITHOUT the capturing override so the PRODUCTION emission body of
+    // warnOptimisticNullRecheckDisagreement runs end-to-end: the first disagreement
+    // passes the rate limiter and logs through LogManager (building the lazy
+    // description); an immediate second disagreement takes the limiter's suppression
+    // return. Both lookups must still return the authoritative pinned result.
+    var plainComponent = new TestStorageComponent(component.storage);
+    for (var i = 0; i < 2; i++) {
+      String result = plainComponent.testExecuteOptimisticStorageReadWithNullRecheck(
+          mockAtomicOp,
+          () -> null,
+          () -> "pinned-found",
+          Objects::isNull,
+          () -> "key=7");
+      assertEquals("pinned-found", result);
+    }
+  }
+
+  @Test
   public void testNullRecheckWarnRateLimiterSuppressesRepeats() {
     // The rate limiter allows at most one WARN per minute per component; tested with
     // controlled timestamps against the package-private seam.
@@ -907,20 +926,6 @@ public class StorageComponentOptimisticReadTest {
       return addFile(op, fileName);
     }
 
-    // --- Validated-null re-check seams ---
-
-    // Captured WARN emissions (the override replaces the LogManager sink so tests can
-    // assert emission counts; the rate limiter is tested separately via its seam).
-    int nullRecheckWarnCount;
-    String lastNullRecheckWarnDescription;
-
-    @Override
-    protected void warnOptimisticNullRecheckDisagreement(
-        Supplier<String> lookupDescription) {
-      nullRecheckWarnCount++;
-      lastNullRecheckWarnDescription = lookupDescription.get();
-    }
-
     <T> T testExecuteOptimisticStorageReadWithNullRecheck(
         AtomicOperation op,
         OptimisticReadFunction<T> optimistic,
@@ -929,6 +934,30 @@ public class StorageComponentOptimisticReadTest {
         Supplier<String> lookupDescription) throws IOException {
       return executeOptimisticStorageReadWithNullRecheck(
           op, optimistic, pinned, recheckTrigger, lookupDescription);
+    }
+  }
+
+  /**
+   * Test subclass whose WARN override replaces the LogManager sink so tests can assert
+   * emission counts and descriptions; the production emission body is exercised
+   * separately through the plain {@link TestStorageComponent} in
+   * {@link #testProductionWarnEmissionIsRateLimited()}, and the rate limiter through its
+   * package-private seam.
+   */
+  private static class WarnCapturingStorageComponent extends TestStorageComponent {
+
+    int nullRecheckWarnCount;
+    String lastNullRecheckWarnDescription;
+
+    WarnCapturingStorageComponent(AbstractStorage storage) {
+      super(storage);
+    }
+
+    @Override
+    protected void warnOptimisticNullRecheckDisagreement(
+        Supplier<String> lookupDescription) {
+      nullRecheckWarnCount++;
+      lastNullRecheckWarnDescription = lookupDescription.get();
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -2,6 +2,8 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -13,6 +15,7 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocat
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFramePool;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.PageView;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
@@ -24,6 +27,7 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -498,6 +502,118 @@ public class StorageComponentOptimisticReadTest {
 
     assertEquals(99L, fileId);
     verify(op).addFile("test-file.dat", false);
+  }
+
+  // --- Apply-phase epoch fallback and nesting detection (YTDB-1178) ---
+
+  @Test
+  public void testFallbackToPinnedWhenApplyPhaseInFlightAtCapture() throws IOException {
+    // A commit apply phase already in flight when the read starts must fail epoch
+    // validation (the capture sees enterSeq != exitSeq) and run the pinned lambda —
+    // even though the page's stamp stays valid the whole time.
+    var epoch = new ApplyPhaseEpoch();
+    scope = new OptimisticReadScope(epoch);
+    when(mockAtomicOp.getOptimisticReadScope()).thenReturn(scope);
+
+    var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
+    when(mockReadCache.getPageFrameOptimistic(FILE_ID, PAGE_INDEX)).thenReturn(frame);
+
+    epoch.enterApplyPhase();
+    try {
+      String result = component.testExecuteOptimisticStorageRead(
+          mockAtomicOp,
+          () -> {
+            component.testLoadPageOptimistic(mockAtomicOp, FILE_ID, PAGE_INDEX);
+            return "optimistic-result";
+          },
+          () -> "pinned-result");
+      assertEquals("pinned-result", result);
+    } finally {
+      epoch.exitApplyPhase();
+    }
+
+    // A failed validation must not bump the eviction frequency sketch.
+    verify(mockReadCache, never()).recordOptimisticAccess(FILE_ID, PAGE_INDEX);
+    releaseFrame(frame);
+  }
+
+  @Test
+  public void testFallbackToPinnedWhenApplyPhaseBeginsMidRead() throws IOException {
+    // Epoch quiescent at capture, but a writer enters (and even completes) an apply
+    // phase between the page read and validation. The live enterSeq no longer matches
+    // the captured value → epoch check fails → pinned fallback runs.
+    var epoch = new ApplyPhaseEpoch();
+    scope = new OptimisticReadScope(epoch);
+    when(mockAtomicOp.getOptimisticReadScope()).thenReturn(scope);
+
+    var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
+    when(mockReadCache.getPageFrameOptimistic(FILE_ID, PAGE_INDEX)).thenReturn(frame);
+
+    String result = component.testExecuteOptimisticStorageRead(
+        mockAtomicOp,
+        () -> {
+          component.testLoadPageOptimistic(mockAtomicOp, FILE_ID, PAGE_INDEX);
+          // Writer commits a full apply phase before this read validates.
+          epoch.enterApplyPhase();
+          epoch.exitApplyPhase();
+          return "optimistic-result";
+        },
+        () -> "pinned-result");
+
+    assertEquals("pinned-result", result);
+    releaseFrame(frame);
+  }
+
+  @Test
+  public void testNestedOptimisticReadSurfacesAssertionError() throws IOException {
+    // Nested executeOptimisticStorageRead calls are a programming error: the inner
+    // reset() wipes the outer scope's stamps, silently voiding the outer validation.
+    // Detection is -ea-only and involves TWO AssertionErrors: the INNER call's
+    // enterAttempt() assert ("... attempt ...") fires first, but it is thrown inside
+    // the outer optimistic lambda and swallowed by the outer fallback catch; the
+    // violation latched in the scope then fails the OUTER catch's exitAttempt() assert,
+    // and THAT error ("... detected ...") is what escapes to the caller — before the
+    // outer pinned lambda gets a chance to run.
+    var assertionsEnabled = false;
+    // Intentional side effect in assert — standard idiom to detect whether -ea is on.
+    assert assertionsEnabled = true;
+    Assume.assumeTrue("Nesting detection requires -ea", assertionsEnabled);
+
+    var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
+    when(mockReadCache.getPageFrameOptimistic(FILE_ID, PAGE_INDEX)).thenReturn(frame);
+
+    final boolean[] outerPinnedRan = {false};
+    try {
+      component.testExecuteOptimisticStorageRead(
+          mockAtomicOp,
+          () -> component.testExecuteOptimisticStorageRead(
+              mockAtomicOp,
+              () -> "inner-optimistic",
+              () -> "inner-pinned"),
+          () -> {
+            outerPinnedRan[0] = true;
+            return "outer-pinned";
+          });
+      fail("Expected AssertionError from nested optimistic read detection");
+    } catch (AssertionError e) {
+      assertTrue(
+          "Expected the outer 'detected' assert to escape, got: " + e.getMessage(),
+          String.valueOf(e.getMessage()).contains("Nested optimistic read detected"));
+    }
+    assertEquals(false, outerPinnedRan[0]);
+
+    // exitAttempt() clears the detection state: a subsequent well-formed read on the
+    // same scope must work normally again.
+    String result = component.testExecuteOptimisticStorageRead(
+        mockAtomicOp,
+        () -> {
+          component.testLoadPageOptimistic(mockAtomicOp, FILE_ID, PAGE_INDEX);
+          return "optimistic-result";
+        },
+        () -> "pinned-result");
+    assertEquals("optimistic-result", result);
+
+    releaseFrame(frame);
   }
 
   private PageFrame acquireFrameWithCoordinates(long fileId, int pageIndex) {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -618,7 +618,7 @@ public class StorageComponentOptimisticReadTest {
 
   @Test
   public void testCheckedIOExceptionPropagatesAndDoesNotPoisonNextRead() throws IOException {
-    // CN-10/BG-1 regression: a checked IOException escaping the optimistic lambda is
+    // Regression: a checked IOException escaping the optimistic lambda is
     // NOT handled by the fallback catch (only RuntimeException | AssertionError route
     // to the pinned path) — it must propagate to the caller. Before the fix, this exit
     // path skipped exitAttempt(), leaving the -ea-only nesting state machine latched

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -616,6 +616,75 @@ public class StorageComponentOptimisticReadTest {
     releaseFrame(frame);
   }
 
+  @Test
+  public void testCheckedIOExceptionPropagatesAndDoesNotPoisonNextRead() throws IOException {
+    // CN-10/BG-1 regression: a checked IOException escaping the optimistic lambda is
+    // NOT handled by the fallback catch (only RuntimeException | AssertionError route
+    // to the pinned path) — it must propagate to the caller. Before the fix, this exit
+    // path skipped exitAttempt(), leaving the -ea-only nesting state machine latched
+    // (attemptActive=true), so the NEXT read on the same scope failed with a spurious
+    // "Nested optimistic read attempt" AssertionError. The finally-based cleanup must
+    // close the attempt on this path too.
+    var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
+    when(mockReadCache.getPageFrameOptimistic(FILE_ID, PAGE_INDEX)).thenReturn(frame);
+
+    try {
+      component.testExecuteOptimisticStorageRead(
+          mockAtomicOp,
+          () -> {
+            throw new IOException("checked failure from optimistic lambda");
+          },
+          () -> "pinned-result");
+      fail("Expected the checked IOException to propagate (not swallowed into fallback)");
+    } catch (IOException expected) {
+      assertEquals("checked failure from optimistic lambda", expected.getMessage());
+    }
+
+    // The next read on the same scope must run normally — no spurious nesting error.
+    String result = component.testExecuteOptimisticStorageRead(
+        mockAtomicOp,
+        () -> {
+          component.testLoadPageOptimistic(mockAtomicOp, FILE_ID, PAGE_INDEX);
+          return "optimistic-result";
+        },
+        () -> "pinned-result");
+    assertEquals("optimistic-result", result);
+
+    releaseFrame(frame);
+  }
+
+  @Test
+  public void testCheckedIOExceptionDoesNotPoisonNextReadVoidVariant() throws IOException {
+    // Void-overload twin of the test above — both overloads carry their own copy of
+    // the enter/exit attempt protocol and must both be exception-complete.
+    var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
+    when(mockReadCache.getPageFrameOptimistic(FILE_ID, PAGE_INDEX)).thenReturn(frame);
+
+    try {
+      component.testExecuteOptimisticStorageReadVoid(
+          mockAtomicOp,
+          () -> {
+            throw new IOException("checked failure from optimistic lambda");
+          },
+          () -> fail("pinned fallback must not run for a checked exception"));
+      fail("Expected the checked IOException to propagate");
+    } catch (IOException expected) {
+      assertEquals("checked failure from optimistic lambda", expected.getMessage());
+    }
+
+    final boolean[] optimisticRan = {false};
+    component.testExecuteOptimisticStorageReadVoid(
+        mockAtomicOp,
+        () -> {
+          component.testLoadPageOptimistic(mockAtomicOp, FILE_ID, PAGE_INDEX);
+          optimisticRan[0] = true;
+        },
+        () -> fail("should not fall back — previous failure must not poison this read"));
+    assertEquals(true, optimisticRan[0]);
+
+    releaseFrame(frame);
+  }
+
   private PageFrame acquireFrameWithCoordinates(long fileId, int pageIndex) {
     var frame = pool.acquire(true, Intention.TEST);
     long exclusiveStamp = frame.acquireExclusiveLock();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -1,7 +1,9 @@
 package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -16,6 +18,7 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocat
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFramePool;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.PageView;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
@@ -24,8 +27,13 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
 import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
@@ -685,6 +693,171 @@ public class StorageComponentOptimisticReadTest {
     releaseFrame(frame);
   }
 
+  // --- Validated-null pinned re-check decision core (belt-and-braces, YTDB-1178) ---
+
+  @Test
+  public void testValidatedNullTriggersExactlyOnePinnedRecheckAndStaysSilent()
+      throws IOException {
+    // A cleanly validated optimistic NULL triggers exactly one pinned re-check; when the
+    // pinned run confirms the miss (agreement), the null is returned silently — no WARN.
+    final int[] pinnedRuns = {0};
+
+    String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
+        mockAtomicOp,
+        () -> null,
+        () -> {
+          pinnedRuns[0]++;
+          return null;
+        },
+        Objects::isNull,
+        () -> "key=42");
+
+    assertNull(result);
+    assertEquals(1, pinnedRuns[0]);
+    assertEquals(0, component.nullRecheckWarnCount);
+  }
+
+  @Test
+  public void testNullRecheckDisagreementReturnsPinnedResultAndWarns() throws IOException {
+    // Disagreement: validated optimistic null, but the pinned re-check finds an entry.
+    // The pinned result is authoritative and returned; exactly one WARN is emitted with
+    // the lookup coordinates.
+    final int[] pinnedRuns = {0};
+
+    String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
+        mockAtomicOp,
+        () -> null,
+        () -> {
+          pinnedRuns[0]++;
+          return "pinned-found";
+        },
+        Objects::isNull,
+        () -> "key=42");
+
+    assertEquals("pinned-found", result);
+    assertEquals(1, pinnedRuns[0]);
+    assertEquals(1, component.nullRecheckWarnCount);
+    assertEquals("key=42", component.lastNullRecheckWarnDescription);
+  }
+
+  @Test
+  public void testNonNullValidatedResultSkipsRecheck() throws IOException {
+    // A cleanly validated non-null result must not pay the re-check: the pinned lambda
+    // never runs.
+    final int[] pinnedRuns = {0};
+    var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
+    when(mockReadCache.getPageFrameOptimistic(FILE_ID, PAGE_INDEX)).thenReturn(frame);
+
+    String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
+        mockAtomicOp,
+        () -> {
+          component.testLoadPageOptimistic(mockAtomicOp, FILE_ID, PAGE_INDEX);
+          return "optimistic-hit";
+        },
+        () -> {
+          pinnedRuns[0]++;
+          return "pinned";
+        },
+        Objects::isNull,
+        () -> "key=42");
+
+    assertEquals("optimistic-hit", result);
+    assertEquals(0, pinnedRuns[0]);
+    assertEquals(0, component.nullRecheckWarnCount);
+    releaseFrame(frame);
+  }
+
+  @Test
+  public void testFallbackPathPerformsNoRecheck() throws IOException {
+    // When the optimistic attempt fails and the pinned fallback runs, its result is
+    // already authoritative: even a null must NOT trigger a re-check — the pinned
+    // lambda executes exactly once (a legitimate miss must not pay the pinned cost
+    // twice more).
+    final int[] pinnedRuns = {0};
+
+    String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
+        mockAtomicOp,
+        () -> {
+          throw OptimisticReadFailedException.INSTANCE;
+        },
+        () -> {
+          pinnedRuns[0]++;
+          return null;
+        },
+        Objects::isNull,
+        () -> "key=42");
+
+    assertNull(result);
+    assertEquals(1, pinnedRuns[0]);
+    assertEquals(0, component.nullRecheckWarnCount);
+  }
+
+  @Test
+  public void testEqualNonNullResultsDoNotWarn() throws IOException {
+    // findVisibleEntry shape: the trigger can fire even when the composed optimistic
+    // result is non-null (inner tree-null with a snapshot-index hit). An equal pinned
+    // result is agreement, not disagreement — no WARN.
+    String result = component.testExecuteOptimisticStorageReadWithNullRecheck(
+        mockAtomicOp,
+        () -> List.of("same"),
+        () -> List.of("same"), // equal by value, distinct instance
+        r -> true,
+        () -> "key=42").get(0);
+
+    assertEquals("same", result);
+    assertEquals(0, component.nullRecheckWarnCount);
+  }
+
+  @Test
+  public void testNullRecheckWarnRateLimiterSuppressesRepeats() {
+    // The rate limiter allows at most one WARN per minute per component; tested with
+    // controlled timestamps against the package-private seam.
+    long t0 = 1L;
+    assertTrue("first emission must be allowed",
+        component.tryAcquireNullRecheckWarnSlot(t0));
+    assertFalse("immediate repeat must be suppressed",
+        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.MILLISECONDS.toNanos(1)));
+    assertFalse("repeat within the interval must be suppressed",
+        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.SECONDS.toNanos(59)));
+    assertTrue("emission after the interval must be allowed",
+        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.SECONDS.toNanos(61)));
+    assertFalse("the fresh emission must restart the interval",
+        component.tryAcquireNullRecheckWarnSlot(t0 + TimeUnit.SECONDS.toNanos(62)));
+  }
+
+  @Test
+  public void testNullRecheckVariantCheckedExceptionDoesNotPoisonNextRead()
+      throws IOException {
+    // The variant carries the same exception-completeness contract as the plain wrapper:
+    // a checked IOException from the optimistic lambda propagates (no fallback, no
+    // re-check) and must not latch the -ea nesting state machine for the next read.
+    try {
+      component.testExecuteOptimisticStorageReadWithNullRecheck(
+          mockAtomicOp,
+          () -> {
+            throw new IOException("checked failure from optimistic lambda");
+          },
+          () -> "pinned",
+          Objects::isNull,
+          () -> "key");
+      fail("Expected the checked IOException to propagate");
+    } catch (IOException expected) {
+      assertEquals("checked failure from optimistic lambda", expected.getMessage());
+    }
+
+    final int[] pinnedRuns = {0};
+    assertNull(component.testExecuteOptimisticStorageReadWithNullRecheck(
+        mockAtomicOp,
+        () -> null,
+        () -> {
+          pinnedRuns[0]++;
+          return null;
+        },
+        Objects::isNull,
+        () -> "key"));
+    assertEquals(1, pinnedRuns[0]);
+  }
+
   private PageFrame acquireFrameWithCoordinates(long fileId, int pageIndex) {
     var frame = pool.acquire(true, Intention.TEST);
     long exclusiveStamp = frame.acquireExclusiveLock();
@@ -732,6 +905,30 @@ public class StorageComponentOptimisticReadTest {
 
     long testAddFile(AtomicOperation op, String fileName) throws IOException {
       return addFile(op, fileName);
+    }
+
+    // --- Validated-null re-check seams ---
+
+    // Captured WARN emissions (the override replaces the LogManager sink so tests can
+    // assert emission counts; the rate limiter is tested separately via its seam).
+    int nullRecheckWarnCount;
+    String lastNullRecheckWarnDescription;
+
+    @Override
+    protected void warnOptimisticNullRecheckDisagreement(
+        Supplier<String> lookupDescription) {
+      nullRecheckWarnCount++;
+      lastNullRecheckWarnDescription = lookupDescription.get();
+    }
+
+    <T> T testExecuteOptimisticStorageReadWithNullRecheck(
+        AtomicOperation op,
+        OptimisticReadFunction<T> optimistic,
+        PinnedReadFunction<T> pinned,
+        Predicate<T> recheckTrigger,
+        Supplier<String> lookupDescription) throws IOException {
+      return executeOptimisticStorageReadWithNullRecheck(
+          op, optimistic, pinned, recheckTrigger, lookupDescription);
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -17,6 +17,7 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocat
 import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocator.Intention;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFramePool;
+import com.jetbrains.youtrackdb.internal.core.config.ContextConfiguration;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
@@ -852,8 +853,30 @@ public class StorageComponentOptimisticReadTest {
   }
 
   @Test
+  public void testNullRecheckErrorRateLimiterHonorsConfiguredInterval() {
+    // The rate-limit interval is configurable via
+    // GlobalConfiguration.STORAGE_OPTIMISTIC_READ_NULL_RECHECK_REPORT_INTERVAL_SECS and is
+    // read through the storage's per-database ContextConfiguration. Injecting a 2-second
+    // interval through the mock storage (per-instance injection — no global configuration
+    // mutation) must shrink the suppression window from the default 60 seconds.
+    var contextConfiguration = new ContextConfiguration();
+    contextConfiguration.setValue(
+        GlobalConfiguration.STORAGE_OPTIMISTIC_READ_NULL_RECHECK_REPORT_INTERVAL_SECS, 2);
+    when(component.storage.getContextConfiguration()).thenReturn(contextConfiguration);
+
+    long t0 = 1L;
+    assertTrue("first emission must be allowed",
+        component.tryAcquireNullRecheckErrorSlot(t0));
+    assertFalse("repeat within the configured 2s interval must be suppressed",
+        component.tryAcquireNullRecheckErrorSlot(t0 + TimeUnit.SECONDS.toNanos(1)));
+    assertTrue("emission after the configured 2s interval must be allowed",
+        component.tryAcquireNullRecheckErrorSlot(t0 + TimeUnit.SECONDS.toNanos(3)));
+  }
+
+  @Test
   public void testNullRecheckErrorRateLimiterSuppressesRepeats() {
-    // The rate limiter allows at most one ERROR per minute per component; tested with
+    // Default interval (60s): no ContextConfiguration is stubbed on the mock storage, so
+    // the limiter takes the GlobalConfiguration-default fallback branch; tested with
     // controlled timestamps against the package-private seam.
     long t0 = 1L;
     assertTrue("first emission must be allowed",

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
@@ -51,8 +51,7 @@ import org.junit.experimental.categories.Category;
  * target key is past its end; the one-hop right-sibling check only inspects sibling
  * index 0 — so any moved key that landed at sibling index &gt; 0 produces a false
  * "absent" result. Upstream, {@code LinkBag.remove} surfaces that as
- * LinksConsistencyException, and {@code LinkBag.add} silently overwrites the counter
- * (AR-4).
+ * LinksConsistencyException, and {@code LinkBag.add} silently overwrites the counter.
  *
  * <p><b>The fix under test:</b> the per-storage {@code ApplyPhaseEpoch} bracket around
  * the commit-time apply loop. A reader whose window overlaps any apply phase fails
@@ -183,7 +182,7 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
   }
 
   /**
-   * Silent add-counter-overwrite variant (AR-4): the first step of a concurrent
+   * Silent add-counter-overwrite variant: the first step of a concurrent
    * {@code LinkBag.add} counter increment is reading the current absolute value via the
    * visible-entry path ({@code findVisibleEntry}). A false-null there makes the add
    * treat the existing rid as absent and reset its counter. While the writer is paused
@@ -205,7 +204,7 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
           operation, RID_BAG_ID, TARGET_COLLECTION, position);
       assertNotNull(
           "findVisibleEntry returned false-null for position " + position
-              + " — a concurrent add would have reset the counter (AR-4)",
+              + " — a concurrent add would have reset the counter",
           pair);
       assertEquals(
           "counter for position " + position + " must be the true committed value",
@@ -425,7 +424,7 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
 
       // The bracket is balanced again. Exactly ONE bump relative to the baseline: the
       // writer's apply. The reader's own commit is a zero-change commit and — since the
-      // CN-11 gating — deliberately does NOT bump the epoch.
+      // zero-change-commit gating — deliberately does NOT bump the epoch.
       assertEquals(epoch.enterSeq(), epoch.exitSeq());
       assertEquals(baseEnter + 1, epoch.enterSeq());
 
@@ -472,7 +471,7 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
       final var state = readerThread.getState();
       final var parked = state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING
           || state == Thread.State.BLOCKED;
-      // Re-check isDone AFTER the state read (TQ-1): a reader that completed between
+      // Re-check isDone AFTER the state read: a reader that completed between
       // the isDone check above and the state read leaves the executor thread parked
       // idle in WAITING, which would be misreported as "blocked on the lock". If it
       // completed, loop back so the isDone branch above surfaces the future's real

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
@@ -246,8 +246,8 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
   private void runMixedStateScenario(LookupAssertion lookup) throws Exception {
     final var epoch = AtomicOperationTestBridge.applyPhaseEpoch(atomicOperationsManager);
     // Baseline is captured while no operation is running (setUp's operations have
-    // committed). Never assert absolute epoch values — every operation (including
-    // read-only ones) brackets its own apply phase at commit.
+    // committed). Never assert absolute epoch values — every commit that mutates
+    // shared cache state bumps the epoch, and this storage is shared across tests.
     final long baseEnter = epoch.enterSeq();
     final long baseExit = epoch.exitSeq();
     assertEquals("epoch must be quiescent at baseline", baseEnter, baseExit);
@@ -423,10 +423,11 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
       assertFalse("writer thread did not finish", writer.isAlive());
       assertNull("writer failed: " + writerError.get(), writerError.get());
 
-      // The bracket is balanced again (writer's apply plus the reader's own read-only
-      // commit both exited); relative lower bound only — never absolute.
+      // The bracket is balanced again. Exactly ONE bump relative to the baseline: the
+      // writer's apply. The reader's own commit is a zero-change commit and — since the
+      // CN-11 gating — deliberately does NOT bump the epoch.
       assertEquals(epoch.enterSeq(), epoch.exitSeq());
-      assertTrue(epoch.enterSeq() >= baseEnter + 2);
+      assertEquals(baseEnter + 1, epoch.enterSeq());
 
       // Final verification on a fresh operation: the fully applied tree serves every
       // pre-built key and the writer's first inserted key correctly.
@@ -456,7 +457,8 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
    * Waits until the reader thread blocks on the component shared lock (its pinned
    * fallback parks after the optimistic attempt failed epoch validation). Completing
    * while the writer is still paused would mean the reader never contended with the
-   * commit — the race would not have been exercised — so that fails the test.
+   * commit — the race would not have been exercised — so that fails the test with the
+   * future's real outcome surfaced.
    */
   private static void awaitReaderBlocked(Thread readerThread, Future<Void> readerFuture)
       throws Exception {
@@ -468,16 +470,24 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
             + " degenerated and the race was not exercised");
       }
       final var state = readerThread.getState();
-      if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING
-          || state == Thread.State.BLOCKED) {
+      final var parked = state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING
+          || state == Thread.State.BLOCKED;
+      // Re-check isDone AFTER the state read (TQ-1): a reader that completed between
+      // the isDone check above and the state read leaves the executor thread parked
+      // idle in WAITING, which would be misreported as "blocked on the lock". If it
+      // completed, loop back so the isDone branch above surfaces the future's real
+      // result or exception instead of a misleading generic assertion.
+      if (parked && !readerFuture.isDone()) {
         return;
       }
       if (System.nanoTime() > deadline) {
         fail("Timed out waiting for the reader to block on the component shared lock;"
-            + " reader state=" + state);
+            + " reader state=" + state + " done=" + readerFuture.isDone());
       }
-      //noinspection BusyWait — polling is the only way to observe lock-park state
-      Thread.sleep(1);
+      if (!readerFuture.isDone()) {
+        //noinspection BusyWait — polling is the only way to observe lock-park state
+        Thread.sleep(1);
+      }
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
@@ -1,0 +1,483 @@
+package com.jetbrains.youtrackdb.internal.core.storage.ridbag.ridbagbtree;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationTestBridge;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsManager;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * End-to-end deterministic regression test for YTDB-1178 against the real
+ * {@link SharedLinkBagBTree} on the disk engine.
+ *
+ * <p><b>The race (CI signature — LinksConsistencyException):</b> a committing
+ * transaction whose leaf split moved keys to a new right sibling applies its changed
+ * pages to the shared read cache one page at a time, in hash order. Per-page StampedLock
+ * stamps are a purely temporal check, so a concurrent optimistic reader overlapping that
+ * apply window can traverse a <em>mixed</em> state with every stamp valid: the shrunk
+ * source leaf and the new sibling already applied, but the parent (and entry point)
+ * still stale. Descending through the stale parent lands on the shrunk leaf; the moved
+ * target key is past its end; the one-hop right-sibling check only inspects sibling
+ * index 0 — so any moved key that landed at sibling index &gt; 0 produces a false
+ * "absent" result. Upstream, {@code LinkBag.remove} surfaces that as
+ * LinksConsistencyException, and {@code LinkBag.add} silently overwrites the counter
+ * (AR-4).
+ *
+ * <p><b>The fix under test:</b> the per-storage {@code ApplyPhaseEpoch} bracket around
+ * the commit-time apply loop. A reader whose window overlaps any apply phase fails
+ * {@code OptimisticReadScope.validateOrThrow()} and falls back to the pinned path, which
+ * blocks on the component shared lock until the writer commits — returning the correct
+ * entry.
+ *
+ * <p><b>Determinism:</b> the {@code PageApplyHook} test seam pins the adversarial apply
+ * order (changed leaves and new sibling pages first, then a barrier, then entry point
+ * and parent/root) and pauses the writer mid-apply — inside the epoch bracket, component
+ * exclusive lock held — while a reader thread performs the lookups. Epoch counters
+ * (baseline-relative), a hook latch, and a reader-blocked check guard against the test
+ * silently degenerating into a non-overlapping schedule.
+ */
+@Category(SequentialTest.class)
+public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
+
+  private static final String DB_NAME = "mixedApplyStateRegressionTest";
+  private static final String DIR_NAME = "/mixedApplyStateRegressionTest";
+
+  // Well-known page indexes of SharedLinkBagBTree (private constants ENTRY_POINT_INDEX
+  // and ROOT_INDEX in production). The hook cross-checks at runtime that both appear
+  // among the changed pages of the split commit, so a drift of these constants fails
+  // loudly instead of silently reordering the wrong pages.
+  private static final long ENTRY_POINT_PAGE = 0;
+  private static final long ROOT_PAGE = 1;
+
+  private static final long RID_BAG_ID = 7L;
+  private static final int TARGET_COLLECTION = 3;
+  // Large enough that the pre-built tree has a root plus several leaves (the harness
+  // tests show a few hundred entries span multiple leaf pages), small enough to stay a
+  // two-level tree so the split leaf's parent is the root.
+  private static final int ENTRY_COUNT = 512;
+  // Counter value used for the writer's new keys, distinguishable from pre-built ones.
+  private static final int NEW_KEY_COUNTER = 7777;
+
+  private static YouTrackDBImpl youTrackDB;
+  private static AbstractStorage storage;
+  private static AtomicOperationsManager atomicOperationsManager;
+  private static String buildDirectory;
+
+  private SharedLinkBagBTree bTree;
+
+  /** Pre-built committed content: targetPosition → expected counter. */
+  private final NavigableMap<Long, Integer> reference = new TreeMap<>();
+
+  @BeforeClass
+  public static void beforeClass() {
+    buildDirectory = System.getProperty("buildDirectory");
+    if (buildDirectory == null) {
+      buildDirectory = "./target" + DIR_NAME;
+    } else {
+      buildDirectory += DIR_NAME;
+    }
+
+    FileUtils.deleteRecursively(new File(buildDirectory));
+
+    youTrackDB = (YouTrackDBImpl) YourTracks.instance(buildDirectory);
+    if (youTrackDB.exists(DB_NAME)) {
+      youTrackDB.drop(DB_NAME);
+    }
+    youTrackDB.create(DB_NAME, DatabaseType.DISK, "admin", "admin", "admin");
+
+    var session = youTrackDB.open(DB_NAME, "admin", "admin");
+    storage = session.getStorage();
+    atomicOperationsManager = storage.getAtomicOperationsManager();
+    session.close();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    youTrackDB.drop(DB_NAME);
+    youTrackDB.close();
+    FileUtils.deleteRecursively(new File(buildDirectory));
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    bTree = new SharedLinkBagBTree(storage, "mixedStateBTree", ".sbc");
+    atomicOperationsManager.executeInsideAtomicOperation(
+        atomicOperation -> bTree.create(atomicOperation));
+
+    // Pre-build and commit the tree in one transaction: EVEN targetPositions only, so
+    // the writer transaction can later interleave new keys at the odd gap positions of
+    // the rightmost leaf until it splits. Committing loads every page into the read
+    // cache, enabling the optimistic read paths.
+    atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+      for (var i = 0; i < ENTRY_COUNT; i++) {
+        var position = 2L * i;
+        bTree.put(atomicOperation,
+            new EdgeKey(RID_BAG_ID, TARGET_COLLECTION, position, 0L),
+            new LinkBagValue(i + 1, 0, 0, false));
+        reference.put(position, i + 1);
+      }
+    });
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    reference.clear();
+    atomicOperationsManager.executeInsideAtomicOperation(
+        atomicOperation -> bTree.delete(atomicOperation));
+  }
+
+  /**
+   * False-null variant (the LinksConsistencyException signature): while the writer is
+   * paused mid-apply in the mixed state, a reader performs {@code findCurrentEntry} —
+   * the prefix lookup used by {@code LinkBag.remove} — for ALL pre-built keys in
+   * descending order. Descending order makes the very first (blocking) lookup target
+   * the moved upper-half range; querying all keys guarantees covering moved keys that
+   * landed at sibling index &gt; 0 without precomputing the split point. With the epoch
+   * every lookup must return the correct entry.
+   */
+  @Test
+  public void testFindCurrentEntryCorrectDuringMixedApplyState() throws Exception {
+    runMixedStateScenario((operation, position, expectedCounter) -> {
+      var pair = bTree.findCurrentEntry(
+          operation, RID_BAG_ID, TARGET_COLLECTION, position);
+      assertNotNull(
+          "findCurrentEntry returned false-null for position " + position
+              + " — the YTDB-1178 mixed-apply-state race leaked through",
+          pair);
+      assertEquals(position, pair.first().targetPosition);
+      assertEquals(
+          "wrong counter for position " + position,
+          expectedCounter, pair.second().counter());
+    });
+  }
+
+  /**
+   * Silent add-counter-overwrite variant (AR-4): the first step of a concurrent
+   * {@code LinkBag.add} counter increment is reading the current absolute value via the
+   * visible-entry path ({@code findVisibleEntry}). A false-null there makes the add
+   * treat the existing rid as absent and reset its counter. While the writer is paused
+   * mid-apply, the reader resolves the visible entry for ALL pre-built rids (descending,
+   * so the first lookup targets the moved range) and must always see the true committed
+   * pre-split counter — never null, never reset.
+   *
+   * <p>Trade-off note: a full two-transaction concurrent add is disproportionate at
+   * this harness level — the second writer's put would serialize on the component
+   * exclusive lock before writing anything, so the only step of the add that can
+   * actually race with the mid-apply state is this initial absolute-value read.
+   * Asserting the read returns the true committed value during the mixed state is the
+   * faithful equivalent of the counter-overwrite scenario.
+   */
+  @Test
+  public void testFindVisibleEntryCounterNotResetDuringMixedApplyState() throws Exception {
+    runMixedStateScenario((operation, position, expectedCounter) -> {
+      var pair = bTree.findVisibleEntry(
+          operation, RID_BAG_ID, TARGET_COLLECTION, position);
+      assertNotNull(
+          "findVisibleEntry returned false-null for position " + position
+              + " — a concurrent add would have reset the counter (AR-4)",
+          pair);
+      assertEquals(
+          "counter for position " + position + " must be the true committed value",
+          expectedCounter, pair.second().counter());
+      assertFalse("entry must not be a tombstone", pair.second().tombstone());
+    });
+  }
+
+  /**
+   * Per-key lookup assertion executed by the reader thread inside its atomic operation.
+   */
+  @FunctionalInterface
+  private interface LookupAssertion {
+
+    void check(AtomicOperation operation, long position, int expectedCounter)
+        throws Exception;
+  }
+
+  /**
+   * Shared choreography for both variants:
+   *
+   * <ol>
+   *   <li>Writer thread: inserts odd-position keys descending from the top gap until
+   *       the rightmost leaf splits (detected via {@code filledUpTo} growth — exactly
+   *       one page is allocated by the split), installs the page-apply hook, and
+   *       returns; the commit then applies changed leaves + new sibling first and pauses
+   *       at the barrier before the entry point and parent/root.
+   *   <li>Main thread: waits for the pause, asserts the epoch is mid-bracket
+   *       (baseline-relative), then starts the reader.
+   *   <li>Reader thread: runs the per-key lookups descending. The first lookup's
+   *       optimistic attempt overlaps the mixed state, fails epoch validation, and its
+   *       pinned fallback blocks on the component shared lock (verified by polling the
+   *       thread state; completing while paused fails the test as degeneration).
+   *   <li>Main thread: releases the barrier; writer finishes; reader unblocks and all
+   *       its assertions must pass; final full verification on a fresh operation.
+   * </ol>
+   */
+  private void runMixedStateScenario(LookupAssertion lookup) throws Exception {
+    final var epoch = AtomicOperationTestBridge.applyPhaseEpoch(atomicOperationsManager);
+    // Baseline is captured while no operation is running (setUp's operations have
+    // committed). Never assert absolute epoch values — every operation (including
+    // read-only ones) brackets its own apply phase at commit.
+    final long baseEnter = epoch.enterSeq();
+    final long baseExit = epoch.exitSeq();
+    assertEquals("epoch must be quiescent at baseline", baseEnter, baseExit);
+
+    final var writerPaused = new CountDownLatch(1);
+    final var releaseWriter = new CountDownLatch(1);
+    final var barrierArmed = new AtomicBoolean(false);
+    final var hookError = new AtomicReference<String>();
+    final var writerError = new AtomicReference<Throwable>();
+    final var insertedCount = new AtomicInteger();
+
+    final var writer = new Thread(() -> {
+      try {
+        atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+          final long btreeFileId = bTree.getFileId();
+          final long preFilled = atomicOperation.filledUpTo(btreeFileId);
+
+          // Insert odd-position keys descending from the top gap. They interleave
+          // with the pre-built even keys of the rightmost leaf, so when the leaf
+          // overflows, the moved upper half is a mix of new and PRE-EXISTING keys —
+          // guaranteeing pre-existing keys land in the new sibling at indexes > 0.
+          // Stop at the first page allocation: the split has happened.
+          var position = 2L * ENTRY_COUNT - 1;
+          while (atomicOperation.filledUpTo(btreeFileId) == preFilled) {
+            if (position < 1) {
+              throw new IllegalStateException(
+                  "Exhausted all odd gap positions without triggering a leaf split"
+                      + " — leaf capacity larger than the pre-built key count");
+            }
+            bTree.put(atomicOperation,
+                new EdgeKey(RID_BAG_ID, TARGET_COLLECTION, position, 0L),
+                new LinkBagValue(NEW_KEY_COUNTER, 0, 0, false));
+            position -= 2;
+            insertedCount.incrementAndGet();
+          }
+
+          // Install the adversarial apply order: changed pre-existing leaves first,
+          // then all new pages (the sibling), then barrier, then entry point + root.
+          AtomicOperationTestBridge.installPageApplyHook(atomicOperation,
+              new AtomicOperationTestBridge.TestPageApplyHook() {
+                @Override
+                public long[] orderPageApplications(
+                    final long fileId, final long[] pageIndexes) {
+                  if (fileId != btreeFileId) {
+                    return null;
+                  }
+                  var hasEntryPoint = false;
+                  var hasRoot = false;
+                  final var preExistingLeaves = new ArrayList<Long>();
+                  final var newPages = new ArrayList<Long>();
+                  for (final var pageIndex : pageIndexes) {
+                    if (pageIndex == ENTRY_POINT_PAGE) {
+                      hasEntryPoint = true;
+                    } else if (pageIndex == ROOT_PAGE) {
+                      hasRoot = true;
+                    } else if (pageIndex < preFilled) {
+                      preExistingLeaves.add(pageIndex);
+                    } else {
+                      newPages.add(pageIndex);
+                    }
+                  }
+                  // Degeneration guards: a leaf split must change the entry point
+                  // (pagesSize), the root (separator), at least one pre-existing leaf
+                  // (the shrunk source), and allocate at least one new page (the
+                  // sibling). Record the violation and keep the default order — the
+                  // barrier stays unarmed so the commit completes and the main thread
+                  // fails on hookError instead of hanging.
+                  if (!hasEntryPoint || !hasRoot
+                      || preExistingLeaves.isEmpty() || newPages.isEmpty()) {
+                    hookError.compareAndSet(null,
+                        "Unexpected changed-page classification: pages="
+                            + Arrays.toString(pageIndexes)
+                            + " preFilled=" + preFilled);
+                    return null;
+                  }
+                  preExistingLeaves.sort(null);
+                  newPages.sort(null);
+                  final var order = new long[pageIndexes.length];
+                  var i = 0;
+                  for (final var pageIndex : preExistingLeaves) {
+                    order[i++] = pageIndex;
+                  }
+                  for (final var pageIndex : newPages) {
+                    order[i++] = pageIndex;
+                  }
+                  order[i++] = ENTRY_POINT_PAGE;
+                  order[i] = ROOT_PAGE;
+                  barrierArmed.set(true);
+                  return order;
+                }
+
+                @Override
+                public void beforePageApply(final long fileId, final long pageIndex) {
+                  // The entry point is the first deferred page: pausing here leaves
+                  // the shrunk leaf and the new sibling applied but the parent/root
+                  // and entry point stale — the CI mixed state.
+                  if (fileId == btreeFileId && pageIndex == ENTRY_POINT_PAGE
+                      && barrierArmed.get()) {
+                    writerPaused.countDown();
+                    try {
+                      if (!releaseWriter.await(120, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException(
+                            "Timed out waiting for the release signal");
+                      }
+                    } catch (InterruptedException e) {
+                      Thread.currentThread().interrupt();
+                      throw new IllegalStateException(e);
+                    }
+                  }
+                }
+              });
+        });
+      } catch (Throwable t) {
+        writerError.set(t);
+      }
+    });
+
+    final ExecutorService readerExecutor = Executors.newSingleThreadExecutor();
+    try {
+      writer.start();
+
+      if (!writerPaused.await(60, TimeUnit.SECONDS)) {
+        writer.join(TimeUnit.SECONDS.toMillis(10));
+        fail("Writer never paused at the mid-apply barrier; hookError="
+            + hookError.get() + " writerError=" + writerError.get());
+      }
+      assertNull("hook classification failed: " + hookError.get(), hookError.get());
+      assertTrue("writer must have inserted at least one key", insertedCount.get() > 0);
+
+      // Mixed-state proof #1: the writer is inside the epoch bracket (one unmatched
+      // enter relative to the baseline). Only the paused writer and this thread are
+      // active, so the relative values are deterministic.
+      assertEquals(baseEnter + 1, epoch.enterSeq());
+      assertEquals(baseExit, epoch.exitSeq());
+
+      // Reader: query ALL pre-built keys in DESCENDING order so the first (blocking)
+      // lookup targets the moved upper-half range.
+      final var readerThreadRef = new AtomicReference<Thread>();
+      final var firstLookupStarted = new CountDownLatch(1);
+      final Future<Void> readerFuture = readerExecutor.submit((Callable<Void>) () -> {
+        readerThreadRef.set(Thread.currentThread());
+        atomicOperationsManager.executeInsideAtomicOperation(operation -> {
+          // Signal right before the first lookup: from here on, the only park point
+          // on the lookup path is the component shared lock in the pinned fallback,
+          // so the main thread's state poll cannot mistake an unrelated wait (class
+          // loading, executor hand-off, operation start) for the lock block.
+          firstLookupStarted.countDown();
+          for (final var entry : reference.descendingMap().entrySet()) {
+            lookup.check(operation, entry.getKey(), entry.getValue());
+          }
+        });
+        return null;
+      });
+
+      assertTrue("reader never reached its first lookup",
+          firstLookupStarted.await(30, TimeUnit.SECONDS));
+      awaitReaderBlocked(readerThreadRef.get(), readerFuture);
+
+      // Mixed-state proof #2: the reader began its lookups during the pause (it is
+      // blocked on the component shared lock) and the apply phase is still open — the
+      // reader's window genuinely overlapped the apply phase.
+      assertEquals(baseEnter + 1, epoch.enterSeq());
+      assertEquals(baseExit, epoch.exitSeq());
+      assertFalse("reader must still be blocked while the writer is paused",
+          readerFuture.isDone());
+
+      releaseWriter.countDown();
+
+      // The reader's per-key assertions run inside the task; get() propagates them.
+      readerFuture.get(120, TimeUnit.SECONDS);
+
+      writer.join(TimeUnit.SECONDS.toMillis(60));
+      assertFalse("writer thread did not finish", writer.isAlive());
+      assertNull("writer failed: " + writerError.get(), writerError.get());
+
+      // The bracket is balanced again (writer's apply plus the reader's own read-only
+      // commit both exited); relative lower bound only — never absolute.
+      assertEquals(epoch.enterSeq(), epoch.exitSeq());
+      assertTrue(epoch.enterSeq() >= baseEnter + 2);
+
+      // Final verification on a fresh operation: the fully applied tree serves every
+      // pre-built key and the writer's first inserted key correctly.
+      atomicOperationsManager.executeInsideAtomicOperation(operation -> {
+        for (final var entry : reference.entrySet()) {
+          final var pair = bTree.findCurrentEntry(
+              operation, RID_BAG_ID, TARGET_COLLECTION, entry.getKey());
+          assertNotNull("post-commit lookup failed for position " + entry.getKey(),
+              pair);
+          assertEquals((int) entry.getValue(), pair.second().counter());
+        }
+        final var firstInserted = bTree.findCurrentEntry(
+            operation, RID_BAG_ID, TARGET_COLLECTION, 2L * ENTRY_COUNT - 1);
+        assertNotNull("writer's first inserted key must be present", firstInserted);
+        assertEquals(NEW_KEY_COUNTER, firstInserted.second().counter());
+      });
+    } finally {
+      // Never leave the writer parked on the barrier (assertion failures above would
+      // otherwise leak a paused thread holding the component exclusive lock).
+      releaseWriter.countDown();
+      readerExecutor.shutdownNow();
+      writer.join(TimeUnit.SECONDS.toMillis(60));
+    }
+  }
+
+  /**
+   * Waits until the reader thread blocks on the component shared lock (its pinned
+   * fallback parks after the optimistic attempt failed epoch validation). Completing
+   * while the writer is still paused would mean the reader never contended with the
+   * commit — the race would not have been exercised — so that fails the test.
+   */
+  private static void awaitReaderBlocked(Thread readerThread, Future<Void> readerFuture)
+      throws Exception {
+    final var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+    while (true) {
+      if (readerFuture.isDone()) {
+        readerFuture.get(); // propagate the real failure, if any
+        fail("Reader completed while the writer was paused mid-apply — the schedule"
+            + " degenerated and the race was not exercised");
+      }
+      final var state = readerThread.getState();
+      if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING
+          || state == Thread.State.BLOCKED) {
+        return;
+      }
+      if (System.nanoTime() > deadline) {
+        fail("Timed out waiting for the reader to block on the component shared lock;"
+            + " reader state=" + state);
+      }
+      //noinspection BusyWait — polling is the only way to observe lock-park state
+      Thread.sleep(1);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeOptimisticReadTest.java
@@ -575,7 +575,7 @@ public class SharedLinkBagBTreeOptimisticReadTest {
    * points. With all pages cached, the optimistic attempt validates cleanly (stamps and
    * epoch), its null result triggers the pinned re-check under the component shared
    * lock, the re-check confirms the miss (agreement), and the null is returned silently
-   * — no disagreement WARN, no behavior change for legitimate misses.
+   * — no disagreement report, no behavior change for legitimate misses.
    */
   @Test
   public void testAbsentKeyLookupsConfirmNullThroughPinnedRecheck() throws Exception {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeOptimisticReadTest.java
@@ -567,6 +567,31 @@ public class SharedLinkBagBTreeOptimisticReadTest {
   }
 
   // ------------------------------------------------------------------
+  // Validated-null pinned re-check (belt-and-braces, YTDB-1178)
+  // ------------------------------------------------------------------
+
+  /**
+   * A lookup of a truly absent key still returns null through both point-lookup entry
+   * points. With all pages cached, the optimistic attempt validates cleanly (stamps and
+   * epoch), its null result triggers the pinned re-check under the component shared
+   * lock, the re-check confirms the miss (agreement), and the null is returned silently
+   * — no disagreement WARN, no behavior change for legitimate misses.
+   */
+  @Test
+  public void testAbsentKeyLookupsConfirmNullThroughPinnedRecheck() throws Exception {
+    atomicOperationsManager.executeInsideAtomicOperation(atomicOperation -> {
+      for (var i = ENTRY_COUNT; i < ENTRY_COUNT + 25; i++) {
+        Assert.assertNull(
+            "findCurrentEntry must confirm the miss for absent key index " + i,
+            bTree.findCurrentEntry(atomicOperation, RID_BAG_ID, i % 32, i));
+        Assert.assertNull(
+            "findVisibleEntry must confirm the miss for absent key index " + i,
+            bTree.findVisibleEntry(atomicOperation, RID_BAG_ID, i % 32, i));
+      }
+    });
+  }
+
+  // ------------------------------------------------------------------
   // Helpers
   // ------------------------------------------------------------------
 


### PR DESCRIPTION
#### Motivation:

A flaky CI failure in `LocalPaginatedStorageRestoreFromWALIT` (`LinksConsistencyException`, YTDB-1178) was root-caused to a general optimistic-read race in the storage layer, not to link bookkeeping. At commit time, a transaction's dirty pages are applied one at a time in hash order, protected only by the component exclusive lock. The pinless optimistic read path takes no component lock, and its per-page stamp validation is purely temporal: it detects pages changing *during* the read window, but cannot detect a mixed state (some of a commit's pages applied, others not yet) that was already in place *before* the window opened. A lock-free multi-page read overlapping an apply phase can therefore compose a per-page-stable but search-inconsistent view of the tree and return a trusted wrong answer:

- a false null from a `LinkBag` point lookup — surfacing as `LinksConsistencyException` on removal, or as a silent counter overwrite on add;
- transient wrong point reads from index engines built on the same read primitive;
- wrong boundary keys from the first/last-key wrappers, whose stamp scopes are vacuous (they record no stamps at all).

Unique-index uniqueness itself was proven safe: the duplicate check, the insert, and the page application all happen under a single component-exclusive-lock hold. The exposure is wrong reads, not persistent index corruption.

#### Planned changes:

**Current state**

Per-page `StampedLock` stamps plus `OptimisticReadScope` chain validation already exist and work as designed — but their guarantee is temporal only. They validate that no page in the read's footprint changed while the read was in flight; they cannot detect that the read started inside a commit's page-application window and observed a mixed, partially-applied state that predates the read window.

**What changes**

No change to query or update semantics. Optimistic reads that overlap a commit's page-application window now detect the overlap and fall back to the existing pinned path under the component shared lock. An ERROR-level anomaly detector reports when a pinned re-check finds an entry that a validated optimistic lookup missed — the lookup self-heals (the pinned result is returned), and the report gives a live signal for any future writer that mutates pages outside the protected bracket. The detector's report is rate-limited, with the interval exposed as a new public `GlobalConfiguration` setting — `youtrackdb.storage.optimisticRead.nullRecheckReportIntervalSecs`, default 60 s (the only new configuration surface). The back-reference consistency diagnostic message now renders the source property's contents instead of a `ClassCastException` placeholder.

**How**

- **Apply-phase epoch.** Two per-storage monotonic counters, owned by `AtomicOperationsManager`, bracket the page-application section of the atomic-operation commit: one enter/exit pair spanning from file deletions through the page-apply loop, with the exit incremented in a finally block so an escaping exception can never leave the epoch permanently "open". Zero-change commits (read-only atomic operations that mutate no shared cache state) skip the bracket entirely, so they never invalidate concurrent readers.
- **Scope wiring.** `OptimisticReadScope` captures both counters when it is reset and, after the per-frame stamp validation loop completes, fails validation if an apply was in flight at capture time or began during the read. Failure reuses the existing optimistic-read-failure fallback, so the caller transparently retries via the pinned path.
- **Belt-and-braces detector.** `SharedLinkBagBTree` additionally re-checks a validated null result via the pinned path under the component shared lock; on disagreement the pinned result is returned and a rate-limited ERROR is logged, with the interval read from the new `GlobalConfiguration` setting.
- **Documentation correction.** The `OptimisticReadScope` documentation is corrected to state that stamps provide a temporal guarantee only, and that the apply-phase epoch is what provides the cross-page consistency guarantee.

**Key decisions**

- **Epoch over B-link reader-only descent:** under hash-ordered page application, a moved entry can transiently exist in *no* applied page, so a reader-side link-chasing protocol cannot recover the entry.
- **Epoch over B-link reader+writer ordering:** bucket pages lack a high key, so this would require a page-format change plus a permanent, fragile apply-ordering contract on the writer.
- **Epoch over validating against the component-lock lifetime:** that window spans the whole commit, which would degrade optimistic reads to blocking under write load.
- **Epoch over a LinkBag-local pinned-retry-only fix:** a local retry leaves index, record, and free-space reads exposed to the same race class.
- **Two enter/exit counters instead of a single odd/even seqlock word:** applies of different components' operations run concurrently, so the parity of one word breaks.
- **Counters owned per-storage by `AtomicOperationsManager`, not by the `ReadCache`:** on the disk engine the read cache is engine-global and shared across storages, so one database's applies would falsely invalidate another's reads.
- **Epoch re-checked after the per-frame stamp loop:** required for JMM soundness — a bare pre-loop read could sink past the stamp checks and void the seqlock-style guarantee.
- **Belt-and-braces retry keyed only on a null that passed both stamp and epoch validation:** this keeps the anomaly detector a genuine signal rather than noise from ordinary stamp races.
- **Detector severity ERROR, not WARN:** visibility is resolved against a fixed operation snapshot, so a benign concurrently committed insert cannot explain a re-check disagreement — any emission is a genuine anomaly worth reporting.

**Out of scope**

Five follow-up issues have been drafted separately:

1. sbtree v3 free-list page reuse keeping stale-but-parsable page images reachable;
2. `ChangeableRecordId` collection-id comparison bug (compares against the wrong field);
3. LinkBag btree manager bagId-counter under-restore on load (bagId reuse after restart);
4. `LinkBagPointer` validity predicate contradicting the negative-id allocator — currently forces delta serialization of bags to embedded form;
5. per-component epoch granularity refinement.

**Risks & accepted trade-offs**

- Retry cost on legitimate lookup misses: the pinned re-check is a cached-page double descent, and it blocks only while a writer is mid-commit — a case where waiting is required for correctness anyway.
- Per-storage epoch granularity causes false invalidation from applies of unrelated components: the cost is only a spurious pinned fallback, never a wrong result.
- Load-bearing invariant documented as part of the change: WAL replay, incremental-backup restore, and file shrinking run reader-free under the storage state write lock — they mutate pages outside the epoch bracket and are safe only because no optimistic reader can exist concurrently.

Adversarial review round 1: passed, decision reversed (epoch primary), 2 accepted risks (AR-1/CN-3 retry cost on legitimate misses; per-storage epoch false-invalidation trade-off) — 2026-07-13

Adversarial review round 2 (epoch design): passed, no blockers, 5 spec gaps folded into design, 0 new accepted risks — 2026-07-14

**Verification approach**

An order-controlling page-application test seam (disk engine only — the in-memory engine's optimistic path is structurally disabled) deterministically reproduces the race without the epoch and proves invalidation plus fallback with it, covering both the deletion-exception and the silent add-counter-overwrite variants. Plus: epoch protocol unit tests including concurrent applies, detector emission and rate-limiter unit tests, content-asserting diagnostic rendering tests, the core unit and storage integration suites, and the coverage gate.

#### Tracks:

| # | Track | Scope | Status | Satellite PR |
|---|-------|-------|--------|--------------|
| 01 | Apply-phase epoch mechanism | Epoch counters in the atomic-operations layer, `OptimisticReadScope` wiring (incl. its documentation correction), order-controlling test seam, regression + unit tests | complete (agent-reviewed, user-reviewed 2026-07-14) | waived |
| 02 | LinkBag hardening + diagnostics | `SharedLinkBagBTree` pinned re-check of validated-null lookups with rate-limited ERROR anomaly detector (configurable report interval) + back-reference diagnostic `ClassCastException` fix with content-asserting tests | complete (agent-reviewed, user-reviewed 2026-07-15) | waived |

Satellite review PRs: declined by user for all tracks.


