### PR TITLE
Document backup and multi-DB support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ YouTrackDB's key features are:
 7. **[Strong security](docs/security.md)**: A strong security profiling system based on user, role,
    and predicate [security policies](docs/yql/YQL-Create-Security-Policy.md).
 8. **Encryption of data at rest**: Optionally encrypts all data stored on disk.
+9. **Online incremental & full backups**: Incremental and full backups run while the database keeps serving reads and writes, requiring only brief internal pauses to establish a consistent recovery point.
+10. **Multiple databases per instance**: A single YouTrackDB instance can host and operate several independent databases simultaneously — each with its own storage, schema, and security — giving you clean data separation through one unified API.
 
 ### Easy to install and use
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ YouTrackDB's key features are:
 7. **[Strong security](docs/security.md)**: A strong security profiling system based on user, role,
    and predicate [security policies](docs/yql/YQL-Create-Security-Policy.md).
 8. **Encryption of data at rest**: Optionally encrypts all data stored on disk.
-9. **Online incremental & full backups**: Incremental and full backups run while the database keeps serving reads and writes, requiring only brief internal pauses to establish a consistent recovery point.
-10. **Multiple databases per instance**: A single YouTrackDB instance can host and operate several independent databases simultaneously — each with its own storage, schema, and security — giving you clean data separation through one unified API.
+9. **Online incremental and full backups**: Incremental and full backups run while the database
+   keeps serving reads and writes, requiring only brief internal pauses to establish a
+   consistent recovery point.
+10. **Multiple databases per instance**: A single YouTrackDB instance can host and operate
+   several independent databases simultaneously — each with its own storage, schema, and
+   security — giving you clean data separation through one unified API.
 
 ### Easy to install and use
 


### PR DESCRIPTION
#### Motivation:

The README feature list omits two capabilities YouTrackDB already ships: online incremental/full backups, and hosting multiple independent databases in a single instance. Users evaluating YouTrackDB from the README cannot discover either today, and no page under docs/ covers them. This change surfaces both in the feature list so they are visible where evaluators look first.

#### Planned changes:

Trivial doc-only change. Add two items to the numbered feature list in the top-level README:

- **Online incremental and full backups** — backups run while the database keeps serving reads and writes, requiring only brief internal pauses to establish a consistent recovery point.
- **Multiple databases per instance** — a single YouTrackDB instance can host and operate several independent databases simultaneously, each with its own storage, schema, and security, through one unified API.

Wording was verified against the code. Backups take a brief global write freeze (AtomicOperationsManager / OperationsFreezer) to fix a consistent WAL recovery point, then copy pages and WAL concurrently with ongoing reads and writes (DiskStorage); reads are never blocked, and only one backup runs at a time. Multi-database support is backed by the per-instance storage and shared-context registries in YouTrackDBInternalEmbedded, exposed through the YouTrackDB API (create / open / drop / list). The literal phrase "zero write downtime" was deliberately avoided because a short global write freeze genuinely exists (two brief freeze windows per backup).

Risks & accepted trade-offs:
- "brief internal pauses" summarizes two short freeze windows per backup — accepted as an accurate simplification for a README.
- Design review: user-approved — 2026-07-23
- Adversarial review: passed, 0 accepted risks — 2026-07-23
