### PR TITLE
Default to Opus 5 with Sol failover; recommend pi + slate

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,5 +1,6 @@
 {
-  "defaultModel": "claude-opus-4-8",
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-opus-5",
   "defaultThinkingLevel": "xhigh",
   "hideThinkingBlock": true,
   "packages": ["npm:ytdb-slate@0.2.1"]

--- a/.pi/slate.json
+++ b/.pi/slate.json
@@ -11,6 +11,7 @@
     "anthropic/claude-opus-4-8": "openai/gpt-5.6-terra",
     "openai/gpt-5.6-terra": "anthropic/claude-opus-4-8",
     "anthropic/claude-fable-5": "openai/gpt-5.6-sol",
-    "openai/gpt-5.6-sol": "anthropic/claude-fable-5"
+    "anthropic/claude-opus-5": "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-sol": "anthropic/claude-opus-5"
   }
 }

--- a/README.md
+++ b/README.md
@@ -144,3 +144,14 @@ compiles and runs MATCH/YQL queries — from SQL text through the parser,
 pattern graph, cost-based planner, execution steps, and traversers —
 starting at
 [Chapter 1 — Why a Graph Database Has Its Own Query Engine](docs/yql-internals-book/chapters/01-why-a-graph-database.md).
+
+We develop YouTrackDB with the `pi` coding agent running our
+[ytdb-slate](https://github.com/JetBrains/ytdb-slate) extension, which
+implements Slate — a new agentic orchestration architecture where an
+orchestrator agent plans the work and delegates bounded tasks to worker
+threads. The extension also encodes this project's development
+workflow: track-based delivery, mandatory design and adversarial
+reviews before implementation, and the test and verification policy
+every change must satisfy. We strongly recommend that contributors
+use it — it is the fastest way to produce changes that match our
+conventions.

--- a/README.md
+++ b/README.md
@@ -147,11 +147,10 @@ starting at
 
 We develop YouTrackDB with the [pi](https://github.com/earendil-works/pi)
 coding agent and strongly recommend you use it too. Our
-[ytdb-slate](https://github.com/JetBrains/ytdb-slate) extension —
-pinned in our pi settings, so a clone picks up the version we
-use — runs Slate, a new orchestration architecture from a
-Random Labs technical report: an orchestrator plans and
-delegates bounded tasks to worker threads, with mandatory
-design and adversarial reviews before implementation. Our own
-coding, test, and verification policy layers on top — see
-[docs-internal](docs-internal/README.md).
+[ytdb-slate](https://github.com/JetBrains/ytdb-slate) extension ships
+Slate, a new agentic orchestration architecture from a Random Labs
+technical report. An orchestrator plans while worker threads execute,
+under mandatory design and adversarial reviews before
+implementation. It is pinned in our pi settings, so a clone uses
+the version we do. Our own coding, test, and verification policy
+layers on top — see [docs-internal](docs-internal/README.md).

--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ pattern graph, cost-based planner, execution steps, and traversers —
 starting at
 [Chapter 1 — Why a Graph Database Has Its Own Query Engine](docs/yql-internals-book/chapters/01-why-a-graph-database.md).
 
-We develop YouTrackDB with the `pi` coding agent running our
-[ytdb-slate](https://github.com/JetBrains/ytdb-slate) extension, which
-implements Slate — a new agentic orchestration architecture where an
-orchestrator agent plans the work and delegates bounded tasks to worker
-threads. The extension also encodes this project's development
-workflow: track-based delivery, mandatory design and adversarial
-reviews before implementation, and the test and verification policy
-every change must satisfy. We strongly recommend that contributors
-use it — it is the fastest way to produce changes that match our
-conventions.
+We develop YouTrackDB with the [pi](https://github.com/earendil-works/pi)
+coding agent and strongly recommend you use it too. Our
+[ytdb-slate](https://github.com/JetBrains/ytdb-slate) extension —
+pinned in our pi settings, so a clone picks up the version we
+use — runs Slate, a new orchestration architecture from a
+Random Labs technical report: an orchestrator plans and
+delegates bounded tasks to worker threads, with mandatory
+design and adversarial reviews before implementation. Our own
+coding, test, and verification policy layers on top — see
+[docs-internal](docs-internal/README.md).


### PR DESCRIPTION
#### Motivation:

Opus 5 is now the strongest model available for this project's agent work, but the project pi settings still pinned Opus 4.8, so every contributor session silently started on the older model. The slate failover map also had no entry for Opus 5, meaning an Opus 5 outage would leave a session with no fallback at all. Separately, the README's Contributing section documented how the query engine works but said nothing about how the project is actually developed — contributors had no pointer to the pi + ytdb-slate setup the maintainers rely on.

#### Planned changes:

The project's pi settings now default to Opus 5 and declare `anthropic` as the explicit default provider. The slate `modelFailover` map gains an Opus 5 → Sol edge and repoints Sol's return edge from Fable 5 to Opus 5. The README's Contributing section gains a paragraph recommending the pi coding agent with the ytdb-slate extension — crediting Slate's origin, noting that the extension is pinned in the repository's pi settings so a clone picks up the version the maintainers use, and pointing at `docs-internal/` for the coding, test, and verification policy the project layers on top of the extension's generic workflow.

**Key decisions**

- *Sol's return edge is repointed to Opus 5, leaving Fable 5 → Sol one-way.* Sol can only have one failover target. Rejected: re-pairing Fable 5 with the unused base `gpt-5.6` to keep every pair symmetric — the map's symmetry is a convention, not a requirement, and failover lookup is single-hop, so the asymmetric edge is functionally inert.
- *An explicit `defaultProvider` accompanies the bare model id.* pi's resolver needs both, and slate's failover persists its model choice to **global** settings — so after one live failover, a provider-less project config would resolve the bare `claude-opus-5` against a global `openai` provider and silently fall back to Opus 4.8. Rejected: leaving the config provider-less to match its prior shape.
- *The README attributes only the generic workflow to the extension.* Slate is credited to a Random Labs technical report, and the project's own test and verification policy stays behind a `docs-internal/` link, because the extension explicitly defers commit/test/push discipline to the consuming project.

**Out of scope:** the Sonnet 5 ↔ Luna and Opus 4.8 ↔ Terra failover pairs; the Claude Code statusline script that separately references Opus 4.8.

**Risks & accepted trade-offs:** Fable 5's failover edge becomes one-way (accepted; inert under single-hop lookup).

Design review: user-approved — 2026-07-26
Adversarial review: passed, 0 accepted risks — 2026-07-26
Peer review: waived by the user — 2026-07-26

**Verification approach:** no product code changed, so no test suite applies. Both JSON files were validated as parseable; `claude-opus-5` and `gpt-5.6-sol` were confirmed resolvable and authenticated via `pi --list-models`; project-over-global settings precedence was confirmed empirically against pi's settings manager; and every URL and relative link added to the README was checked for reachability.
