### PR TITLE
Run integration tests on every PR on Linux x86 (mandatory, with title opt-out)

### DIFF
--- a/.github/workflows/fork-approval-policy-check.yml
+++ b/.github/workflows/fork-approval-policy-check.yml
@@ -1,0 +1,92 @@
+# ------------------------------------------------------------------
+# WORKFLOW: Fork Approval Policy Drift Check
+#
+# Guards the repository's fork-PR approval policy. External-contributor
+# fork PRs must require an explicit maintainer "Approve and run" before
+# any workflow executes — this is what stops a malicious fork PR from
+# running arbitrary code in CI on first push. GitHub exposes that
+# setting via the Actions API:
+#
+#   gh api repos/<owner>/<repo>/actions/permissions/fork-pr-contributor-approval
+#     --jq '.approval_policy'
+#
+# We assert the value stays exactly `all_external_contributors`. If it
+# drifts (e.g. someone relaxes it to first-time contributors only), or
+# if the policy cannot be read at all, this workflow fails and alerts
+# Zulip — a failure to verify is treated as alert-worthy, not ignored.
+#
+# Requires the `FORK_POLICY_AUDIT_TOKEN` secret: a PAT/token with
+# repository Administration:read, provisioned by a maintainer. The
+# workflow-level GITHUB_TOKEN is deliberately given no permissions
+# (permissions: {}); the audit uses the dedicated token instead.
+#
+# Scheduled + manual dispatch only — it never runs on pull_request or
+# push events, so it cannot be triggered (or observed) by fork PRs.
+# ------------------------------------------------------------------
+name: Fork Approval Policy Drift Check
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  check-policy:
+    name: Check Fork Approval Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Read and verify fork-approval policy
+        env:
+          # Dedicated PAT with repository Administration:read; the
+          # workflow-level GITHUB_TOKEN has no permissions here.
+          GH_TOKEN: ${{ secrets.FORK_POLICY_AUDIT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          EXPECTED="all_external_contributors"
+
+          # Read the current fork-PR contributor approval policy. A failure
+          # here (missing/insufficient token, API error) is itself
+          # alert-worthy — we must not pass silently when we cannot verify.
+          if ! POLICY=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/permissions/fork-pr-contributor-approval" \
+            --jq '.approval_policy'); then
+            echo "::error::Could not read the fork-PR contributor approval policy" \
+              "for ${GITHUB_REPOSITORY}. The FORK_POLICY_AUDIT_TOKEN secret may be" \
+              "missing or lack repository Administration:read, or the GitHub API" \
+              "call failed. A failure to verify is treated as a drift alert."
+            exit 1
+          fi
+
+          if [[ "$POLICY" != "$EXPECTED" ]]; then
+            echo "::error::Fork-PR approval policy has drifted:" \
+              "expected '$EXPECTED' but found '$POLICY'." \
+              "External-contributor PRs may no longer require maintainer" \
+              "approval before workflows run. Restore the setting in" \
+              "Settings > Actions > General > Fork pull request workflows" \
+              "from outside collaborators."
+            exit 1
+          fi
+
+          echo "OK: fork-PR approval policy is '$POLICY' (expected '$EXPECTED')."
+
+      - name: Send Zulip notification on failure
+        if: failure()
+        uses: zulip/github-actions-zulip/send-message@v2
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: ci-status-bot@youtrackdb.zulipchat.com
+          organization-url: 'https://youtrackdb.zulipchat.com'
+          to: 'ytdb'
+          type: 'stream'
+          topic: 'ci status'
+          content: |
+            **FORK APPROVAL POLICY DRIFT** :warning:
+            The fork-approval policy drift check failed for ${{ github.repository }} — the policy either drifted away from `all_external_contributors` or could not be verified. External-contributor PRs may no longer require maintainer approval before workflows run; check the repository Actions settings.
+            [View Run Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/fork-approval-policy-check.yml
+++ b/.github/workflows/fork-approval-policy-check.yml
@@ -20,8 +20,18 @@
 # workflow-level GITHUB_TOKEN is deliberately given no permissions
 # (permissions: {}); the audit uses the dedicated token instead.
 #
+# NOTE: until that secret is provisioned, every scheduled run will FAIL
+# (red) and fire the daily Zulip alert. A maintainer seeing daily
+# red/alerts should first confirm the FORK_POLICY_AUDIT_TOKEN secret
+# exists before assuming an actual policy drift.
+#
 # Scheduled + manual dispatch only — it never runs on pull_request or
 # push events, so it cannot be triggered (or observed) by fork PRs.
+#
+# NOTE: GitHub runs `schedule` triggers only from the repository's
+# DEFAULT branch (develop). This workflow is therefore not exercised on
+# the daily cron until it merges to develop; before then it can only be
+# run manually via workflow_dispatch.
 # ------------------------------------------------------------------
 name: Fork Approval Policy Drift Check
 

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -392,6 +392,82 @@ jobs:
           if-no-files-found: ignore
 
   # ------------------------------------------------------------------
+  # JOB: INTEGRATION TESTS (Linux x86) — mandatory on PRs
+  #
+  # Runs the full integration-test suite (ci-integration-tests profile)
+  # on every pull request and blocks the merge via ci-status. Opt out
+  # by putting the literal [no-it-tests] in the PR title (e.g. for
+  # trivial changes where a multi-hour IT run is unwarranted).
+  #
+  # docker-images is deliberately dropped here: the unit x86 leg already
+  # builds the Docker images and covers the Docker-dependent tests, so
+  # rebuilding them for this leg would only add time without extra
+  # coverage. The ci-integration-tests profile already sets
+  # youtrackdb.test.env=ci, so that flag is not repeated on the command.
+  #
+  # pull_request-only (NOT merge_group): this multi-hour suite would blow
+  # past the merge queue's check-response timeout, so it is not attached
+  # to merge_group events. Integration coverage of the merged state is
+  # provided by the nightly IT pipeline instead.
+  #
+  # Draft PRs and doc-only / no-build changes are excluded automatically:
+  # the gate is inherited from detect-changes (should_build) exactly like
+  # the unit-test legs.
+  # ------------------------------------------------------------------
+  test-integration-linux:
+    name: Integration Tests (Linux x86)
+    needs: [ detect-changes ]
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.detect-changes.outputs.should_build == 'true' &&
+      !contains(github.event.pull_request.title, '[no-it-tests]')
+    runs-on: [ self-hosted, type-cpx42, image-x86-system-ubuntu-24.04, in-nbg1-fsn1-hel1 ]
+    timeout-minutes: 720
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: x64
+          overwrite-settings: false
+      - name: Run Integration Tests
+        id: tests
+        run: ./mvnw -s .github/workflows/settings.xml clean verify -B -P ci-integration-tests -Dmaven.test.failure.ignore=true
+        env:
+          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
+          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            **/target/surefire-reports/TEST-*.xml
+            **/target/failsafe-reports/TEST-*.xml
+          action_fail: true
+          large_files: true
+          comment_mode: off
+          compare_to_earlier_commit: false
+          check_name: Integration Tests Results (Linux x86)
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        if: "!cancelled()"
+        with:
+          name: test-diagnostics-pr-integration-linux
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # ------------------------------------------------------------------
   # JOB: SMALL CACHE INTEGRATION TESTS (advisory, not in ci-status gate)
   # Runs StorageComponent ITs with 4 MB disk cache to exercise
   # optimistic read fallback under heavy eviction pressure.
@@ -724,7 +800,7 @@ jobs:
   ci-status:
     name: CI Status
     if: always() && github.event.pull_request.draft != true
-    needs: [ detect-changes, test-linux, test-windows, test-macos, coverage-gate, test-count-gate ]
+    needs: [ detect-changes, test-linux, test-windows, test-macos, test-integration-linux, coverage-gate, test-count-gate ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Source Code
@@ -752,6 +828,7 @@ jobs:
           LINUX_RESULT: ${{ needs.test-linux.result }}
           WINDOWS_RESULT: ${{ needs.test-windows.result }}
           MACOS_RESULT: ${{ needs.test-macos.result }}
+          INTEGRATION_RESULT: ${{ needs.test-integration-linux.result }}
           COVERAGE_RESULT: ${{ needs.coverage-gate.result }}
           TEST_COUNT_RESULT: ${{ needs.test-count-gate.result }}
         run: |
@@ -772,6 +849,13 @@ jobs:
              [[ "$WINDOWS_RESULT" != "success" ]]; then
             echo "Not all required jobs succeeded" \
               "(linux=$LINUX_RESULT, windows=$WINDOWS_RESULT)"
+            exit 1
+          fi
+          # The integration-test leg runs on pull_request events only, so on
+          # push/merge_group events (or when opted out via [no-it-tests], or a
+          # doc-only PR) its result is "skipped", which is acceptable here.
+          if [[ "$INTEGRATION_RESULT" != "success" && "$INTEGRATION_RESULT" != "skipped" ]]; then
+            echo "Integration tests did not succeed (result: $INTEGRATION_RESULT)"
             exit 1
           fi
           # coverage-gate and test-count-gate only run on PRs;


### PR DESCRIPTION
#### Motivation:

Integration tests (IT) currently run only on the nightly/develop pipeline, never on PRs. A change that passes unit tests can still break IT and only be caught after merge on `develop`, where it blocks the nightly deploy and merge-to-main and is expensive to trace. Running IT on every PR shifts that feedback left: a PR cannot go green until the Linux x86 integration suite passes. A `[no-it-tests]` title escape hatch covers changes where the ~3h run is unwarranted. External-contributor safety is preserved — fork-PR workflows already require maintainer approval before any run (repo Actions setting `approval_policy = all_external_contributors`) — and this change adds a drift check so that guarantee cannot silently regress.

#### Planned changes:

**Current state**
- The PR pipeline (Java CI/CD Pipeline) runs unit tests only (`clean package`) across Linux x86/arm, Windows, macOS, plus the coverage and test-count gates, all funnelled into the single required `CI Status` check.
- Integration tests (the `ci-integration-tests` profile, `clean verify`) run only on the separate nightly/develop pipeline, which also performs merge-to-main and Maven Central deploy.
- Fork-PR execution is gated by the repo Actions setting `approval_policy = all_external_contributors`, but that guarantee lives outside version control with no drift detection.

**What changes**
- Every PR (including approved fork PRs) with build-relevant changes runs the Linux x86 integration suite, and `CI Status` does not go green until it passes — IT success becomes mandatory for merge.
- Adding `[no-it-tests]` to the PR title opts the PR out (the IT job is skipped and the gate accepts the skip). Toggling the flag takes effect on the next push.
- A scheduled drift check alerts (Zulip) whenever the fork-approval policy is no longer `all_external_contributors`.

**How**
- A new integration-test job is added to the PR pipeline, mirroring the existing Linux x86 unit leg's runner and result-publishing pattern; failure is surfaced through the test-results publisher (mandatory success). It is registered in the `CI Status` aggregation with the same `success || skipped` acceptance used by the coverage and test-count gates.
- The job runs on the `pull_request` event only (not the merge queue) and inherits the pipeline's existing draft-PR and change-detection exclusions.
- The IT job uses `ci-integration-tests` without the `docker-images` profile; Docker-dependent tests remain covered on the PR by the existing unit leg, which already builds images.
- A standalone scheduled workflow reads the fork-approval policy via the GitHub API and alerts on drift.

**Key decisions**
- IT on `pull_request` only, not `merge_group`: a multi-hour suite in the merge queue would exceed its check-response timeout and throttle merges; merged-state IT stays covered by nightly. (WH1)
- Drop `docker-images` from the IT job: the unit x86 leg already runs the Docker-dependent tests, so there is no net PR coverage loss. (WH2)
- Author-settable `[no-it-tests]` accepted as the opt-out: it is auditable (PR title + visibly-skipped job). No `edited` trigger, to avoid re-running IT on title edits. (SE1)
- Fork gating left to the repo Actions approval setting rather than a workflow `author_association` guard: the setting is stronger and covers the whole pipeline; a drift check compensates for it living outside version control. (SE2, SE3)
- Rejected: restricting IT to non-fork PRs — code safety (validating all contributed code) was prioritized over extra runner time; fork runs are approval-gated and receive no secrets.

**Out of scope**
- The nightly/develop integration-tests pipeline (merge-to-main, deploy, YouTrack sync) is unchanged.
- Windows/macOS/arm and JDK 25 IT legs, and the Docker-image/`docker-tests` suite, remain nightly-only.

**Risks & accepted trade-offs**
- WH1 — merge queue re-validates unit tests only; merged-state IT covered by nightly.
- WH3 — added self-hosted x86 pool contention (unit + IT per PR); bounded by ~3h typical runtime (720-min timeout is a ceiling).
- SE1 — `[no-it-tests]` is author-settable; mitigated by title/skipped-job auditability.
- SE2 — approved fork PRs get ~3h self-hosted execution (no secrets exposed on fork `pull_request`); gated by "Approve and run".
- Design review: user-approved — 2026-07-22
- Adversarial review: passed, 4 accepted risks — 2026-07-22

**Verification approach**
- The umbrella PR itself exercises the new IT job (dogfooding) on its CI run; workflow YAML validated for syntax; drift-check logic exercised against the live setting.

#### Tracks:

| # | Track | Scope | Status | Satellite PR |
|---|-------|-------|--------|--------------|
| 01 | PR integration-test job | Add `test-integration-linux` to the PR pipeline; wire into `CI Status`; `[no-it-tests]` opt-out | Complete | None (sticky: no) |
| 02 | Fork-approval drift check | Scheduled workflow asserting `approval_policy = all_external_contributors` (uses `FORK_POLICY_AUDIT_TOKEN`) | Planned | None (sticky: no) |
| 03 | Docs & PR template sync | Document IT-on-PR, opt-out flags, PR-IT scope, fork-gating guarantee | Planned | None (sticky: no) |

_Satellite review PRs declined for all tracks (sticky "no", 2026-07-22)._


