### PR TITLE
Add user documentation link to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Reddit](https://img.shields.io/badge/Reddit-%23FF4500.svg?style=for-the-badge&logo=Reddit&logoColor=white)](https://www.reddit.com/r/youtrackdb/)<br/>
 
 ------
-[Issue tracker](https://youtrack.jetbrains.com/issues/YTDB) | [Getting started](docs/getting-started.md) | [Daily LDBC benchmarks](https://bench.youtrackdb.io/)
+[Issue tracker](https://youtrack.jetbrains.com/issues/YTDB) | [Getting started](docs/getting-started.md) | [Documentation](docs/README.md) | [Daily LDBC benchmarks](https://bench.youtrackdb.io/)
 
 ### Join our Zulip community!
 


### PR DESCRIPTION
#### Motivation:

The root README's quick-links header points to the issue tracker, getting-started guide, and daily LDBC benchmarks, but has no direct link to the user documentation index. New readers landing on the repository have no one-click path from the header to the full docs. This change adds that entry point.

#### Planned changes:

Add a "Documentation" quick-link to the root README's header line, pointing at the user documentation index (docs/README.md), placed immediately after the existing "Getting started" link. This is a doc-only, single-line change; no other README content is affected.

Risks & accepted trade-offs:
- Design review: user-approved — 2026-07-20.
- Adversarial review: skipped with user consent — 2026-07-20.
