### PR TITLE
Slate: start orchestrator mode by default via .pi/slate.json config

### DIFF
--- a/.pi/extensions/slate/index.ts
+++ b/.pi/extensions/slate/index.ts
@@ -18,7 +18,7 @@
  *
  * Optional config at .pi/slate.json:
  *   { "episodeModel": "provider/id", "workerTools": [...], "maxConcurrent": 4,
- *     "pauseThresholdPercent": 40,
+ *     "pauseThresholdPercent": 40, "orchestratorModeDefault": true,
  *     "orchestratorPromptDocs": ["docs/agents/orchestrator-guidelines.md"],
  *     "workerPromptDocs": ["docs/agents/thread-guidelines.md"] }
  */

--- a/.pi/extensions/slate/mode.ts
+++ b/.pi/extensions/slate/mode.ts
@@ -190,9 +190,11 @@ export function registerSlateMode(
 		// seed, while resumed/forked real sessions and explicit /slate off
 		// decisions stay untouched. Deliberately NOT saved — persisting would
 		// lock the default into old sessions even after the config flag is later
-		// turned off; the first real mutation persists it. The hasUI gate keeps
-		// non-interactive (print/RPC) sessions unaffected.
-		if (!store.orchestratorMode && ctx.hasUI && getConfig().orchestratorModeDefault === true) {
+		// turned off; the first real mutation persists it. The mode === "tui"
+		// gate limits the seed to interactive terminal sessions — hasUI would not
+		// do: it is also true in RPC mode, and scripted/automated runs
+		// (print/JSON/RPC) must not silently lose tactical tools.
+		if (!store.orchestratorMode && ctx.mode === "tui" && getConfig().orchestratorModeDefault === true) {
 			const fresh = !ctx.sessionManager.getBranch().some((entry) => {
 				// Loose cast like state.ts restore(): tolerate malformed/legacy entries.
 				const e = entry as { type: string; customType?: string };

--- a/.pi/extensions/slate/mode.ts
+++ b/.pi/extensions/slate/mode.ts
@@ -6,7 +6,10 @@
  *     delegation becomes the natural behavior;
  *   - the thread-weaving doctrine is appended to the system prompt each turn;
  *   - a widget above the editor shows live thread status;
- *   - the mode persists in slate state and is re-applied on session restore.
+ *   - the mode persists in slate state and is re-applied on session restore;
+ *   - with config `orchestratorModeDefault` (.pi/slate.json), genuinely fresh
+ *     interactive sessions are seeded with the mode ON (unsaved until the
+ *     first real state mutation).
  *
  * `/slate handoff [focus]` / `/slate resume` interact with the auto-pause
  * machinery in handoff.ts (context budget → paused → fresh-session handoff).
@@ -178,6 +181,25 @@ export function registerSlateMode(
 		// store.restore() (index.ts) and pending-handoff adoption (handoff.ts)
 		// ran before this handler in registration order; re-apply the persisted
 		// mode to the fresh runtime.
+		//
+		// Config-driven default: seed orchestrator mode ON for a genuinely FRESH
+		// interactive session. Running AFTER restore and handoff adoption means
+		// the seed can neither clobber persisted state nor trip the adoption
+		// guard. "Fresh" = no message entries and no recorded slate state on the
+		// branch: metadata-only entries (e.g., session naming) don't suppress the
+		// seed, while resumed/forked real sessions and explicit /slate off
+		// decisions stay untouched. Deliberately NOT saved — persisting would
+		// lock the default into old sessions even after the config flag is later
+		// turned off; the first real mutation persists it. The hasUI gate keeps
+		// non-interactive (print/RPC) sessions unaffected.
+		if (!store.orchestratorMode && ctx.hasUI && getConfig().orchestratorModeDefault === true) {
+			const fresh = !ctx.sessionManager.getBranch().some((entry) => {
+				// Loose cast like state.ts restore(): tolerate malformed/legacy entries.
+				const e = entry as { type: string; customType?: string };
+				return e.type === "message" || (e.type === "custom" && e.customType === "slate-state");
+			});
+			if (fresh) store.orchestratorMode = true;
+		}
 		if (store.orchestratorMode) {
 			const active = pi.getActiveTools();
 			const alreadyRestricted =

--- a/.pi/extensions/slate/state.ts
+++ b/.pi/extensions/slate/state.ts
@@ -46,6 +46,7 @@ export interface SlateConfig {
 	workerTools?: string[];
 	maxConcurrent?: number;
 	pauseThresholdPercent?: number; // orchestrator context budget for auto-pause (default 40)
+	orchestratorModeDefault?: boolean; // seed orchestrator mode ON for fresh interactive sessions (unsaved until first real mutation)
 	orchestratorPromptDocs?: string[]; // role-guideline docs appended to the orchestrator prompt (paths, cwd-relative)
 	workerPromptDocs?: string[]; // role-guideline docs appended to worker system prompts (paths, cwd-relative)
 }

--- a/.pi/slate.json
+++ b/.pi/slate.json
@@ -1,0 +1,3 @@
+{
+  "orchestratorModeDefault": true
+}


### PR DESCRIPTION
#### Motivation:

Slate orchestrator mode is the standard working mode for this repository, but every new pi session starts with it off, requiring a manual `/slate on`. Forgetting it leaves sessions running without the orchestrator workflow guards. This change makes orchestrator mode the default for fresh interactive sessions via project configuration.

#### Planned changes:

**Current state.** The slate extension loads automatically in trusted checkouts, but orchestrator mode always starts off; enabling it is a per-session manual toggle persisted in slate's session state.
**What changes.** Slate's project config (`.pi/slate.json`) gains an `orchestratorModeDefault` flag (default off). With the flag on — as committed for this repository — a genuinely fresh interactive session starts in orchestrator mode. Persisted slate state always takes precedence: a session where `/slate off` was recorded stays off across restarts. Non-interactive sessions (print/JSON/RPC) are never seeded.
**How.** The seed is applied during the mode-restore step at session start, after persisted-state restore and pending-handoff adoption, and only when the session has no prior conversation (no message entries) and no recorded slate state. The seeded mode is not persisted until a real state mutation occurs.
**Key decisions.**
- Seed after handoff adoption, not before: an earlier seed would trip the adoption guard and discard pending handoff state (threads, episodes, carried cost).
- Freshness defined as "no conversation and no recorded slate state" rather than an entirely empty session or the session-start reason: metadata entries (e.g., session naming) must not suppress the seed, and resumed/continued old sessions must never be force-flipped mid-task.
- Unsaved seed: persisting it would lock the default into old sessions even after the config flag is later turned off.
- Interactive TUI sessions only: the seed fires only in interactive TUI sessions — the UI-availability flag was insufficient because it is also set in RPC mode (caught and fixed in code review); scripted/automated runs (print/JSON/RPC) never lose tactical tools.
**Risks & accepted trade-offs.**
- Precedence of an explicit `/slate off` is branch-scoped: forking from a point before the off-record re-applies the default.
- A seeded session with zero slate mutations is not re-seeded on continue/resume (nothing was persisted).
- No per-user opt-out of the committed flag; escape hatches are `/slate off`, `--no-extensions`, or a local config edit.
- Design review: user-approved — 2026-07-14
- Adversarial review: passed, 3 accepted risks — 2026-07-14 (2 rounds; round-1 blocker and should-fix reversed, round-2 should-fixes folded into the design)
- Code review: passed — 1 should-fix fixed and independently verified, remaining suggestion covered by the accepted opt-out risk — 2026-07-14
**Verification approach.** Manual session-lifecycle checks (fresh start seeds mode; off-then-restart stays off; handoff adoption unaffected; named-session start still seeds; print mode not seeded). No automated test infra exists for `.pi` extensions.
