### PR TITLE
Bump Gremlin snapshot to 3.8.1-67860f6-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <log4j.version>2.25.4</log4j.version>
     <jackson.verson>2.22.1</jackson.verson>
     <toolchain.jdk.version>[21,)</toolchain.jdk.version>
-    <gremlin.version>3.8.1-af9db90-SNAPSHOT</gremlin.version>
+    <gremlin.version>3.8.1-67860f6-SNAPSHOT</gremlin.version>
     <hamcrest.version>3.0</hamcrest.version>
     <cucumber.version>7.34.4</cucumber.version>
     <docker.platforms>linux/amd64,linux/arm64/v8</docker.platforms>


### PR DESCRIPTION
#### Motivation:

The previously pinned Gremlin/TinkerPop snapshot `3.8.1-af9db90-SNAPSHOT` expired from the snapshot repository, breaking dependency resolution. A functionally identical snapshot was re-published as `3.8.1-67860f6-SNAPSHOT`. This bump restores a resolvable build with zero behavioral change.

#### Planned changes:

Single-property version bump: update `<gremlin.version>` in the root `pom.xml` from `3.8.1-af9db90-SNAPSHOT` to `3.8.1-67860f6-SNAPSHOT`. All module POMs resolve the Gremlin version through that property, so no other files change. Pure re-publish of the same snapshot content — no functional change. (trivial tier)

Verification: `./mvnw -pl core,embedded -am compile` → BUILD SUCCESS; the new `3.8.1-67860f6-SNAPSHOT` artifact resolved and downloaded, and the Gremlin-consuming modules (`core`, `embedded`) compiled cleanly.

Risks & accepted trade-offs:
- Design review: user-approved — 2026-07-27
- Adversarial review: skipped with user consent — 2026-07-27
