### PR TITLE
YTDB-1203: Refine optimistic-read apply-phase epoch to per-component granularity

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpoch.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpoch.java
@@ -3,7 +3,8 @@ package com.jetbrains.youtrackdb.internal.core.storage.cache;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Per-storage epoch bracketing the commit-time page-apply phase of atomic operations.
+ * Per-component epoch bracketing the commit-time page-apply phase of atomic operations
+ * for the files of one top-level storage component.
  *
  * <p>Optimistic multi-page reads validate each page individually via {@link
  * com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame} stamps, but per-page
@@ -19,23 +20,27 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * <ul>
  *   <li>{@code applyEnterSeq} — incremented immediately <em>before</em> a committing
- *       operation starts mutating shared cache state (file deletion/creation/truncation
- *       and the per-page apply loop);
+ *       operation that mutates this component's files starts mutating shared cache state
+ *       (file deletion/creation/truncation and the per-page apply loop);
  *   <li>{@code applyExitSeq} — incremented immediately <em>after</em> that section
  *       completes (in a {@code finally} block, so an escaping exception cannot leave the
  *       epoch permanently "in apply" and shut down optimistic reads).
  * </ul>
  *
  * <p>Two independent counters are used instead of a single odd/even parity word because
- * apply phases of <em>different</em> components may run concurrently within one storage:
- * with parity, a second writer entering while the first is still applying would flip the
- * bit back to "idle" and mask the overlap. With separate counters the idle condition is
- * {@code enterSeq == exitSeq}, which holds only when no apply phase is in flight.
+ * apply phases bumping the <em>same</em> epoch may overlap: an epoch instance is shared
+ * between a parent component and its sub-components (e.g., a collection and its position
+ * map), and two commits that locked different components of that family can apply
+ * concurrently. With parity, a second writer entering while the first is still applying
+ * would flip the bit back to "idle" and mask the overlap. With separate counters the idle
+ * condition is {@code enterSeq == exitSeq}, which holds only when no apply phase is in
+ * flight.
  *
  * <p>Reader protocol (see {@link OptimisticReadScope}):
  *
  * <ol>
