### PR TITLE
Streamline README and remove jmh-ldbc README frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Reddit](https://img.shields.io/badge/Reddit-%23FF4500.svg?style=for-the-badge&logo=Reddit&logoColor=white)](https://www.reddit.com/r/youtrackdb/)<br/>
 
 ------
-[Issue tracker](https://youtrack.jetbrains.com/issues/YTDB) | [Getting started](docs/getting-started.md)
+[Issue tracker](https://youtrack.jetbrains.com/issues/YTDB) | [Getting started](docs/getting-started.md) | [Daily LDBC benchmarks](https://bench.youtrackdb.io/)
 
 ### Join our Zulip community!
 
@@ -131,12 +131,6 @@ For more examples covering both server and embedded deployments, check out the
 [examples](examples/src/main/java/io/youtrackdb/examples) project.
 
 ### Contributing
-
-YouTrackDB runs every non-trivial change through a structured development
-workflow: research, design, plan review, track-by-track implementation, and
-review. The full protocol and contributor role guidelines live in the
-internal documentation — start at the
-[project-internal documentation index](docs-internal/README.md).
 
 To understand how the query engine itself works, read *Inside the
 YouTrackDB Query Engine*, a deep-dive book explaining how YouTrackDB

--- a/jmh-ldbc/README.md
+++ b/jmh-ldbc/README.md
@@ -1,13 +1,3 @@
----
-source_files:
-  - jmh-ldbc/src/main/java/**
-  - jmh-ldbc/src/main/resources/ldbc-schema.sql
-  - jmh-ldbc/src/main/resources/ldbc-queries/**
-  - jmh-ldbc/pom.xml
-related_docs:
-  - docs/README.md
----
-
 # YouTrackDB LDBC JMH Benchmarks
 
 JMH microbenchmarks for YouTrackDB based on the [LDBC Social Network Benchmark (SNB)](https://ldbcouncil.org/benchmarks/snb/) Interactive workload. Each benchmark method executes a single LDBC read query using YouTrackDB's SQL engine (MATCH queries).


### PR DESCRIPTION
#### Motivation:

The README Contributing section restated the internal development
workflow that already lives in `docs-internal/`, duplicating content
that can drift out of sync; it now points only to the query-engine
deep-dive book. The header lacked a link to the public daily LDBC
benchmark dashboard, which is useful for anyone tracking performance.
The `jmh-ldbc` README carried YAML frontmatter
(`source_files`/`related_docs`) that served no purpose in the rendered
document.

#### Planned changes:

Doc-only, trivial change. Add a "Daily LDBC benchmarks" link
(https://bench.youtrackdb.io/) to the README header nav line, remove
the development-workflow paragraph from the Contributing section
(leaving only the query-engine book pointer), and strip the YAML
frontmatter block from `jmh-ldbc/README.md`.

#### Tracks:

N/A (single-track)
