### PR TITLE
Bump ytdb-slate pin to 0.1.1

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -2,5 +2,5 @@
   "defaultModel": "claude-opus-4-8",
   "defaultThinkingLevel": "xhigh",
   "hideThinkingBlock": true,
-  "packages": ["npm:ytdb-slate@0.1.0"]
+  "packages": ["npm:ytdb-slate@0.1.1"]
 }


### PR DESCRIPTION
#### Motivation:

The pinned `ytdb-slate` package at 0.1.0 crashed on every worker-thread dispatch with `Cannot read properties of undefined (reading 'create')`: its worker-session bootstrap called `AuthStorage.create()` / `ModelRegistry.create()`, SDK symbols removed in pi >= 0.80.8. This made the slate orchestration workflow (parallel worker actions, code/adversarial reviews) unusable. 0.1.1 is a bugfix release that drops those calls and relies on the default model runtime from `createAgentSession`.

#### Planned changes:

Bump the pinned slate package in `.pi/settings.json` from `npm:ytdb-slate@0.1.0` to `npm:ytdb-slate@0.1.1`. 0.1.1 is bugfix-only (fixes the worker-dispatch crash) plus a documentation-only `maxConcurrent` rationale note; the workflow protocol docs the repo doctrine is written against (`track-workflow.md`, `pr-publishing.md`, `review-rules.md`) are byte-identical between the two versions, so the mandatory package pin-bump skew re-read (`track-development.md` § Package pin bumps) produced no doc changes. No source, doctrine, or test changes.

Risks & accepted trade-offs:
- 0.1.1's default model runtime may perform a cached (~4h) network catalog refresh that 0.1.0's hand-built path did not; mitigated by the cache and by `PI_OFFLINE`. No alternative exists — the SDK removed the old options.
- Design review: user-approved — 2026-07-17
- Adversarial review: passed, 0 accepted risks — 2026-07-17

Verification approach: integrity-checked the installed 0.1.1 against the registry `dist.integrity`, confirmed the extension has no live `AuthStorage`/`ModelRegistry` `.create()` calls, confirmed `.pi/settings.json` stays valid JSON, and confirmed worker dispatch succeeds after a session restart.