- *   <li>At {@link OptimisticReadScope#reset()}, capture {@code exitSeq} first, then
+ *   <li>At {@link OptimisticReadScope#reset(ApplyPhaseEpoch)}, capture {@code exitSeq}
+ *       first, then
  *       {@code enterSeq}. Reading exit before enter is deliberate: if the two captured
  *       values are equal, every apply that had entered by the time {@code enterSeq} was
  *       read had already exited <em>before</em> the capture started, so no apply phase
@@ -53,11 +58,18 @@ import java.util.concurrent.atomic.AtomicLong;
  * unchanged {@code enterSeq} therefore observed either none or all of any committed
  * apply's effects — never a partial mix.
  *
- * <p>Ownership: one instance per storage, owned by
- * {@code AtomicOperationsManager}. Deliberately <em>not</em> placed on {@code ReadCache}:
- * on the disk engine a single read cache is shared by all storages of the engine, and an
- * engine-global epoch would let commits in one database spuriously invalidate optimistic
- * reads in another.
+ * <p>Ownership (YTDB-1203): one instance per <em>top-level</em>
+ * {@code StorageComponent}; sub-components (position map, free-space map, dirty-page
+ * bit set) share their parent collection's instance so one optimistic read spanning
+ * parent and sub-component files validates a single epoch. Every file id a component
+ * creates or opens is mapped to the component's epoch in the per-storage
+ * {@link ComponentEpochRegistry} (owned by {@code AtomicOperationsManager}); committing
+ * operations resolve their mutated file ids through that registry and bracket every
+ * distinct resolved epoch. The epoch is per component rather than per storage so a
+ * commit into one component does not spuriously invalidate concurrent optimistic reads
+ * of unrelated components, and deliberately <em>not</em> engine-global (on
+ * {@code ReadCache}) because on the disk engine a single read cache is shared by all
+ * storages of the engine.
  */
 public final class ApplyPhaseEpoch {
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ComponentEpochRegistry.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ComponentEpochRegistry.java
@@ -1,0 +1,96 @@
+package com.jetbrains.youtrackdb.internal.core.storage.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Per-storage registry mapping every component-owned file id to the {@link ApplyPhaseEpoch}
+ * of the top-level storage component that owns the file (YTDB-1203).
+ *
+ * <p>Keys are <em>external</em> composed file ids (storage id in the high 32 bits, see
+ * {@code AbstractWriteCache.composeFileId}), matching the ids stored in component
+ * {@code fileId} fields and reported by {@code PageFrame.getFileId()}, so entries of
+ * different storages can never collide even if registries were ever merged.
+ *
+ * <p>Population: exclusively through the {@code StorageComponent.addFile}/{@code openFile}
+ * funnel — every file a component creates or opens is mapped to that component's epoch
+ * (sub-components register their files under the parent component's epoch instance).
+ * Registration may run under the storage {@code stateLock} <em>read</em> side (e.g.,
+ * {@code SharedLinkBagBTree} creation during normal transactions), so the registry is a
+ * lock-free concurrent map and assumes no external locking.
+ *
+ * <p>Lifecycle invariants:
+ *
+ * <ul>
+ *   <li><b>Entries are never removed.</b> The commit that deletes a file must itself
+ *       resolve the deleted file id to the owner's epoch and bump it (see
+ *       {@code AtomicOperationBinaryTracking.commitChanges}); removing the entry when the
+ *       component is dropped — which happens <em>before</em> that commit applies — would
+ *       make the deleting commit miss its own bump.
+ *   <li><b>Overwrite on reuse.</b> The disk engine reuses the internal file id when a file
+ *       with the same name is recreated after a delete; the recreating component's
+ *       registration simply overwrites the stale mapping. (Accepted narrowing: a stale
+ *       component reference surviving such a drop/recreate reads the new incarnation's
+ *       pages under the dead epoch — such use-after-drop access is already semantically
+ *       void and is excluded by the storage {@code stateLock} for live readers.)
+ * </ul>
+ */
+public final class ComponentEpochRegistry {
+
+  private final ConcurrentHashMap<Long, ApplyPhaseEpoch> epochsByFileId =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Standalone fallback (see {@link #uniform(ApplyPhaseEpoch)}): when non-null, every
+   * file id without an explicit entry resolves to this epoch instead of {@code null}.
+   * Always {@code null} for production registries.
+   */
+  @Nullable private final ApplyPhaseEpoch universalEpoch;
+
+  /**
+   * Creates a production registry: file ids resolve only through explicit
+   * {@link #register} calls, and a miss returns {@code null} so
+   * {@code AtomicOperationBinaryTracking.commitChanges} can fail loud on files created
+   * or loaded outside the {@code StorageComponent} funnel.
+   */
+  public ComponentEpochRegistry() {
+    this.universalEpoch = null;
+  }
+
+  private ComponentEpochRegistry(@Nonnull final ApplyPhaseEpoch universalEpoch) {
+    this.universalEpoch = universalEpoch;
+  }
+
+  /**
+   * Creates a standalone registry (tests, tooling) that resolves <em>every</em> file id
+   * to the single given epoch. This mirrors the pre-per-component (storage-wide) epoch
+   * semantics for atomic operations constructed outside a storage: commit-time epoch
+   * resolution always succeeds and produces exactly one enter/exit pair per commit.
+   * Production code must use {@link #ComponentEpochRegistry()} and the component funnel.
+   */
+  public static ComponentEpochRegistry uniform(@Nonnull final ApplyPhaseEpoch epoch) {
+    assert epoch != null : "epoch must not be null";
+    return new ComponentEpochRegistry(epoch);
+  }
+
+  /**
+   * Maps {@code fileId} to the owning component's epoch, overwriting any previous
+   * mapping (file-id reuse on same-name recreate). Never removes entries — see the
+   * class-level lifecycle invariants.
+   */
+  public void register(final long fileId, @Nonnull final ApplyPhaseEpoch epoch) {
+    assert epoch != null : "epoch must not be null";
+    epochsByFileId.put(fileId, epoch);
+  }
+
+  /**
+   * Returns the epoch guarding the given file, or {@code null} if the file was never
+   * registered (production registries only; {@link #uniform(ApplyPhaseEpoch)} registries
+   * fall back to their universal epoch and never return {@code null}).
+   */
+  @Nullable public ApplyPhaseEpoch epochFor(final long fileId) {
+    final var epoch = epochsByFileId.get(fileId);
+    return epoch != null ? epoch : universalEpoch;
+  }
+}

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
@@ -14,14 +14,21 @@ import java.util.Arrays;
  *       committing transaction applies its changes page-by-page, so a reader overlapping
  *       that apply window can see a mix of pre- and post-commit pages while every stamp
  *       stays valid.
- *   <li><b>Apply-phase epoch</b> — the cross-page consistency guarantee. {@link #reset()}
- *       captures the storage's {@link ApplyPhaseEpoch} counters and
+ *   <li><b>Apply-phase epoch</b> — the cross-page consistency guarantee.
+ *       {@link #reset(ApplyPhaseEpoch)} captures the counters of the target
+ *       <em>component's</em> {@link ApplyPhaseEpoch} (YTDB-1203) and
  *       {@link #validateOrThrow()} re-checks them after the stamp loop; the read fails if
- *       any commit-time apply phase overlapped the read window.
+ *       a commit-time apply phase of that component overlapped the read window. One
+ *       attempt validates exactly one epoch, so an optimistic lambda must not span files
+ *       of two different top-level components (sub-components share the parent's epoch
+ *       instance, which is what makes multi-file reads like collection + position map
+ *       sound).
  * </ul>
  *
  * <p>Stored in {@code AtomicOperation} and reused across optimistic read attempts within
- * the same transaction. {@link #reset()} is called before each attempt.
+ * the same transaction — including attempts on <em>different</em> components, which is
+ * why the epoch is re-captured per attempt via {@link #reset(ApplyPhaseEpoch)} rather
+ * than fixed at construction.
  *
  * <p>Not thread-safe — each AtomicOperation belongs to a single thread.
  */
@@ -29,8 +36,11 @@ public final class OptimisticReadScope {
 
   private static final int INITIAL_CAPACITY = 8;
 
-  // Per-storage apply-phase epoch shared with all writers of the same storage.
-  private final ApplyPhaseEpoch applyPhaseEpoch;
+  // Apply-phase epoch of the component the CURRENT read attempt targets; set by
+  // reset(ApplyPhaseEpoch) before each attempt. Initialized to a private, never-bumped
+  // epoch so scopes used without a reset (standalone tests, tooling) trivially pass the
+  // epoch check and only per-page stamp validation applies.
+  private ApplyPhaseEpoch applyPhaseEpoch = new ApplyPhaseEpoch();
 
   private PageFrame[] frames;
   private long[] stamps;
@@ -52,20 +62,13 @@ public final class OptimisticReadScope {
   private boolean nestedResetDetected;
 
   /**
-   * Convenience constructor for standalone use (tests, tooling) where no epoch is shared
-   * with concurrent writers: allocates a private {@link ApplyPhaseEpoch} that no writer
-   * ever bumps, so epoch validation trivially passes and only per-page stamp validation
-   * applies. Production code must pass the storage-wide epoch owned by
-   * {@code AtomicOperationsManager} (via {@code AtomicOperationBinaryTracking}), otherwise
-   * commit-time apply phases would be invisible to this scope.
+   * Creates an empty scope. No epoch is bound at construction — production readers
+   * capture the target component's epoch per attempt via {@link #reset(ApplyPhaseEpoch)}.
+   * Until the first reset, the scope holds a private, never-bumped epoch so standalone
+   * use (tests, tooling) that records and validates stamps without a reset gets a
+   * trivially passing epoch check.
    */
   public OptimisticReadScope() {
-    this(new ApplyPhaseEpoch());
-  }
-
-  public OptimisticReadScope(ApplyPhaseEpoch applyPhaseEpoch) {
-    assert applyPhaseEpoch != null : "ApplyPhaseEpoch must not be null";
-    this.applyPhaseEpoch = applyPhaseEpoch;
     this.frames = new PageFrame[INITIAL_CAPACITY];
     this.stamps = new long[INITIAL_CAPACITY];
     this.count = 0;
@@ -130,15 +133,23 @@ public final class OptimisticReadScope {
   }
 
   /**
-   * Resets the scope for reuse and captures the apply-phase epoch for the upcoming read
-   * attempt. Nulls frame references up to the current count to avoid preventing garbage
-   * collection of evicted PageFrames.
+   * Resets the scope for reuse and captures the given component's apply-phase epoch for
+   * the upcoming read attempt (YTDB-1203: the scope serves sequential attempts on
+   * different components within one atomic operation, so the epoch is bound per attempt,
+   * not per scope). Nulls frame references up to the current count to avoid preventing
+   * garbage collection of evicted PageFrames.
    *
    * <p>Contract: this method must never throw — it is invoked outside the try/fallback
    * block of {@code StorageComponent.executeOptimisticStorageRead}, so an exception here
-   * would escape past the pinned fallback instead of triggering it.
+   * would escape past the pinned fallback instead of triggering it. (The null-check
+   * assert below can only fire on a programming error: production callers pass their
+   * component's final epoch field.)
+   *
+   * @param componentEpoch the apply-phase epoch of the component this attempt reads
    */
-  public void reset() {
+  public void reset(final ApplyPhaseEpoch componentEpoch) {
+    assert componentEpoch != null : "componentEpoch must not be null";
+    applyPhaseEpoch = componentEpoch;
     // Nesting detection (-ea builds only): attemptActive can be true here only when a
     // surrounding executeOptimisticStorageRead is still in flight — i.e., this reset
     // belongs to a nested attempt that is about to wipe the outer scope's stamps.
@@ -192,6 +203,28 @@ public final class OptimisticReadScope {
     attemptActive = false;
     nestedResetDetected = false;
     return wellFormed;
+  }
+
+  /**
+   * Returns the epoch captured by the last {@link #reset(ApplyPhaseEpoch)} (or the
+   * private standalone epoch if the scope was never reset). Consumed by the -ea-only
+   * invariant checks in {@code StorageComponent}: every page recorded — or pinned-read
+   * while an optimistic attempt is in flight — must belong to a file whose registered
+   * epoch IS (reference equality) this captured epoch.
+   */
+  public ApplyPhaseEpoch capturedEpoch() {
+    return applyPhaseEpoch;
+  }
+
+  /**
+   * Returns whether an optimistic read attempt is currently in flight. The underlying
+   * flag is maintained only under {@code -ea} ({@link #enterAttempt()}/
+   * {@link #exitAttempt()} are invoked via {@code assert}), so this accessor must itself
+   * only be consulted from {@code assert} statements — with assertions disabled it is
+   * always {@code false}.
+   */
+  public boolean isAttemptActive() {
+    return attemptActive;
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
@@ -36,11 +36,19 @@ public final class OptimisticReadScope {
 
   private static final int INITIAL_CAPACITY = 8;
 
+  // Shared never-bumped sentinel bound to scopes that were not yet reset(...). Safe to
+  // share across all scopes because no writer ever bumps it — its counters stay 0/0
+  // forever, so epoch validation against it trivially passes and no cross-scope
+  // interference is possible. Avoids allocating a throwaway epoch (plus two
+  // AtomicLongs) per scope that the first reset immediately discards (review findings
+  // CN-2/PF-1).
+  private static final ApplyPhaseEpoch NEVER_BUMPED_SENTINEL = new ApplyPhaseEpoch();
+
   // Apply-phase epoch of the component the CURRENT read attempt targets; set by
-  // reset(ApplyPhaseEpoch) before each attempt. Initialized to a private, never-bumped
-  // epoch so scopes used without a reset (standalone tests, tooling) trivially pass the
-  // epoch check and only per-page stamp validation applies.
-  private ApplyPhaseEpoch applyPhaseEpoch = new ApplyPhaseEpoch();
+  // reset(ApplyPhaseEpoch) before each attempt. Initialized to the never-bumped
+  // sentinel so scopes used without a reset (standalone tests, tooling) trivially pass
+  // the epoch check and only per-page stamp validation applies.
+  private ApplyPhaseEpoch applyPhaseEpoch = NEVER_BUMPED_SENTINEL;
 
   private PageFrame[] frames;
   private long[] stamps;
@@ -69,9 +77,9 @@ public final class OptimisticReadScope {
   /**
    * Creates an empty scope. No epoch is bound at construction — production readers
    * capture the target component's epoch per attempt via {@link #reset(ApplyPhaseEpoch)}.
-   * Until the first reset, the scope holds a private, never-bumped epoch so standalone
-   * use (tests, tooling) that records and validates stamps without a reset gets a
-   * trivially passing epoch check.
+   * Until the first reset, the scope holds the shared never-bumped sentinel epoch so
+   * standalone use (tests, tooling) that records and validates stamps without a reset
+   * gets a trivially passing epoch check.
    */
   public OptimisticReadScope() {
     this.frames = new PageFrame[INITIAL_CAPACITY];
@@ -158,9 +166,14 @@ public final class OptimisticReadScope {
     // Nesting detection (-ea builds only): attemptActive can be true here only when a
     // surrounding executeOptimisticStorageRead is still in flight — i.e., this reset
     // belongs to a nested attempt that is about to wipe the outer scope's stamps.
-    // Record the violation; the outer exitAttempt() assert will surface it.
+    // Record the violation; the outer exitAttempt() assert will surface it. With no
+    // attempt in flight, any latched violation is stale (recorded by an out-of-protocol
+    // call outside enterAttempt/exitAttempt) and is cleared so it cannot be
+    // misattributed to the attempt this reset opens (review finding CQ-2).
     if (attemptActive) {
       attemptViolationDetected = true;
+    } else {
+      attemptViolationDetected = false;
     }
 
     // Capture the epoch. Exit is read BEFORE enter deliberately: if the two values are

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScope.java
@@ -51,15 +51,20 @@ public final class OptimisticReadScope {
   private long enterSeqAtCapture;
   private long exitSeqAtCapture;
 
-  // Nesting-detection state (-ea builds only). attemptActive is flipped exclusively
+  // Attempt-protocol state (-ea builds only). attemptActive is flipped exclusively
   // by enterAttempt()/exitAttempt(), which are invoked from assert statements in
   // StorageComponent.executeOptimisticStorageRead — with assertions disabled neither
   // runs and both fields stay false, so production builds pay only the dead branch
-  // in reset(). A nested executeOptimisticStorageRead call inside an optimistic
-  // lambda would wipe the outer scope's stamps via reset(), silently voiding the
-  // outer validation; this state machine surfaces that as an AssertionError.
+  // in reset(). attemptViolationDetected is the general violation latch: any -ea
+  // check that fires INSIDE an optimistic lambda has its AssertionError swallowed by
+  // the fallback catch, so it latches here instead and the attempt-closing
+  // exitAttempt() assert surfaces the violation to the caller. Latched violations:
+  // a nested executeOptimisticStorageRead call (would wipe the outer scope's stamps
+  // via reset(), silently voiding the outer validation) and an epoch-coverage breach
+  // (a page recorded or pinned-read during the attempt whose file is guarded by a
+  // different component's epoch — see the guards in StorageComponent, YTDB-1203).
   private boolean attemptActive;
-  private boolean nestedResetDetected;
+  private boolean attemptViolationDetected;
 
   /**
    * Creates an empty scope. No epoch is bound at construction — production readers
@@ -155,7 +160,7 @@ public final class OptimisticReadScope {
     // belongs to a nested attempt that is about to wipe the outer scope's stamps.
     // Record the violation; the outer exitAttempt() assert will surface it.
     if (attemptActive) {
-      nestedResetDetected = true;
+      attemptViolationDetected = true;
     }
 
     // Capture the epoch. Exit is read BEFORE enter deliberately: if the two values are
@@ -183,7 +188,7 @@ public final class OptimisticReadScope {
       // The AssertionError raised here (inside the outer optimistic lambda) is
       // swallowed by the outer fallback catch, so the latch is what actually
       // surfaces the bug to the caller.
-      nestedResetDetected = true;
+      attemptViolationDetected = true;
       return false;
     }
     attemptActive = true;
@@ -191,17 +196,31 @@ public final class OptimisticReadScope {
   }
 
   /**
+   * Latches an attempt-protocol violation detected while the current optimistic
+   * attempt is in flight (-ea builds only — called exclusively from the boolean
+   * helpers behind {@code assert} statements in {@code StorageComponent}). Used by the
+   * YTDB-1203 epoch-coverage guards: their AssertionError fires inside the optimistic
+   * lambda and is swallowed by the fallback catch, so the latch makes the
+   * attempt-closing {@link #exitAttempt()} assert fail instead, surfacing the
+   * violation to the caller (the same mechanism nested-attempt detection uses).
+   */
+  public void markAttemptViolation() {
+    attemptViolationDetected = true;
+  }
+
+  /**
    * Marks the end of an optimistic read attempt (successful or falling back). Called only
    * via {@code assert} from {@code StorageComponent.executeOptimisticStorageRead}.
    * Returns {@code false} — failing the assert — if the attempt was not well-formed:
-   * either it was never entered, or a nested reset was detected while it was in flight.
-   * Clears the detection state so a subsequent pinned fallback that legitimately starts
-   * a fresh optimistic read does not trip a stale flag.
+   * either it was never entered, or a violation (nested attempt/reset, epoch-coverage
+   * breach) was latched while it was in flight. Clears the detection state so a
+   * subsequent pinned fallback that legitimately starts a fresh optimistic read does
+   * not trip a stale flag.
    */
   public boolean exitAttempt() {
-    final boolean wellFormed = attemptActive && !nestedResetDetected;
+    final boolean wellFormed = attemptActive && !attemptViolationDetected;
     attemptActive = false;
-    nestedResetDetected = false;
+    attemptViolationDetected = false;
     return wellFormed;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPositionMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/CollectionPositionMap.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.storage.collection;
 
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.StorageComponent;
 
@@ -11,5 +12,16 @@ public abstract class CollectionPositionMap extends StorageComponent {
       AbstractStorage storage, String name, String extension, String lockName,
       boolean durable) {
     super(storage, name, extension, lockName, durable);
+  }
+
+  /**
+   * Sub-component constructor (YTDB-1203): the position map is owned by a collection and
+   * must share the parent collection's apply-phase epoch so one optimistic read spanning
+   * collection and position-map files validates a single epoch.
+   */
+  protected CollectionPositionMap(
+      AbstractStorage storage, String name, String extension, String lockName,
+      boolean durable, ApplyPhaseEpoch parentEpoch) {
+    super(storage, name, extension, lockName, durable, parentEpoch);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/CollectionDirtyPageBitSet.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/CollectionDirtyPageBitSet.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.storage.collection.v2;
 
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.StorageComponent;
@@ -36,12 +37,33 @@ public final class CollectionDirtyPageBitSet extends StorageComponent {
   /** Internal file ID assigned by the disk cache when the .dpb file is opened/created. */
   private long fileId;
 
+  /**
+   * Standalone constructor (tests only): the bit set owns a private apply-phase epoch.
+   * Production instances are created by {@link PaginatedCollectionV2} via the
+   * epoch-taking overload below.
+   */
   public CollectionDirtyPageBitSet(
       @Nonnull AbstractStorage storage,
       @Nonnull String name,
       String extension,
       String lockName) {
     super(storage, name, extension, lockName, true);
+  }
+
+  /**
+   * Production constructor used by {@link PaginatedCollectionV2}: the bit set shares the
+   * parent collection's apply-phase epoch (YTDB-1203). The bit set is never read
+   * optimistically, so sharing the parent epoch only means commits touching {@code .dpb}
+   * pages bump the family epoch — harmless for readers, and it keeps every family file
+   * resolvable at commit time.
+   */
+  CollectionDirtyPageBitSet(
+      @Nonnull AbstractStorage storage,
+      @Nonnull String name,
+      String extension,
+      String lockName,
+      @Nonnull ApplyPhaseEpoch parentEpoch) {
+    super(storage, name, extension, lockName, true, parentEpoch);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/CollectionPositionMapV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/CollectionPositionMapV2.java
@@ -23,6 +23,7 @@ package com.jetbrains.youtrackdb.internal.core.storage.collection.v2;
 import com.jetbrains.youtrackdb.internal.common.util.CommonConst;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.CollectionPositionMapException;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.collection.CollectionPositionMap;
@@ -111,13 +112,31 @@ public final class CollectionPositionMapV2 extends CollectionPositionMap {
   /** Internal file ID assigned by the disk cache when the .cpm file is opened/created. */
   private volatile long fileId;
 
-  /** Package-private constructor; instances are created by {@link PaginatedCollectionV2}. */
+  /**
+   * Standalone constructor (tests only): the position map owns a private apply-phase
+   * epoch. Production instances are created by {@link PaginatedCollectionV2} via the
+   * epoch-taking overload below.
+   */
   CollectionPositionMapV2(
       final AbstractStorage storage,
       final String name,
       final String lockName,
       final String extension) {
     super(storage, name, extension, lockName, true);
+  }
+
+  /**
+   * Production constructor used by {@link PaginatedCollectionV2}: the position map
+   * shares the parent collection's apply-phase epoch (YTDB-1203) so one optimistic read
+   * spanning {@code .pcl} and {@code .cpm} pages validates a single epoch.
+   */
+  CollectionPositionMapV2(
+      final AbstractStorage storage,
+      final String name,
+      final String lockName,
+      final String extension,
+      @Nonnull final ApplyPhaseEpoch parentEpoch) {
+    super(storage, name, extension, lockName, true, parentEpoch);
   }
 
   /** Opens an existing position-map file by name through the disk cache. */

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMap.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMap.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.storage.collection.v2;
 
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurablePage;
@@ -87,12 +88,31 @@ public final class FreeSpaceMap extends StorageComponent {
   /** Internal file ID assigned by the disk cache when the .fsm file is opened/created. */
   private volatile long fileId;
 
+  /**
+   * Standalone constructor (tests only): the free-space map owns a private apply-phase
+   * epoch. Production instances are created by {@link PaginatedCollectionV2} via the
+   * epoch-taking overload below.
+   */
   public FreeSpaceMap(
       @Nonnull AbstractStorage storage,
       @Nonnull String name,
       String extension,
       String lockName) {
     super(storage, name, extension, lockName, true);
+  }
+
+  /**
+   * Production constructor used by {@link PaginatedCollectionV2}: the free-space map
+   * shares the parent collection's apply-phase epoch (YTDB-1203) so its optimistic reads
+   * and the collection's commits agree on a single epoch for the whole family.
+   */
+  FreeSpaceMap(
+      @Nonnull AbstractStorage storage,
+      @Nonnull String name,
+      String extension,
+      String lockName,
+      @Nonnull ApplyPhaseEpoch parentEpoch) {
+    super(storage, name, extension, lockName, true, parentEpoch);
   }
 
   public boolean exists(final AtomicOperation atomicOperation) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2.java
@@ -282,11 +282,15 @@ public final class PaginatedCollectionV2 extends PaginatedCollection {
     super(storage, name, dataExtension, name + dataExtension, true);
 
     systemCollection = MetadataInternal.SYSTEM_COLLECTION.contains(name);
+    // Sub-components share this collection's apply-phase epoch (YTDB-1203): readRecord
+    // spans .pcl + .cpm pages in one optimistic scope, and the scope validates exactly
+    // one epoch per attempt, so the whole component family must map to one instance.
     collectionPositionMap = new CollectionPositionMapV2(storage, getName(), getFullName(),
-        cpmExtension);
-    freeSpaceMap = new FreeSpaceMap(storage, name, fsmExtension, getFullName());
+        cpmExtension, applyPhaseEpoch());
+    freeSpaceMap = new FreeSpaceMap(storage, name, fsmExtension, getFullName(),
+        applyPhaseEpoch());
     dirtyPageBitSet = new CollectionDirtyPageBitSet(
-        storage, name, dpbExtension, getFullName());
+        storage, name, dpbExtension, getFullName(), applyPhaseEpoch());
     storageName = storage.getName();
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -1006,6 +1006,20 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     try {
       LogSequenceNumber txEndLsn;
 
+      // Resolve the mutated components' epochs FIRST — before flushPendingOperations
+      // and before any WAL record is written. The mutated set is frozen at entry:
+      // flushPendingOperations only assigns changeLSNs to already-registered page
+      // overlays (it creates no FileChanges entries and adds no binary changes), and
+      // the WAL phase below only prunes page entries WITHOUT changes — so resolving
+      // early is result-identical on the success path. What it changes is the failure
+      // point: the fail-loud IllegalStateException for an unregistered mutated file
+      // (see collectMutatedComponentEpochs) now fires BEFORE the durability point of
+      // no return. Resolving after the AtomicUnitEndRecord would leave a torn state on
+      // a miss — WAL says committed, the cache apply never ran, and recovery would
+      // replay the orphaned unit against later transactions' writes (review finding
+      // CS-1).
+      final var mutatedComponentEpochs = collectMutatedComponentEpochs();
+
       // Precompute non-durable classification once per file to guarantee
       // consistent classification between the WAL phase and cache application
       // phase. Reading the volatile nonDurableFileIds twice could see different
@@ -1148,10 +1162,9 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
       // not mutate shared cache pages (snapshot-index entries are SI-filtered on read).
       //
       // Zero-change commits — read-only atomic operations, pure metadata ops — resolve
-      // an empty mutated set, perform no readCache calls in the section below, and bump
-      // nothing; bumping would only spuriously invalidate concurrently overlapping
-      // optimistic reads.
-      final var mutatedComponentEpochs = collectMutatedComponentEpochs();
+      // an empty mutated set (computed at method entry, before the WAL phase), perform
+      // no readCache calls in the section below, and bump nothing; bumping would only
+      // spuriously invalidate concurrently overlapping optimistic reads.
       for (final var epoch : mutatedComponentEpochs) {
         epoch.enterApplyPhase();
       }
@@ -1223,8 +1236,11 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
           }
         }
       } finally {
-        for (final var epoch : mutatedComponentEpochs) {
-          epoch.exitApplyPhase();
+        // Indexed loop on purpose: no Iterator allocation inside this finally, so the
+        // bracket exit cannot itself fail under allocation pressure while unwinding
+        // (review finding CS-3). exitApplyPhase() never throws.
+        for (var i = 0; i < mutatedComponentEpochs.size(); i++) {
+          mutatedComponentEpochs.get(i).exitApplyPhase();
         }
       }
 
@@ -1305,6 +1321,13 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
    * set of files the apply section acts on. Merely-loaded files (empty
    * {@link FileChanges}) resolve nothing, so zero-change commits (read-only atomic
    * operations) return an empty list and skip the epoch bracket entirely.
+   *
+   * <p>Invoked at the very top of {@link #commitChanges} — before
+   * {@code flushPendingOperations} and before any WAL record is written — so the
+   * fail-loud miss below aborts the commit cleanly instead of firing after the
+   * {@code AtomicUnitEndRecord} durability point (which would produce a
+   * recovery-visible torn state: WAL committed, cache never applied). The early call is
+   * safe because the mutated set is frozen at {@code commitChanges} entry.
    *
    * <p>Epochs are deduplicated BY IDENTITY: sub-components share their parent
    * component's epoch instance, and one commit frequently touches several files of the

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationBinaryTracking.java
@@ -30,6 +30,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntryImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ComponentEpochRegistry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
@@ -163,18 +164,25 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   // separate writer thread.
   @Nullable private volatile PageApplyHook pageApplyHook;
 
-  // Per-storage apply-phase epoch, owned by AtomicOperationsManager and shared by all
-  // atomic operations of the same storage. Bumped around the cache-apply section of
-  // commitChanges so concurrent optimistic readers can detect overlap with a partially
-  // applied commit (per-page stamps alone cannot — they are a temporal check only).
-  private final ApplyPhaseEpoch applyPhaseEpoch;
+  // Per-storage registry resolving each fileId to the owning component's apply-phase
+  // epoch (YTDB-1203), owned by AtomicOperationsManager and shared by all atomic
+  // operations of the same storage. At commit time the epochs of all mutated components
+  // are bumped around the cache-apply section of commitChanges so concurrent optimistic
+  // readers of those components can detect overlap with a partially applied commit
+  // (per-page stamps alone cannot — they are a temporal check only).
+  private final ComponentEpochRegistry componentEpochRegistry;
 
   /**
-   * Convenience constructor for standalone use (tests, tooling) where no epoch is shared
-   * with concurrent optimistic readers: allocates a private {@link ApplyPhaseEpoch}.
-   * Production code must use the primary constructor with the storage-wide epoch owned by
-   * {@link AtomicOperationsManager} — a private epoch would make commit-time applies
-   * invisible to optimistic readers of other operations on the same storage.
+   * Convenience constructor for standalone use (tests, tooling) where no epoch registry
+   * is shared with concurrent optimistic readers: wires a private single-epoch registry
+   * that resolves EVERY fileId to one epoch nobody else observes (see
+   * {@link ComponentEpochRegistry#uniform}), so the fail-loud mutated-fileId resolution
+   * in {@link #commitChanges} always succeeds and standalone commits keep the
+   * pre-per-component behaviour of exactly one enter/exit pair per commit. Production
+   * code must use the primary constructor with the registry owned by
+   * {@link AtomicOperationsManager} and populated by the StorageComponent funnel — a
+   * private registry would make commit-time applies invisible to optimistic readers of
+   * other operations on the same storage.
    */
   AtomicOperationBinaryTracking(
       final ReadCache readCache,
@@ -190,7 +198,8 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
       @Nonnull AtomicLong edgeSnapshotIndexSize) {
     this(readCache, writeCache, writeAheadLog, storageId, snapshot, sharedSnapshotIndex,
         sharedVisibilityIndex, snapshotIndexSize, sharedEdgeSnapshotIndex,
-        sharedEdgeVisibilityIndex, edgeSnapshotIndexSize, new ApplyPhaseEpoch());
+        sharedEdgeVisibilityIndex, edgeSnapshotIndexSize,
+        ComponentEpochRegistry.uniform(new ApplyPhaseEpoch()));
   }
 
   AtomicOperationBinaryTracking(
@@ -205,7 +214,7 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
       @Nonnull ConcurrentSkipListMap<EdgeSnapshotKey, LinkBagValue> sharedEdgeSnapshotIndex,
       @Nonnull ConcurrentSkipListMap<EdgeVisibilityKey, EdgeSnapshotKey> sharedEdgeVisibilityIndex,
       @Nonnull AtomicLong edgeSnapshotIndexSize,
-      @Nonnull ApplyPhaseEpoch applyPhaseEpoch) {
+      @Nonnull ComponentEpochRegistry componentEpochRegistry) {
     this.snapshot = snapshot;
     newFileNamesId.defaultReturnValue(-1);
     deletedFileNameIdMap.defaultReturnValue(-1);
@@ -220,8 +229,10 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
     this.sharedEdgeSnapshotIndex = sharedEdgeSnapshotIndex;
     this.sharedEdgeVisibilityIndex = sharedEdgeVisibilityIndex;
     this.edgeSnapshotIndexSize = edgeSnapshotIndexSize;
-    this.applyPhaseEpoch = applyPhaseEpoch;
-    this.optimisticReadScope = new OptimisticReadScope(applyPhaseEpoch);
+    this.componentEpochRegistry = componentEpochRegistry;
+    // No epoch is bound at scope construction: the scope re-captures the epoch of the
+    // component each read attempt targets via reset(ApplyPhaseEpoch) (YTDB-1203).
+    this.optimisticReadScope = new OptimisticReadScope();
     this.active = true;
   }
 
@@ -1119,29 +1130,30 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
         flushEdgeSnapshotBuffers();
       }
 
-      // Apply-phase epoch bracket: exactly ONE enter/exit pair spanning the entire
-      // shared-cache mutation section — the readCache.deleteFile loop plus the whole
-      // per-file apply loop (addFile/truncateFile/loadOrAddForWrite/releaseFromWrite).
-      // Pages are applied one at a time in hash order, so a concurrent optimistic
-      // reader overlapping this section could see a mix of pre- and post-commit pages
-      // with every per-page stamp still valid; the epoch lets it detect the overlap
-      // and fall back to the pinned path. The exit MUST be in a finally block: an
-      // exception escaping this section must not leave the epoch permanently "in
-      // apply", which would disable optimistic reads for the storage's lifetime.
+      // Apply-phase epoch bracket (per component, YTDB-1203): exactly ONE enter/exit
+      // pair per MUTATED COMPONENT, spanning the entire shared-cache mutation section —
+      // the readCache.deleteFile loop plus the whole per-file apply loop
+      // (addFile/truncateFile/loadOrAddForWrite/releaseFromWrite). Pages are applied one
+      // at a time in hash order, so a concurrent optimistic reader overlapping this
+      // section could see a mix of pre- and post-commit pages with every per-page stamp
+      // still valid; the epoch lets it detect the overlap and fall back to the pinned
+      // path. Epochs are per top-level component, so this commit only invalidates
+      // optimistic reads of the components it actually mutates — readers of unrelated
+      // components are untouched. The exits MUST be in a finally block: an exception
+      // escaping this section must not leave any epoch permanently "in apply", which
+      // would disable optimistic reads of that component for the storage's lifetime.
       // Rolled-back operations never reach commitChanges (see the gate in
-      // AtomicOperationsManager.endAtomicOperation), so rollback does not bump the
-      // epoch. The WAL phase and snapshot-buffer flushes above are deliberately NOT
-      // bracketed — they do not mutate shared cache pages (snapshot-index entries are
-      // SI-filtered on read).
+      // AtomicOperationsManager.endAtomicOperation), so rollback bumps no epoch. The WAL
+      // phase and snapshot-buffer flushes above are deliberately NOT bracketed — they do
+      // not mutate shared cache pages (snapshot-index entries are SI-filtered on read).
       //
-      // The bracket is gated on the commit actually having shared-cache mutations:
-      // zero-change commits — read-only atomic operations, pure metadata ops —
-      // perform no readCache calls in the section below, so bumping the epoch for them
-      // would only spuriously invalidate every concurrently overlapping optimistic
-      // read in the storage.
-      final var mutatesSharedCache = commitMutatesSharedCache();
-      if (mutatesSharedCache) {
-        applyPhaseEpoch.enterApplyPhase();
+      // Zero-change commits — read-only atomic operations, pure metadata ops — resolve
+      // an empty mutated set, perform no readCache calls in the section below, and bump
+      // nothing; bumping would only spuriously invalidate concurrently overlapping
+      // optimistic reads.
+      final var mutatedComponentEpochs = collectMutatedComponentEpochs();
+      for (final var epoch : mutatedComponentEpochs) {
+        epoch.enterApplyPhase();
       }
       try {
         deletedFilesIterator = deletedFiles.longIterator();
@@ -1211,8 +1223,8 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
           }
         }
       } finally {
-        if (mutatesSharedCache) {
-          applyPhaseEpoch.exitApplyPhase();
+        for (final var epoch : mutatedComponentEpochs) {
+          epoch.exitApplyPhase();
         }
       }
 
@@ -1287,27 +1299,81 @@ final class AtomicOperationBinaryTracking implements AtomicOperation {
   }
 
   /**
-   * Returns whether this commit will mutate shared read-cache state in the apply
-   * section: any file deletion, any new/truncated file, or any page with accumulated
-   * changes. Zero-change commits (read-only atomic operations) return {@code false}
-   * and skip the apply-phase epoch bracket entirely.
+   * Resolves the apply-phase epochs of every component this commit will mutate in the
+   * shared read-cache apply section: the owners of all deleted files plus of every file
+   * with a new/truncate flag or at least one page with accumulated changes — exactly the
+   * set of files the apply section acts on. Merely-loaded files (empty
+   * {@link FileChanges}) resolve nothing, so zero-change commits (read-only atomic
+   * operations) return an empty list and skip the epoch bracket entirely.
+   *
+   * <p>Epochs are deduplicated BY IDENTITY: sub-components share their parent
+   * component's epoch instance, and one commit frequently touches several files of the
+   * same component family, which must produce exactly one enter/exit pair on that epoch.
+   *
+   * <p>Fail-loud contract (review finding AR-2): a mutated fileId with no registry entry
+   * throws {@link IllegalStateException}. Every production file is registered by the
+   * {@code StorageComponent.addFile/openFile} funnel before it can be mutated, so a miss
+   * means a file was created or loaded behind the funnel's back — its optimistic readers
+   * would silently lose epoch protection if the bump were skipped. Operations built via
+   * the standalone convenience constructor cannot miss: their private
+   * {@link ComponentEpochRegistry#uniform} registry resolves every fileId to one
+   * universal epoch. Tests using the primary constructor must register an epoch for
+   * every fileId they mutate, exactly as the production funnel does.
    */
-  private boolean commitMutatesSharedCache() {
-    if (!deletedFiles.isEmpty()) {
-      return true;
+  private ArrayList<ApplyPhaseEpoch> collectMutatedComponentEpochs() {
+    final var epochs = new ArrayList<ApplyPhaseEpoch>();
+    final var deletedFilesIterator = deletedFiles.longIterator();
+    while (deletedFilesIterator.hasNext()) {
+      addMutatedComponentEpoch(epochs, deletedFilesIterator.nextLong());
     }
     for (final var fileChangesEntry : fileChanges.long2ObjectEntrySet()) {
       final var changes = fileChangesEntry.getValue();
-      if (changes.isNew || changes.truncate) {
-        return true;
+      if (changes.isNew || changes.truncate || anyPageHasChanges(changes)) {
+        addMutatedComponentEpoch(epochs, fileChangesEntry.getLongKey());
       }
-      for (final var pageEntry : changes.pageChangesMap.long2ObjectEntrySet()) {
-        if (pageEntry.getValue().changes.hasChanges()) {
-          return true;
-        }
+    }
+    return epochs;
+  }
+
+  /**
+   * Returns whether any page of the given file carries accumulated binary changes — the
+   * per-page half of the mutated-file predicate in {@link #collectMutatedComponentEpochs}
+   * (the apply loop applies exactly the pages for which this holds).
+   */
+  private static boolean anyPageHasChanges(final FileChanges changes) {
+    for (final var pageEntry : changes.pageChangesMap.long2ObjectEntrySet()) {
+      if (pageEntry.getValue().changes.hasChanges()) {
+        return true;
       }
     }
     return false;
+  }
+
+  /**
+   * Resolves {@code fileId} to its component epoch and appends it to {@code epochs}
+   * unless the identical instance is already present. See
+   * {@link #collectMutatedComponentEpochs} for the fail-loud contract on misses.
+   */
+  private void addMutatedComponentEpoch(
+      final ArrayList<ApplyPhaseEpoch> epochs, final long fileId) {
+    final var epoch = componentEpochRegistry.epochFor(fileId);
+    if (epoch == null) {
+      throw new IllegalStateException(
+          "No component apply-phase epoch registered for mutated file " + fileId
+              + " in storage " + writeCache.getStorageName()
+              + " — the file was created or loaded outside the"
+              + " StorageComponent.addFile/openFile funnel, so optimistic readers of its"
+              + " pages would not be protected against this commit's apply phase");
+    }
+    // Identity-based dedupe: sub-components share the parent's epoch INSTANCE, and the
+    // mutated set is small (typically 1-3 components per commit), so a linear reference
+    // scan beats a hash-based identity set.
+    for (final var existing : epochs) {
+      if (existing == epoch) {
+        return;
+      }
+    }
+    epochs.add(epoch);
   }
 
   /**

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationsManager.java
@@ -29,6 +29,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.CommonStorageComponentEx
 import com.jetbrains.youtrackdb.internal.core.exception.CoreException;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ComponentEpochRegistry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
@@ -68,24 +69,40 @@ public class AtomicOperationsManager {
   private final OperationsFreezer writeOperationsFreezer = new OperationsFreezer();
   private final AtomicOperationsTable atomicOperationsTable;
 
-  // Apply-phase epoch shared by all atomic operations of this storage. Owned here (one
-  // manager per storage) rather than by ReadCache, because on the disk engine a single
-  // read cache is shared by all storages of the engine — an engine-global epoch would
-  // let commits in one database spuriously invalidate optimistic reads in another.
-  // Writers bump it around the cache-apply section of commitChanges; readers capture
-  // and validate it via OptimisticReadScope.
-  private final ApplyPhaseEpoch applyPhaseEpoch = new ApplyPhaseEpoch();
+  // Per-storage registry mapping every component-owned fileId to the owning component's
+  // apply-phase epoch (YTDB-1203). Owned here (one manager per storage) rather than by
+  // ReadCache, because on the disk engine a single read cache is shared by all storages
+  // of the engine — engine-global epochs would let commits in one database spuriously
+  // invalidate optimistic reads in another. Populated by the
+  // StorageComponent.addFile/openFile funnel — possibly under the storage stateLock READ
+  // side (SharedLinkBagBTree creation during normal transactions), hence the lock-free
+  // concurrent registry; entries are never removed. Writers resolve their mutated
+  // fileIds through the registry in AtomicOperationBinaryTracking.commitChanges and bump
+  // each distinct resolved epoch around the cache-apply section; readers capture and
+  // validate their component's epoch via OptimisticReadScope.
+  private final ComponentEpochRegistry componentEpochRegistry = new ComponentEpochRegistry();
 
   /**
-   * TEST-ONLY accessor for this storage's apply-phase epoch, exposed package-private for
-   * the test bridge in the same test package (used by the YTDB-1178 mixed-apply-state
-   * regression tests to make baseline-relative assertions on the epoch counters).
-   * Production code must not call this — writers bump the epoch only through
-   * {@code AtomicOperationBinaryTracking.commitChanges} and readers observe it only
-   * through {@code OptimisticReadScope}.
+   * Maps {@code fileId} to the given component's apply-phase epoch in this storage's
+   * registry. Called exclusively from the {@link StorageComponent#addFile}/{@code
+   * openFile} funnel; overwrites any previous mapping (fileId reuse on same-name
+   * recreate) and never removes entries — see {@link ComponentEpochRegistry}.
    */
-  ApplyPhaseEpoch getApplyPhaseEpoch() {
-    return applyPhaseEpoch;
+  public void registerComponentEpoch(final long fileId, @Nonnull final ApplyPhaseEpoch epoch) {
+    componentEpochRegistry.register(fileId, epoch);
+  }
+
+  /**
+   * Returns this storage's fileId → component-epoch registry. Consulted by
+   * {@code AtomicOperationBinaryTracking.commitChanges} to resolve the epochs of the
+   * components a commit mutates, and by the -ea-only invariant checks in
+   * {@link StorageComponent}; tests resolve per-component epochs through the test bridge.
+   * Production code must not bump epochs directly — writers bump them only through
+   * {@code commitChanges} and readers observe them only through
+   * {@code OptimisticReadScope}.
+   */
+  public ComponentEpochRegistry getComponentEpochRegistry() {
+    return componentEpochRegistry;
   }
 
   public AtomicOperationsManager(
@@ -121,7 +138,7 @@ public class AtomicOperationsManager {
         snapshot, storage.getSharedSnapshotIndex(), storage.getVisibilityIndex(),
         storage.getSnapshotIndexSize(),
         storage.getSharedEdgeSnapshotIndex(), storage.getEdgeVisibilityIndex(),
-        storage.getEdgeSnapshotIndexSize(), applyPhaseEpoch);
+        storage.getEdgeSnapshotIndexSize(), componentEpochRegistry);
   }
 
   public void startToApplyOperations(AtomicOperation atomicOperation) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -26,6 +26,7 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.function.TxConsumer;
 import com.jetbrains.youtrackdb.internal.common.function.TxFunction;
 import com.jetbrains.youtrackdb.internal.common.log.LogManager;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
@@ -90,14 +91,45 @@ public abstract class StorageComponent extends SharedResourceAbstract {
 
   private final boolean durable;
 
+  // Apply-phase epoch guarding optimistic reads of this component's files (YTDB-1203).
+  // Top-level components own a private instance; sub-components receive their parent's
+  // instance so one optimistic read spanning parent and sub-component files (e.g., a
+  // collection's .pcl + its position map's .cpm) validates a single epoch. Every fileId
+  // this component creates or opens is mapped to this epoch in the per-storage
+  // ComponentEpochRegistry (see addFile/openFile below); committing operations resolve
+  // their mutated fileIds through that registry and bump each distinct resolved epoch.
+  private final ApplyPhaseEpoch applyPhaseEpoch;
+
+  /**
+   * Constructor for top-level components: allocates a private {@link ApplyPhaseEpoch}
+   * for this component. Sub-components constructed and owned by another component must
+   * use the epoch-taking overload with the parent's {@link #applyPhaseEpoch()} instead.
+   */
   public StorageComponent(
       @Nonnull final AbstractStorage storage,
       @Nonnull final String name,
       final String extension,
       final String lockName,
       final boolean durable) {
+    this(storage, name, extension, lockName, durable, new ApplyPhaseEpoch());
+  }
+
+  /**
+   * Constructor for sub-components that share their parent component's apply-phase
+   * epoch (YTDB-1203) — e.g., {@code CollectionPositionMapV2}, {@code FreeSpaceMap} and
+   * {@code CollectionDirtyPageBitSet} receive {@code PaginatedCollectionV2}'s epoch so
+   * one optimistic read spanning the family's files validates a single epoch.
+   */
+  protected StorageComponent(
+      @Nonnull final AbstractStorage storage,
+      @Nonnull final String name,
+      final String extension,
+      final String lockName,
+      final boolean durable,
+      @Nonnull final ApplyPhaseEpoch applyPhaseEpoch) {
     super();
 
+    assert applyPhaseEpoch != null : "applyPhaseEpoch must not be null";
     this.extension = extension;
     this.storage = storage;
     this.fullName = name + extension;
@@ -107,6 +139,16 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     this.writeCache = storage.getWriteCache();
     this.lockName = lockName;
     this.durable = durable;
+    this.applyPhaseEpoch = applyPhaseEpoch;
+  }
+
+  /**
+   * Returns the apply-phase epoch guarding optimistic reads of this component's files.
+   * A component that constructs sub-components must hand them this instance (via the
+   * epoch-taking constructor overload) so the whole family shares one epoch.
+   */
+  protected final ApplyPhaseEpoch applyPhaseEpoch() {
+    return applyPhaseEpoch;
   }
 
   /** Returns {@code true} if this component participates in WAL crash recovery. */
@@ -276,7 +318,51 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       @Nonnull final AtomicOperation atomicOperation, final long fileId, final long pageIndex)
       throws IOException {
     assert atomicOperation != null;
+    // -ea-only pinned-inside-optimistic guard (YTDB-1203, review finding AR-1): a pinned
+    // read issued while an optimistic attempt is in flight (the pattern used by the
+    // position-map delegates and the BTree/SharedLinkBagBTree firstItem/lastItem
+    // descents) is epoch-safe only if the file belongs to the same epoch the scope
+    // captured at reset — the scope records nothing for pinned pages, so a pinned
+    // delegate into a DIFFERENT top-level component would escape epoch validation
+    // entirely, silently resurrecting the YTDB-1178 mixed-apply-state bug.
+    assert pinnedReadEpochConsistent(atomicOperation, fileId)
+        : "Pinned read of file " + fileId + " inside an optimistic attempt of component "
+            + getLockName() + " whose captured epoch does not guard that file";
     return atomicOperation.loadPageForRead(fileId, pageIndex);
+  }
+
+  /**
+   * -ea-only helper backing the pinned-inside-optimistic guard in
+   * {@link #loadPageForRead(AtomicOperation, long, long)}. Passes trivially when no
+   * optimistic attempt is in flight (plain pinned reads are epoch-independent — this
+   * includes the pinned fallback lambdas, which run after the attempt was closed) or
+   * when no scope/registry is reachable (mock operations and managers in unit tests).
+   */
+  private boolean pinnedReadEpochConsistent(
+      final AtomicOperation atomicOperation, final long fileId) {
+    final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
+    if (scope == null || !scope.isAttemptActive()) {
+      return true;
+    }
+    return registeredEpochIs(fileId, scope.capturedEpoch());
+  }
+
+  /**
+   * -ea-only helper: whether the per-storage component-epoch registry maps
+   * {@code fileId} to exactly (reference equality) the given epoch. Lenient when no
+   * registry is reachable (mock managers in unit tests); with a real registry, both a
+   * missing entry and a different owner are violations — either way the page would not
+   * be covered by the epoch the current scope validates.
+   */
+  private boolean registeredEpochIs(final long fileId, final ApplyPhaseEpoch expected) {
+    if (atomicOperationsManager == null) {
+      return true;
+    }
+    final var registry = atomicOperationsManager.getComponentEpochRegistry();
+    if (registry == null) {
+      return true;
+    }
+    return registry.epochFor(fileId) == expected;
   }
 
   protected void releasePageFromWrite(
@@ -295,13 +381,24 @@ public abstract class StorageComponent extends SharedResourceAbstract {
   protected long addFile(@Nonnull final AtomicOperation atomicOperation, final String fileName)
       throws IOException {
     assert atomicOperation != null;
-    return atomicOperation.addFile(fileName, !durable);
+    final long fileId = atomicOperation.addFile(fileName, !durable);
+    // Map the new file to this component's epoch so commit-time apply phases and
+    // optimistic readers agree on which epoch guards its pages (YTDB-1203). Entries are
+    // never removed — the commit that later deletes the file must itself resolve this
+    // fileId to bump the epoch; a same-name recreate that reuses the fileId simply
+    // overwrites the mapping with the new owner.
+    atomicOperationsManager.registerComponentEpoch(fileId, applyPhaseEpoch);
+    return fileId;
   }
 
   protected long openFile(@Nonnull final AtomicOperation atomicOperation, final String fileName)
       throws IOException {
     assert atomicOperation != null;
-    return atomicOperation.loadFile(fileName);
+    final long fileId = atomicOperation.loadFile(fileName);
+    // See the registration comment in addFile above — open re-registers on every storage
+    // open, which also refreshes the mapping after a same-name delete/recreate cycle.
+    atomicOperationsManager.registerComponentEpoch(fileId, applyPhaseEpoch);
+    return fileId;
   }
 
   protected void deleteFile(@Nonnull final AtomicOperation atomicOperation, final long fileId)
@@ -570,6 +667,14 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     }
 
     final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
+    // -ea-only epoch-coverage invariant (YTDB-1203): the recorded page must belong to a
+    // file guarded by the same epoch the scope captured at reset — i.e., an optimistic
+    // lambda must not span files of two different top-level components, because one
+    // attempt validates exactly one epoch. Sub-component files pass because they are
+    // registered under the parent component's epoch instance.
+    assert registeredEpochIs(fileId, scope.capturedEpoch())
+        : "Optimistic read of file " + fileId + " in component " + getLockName()
+            + " whose registered epoch differs from the scope's captured epoch";
     scope.record(frame, stamp);
 
     return new PageView(frame.getBuffer(), frame, stamp);
@@ -599,7 +704,10 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     assert atomicOperation != null;
 
     final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
-    scope.reset();
+    // Capture THIS component's epoch for the attempt: the scope is shared across all
+    // components read by the same atomic operation, so the epoch is re-captured per
+    // attempt rather than fixed at scope construction (YTDB-1203).
+    scope.reset(applyPhaseEpoch);
     // -ea-only guard against nested optimistic read attempts: a nested
     // executeOptimisticStorageRead call from inside an optimistic lambda would wipe the
     // outer scope's stamps via reset(), silently voiding the outer validation. Kept
@@ -668,8 +776,8 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     assert atomicOperation != null;
 
     final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
-    scope.reset();
-    // See the nesting-guard comments in the T-returning overload above.
+    // See the epoch-capture and nesting-guard comments in the T-returning overload above.
+    scope.reset(applyPhaseEpoch);
     assert scope.enterAttempt() : "Nested optimistic read attempt on " + getLockName();
 
     var attemptClosedByFallback = false;
@@ -742,8 +850,8 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     assert atomicOperation != null;
 
     final OptimisticReadScope scope = atomicOperation.getOptimisticReadScope();
-    scope.reset();
-    // See the nesting-guard comments in executeOptimisticStorageRead.
+    // See the epoch-capture and nesting-guard comments in executeOptimisticStorageRead.
+    scope.reset(applyPhaseEpoch);
     assert scope.enterAttempt() : "Nested optimistic read attempt on " + getLockName();
 
     final T result;

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -365,6 +365,14 @@ public abstract class StorageComponent extends SharedResourceAbstract {
    */
   private boolean optimisticRecordEpochConsistent(
       final long fileId, final OptimisticReadScope scope) {
+    if (!scope.isAttemptActive()) {
+      // Out-of-protocol call — no attempt in flight (e.g., a direct loadPageOptimistic
+      // invocation outside executeOptimisticStorageRead, which only tests do). Mirror
+      // pinnedReadEpochConsistent's gate: there is no captured epoch to check against,
+      // and latching here would misattribute the violation to the NEXT legitimate
+      // attempt's exitAttempt() (review finding CQ-2).
+      return true;
+    }
     if (registeredEpochIs(fileId, scope.capturedEpoch())) {
       return true;
     }
@@ -770,13 +778,12 @@ public abstract class StorageComponent extends SharedResourceAbstract {
 
       // Close the attempt before the pinned fallback runs: the fallback may itself
       // legitimately start fresh optimistic reads (e.g., via helper methods), which
-      // must not trip a stale nesting flag. If a nested reset was detected during the
-      // failed attempt, this assert surfaces it (the nested AssertionError itself was
-      // swallowed by this catch).
+      // must not trip a stale nesting flag. If a violation was latched during the
+      // failed attempt, the helper surfaces it as an AssertionError carrying the
+      // original lambda throwable as suppressed — the guard must not silently replace
+      // a genuine corruption-signaling exception (review finding CS-2).
       attemptClosedByFallback = true;
-      assert scope.exitAttempt()
-          : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
-              + getLockName();
+      assert closeAttemptAfterFallback(scope, e);
 
       acquireSharedLock();
       try {
@@ -820,9 +827,7 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     } catch (final RuntimeException | AssertionError e) {
       // See comment in the T-returning overload above.
       attemptClosedByFallback = true;
-      assert scope.exitAttempt()
-          : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
-              + getLockName();
+      assert closeAttemptAfterFallback(scope, e);
 
       acquireSharedLock();
       try {
@@ -837,6 +842,28 @@ public abstract class StorageComponent extends SharedResourceAbstract {
                 + getLockName();
       }
     }
+  }
+
+  /**
+   * -ea-only attempt-closing check for the optimistic-fallback catch blocks: behaves
+   * like {@code assert scope.exitAttempt()} but, when the attempt was ill-formed
+   * (nested read or epoch-coverage breach latched on the scope), raises the
+   * AssertionError with the original lambda throwable attached as SUPPRESSED instead
+   * of silently replacing it — the original exception may itself signal corruption and
+   * must stay visible (review finding CS-2). Invoked exclusively via {@code assert},
+   * so {@code -da} builds skip the call entirely, exactly like the plain assert this
+   * replaces.
+   */
+  private boolean closeAttemptAfterFallback(
+      final OptimisticReadScope scope, final Throwable original) {
+    if (scope.exitAttempt()) {
+      return true;
+    }
+    final var violation = new AssertionError(
+        "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
+            + getLockName());
+    violation.addSuppressed(original);
+    throw violation;
   }
 
   // Rate limiter state for the null-recheck disagreement ERROR: nanoTime of the last
@@ -900,9 +927,7 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // Same fallback semantics as executeOptimisticStorageRead — and deliberately NO
       // re-check on this path: the pinned result below is already authoritative.
       attemptClosedByFallback = true;
-      assert scope.exitAttempt()
-          : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
-              + getLockName();
+      assert closeAttemptAfterFallback(scope, e);
 
       acquireSharedLock();
       try {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponent.java
@@ -337,6 +337,12 @@ public abstract class StorageComponent extends SharedResourceAbstract {
    * optimistic attempt is in flight (plain pinned reads are epoch-independent — this
    * includes the pinned fallback lambdas, which run after the attempt was closed) or
    * when no scope/registry is reachable (mock operations and managers in unit tests).
+   *
+   * <p>On violation the helper LATCHES the failure on the scope before returning
+   * {@code false}: the enclosing assert fires inside the optimistic lambda, where the
+   * fallback catch swallows AssertionError — the latch makes the attempt-closing
+   * {@code exitAttempt()} assert fail instead, so the violation actually reaches the
+   * caller (same surfacing mechanism as nested-attempt detection).
    */
   private boolean pinnedReadEpochConsistent(
       final AtomicOperation atomicOperation, final long fileId) {
@@ -344,7 +350,26 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     if (scope == null || !scope.isAttemptActive()) {
       return true;
     }
-    return registeredEpochIs(fileId, scope.capturedEpoch());
+    if (registeredEpochIs(fileId, scope.capturedEpoch())) {
+      return true;
+    }
+    scope.markAttemptViolation();
+    return false;
+  }
+
+  /**
+   * -ea-only helper backing the epoch-coverage guard in {@code loadPageOptimistic}:
+   * like {@link #pinnedReadEpochConsistent} it latches the violation on the scope
+   * before returning {@code false}, because the enclosing assert fires inside the
+   * optimistic lambda where AssertionError is swallowed by the fallback catch.
+   */
+  private boolean optimisticRecordEpochConsistent(
+      final long fileId, final OptimisticReadScope scope) {
+    if (registeredEpochIs(fileId, scope.capturedEpoch())) {
+      return true;
+    }
+    scope.markAttemptViolation();
+    return false;
   }
 
   /**
@@ -671,8 +696,10 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     // file guarded by the same epoch the scope captured at reset — i.e., an optimistic
     // lambda must not span files of two different top-level components, because one
     // attempt validates exactly one epoch. Sub-component files pass because they are
-    // registered under the parent component's epoch instance.
-    assert registeredEpochIs(fileId, scope.capturedEpoch())
+    // registered under the parent component's epoch instance. The helper latches
+    // violations on the scope (this assert fires inside the optimistic lambda, whose
+    // fallback catch swallows AssertionError — the latch surfaces it at exitAttempt).
+    assert optimisticRecordEpochConsistent(fileId, scope)
         : "Optimistic read of file " + fileId + " in component " + getLockName()
             + " whose registered epoch differs from the scope's captured epoch";
     scope.record(frame, stamp);
@@ -747,7 +774,9 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // failed attempt, this assert surfaces it (the nested AssertionError itself was
       // swallowed by this catch).
       attemptClosedByFallback = true;
-      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+      assert scope.exitAttempt()
+          : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
+              + getLockName();
 
       acquireSharedLock();
       try {
@@ -760,7 +789,9 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // throwable the catch above does not handle. Skipped when the fallback already
       // closed it (exitAttempt is not idempotent — a second call reports ill-formed).
       if (!attemptClosedByFallback) {
-        assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+        assert scope.exitAttempt()
+            : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
+                + getLockName();
       }
     }
   }
@@ -789,7 +820,9 @@ public abstract class StorageComponent extends SharedResourceAbstract {
     } catch (final RuntimeException | AssertionError e) {
       // See comment in the T-returning overload above.
       attemptClosedByFallback = true;
-      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+      assert scope.exitAttempt()
+          : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
+              + getLockName();
 
       acquireSharedLock();
       try {
@@ -799,7 +832,9 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       }
     } finally {
       if (!attemptClosedByFallback) {
-        assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+        assert scope.exitAttempt()
+            : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
+                + getLockName();
       }
     }
   }
@@ -865,7 +900,9 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       // Same fallback semantics as executeOptimisticStorageRead — and deliberately NO
       // re-check on this path: the pinned result below is already authoritative.
       attemptClosedByFallback = true;
-      assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+      assert scope.exitAttempt()
+          : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
+              + getLockName();
 
       acquireSharedLock();
       try {
@@ -875,7 +912,9 @@ public abstract class StorageComponent extends SharedResourceAbstract {
       }
     } finally {
       if (!attemptClosedByFallback) {
-        assert scope.exitAttempt() : "Nested optimistic read detected on " + getLockName();
+        assert scope.exitAttempt()
+            : "Optimistic attempt protocol violation (nested read or epoch-coverage breach) on "
+                + getLockName();
       }
     }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpochTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ApplyPhaseEpochTest.java
@@ -13,7 +13,8 @@ import org.junit.Test;
 /**
  * Tests for the {@link ApplyPhaseEpoch} reader/writer protocol (YTDB-1178): writers
  * bracket the commit-time page-apply section with enterApplyPhase()/exitApplyPhase();
- * readers capture both counters in {@link OptimisticReadScope#reset()} and re-check them
+ * readers capture both counters in {@link OptimisticReadScope#reset(ApplyPhaseEpoch)}
+ * and re-check them
  * in {@link OptimisticReadScope#validateOrThrow()}. A reader must fail whenever any apply
  * phase overlaps its read window — including the parity-defeating interleaving where two
  * writers' apply phases overlap each other.
@@ -41,15 +42,15 @@ public class ApplyPhaseEpochTest {
     // A read whose window overlaps no apply phase must pass the epoch check — both on a
     // fresh epoch and after previous apply phases have fully completed.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
 
-    scope.reset();
+    scope.reset(epoch);
     scope.validateOrThrow(); // fresh epoch: passes
 
     // A completed apply BEFORE the capture must not affect the next read.
     epoch.enterApplyPhase();
     epoch.exitApplyPhase();
-    scope.reset();
+    scope.reset(epoch);
     scope.validateOrThrow(); // quiescent again: passes
   }
 
@@ -59,10 +60,10 @@ public class ApplyPhaseEpochTest {
     // at capture time) must fail validation — the reader could see partially applied
     // pages with all stamps still valid.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
 
     epoch.enterApplyPhase();
-    scope.reset(); // capture sees enter=1, exit=0
+    scope.reset(epoch); // capture sees enter=1, exit=0
     expectValidateFails(scope);
     epoch.exitApplyPhase();
   }
@@ -72,9 +73,9 @@ public class ApplyPhaseEpochTest {
     // Epoch quiescent at capture, but a writer enters the apply phase before the reader
     // validates: the live enterSeq no longer matches the captured value → fail.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
 
-    scope.reset(); // capture sees enter=0, exit=0
+    scope.reset(epoch); // capture sees enter=0, exit=0
     epoch.enterApplyPhase();
     expectValidateFails(scope);
     epoch.exitApplyPhase();
@@ -85,9 +86,9 @@ public class ApplyPhaseEpochTest {
     // A full apply phase (enter AND exit) between capture and validation must still
     // fail: the reader may have read some pages before and some after the apply.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
 
-    scope.reset();
+    scope.reset(epoch);
     epoch.enterApplyPhase();
     epoch.exitApplyPhase();
     expectValidateFails(scope); // enterSeq moved from 0 to 1 since capture
@@ -100,14 +101,14 @@ public class ApplyPhaseEpochTest {
     // an apply phase is in flight. After the apply completes, a fresh reset() must
     // re-capture and let validation pass again.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
 
     epoch.enterApplyPhase();
-    scope.reset(); // in-flight apply: must not throw, only latch the doomed capture
+    scope.reset(epoch); // in-flight apply: must not throw, only latch the doomed capture
     expectValidateFails(scope);
 
     epoch.exitApplyPhase();
-    scope.reset(); // re-captures enter=1, exit=1 → quiescent
+    scope.reset(epoch); // re-captures enter=1, exit=1 → quiescent
     scope.validateOrThrow();
   }
 
@@ -120,7 +121,7 @@ public class ApplyPhaseEpochTest {
     // The two-counter scheme must keep failing an overlapping reader until BOTH writers
     // have exited. The interleaving is made deterministic with latches.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
 
     var aEntered = new CountDownLatch(1);
     var bEntered = new CountDownLatch(1);
@@ -158,13 +159,13 @@ public class ApplyPhaseEpochTest {
       await(bEntered);
 
       // Both applies in flight (enter=2, exit=0): reader must fail.
-      scope.reset();
+      scope.reset(epoch);
       expectValidateFails(scope);
 
       // A exits while B is still applying (enter=2, exit=1) — the parity trap.
       aMayExit.countDown();
       await(aExited);
-      scope.reset();
+      scope.reset(epoch);
       expectValidateFails(scope);
     } finally {
       // Always release the writers so a failing assertion cannot hang the test.
@@ -177,7 +178,7 @@ public class ApplyPhaseEpochTest {
     assertNull("Writer thread failed: " + error.get(), error.get());
 
     // Both writers exited (enter=2, exit=2): a fresh capture passes.
-    scope.reset();
+    scope.reset(epoch);
     scope.validateOrThrow();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ComponentEpochRegistryTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/ComponentEpochRegistryTest.java
@@ -1,0 +1,80 @@
+package com.jetbrains.youtrackdb.internal.core.storage.cache;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link ComponentEpochRegistry} — the per-storage fileId → component-epoch
+ * map behind the YTDB-1203 per-component apply-phase epochs. Pins the lifecycle rules
+ * the writer-side commit resolution depends on: identity-preserving lookups, miss →
+ * {@code null} on production registries (so {@code commitChanges} can fail loud, AR-2),
+ * overwrite-on-reuse, and the {@link ComponentEpochRegistry#uniform} standalone fallback
+ * that resolves every fileId to one epoch.
+ */
+public class ComponentEpochRegistryTest {
+
+  @Test
+  public void testRegisterAndResolveReturnsIdenticalInstance() {
+    // Lookups must return the exact registered instance — commit-time dedupe and the
+    // -ea coverage guards compare epochs by reference, never by value.
+    var registry = new ComponentEpochRegistry();
+    var epoch = new ApplyPhaseEpoch();
+
+    registry.register(42L, epoch);
+
+    assertSame(epoch, registry.epochFor(42L));
+  }
+
+  @Test
+  public void testMissReturnsNullOnProductionRegistry() {
+    // A production registry must report a miss as null so commitChanges can fail loud
+    // (AR-2) for files created or loaded outside the StorageComponent funnel.
+    var registry = new ComponentEpochRegistry();
+    registry.register(1L, new ApplyPhaseEpoch());
+
+    assertNull(registry.epochFor(2L));
+  }
+
+  @Test
+  public void testReRegistrationOverwritesMapping() {
+    // FileId reuse (disk engine, same-name delete+recreate): the recreating component's
+    // registration must replace the dead owner's epoch — subsequent commits on the
+    // fileId must resolve the NEW instance.
+    var registry = new ComponentEpochRegistry();
+    var oldOwner = new ApplyPhaseEpoch();
+    var newOwner = new ApplyPhaseEpoch();
+
+    registry.register(7L, oldOwner);
+    registry.register(7L, newOwner);
+
+    assertSame(newOwner, registry.epochFor(7L));
+  }
+
+  @Test
+  public void testUniformRegistryResolvesEveryFileIdToTheGivenEpoch() {
+    // uniform() is the standalone/test fallback: every fileId — registered or not —
+    // resolves to the single given epoch, reproducing the pre-per-component
+    // (storage-wide) bump semantics for operations constructed outside a storage.
+    var universal = new ApplyPhaseEpoch();
+    var registry = ComponentEpochRegistry.uniform(universal);
+
+    assertSame(universal, registry.epochFor(1L));
+    assertSame(universal, registry.epochFor(Long.MAX_VALUE));
+  }
+
+  @Test
+  public void testUniformRegistryPrefersExplicitRegistration() {
+    // An explicit registration on a uniform registry takes precedence over the
+    // universal fallback — the fallback only covers fileIds nobody registered.
+    var universal = new ApplyPhaseEpoch();
+    var explicit = new ApplyPhaseEpoch();
+    var registry = ComponentEpochRegistry.uniform(universal);
+
+    registry.register(5L, explicit);
+
+    assertSame(explicit, registry.epochFor(5L));
+    assertSame(universal, registry.epochFor(6L));
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScopeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScopeTest.java
@@ -1,6 +1,7 @@
 package com.jetbrains.youtrackdb.internal.core.storage.cache;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
@@ -19,8 +20,9 @@ import org.junit.Test;
  * Covers: record/validate happy path, validateOrThrow on invalid stamp, validateLastOrThrow,
  * reset clears state, grow on overflow, empty scope validates, cross-thread stamp
  * invalidation via PageFrame exclusive lock (review finding R2), and the interplay of
- * per-page stamps with the apply-phase epoch check (YTDB-1178) — see
- * {@link ApplyPhaseEpochTest} for the pure epoch protocol.
+ * per-page stamps with the per-component apply-phase epoch check (YTDB-1178 /
+ * YTDB-1203), including {@code reset(epoch)} rebinding one scope to different component
+ * epochs across attempts — see {@link ApplyPhaseEpochTest} for the pure epoch protocol.
  */
 public class OptimisticReadScopeTest {
 
@@ -258,6 +260,49 @@ public class OptimisticReadScopeTest {
     } finally {
       epoch.exitApplyPhase();
     }
+
+    releaseFrame(frame);
+  }
+
+  @Test
+  public void testSequentialResetsRebindScopeToDifferentComponentEpochs() {
+    // One scope object serves consecutive attempts on DIFFERENT components within the
+    // same atomic operation (YTDB-1203): each reset(epoch) must rebind validation to
+    // the epoch passed for THAT attempt. Bumps on an epoch the scope is NOT currently
+    // bound to must be invisible; bumps on the currently bound one must fail
+    // validation — and rebinding away from a bumped epoch must clear its effect.
+    var epochA = new ApplyPhaseEpoch();
+    var epochB = new ApplyPhaseEpoch();
+    var scope = new OptimisticReadScope();
+    var frame = pool.acquire(true, Intention.TEST);
+
+    // Attempt 1: bound to A. A completed apply on B mid-read is another component's
+    // business — validation must pass.
+    scope.reset(epochA);
+    assertSame(epochA, scope.capturedEpoch());
+    scope.record(frame, frame.tryOptimisticRead());
+    epochB.enterApplyPhase();
+    epochB.exitApplyPhase();
+    scope.validateOrThrow();
+
+    // Attempt 2: rebound to B. Now an apply entering on B must fail validation.
+    scope.reset(epochB);
+    assertSame(epochB, scope.capturedEpoch());
+    scope.record(frame, frame.tryOptimisticRead());
+    epochB.enterApplyPhase();
+    try {
+      scope.validateOrThrow();
+      fail("Expected OptimisticReadFailedException — bound epoch B moved mid-read");
+    } catch (OptimisticReadFailedException expected) {
+      // expected — the scope is now bound to B
+    }
+    epochB.exitApplyPhase();
+
+    // Attempt 3: rebound back to A. B's counters moved since attempt 1, but that is
+    // irrelevant now — the fresh capture of quiescent A passes.
+    scope.reset(epochA);
+    scope.record(frame, frame.tryOptimisticRead());
+    scope.validateOrThrow();
 
     releaseFrame(frame);
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScopeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/OptimisticReadScopeTest.java
@@ -122,7 +122,7 @@ public class OptimisticReadScopeTest {
     scope.record(frame, frame.tryOptimisticRead());
     assertEquals(1, scope.count());
 
-    scope.reset();
+    scope.reset(new ApplyPhaseEpoch());
     assertEquals(0, scope.count());
 
     // Empty scope should validate fine
@@ -206,7 +206,7 @@ public class OptimisticReadScopeTest {
 
     scope.record(frame, frame.tryOptimisticRead());
     scope.validateOrThrow();
-    scope.reset();
+    scope.reset(new ApplyPhaseEpoch());
 
     // Record a fresh stamp and validate again
     scope.record(frame, frame.tryOptimisticRead());
@@ -242,10 +242,10 @@ public class OptimisticReadScopeTest {
     // read window must fail validateOrThrow() even though every recorded stamp is still
     // valid — the pages could be a mix of pre- and post-commit state.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
     var frame = pool.acquire(true, Intention.TEST);
 
-    scope.reset(); // capture the quiescent epoch
+    scope.reset(epoch); // capture the quiescent epoch
     scope.record(frame, frame.tryOptimisticRead());
 
     // A writer enters the apply phase mid-read; the frame's stamp is untouched.
@@ -269,10 +269,10 @@ public class OptimisticReadScopeTest {
     // With an apply phase in flight, validateLastOrThrow must still pass for a valid
     // stamp while validateOrThrow on the same scope must fail.
     var epoch = new ApplyPhaseEpoch();
-    var scope = new OptimisticReadScope(epoch);
+    var scope = new OptimisticReadScope();
     var frame = pool.acquire(true, Intention.TEST);
 
-    scope.reset();
+    scope.reset(epoch);
     scope.record(frame, frame.tryOptimisticRead());
 
     epoch.enterApplyPhase();

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2VerifyAndTruncateOrphansTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/PaginatedCollectionV2VerifyAndTruncateOrphansTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +17,7 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.DirectMemoryAllocat
 import com.jetbrains.youtrackdb.internal.common.function.TxConsumer;
 import com.jetbrains.youtrackdb.internal.core.db.record.CurrentStorageComponentsFactory;
 import com.jetbrains.youtrackdb.internal.core.serialization.serializer.binary.BinarySerializerFactory;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntryImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
@@ -31,6 +33,7 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 
 /**
@@ -71,6 +74,7 @@ public class PaginatedCollectionV2VerifyAndTruncateOrphansTest {
   private ReadCache mockReadCache;
   private WriteCache mockWriteCache;
   private AbstractStorage mockStorage;
+  private AtomicOperationsManager mockAtomicOperationsManager;
   private AtomicOperation atomicOperation;
 
   // Per-file page count + page-pointer map so reads/writes against the same
@@ -89,7 +93,7 @@ public class PaginatedCollectionV2VerifyAndTruncateOrphansTest {
     when(mockWriteCache.pageSize()).thenReturn(PAGE_SIZE_BYTES);
     mockStorage = mock(AbstractStorage.class);
 
-    var mockAtomicOperationsManager = mock(AtomicOperationsManager.class);
+    mockAtomicOperationsManager = mock(AtomicOperationsManager.class);
     // PCV2.create() routes through executeInsideComponentOperation; install an
     // Answer that runs the consumer so create()'s body actually executes (otherwise
     // PCV2.fileId stays at 0 and the helper would read a fileId=0 file).
@@ -135,6 +139,32 @@ public class PaginatedCollectionV2VerifyAndTruncateOrphansTest {
   public void createLeavesCollectionInExpectedShape() throws IOException {
     assertThat(collection.getFileId()).isEqualTo(FILE_ID);
     assertThat(readFileSizeFromStatePage()).isEqualTo(0);
+  }
+
+  // Sub-component epoch sharing (YTDB-1203), structural half: PCV2's create() must
+  // register its own .pcl file AND all three sub-component files (.cpm/.fsm/.dpb)
+  // under ONE ApplyPhaseEpoch INSTANCE — the collection's own — because readRecord
+  // spans .pcl + .cpm pages in a single optimistic scope that validates exactly one
+  // epoch per attempt. Verified through the production registration funnel
+  // (AtomicOperationsManager.registerComponentEpoch), i.e., exactly what a real
+  // storage's registry would end up containing. The behavioral half (a commit on the
+  // sub-component file invalidating a family-epoch reader) is pinned in
+  // CommitChangesPageApplyHookTest.testSubComponentFileCommitInvalidatesReaderOfSharedFamilyEpoch.
+  @Test
+  public void createRegistersAllFamilyFilesUnderOneSharedEpoch() {
+    var fileIdCaptor = ArgumentCaptor.forClass(Long.class);
+    var epochCaptor = ArgumentCaptor.forClass(ApplyPhaseEpoch.class);
+    verify(mockAtomicOperationsManager, times(4))
+        .registerComponentEpoch(fileIdCaptor.capture(), epochCaptor.capture());
+
+    assertThat(fileIdCaptor.getAllValues())
+        .containsExactlyInAnyOrder(FILE_ID, CPM_FILE_ID, FSM_FILE_ID, DPB_FILE_ID);
+
+    var epochs = epochCaptor.getAllValues();
+    var familyEpoch = epochs.get(0);
+    for (var epoch : epochs) {
+      assertThat(epoch).isSameAs(familyEpoch);
+    }
   }
 
   // Orphan-present branch: bump the state page's fileSize to a non-zero value and

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationTestBridge.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/AtomicOperationTestBridge.java
@@ -13,10 +13,11 @@ import javax.annotation.Nullable;
  *   <li>{@link AtomicOperationBinaryTracking.PageApplyHook} installation on a live
  *       atomic operation, so an integration test can dictate the commit-time page-apply
  *       order and pause the writer mid-apply inside the epoch bracket;
- *   <li>the per-storage {@link ApplyPhaseEpoch} owned by {@link AtomicOperationsManager},
- *       so a test can make baseline-relative assertions on the epoch counters (never
- *       absolute ones — any commit that mutates shared cache state bumps the epoch,
- *       and storages are shared across tests).
+ *   <li>per-component {@link ApplyPhaseEpoch} lookups through the per-storage
+ *       component-epoch registry owned by {@link AtomicOperationsManager} (YTDB-1203),
+ *       so a test can make baseline-relative assertions on a component's epoch counters
+ *       (never absolute ones — any commit that mutates that component's files bumps the
+ *       epoch, and storages are shared across tests).
  * </ul>
  */
 public final class AtomicOperationTestBridge {
@@ -75,10 +76,22 @@ public final class AtomicOperationTestBridge {
   }
 
   /**
-   * Returns the apply-phase epoch of the given manager's storage. Tests must only make
-   * baseline-relative assertions on the returned counters.
+   * Returns the apply-phase epoch guarding the given file — i.e., the epoch of the
+   * storage component that owns it — resolved through the manager's per-storage
+   * component-epoch registry (YTDB-1203). Tests must only make baseline-relative
+   * assertions on the returned counters.
+   *
+   * @throws IllegalStateException if no epoch is registered for the file (the file was
+   *                               never created/opened through the StorageComponent
+   *                               funnel on this storage)
    */
-  public static ApplyPhaseEpoch applyPhaseEpoch(final AtomicOperationsManager manager) {
-    return manager.getApplyPhaseEpoch();
+  public static ApplyPhaseEpoch applyPhaseEpoch(
+      final AtomicOperationsManager manager, final long fileId) {
+    final var epoch = manager.getComponentEpochRegistry().epochFor(fileId);
+    if (epoch == null) {
+      throw new IllegalStateException(
+          "No component apply-phase epoch registered for file " + fileId);
+    }
+    return epoch;
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ComponentEpochRegistry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ReadCache;
@@ -132,7 +133,10 @@ public class CommitChangesPageApplyHookTest {
         new ConcurrentSkipListMap<>(),
         new ConcurrentSkipListMap<>(),
         new AtomicLong(),
-        epoch);
+        // Uniform registry: every fileId resolves to the single shared test epoch,
+        // mirroring the pre-per-component (storage-wide) bump semantics these tests
+        // assert on (YTDB-1203 compile adaptation; full test rework tracked separately).
+        ComponentEpochRegistry.uniform(epoch));
     op.startToApplyOperations(42);
     return op;
   }
@@ -281,8 +285,8 @@ public class CommitChangesPageApplyHookTest {
 
       // Overlapping reader (a different operation sharing the storage epoch): capture
       // now → validation must fail deterministically.
-      var readerScope = new OptimisticReadScope(epoch);
-      readerScope.reset();
+      var readerScope = new OptimisticReadScope();
+      readerScope.reset(epoch);
       try {
         readerScope.validateOrThrow();
         Assert.fail("Reader overlapping a mid-apply writer must fail epoch validation");
@@ -302,8 +306,8 @@ public class CommitChangesPageApplyHookTest {
     Assert.assertEquals(List.of(0L, 1L), appliedPageOrder);
     Assert.assertEquals(1, epoch.enterSeq());
     Assert.assertEquals(1, epoch.exitSeq());
-    var readerScope = new OptimisticReadScope(epoch);
-    readerScope.reset();
+    var readerScope = new OptimisticReadScope();
+    readerScope.reset(epoch);
     readerScope.validateOrThrow();
   }
 
@@ -332,8 +336,8 @@ public class CommitChangesPageApplyHookTest {
     // Bracket balanced despite the exception — a fresh reader capture passes.
     Assert.assertEquals(1, epoch.enterSeq());
     Assert.assertEquals(1, epoch.exitSeq());
-    var readerScope = new OptimisticReadScope(epoch);
-    readerScope.reset();
+    var readerScope = new OptimisticReadScope();
+    readerScope.reset(epoch);
     readerScope.validateOrThrow();
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
@@ -3,7 +3,10 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atom
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
@@ -17,6 +20,8 @@ import com.jetbrains.youtrackdb.internal.core.storage.cache.WriteCache;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationBinaryTracking.PageApplyHook;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.atomicoperations.AtomicOperationsTable.AtomicOperationsSnapshot;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurablePage;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.AtomicUnitEndRecord;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.FileCreatedWALRecord;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.LogSequenceNumber;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.TestPageOperation;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.WALRecordsFactory;
@@ -308,7 +313,7 @@ public class CommitChangesPageApplyHookTest {
       } catch (Throwable t) {
         writerError.set(t);
       }
-    });
+    }, "mid-apply-writer");
     writer.start();
 
     try {
@@ -333,10 +338,13 @@ public class CommitChangesPageApplyHookTest {
         // expected — apply phase in flight at capture time
       }
     } finally {
+      // Always release AND join the writer inside the finally: an assertion failure
+      // above must not leak a running writer thread past the test method (review
+      // finding TS-2; pattern from SharedLinkBagBTreeMixedApplyStateRegressionTest).
       resume.countDown();
+      writer.join(TimeUnit.SECONDS.toMillis(10));
     }
 
-    writer.join(TimeUnit.SECONDS.toMillis(10));
     Assert.assertFalse("Writer thread did not finish", writer.isAlive());
     Assert.assertNull("Writer failed: " + writerError.get(), writerError.get());
     Assert.assertNotNull(txEndLsn.get());
@@ -569,7 +577,7 @@ public class CommitChangesPageApplyHookTest {
       } catch (Throwable t) {
         writerError.set(t);
       }
-    });
+    }, "untouched-component-writer");
     writer.start();
 
     try {
@@ -599,10 +607,12 @@ public class CommitChangesPageApplyHookTest {
         // expected — A's apply phase in flight at capture time
       }
     } finally {
+      // Always release AND join the writer inside the finally — see the join comment
+      // in testReaderFailsDeterministicallyWhileWriterPausedMidApply (review TS-2).
       resume.countDown();
+      writer.join(TimeUnit.SECONDS.toMillis(10));
     }
 
-    writer.join(TimeUnit.SECONDS.toMillis(10));
     Assert.assertFalse("Writer thread did not finish", writer.isAlive());
     Assert.assertNull("Writer failed: " + writerError.get(), writerError.get());
 
@@ -713,6 +723,73 @@ public class CommitChangesPageApplyHookTest {
     // The resolution failure happens BEFORE any epoch is entered — nothing was applied
     // to the shared cache and no bracket was left open.
     Assert.assertEquals(0, appliedPageOrder.size());
+
+    // And BEFORE any WAL side effect of the commit (review finding CS-1): no file
+    // lifecycle record and — critically — no AtomicUnitEndRecord may have been logged,
+    // otherwise the failed commit would already be durable (WAL says committed, cache
+    // never applied) and crash recovery would replay it as a torn state interleaved
+    // with later transactions. The page-operation records flushed during setup are
+    // expected; the commit itself must add nothing.
+    verify(wal, never()).log(any(FileCreatedWALRecord.class));
+    verify(wal, never()).log(any(AtomicUnitEndRecord.class));
+  }
+
+  @Test
+  public void testTruncatingCommitBumpsComponentEpoch() throws IOException {
+    // Mutated-set predicate, truncate limb (review finding TQ-1): a commit whose only
+    // shared-cache mutation is a file truncation must resolve the file's owner epoch
+    // and bump it exactly once — readCache.truncateFile runs inside the apply section,
+    // so skipping the bump would expose concurrent optimistic readers of that
+    // component to mixed apply state (the YTDB-1178 bug on the truncate path).
+    var op = createOperation();
+    var truncateEpoch = new ApplyPhaseEpoch();
+    long fileId = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    when(writeCache.loadFile("truncated.dat")).thenReturn(fileId);
+    registry.register(fileId, truncateEpoch);
+
+    Assert.assertEquals(fileId, op.loadFile("truncated.dat"));
+    op.truncateFile(fileId);
+
+    // Truncate emits no WAL record (unsafe-operation warning only), so the commit
+    // returns a null txEndLsn — but it still mutates the shared cache and must bump.
+    Assert.assertNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(1, truncateEpoch.enterSeq());
+    Assert.assertEquals(1, truncateEpoch.exitSeq());
+    verify(readCache).truncateFile(fileId, writeCache);
+  }
+
+  @Test
+  public void testPageChangesOnLoadedFileBumpComponentEpoch() throws IOException {
+    // Mutated-set predicate, page-changes limb (review finding TQ-2): a pre-existing
+    // LOADED file (isNew=false, no truncate) whose only mutation is accumulated binary
+    // page changes must be resolved via the anyPageHasChanges limb and bump its owner
+    // epoch. This is the everyday update-commit shape; the other fixtures in this
+    // suite all use isNew=true, so without this case the anyPageHasChanges limb would
+    // only be covered remotely by the SLBB integration test.
+    var op = createOperation();
+    var updateEpoch = new ApplyPhaseEpoch();
+    long fileId = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    when(writeCache.loadFile("updated.dat")).thenReturn(fileId);
+    // The write overlay for an EXISTING page first loads the committed page through
+    // the read cache.
+    when(readCache.loadForRead(eq(fileId), eq(0L), any(), anyBoolean()))
+        .thenAnswer(inv -> newCacheEntry(fileId, 0));
+    registry.register(fileId, updateEpoch);
+
+    Assert.assertEquals(fileId, op.loadFile("updated.dat"));
+    var page = op.loadPageForWrite(fileId, 0, 1, false);
+    Assert.assertNotNull(page);
+    page.getChanges().setByteValue(null, (byte) 1, 100);
+    op.registerPageOperation(fileId, 0,
+        new TestPageOperation(0, fileId, 0, new LogSequenceNumber(0, 0), 0));
+    op.flushPendingOperations();
+
+    Assert.assertNotNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(List.of(0L), appliedPageOrder);
+    Assert.assertEquals(1, updateEpoch.enterSeq());
+    Assert.assertEquals(1, updateEpoch.exitSeq());
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/atomicoperations/CommitChangesPageApplyHookTest.java
@@ -41,8 +41,8 @@ import org.junit.Test;
 
 /**
  * Tests for the TEST-ONLY {@link PageApplyHook} seam in
- * {@link AtomicOperationBinaryTracking#commitChanges} and for the apply-phase epoch
- * bracket around the page-apply loop (YTDB-1178).
+ * {@link AtomicOperationBinaryTracking#commitChanges} and for the per-component
+ * apply-phase epoch bracket around the page-apply loop (YTDB-1178 / YTDB-1203).
  *
  * <p>The seam exists because the production page-apply order is fastutil hash order,
  * which makes the mixed-state race (a reader overlapping a partially applied commit)
@@ -51,9 +51,17 @@ import org.junit.Test;
  * <ul>
  *   <li>the hook can dictate and observe the page-apply order;
  *   <li>a reader overlapping a writer paused mid-apply (between two page applications,
- *       inside the epoch bracket) deterministically fails epoch validation;
- *   <li>the epoch bracket is exactly one enter/exit pair per commit, with the exit in a
- *       finally block that runs even when the hook throws.
+ *       inside the epoch bracket) deterministically fails epoch validation, while a
+ *       reader of a component the commit does not touch keeps passing (per-component
+ *       granularity, YTDB-1203);
+ *   <li>the epoch bracket is exactly one enter/exit pair per MUTATED COMPONENT —
+ *       resolved through a real {@link ComponentEpochRegistry}, deduplicated by epoch
+ *       identity across files of the same component — with the exits in a finally
+ *       block that runs even when the hook throws;
+ *   <li>the commit-time mutated-set predicate and registry lifecycle rules hold:
+ *       deleted files bump their owner's epoch, merely-loaded files bump nothing,
+ *       fileId reuse follows the overwritten registration, and a mutated file missing
+ *       from the registry fails the commit loudly (AR-2).
  * </ul>
  */
 public class CommitChangesPageApplyHookTest {
@@ -66,6 +74,14 @@ public class CommitChangesPageApplyHookTest {
   private WriteAheadLog wal;
   private AtomicInteger lsnCounter;
   private AtomicLong fileIdCounter;
+
+  // Real per-storage registry (not uniform()): every file a test creates is explicitly
+  // registered to a component epoch, exercising the same resolution path production
+  // commits take.
+  private ComponentEpochRegistry registry;
+
+  // Default component epoch: files created via the 3-arg setupNewFileWithPages overload
+  // register here, mimicking one storage component owning all of them.
   private ApplyPhaseEpoch epoch;
 
   // Order in which pages hit readCache.loadOrAddForWrite — the authoritative signal of
@@ -80,6 +96,7 @@ public class CommitChangesPageApplyHookTest {
     wal = mock(WriteAheadLog.class);
     lsnCounter = new AtomicInteger(1);
     fileIdCounter = new AtomicLong(100);
+    registry = new ComponentEpochRegistry();
     epoch = new ApplyPhaseEpoch();
     appliedPageOrder = Collections.synchronizedList(new ArrayList<>());
 
@@ -133,10 +150,7 @@ public class CommitChangesPageApplyHookTest {
         new ConcurrentSkipListMap<>(),
         new ConcurrentSkipListMap<>(),
         new AtomicLong(),
-        // Uniform registry: every fileId resolves to the single shared test epoch,
-        // mirroring the pre-per-component (storage-wide) bump semantics these tests
-        // assert on (YTDB-1203 compile adaptation; full test rework tracked separately).
-        ComponentEpochRegistry.uniform(epoch));
+        registry);
     op.startToApplyOperations(42);
     return op;
   }
@@ -148,9 +162,33 @@ public class CommitChangesPageApplyHookTest {
   /**
    * Creates a new durable file with {@code pageCount} changed pages (indexes 0..n-1),
    * registers a logical PageOperation per page, and flushes so every page carries a
-   * changeLSN — the precondition for reaching the commit-time apply loop.
+   * changeLSN — the precondition for reaching the commit-time apply loop. The file is
+   * registered to the default component {@link #epoch}, as the production
+   * StorageComponent funnel would do for the owning component.
    */
   private long setupNewFileWithPages(
+      AtomicOperationBinaryTracking op, String fileName, int pageCount) throws IOException {
+    return setupNewFileWithPages(op, fileName, pageCount, epoch);
+  }
+
+  /**
+   * Variant of {@link #setupNewFileWithPages(AtomicOperationBinaryTracking, String, int)}
+   * registering the file to an explicit component epoch — used by the per-component
+   * granularity tests to simulate files owned by different components.
+   */
+  private long setupNewFileWithPages(
+      AtomicOperationBinaryTracking op, String fileName, int pageCount,
+      ApplyPhaseEpoch componentEpoch) throws IOException {
+    long fileId = setupUnregisteredNewFileWithPages(op, fileName, pageCount);
+    registry.register(fileId, componentEpoch);
+    return fileId;
+  }
+
+  /**
+   * Same file/page setup but WITHOUT registering an epoch for the file — only for the
+   * AR-2 fail-loud test; every other test must register, as the production funnel does.
+   */
+  private long setupUnregisteredNewFileWithPages(
       AtomicOperationBinaryTracking op, String fileName, int pageCount) throws IOException {
     long internalId = fileIdCounter.getAndIncrement();
     long fullFileId = composeFileId(internalId, STORAGE_ID);
@@ -283,8 +321,9 @@ public class CommitChangesPageApplyHookTest {
       Assert.assertEquals(1, epoch.enterSeq());
       Assert.assertEquals(0, epoch.exitSeq());
 
-      // Overlapping reader (a different operation sharing the storage epoch): capture
-      // now → validation must fail deterministically.
+      // Overlapping reader of the SAME component (a different operation that resolved
+      // the mutated file's epoch through the registry): capture now → validation must
+      // fail deterministically.
       var readerScope = new OptimisticReadScope();
       readerScope.reset(epoch);
       try {
@@ -445,10 +484,12 @@ public class CommitChangesPageApplyHookTest {
   }
 
   @Test
-  public void testCommitWithoutHookBumpsEpochExactlyOnce() throws IOException {
-    // The production path (no hook installed) must also bracket the apply section with
-    // exactly one enter/exit pair per commit — one pair for the whole commit, not one
-    // per page or per file.
+  public void testCommitWithoutHookBumpsComponentEpochExactlyOnce() throws IOException {
+    // The production path (no hook installed) must bracket the apply section with
+    // exactly one enter/exit pair per MUTATED COMPONENT. Both files here belong to the
+    // same component (registered to the same epoch instance — the sub-component sharing
+    // shape), so identity dedupe must collapse them into ONE pair for the whole commit,
+    // not one per page or per file.
     var op = createOperation();
     setupNewFileWithPages(op, "no-hook-a.dat", 2);
     setupNewFileWithPages(op, "no-hook-b.dat", 1);
@@ -458,5 +499,240 @@ public class CommitChangesPageApplyHookTest {
     Assert.assertEquals(3, appliedPageOrder.size());
     Assert.assertEquals(1, epoch.enterSeq());
     Assert.assertEquals(1, epoch.exitSeq());
+  }
+
+  @Test
+  public void testTwoComponentCommitBumpsEachComponentEpochOnce() throws IOException {
+    // A commit spanning files of TWO components must bump each component's epoch
+    // exactly once: component A owns two mutated files (deduped to one pair by epoch
+    // identity), component B owns one. This pins the resolved-set semantics of
+    // collectMutatedComponentEpochs — per component, not per commit and not per file.
+    var op = createOperation();
+    var epochA = new ApplyPhaseEpoch();
+    var epochB = new ApplyPhaseEpoch();
+    setupNewFileWithPages(op, "comp-a1.dat", 1, epochA);
+    setupNewFileWithPages(op, "comp-a2.dat", 2, epochA);
+    setupNewFileWithPages(op, "comp-b.dat", 1, epochB);
+
+    Assert.assertNotNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(1, epochA.enterSeq());
+    Assert.assertEquals(1, epochA.exitSeq());
+    Assert.assertEquals(1, epochB.enterSeq());
+    Assert.assertEquals(1, epochB.exitSeq());
+  }
+
+  @Test
+  public void testReaderOfUntouchedComponentSurvivesConcurrentCommitMidApply()
+      throws Exception {
+    // THE per-component granularity payoff (YTDB-1203): a writer thread is paused
+    // mid-apply on component A's file — inside A's epoch bracket, mixed state visible —
+    // while a reader that captured component B's epoch validates successfully, because
+    // the commit never touches B. A reader of A's epoch captured at the same moment
+    // must still fail. Under the old storage-wide epoch both readers failed.
+    var op = createOperation();
+    var epochA = new ApplyPhaseEpoch();
+    var epochB = new ApplyPhaseEpoch();
+    setupNewFileWithPages(op, "touched-a.dat", 2, epochA);
+    // Component B exists in the registry (its file was opened at some point) but the
+    // commit does not mutate it.
+    registry.register(composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID), epochB);
+
+    var midApplyReached = new CountDownLatch(1);
+    var resume = new CountDownLatch(1);
+    op.setPageApplyHook(new PageApplyHook() {
+      @Override
+      public long[] orderPageApplications(long fileId, long[] pageIndexes) {
+        return new long[] {0, 1};
+      }
+
+      @Override
+      public void beforePageApply(long fileId, long pageIndex) {
+        if (pageIndex == 1) {
+          midApplyReached.countDown();
+          try {
+            if (!resume.await(10, TimeUnit.SECONDS)) {
+              throw new IllegalStateException("Timed out waiting for resume signal");
+            }
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+          }
+        }
+      }
+    });
+
+    var writerError = new AtomicReference<Throwable>();
+    var writer = new Thread(() -> {
+      try {
+        op.commitChanges(42L, wal);
+      } catch (Throwable t) {
+        writerError.set(t);
+      }
+    });
+    writer.start();
+
+    try {
+      Assert.assertTrue(
+          "Writer never reached the mid-apply barrier",
+          midApplyReached.await(10, TimeUnit.SECONDS));
+
+      // Writer paused inside A's bracket: A's epoch is mid-apply, B's untouched.
+      Assert.assertEquals(1, epochA.enterSeq());
+      Assert.assertEquals(0, epochA.exitSeq());
+      Assert.assertEquals(0, epochB.enterSeq());
+      Assert.assertEquals(0, epochB.exitSeq());
+
+      // Reader of the UNTOUCHED component B: capture and validation both succeed while
+      // the commit into A is still mid-apply.
+      var readerB = new OptimisticReadScope();
+      readerB.reset(epochB);
+      readerB.validateOrThrow();
+
+      // Reader of the MUTATED component A captured at the same moment must fail.
+      var readerA = new OptimisticReadScope();
+      readerA.reset(epochA);
+      try {
+        readerA.validateOrThrow();
+        Assert.fail("Reader of the mutated component must fail while mid-apply");
+      } catch (OptimisticReadFailedException expected) {
+        // expected — A's apply phase in flight at capture time
+      }
+    } finally {
+      resume.countDown();
+    }
+
+    writer.join(TimeUnit.SECONDS.toMillis(10));
+    Assert.assertFalse("Writer thread did not finish", writer.isAlive());
+    Assert.assertNull("Writer failed: " + writerError.get(), writerError.get());
+
+    // Commit finished: A bumped once, B never touched.
+    Assert.assertEquals(1, epochA.enterSeq());
+    Assert.assertEquals(1, epochA.exitSeq());
+    Assert.assertEquals(0, epochB.enterSeq());
+    Assert.assertEquals(0, epochB.exitSeq());
+  }
+
+  @Test
+  public void testSubComponentFileCommitInvalidatesReaderOfSharedFamilyEpoch()
+      throws IOException {
+    // Sub-component epoch sharing, behavioral half (YTDB-1203): a collection family
+    // registers ALL its files (.pcl data file + .cpm position map + ...) under ONE
+    // shared epoch instance. A reader that captured the family epoch (e.g., while
+    // reading the collection) must be invalidated by a commit that mutates ONLY the
+    // sub-component's file — that is exactly what makes the readRecord .pcl+.cpm
+    // two-file optimistic scope sound under per-component epochs.
+    var op = createOperation();
+    var familyEpoch = new ApplyPhaseEpoch();
+    // .pcl-like file: registered to the family epoch but NOT mutated by this commit.
+    registry.register(composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID),
+        familyEpoch);
+    // .cpm-like file: same family epoch, mutated below.
+    setupNewFileWithPages(op, "family.cpm", 1, familyEpoch);
+
+    var reader = new OptimisticReadScope();
+    reader.reset(familyEpoch); // reader captured the family epoch pre-commit
+
+    Assert.assertNotNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(1, familyEpoch.enterSeq());
+    Assert.assertEquals(1, familyEpoch.exitSeq());
+    try {
+      reader.validateOrThrow();
+      Assert.fail("Commit on the sub-component file must invalidate the family reader");
+    } catch (OptimisticReadFailedException expected) {
+      // expected — the family epoch moved since the reader's capture
+    }
+  }
+
+  @Test
+  public void testDeletingCommitBumpsDeletedFilesComponentEpoch() throws IOException {
+    // Delete-bump ordering (YTDB-1203): a commit whose deletedFiles set contains file F
+    // must resolve F through the registry and bump F's owner epoch. This only works
+    // because registry entries are NEVER removed — the owning component is unregistered
+    // from storage maps before the deleting commit applies, so a remove-on-drop registry
+    // would make this very commit miss its own bump.
+    var op = createOperation();
+    var victimEpoch = new ApplyPhaseEpoch();
+    long victimFileId = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    registry.register(victimFileId, victimEpoch);
+    when(writeCache.fileNameById(victimFileId)).thenReturn("victim.dat");
+
+    // Delete a PRE-EXISTING file (not created inside this operation): lands in
+    // deletedFiles rather than just dropping an in-TX fileChanges entry.
+    op.deleteFile(victimFileId);
+
+    Assert.assertNotNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(1, victimEpoch.enterSeq());
+    Assert.assertEquals(1, victimEpoch.exitSeq());
+  }
+
+  @Test
+  public void testFileIdReuseFollowsOverwrittenRegistration() throws IOException {
+    // FileId-reuse overwrite (YTDB-1203): re-registering an existing fileId (the disk
+    // engine reuses the internal id on same-name delete+recreate) must overwrite the
+    // mapping — a subsequent commit mutating that fileId bumps ONLY the new owner's
+    // epoch; the dead component's epoch stays untouched.
+    var op = createOperation();
+    var oldOwnerEpoch = new ApplyPhaseEpoch();
+    var newOwnerEpoch = new ApplyPhaseEpoch();
+    long fileId = setupNewFileWithPages(op, "reused.dat", 1, oldOwnerEpoch);
+    // The recreated component re-registers the same fileId before the commit applies.
+    registry.register(fileId, newOwnerEpoch);
+
+    Assert.assertNotNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(0, oldOwnerEpoch.enterSeq());
+    Assert.assertEquals(0, oldOwnerEpoch.exitSeq());
+    Assert.assertEquals(1, newOwnerEpoch.enterSeq());
+    Assert.assertEquals(1, newOwnerEpoch.exitSeq());
+  }
+
+  @Test
+  public void testCommitFailsLoudWhenMutatedFileMissingFromRegistry() throws IOException {
+    // AR-2 fail-loud contract: a mutated fileId with no registry entry must abort the
+    // commit with an IllegalStateException naming the fileId — silently skipping the
+    // bump would leave that component's optimistic readers permanently unprotected
+    // against this commit's apply phase.
+    var op = createOperation();
+    long fileId = setupUnregisteredNewFileWithPages(op, "behind-funnel.dat", 1);
+
+    try {
+      op.commitChanges(42L, wal);
+      Assert.fail("Expected IllegalStateException for the unregistered mutated file");
+    } catch (IllegalStateException e) {
+      Assert.assertTrue(
+          "Message should name the unregistered fileId: " + e.getMessage(),
+          e.getMessage().contains(String.valueOf(fileId)));
+      Assert.assertTrue(
+          "Message should point at the component funnel: " + e.getMessage(),
+          e.getMessage().contains("StorageComponent.addFile/openFile funnel"));
+    }
+
+    // The resolution failure happens BEFORE any epoch is entered — nothing was applied
+    // to the shared cache and no bracket was left open.
+    Assert.assertEquals(0, appliedPageOrder.size());
+  }
+
+  @Test
+  public void testReadOnlyLoadedFileDoesNotBumpItsEpoch() throws IOException {
+    // Mutated-set predicate: a file that was merely LOADED by the operation (present in
+    // fileChanges with an empty change set — the read-only shape) is not part of the
+    // apply section, so its component epoch must NOT be bumped; bumping it would
+    // spuriously invalidate every overlapping optimistic read of that component.
+    var op = createOperation();
+    var readOnlyEpoch = new ApplyPhaseEpoch();
+    long loadedFileId = composeFileId(fileIdCounter.getAndIncrement(), STORAGE_ID);
+    when(writeCache.loadFile("read-only.dat")).thenReturn(loadedFileId);
+    registry.register(loadedFileId, readOnlyEpoch);
+
+    Assert.assertEquals(loadedFileId, op.loadFile("read-only.dat"));
+
+    // Pure read-only commit: nothing to apply, no WAL unit — and no bump.
+    Assert.assertNull(op.commitChanges(42L, wal));
+
+    Assert.assertEquals(0, readOnlyEpoch.enterSeq());
+    Assert.assertEquals(0, readOnlyEpoch.exitSeq());
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -519,9 +519,10 @@ public class StorageComponentOptimisticReadTest {
   public void testFallbackToPinnedWhenApplyPhaseInFlightAtCapture() throws IOException {
     // A commit apply phase already in flight when the read starts must fail epoch
     // validation (the capture sees enterSeq != exitSeq) and run the pinned lambda —
-    // even though the page's stamp stays valid the whole time.
-    var epoch = new ApplyPhaseEpoch();
-    scope = new OptimisticReadScope(epoch);
+    // even though the page's stamp stays valid the whole time. The component under test
+    // resets the scope against ITS OWN epoch (YTDB-1203), so the test bumps that epoch.
+    var epoch = component.testApplyPhaseEpoch();
+    scope = new OptimisticReadScope();
     when(mockAtomicOp.getOptimisticReadScope()).thenReturn(scope);
 
     var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
@@ -550,9 +551,10 @@ public class StorageComponentOptimisticReadTest {
   public void testFallbackToPinnedWhenApplyPhaseBeginsMidRead() throws IOException {
     // Epoch quiescent at capture, but a writer enters (and even completes) an apply
     // phase between the page read and validation. The live enterSeq no longer matches
-    // the captured value → epoch check fails → pinned fallback runs.
-    var epoch = new ApplyPhaseEpoch();
-    scope = new OptimisticReadScope(epoch);
+    // the captured value → epoch check fails → pinned fallback runs. The component under
+    // test resets the scope against ITS OWN epoch (YTDB-1203), so the test bumps that.
+    var epoch = component.testApplyPhaseEpoch();
+    scope = new OptimisticReadScope();
     when(mockAtomicOp.getOptimisticReadScope()).thenReturn(scope);
 
     var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
@@ -971,6 +973,10 @@ public class StorageComponentOptimisticReadTest {
 
     long testAddFile(AtomicOperation op, String fileName) throws IOException {
       return addFile(op, fileName);
+    }
+
+    ApplyPhaseEpoch testApplyPhaseEpoch() {
+      return applyPhaseEpoch();
     }
 
     <T> T testExecuteOptimisticStorageReadWithNullRecheck(

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -3,7 +3,9 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -741,25 +743,27 @@ public class StorageComponentOptimisticReadTest {
     long foreignFileId = 777L;
     registry.register(foreignFileId, new ApplyPhaseEpoch()); // another component's epoch
 
+    // assertThrows keeps the expected-error window scoped to the lambda alone: a
+    // non-firing guard fails assertThrows itself instead of a fail() call satisfying
+    // the test's own catch (review finding TS-3).
     final boolean[] pinnedFallbackRan = {false};
-    try {
-      component.testExecuteOptimisticStorageRead(
-          mockAtomicOp,
-          () -> {
-            component.testLoadPageForRead(mockAtomicOp, foreignFileId, 0);
-            return "optimistic-result";
-          },
-          () -> {
-            pinnedFallbackRan[0] = true;
-            return "pinned-result";
-          });
-      fail("Expected AssertionError from the pinned-inside-optimistic epoch guard");
-    } catch (AssertionError e) {
-      assertTrue(
-          "Expected the protocol-violation assert, got: " + e.getMessage(),
-          String.valueOf(e.getMessage())
-              .contains("Optimistic attempt protocol violation"));
-    }
+    var violation = assertThrows(
+        "Expected AssertionError from the pinned-inside-optimistic epoch guard",
+        AssertionError.class,
+        () -> component.testExecuteOptimisticStorageRead(
+            mockAtomicOp,
+            () -> {
+              component.testLoadPageForRead(mockAtomicOp, foreignFileId, 0);
+              return "optimistic-result";
+            },
+            () -> {
+              pinnedFallbackRan[0] = true;
+              return "pinned-result";
+            }));
+    assertTrue(
+        "Expected the protocol-violation assert, got: " + violation.getMessage(),
+        String.valueOf(violation.getMessage())
+            .contains("Optimistic attempt protocol violation"));
     assertEquals(false, pinnedFallbackRan[0]);
 
     // exitAttempt() cleared the latch: a well-formed read on the same scope works.
@@ -787,21 +791,36 @@ public class StorageComponentOptimisticReadTest {
     installRealRegistryWithOwnFile();
     long unregisteredFileId = 778L;
 
-    try {
-      component.testExecuteOptimisticStorageRead(
-          mockAtomicOp,
-          () -> {
-            component.testLoadPageForRead(mockAtomicOp, unregisteredFileId, 0);
-            return "optimistic-result";
-          },
-          () -> "pinned-result");
-      fail("Expected AssertionError for the unregistered pinned file");
-    } catch (AssertionError e) {
-      assertTrue(
-          "Expected the protocol-violation assert, got: " + e.getMessage(),
-          String.valueOf(e.getMessage())
-              .contains("Optimistic attempt protocol violation"));
-    }
+    // See the assertThrows-scoping comment in the foreign-file variant above (TS-3).
+    var violation = assertThrows(
+        "Expected AssertionError for the unregistered pinned file",
+        AssertionError.class,
+        () -> component.testExecuteOptimisticStorageRead(
+            mockAtomicOp,
+            () -> {
+              component.testLoadPageForRead(mockAtomicOp, unregisteredFileId, 0);
+              return "optimistic-result";
+            },
+            () -> "pinned-result"));
+    assertTrue(
+        "Expected the protocol-violation assert, got: " + violation.getMessage(),
+        String.valueOf(violation.getMessage())
+            .contains("Optimistic attempt protocol violation"));
+  }
+
+  @Test
+  public void testTopLevelComponentsOwnDistinctEpochInstances() {
+    // The per-component granularity (YTDB-1203) rests on every TOP-LEVEL component
+    // allocating its OWN ApplyPhaseEpoch in the default StorageComponent constructor.
+    // All other epoch tests inject manually built epochs through the registry seam, so
+    // a regression to a shared/static epoch (silently reverting to storage-wide
+    // invalidation) would keep them green — pin the constructor behavior directly on
+    // two real component instances (review finding TS-1).
+    var other = new TestStorageComponent(component.storage);
+    assertNotSame(
+        "Two top-level components must not share an ApplyPhaseEpoch instance",
+        component.testApplyPhaseEpoch(),
+        other.testApplyPhaseEpoch());
   }
 
   @Test
@@ -856,21 +875,21 @@ public class StorageComponentOptimisticReadTest {
     var frame = acquireFrameWithCoordinates(foreignFileId, 0);
     when(mockReadCache.getPageFrameOptimistic(foreignFileId, 0)).thenReturn(frame);
 
-    try {
-      component.testExecuteOptimisticStorageRead(
-          mockAtomicOp,
-          () -> {
-            component.testLoadPageOptimistic(mockAtomicOp, foreignFileId, 0);
-            return "optimistic-result";
-          },
-          () -> "pinned-result");
-      fail("Expected AssertionError from the optimistic epoch-coverage guard");
-    } catch (AssertionError e) {
-      assertTrue(
-          "Expected the protocol-violation assert, got: " + e.getMessage(),
-          String.valueOf(e.getMessage())
-              .contains("Optimistic attempt protocol violation"));
-    }
+    // See the assertThrows-scoping comment in the pinned foreign-file variant (TS-3).
+    var violation = assertThrows(
+        "Expected AssertionError from the optimistic epoch-coverage guard",
+        AssertionError.class,
+        () -> component.testExecuteOptimisticStorageRead(
+            mockAtomicOp,
+            () -> {
+              component.testLoadPageOptimistic(mockAtomicOp, foreignFileId, 0);
+              return "optimistic-result";
+            },
+            () -> "pinned-result"));
+    assertTrue(
+        "Expected the protocol-violation assert, got: " + violation.getMessage(),
+        String.valueOf(violation.getMessage())
+            .contains("Optimistic attempt protocol violation"));
     releaseFrame(frame);
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/base/StorageComponentOptimisticReadTest.java
@@ -19,6 +19,8 @@ import com.jetbrains.youtrackdb.internal.common.directmemory.PageFrame;
 import com.jetbrains.youtrackdb.internal.common.directmemory.PageFramePool;
 import com.jetbrains.youtrackdb.internal.core.config.ContextConfiguration;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.ApplyPhaseEpoch;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.CacheEntry;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.ComponentEpochRegistry;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadFailedException;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.OptimisticReadScope;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.PageView;
@@ -53,6 +55,7 @@ public class StorageComponentOptimisticReadTest {
   private DirectMemoryAllocator allocator;
   private PageFramePool pool;
   private ReadCache mockReadCache;
+  private AtomicOperationsManager mockAtomicOpsMgr;
   private AtomicOperation mockAtomicOp;
   private OptimisticReadScope scope;
   private ErrorCapturingStorageComponent component;
@@ -66,7 +69,7 @@ public class StorageComponentOptimisticReadTest {
     mockReadCache = mock(ReadCache.class);
     var mockWriteCache = mock(WriteCache.class);
     var mockStorage = mock(AbstractStorage.class);
-    var mockAtomicOpsMgr = mock(AtomicOperationsManager.class);
+    mockAtomicOpsMgr = mock(AtomicOperationsManager.class);
     when(mockStorage.getReadCache()).thenReturn(mockReadCache);
     when(mockStorage.getWriteCache()).thenReturn(mockWriteCache);
     when(mockStorage.getAtomicOperationsManager()).thenReturn(mockAtomicOpsMgr);
@@ -580,11 +583,12 @@ public class StorageComponentOptimisticReadTest {
     // Nested executeOptimisticStorageRead calls are a programming error: the inner
     // reset() wipes the outer scope's stamps, silently voiding the outer validation.
     // Detection is -ea-only and involves TWO AssertionErrors: the INNER call's
-    // enterAttempt() assert ("... attempt ...") fires first, but it is thrown inside
-    // the outer optimistic lambda and swallowed by the outer fallback catch; the
-    // violation latched in the scope then fails the OUTER catch's exitAttempt() assert,
-    // and THAT error ("... detected ...") is what escapes to the caller — before the
-    // outer pinned lambda gets a chance to run.
+    // enterAttempt() assert ("Nested optimistic read attempt") fires first, but it is
+    // thrown inside the outer optimistic lambda and swallowed by the outer fallback
+    // catch; the violation latched in the scope then fails the OUTER catch's
+    // exitAttempt() assert, and THAT error ("Optimistic attempt protocol violation")
+    // is what escapes to the caller — before the outer pinned lambda gets a chance to
+    // run.
     var assertionsEnabled = false;
     // Intentional side effect in assert — standard idiom to detect whether -ea is on.
     assert assertionsEnabled = true;
@@ -608,8 +612,9 @@ public class StorageComponentOptimisticReadTest {
       fail("Expected AssertionError from nested optimistic read detection");
     } catch (AssertionError e) {
       assertTrue(
-          "Expected the outer 'detected' assert to escape, got: " + e.getMessage(),
-          String.valueOf(e.getMessage()).contains("Nested optimistic read detected"));
+          "Expected the outer protocol-violation assert to escape, got: " + e.getMessage(),
+          String.valueOf(e.getMessage())
+              .contains("Optimistic attempt protocol violation"));
     }
     assertEquals(false, outerPinnedRan[0]);
 
@@ -693,6 +698,179 @@ public class StorageComponentOptimisticReadTest {
         () -> fail("should not fall back — previous failure must not poison this read"));
     assertEquals(true, optimisticRan[0]);
 
+    releaseFrame(frame);
+  }
+
+  // --- Per-component epoch-coverage guards (-ea only, YTDB-1203 / review AR-1) ---
+
+  /**
+   * Installs a REAL component-epoch registry on the mock manager (setUp leaves it
+   * unstubbed/null so the guards stay lenient for all other tests) and maps the
+   * component's own file to its own epoch — the well-formed baseline the violation
+   * tests deviate from.
+   */
+  private ComponentEpochRegistry installRealRegistryWithOwnFile() {
+    var registry = new ComponentEpochRegistry();
+    when(mockAtomicOpsMgr.getComponentEpochRegistry()).thenReturn(registry);
+    registry.register(FILE_ID, component.testApplyPhaseEpoch());
+    return registry;
+  }
+
+  private static boolean assertionsEnabled() {
+    var enabled = false;
+    // Intentional side effect in assert — standard idiom to detect whether -ea is on.
+    assert enabled = true;
+    return enabled;
+  }
+
+  @Test
+  public void testPinnedReadOfForeignFileInsideOptimisticAttemptFailsEaGuard()
+      throws IOException {
+    // AR-1 counterexample: inside an optimistic attempt, the lambda issues a PINNED
+    // loadPageForRead against a file registered to a DIFFERENT component's epoch (the
+    // hypothetical future "PCV2→SLBB pinned delegate" shape). The scope records nothing
+    // for pinned pages, so under per-component epochs the read would escape epoch
+    // validation entirely — the -ea guard must surface this as an AssertionError to the
+    // caller. Note the surfacing mechanism: the guard's own AssertionError fires inside
+    // the optimistic lambda and is swallowed by the fallback catch; the latched
+    // violation then fails the attempt-closing exitAttempt() assert, and the pinned
+    // fallback must NOT run.
+    Assume.assumeTrue("Epoch-coverage guard requires -ea", assertionsEnabled());
+
+    var registry = installRealRegistryWithOwnFile();
+    long foreignFileId = 777L;
+    registry.register(foreignFileId, new ApplyPhaseEpoch()); // another component's epoch
+
+    final boolean[] pinnedFallbackRan = {false};
+    try {
+      component.testExecuteOptimisticStorageRead(
+          mockAtomicOp,
+          () -> {
+            component.testLoadPageForRead(mockAtomicOp, foreignFileId, 0);
+            return "optimistic-result";
+          },
+          () -> {
+            pinnedFallbackRan[0] = true;
+            return "pinned-result";
+          });
+      fail("Expected AssertionError from the pinned-inside-optimistic epoch guard");
+    } catch (AssertionError e) {
+      assertTrue(
+          "Expected the protocol-violation assert, got: " + e.getMessage(),
+          String.valueOf(e.getMessage())
+              .contains("Optimistic attempt protocol violation"));
+    }
+    assertEquals(false, pinnedFallbackRan[0]);
+
+    // exitAttempt() cleared the latch: a well-formed read on the same scope works.
+    var frame = acquireFrameWithCoordinates(FILE_ID, PAGE_INDEX);
+    when(mockReadCache.getPageFrameOptimistic(FILE_ID, PAGE_INDEX)).thenReturn(frame);
+    String result = component.testExecuteOptimisticStorageRead(
+        mockAtomicOp,
+        () -> {
+          component.testLoadPageOptimistic(mockAtomicOp, FILE_ID, PAGE_INDEX);
+          return "optimistic-result";
+        },
+        () -> "pinned-result");
+    assertEquals("optimistic-result", result);
+    releaseFrame(frame);
+  }
+
+  @Test
+  public void testPinnedReadOfUnregisteredFileInsideOptimisticAttemptFailsEaGuard()
+      throws IOException {
+    // AR-1, missing-entry flavor: with a real registry installed, a pinned read of a
+    // file that has NO registration at all (created behind the funnel's back) is
+    // equally uncovered by the scope's epoch and must fail the guard.
+    Assume.assumeTrue("Epoch-coverage guard requires -ea", assertionsEnabled());
+
+    installRealRegistryWithOwnFile();
+    long unregisteredFileId = 778L;
+
+    try {
+      component.testExecuteOptimisticStorageRead(
+          mockAtomicOp,
+          () -> {
+            component.testLoadPageForRead(mockAtomicOp, unregisteredFileId, 0);
+            return "optimistic-result";
+          },
+          () -> "pinned-result");
+      fail("Expected AssertionError for the unregistered pinned file");
+    } catch (AssertionError e) {
+      assertTrue(
+          "Expected the protocol-violation assert, got: " + e.getMessage(),
+          String.valueOf(e.getMessage())
+              .contains("Optimistic attempt protocol violation"));
+    }
+  }
+
+  @Test
+  public void testPinnedReadOfOwnFileInsideOptimisticAttemptPassesEaGuard()
+      throws IOException {
+    // The legitimate pinned-inside-optimistic shape (position-map delegates,
+    // firstItem/lastItem descents): the pinned file belongs to the SAME epoch the scope
+    // captured, so the guard passes and the optimistic result is returned normally.
+    var registry = installRealRegistryWithOwnFile();
+    // Sub-component shape: a second file registered to the same epoch instance.
+    long subComponentFileId = 779L;
+    registry.register(subComponentFileId, component.testApplyPhaseEpoch());
+
+    String result = component.testExecuteOptimisticStorageRead(
+        mockAtomicOp,
+        () -> {
+          component.testLoadPageForRead(mockAtomicOp, FILE_ID, PAGE_INDEX);
+          component.testLoadPageForRead(mockAtomicOp, subComponentFileId, 0);
+          return "optimistic-result";
+        },
+        () -> "pinned-result");
+
+    assertEquals("optimistic-result", result);
+  }
+
+  @Test
+  public void testPinnedReadOfForeignFileOutsideOptimisticAttemptPassesEaGuard()
+      throws IOException {
+    // Plain pinned reads (no optimistic attempt in flight) are epoch-independent: the
+    // guard must not constrain them even when the file belongs to another component —
+    // this includes pinned FALLBACK lambdas, which run after the attempt was closed.
+    var registry = installRealRegistryWithOwnFile();
+    long foreignFileId = 780L;
+    registry.register(foreignFileId, new ApplyPhaseEpoch());
+
+    // Direct pinned read, no attempt in flight — must not throw.
+    component.testLoadPageForRead(mockAtomicOp, foreignFileId, 0);
+  }
+
+  @Test
+  public void testOptimisticRecordOfForeignFileFailsEaGuard() throws IOException {
+    // The optimistic-path twin of AR-1: recording a page of a file registered to a
+    // DIFFERENT component's epoch in the scope (an optimistic lambda spanning two
+    // top-level components) must fail the -ea guard through the same latch mechanism —
+    // one attempt validates exactly one epoch, so the foreign page would never be
+    // protected.
+    Assume.assumeTrue("Epoch-coverage guard requires -ea", assertionsEnabled());
+
+    var registry = installRealRegistryWithOwnFile();
+    long foreignFileId = 781L;
+    registry.register(foreignFileId, new ApplyPhaseEpoch());
+    var frame = acquireFrameWithCoordinates(foreignFileId, 0);
+    when(mockReadCache.getPageFrameOptimistic(foreignFileId, 0)).thenReturn(frame);
+
+    try {
+      component.testExecuteOptimisticStorageRead(
+          mockAtomicOp,
+          () -> {
+            component.testLoadPageOptimistic(mockAtomicOp, foreignFileId, 0);
+            return "optimistic-result";
+          },
+          () -> "pinned-result");
+      fail("Expected AssertionError from the optimistic epoch-coverage guard");
+    } catch (AssertionError e) {
+      assertTrue(
+          "Expected the protocol-violation assert, got: " + e.getMessage(),
+          String.valueOf(e.getMessage())
+              .contains("Optimistic attempt protocol violation"));
+    }
     releaseFrame(frame);
   }
 
@@ -973,6 +1151,11 @@ public class StorageComponentOptimisticReadTest {
 
     long testAddFile(AtomicOperation op, String fileName) throws IOException {
       return addFile(op, fileName);
+    }
+
+    CacheEntry testLoadPageForRead(AtomicOperation op, long fileId, long pageIndex)
+        throws IOException {
+      return loadPageForRead(op, fileId, pageIndex);
     }
 
     ApplyPhaseEpoch testApplyPhaseEpoch() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/ridbag/ridbagbtree/SharedLinkBagBTreeMixedApplyStateRegressionTest.java
@@ -243,10 +243,14 @@ public class SharedLinkBagBTreeMixedApplyStateRegressionTest {
    * </ol>
    */
   private void runMixedStateScenario(LookupAssertion lookup) throws Exception {
-    final var epoch = AtomicOperationTestBridge.applyPhaseEpoch(atomicOperationsManager);
+    // Per-component epoch (YTDB-1203): resolve the epoch of the SLBB component under
+    // test through its file id — the writer's commit mutates only this component's file,
+    // so its epoch carries the single bump pair the assertions below track.
+    final var epoch = AtomicOperationTestBridge.applyPhaseEpoch(
+        atomicOperationsManager, bTree.getFileId());
     // Baseline is captured while no operation is running (setUp's operations have
     // committed). Never assert absolute epoch values — every commit that mutates
-    // shared cache state bumps the epoch, and this storage is shared across tests.
+    // this component's files bumps the epoch, and this storage is shared across tests.
     final long baseEnter = epoch.enterSeq();
     final long baseExit = epoch.exitSeq();
     assertEquals("epoch must be quiescent at baseline", baseEnter, baseExit);

--- a/docs-internal/adr/YTDB-1203-optimistic-read-component-granularity/adr.md
+++ b/docs-internal/adr/YTDB-1203-optimistic-read-component-granularity/adr.md
@@ -1,0 +1,342 @@
+# Per-component apply-phase epoch granularity — Architecture Decision Record
+
+## Summary
+
+Refines the YTDB-1178 apply-phase epoch from one instance per storage to one
+instance per top-level storage component. YTDB-1178 closed the
+mixed-apply-state race — a committing transaction applies its page changes to
+the shared read cache one page at a time, so an optimistic multi-page reader
+overlapping that window could observe a mix of pre- and post-commit pages
+with every per-page stamp still valid — by bracketing the commit-time apply
+section with a two-counter seqlock-style epoch that readers capture before
+the attempt and re-validate after the stamp loop. That epoch was
+storage-wide, so *every* commit invalidated *every* concurrent optimistic
+read in the storage, including reads of components the commit never touched.
+This change makes `ApplyPhaseEpoch` a per-component instance held by the
+`StorageComponent` base class, adds a writer-side `ComponentEpochRegistry`
+(fileId → epoch) so commits resolve and bump only the epochs of components
+they actually mutate, and adds `-ea`-only guards enforcing that one
+optimistic read scope reads exactly one high-level component. Public API,
+WAL format, and the on-disk format are unchanged.
+
+## Goals
+
+- **Stop over-invalidation**: a commit into one component must not fail
+  concurrent optimistic reads of unrelated components. Achieved: readers
+  validate the epoch of the component they read; commits bump only the
+  epochs resolved from their actually-mutated fileIds.
+- **Preserve the YTDB-1178 correctness guarantee**: an optimistic read
+  overlapping a commit-time apply phase of the *same* component (or its
+  sub-components) must still fail and fall back to the pinned path.
+  Achieved: sub-components share the parent's epoch instance, and the
+  reader/writer protocol on each instance is unchanged.
+- **Keep the reader hot path free of lookups**: capturing the epoch at
+  optimistic-attempt start is a plain field access on the component
+  (`this.applyPhaseEpoch`), not a registry or map lookup.
+- **Fail loud on funnel bypass**: a mutated file with no registered epoch is
+  a correctness hole (its optimistic readers would silently lose apply-phase
+  protection), so commit throws rather than skipping the bump.
+
+## Constraints
+
+- Edits stay inside `core`'s storage engine: `ApplyPhaseEpoch`,
+  `OptimisticReadScope`, the new `ComponentEpochRegistry` (all in
+  `storage/cache`), `StorageComponent`, `AtomicOperationBinaryTracking`,
+  `AtomicOperationsManager`, and the component constructors that wire epoch
+  sharing (`PaginatedCollectionV2` family).
+- WAL format, replay-record schema, and on-disk layout unchanged.
+- The reader/writer memory-ordering argument of YTDB-1178 is preserved
+  verbatim per epoch instance: volatile enter/exit counters, exit-then-enter
+  capture order, validation after the stamp loop.
+- The attempt-protocol machinery (`enterAttempt`/`exitAttempt`, violation
+  latch) is `-ea`-only: production builds pay only dead branches. Guards are
+  invoked exclusively from `assert` statements.
+- 2-space indent, 100-column, braces always, Spotless-clean, JDK 21.
+
+## Architecture Notes
+
+### Component Map
+
+```mermaid
+flowchart TD
+    SC["StorageComponent<br/>final ApplyPhaseEpoch applyPhaseEpoch<br/>addFile / openFile funnel"]
+    APE["ApplyPhaseEpoch<br/>enterSeq / exitSeq<br/>(one per top-level component)"]
+    REG["ComponentEpochRegistry<br/>ConcurrentHashMap fileId → epoch<br/>(one per storage, owned by AtomicOperationsManager)"]
+    ORS["OptimisticReadScope<br/>reset(epoch) captures counters<br/>validateOrThrow() re-checks<br/>attempt-violation latch (-ea)"]
+    AOBT["AtomicOperationBinaryTracking.commitChanges<br/>collectMutatedComponentEpochs()<br/>enter/exit bracket per distinct epoch"]
+    TOP["Top-level components<br/>BTree v3 (per instance)<br/>PaginatedCollectionV2<br/>SharedLinkBagBTree<br/>IndexHistogramManager"]
+    SUB["Sub-components<br/>CollectionPositionMapV2<br/>FreeSpaceMap<br/>CollectionDirtyPageBitSet"]
+
+    TOP -->|"default ctor: new ApplyPhaseEpoch()"| SC
+    SUB -->|"epoch-taking ctor: parent's instance"| SC
+    SC -->|holds| APE
+    SC -->|"register(fileId, epoch) on addFile/openFile"| REG
+    ORS -->|"captures at attempt start<br/>(plain field access)"| APE
+    AOBT -->|"resolves mutated fileIds"| REG
+    AOBT -->|"enterApplyPhase / exitApplyPhase"| APE
+```
+
+- `ApplyPhaseEpoch` itself is unchanged in protocol: two monotonic
+  `AtomicLong` counters (`applyEnterSeq`, `applyExitSeq`); readers capture
+  exit-then-enter and a read is valid only if `enterAtCapture ==
+  exitAtCapture` and the live `enterSeq` is unchanged after the stamp loop.
+  Two counters instead of odd/even parity because apply phases bumping the
+  *same* epoch may now overlap: an epoch is shared between a parent and its
+  sub-components, and two commits that locked different components of that
+  family can apply concurrently — parity would flip back to "idle" and mask
+  the overlap.
+- `StorageComponent` gains a `private final ApplyPhaseEpoch applyPhaseEpoch`
+  field with two constructor overloads: the default overload allocates a
+  fresh instance (top-level components), the epoch-taking overload accepts
+  the parent's instance (sub-components). A `protected final
+  applyPhaseEpoch()` accessor exposes it to subclasses for wiring.
+- `ComponentEpochRegistry` is a per-storage `ConcurrentHashMap<Long,
+  ApplyPhaseEpoch>` owned by `AtomicOperationsManager`, keyed by external
+  composed fileIds. A `uniform(epoch)` factory serves standalone atomic
+  operations (tests, tooling): every fileId resolves to one private epoch,
+  mirroring the pre-YTDB-1203 storage-wide semantics so the fail-loud
+  resolution cannot misfire outside a real storage.
+- `OptimisticReadScope.reset(ApplyPhaseEpoch)` binds the epoch per attempt,
+  not per scope — the scope lives in the `AtomicOperation` and serves
+  sequential attempts on different components within one transaction.
+- `AtomicOperationBinaryTracking.commitChanges` computes the mutated-epoch
+  set before mutating shared cache state and brackets the whole apply
+  section (file deletion/creation/truncation plus the per-page apply loop)
+  with one `enterApplyPhase`/`exitApplyPhase` pair per distinct epoch; exits
+  run in a `finally` block so an escaping exception cannot leave an epoch
+  permanently "in apply".
+
+### Decision Records
+
+#### D1: Epoch instance lives on `StorageComponent`; sub-components share the parent's
+
+The component base class is the one place every page-holding storage
+structure already passes through, so the epoch field is inherited rather
+than re-implemented per component. Top-level components — each `BTree` (v3)
+instance including both trees of the multi-value index engine,
+`PaginatedCollectionV2`, `SharedLinkBagBTree`, `IndexHistogramManager` —
+allocate their own instance via the default constructor. Sub-components —
+`CollectionPositionMapV2`, `FreeSpaceMap`, `CollectionDirtyPageBitSet` —
+receive `PaginatedCollectionV2`'s instance through the epoch-taking
+overload, so one optimistic read spanning the collection family's files
+(e.g., `.pcl` + `.cpm`) validates a single epoch and a commit into any
+family file invalidates readers of the whole family exactly once.
+
+**Alternatives rejected**: a `HighLevelStorageComponent` marker interface to
+tag epoch owners — it adds no enforcement (nothing stops a sub-component
+from implementing it or an owner from forgetting it), and the actual wiring
+decision lives in constructor calls anyway; the constructor-overload split
+already makes ownership explicit at the only place it matters.
+
+#### D2: Reader captures the component epoch by plain field access
+
+`StorageComponent.executeOptimisticStorageRead` passes its own
+`applyPhaseEpoch` field to `OptimisticReadScope.reset(epoch)` at attempt
+start. No registry lookup, no indirection — the optimistic hot path gains
+zero cost over the YTDB-1178 storage-wide design. The registry (D3) exists
+solely for the writer side, which cannot know component identity from the
+fileIds it tracks.
+
+**Alternatives rejected**: a striped per-file epoch array indexed by
+`fileId % stripes`, with lazy per-file capture as the reader touches each
+file. Rejected because (a) lazy capture reopens a cross-file capture-gap
+risk — the mixed-state hazard the epoch exists to close reappears between
+the capture points of two files read in one attempt; (b) it needs hot-path
+capture machinery on every first-touch of a file instead of one field read
+per attempt; (c) stripe sizing becomes a tuning knob with false-sharing
+(too few stripes re-creates over-invalidation) on one side and footprint on
+the other; (d) detecting "first touch of a new file in this attempt"
+requires promoting the `-ea`-only attempt-active flag into production code.
+
+#### D3: Writer-side `ComponentEpochRegistry`, populated in the `addFile`/`openFile` funnel
+
+Commit-time apply works on fileIds (`deletedFiles`, `fileChanges`), not on
+component references, so the writer needs a fileId → epoch mapping. Every
+file a component creates or opens flows through `StorageComponent.addFile`
+/ `openFile`, which registers the fileId under the component's epoch
+(sub-components register under the parent's instance) via
+`AtomicOperationsManager.registerComponentEpoch`. Registration can run
+under the storage `stateLock` *read* side (e.g., `SharedLinkBagBTree`
+creation during normal transactions), so the registry is a lock-free
+`ConcurrentHashMap` assuming no external locking.
+
+Lifecycle: **entries are never removed** (see I2 — the deleting commit must
+still resolve the fileId after the component has unregistered itself), and
+**re-registration overwrites** — the disk engine reuses the internal fileId
+when a same-name file is recreated after a delete, and the recreating
+component's registration simply replaces the stale mapping. `openFile`
+re-registers on every storage open, which also refreshes mappings after a
+delete/recreate cycle.
+
+**Alternatives rejected**: avoiding `Long` boxing by reusing the in-tree
+`ConcurrentLongIntHashMap` with `(fileId, 0)`-style keys plus a side table,
+or porting BookKeeper's `ConcurrentLongHashMap`. The registry is cold-path
+— puts happen on component create/open, gets happen once per commit — so
+boxing overhead is immaterial, and a ported concurrent map would demand an
+equivalent concurrent-stress test suite to earn the trust the JDK map gets
+for free.
+
+#### D4: Commit resolves actually-mutated fileIds, dedupes epochs by identity, fails loud on a miss
+
+`collectMutatedComponentEpochs()` resolves exactly the fileIds the apply
+section acts on: deleted files ∪ files flagged new ∪ files flagged
+truncated ∪ files with at least one page carrying accumulated changes.
+Merely-loaded files (empty `FileChanges`) resolve nothing, so read-only
+atomic operations skip the epoch bracket entirely. Epochs are deduplicated
+**by identity** — sub-components share the parent's epoch *instance* and one
+commit frequently touches several files of the same family, which must
+produce exactly one enter/exit pair per epoch; the mutated set is small
+(typically 1–3 components), so a linear reference scan beats an identity
+hash set. A mutated fileId with no registry entry throws
+`IllegalStateException` (review finding AR-2): every production file is
+registered by the funnel before it can be mutated, so a miss means a file
+was created or loaded behind the funnel's back and its optimistic readers
+would silently lose epoch protection if the bump were skipped.
+
+**Alternatives rejected**: skip-and-log on a registry miss (converts a
+correctness hole into a silent one); bumping every epoch in the registry on
+a miss (re-creates storage-wide over-invalidation to paper over a bug).
+
+#### D5: `-ea`-only one-component-per-scope guards with a latched-violation protocol
+
+One optimistic attempt validates exactly one epoch, so an optimistic lambda
+must not read files of two different top-level components. This invariant
+was verified across all optimistic call sites at design time; runtime
+enforcement is `-ea`-only, on **both** page-load paths: the optimistic load
+(`loadPageOptimistic`) asserts the recorded page's registered epoch IS
+(reference equality) the scope's captured epoch, and the pinned load asserts
+the same whenever an optimistic attempt is in flight (a pinned read inside
+an optimistic lambda that delegates into a different top-level component
+would escape epoch validation entirely). Violations are **latched on the
+scope** (`markAttemptViolation`) and surfaced by the attempt-closing
+`exitAttempt()` assert — an `AssertionError` thrown *inside* the optimistic
+lambda would otherwise be swallowed by the pinned-fallback catch, silently
+converting a protocol bug into a fallback. The same latch also detects
+nested `executeOptimisticStorageRead` calls (a nested `reset` would wipe the
+outer scope's stamps and void its validation). `exitAttempt()` clears the
+latch so a legitimate pinned-fallback retry does not trip a stale flag.
+
+**Alternatives rejected**: production-grade enforcement (promotes the
+attempt-active flag and per-page registry lookups into the hot path for a
+design-time-verified invariant); throwing directly from the guard (swallowed
+by the fallback catch, see above).
+
+#### D6: Accepted narrowing on same-name drop+recreate (adversarial finding AR-3)
+
+A stale component reference that survives a same-name drop+recreate cycle
+reads the reused fileId's pages under the dead component's epoch: the
+recreating component overwrote the registry mapping (D3), so commits into
+the new incarnation bump the new epoch and the stale reader's validation
+passes vacuously. This is a **pre-existing use-after-drop defect class** —
+such access is already semantically void (the component was dropped) and is
+excluded by the storage `stateLock` for live readers. The storage-wide
+YTDB-1178 epoch would have *coincidentally* invalidated such reads (every
+commit bumped the one epoch); the per-component epoch will not. Accepted:
+the coincidental protection was never a contract, and restoring it would
+require registry removal hooks that break I2.
+
+### Invariants & Contracts
+
+- **I1.** One optimistic read scope reads exactly one high-level component
+  per attempt: every page recorded — or pinned-read while an attempt is in
+  flight — belongs to a file whose registered epoch is reference-equal to
+  the epoch captured at `reset`. Verified across all optimistic call sites
+  at design time; enforced at runtime under `-ea` via the latched-violation
+  protocol (D5).
+- **I2.** `ComponentEpochRegistry` entries are never removed. This is
+  load-bearing, not hygiene: components unregister from the storage-level
+  maps **before** the deleting commit's page application runs, so the commit
+  that deletes a file must still be able to resolve the deleted fileId to
+  the owner's epoch and bump it. Removal on drop would make the deleting
+  commit miss its own bump and expose concurrent readers of the dying
+  component to mixed apply state.
+- **I3.** Every fileId a production component mutates has a registry entry
+  before the mutating commit applies — established by the `addFile`/
+  `openFile` funnel (D3), enforced fail-loud at commit (D4).
+- **I4.** Exactly one `enterApplyPhase`/`exitApplyPhase` pair per distinct
+  epoch per commit, with exits in `finally` — an epoch can never be left
+  permanently "in apply" (which would disable optimistic reads of that
+  component for good). Rollbacks never enter `commitChanges`, so they bump
+  no epoch.
+- **I5.** Per epoch instance, the YTDB-1178 reader protocol is unchanged:
+  capture `exitSeq` then `enterSeq` at attempt start; valid iff
+  `enterAtCapture == exitAtCapture` and live `enterSeq` unchanged after the
+  per-page stamp loop.
+
+### Integration Points
+
+- `StorageComponent.addFile` / `openFile` — the sole registry-population
+  funnel; both call `AtomicOperationsManager.registerComponentEpoch(fileId,
+  applyPhaseEpoch)`.
+- `PaginatedCollectionV2` constructor — passes `applyPhaseEpoch()` to
+  `CollectionPositionMapV2`, `FreeSpaceMap`, and
+  `CollectionDirtyPageBitSet` so the family shares one instance.
+- `BTreeMultiValueIndexEngine` — creates two `BTree` instances (main and
+  `$null` sub-tree); each is its own top-level component with its own epoch.
+- `AtomicOperationBinaryTracking.commitChanges` — computes
+  `collectMutatedComponentEpochs()` before mutating shared cache state and
+  brackets the apply section per resolved epoch.
+- `AtomicOperationBinaryTracking` standalone constructor — wires
+  `ComponentEpochRegistry.uniform(new ApplyPhaseEpoch())` so operations
+  built outside a storage keep pre-per-component semantics with the
+  fail-loud path unreachable.
+- `OptimisticReadScope` — bound per attempt via `reset(epoch)`; carries the
+  `-ea` attempt/violation state consumed by
+  `StorageComponent.executeOptimisticStorageRead`.
+- Rename operations are epoch-irrelevant by construction: component rename
+  goes straight to `WriteCache.renameFile(fileId, newName)`, preserving the
+  fileId and bypassing atomic-operation file tracking entirely — no
+  registry entry changes and no epoch bump is needed.
+
+### Non-Goals
+
+- **Restoring cross-component invalidation for stale references** (the AR-3
+  narrowing, D6) — use-after-drop is an orthogonal, pre-existing defect
+  class.
+- **Production-grade enforcement of the one-component-per-scope invariant**
+  — deliberately `-ea`-only (D5).
+- **Per-file or striped epoch granularity** — rejected (D2); per-component
+  is the finest granularity that keeps single-capture semantics.
+- **Registry entry reclamation** — entries are permanent by contract (I2);
+  the footprint is one map entry per file ever opened, which is bounded by
+  the storage's file population.
+- **Engine-global epoch placement** (on `ReadCache`) — on the disk engine a
+  single read cache is shared by all storages of the engine, which would be
+  even coarser than per-storage.
+
+## Key Discoveries
+
+- **The never-remove registry rule is load-bearing.** Components unregister
+  from storage-level maps *before* commit-time page application runs. If the
+  registry dropped entries on component drop, the deleting commit's own
+  epoch resolution would miss, skipping the bump exactly when concurrent
+  readers of the dying component most need it. "Overwrite on reuse, never
+  remove" is the only lifecycle that keeps the deleting commit sound.
+- **Assertions inside optimistic lambdas are invisible.** The pinned-fallback
+  catch in `executeOptimisticStorageRead` swallows everything the lambda
+  throws — including `AssertionError` from `-ea` guards. Any invariant check
+  that can fire inside the lambda must latch its violation on the scope and
+  surface it from the attempt-closing assert *outside* the catch. This
+  latched-violation pattern (D5) is reusable for future in-lambda checks.
+- **Parity seqlocks break under shared epochs.** With sub-components sharing
+  the parent's epoch instance, two commits that locked different family
+  components can be in their apply phases concurrently. A single odd/even
+  parity word would flip back to "idle" when the second writer enters; the
+  two-counter form (`enter == exit` ⇔ idle) is what makes instance sharing
+  sound. YTDB-1178 already chose two counters; per-component sharing is the
+  first configuration where the choice is essential rather than defensive.
+- **`reset(ApplyPhaseEpoch)` must never throw.** It runs outside the
+  try/fallback block, so an exception there escapes past the pinned fallback
+  instead of triggering it. The null-epoch check is an `assert`, not a
+  production throw, for exactly this reason.
+- **Fail-loud epoch resolution needs a standalone escape hatch.** Atomic
+  operations constructed outside a storage (tests, tooling) have no funnel
+  to populate a registry; without `ComponentEpochRegistry.uniform`, the
+  AR-2 fail-loud contract would make every standalone commit throw. The
+  uniform registry reproduces storage-wide semantics privately, keeping the
+  production contract strict.
+- **Rename never intersects the epoch machinery.** `renameFile` operates
+  directly on the write cache with a preserved fileId and never enters the
+  atomic-operation `deletedFiles`/`fileChanges` tracking, so renames need no
+  registry maintenance — worth stating because rename is the one file-level
+  operation the funnel does not see.

--- a/docs-internal/adr/YTDB-1203-optimistic-read-component-granularity/adr.md
+++ b/docs-internal/adr/YTDB-1203-optimistic-read-component-granularity/adr.md
@@ -319,8 +319,8 @@ require registry removal hooks that break I2.
 - **Restoring cross-component invalidation for stale references** (the
   stale-reader narrowing accepted in D6) — use-after-drop is an orthogonal,
   pre-existing defect class.
-- **Production-grade enforcement of the one-component-per-scope invariant**
-  — deliberately `-ea`-only (D5).
+- **Production-grade enforcement of the one-component-per-attempt
+  invariant** — deliberately `-ea`-only (D5).
 - **Per-file or striped epoch granularity** — rejected (D2); per-component
   is the finest granularity that keeps single-capture semantics.
 - **Registry entry reclamation** — entries are permanent by contract (I2);

--- a/docs-internal/adr/YTDB-1203-optimistic-read-component-granularity/adr.md
+++ b/docs-internal/adr/YTDB-1203-optimistic-read-component-granularity/adr.md
@@ -9,15 +9,19 @@ the shared read cache one page at a time, so an optimistic multi-page reader
 overlapping that window could observe a mix of pre- and post-commit pages
 with every per-page stamp still valid — by bracketing the commit-time apply
 section with a two-counter seqlock-style epoch that readers capture before
-the attempt and re-validate after the stamp loop. That epoch was
-storage-wide, so *every* commit invalidated *every* concurrent optimistic
-read in the storage, including reads of components the commit never touched.
+the attempt and re-validate after the stamp loop. (YTDB-1178 has no ADR of
+its own; it landed in PR #1222, commit `8950fe0282`, with its rationale in
+code javadocs.) That epoch was storage-wide, so every *mutating* commit
+invalidated *every* concurrent optimistic read in the storage, including
+reads of components the commit never touched (zero-change commits were
+already gated out by the since-replaced `commitMutatesSharedCache()` check).
 This change makes `ApplyPhaseEpoch` a per-component instance held by the
 `StorageComponent` base class, adds a writer-side `ComponentEpochRegistry`
 (fileId → epoch) so commits resolve and bump only the epochs of components
 they actually mutate, and adds `-ea`-only guards enforcing that one
-optimistic read scope reads exactly one high-level component. Public API,
-WAL format, and the on-disk format are unchanged.
+optimistic read attempt reads exactly one high-level component (the scope is
+re-bound to the target component's epoch at each attempt's `reset`). Public
+API, WAL format, and the on-disk format are unchanged.
 
 ## Goals
 
@@ -100,11 +104,12 @@ flowchart TD
   not per scope — the scope lives in the `AtomicOperation` and serves
   sequential attempts on different components within one transaction.
 - `AtomicOperationBinaryTracking.commitChanges` computes the mutated-epoch
-  set before mutating shared cache state and brackets the whole apply
-  section (file deletion/creation/truncation plus the per-page apply loop)
-  with one `enterApplyPhase`/`exitApplyPhase` pair per distinct epoch; exits
-  run in a `finally` block so an escaping exception cannot leave an epoch
-  permanently "in apply".
+  set at method entry — before `flushPendingOperations` and before any WAL
+  record is written (see D4) — and brackets the whole apply section (file
+  deletion/creation/truncation plus the per-page apply loop) with one
+  `enterApplyPhase`/`exitApplyPhase` pair per distinct epoch; exits run in a
+  `finally` block so an escaping exception cannot leave an epoch permanently
+  "in apply".
 
 ### Decision Records
 
@@ -134,8 +139,11 @@ already makes ownership explicit at the only place it matters.
 `applyPhaseEpoch` field to `OptimisticReadScope.reset(epoch)` at attempt
 start. No registry lookup, no indirection — the optimistic hot path gains
 zero cost over the YTDB-1178 storage-wide design. The registry (D3) exists
-solely for the writer side, which cannot know component identity from the
-fileIds it tracks.
+primarily for the writer side, which cannot know component identity from the
+fileIds it tracks; the only reader-side accesses are the `-ea`-only guard
+lookups of D5 (`StorageComponent.loadPageOptimistic` / `loadPageForRead` via
+`registeredEpochIs`), which sit inside `assert` operands and never run on
+the production hot path.
 
 **Alternatives rejected**: a striped per-file epoch array indexed by
 `fileId % stripes`, with lazy per-file capture as the reader touches each
@@ -188,16 +196,30 @@ commit frequently touches several files of the same family, which must
 produce exactly one enter/exit pair per epoch; the mutated set is small
 (typically 1–3 components), so a linear reference scan beats an identity
 hash set. A mutated fileId with no registry entry throws
-`IllegalStateException` (review finding AR-2): every production file is
-registered by the funnel before it can be mutated, so a miss means a file
-was created or loaded behind the funnel's back and its optimistic readers
-would silently lose epoch protection if the bump were skipped.
+`IllegalStateException` (pre-implementation review finding AR-2, which asked
+for an explicit fail-loud policy instead of a silent skip on a registry
+miss; the review artifacts themselves are not archived in-repo): every
+production file is registered by the funnel before it can be mutated, so a
+miss means a file was created or loaded behind the funnel's back and its
+optimistic readers would silently lose epoch protection if the bump were
+skipped.
+
+The resolution runs at the very top of `commitChanges` — before
+`flushPendingOperations` and before any WAL record is written — so the
+fail-loud miss aborts the commit cleanly *before* the durability point of no
+return. Resolving after the `AtomicUnitEndRecord` (as an earlier revision
+did) would turn a miss into a recovery-visible torn state: WAL says
+committed, the cache apply never ran, and replay would apply the orphaned
+unit against later transactions' writes. The early call is safe because the
+mutated set is frozen at `commitChanges` entry — `flushPendingOperations`
+only assigns changeLSNs to already-registered page overlays, and the WAL
+phase only prunes page entries without changes.
 
 **Alternatives rejected**: skip-and-log on a registry miss (converts a
 correctness hole into a silent one); bumping every epoch in the registry on
 a miss (re-creates storage-wide over-invalidation to paper over a bug).
 
-#### D5: `-ea`-only one-component-per-scope guards with a latched-violation protocol
+#### D5: `-ea`-only one-component-per-attempt guards with a latched-violation protocol
 
 One optimistic attempt validates exactly one epoch, so an optimistic lambda
 must not read files of two different top-level components. This invariant
@@ -221,7 +243,11 @@ attempt-active flag and per-page registry lookups into the hot path for a
 design-time-verified invariant); throwing directly from the guard (swallowed
 by the fallback catch, see above).
 
-#### D6: Accepted narrowing on same-name drop+recreate (adversarial finding AR-3)
+#### D6: Accepted narrowing on same-name drop+recreate
+
+Raised as pre-implementation adversarial-review finding AR-3, which asked
+for this residual risk to be documented explicitly (the review artifacts
+themselves are not archived in-repo).
 
 A stale component reference that survives a same-name drop+recreate cycle
 reads the reused fileId's pages under the dead component's epoch: the
@@ -237,8 +263,8 @@ require registry removal hooks that break I2.
 
 ### Invariants & Contracts
 
-- **I1.** One optimistic read scope reads exactly one high-level component
-  per attempt: every page recorded — or pinned-read while an attempt is in
+- **I1.** One optimistic read attempt reads exactly one high-level
+  component (the scope re-binds per attempt at `reset`): every page recorded — or pinned-read while an attempt is in
   flight — belongs to a file whose registered epoch is reference-equal to
   the epoch captured at `reset`. Verified across all optimistic call sites
   at design time; enforced at runtime under `-ea` via the latched-violation
@@ -274,8 +300,8 @@ require registry removal hooks that break I2.
 - `BTreeMultiValueIndexEngine` — creates two `BTree` instances (main and
   `$null` sub-tree); each is its own top-level component with its own epoch.
 - `AtomicOperationBinaryTracking.commitChanges` — computes
-  `collectMutatedComponentEpochs()` before mutating shared cache state and
-  brackets the apply section per resolved epoch.
+  `collectMutatedComponentEpochs()` at method entry, before any WAL side
+  effect (D4), and brackets the apply section per resolved epoch.
 - `AtomicOperationBinaryTracking` standalone constructor — wires
   `ComponentEpochRegistry.uniform(new ApplyPhaseEpoch())` so operations
   built outside a storage keep pre-per-component semantics with the
@@ -290,16 +316,19 @@ require registry removal hooks that break I2.
 
 ### Non-Goals
 
-- **Restoring cross-component invalidation for stale references** (the AR-3
-  narrowing, D6) — use-after-drop is an orthogonal, pre-existing defect
-  class.
+- **Restoring cross-component invalidation for stale references** (the
+  stale-reader narrowing accepted in D6) — use-after-drop is an orthogonal,
+  pre-existing defect class.
 - **Production-grade enforcement of the one-component-per-scope invariant**
   — deliberately `-ea`-only (D5).
 - **Per-file or striped epoch granularity** — rejected (D2); per-component
   is the finest granularity that keeps single-capture semantics.
 - **Registry entry reclamation** — entries are permanent by contract (I2);
-  the footprint is one map entry per file ever opened, which is bounded by
-  the storage's file population.
+  the footprint is one map entry (plus a possibly-dead epoch) per file ever
+  opened or created in the storage's lifetime — monotonic under
+  unique-name create/drop churn, not bounded by the *live* file population.
+  Accepted: entries are ~100 bytes and DDL churn at a scale where this
+  matters is not an existing workload.
 - **Engine-global epoch placement** (on `ReadCache`) — on the disk engine a
   single read cache is shared by all storages of the engine, which would be
   even coarser than per-storage.
@@ -332,9 +361,9 @@ require registry removal hooks that break I2.
 - **Fail-loud epoch resolution needs a standalone escape hatch.** Atomic
   operations constructed outside a storage (tests, tooling) have no funnel
   to populate a registry; without `ComponentEpochRegistry.uniform`, the
-  AR-2 fail-loud contract would make every standalone commit throw. The
-  uniform registry reproduces storage-wide semantics privately, keeping the
-  production contract strict.
+  fail-loud registry-miss contract of D4 would make every standalone commit
+  throw. The uniform registry reproduces storage-wide semantics privately,
+  keeping the production contract strict.
 - **Rename never intersects the epoch machinery.** `renameFile` operates
   directly on the write cache with a preserved fileId and never enters the
   atomic-operation `deletedFiles`/`fileChanges` tracking, so renames need no


### PR DESCRIPTION
#### Motivation:

YTDB-1178 fixed the optimistic-read mixed-state race with an apply-phase epoch (seqlock): a per-storage epoch bumped around commit-time page application, captured by each optimistic read scope and validated at the end of every lock-free read. Storage-wide granularity over-invalidates: an optimistic read that overlaps the apply phase of a transaction touching unrelated components is needlessly invalidated and falls back to the slower pinned path. This change refines the epoch to per-component granularity so a commit invalidates only concurrent optimistic reads of the components it actually mutates (YTDB-1203).

#### Planned changes:

**Current state** — ApplyPhaseEpoch is a single per-storage instance owned by AtomicOperationsManager. AtomicOperationBinaryTracking brackets its whole commit-time shared-cache mutation section (file deletes, creations, truncations, page application) with one epoch enter/exit pair whenever the commit mutates the shared cache. OptimisticReadScope captures the storage-wide epoch at the start of each optimistic attempt and validates it after the per-page stamp checks; any overlapping commit anywhere in the storage forces the read down the pinned fallback path.

**What changes** — The concurrency guarantee is refined, not weakened: an optimistic read now fails validation only if an overlapping commit mutated the component (or its sub-components) the read traverses. Commits to unrelated components no longer invalidate it. Public API, persisted formats, and transaction semantics are unchanged; the observable effect is fewer spurious pinned-path fallbacks.

**How** — ApplyPhaseEpoch (enter/exit seqlock semantics unchanged) becomes a per-component instance held by the StorageComponent base class. Top-level components — BTree (per instance, including both trees of BTreeMultiValueIndexEngine), PaginatedCollectionV2, SharedLinkBagBTree, IndexHistogramManager — create their own epoch; sub-components — CollectionPositionMapV2, FreeSpaceMap, CollectionDirtyPageBitSet — share their parent collection's instance, so a collection read spanning the position map and the collection file validates a single epoch.

Readers: OptimisticReadScope captures the reading component's epoch at the start of each attempt — a plain field access; the read path performs no lookups. Pinned page reads made inside an optimistic scope (the position-map delegate pattern) are covered by construction, since they read the same component's files under the already-captured epoch.

Writers: a fileId-to-epoch registry (ConcurrentHashMap) is populated when a component registers or opens its files. Entries are never removed and are overwritten on fileId reuse — removal would let a deleting commit miss its own bump, since components unregister before commit-time page application runs. At commit, AtomicOperationBinaryTracking resolves the fileIds it actually mutated (deleted, created, truncated, or carrying page changes) to their epochs, dedupes them by identity, and enters all before / exits all after the apply section. A mutated fileId missing from the registry fails the commit loudly.

Assertions (enabled with -ea) enforce the design invariant that one optimistic scope reads one high-level component: both optimistic page loads and pinned page loads inside an active optimistic attempt assert that the touched file's registered epoch is the captured one.

An ADR under docs-internal/adr/ records the granularity decision and its accepted narrowing.

**Key decisions** —
- Component-embedded epochs over a striped per-file epoch array: eager capture at attempt start keeps today's capture-before-read semantics with no hot-path lookups; the cross-file capture-gap risk of lazy per-file capture disappears by construction; no stripe-sizing knob needed.
- Epoch as a StorageComponent base-class field wired via constructors; a HighLevelStorageComponent marker interface was rejected as adding no enforcement.
- Plain ConcurrentHashMap for the registry: touched only at component create/open and once per mutated file per commit, so boxing is immaterial. Reusing ConcurrentLongIntHashMap with dummy keys or porting BookKeeper's ConcurrentLongHashMap was rejected as unnecessary (a port would also require an equivalent concurrent-stress test suite).
- Never-remove registry semantics: load-bearing given the existing unregister-before-commit ordering; stale entries are harmless and bounded by the number of files ever created.
- Per-BTree-instance epochs for the multi-value index engine's two trees: no optimistic scope spans both.
- Assertion-violation latching: -ea epoch-coverage guards cannot simply throw inside an optimistic lambda — the pinned-fallback catch (RuntimeException | AssertionError) would swallow them and silently degrade to the pinned path. Violations are instead latched on OptimisticReadScope (generalizing the existing nested-attempt detection) and surfaced by the attempt-exit assertion.

**Out of scope** —
- Rename operations: they preserve fileId and bypass atomic-operation file tracking; no epoch interaction needed.
- Removing the vacuous optimistic wrappers that only construct lazy streams (future cleanup candidate).

**Risks & accepted trade-offs** —
- Correctness relies on the invariant that no optimistic scope spans two high-level components — verified across all current call sites and guarded by assertions.
- Accepted narrowing (adversarial finding AR-3): a stale component reference surviving a same-name drop+recreate reads the reused fileId's pages under the dead epoch — already a use-after-drop defect; documented in the ADR.
- Registry grows with distinct fileIds ever created (bounded, small); boxed keys on cold paths only.

Design review: user-approved — 2026-07-16

Adversarial review: passed, 1 accepted risk — 2026-07-16

**Verification approach** — Reworked the two tests asserting one epoch bump per commit; new unit tests for per-component isolation (a commit on one component leaves another component's concurrent optimistic read valid), sub-component epoch sharing, delete-bump ordering, fileId-reuse overwrite, and registry-miss fail-loud behavior. Coverage gate passed at 99.0% line / 93.2% branch on new+changed code; full core unit suite (17,154 + 2,201 + 18 tests) and core integration suite (-P ci-integration-tests, 513 ITs) green. ADR added under docs-internal/adr/YTDB-1203-optimistic-read-component-granularity/.

#### Tracks:

N/A (single-track)

