### PR TITLE
Document design decisions in scoped JavaDoc instead of ADRs

### DIFF
--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -9,7 +9,8 @@ product documentation lives in the [user documentation index](../docs/README.md)
 | Document | Description |
 |---|---|
 | [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, satellite peer-review layer, package pin-bump rule |
+| [Design Decisions in Scoped JavaDoc](dev-workflow/design-decisions.md) | Where code design rationale lives (method/class/package-info JavaDoc, owning package for cross-cutting decisions), entry structure, staleness rule; replaces ADR authoring |
 | [Satellite Review PRs](dev-workflow/satellite-pr.md) | Draft-only per-track peer-review PRs for multi-track changes (single-track and trivial peer review runs on the umbrella PR) — pinned base/head branches, observation loop, rebase re-pinning, cleanup at merge |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |
-| [Architecture Decision Records](adr/) | Archive of Architecture Decision Records, plus historical/sunset workflow research logs |
+| [Architecture Decision Records](adr/) | Frozen archive of Architecture Decision Records from the previous workflow generation, plus historical/sunset workflow research logs — no new entries; new design rationale lives in scoped JavaDoc per [design-decisions.md](dev-workflow/design-decisions.md) |

--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -14,3 +14,4 @@ product documentation lives in the [user documentation index](../docs/README.md)
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |
 | [Architecture Decision Records](adr/) | Frozen archive of Architecture Decision Records from the previous workflow generation, plus historical/sunset workflow research logs — no new entries; new design rationale lives in scoped JavaDoc per [design-decisions.md](dev-workflow/design-decisions.md) |
+| [Enable Scoped doclint](backlog/enable-scoped-doclint.md) | Proposed follow-up to enable syntax/reference doclint validation of JavaDoc cross-references; probe data and rollout plan |

--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -1,7 +1,8 @@
 # YouTrackDB Internal Documentation
 
 Project-internal documentation for contributors and agents: the development
-workflow, role guidelines, and the architecture-decision archive. User-facing
+workflow, role guidelines, the architecture-decision archive, and backlog notes
+for proposed follow-up changes. User-facing
 product documentation lives in the [user documentation index](../docs/README.md).
 
 ## Table of Contents

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -92,7 +92,7 @@ dispatch a build there while another build or test run is in progress.
 - **Satellite review PRs** are draft-only review vehicles for individual tracks (multi-track changes only): they are never merged and never marked ready for review — see `docs-internal/dev-workflow/satellite-pr.md`.
 
 ### Rebase Conflict Resolution
-- When a rebase produces conflicts in prose-heavy files (e.g., `AGENTS.md` or `docs-internal/adr/**`), re-read every resolved file end-to-end before continuing — three-way prose merges can splice text that parses but contradicts itself.
+- When a rebase produces conflicts in prose-heavy files (e.g., `AGENTS.md` or other `docs-internal/` documents), re-read every resolved file end-to-end before continuing — three-way prose merges can splice text that parses but contradicts itself.
 - The recheck covers the whole document, not just the conflict hunks — a clean hunk-level resolution can still leave unchanged paragraphs referencing rules that were renamed or removed on the other side.
 
 ## Documentation Sync
@@ -101,4 +101,4 @@ dispatch a build there while another build or test run is in progress.
 
 1. **When modifying source code**: Review docs in `docs/` and module `README.md` files to see if any cover the area you changed. Update them if needed.
 2. **When adding new features**: If the feature affects public API, configuration, build process, or CI/CD, update the relevant docs.
-3. **When changing code covered by design-decision JavaDoc**: the covering entries (method/class/package-info level, per `docs-internal/dev-workflow/design-decisions.md`) must be updated in the same change.
+3. **When changing code covered by design-decision JavaDoc**: The covering entries (method/class/package-info level, per `docs-internal/dev-workflow/design-decisions.md`) must be updated in the same change.

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -101,3 +101,4 @@ dispatch a build there while another build or test run is in progress.
 
 1. **When modifying source code**: Review docs in `docs/` and module `README.md` files to see if any cover the area you changed. Update them if needed.
 2. **When adding new features**: If the feature affects public API, configuration, build process, or CI/CD, update the relevant docs.
+3. **When changing code covered by design-decision JavaDoc**: the covering entries (method/class/package-info level, per `docs-internal/dev-workflow/design-decisions.md`) must be updated in the same change.

--- a/docs-internal/agents/review-perspectives.md
+++ b/docs-internal/agents/review-perspectives.md
@@ -8,3 +8,11 @@ its own stable finding-ID prefix (§4).
   WAL, storage engine, page cache, recovery, or atomic operations;
   reasoning about persistence ordering, fsync boundaries, torn writes,
   and crash-recovery invariants.
+- **Design-decision documentation** (prefix `DD`) — any change touching
+  code that carries design-decision JavaDoc, or introducing a
+  non-obvious design choice; checks that decisions are documented at
+  the correct scope level per
+  `docs-internal/dev-workflow/design-decisions.md`, that existing
+  design-decision entries in the diff's blast radius are not left
+  stale, and that cross-package rationale is referenced via
+  `{@link}`/`@see` rather than duplicated.

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -54,6 +54,7 @@ verification-scope, and PR rules live in `docs-internal/agents/orchestrator-guid
 - **Comment non-obvious code**: Add comments to any logic that is not immediately self-evident, so reviewers can easily verify intent without reverse-engineering the code.
 - **Test descriptions**: Every test must have a detailed description (in a comment or descriptive method name) explaining what scenario is being tested and what the expected outcome is, so a reviewer can quickly grasp the purpose.
 - **Keep comments in sync**: When modifying code, always update the surrounding comments to match the new behavior. Stale or contradictory comments are worse than no comments.
+- **Design decisions**: design rationale lives in JavaDoc at the scope it governs. Before writing or editing a design-decision section, read `docs-internal/dev-workflow/design-decisions.md` (scoping ladder, entry structure, staleness rule).
 
 ### Formatting (Spotless)
 

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -54,7 +54,7 @@ verification-scope, and PR rules live in `docs-internal/agents/orchestrator-guid
 - **Comment non-obvious code**: Add comments to any logic that is not immediately self-evident, so reviewers can easily verify intent without reverse-engineering the code.
 - **Test descriptions**: Every test must have a detailed description (in a comment or descriptive method name) explaining what scenario is being tested and what the expected outcome is, so a reviewer can quickly grasp the purpose.
 - **Keep comments in sync**: When modifying code, always update the surrounding comments to match the new behavior. Stale or contradictory comments are worse than no comments.
-- **Design decisions**: design rationale lives in JavaDoc at the scope it governs. Before writing or editing a design-decision section, read `docs-internal/dev-workflow/design-decisions.md` (scoping ladder, entry structure, staleness rule).
+- **Design decisions**: Design rationale lives in JavaDoc at the scope it governs. Before writing or editing a design-decision section, read `docs-internal/dev-workflow/design-decisions.md` (scoping ladder, entry structure, staleness rule).
 
 ### Formatting (Spotless)
 

--- a/docs-internal/backlog/enable-scoped-doclint.md
+++ b/docs-internal/backlog/enable-scoped-doclint.md
@@ -30,8 +30,9 @@ profile. The `reference` doclint category would automate exactly this validation
 
 ## Proposed plan
 
-1. Fix the ~43 `syntax,reference` errors in `core` (triage by file;
-   `CronExpression.java` first).
+1. Triage the 43 `syntax,reference` errors in `core` by file first, then fix them
+   (`CronExpression.java` carried about half of the all-category errors in the probe,
+   but its share of the `syntax,reference` subset was not measured).
 2. Set `<doclint>syntax,reference</doclint>` in the root pom pluginManagement.
 3. Wire a PR-CI step running per-module `compile javadoc:javadoc` so violations gate
    PRs, not only the weekly release.

--- a/docs-internal/backlog/enable-scoped-doclint.md
+++ b/docs-internal/backlog/enable-scoped-doclint.md
@@ -1,0 +1,49 @@
+# Backlog: Enable Scoped doclint (`syntax,reference`)
+
+Proposed follow-up change — no YouTrack issue yet. Origin: review discussion on PR #1240;
+empirical probe run 2026-07-21.
+
+## Motivation
+
+The design-decision convention (`docs-internal/dev-workflow/design-decisions.md`) relies
+on `{@link}`/`@see` cross-references between documentation sites, but nothing validates
+them: doclint is disabled (`<doclint>none</doclint>` in the root pom's
+maven-javadoc-plugin config) and JavaDoc is generated only in the `sonatype-oss-release`
+profile. The `reference` doclint category would automate exactly this validation.
+
+## Probe findings (2026-07-21)
+
+- `doclint=all` on `core`: 164 errors, 14,680 warnings — would fail the weekly release
+  build. The `missing` category alone contributes 14,666 warnings ("no comment" on legacy
+  code); it must never be enabled.
+- `doclint=syntax,reference` on `core`: 43 errors — tractable. `server`: 0 errors under
+  every variant.
+- Errors are dominated by legacy OrientDB-era files; `CronExpression.java` (2016,
+  pre-HTML5 markup) alone carries about half of the all-category errors. Generated
+  sources (SQL parser, ANTLR, annotation processors) contribute zero errors, only
+  `missing` warnings.
+- There is NO command-line override: the pom-configured `<doclint>` silently wins over
+  `-Ddoclint=...` and over `-DadditionalJOption=-Xdoclint:...`. Enabling requires a pom
+  edit.
+- Cost: pure javadoc on `core` ≈ 7s; `compile javadoc:javadoc` ≈ 30s — a PR-CI gate is
+  affordable.
+
+## Proposed plan
+
+1. Fix the ~43 `syntax,reference` errors in `core` (triage by file;
+   `CronExpression.java` first).
+2. Set `<doclint>syntax,reference</doclint>` in the root pom pluginManagement.
+3. Wire a PR-CI step running per-module `compile javadoc:javadoc` so violations gate
+   PRs, not only the weekly release.
+4. Update `docs-internal/dev-workflow/design-decisions.md` § Tooling notes: `{@link}`
+   targets become CI-validated; reviewers keep checking semantic staleness only.
+5. Optional later phase: enable `html` after cleaning legacy markup. Never enable
+   `missing`.
+
+## Probe reproduction recipe (no pom edit needed)
+
+Run `./mvnw -pl <module> compile javadoc:javadoc -Ddebug=true`, copy
+`<module>/target/reports/apidocs/{options,packages}` to a temp dir, replace the
+`-Xdoclint:none` line with the desired setting, then invoke
+`javadoc -J-Xmx2G @options @packages` directly — output matches a real plugin run with
+that doclint value.

--- a/docs-internal/dev-workflow/design-decisions.md
+++ b/docs-internal/dev-workflow/design-decisions.md
@@ -1,0 +1,57 @@
+# Design Decisions in Scoped JavaDoc
+
+Code design decisions are documented in JavaDoc at the scope they govern; separate ADR
+files are retired. The umbrella PR description (which becomes the squash-commit body)
+remains the point-in-time record of WHY a change was made; JavaDoc carries the living
+design rationale of the code as it stands.
+
+## Scoping ladder
+
+The narrowest correct level wins:
+
+- **Decision local to one method** (algorithm choice, tricky invariant) → method JavaDoc.
+- **Decision shaping one class** (data structure, concurrency policy) → class JavaDoc,
+  with an own `<h2>Design decisions</h2>` section when substantial.
+- **Decision spanning classes within one package** → a "Design decisions" section in that
+  package's `package-info.java`.
+- **Decision spanning packages or modules** → exactly ONE owning `package-info.java`
+  carries the full rationale; every other affected package or class carries only a
+  `{@link}`/`@see` reference to it — rationale text is NEVER duplicated.
+- **Decision with no Java home** (build system, CI, code-generation/parser pipeline,
+  tooling) → the nearest prose document (module `README.md` or a `docs-internal/` doc) —
+  never a new ADR.
+
+## Entry structure
+
+Entries are numbered (D1, D2, …) per documentation site. Each entry states the decision,
+the rationale, and the rejected alternatives; cite the YTDB issue where one exists,
+otherwise the PR number, for provenance. Process artifacts (review verdicts, telemetry,
+workflow notes) never go into JavaDoc — they belong to the PR description.
+
+## Depth exemplar
+
+The MATCH executor package documentation (`core`,
+`com.jetbrains.youtrackdb.internal.core.sql.executor.match` `package-info.java`) shows the
+expected depth and quality. It predates this convention and is narrative prose — it is a
+depth exemplar, NOT a structural template; new design-decision sections use the numbered
+entry structure above.
+
+## Staleness rule
+
+A change that modifies code covered by a design-decision entry MUST update that entry in
+the same change (this extends the "keep comments in sync" rule in
+`docs-internal/agents/thread-guidelines.md`). Reviews compose the DD charter
+(`docs-internal/agents/review-perspectives.md`) to guard this.
+
+## Tooling notes
+
+doclint is disabled and JavaDoc is generated only at release time, so design-decision
+JavaDoc receives no automated validation — the DD review charter and the mandatory user
+review are the quality gates; malformed `{@link}` targets will not fail CI, so reviewers
+check them.
+
+## ADR archive
+
+`docs-internal/adr/` is a frozen historical archive of the previous workflow generation —
+no new entries are added for code OR workflow/process decisions. Workflow decisions live
+in the slate extension docs and the `docs-internal/` guidance docs.

--- a/docs-internal/dev-workflow/design-decisions.md
+++ b/docs-internal/dev-workflow/design-decisions.md
@@ -11,12 +11,16 @@ The narrowest correct level wins:
 
 - **Decision local to one method** (algorithm choice, tricky invariant) → method JavaDoc.
 - **Decision shaping one class** (data structure, concurrency policy) → class JavaDoc,
-  with an own `<h2>Design decisions</h2>` section when substantial.
+  with a dedicated `<h2>Design decisions</h2>` section when substantial.
 - **Decision spanning classes within one package** → a "Design decisions" section in that
   package's `package-info.java`.
 - **Decision spanning packages or modules** → exactly ONE owning `package-info.java`
   carries the full rationale; every other affected package or class carries only a
-  `{@link}`/`@see` reference to it — rationale text is NEVER duplicated.
+  `{@link}`/`@see` reference to it — rationale text is NEVER duplicated. The owning
+  package is the one whose code enforces the decision's central mechanism or invariant —
+  the package a maintainer would edit first to change the decision; when still ambiguous,
+  pick the lowest-level (most fundamental) of the candidate packages and keep the choice
+  stable once made.
 - **Decision with no Java home** (build system, CI, code-generation/parser pipeline,
   tooling) → the nearest prose document (module `README.md` or a `docs-internal/` doc) —
   never a new ADR.
@@ -25,8 +29,12 @@ The narrowest correct level wins:
 
 Entries are numbered (D1, D2, …) per documentation site. Each entry states the decision,
 the rationale, and the rejected alternatives; cite the YTDB issue where one exists,
-otherwise the PR number, for provenance. Process artifacts (review verdicts, telemetry,
-workflow notes) never go into JavaDoc — they belong to the PR description.
+otherwise the PR number, for provenance. Entry numbers are stable identifiers within a
+documentation site and are never reused: when a decision evolves but keeps its scope, the
+entry is rewritten in place under the same number (JavaDoc describes the design as it
+stands); when an entry is deleted, its number is retired. Process artifacts (review
+verdicts, telemetry, workflow notes) never go into JavaDoc — they belong to the PR
+description.
 
 ## Depth exemplar
 


### PR DESCRIPTION
#### Motivation:

The docs-internal/adr archive is a leftover of the previous, now-sunset workflow generation: the current slate-based flow neither writes nor reads ADRs, and rationale recorded there is invisible at the code site it describes. Going forward, code design decisions are documented in JavaDoc at the scope they govern — discoverable while reading code and kept in sync by review — while the PR description (squash-commit body) already serves as the point-in-time decision record. Workflow/process decisions no longer need ADRs either: the slate extension and docs-internal guidance docs cover them.

#### Planned changes:

**Current state**

Design rationale historically landed in the ADR archive (56 directories, produced by the previous workflow generation). Rich design JavaDoc exists only in recently reworked areas — 3 package-info.java files across 225 packages. No convention governs where design rationale lives, and the review perspectives have no documentation-staleness charter.

**What changes**

A new convention document, design-decisions.md under docs-internal/dev-workflow, defines where code design rationale lives: the narrowest correct JavaDoc scope — method JavaDoc for method-local decisions; class JavaDoc for class-shaping decisions (a dedicated "Design decisions" heading when substantial); package-info for decisions spanning classes in one package; one OWNING package-info plus @see/{@link} references from other affected packages for cross-package decisions — rationale text is never duplicated; the owning package is the one whose code enforces the decision's central mechanism or invariant (the package a maintainer would edit first to change the decision), with ties resolved to the lowest-level candidate and the choice kept stable once made. Entries are numbered (D1..Dn) with rationale and rejected alternatives, citing the YTDB issue where one exists (otherwise the PR). Entry numbers are stable identifiers within a documentation site and are never reused: an evolved decision is rewritten in place under the same number, and a deleted entry retires its number. Decisions with no Java home (build system, CI, tooling) go in the nearest prose document (module README or docs-internal doc) — never a new ADR. Modifying code covered by a design-decision entry requires updating that entry in the same change. The ADR archive is frozen: no new entries for code or workflow decisions. The MATCH executor package documentation serves as the depth/quality exemplar (it predates the convention and is not a structural template). A new DD review charter in the project review perspectives guards correct scoping, entry staleness in a diff's blast radius, and cross-linking instead of duplication. Worker-thread and orchestrator guidelines gain one-line pointers to the convention; the internal-docs index marks the ADR directory as a frozen archive. A backlog document records the proposed follow-up to enable scoped doclint (`syntax,reference`) so {@link} references become CI-validated.

**Key decisions**

- Scoped JavaDoc replaces ADR authoring for code design rationale; rejected: continuing ADRs — redundant with squash-commit PR descriptions and decoupled from the live workflow.
- Standalone on-demand convention doc with pointer lines from the guidelines; rejected: inlining into thread-guidelines — grows the always-loaded surface against the load-on-demand principle.
- Narrowest-correct-scope ladder; rejected: "always package-info" — bloats package docs with local decisions.
- Single owning package-info for cross-cutting rationale with @see links elsewhere; rejected: duplicating text — staleness divergence.
- ADR archive frozen in place; rejected: deletion/retro-migration of 56 dirs — effort without payoff, breaks the inbound reference and history.
- Review charter as guard-rail; rejected: enabling doclint/CI enforcement — fails on legacy code, out of scope.

**Out of scope**

Retro-migrating existing ADR directories; enabling doclint (the follow-up is now filed as a backlog document shipped with this change, proposing a scoped `syntax,reference` rollout); backfilling package-info for legacy packages; any Java source changes; cleanup of the legacy Claude-harness configuration (sunset, removed separately).

**Risks & accepted trade-offs**

- Legacy Claude-harness config still mandates ADR production; the textual contradiction is accepted as risk because that workflow is at sunset and slated for removal (adversarial finding AV-2, accepted).
- JavaDoc receives no automated validation (doclint disabled) — quality is guarded only by the DD review charter and user review.
- Design review: user-approved — 2026-07-21
- Adversarial review: passed, 1 accepted risk — 2026-07-21

**Verification approach**

Doc-only change: proofread and cross-reference check of the six touched/created markdown docs; no code, no tests.
