### PR TITLE
Bump ytdb-slate to 0.2.1 and configure bidirectional model failover

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -2,5 +2,5 @@
   "defaultModel": "claude-opus-4-8",
   "defaultThinkingLevel": "xhigh",
   "hideThinkingBlock": true,
-  "packages": ["npm:ytdb-slate@0.1.1"]
+  "packages": ["npm:ytdb-slate@0.2.1"]
 }

--- a/.pi/slate.json
+++ b/.pi/slate.json
@@ -4,5 +4,13 @@
   "orchestratorPromptDocs": ["docs-internal/agents/orchestrator-guidelines.md"],
   "workerPromptDocs": ["docs-internal/agents/thread-guidelines.md"],
   "doctrineExtraPath": "docs-internal/agents/slate-doctrine-extra.md",
-  "reviewPerspectivesPath": "docs-internal/agents/review-perspectives.md"
+  "reviewPerspectivesPath": "docs-internal/agents/review-perspectives.md",
+  "modelFailover": {
+    "anthropic/claude-sonnet-5": "openai/gpt-5.6-luna",
+    "openai/gpt-5.6-luna": "anthropic/claude-sonnet-5",
+    "anthropic/claude-opus-4-8": "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-terra": "anthropic/claude-opus-4-8",
+    "anthropic/claude-fable-5": "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-sol": "anthropic/claude-fable-5"
+  }
 }


### PR DESCRIPTION
#### Motivation:

The orchestration harness pins `ytdb-slate@0.1.1`, which has no model-failover capability. When a provider is unavailable, model calls simply fail. ytdb-slate 0.2.1 introduces a `modelFailover` config key that lets a failed model call automatically retry once on an equivalent model from another provider. This change bumps the pin to 0.2.1 and wires three Anthropic↔OpenAI failover pairs in both directions, so orchestrator, worker, and episode-compression calls degrade gracefully across providers.

#### Planned changes:

Single-track change.

**Current state**
- `.pi/settings.json` pins `npm:ytdb-slate@0.1.1`; slate 0.1.1 has no failover mechanism.
- `.pi/slate.json` configures orchestrator mode, the draft-PR workflow, prompt-doc paths, and doctrine/review-perspective paths — no failover.
- Orchestrator auto-pause uses slate 0.1.1's default (40% of the context window); neither `pauseThresholdPercent` nor `contextBudget` is pinned.

**What changes**
- The harness runs on ytdb-slate 0.2.1.
- A new `modelFailover` map wires three bidirectional pairs: Claude Sonnet 5 ↔ GPT-5.6 Luna, Claude Opus 4.8 ↔ GPT-5.6 Terra, Claude Fable 5 ↔ GPT-5.6 Sol. slate's failover map is one-directional and non-recursive per entry, so each pair is two entries — six entries total.
- Orchestrator auto-pause moves to slate 0.2.1's default `contextBudget` (absolute tokens: 256k, 400k for anthropic/*). Neither `contextBudget` nor the deprecated `pauseThresholdPercent` is pinned; the new defaults are accepted.

**How**
- Model failover is a slate 0.2.1 feature: at worker dispatch, episode compression, and the orchestrator, a failed model call that is not a context-overflow/abort — after pi's own retries — retries once on the mapped model. The map is read once at session start and only under project trust.

**Key decisions**
- Bump to 0.2.1 rather than staying on 0.1.1 — 0.1.1 cannot express failover.
- Six entries, not three — the failover map is one-directional per entry, so both directions need two entries per pair.
- Codename resolution: Sonet = claude-sonnet-5 (newest; user-confirmed), Opus = claude-opus-4-8 (matches the repo's defaultModel), Fable = claude-fable-5, Luna = gpt-5.6-luna, Terra = gpt-5.6-terra (registry spelling), Sol = gpt-5.6-sol.
- Accept 0.2.1's contextBudget defaults instead of pinning — the repo never pinned an auto-pause value, and 400k for anthropic/* matches the prior effective pause point for the default claude-opus-4-8.
- Pin-bump obligation (docs-internal/dev-workflow/track-development.md § Package pin bumps): verified the package's workflow docs are byte-identical between 0.1.1 and 0.2.1 and no repo doc names the changed config keys — no doc edits required.

**Out of scope**
- Provisioning OpenAI authentication (see Risks). No changes to the model catalog, default model, or workflow docs. The stale `bump-ytdb-slate-0.1.1` branch is left untouched.

**Risks & accepted trade-offs**
- WH1 (accepted): the anthropic→openai direction silently no-ops if OpenAI is not authenticated in the environment; the config is correct, but its high-availability benefit depends on OpenAI auth/proxy being provisioned.
- WI2 (accepted): orchestrator-side failover persists the mapped model as pi's global default until reset via `/model`, which can bleed into other projects/sessions.
- WH2 (accepted): both the 0.2.1 auto-install and `modelFailover` require project trust; an untrusted fresh checkout silently gets neither.
- WC2 (kept by design): the Fable ↔ Sol pair only auto-routes when one of those models is selected; retained per explicit request for all three pairs.
- Confirmed non-issues: 400k anthropic contextBudget is equivalent to the old 40%-of-1M pause point for claude-opus-4-8 (no regression); all six entries pass slate's failover sanitizer; post-failover budget on gpt-5.6-* (272k window) clamps to ~222,848 tokens, guarding the OpenAI pricing cliff.
- Design review: user-approved — 2026-07-24
- Adversarial review: passed, 3 accepted risks — 2026-07-24

**Verification approach**
- Confirmed `.pi/slate.json` is well-formed JSON, all six failover entries survive slate's sanitizer (flat provider/id→provider/id, no self-maps), and every model id resolves in the registry (models-store.json). Config-only change; no Maven/JUnit tests apply.
