### PR TITLE
[no-test-number-check] Republish the pinned TinkerPop fork snapshot before Sonatype purges it

### DIFF
--- a/.github/workflows/gremlin-fork-snapshot-refresh.yml
+++ b/.github/workflows/gremlin-fork-snapshot-refresh.yml
@@ -1,0 +1,478 @@
+name: Refresh TinkerPop Fork Snapshot
+
+# YouTrackDB compiles against io.youtrackdb:gremlin-*, the JetBrains fork of
+# Apache TinkerPop that lives in JetBrains/ytdb-tinkerpop and is published as a
+# SNAPSHOT. Sonatype deletes snapshots 90 days after they are published, and
+# the fork only publishes on a push to ytdb-fork-3.8-dev. A coordinate that
+# nobody republishes for three months therefore stops resolving, and every
+# YouTrackDB build then fails during dependency resolution, before a single
+# class is compiled. That is what happened to 3.8.1-af9db90-SNAPSHOT: published
+# 2026-04-27, purged 2026-07-26, nightly integration pipeline red on 2026-07-27.
+#
+# This workflow rebuilds the pinned fork commit from source and republishes it
+# under the same coordinate, which resets the 90-day clock without changing the
+# coordinate the build resolves. See
+# docs-internal/dev-workflow/tinkerpop-fork-dependency.md for the full
+# procedure, including how to bump the pin.
+
+on:
+  schedule:
+    # 03:00 UTC on the 1st and 15th of each month, clear of the 01:00 UTC
+    # nightly integration pipeline. Twice a month against a 90-day retention
+    # window means five consecutive runs have to fail before the artifact can
+    # disappear, so a transient Sonatype outage cannot break the build.
+    - cron: '0 3 1,15 * *'
+  workflow_dispatch:
+  push:
+    # Bootstrap only: this workflow's own merge republishes immediately,
+    # recovering the snapshot purged today. Nothing routine edits this file, so
+    # later recoveries go through workflow_dispatch. A gremlin.version bump
+    # deliberately does not fire this — the fork has just published that
+    # coordinate, so its 90-day window has only just started.
+    branches: [ develop ]
+    paths: [ '.github/workflows/gremlin-fork-snapshot-refresh.yml' ]
+
+# Two republishes of the same coordinate must not race each other. A queued run
+# waits instead of being cancelled, because the point of the run is the upload.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORK_REPO: JetBrains/ytdb-tinkerpop
+  # The only branch a pinned commit may come from. Anything else is either a
+  # typo or a commit from a sibling fork of apache/tinkerpop — see the
+  # provenance step below for why that distinction matters.
+  FORK_BRANCH: ytdb-fork-3.8-dev
+  # The ten io.youtrackdb jars this workflow owns: the nine YouTrackDB declares
+  # in <dependencyManagement>, plus gremlin-shaded, which gremlin-core pulls in
+  # transitively. Both the deploy and the verification derive their module
+  # lists from this one string, so the two cannot drift apart.
+  #
+  # -am also republishes gremlin-annotations and gremlin-socket-server, and
+  # neither is listed here because neither is transitive: the fork declares the
+  # first <optional>true</optional> in gremlin-groovy and the second at test
+  # scope in gremlin-driver, so no consumer resolves them. Should the fork drop
+  # that optional flag, gremlin-annotations joins YouTrackDB's compile classpath
+  # and belongs in this list — otherwise its coordinate would quietly count down
+  # to its own purge behind a green refresh.
+  GREMLIN_ARTIFACTS: >-
+    gremlin-core gremlin-groovy gremlin-language gremlin-util gremlin-shaded
+    gremlin-driver gremlin-server gremlin-test gremlin-console tinkergraph-gremlin
+  # Every module above inherits its version from io.youtrackdb:tinkerpop, so
+  # Maven must resolve that pom to build the effective model of any of them. It
+  # is an artifact like the rest and expires like the rest, so it is verified
+  # like the rest — but it is packaging:pom, so it has no jar to check.
+  GREMLIN_POM_ARTIFACTS: tinkerpop
+
+jobs:
+  refresh:
+    name: Rebuild and republish io.youtrackdb:gremlin-*
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    # Exposed so the failure notification can name the coordinate at risk
+    # instead of sending the responder to the run log for it.
+    outputs:
+      version: ${{ steps.coords.outputs.version }}
+    steps:
+      - name: Checkout YouTrackDB
+        uses: actions/checkout@v7
+        with:
+          # Pinned for the same reason the Deploy Artifacts job pins it: a
+          # workflow_dispatch run must not be able to publish the coordinate
+          # named by an arbitrary branch under the project's group ID. It pins
+          # which pom.xml supplies that coordinate and nothing more — on
+          # workflow_dispatch GitHub still runs the workflow file from the
+          # dispatched ref, which only an environment gate with required
+          # reviewers would constrain.
+          ref: 'develop'
+          fetch-depth: 1
+          # A build of another repository's source runs in this workspace below.
+          # Keep the checkout token off disk while it does.
+          persist-credentials: false
+
+      - name: Resolve the pinned fork coordinate
+        id: coords
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # gremlin.version has the shape <base>-<fork-sha>-SNAPSHOT. The fork's
+          # own pom builds its version from ${revision}${sha1}${changelist}, so
+          # building <fork-sha> with -Dsha1=-<fork-sha> reproduces the exact
+          # coordinate YouTrackDB asks for. Parsed with sed rather than
+          # `mvn help:evaluate` so the coordinate is known before any JDK or
+          # Maven setup, and before any fork source reaches the workspace.
+          pattern='s:.*<gremlin\.version>\(.*\)</gremlin\.version>.*:\1:p'
+          mapfile -t matches < <(sed -n "$pattern" pom.xml)
+          if [ "${#matches[@]}" -ne 1 ]; then
+            echo "::error::Found ${#matches[@]} <gremlin.version> declarations in pom.xml," \
+                 "expected exactly one. A profile override or a commented-out copy makes" \
+                 "the pinned coordinate ambiguous, and this workflow will not guess which" \
+                 "one wins."
+            exit 1
+          fi
+          version="${matches[0]}"
+          if [[ ! "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9a-f]{7,40})-SNAPSHOT$ ]]; then
+            echo "::error::gremlin.version is '$version', which does not match" \
+                 "<base>-<fork-sha>-SNAPSHOT. Either the property moved in pom.xml" \
+                 "or the fork changed its versioning scheme; this workflow cannot" \
+                 "derive the fork commit until it is taught the new shape."
+            exit 1
+          fi
+          short_sha="${BASH_REMATCH[2]}"
+
+          # actions/checkout cannot fetch an abbreviated SHA, so expand it. An
+          # empty answer would be passed on as an empty `ref:`, which silently
+          # checks out the fork's default branch, so treat it as a failure.
+          if ! full_sha="$(gh api "repos/${FORK_REPO}/commits/${short_sha}" --jq .sha)" \
+             || [ -z "$full_sha" ]; then
+            echo "::error::Cannot expand ${short_sha} against ${FORK_REPO}. The commit" \
+                 "was probably garbage-collected after a force-push. Re-pin" \
+                 "gremlin.version to a commit that still exists on ${FORK_BRANCH}."
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "short_sha=$short_sha"
+            echo "full_sha=$full_sha"
+          } >> "$GITHUB_OUTPUT"
+
+          # Recorded in the run summary so a later audit can see exactly which
+          # commit was resolved, not just its seven-character prefix. This runs
+          # before the provenance gate, so it reports the pin, not a publish.
+          echo "Resolved pin: \`io.youtrackdb:gremlin-*:$version\` at" \
+               "\`${FORK_REPO}@$full_sha\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify the pinned commit belongs to the fork branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FULL_SHA: ${{ steps.coords.outputs.full_sha }}
+        # An abbreviated SHA resolves against the shared object store of the
+        # whole apache/tinkerpop fork network, not against refs in
+        # ytdb-tinkerpop, and `git fetch <full-sha>` retrieves such an object
+        # without complaint. Without this gate, a commit authored in any of the
+        # hundreds of sibling forks would be checked out and built with this
+        # repository's Maven Central credentials in the environment. Ancestry is
+        # what pins the source, so assert it before the fork's code reaches the
+        # runner.
+        run: |
+          set -euo pipefail
+          status="$(gh api "repos/${FORK_REPO}/compare/${FULL_SHA}...${FORK_BRANCH}" --jq .status)"
+          case "$status" in
+            # identical: the pin is the branch head.
+            # ahead: the branch has moved on, the pin is still an ancestor.
+            identical|ahead) echo "Pin is on ${FORK_BRANCH} (compare status: $status)." ;;
+            *)
+              echo "::error::${FULL_SHA} is not an ancestor of ${FORK_BRANCH} in" \
+                   "${FORK_REPO} (compare status: $status). Refusing to build and" \
+                   "publish a commit that does not come from the fork branch."
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout the TinkerPop fork at the pinned commit
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.FORK_REPO }}
+          ref: ${{ steps.coords.outputs.full_sha }}
+          path: ytdb-tinkerpop
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        # The fork enforces requireJavaVersion [11,18), and JDK 17 is what its
+        # own publish pipeline uses, so the rebuild runs in the same toolchain
+        # that produced the original artifacts. No Maven cache: this job's
+        # output is published, so it builds from what the repositories serve
+        # rather than from whatever a previous run left behind.
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          overwrite-settings: false
+
+      - name: Verify the rebuild produces exactly the pinned coordinate
+        working-directory: ytdb-tinkerpop
+        env:
+          SHORT_SHA: ${{ steps.coords.outputs.short_sha }}
+          VERSION: ${{ steps.coords.outputs.version }}
+        # No -s and no secrets: this step reads the fork's own pom, and reading
+        # it means resolving and instantiating the build extensions the fork
+        # declares. Keep it where it is, after the provenance gate, and keep it
+        # credential-free.
+        #
+        # Ask Maven what it will call the artifacts rather than checking one
+        # component of ${revision}${sha1}${changelist} by hand: a fork-side
+        # change to changelist or to the <version> expression would slip past a
+        # <revision> comparison and publish a coordinate YouTrackDB cannot
+        # resolve. Running it before the deploy costs one Maven startup and
+        # turns a bad publish into a clean refusal. Reading the root pom alone
+        # is enough because no module declares its own <version>; they all
+        # inherit it. This is the same help:evaluate pattern the Deploy
+        # Artifacts and weekly-beta-release jobs use.
+        run: |
+          set -euo pipefail
+          built="$(mvn -q -N -B \
+            -DforceStdout help:evaluate -Dexpression=project.version \
+            -Dsha1="-${SHORT_SHA}" -Dchangelist=-SNAPSHOT \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)"
+          if [ "$built" != "$VERSION" ]; then
+            echo "::error::Fork commit ${SHORT_SHA} builds as '${built}', but" \
+                 "gremlin.version pins '${VERSION}'. Refusing to publish a coordinate" \
+                 "YouTrackDB does not resolve."
+            exit 1
+          fi
+          echo "Rebuild coordinate matches the pin: $built"
+
+      - name: Rebuild and republish the snapshot
+        id: deploy
+        working-directory: ytdb-tinkerpop
+        env:
+          SHORT_SHA: ${{ steps.coords.outputs.short_sha }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+        # The fork declares central-publishing-maven-plugin with
+        # <extensions>true</extensions>, so `deploy` routes through the Central
+        # Portal plugin and uploads to central-portal-snapshots, which is the
+        # repository YouTrackDB's root pom reads from.
+        # -DaltDeploymentRepository would be ignored here, so it is not set.
+        # This repository's own Deploy Artifacts job is the precedent: it runs a
+        # bare `mvn deploy` under the same plugin configuration, declares no
+        # distributionManagement, and its snapshots still land on
+        # central-portal-snapshots.
+        #
+        # -Dchangelist=-SNAPSHOT restates the fork's own default. The plugin
+        # runs with autoPublish=true, so a fork-side change to that default
+        # would turn this into an immutable release deploy that cannot be
+        # retracted; pinning it makes that path unreachable.
+        #
+        # -DskipTests because this rebuilds a commit the fork's own pipeline
+        # already tested when it first published this coordinate. The source is
+        # identical, so the tests would only repeat what that pipeline already
+        # ran, at the cost of wall-clock time.
+        run: |
+          set -euo pipefail
+
+          # Floor for the freshness assertion in the next step, backdated to
+          # absorb clock skew between this runner and Sonatype. The backdating
+          # means an artifact republished by another run inside that window
+          # would read as fresh here; the concurrency group serialises runs and
+          # the cadence is twice monthly, so the simpler floor is preferred to
+          # capturing per-artifact lastUpdated before the deploy.
+          echo "floor=$(date -u -d '10 minutes ago' +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
+
+          # A settings.xml holding one server rather than the repository's
+          # shared one. Maven matches <server> entries by id, so a <repository>
+          # the fork declares under the shared file's ytdb-maven-central id
+          # would be sent the mirror credentials. The fork build has no need of
+          # them, so it never sees them; dependencies come from Maven Central
+          # directly, which is cheap at twice a month. The password stays an
+          # env placeholder, so no secret is written to disk.
+          # The id must match the fork's central-publishing-maven-plugin
+          # publishingServerId, which is the plugin default. If the fork ever
+          # overrides it, the deploy fails with a 401 that looks like bad
+          # credentials rather than a missing <server> entry.
+          settings="$RUNNER_TEMP/fork-settings.xml"
+          cat > "$settings" <<'XML'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+            <servers>
+              <server>
+                <id>central</id>
+                <username>${env.MAVEN_USERNAME}</username>
+                <password>${env.MAVEN_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          XML
+
+          # ":a,:b,:c" from the shared artifact list, so the modules named
+          # here and the ones verified afterwards cannot drift apart. -am makes
+          # the deployed set a superset of that list. Unquoted on purpose: the
+          # word splitting is what turns the list into arguments.
+          # shellcheck disable=SC2086
+          projects="$(printf ':%s,' $GREMLIN_ARTIFACTS)"
+          projects="${projects%,}"
+
+          # -am is load-bearing, not a safety net: it is what pulls the
+          # io.youtrackdb:tinkerpop parent pom into the reactor, and every
+          # module above needs that pom to resolve. It also absorbs any new
+          # inter-module dependency the fork adds later.
+          mvn -B -s "$settings" \
+            -Dsha1="-${SHORT_SHA}" \
+            -Dchangelist=-SNAPSHOT \
+            -DskipTests \
+            -pl "$projects" -am \
+            clean deploy
+
+      - name: Verify every pinned artifact republished
+        timeout-minutes: 20
+        env:
+          # Must stay in sync with the central-portal-snapshots <url> in the
+          # root pom.xml; that is the repository consumers actually read.
+          SNAPSHOT_REPO: https://central.sonatype.com/repository/maven-snapshots/io/youtrackdb
+          VERSION: ${{ steps.coords.outputs.version }}
+          FLOOR: ${{ steps.deploy.outputs.floor }}
+          GREMLIN_ARTIFACTS: ${{ env.GREMLIN_ARTIFACTS }}
+          GREMLIN_POM_ARTIFACTS: ${{ env.GREMLIN_POM_ARTIFACTS }}
+        # Existence is not enough. On a routine run the coordinate is still
+        # live, so an artifact the deploy skipped answers with its months-old
+        # metadata and HTTP 200 — the run would go green while that one artifact
+        # kept counting down to its original purge date. So assert freshness
+        # (lastUpdated at or after this run's floor) and then fetch the file the
+        # metadata points at, which is what a consumer's build resolves.
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import http.client, os, sys, time, urllib.error, urllib.request
+          import xml.etree.ElementTree as ET
+
+          repo = os.environ["SNAPSHOT_REPO"]
+          version = os.environ["VERSION"]
+          floor = os.environ["FLOOR"]
+
+          ATTEMPTS = 5
+          RETRY_SLEEP = 8
+          # Bound the step as a whole rather than each artifact: eleven targets
+          # each retrying to exhaustion could outlast the job timeout and
+          # surface as an opaque cancellation instead of a named failure.
+          DEADLINE = time.monotonic() + 600
+
+          # urlopen raises TimeoutError and ConnectionResetError on the two most
+          # common transients, and neither is a URLError. Both are OSError, so
+          # catch that; IncompleteRead is not, hence HTTPException beside it.
+          TRANSIENT = (OSError, http.client.HTTPException, ET.ParseError)
+
+          def fetch(url, limit=-1):
+              # A default Python-urllib User-Agent is a common CDN filter target.
+              request = urllib.request.Request(url, headers={"User-Agent": "ytdb-snapshot-refresh"})
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return response.read(limit)
+
+          def check(artifact, packaging):
+              """Return None when the artifact is fresh, else (reason, retryable).
+
+              retryable marks the failures Central Portal can still resolve on
+              its own — it lags a few seconds behind a deploy, so a 404, a
+              network error, or metadata that still reads stale may all clear by
+              themselves. A structurally wrong answer never will, and retrying
+              one only burns the deadline that the genuinely slow cases need.
+              """
+              base = f"{repo}/{artifact}/{version}"
+              try:
+                  root = ET.fromstring(fetch(f"{base}/maven-metadata.xml"))
+              except urllib.error.HTTPError as exc:
+                  return (f"metadata HTTP {exc.code}", True)
+              except TRANSIENT as exc:
+                  return (f"metadata unreadable ({exc!r})", True)
+
+              updated = root.findtext("versioning/lastUpdated")
+              if not updated:
+                  return ("metadata carries no versioning/lastUpdated", False)
+              if updated < floor:
+                  return (f"stale: lastUpdated={updated} predates this run ({floor})", True)
+
+              # The main artifact is the snapshotVersion with the packaging
+              # extension and no classifier; sources and tests entries carry one.
+              stamped = next(
+                  (sv.findtext("value")
+                   for sv in root.iterfind("versioning/snapshotVersions/snapshotVersion")
+                   if sv.findtext("extension") == packaging and not sv.findtext("classifier")),
+                  None,
+              )
+              if stamped is None:
+                  return (f"metadata lists no unclassified {packaging}", False)
+
+              url = f"{base}/{artifact}-{stamped}.{packaging}"
+              # Four bytes is enough to tell a jar from an empty body or from a
+              # CDN error page served with HTTP 200, and it avoids pulling tens
+              # of megabytes across ten artifacts. It does not detect a
+              # truncated jar: those keep their zip magic and pass.
+              try:
+                  body = fetch(url, 4 if packaging == "jar" else -1)
+              except urllib.error.HTTPError as exc:
+                  return (f"{packaging} HTTP {exc.code} at {url}", True)
+              except TRANSIENT as exc:
+                  return (f"{packaging} unreachable ({exc!r})", True)
+
+              if packaging == "jar":
+                  if body[:4] != b"PK\x03\x04":
+                      return (f"{url} does not open with the zip magic "
+                              f"({len(body)} bytes read)", False)
+              else:
+                  try:
+                      ET.fromstring(body)
+                  except ET.ParseError as exc:
+                      return (f"{url} is not parseable XML ({exc})", False)
+              return None
+
+          targets = [(a, "jar") for a in os.environ["GREMLIN_ARTIFACTS"].split()]
+          targets += [(a, "pom") for a in os.environ["GREMLIN_POM_ARTIFACTS"].split()]
+
+          failures = {}
+          exhausted = False
+          for artifact, packaging in targets:
+              # Not None, so an ATTEMPTS of zero could never report a pass.
+              result = ("not checked", False)
+              for attempt in range(ATTEMPTS):
+                  result = check(artifact, packaging)
+                  if result is None or not result[1]:
+                      break
+                  if time.monotonic() > DEADLINE:
+                      exhausted = True
+                      break
+                  if attempt < ATTEMPTS - 1:
+                      time.sleep(RETRY_SLEEP)
+              if result is None:
+                  print(f"ok       {artifact} ({packaging})")
+              else:
+                  reason = result[0]
+                  # Otherwise a budget-truncated check reads exactly like a
+                  # settled failure, and the responder chases the wrong cause.
+                  if exhausted:
+                      reason += "  [retry budget exhausted; attempts cut short]"
+                  print(f"FAILED   {artifact} ({packaging}): {reason}")
+                  failures[(artifact, packaging)] = reason
+
+          if failures:
+              named = ", ".join(f"{a} ({p})" for a, p in sorted(failures))
+              print(f"::error::{len(failures)} artifact(s) did not republish: {named}")
+              sys.exit(1)
+          print(f"All {len(targets)} artifacts of {version} republished and resolve.")
+          PY
+
+  notify-failure:
+    name: Notify refresh failure on Zulip
+    needs: [ refresh ]
+    # The snapshot still has whatever is left of its 90-day window when a
+    # refresh fails, so the job posts a low-severity Zulip message instead of
+    # dispatching the CI fix agent. After two consecutive failures, treat the
+    # refresh as urgent.
+    #
+    # Unlike the notify jobs in the integration pipeline, this one does not
+    # exempt workflow_dispatch: a manual run is the documented recovery path for
+    # an already-broken build, so its failure is the case most worth paging on.
+    if: always() && needs.refresh.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Send Zulip Notification
+        uses: zulip/github-actions-zulip/send-message@v2
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: ci-status-bot@youtrackdb.zulipchat.com
+          organization-url: 'https://youtrackdb.zulipchat.com'
+          to: 'ytdb'
+          type: 'stream'
+          topic: 'ci status'
+          content: |
+            **TINKERPOP SNAPSHOT REFRESH FAILED** :warning:
+            `io.youtrackdb:gremlin-*:${{ needs.refresh.outputs.version || 'unknown version' }}` was not republished for repo ${{ github.repository }}.
+            Sonatype purges snapshots 90 days after publication; once that window closes every build fails at dependency resolution.
+            Read the run logs, then either fix the failure or bump the pin — see `docs-internal/dev-workflow/tinkerpop-fork-dependency.md`.
+            [View Run Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -9,6 +9,7 @@ product documentation lives in the [user documentation index](../docs/README.md)
 | Document | Description |
 |---|---|
 | [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, umbrella-PR peer-review policy, package pin-bump rule |
+| [TinkerPop Fork Dependency](dev-workflow/tinkerpop-fork-dependency.md) | `io.youtrackdb:gremlin-*` SNAPSHOT pin and its 90-day Sonatype expiry — the twice-monthly refresh workflow, recovering a purged snapshot, bumping the pin |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, codebase tips |
 | [Architecture Decision Records](adr/) | Archive of Architecture Decision Records, plus historical/sunset workflow research logs |

--- a/docs-internal/dev-workflow/tinkerpop-fork-dependency.md
+++ b/docs-internal/dev-workflow/tinkerpop-fork-dependency.md
@@ -1,0 +1,76 @@
+# TinkerPop Fork Dependency
+
+YouTrackDB compiles against `io.youtrackdb:gremlin-*`, a JetBrains fork of Apache TinkerPop, and pins it to a SNAPSHOT version that Sonatype deletes 90 days after publication. The fork republishes only when someone pushes to its source branch. A coordinate left pinned for three months therefore stops resolving, and every YouTrackDB build then fails during dependency resolution, before a single class is compiled. The `Refresh TinkerPop Fork Snapshot` workflow (`.github/workflows/gremlin-fork-snapshot-refresh.yml`) rebuilds the pinned commit from source twice a month and republishes it under the same coordinate, which resets the retention clock.
+
+## What the dependency is
+
+The fork lives in [JetBrains/ytdb-tinkerpop](https://github.com/JetBrains/ytdb-tinkerpop) on the `ytdb-fork-3.8-dev` branch. It re-publishes Apache TinkerPop's modules under the `io.youtrackdb` group ID with YouTrackDB-specific patches. Its root pom builds the version from `${revision}${sha1}${changelist}`, and its publish pipeline passes `-Dsha1=-<short-sha>`, so each push to `ytdb-fork-3.8-dev` produces one coordinate stamped with the commit it was built from — `3.8.1-af9db90-SNAPSHOT` is TinkerPop 3.8.1 at fork commit `af9db90`.
+
+The root `pom.xml` holds that coordinate once, in the `gremlin.version` property, and `<dependencyManagement>` applies it to all nine artifacts YouTrackDB declares (`gremlin-core`, `gremlin-groovy`, `tinkergraph-gremlin`, `gremlin-test`, `gremlin-driver`, `gremlin-server`, `gremlin-util`, `gremlin-console`, `gremlin-language`). The fork publishes all nine at one version, so a single property bump moves all of them.
+
+## Why the pin expires
+
+A pinned coordinate stops resolving 90 days after it was published, because two facts combine. The fork publishes only on a push to `ytdb-fork-3.8-dev`, so a coordinate is written once and never refreshed. YouTrackDB pins one coordinate and holds it until someone bumps `gremlin.version`. Nobody republishes in between.
+
+The fork publishes through `central-publishing-maven-plugin`, which uploads SNAPSHOT versions to `https://central.sonatype.com/repository/maven-snapshots/`. YouTrackDB's root pom declares that URL as its only repository for these artifacts, under the id `central-portal-snapshots`, which is the name Maven prints when resolution fails. Sonatype purges snapshots 90 days after they are published.
+
+Nothing warns before the break. Local builds and any CI job with a warm Maven cache keep working from the cached copy long after the remote artifact is gone, so the first symptom is a cold runner failing to resolve. That is how it surfaced on 2026-07-27. `3.8.1-af9db90-SNAPSHOT` was published on 2026-04-27 and purged around 2026-07-26; the nightly integration pipeline then went red on all four Linux jobs while both Windows jobs stayed green, because the Windows matrix enables `cache: 'maven'` in `actions/setup-java` and the Linux matrix does not.
+
+## The refresh workflow
+
+### Triggers
+
+`Refresh TinkerPop Fork Snapshot` runs at 03:00 UTC on the 1st and 15th of each month, on manual dispatch, and once on any push to `develop` that touches the workflow file itself. That last trigger is a bootstrap: landing a change to the workflow republishes immediately, rather than leaving a purged snapshot broken until the next scheduled run. Nothing routine edits that file, so later recoveries go through manual dispatch. A `gremlin.version` bump deliberately does not fire it, because the fork has just published the new coordinate and its 90-day window has only started.
+
+### What each run does
+
+1. Reads `gremlin.version` from `pom.xml` and splits it into a base version and a fork commit.
+2. Checks out the fork at that commit.
+3. Rebuilds it with `-Dsha1=-<short-sha>`, so the deploy lands on the coordinate the pin already names.
+
+The source commit is fixed, so every refresh compiles the same code. The jars are rebuilt rather than copied, and the fork sets no `project.build.outputTimestamp`. The bytes behind the coordinate therefore change from run to run, even though the source does not.
+
+### When a run fails
+
+A run every two weeks against a 90-day window leaves margin: five consecutive runs must fail before the artifact can disappear. That margin absorbs a Sonatype outage or an expired token, so a failed run posts to the `ytdb` Zulip stream at low severity and does not dispatch the CI fix agent. After two consecutive failures, read the run logs and either fix the failure or bump the pin (see [Bumping the pin](#bumping-the-pin)).
+
+### The publication gates
+
+Three checks abort the run before anything is published:
+
+- `gremlin.version` does not parse as `<base>-<fork-sha>-SNAPSHOT`, or `pom.xml` declares the property more than once.
+- The pinned commit is not an ancestor of `ytdb-fork-3.8-dev`. An abbreviated SHA resolves against the shared object store of the whole `apache/tinkerpop` fork network, so without this gate a commit authored in any sibling fork would be built and published under the `io.youtrackdb` group ID. The gate's guarantee rests on `ytdb-fork-3.8-dev` being a protected branch in a repository this workflow does not control.
+- Maven reports a `project.version` for the rebuild that differs from the pin.
+
+A fourth check runs after the deploy, and it is the reason the workflow can be trusted on a routine run. Existence proves nothing while the coordinate is still live: an artifact the deploy skipped answers with its months-old metadata and HTTP 200, and would keep counting down to its original purge date behind a green run. So the check asserts that each artifact's `<lastUpdated>` has advanced past a floor stamped just before the deploy, then fetches the file that metadata points at.
+
+It covers eleven artifacts: the nine YouTrackDB declares, `gremlin-shaded`, which `gremlin-core` pulls in transitively, and the `io.youtrackdb:tinkerpop` parent pom, which every one of them inherits its version from and which Maven must resolve to build any of their effective models.
+
+## Recovering a purged snapshot
+
+Run the workflow manually:
+
+```bash
+gh workflow run gremlin-fork-snapshot-refresh.yml --repo JetBrains/youtrackdb
+```
+
+It restores whatever `gremlin.version` currently names. No other edit is needed: the republished coordinate is identical to the purged one, so every existing build resolves again as soon as the deploy lands.
+
+Rebuilding the artifacts locally unblocks only that one machine — the jars land in `~/.m2`, not in `central-portal-snapshots`, so CI and every other developer stay broken.
+
+Build with JDK 17: the fork enforces `requireJavaVersion [11,18)`, even though YouTrackDB itself needs 21. `<fork-short-sha>` is the abbreviated form that appears in `gremlin.version`, and it must be passed to `-Dsha1` exactly as written there, because it becomes part of the version string:
+
+```bash
+git clone --branch ytdb-fork-3.8-dev https://github.com/JetBrains/ytdb-tinkerpop.git
+cd ytdb-tinkerpop && git checkout <fork-short-sha>
+JAVA_HOME=/path/to/jdk17 mvn -Dsha1=-<fork-short-sha> -DskipTests \
+  -pl :gremlin-core,:gremlin-driver,:gremlin-server,:gremlin-test,:gremlin-console -am install
+```
+
+## Bumping the pin
+
+Push to `ytdb-fork-3.8-dev` in the fork; its pipeline tests the change and publishes a snapshot stamped with the new commit. Then set `gremlin.version` in YouTrackDB's root `pom.xml` to `<base>-<new-short-sha>-SNAPSHOT`. The refresh workflow needs no change: it re-reads `gremlin.version` on every run.
+
+## The durable fix this does not do
+
+Refreshing a snapshot keeps the build working; it does not make the build reproducible. A SNAPSHOT coordinate is mutable by definition, so a checkout of an old YouTrackDB commit resolves whatever `gremlin-core:3.8.1-af9db90-SNAPSHOT` happens to contain today rather than what it contained when that commit was written. Publishing the fork as an immutable release (`3.8.1-af9db90`, no `-SNAPSHOT`) to Maven Central would end both the 90-day expiry and the mutability, and retire this workflow. That change belongs in the fork, because it needs GPG signing and a Central Portal release deploy.


### PR DESCRIPTION
## Summary

The nightly integration pipeline fails on all four Linux jobs because `io.youtrackdb:gremlin-core:jar:3.8.1-af9db90-SNAPSHOT` no longer exists. This adds a workflow that rebuilds the pinned TinkerPop fork commit from source and republishes it under the same coordinate, twice a month plus on manual dispatch, so the coordinate cannot expire again.

Merging this PR runs the workflow once, which restores the missing artifact and unblocks CI. No other change is needed.

## Root Cause

Not a test failure and not a code change — dependency resolution fails before compilation:

```
[ERROR] Failed to execute goal on project youtrackdb-gremlin-annotations:
  Could not resolve dependencies for project io.youtrackdb:youtrackdb-gremlin-annotations
  dependency: io.youtrackdb:gremlin-core:jar:3.8.1-af9db90-SNAPSHOT (compile)
  Could not find artifact ... in central-portal-snapshots
```

YouTrackDB pins its Apache TinkerPop fork (`JetBrains/ytdb-tinkerpop`) to a SNAPSHOT coordinate. Sonatype deletes snapshots 90 days after publication. The fork published `3.8.1-af9db90-SNAPSHOT` on 2026-04-27 and publishes only on a push to `ytdb-fork-3.8-dev`, which has not moved since. The purge landed around 2026-07-26; the pipeline went red on 2026-07-27, one day later.

I confirmed the artifact is absent from central-portal-snapshots, `oss.sonatype.org`, `s01.oss.sonatype.org`, Maven Central, and the YTDB mirror, while `io.youtrackdb:youtrackdb-core:0.5.0-dev-SNAPSHOT` still resolves from the same repository — so the probe is sound and the absence is real.

Both Windows jobs passed. Their matrix enables `cache: 'maven'` in `actions/setup-java` and the Linux matrix does not, so Windows resolved from a warm cache. A cache hides this failure until a cold runner hits it.

## Changes

**`.github/workflows/gremlin-fork-snapshot-refresh.yml`** — rebuilds the pinned fork commit with `-Dsha1=-<short-sha>` and republishes it. Runs at 03:00 UTC on the 1st and 15th, on `workflow_dispatch`, and once on a push to `develop` that touches the workflow file, which is what makes the merge itself restore the artifact. The commit comes from `gremlin.version`, so a pin bump needs no edit here.

Four gates stop a wrong artifact reaching Maven Central:

- `gremlin.version` must parse as `<base>-<fork-sha>-SNAPSHOT` and be declared exactly once.
- The commit must be an ancestor of `ytdb-fork-3.8-dev`. An abbreviated SHA resolves against the shared object store of the whole `apache/tinkerpop` fork network, so without this a commit from any sibling fork would be built and published under `io.youtrackdb`.
- `mvn help:evaluate` must report the pinned coordinate for the rebuild.
- After the deploy, all eleven artifacts must show a `lastUpdated` newer than this run's floor, and the file the metadata points at must be fetchable. Checking existence alone would pass a partial refresh while the coordinate is still live.

**`docs-internal/dev-workflow/tinkerpop-fork-dependency.md`** — why the pin expires, how the refresh works, how to recover a purged snapshot, how to bump the pin.

## Motivation

CI failure on `develop`: https://github.com/JetBrains/youtrackdb/actions/runs/30230187035

## Test plan

- [x] Reproduced the root cause: the artifact 404s on every public repository, while a sibling coordinate from the same repository resolves.
- [x] Rebuilt `ytdb-tinkerpop@af9db90` with JDK 17 and `-Dsha1=-af9db90`; it produces all ten jars plus the parent pom at exactly the pinned coordinate.
- [x] Full reactor compiles against the rebuilt artifacts.
- [x] Full suite (`clean verify -P ci-integration-tests -Dyoutrackdb.test.env=ci`) against the rebuilt artifacts — this is the real check that a rebuild from the pinned source is behaviourally identical to the purged originals.
- [x] `bash -n` on every `run:` block; the embedded Python compiles.
- [x] Coordinate resolution and the provenance gate dry-run against the live API: the real pin returns `identical`; `apache/tinkerpop@2e56ccc1`, which does resolve through our fork's object store, returns `diverged` and is rejected.
- [x] Verification script tested against live coordinates for fresh-jar, fresh-pom, stale, and 404, and against a local mock for terminal-versus-retryable failures.
- [x] Three rounds of dimensional review (security, code quality, shell/hook safety, house style); no blockers or should-fixes remain.

## Follow-ups this PR does not do

These need repository-admin action or a change in the fork, so they are called out rather than attempted:

- **Scope the publishing credential.** The deploy hands `MAVEN_CENTRAL_TOKEN` to a build of the fork's source, and that token covers the whole `io.youtrackdb` namespace. A separate Sonatype user token plus a GitHub `environment:` with required reviewers would contain it. This PR removes `MAVEN_MIRROR_*` from the fork build entirely and generates a minimal `settings.xml` holding only the `central` server, which is as far as it can go without admin access.
- **Publish the fork as an immutable release.** `3.8.1-af9db90` with no `-SNAPSHOT` would end both the expiry and the mutability and retire this workflow. It needs GPG signing and a Central Portal release deploy in `JetBrains/ytdb-tinkerpop`.
- **A dead-man's switch for the schedule.** GitHub disables scheduled workflows after 60 days of repository inactivity, and a workflow that never runs pages nobody. Having the nightly pipeline warn when the pinned coordinate's `lastUpdated` passes ~45 days would close that. Left out to keep this PR off the critical nightly path.
