### PR TITLE
Fix Windows integration-test timeouts and write-cache exclusive-page accounting leak

### DIFF
--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -132,15 +132,16 @@ jobs:
 
       - name: Run Maven Test
         id: tests
-        # Step-level timeout 30 minutes inside the job's own timeout-minutes: 600. A step
-        # timeout is recorded as a step FAILURE, not a cancellation, so the remaining steps run
-        # with the normal job budget instead of racing GitHub's ~5-minute forced-termination
-        # window — which is what makes the diagnostics upload below actually reachable on a
-        # hang. Any run this kills would have been killed by the job timeout 30 minutes later
-        # anyway, so it cannot fail a run that passes today. (On the arm leg the effective cap
-        # is the hosted-runner 360-minute limit, which is lower still; this step timeout does
-        # not change that leg's behaviour.)
-        timeout-minutes: 570
+        # No step-level timeout here, deliberately. The obvious value (just inside this job's
+        # timeout-minutes: 600) is not expressible: GitHub documents a maximum of 360 for
+        # jobs.<job_id>.steps[*].timeout-minutes on both hosted and self-hosted runners, so a
+        # 570 would be out of range — currently unenforced, but not something to rely on. Any
+        # in-range value (<= 360) would be well below this job's 600-minute budget and could
+        # kill integration runs that legitimately take longer, which is a real regression for a
+        # nightly suite sized at 600. The always() condition on the diagnostics upload below
+        # already covers the timeout case on its own; a step timeout would only have been
+        # belt-and-braces, so it is not worth that risk here. The small-cache job in
+        # maven-pipeline.yml keeps its step timeout because 105 is comfortably in range.
         run: ./mvnw -s .github/workflows/settings.xml ${{ matrix.maven_goals }} -B ${{ matrix.mvn_opts }}
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -138,9 +138,16 @@ jobs:
         # 570 would be out of range — currently unenforced, but not something to rely on. Any
         # in-range value (<= 360) would be well below this job's 600-minute budget and could
         # kill integration runs that legitimately take longer, which is a real regression for a
-        # nightly suite sized at 600. The always() condition on the diagnostics upload below
-        # already covers the timeout case on its own; a step timeout would only have been
-        # belt-and-braces, so it is not worth that risk here. The small-cache job in
+        # nightly suite sized at 600.
+        #
+        # What this job gives up by not having one, stated precisely (see the canonical note on
+        # the test-linux diagnostics upload in maven-pipeline.yml): always() still makes the
+        # upload ELIGIBLE after the job timeout, and the upload is ordered before the heavy
+        # publish step so it is LIKELY to finish — but on this job that remains best-effort
+        # inside GitHub's roughly five minutes of forced-termination time, because only a
+        # step-level timeout removes that time box. That is the trade accepted here: a
+        # best-effort upload on a 600-minute nightly, versus a step cap that could kill runs
+        # which legitimately need more than 360 minutes. The small-cache job in
         # maven-pipeline.yml keeps its step timeout because 105 is comfortably in range.
         run: ./mvnw -s .github/workflows/settings.xml ${{ matrix.maven_goals }} -B ${{ matrix.mvn_opts }}
         env:
@@ -176,13 +183,15 @@ jobs:
           path: 'core/target/vmlens-report/'
           if-no-files-found: ignore
           retention-days: 30
-      # Diagnostics upload runs BEFORE Publish Test Results, deliberately. Both are
-      # always()-gated, and after a job timeout GitHub allows roughly five minutes of
-      # forced-termination time for the remaining steps; the publish action is the heavy one
-      # (it parses every report XML and calls the checks API) and this job produces the most
-      # reports of any, so with the old order it could consume that budget and the upload —
-      # the whole point of these steps — would never run. Nothing depends on the publish
-      # step's outputs, so the order is free.
+      # Diagnostics upload runs BEFORE Publish Test Results, deliberately — mechanism (2) of the
+      # canonical note on the test-linux diagnostics upload in maven-pipeline.yml. Both steps are
+      # always()-gated, so both are eligible after a timeout, but once the job is cancelled they
+      # share only GitHub's roughly five minutes of forced-termination time; the publish action is
+      # the heavy one (it parses every report XML and calls the checks API) and this job produces
+      # the most reports of any, so behind it the upload could fail to finish. This job has no
+      # step-level timeout to remove that time box (see the Run Maven Test note above), so the
+      # ordering is the only thing improving the odds here. Nothing depends on the publish step's
+      # outputs, so the order is free.
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
         # always(), NOT !cancelled(): a job killed by a timeout is reported as cancelled, so

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -132,6 +132,15 @@ jobs:
 
       - name: Run Maven Test
         id: tests
+        # Step-level timeout 30 minutes inside the job's own timeout-minutes: 600. A step
+        # timeout is recorded as a step FAILURE, not a cancellation, so the remaining steps run
+        # with the normal job budget instead of racing GitHub's ~5-minute forced-termination
+        # window — which is what makes the diagnostics upload below actually reachable on a
+        # hang. Any run this kills would have been killed by the job timeout 30 minutes later
+        # anyway, so it cannot fail a run that passes today. (On the arm leg the effective cap
+        # is the hosted-runner 360-minute limit, which is lower still; this step timeout does
+        # not change that leg's behaviour.)
+        timeout-minutes: 570
         run: ./mvnw -s .github/workflows/settings.xml ${{ matrix.maven_goals }} -B ${{ matrix.mvn_opts }}
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
@@ -166,6 +175,41 @@ jobs:
           path: 'core/target/vmlens-report/'
           if-no-files-found: ignore
           retention-days: 30
+      # Diagnostics upload runs BEFORE Publish Test Results, deliberately. Both are
+      # always()-gated, and after a job timeout GitHub allows roughly five minutes of
+      # forced-termination time for the remaining steps; the publish action is the heavy one
+      # (it parses every report XML and calls the checks API) and this job produces the most
+      # reports of any, so with the old order it could consume that budget and the upload —
+      # the whole point of these steps — would never run. Nothing depends on the publish
+      # step's outputs, so the order is free.
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        # always(), NOT !cancelled(): a job killed by a timeout is reported as cancelled, so
+        # !cancelled() skipped the upload in exactly the case the dumps are the only evidence
+        # of what hung. Which timeout fires differs per leg: the x86 leg is self-hosted, so
+        # this job's timeout-minutes: 600 applies; the arm leg runs on a GitHub-hosted runner,
+        # where the 6-hour (360-minute) hard limit on hosted jobs is reached first and the 600
+        # setting can never fire.
+        #
+        # Mixed matrix, so BOTH report directories are needed and neither may be dropped: the
+        # x86 leg runs `clean verify` (failsafe — previously not collected here at all) and the
+        # arm leg runs `clean package` (surefire only). The surefire globs are kept as-is and
+        # the failsafe ones added.
+        #
+        # run_attempt is in the artifact name because upload-artifact v4+ rejects a duplicate
+        # name within a run: on a job re-run the previous attempt's artifact still exists, so a
+        # fixed name would 409 and fail the step. Suffixing keeps both attempts' diagnostics.
+        if: always()
+        with:
+          name: test-diagnostics-integration-linux-${{ matrix.arch }}-jdk${{ matrix.java }}-${{ matrix.distribution }}-attempt${{ github.run_attempt }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
@@ -178,27 +222,6 @@ jobs:
           comment_mode: off
           compare_to_earlier_commit: false
           check_name: Integration Tests Results (Linux ${{ matrix.arch }}, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
-      - name: Upload Test Diagnostics
-        uses: actions/upload-artifact@v7
-        # always(), NOT !cancelled(): this job has timeout-minutes: 600 and a
-        # timeout kill is reported as cancelled, so !cancelled() skipped the upload in
-        # exactly the case the dumps are the only evidence of what hung.
-        #
-        # Mixed matrix, so BOTH report directories are needed and neither may be
-        # dropped: the x86 leg runs `clean verify` (failsafe — previously not collected
-        # here at all) and the arm leg runs `clean package` (surefire only). The
-        # surefire globs are kept as-is and the failsafe ones added.
-        if: always()
-        with:
-          name: test-diagnostics-integration-linux-${{ matrix.arch }}-jdk${{ matrix.java }}-${{ matrix.distribution }}
-          path: |
-            **/target/deadlock-report.txt
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-            **/target/failsafe-reports/*.dumpstream
-            **/target/failsafe-reports/*.dump
-          retention-days: 7
-          if-no-files-found: ignore
 
   test-windows:
     name: Windows x64 - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
@@ -234,6 +257,32 @@ jobs:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
 
+      # Ordered before Publish Test Results on purpose — see the comment in the Linux job:
+      # both steps are always()-gated and share the ~5-minute post-timeout window, and the
+      # publish action is the expensive one, so it must not starve the upload.
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        # always(), NOT !cancelled(): a timeout-killed job is reported as cancelled, which is
+        # precisely when these dumps are the only diagnostic left. This job declares no
+        # timeout-minutes and runs on a GitHub-hosted Windows runner, so the effective limit is
+        # the hosted 6-hour (360-minute) job cap.
+        #
+        # This leg runs `clean package -P ci-integration-tests`, so failsafe never executes;
+        # the failsafe globs are deliberate future-proofing for a promotion to verify and match
+        # nothing today (if-no-files-found: ignore makes them free).
+        #
+        # run_attempt in the name avoids the upload-artifact v4+ duplicate-name 409 on re-runs.
+        if: always()
+        with:
+          name: test-diagnostics-integration-windows-jdk${{ matrix.java }}-${{ matrix.distribution }}-attempt${{ github.run_attempt }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2
         if: always()
@@ -246,24 +295,6 @@ jobs:
           comment_mode: off
           compare_to_earlier_commit: false
           check_name: Integration Tests Results (Windows x64, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
-      - name: Upload Test Diagnostics
-        uses: actions/upload-artifact@v7
-        # always(), NOT !cancelled(): a timeout-killed job is reported as cancelled,
-        # which is precisely when these dumps are the only diagnostic left. This leg
-        # runs `clean package -P ci-integration-tests`, so failsafe does not execute
-        # today; the failsafe globs are added defensively so the step keeps collecting
-        # everything if the goal is ever promoted to verify (ignored when absent).
-        if: always()
-        with:
-          name: test-diagnostics-integration-windows-jdk${{ matrix.java }}-${{ matrix.distribution }}
-          path: |
-            **/target/deadlock-report.txt
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-            **/target/failsafe-reports/*.dumpstream
-            **/target/failsafe-reports/*.dump
-          retention-days: 7
-          if-no-files-found: ignore
 
   merge-to-main:
     name: Merge develop into main

--- a/.github/workflows/maven-integration-tests-pipeline.yml
+++ b/.github/workflows/maven-integration-tests-pipeline.yml
@@ -180,13 +180,23 @@ jobs:
           check_name: Integration Tests Results (Linux ${{ matrix.arch }}, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
-        if: "!cancelled()"
+        # always(), NOT !cancelled(): this job has timeout-minutes: 600 and a
+        # timeout kill is reported as cancelled, so !cancelled() skipped the upload in
+        # exactly the case the dumps are the only evidence of what hung.
+        #
+        # Mixed matrix, so BOTH report directories are needed and neither may be
+        # dropped: the x86 leg runs `clean verify` (failsafe — previously not collected
+        # here at all) and the arm leg runs `clean package` (surefire only). The
+        # surefire globs are kept as-is and the failsafe ones added.
+        if: always()
         with:
           name: test-diagnostics-integration-linux-${{ matrix.arch }}-jdk${{ matrix.java }}-${{ matrix.distribution }}
           path: |
             **/target/deadlock-report.txt
             **/target/surefire-reports/*.dumpstream
             **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
 
@@ -238,13 +248,20 @@ jobs:
           check_name: Integration Tests Results (Windows x64, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
-        if: "!cancelled()"
+        # always(), NOT !cancelled(): a timeout-killed job is reported as cancelled,
+        # which is precisely when these dumps are the only diagnostic left. This leg
+        # runs `clean package -P ci-integration-tests`, so failsafe does not execute
+        # today; the failsafe globs are added defensively so the step keeps collecting
+        # everything if the goal is ever promoted to verify (ignored when absent).
+        if: always()
         with:
           name: test-diagnostics-integration-windows-jdk${{ matrix.java }}-${{ matrix.distribution }}
           path: |
             **/target/deadlock-report.txt
             **/target/surefire-reports/*.dumpstream
             **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -244,13 +244,21 @@ jobs:
           check_name: Tests Results (Linux ${{ matrix.arch }}, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
-        if: "!cancelled()"
+        # always(), NOT !cancelled(): a job killed by its own timeout-minutes is
+        # reported as cancelled, so !cancelled() skipped the upload in exactly the
+        # case the dumps are the only evidence of what hung. Failsafe globs are
+        # included alongside surefire so the step keeps working unchanged if this
+        # job ever gains a verify phase; if-no-files-found: ignore makes the
+        # non-matching globs free.
+        if: always()
         with:
           name: test-diagnostics-linux-${{ matrix.arch }}-jdk${{ matrix.java }}-${{ matrix.distribution }}
           path: |
             **/target/deadlock-report.txt
             **/target/surefire-reports/*.dumpstream
             **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
       - name: Upload Coverage Data
@@ -316,13 +324,18 @@ jobs:
           check_name: Tests Results (Windows x64, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
-        if: "!cancelled()"
+        # always(), NOT !cancelled(): a timeout-killed job is reported as cancelled,
+        # which is precisely when these dumps are the only diagnostic left. Failsafe
+        # globs added defensively next to the surefire ones (ignored when absent).
+        if: always()
         with:
           name: test-diagnostics-windows-jdk${{ matrix.java }}-${{ matrix.distribution }}
           path: |
             **/target/deadlock-report.txt
             **/target/surefire-reports/*.dumpstream
             **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
 
@@ -381,13 +394,18 @@ jobs:
           check_name: Tests Results (macOS arm, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
-        if: "!cancelled()"
+        # always(), NOT !cancelled(): a timeout-killed job is reported as cancelled,
+        # which is precisely when these dumps are the only diagnostic left. Failsafe
+        # globs added defensively next to the surefire ones (ignored when absent).
+        if: always()
         with:
           name: test-diagnostics-macos-jdk${{ matrix.java }}-${{ matrix.distribution }}
           path: |
             **/target/deadlock-report.txt
             **/target/surefire-reports/*.dumpstream
             **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
 
@@ -449,13 +467,23 @@ jobs:
           check_name: Tests Results (Small Cache IT)
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
-        if: "!cancelled()"
+        # always(), NOT !cancelled(): this job has timeout-minutes: 120 and runs the
+        # longest suite in the pipeline, so a timeout kill (reported as cancelled) is
+        # its most likely failure mode — exactly when the dumps matter most.
+        #
+        # The failsafe globs below are this step's ONLY diagnostics source and must not
+        # be replaced. The surefire globs are ADDED: `-pl core -am clean verify` runs
+        # the unit tests through surefire before failsafe's integration-test phase, so
+        # surefire dumps exist here today and were silently being dropped.
+        if: always()
         with:
           name: test-diagnostics-small-cache-linux
           path: |
             **/target/deadlock-report.txt
             **/target/failsafe-reports/*.dumpstream
             **/target/failsafe-reports/*.dump
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
           retention-days: 7
           if-no-files-found: ignore
       # Inline dispatch (single non-matrix job, no dedicated notify-failure job needed)

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -230,6 +230,39 @@ jobs:
           path: 'core/target/vmlens-report/'
           if-no-files-found: ignore
           retention-days: 30
+      # Diagnostics upload runs BEFORE Publish Test Results, deliberately. Both are
+      # always()-gated, and after a job timeout GitHub allows roughly five minutes of
+      # forced-termination time for the remaining steps; the publish action is the heavy
+      # one (it parses every report XML and calls the checks API), so with the old order it
+      # could consume that budget and the upload — the whole point of these steps — would
+      # never run. Nothing depends on the publish step's outputs, so the order is free.
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        # always(), NOT !cancelled(): this job declares no timeout-minutes, so GitHub's
+        # default 360-minute job limit is what fires, and a job killed by any timeout is
+        # reported as cancelled — so !cancelled() skipped the upload in exactly the case the
+        # dumps are the only evidence of what hung.
+        #
+        # The failsafe globs are deliberate future-proofing and match nothing today: this leg
+        # runs `clean package`, which never reaches failsafe's integration-test phase. They
+        # are kept so the step needs no edit if a verify phase is ever added, and
+        # if-no-files-found: ignore makes a non-matching glob free.
+        #
+        # run_attempt is in the artifact name because upload-artifact v4+ rejects a duplicate
+        # name within a run: on a job re-run the previous attempt's artifact still exists, so
+        # a fixed name would 409 and fail the step. Suffixing keeps both attempts' diagnostics
+        # instead of overwriting the first.
+        if: always()
+        with:
+          name: test-diagnostics-linux-${{ matrix.arch }}-jdk${{ matrix.java }}-${{ matrix.distribution }}-attempt${{ github.run_attempt }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
@@ -242,25 +275,6 @@ jobs:
           comment_mode: off
           compare_to_earlier_commit: false
           check_name: Tests Results (Linux ${{ matrix.arch }}, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
-      - name: Upload Test Diagnostics
-        uses: actions/upload-artifact@v7
-        # always(), NOT !cancelled(): a job killed by its own timeout-minutes is
-        # reported as cancelled, so !cancelled() skipped the upload in exactly the
-        # case the dumps are the only evidence of what hung. Failsafe globs are
-        # included alongside surefire so the step keeps working unchanged if this
-        # job ever gains a verify phase; if-no-files-found: ignore makes the
-        # non-matching globs free.
-        if: always()
-        with:
-          name: test-diagnostics-linux-${{ matrix.arch }}-jdk${{ matrix.java }}-${{ matrix.distribution }}
-          path: |
-            **/target/deadlock-report.txt
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-            **/target/failsafe-reports/*.dumpstream
-            **/target/failsafe-reports/*.dump
-          retention-days: 7
-          if-no-files-found: ignore
       - name: Upload Coverage Data
         uses: actions/upload-artifact@v7
         if: "!cancelled() && matrix.arch == 'x86' && matrix.java == '21' && matrix.distribution == 'temurin'"
@@ -310,6 +324,28 @@ jobs:
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+      # Ordered before Publish Test Results on purpose — see the comment in the Linux job:
+      # both steps are always()-gated and share the ~5-minute post-timeout window, and the
+      # publish action is the expensive one, so it must not starve the upload.
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        # always(), NOT !cancelled(): this job declares no timeout-minutes, so GitHub's
+        # default 360-minute job limit is what fires; either way a timeout-killed job is
+        # reported as cancelled, which is precisely when these dumps are the only diagnostic
+        # left. The failsafe globs are deliberate future-proofing and match nothing today
+        # (`clean package` never runs failsafe); if-no-files-found: ignore makes them free.
+        # run_attempt in the name avoids the upload-artifact v4+ duplicate-name 409 on re-runs.
+        if: always()
+        with:
+          name: test-diagnostics-windows-jdk${{ matrix.java }}-${{ matrix.distribution }}-attempt${{ github.run_attempt }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2
         if: always()
@@ -322,22 +358,6 @@ jobs:
           comment_mode: off
           compare_to_earlier_commit: false
           check_name: Tests Results (Windows x64, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
-      - name: Upload Test Diagnostics
-        uses: actions/upload-artifact@v7
-        # always(), NOT !cancelled(): a timeout-killed job is reported as cancelled,
-        # which is precisely when these dumps are the only diagnostic left. Failsafe
-        # globs added defensively next to the surefire ones (ignored when absent).
-        if: always()
-        with:
-          name: test-diagnostics-windows-jdk${{ matrix.java }}-${{ matrix.distribution }}
-          path: |
-            **/target/deadlock-report.txt
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-            **/target/failsafe-reports/*.dumpstream
-            **/target/failsafe-reports/*.dump
-          retention-days: 7
-          if-no-files-found: ignore
 
   test-macos:
     name: macOS arm - JDK ${{ matrix.java }} - ${{ matrix.distribution }}
@@ -380,6 +400,28 @@ jobs:
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+      # Ordered before Publish Test Results on purpose — see the comment in the Linux job:
+      # both steps are always()-gated and share the ~5-minute post-timeout window, and the
+      # publish action is the expensive one, so it must not starve the upload.
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        # always(), NOT !cancelled(): this job declares no timeout-minutes, so GitHub's
+        # default 360-minute job limit is what fires; either way a timeout-killed job is
+        # reported as cancelled, which is precisely when these dumps are the only diagnostic
+        # left. The failsafe globs are deliberate future-proofing and match nothing today
+        # (`clean package` never runs failsafe); if-no-files-found: ignore makes them free.
+        # run_attempt in the name avoids the upload-artifact v4+ duplicate-name 409 on re-runs.
+        if: always()
+        with:
+          name: test-diagnostics-macos-jdk${{ matrix.java }}-${{ matrix.distribution }}-attempt${{ github.run_attempt }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/macos@v2
         if: always()
@@ -392,22 +434,6 @@ jobs:
           comment_mode: off
           compare_to_earlier_commit: false
           check_name: Tests Results (macOS arm, JDK ${{ matrix.java }} - ${{ matrix.distribution }})
-      - name: Upload Test Diagnostics
-        uses: actions/upload-artifact@v7
-        # always(), NOT !cancelled(): a timeout-killed job is reported as cancelled,
-        # which is precisely when these dumps are the only diagnostic left. Failsafe
-        # globs added defensively next to the surefire ones (ignored when absent).
-        if: always()
-        with:
-          name: test-diagnostics-macos-jdk${{ matrix.java }}-${{ matrix.distribution }}
-          path: |
-            **/target/deadlock-report.txt
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-            **/target/failsafe-reports/*.dumpstream
-            **/target/failsafe-reports/*.dump
-          retention-days: 7
-          if-no-files-found: ignore
 
   # ------------------------------------------------------------------
   # JOB: SMALL CACHE INTEGRATION TESTS (advisory, not in ci-status gate)
@@ -451,10 +477,50 @@ jobs:
           architecture: x64
           overwrite-settings: false
       - name: Run Small Cache Integration Tests
+        # Step-level timeout 15 minutes inside the job's own timeout-minutes: 120. A step
+        # timeout is recorded as a step FAILURE, not a cancellation, so the remaining steps
+        # run with the normal job budget instead of racing GitHub's ~5-minute
+        # forced-termination window — which is what makes the diagnostics upload below
+        # actually reachable on a hang. Any run this kills would have been killed by the job
+        # timeout 15 minutes later anyway, so it cannot fail a run that passes today.
+        timeout-minutes: 105
         run: ./mvnw -s .github/workflows/settings.xml -pl core -am clean verify -P small-cache-it -Dmaven.test.failure.ignore=true -B
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+      # Ordered before Publish Test Results on purpose, and it matters most here: this is
+      # the job with the tightest timeout (120 min) and the longest suite, so a timeout kill
+      # is its most likely failure mode. Both steps are always()-gated and share the
+      # ~5-minute post-timeout window; letting the expensive publish action go first could
+      # consume it and drop the upload entirely.
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        # always(), NOT !cancelled(): this job's own timeout-minutes: 120 fires long before
+        # GitHub's default, and a timeout kill is reported as cancelled — exactly when the
+        # dumps matter most.
+        #
+        # The failsafe globs below are this step's ONLY real diagnostics source and must not
+        # be replaced. The surefire globs are ADDED as future-proofing, not because core unit
+        # dumps appear here: the small-cache-it profile sets surefire skipTests=true for core
+        # (core/pom.xml), so core runs no unit tests in this job at all. The only surefire
+        # reports reachable are from the `-am` upstream modules (gremlin-annotations), which
+        # is why the globs are kept rather than claimed to be load-bearing.
+        #
+        # run_attempt in the name avoids the upload-artifact v4+ duplicate-name 409 on a job
+        # re-run. That collision mattered here beyond the lost artifact: a failing upload
+        # step fails the job, which triggers the failure()-gated Dispatch CI Fix Agent and
+        # Zulip notification steps below on what was only an artifact-name conflict.
+        if: always()
+        with:
+          name: test-diagnostics-small-cache-linux-attempt${{ github.run_attempt }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
@@ -465,27 +531,6 @@ jobs:
           comment_mode: off
           compare_to_earlier_commit: false
           check_name: Tests Results (Small Cache IT)
-      - name: Upload Test Diagnostics
-        uses: actions/upload-artifact@v7
-        # always(), NOT !cancelled(): this job has timeout-minutes: 120 and runs the
-        # longest suite in the pipeline, so a timeout kill (reported as cancelled) is
-        # its most likely failure mode — exactly when the dumps matter most.
-        #
-        # The failsafe globs below are this step's ONLY diagnostics source and must not
-        # be replaced. The surefire globs are ADDED: `-pl core -am clean verify` runs
-        # the unit tests through surefire before failsafe's integration-test phase, so
-        # surefire dumps exist here today and were silently being dropped.
-        if: always()
-        with:
-          name: test-diagnostics-small-cache-linux
-          path: |
-            **/target/deadlock-report.txt
-            **/target/failsafe-reports/*.dumpstream
-            **/target/failsafe-reports/*.dump
-            **/target/surefire-reports/*.dumpstream
-            **/target/surefire-reports/*.dump
-          retention-days: 7
-          if-no-files-found: ignore
       # Inline dispatch (single non-matrix job, no dedicated notify-failure job needed)
       - name: Dispatch CI Fix Agent
         if: failure()

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -477,12 +477,19 @@ jobs:
           architecture: x64
           overwrite-settings: false
       - name: Run Small Cache Integration Tests
-        # Step-level timeout 15 minutes inside the job's own timeout-minutes: 120. A step
-        # timeout is recorded as a step FAILURE, not a cancellation, so the remaining steps
-        # run with the normal job budget instead of racing GitHub's ~5-minute
-        # forced-termination window — which is what makes the diagnostics upload below
-        # actually reachable on a hang. Any run this kills would have been killed by the job
-        # timeout 15 minutes later anyway, so it cannot fail a run that passes today.
+        # Step-level timeout 15 minutes inside the job's own timeout-minutes: 120, and within
+        # GitHub's documented 360-minute maximum for a step timeout. A step timeout is recorded
+        # as a step FAILURE, not a cancellation, so the remaining steps run with the normal job
+        # budget instead of racing GitHub's ~5-minute forced-termination window — which is what
+        # makes the diagnostics upload below actually reachable on a hang. Any run this kills
+        # would have been killed by the job timeout 15 minutes later anyway, so it cannot fail a
+        # run that passes today.
+        #
+        # Deliberate side effect: a hang now ends the job as FAILED rather than CANCELLED, so it
+        # reaches the failure()-gated Dispatch CI Fix Agent and Zulip steps below, which a
+        # cancellation silently skipped. That is the intent — a suite that hangs for 105 minutes
+        # is exactly the event those notifications exist for, and the diagnostics artifact the
+        # agent needs is now uploaded before them.
         timeout-minutes: 105
         run: ./mvnw -s .github/workflows/settings.xml -pl core -am clean verify -P small-cache-it -Dmaven.test.failure.ignore=true -B
         env:

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -230,12 +230,23 @@ jobs:
           path: 'core/target/vmlens-report/'
           if-no-files-found: ignore
           retention-days: 30
-      # Diagnostics upload runs BEFORE Publish Test Results, deliberately. Both are
-      # always()-gated, and after a job timeout GitHub allows roughly five minutes of
-      # forced-termination time for the remaining steps; the publish action is the heavy
-      # one (it parses every report XML and calls the checks API), so with the old order it
-      # could consume that budget and the upload — the whole point of these steps — would
-      # never run. Nothing depends on the publish step's outputs, so the order is free.
+      # CANONICAL NOTE on what the timeout guarantee actually is; the other diagnostics-upload
+      # steps in this file and in maven-integration-tests-pipeline.yml refer back to this one.
+      # Three separate mechanisms, each doing a different job — none of them sufficient alone:
+      #   1. always() makes the upload ELIGIBLE after a timeout. A timeout is reported as a
+      #      cancellation, and the previous !cancelled() condition skipped the step outright in
+      #      exactly that case. Necessary, but eligibility is not completion.
+      #   2. Step ORDER makes it LIKELY to finish. Once a job is cancelled, the remaining steps
+      #      share only GitHub's roughly five minutes of forced-termination time, so the upload is
+      #      placed before the heavy publish action (which parses every report XML and calls the
+      #      checks API) rather than behind it. This is best-effort inside a time box, not a
+      #      guarantee. Nothing depends on the publish step's outputs, so the order is free.
+      #   3. A step-level timeout, where one is in range, REMOVES the time box: it fails the step
+      #      instead of cancelling the job, so the later steps run on the normal job budget. Only
+      #      the small-cache job below has one; see the note there for why the nightly
+      #      integration job cannot.
+      # So: with (1) and (2) the upload is best-effort within about five minutes; with (3) it is
+      # unconstrained.
       - name: Upload Test Diagnostics
         uses: actions/upload-artifact@v7
         # always(), NOT !cancelled(): this job declares no timeout-minutes, so GitHub's
@@ -480,8 +491,10 @@ jobs:
         # Step-level timeout 15 minutes inside the job's own timeout-minutes: 120, and within
         # GitHub's documented 360-minute maximum for a step timeout. A step timeout is recorded
         # as a step FAILURE, not a cancellation, so the remaining steps run with the normal job
-        # budget instead of racing GitHub's ~5-minute forced-termination window — which is what
-        # makes the diagnostics upload below actually reachable on a hang. Any run this kills
+        # budget instead of racing GitHub's ~5-minute forced-termination window. This is
+        # mechanism (3) of the canonical note on the test-linux diagnostics upload above: always()
+        # is what makes the upload eligible at all, and the step order is what makes it likely to
+        # finish inside that window — this timeout is what removes the window. Any run this kills
         # would have been killed by the job timeout 15 minutes later anyway, so it cannot fail a
         # run that passes today.
         #

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -1896,6 +1896,28 @@ public final class WOWCache extends AbstractWriteCache
   }
 
   /**
+   * Test-only accessor: number of page keys currently held in {@code exclusiveWritePages}.
+   *
+   * <p>{@link #getExclusiveWriteCachePagesSize()} exposes the {@code exclusiveWriteCacheSize}
+   * counter that drives the flush scheduling and the writer back-pressure, but not the set the
+   * counter is supposed to track. The regression suite for the {@code doRemoveCachePages}
+   * accounting leak needs both, because "the counter came back to zero" and "the set was
+   * actually emptied" are different claims and a fix can satisfy one without the other. Tests
+   * must assert absolute expected values for each; cross-checking counter against set size is
+   * vacuous, since the two leak in lockstep whenever the accounting is skipped.
+   *
+   * <p>Not part of the production API surface. Note also that this is a
+   * {@link java.util.concurrent.ConcurrentSkipListSet} size — O(n) and not a snapshot — so it
+   * must never be called on a hot path.
+   *
+   * <p>The {@code ForTest} suffix is intentional: it makes the test-only intent visible at
+   * every call site.
+   */
+  public int getExclusiveWritePagesCountForTest() {
+    return exclusiveWritePages.size();
+  }
+
+  /**
    * Test-only accessor: number of times the single-page extend branch of
    * {@link #loadOrAdd} has run to completion (post-allocate, post-sanity-check) since this
    * cache instance was constructed. The regression suite for the original poison-cascade
@@ -3736,14 +3758,53 @@ public final class WOWCache extends AbstractWriteCache
   }
 
   /**
+   * Removes {@code pageKey} from {@link #exclusiveWritePages} and keeps
+   * {@link #exclusiveWriteCacheSize} in step, but only if the key was actually present.
+   *
+   * <p>The conditional shape is load-bearing: {@link #doRemoveCachePages} runs against
+   * caller orderings where the key may or may not have been published into the set yet
+   * (see the call sites there), and an unconditional decrement would drive the counter
+   * negative on the orderings where it has not.
+   *
+   * @return {@code true} if this call is the one that removed the key
+   */
+  private boolean removeExclusiveWritePage(final PageKey pageKey) {
+    if (!exclusiveWritePages.remove(pageKey)) {
+      return false;
+    }
+
+    final var remaining = exclusiveWriteCacheSize.decrementAndGet();
+    // Load-bearing assertion (core surefire runs with -ea): a negative counter is worse
+    // than a leaked one. flushExclusivePagesIfNeeded / flushWriteCacheFromMinLSN compare
+    // the counter against exclusiveWriteCacheMaxSize, so a negative value silently
+    // disables the exclusive-write back-pressure for the rest of the storage's lifetime
+    // and the symptom (unbounded write cache growth) surfaces nowhere near the cause.
+    // Fail loudly here instead if a future caller-ordering change breaks the invariant.
+    // coverage-gate.py excludes assert lines, so this costs nothing in production.
+    assert remaining >= 0
+        : "exclusiveWriteCacheSize went negative ("
+            + remaining
+            + ") while purging "
+            + pageKey;
+    return true;
+  }
+
+  /**
    * Removes every {@code writeCachePages} entry whose {@code pageKey} matches
-   * {@code (fileId == internalFileId && pageIndex >= minPageIndex)}. With
+   * {@code (fileId == internalFileId && pageIndex >= minPageIndex)}, and drops the matching
+   * {@link #exclusiveWritePages} bookkeeping for the same range. With
    * {@code minPageIndex = 0} this is "drop every dirty entry for this fileId" — the shape
    * used by {@code closeFile} / {@code truncateFile} / {@code deleteFile}. With a positive
    * {@code minPageIndex} the dirty pages below the truncate target survive (they belong to
    * file regions the truncate does NOT drop and must be persisted by the next periodic
    * flush), while pages at or past the target are dropped before the underlying file
    * shrink runs.
+   *
+   * <p>Because the purge nulls each page's writers listener (deliberately suppressing the
+   * {@code removeOnlyWriters} callback that {@code decrementWritersReferrer} would fire),
+   * the exclusive-write accounting has to be maintained by hand here — both for the keys
+   * the {@code writeCachePages} scan visits and, in the post-loop sweep, for keys that
+   * exist only in {@link #exclusiveWritePages}.
    */
   void doRemoveCachePages(int internalFileId, int minPageIndex) {
     final var entryIterator =
@@ -3759,6 +3820,26 @@ public final class WOWCache extends AbstractWriteCache
           long exclusiveStamp = pagePointer.acquireExclusiveLock();
           try {
             pagePointer.setWritersListener(null);
+            // Nulling the listener above suppresses the removeOnlyWriters() callback that
+            // decrementWritersReferrer() (below) would otherwise fire, so the
+            // exclusive-write accounting must be done explicitly here. Without it the key
+            // stays in exclusiveWritePages forever and exclusiveWriteCacheSize never
+            // returns to zero, which pins the periodic flush task at its 1 ms re-arm
+            // interval instead of 25 ms for the rest of the storage's lifetime and
+            // eventually latches writers once the leaked count reaches
+            // exclusiveWriteCacheMaxSize.
+            //
+            // The removal is CONDITIONAL because the two caller orderings differ:
+            //   * LockFreeReadCache.closeFile/deleteFile purge the read cache BEFORE this
+            //     write-cache purge, so the page is already readers-free and the key IS in
+            //     exclusiveWritePages — this is the leak being fixed;
+            //   * LockFreeReadCache.truncateFile/shrinkFile purge the write cache FIRST and
+            //     clear the read cache afterwards, so the page still has readers and the key
+            //     is NOT in the set yet — an unconditional decrement would push the counter
+            //     negative and disable the exclusive-write back-pressure entirely.
+            // Done inside the page-frame exclusive-lock region so the lock-acquisition
+            // ordering documented below is unchanged (set/counter mutations take no lock).
+            removeExclusiveWritePage(pageKey);
             writeCacheSize.decrementAndGet();
 
             removeFromDirtyPages(pageKey);
@@ -3779,6 +3860,46 @@ public final class WOWCache extends AbstractWriteCache
         } finally {
           groupLock.unlock();
         }
+      }
+    }
+
+    // Post-loop sweep for keys that exist ONLY in exclusiveWritePages. The loop above
+    // iterates writeCachePages, so it structurally cannot see them: the two structures are
+    // only eventually consistent (flushExclusiveWriteCache documents writeCachePages as the
+    // source of truth), and once the file is gone nothing else will ever remove such a key.
+    //
+    // Two constraints on this sweep:
+    //   * It is RANGE-BOUND to [minPageIndex, +inf) for this file, never whole-file. Keys
+    //     below minPageIndex belong to file regions truncateFile/shrinkFile deliberately
+    //     keep, their writeCachePages entries survive, and decrementing for them would push
+    //     exclusiveWriteCacheSize negative. exclusiveWritePages is a skip-list ordered by
+    //     (fileId, pageIndex), so the bounded view is an O(log n + k) slice, not a scan.
+    //   * It takes NO additional lock. This method runs on the commit executor, while
+    //     filesLock's write lock is held by the thread that submitted the purge task
+    //     (deleteFile / truncateFile / shrinkFile / close), so acquiring filesLock here
+    //     would deadlock against the submitter. Both structures touched are concurrent, and
+    //     the per-key group lock would buy nothing because CachePointer fires
+    //     addOnlyWriters/removeOnlyWriters without holding it.
+    //
+    // KNOWN LIMITATION: this sweep NARROWS the orphan window, it does not close it. On the
+    // truncateFile/shrinkFile ordering the read cache is still populated while the purge
+    // runs, so a concurrent release or eviction (WTinyLFUPolicy.invalidateStampsAndRelease)
+    // can call decrementReadersReferrer -> addOnlyWriters for a page whose listener this
+    // method had not yet nulled and land the key in exclusiveWritePages after the sweep has
+    // already moved past it; that key is still leaked. On the closeFile/deleteFile ordering
+    // the read cache is purged first, so no such concurrent source exists and the sweep is
+    // complete.
+    final var orphanCandidates =
+        exclusiveWritePages.subSet(
+            new PageKey(internalFileId, minPageIndex), true,
+            new PageKey(internalFileId, Long.MAX_VALUE), true);
+    for (final var orphanKey : orphanCandidates) {
+      // writeCachePages stays the source of truth: if an entry exists for this key the page
+      // is still dirty and must remain a flush candidate, otherwise flushExclusiveWriteCache
+      // would never write it back. store() needs filesLock's read lock, so no entry can
+      // appear while the purge's submitter holds the write lock — this is defense in depth.
+      if (!writeCachePages.containsKey(orphanKey)) {
+        removeExclusiveWritePage(orphanKey);
       }
     }
   }
@@ -4107,6 +4228,12 @@ public final class WOWCache extends AbstractWriteCache
               "Can not write valid page in file because of the problems with data write, %s",
               null,
               flushError.getMessage());
+      // Abandon the stamp, as the log message above already claims. Every other flush-path
+      // entry point returns immediately after reporting flushError (executeFileFlush,
+      // executeFindDirtySegment, ...); falling through here contradicted the diagnostic and
+      // kept issuing writes into a file whose write cache is already known to be
+      // unflushable, which can lay a blank page on top of data the failed flush left behind.
+      return;
     }
 
     if (stopFlush) {
@@ -4116,6 +4243,31 @@ public final class WOWCache extends AbstractWriteCache
     try {
       var pagePosition = (long) pageIndex * pageSize;
       var entry = files.acquire(externalFileId(internalFileId));
+      if (entry == null) {
+        // The file disappeared between this task being queued and it running: loadOrAdd's
+        // extend / gap-fill branches submit EnsurePageIsValidInFileTask asynchronously, and
+        // deleteFile or replaceFileId (which unregisters both ids while it rebinds them) or a
+        // restore can drop the id in the meantime. Nothing can be stamped — writing now would
+        // either resurrect a deleted file or stamp a page into a file id that has since been
+        // rebound to a different component — so bail out instead of dereferencing null.
+        //
+        // WARN rather than a silent skip, deliberately asymmetric with the null-entry skips on
+        // the fsync paths (fsyncFiles, and the callFsync loop in executeFileFlush): there a
+        // concurrently deleted file genuinely has nothing left to sync, so the null case is a
+        // benign no-op. Here an allocation has already been acknowledged to a caller for a page
+        // whose file has vanished; that is recoverable (the missing stamp can never be read
+        // back from a file that no longer exists) but unexpected, so it must stay visible.
+        LogManager.instance()
+            .warn(
+                this,
+                "%s: skipping blank-page stamp for file id %d, page %d - the file was removed"
+                    + " before the asynchronous page validation task ran",
+                (Throwable) null,
+                storageName,
+                internalFileId,
+                pageIndex);
+        return;
+      }
       try {
         var file = entry.get();
         if (file.getUnderlyingFileSize() <= pagePosition) {
@@ -4386,10 +4538,12 @@ public final class WOWCache extends AbstractWriteCache
               writeCacheSize.decrementAndGet();
 
               // Decrement BEFORE nulling the listener: the page was flushed
-              // successfully, so the listener notification should fire.
-              // (Contrast with doRemoveCachePages where the listener is nulled
-              // first because the file is being deleted and notification must
-              // be suppressed.)
+              // successfully, so the listener notification should fire and let
+              // removeOnlyWriters do the exclusive-write accounting.
+              // (Contrast with doRemoveCachePages, which nulls the listener first
+              // because the file is being dropped and the notification must be
+              // suppressed, and therefore performs the exclusiveWritePages /
+              // exclusiveWriteCacheSize bookkeeping by hand instead.)
               pointer.decrementWritersReferrer();
               pointer.setWritersListener(null);
             }
@@ -4914,6 +5068,10 @@ public final class WOWCache extends AbstractWriteCache
 
         final var finalId = composeFileId(id, intFileId);
         final var entry = files.acquire(finalId);
+        // Silent skip is correct here: a file deleted concurrently with this flush has
+        // nothing left to fsync, so the null case is a benign no-op. Contrast
+        // writeValidPageInFile, which logs at WARN for the same null because there the
+        // missing file means an already-acknowledged page allocation lost its backing file.
         if (entry != null) {
           try {
             entry.get().synch();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -111,6 +111,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.zip.CRC32;
@@ -414,6 +415,20 @@ public final class WOWCache extends AbstractWriteCache
    * is a real accounting regression.
    */
   private final LongAdder exclusiveWriteAccountingClamps = new LongAdder();
+
+  /**
+   * Latch ensuring the accounting-clamp diagnostic in {@link #removeExclusiveWritePage} is logged
+   * at most once per cache instance.
+   *
+   * <p>The clamp is invoked per page key from inside {@code doRemoveCachePages}' main loop, which
+   * holds both the per-key group lock and the page frame's exclusive lock, on the single
+   * commit-executor thread that also runs every flush. If a drift ever affected many keys of one
+   * file, an unbounded per-key WARN would emit one formatted log record per page while holding
+   * those locks, turning an accounting nuisance into a flush-thread stall. One record per cache
+   * instance is enough to raise the alarm; {@link #exclusiveWriteAccountingClamps} keeps the exact
+   * count for anyone who needs it.
+   */
+  private final AtomicBoolean exclusiveWriteAccountingClampWarned = new AtomicBoolean();
 
   /**
    * Amount of exclusive pages are hold by write cache.
@@ -2321,14 +2336,27 @@ public final class WOWCache extends AbstractWriteCache
       }
     }
 
-    // Quiescent-point invariant check for the exclusive-write accounting. This is the only
-    // place the invariant can be asserted without collateral damage: stopFlush is set, every
-    // triggered ExclusiveFlushTask has completed, and the periodic flush future has returned,
-    // so no flush or purge is in flight. The same assertion inside doRemoveCachePages would
-    // abort the purge mid-loop — leaking a PageFrame, orphaning a writeCachePages entry whose
-    // listener was already nulled, and throwing out of deleteFile/truncateFile after the dirty
-    // pages were dropped but the file was not removed — which is strictly worse than the leak
-    // being fixed, so removeExclusiveWritePage clamps and logs there instead.
+    // Quiescent-point invariant check for the exclusive-write accounting.
+    //
+    // What "quiescent" does and does not mean here. It is FLUSH-side quiescence only, and it
+    // rests on the three things this method just did: stopFlush is set (so a periodic flush
+    // exits at its entry guard), every triggered ExclusiveFlushTask's completionLatch has been
+    // awaited, and the periodic flushFuture has been awaited. It does NOT rest on stateLock:
+    // close(session, force = true) reaches doShutdown() without taking the write lock at all
+    // (AbstractStorage.close), so page releases on other threads can in principle still fire
+    // addOnlyWriters/removeOnlyWriters while this runs.
+    //
+    // That residual is acceptable because it is not new: two pre-existing assertions on this
+    // same counter (in flushExclusivePagesIfNeeded and in the exclusive-flush task) sample it
+    // on the hot flush path under far more concurrency than this one does. This assertion is
+    // strictly less exposed than both, so it adds no failure mode the file did not already
+    // carry.
+    //
+    // It is here rather than inside doRemoveCachePages because an assertion firing in the purge
+    // aborts it mid-loop — leaking a PageFrame, orphaning a writeCachePages entry whose listener
+    // was already nulled, and throwing out of deleteFile/truncateFile after the dirty pages were
+    // dropped but the file was not removed — which is strictly worse than the leak being fixed.
+    // removeExclusiveWritePage clamps and logs there instead.
     //
     // A failure here means some path other than removeExclusiveWritePage (which cannot go
     // negative by construction) drove the counter below zero; the prime suspect would be the
@@ -3850,20 +3878,25 @@ public final class WOWCache extends AbstractWriteCache
         exclusiveWriteCacheSize.getAndUpdate(current -> current > 0 ? current - 1 : current);
     if (previous <= 0) {
       exclusiveWriteAccountingClamps.increment();
-      LogManager.instance()
-          .warn(
-              this,
-              "%s: exclusive-write page (%d,%d) was present in exclusiveWritePages while the"
-                  + " counter was already %d; removed the key and left the counter unchanged"
-                  + " rather than decrementing below zero. This is the known non-atomic"
-                  + " addOnlyWriters/removeOnlyWriters drift and is harmless for durability"
-                  + " (writeCachePages is the source of truth), but a repeating message points"
-                  + " at a real accounting regression.",
-              (Throwable) null,
-              storageName,
-              pageKey.fileId,
-              pageKey.pageIndex,
-              previous);
+      // At most one record per cache instance — see exclusiveWriteAccountingClampWarned. The
+      // counter above still records every occurrence.
+      if (exclusiveWriteAccountingClampWarned.compareAndSet(false, true)) {
+        LogManager.instance()
+            .warn(
+                this,
+                "%s: exclusive-write page (%d,%d) was present in exclusiveWritePages while the"
+                    + " counter was already %d; removed the key and left the counter unchanged"
+                    + " rather than decrementing below zero. This is the known non-atomic"
+                    + " addOnlyWriters/removeOnlyWriters drift and is harmless for durability"
+                    + " (writeCachePages is the source of truth). Further occurrences on this"
+                    + " cache instance are not logged; a growing clamp count is what signals a"
+                    + " real accounting regression.",
+                (Throwable) null,
+                storageName,
+                pageKey.fileId,
+                pageKey.pageIndex,
+                previous);
+      }
     }
   }
 
@@ -3910,8 +3943,11 @@ public final class WOWCache extends AbstractWriteCache
             // The removal is CONDITIONAL because whether the key is in the set depends on the
             // caller's ordering AND on whether the page happens to be readers-free right now:
             //   * LockFreeReadCache.closeFile/deleteFile purge the read cache BEFORE this
-            //     write-cache purge, so every page is already readers-free and its key IS in
-            //     exclusiveWritePages — this is the leak being fixed;
+            //     write-cache purge, so a page whose readers the purge released is readers-free
+            //     by now and its key IS in exclusiveWritePages — this is the leak being fixed.
+            //     Not a universal claim: a reference the read-cache purge cannot see (the
+            //     silentLoadForRead blind spot described at the sweep below) would keep a page
+            //     readers-held here too, which is the other reason the removal is conditional;
             //   * LockFreeReadCache.truncateFile/shrinkFile purge the write cache FIRST and
             //     clear the read cache afterwards, so a page that still has a reader has NOT
             //     been published into the set (its key is absent), while a page whose readers
@@ -3977,15 +4013,24 @@ public final class WOWCache extends AbstractWriteCache
     //     (WTinyLFUPolicy.invalidateStampsAndRelease) can fire the callback for a page whose
     //     listener this method had not yet nulled.
     //   * closeFile/deleteFile ordering — eviction IS excluded here (clearFile ran first and
-    //     WTinyLFUPolicy skips dead entries), but LockFreeReadCache.silentLoadForRead builds
-    //     its CacheEntryImpl with insideCache=false and never inserts it into the read cache's
-    //     map, so clearFile can neither see nor freeze it; the matching releaseFromRead then
-    //     calls decrementReadersReferrer with no filesLock held. That is reachable from
-    //     DiskStorage.backupPagesWithChanges, which holds no stateLock across its per-page
-    //     load/release loop.
-    // Closing either window means changing read-cache or backup locking, which is out of scope
-    // here; a leaked key is accounting-only (writeCachePages remains the source of truth for
-    // durability) and is now bounded by the clamp in removeExclusiveWritePage.
+    //     WTinyLFUPolicy skips dead entries), but LockFreeReadCache.silentLoadForRead is a
+    //     structural blind spot: it builds its CacheEntryImpl with insideCache=false and never
+    //     inserts it into the read cache's map, so clearFile can neither see nor freeze it, and
+    //     the matching releaseFromRead calls decrementReadersReferrer with no filesLock held.
+    //     That blind spot is NOT demonstrated to be live today. silentLoadForRead has exactly
+    //     one production caller, DiskStorage.backupPagesWithChanges, and the whole per-page
+    //     load/release loop runs under DiskStorage.backup's stateLock.readLock()
+    //     (backup :930 acquires, :1000 releases, :979 calls storeBackupDataToStream, which calls
+    //     backupPagesWithChanges at :1297), so it is excluded from any purge dispatched by a
+    //     stateLock.writeLock() holder — which is what a schema-carry commit takes (see
+    //     AbstractStorage.computeCommitWorkingSet's contract: read lock for a pure-data commit,
+    //     write lock for a schema-carry commit). Whether EVERY file-dropping path takes the
+    //     write lock has not been exhaustively verified, so treat this as "not demonstrated
+    //     live" rather than "proven impossible", and re-check it if a second silentLoadForRead
+    //     caller ever appears without that exclusion.
+    // Closing the truncate/shrink window means changing read-cache locking, which is out of
+    // scope here; a leaked key is accounting-only (writeCachePages remains the source of truth
+    // for durability) and is now bounded by the clamp in removeExclusiveWritePage.
     final var orphanCandidates =
         exclusiveWritePages.subSet(
             new PageKey(internalFileId, minPageIndex), true,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -111,7 +111,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.zip.CRC32;
@@ -161,6 +160,14 @@ public final class WOWCache extends AbstractWriteCache
     implements WriteCache, CachePointer.WritersListener {
 
   private static final Logger logger = LoggerFactory.getLogger(WOWCache.class);
+
+  /**
+   * Minimum spacing between two emitted exclusive-write accounting-clamp diagnostics — see
+   * {@link #exclusiveWriteAccountingClampWarnNanos}. One minute keeps a recurring drift visible for
+   * as long as it lasts while bounding the log volume produced under the purge's page/group locks,
+   * however many page keys are affected.
+   */
+  private static final long ACCOUNTING_CLAMP_WARN_INTERVAL_NANOS = TimeUnit.MINUTES.toNanos(1);
 
   private static final String ALGORITHM_NAME = "AES";
   private static final String TRANSFORMATION = "AES/CTR/NoPadding";
@@ -417,18 +424,32 @@ public final class WOWCache extends AbstractWriteCache
   private final LongAdder exclusiveWriteAccountingClamps = new LongAdder();
 
   /**
-   * Latch ensuring the accounting-clamp diagnostic in {@link #removeExclusiveWritePage} is logged
-   * at most once per cache instance.
-   *
-   * <p>The clamp is invoked per page key from inside {@code doRemoveCachePages}' main loop, which
-   * holds both the per-key group lock and the page frame's exclusive lock, on the single
-   * commit-executor thread that also runs every flush. If a drift ever affected many keys of one
-   * file, an unbounded per-key WARN would emit one formatted log record per page while holding
-   * those locks, turning an accounting nuisance into a flush-thread stall. One record per cache
-   * instance is enough to raise the alarm; {@link #exclusiveWriteAccountingClamps} keeps the exact
-   * count for anyone who needs it.
+   * Counts how many accounting-clamp events actually emitted a log record, as opposed to being
+   * throttled. Test-only observable, so a regression test can pin both arms of the throttle in
+   * {@link #removeExclusiveWritePage}; exposed via
+   * {@link #getExclusiveWriteAccountingClampWarningsForTest()}.
    */
-  private final AtomicBoolean exclusiveWriteAccountingClampWarned = new AtomicBoolean();
+  private final LongAdder exclusiveWriteAccountingClampWarnings = new LongAdder();
+
+  /**
+   * {@code System.nanoTime()} of the last emitted accounting-clamp diagnostic, throttling it to at
+   * most one record per {@link #ACCOUNTING_CLAMP_WARN_INTERVAL_NANOS}.
+   *
+   * <p>Two opposing constraints meet here. The clamp is invoked per page key from inside
+   * {@code doRemoveCachePages}' main loop, which holds both the per-key group lock and the page
+   * frame's exclusive lock, on the single commit-executor thread that also runs every flush — so an
+   * unbounded per-key WARN would emit one formatted record per page while holding those locks,
+   * turning an accounting nuisance into a flush-thread stall. But a one-shot latch is the wrong
+   * bound in the other direction: on a long-lived server a drift that recurs for months would be
+   * invisible after its first occurrence, while the leak it accompanies can pin the periodic flush
+   * at its 1 ms re-arm and eventually latch writer back-pressure. A time-based throttle keeps the
+   * volume bounded (at most one record per interval per cache, however many keys drift) while
+   * keeping a recurring problem permanently visible in the log.
+   *
+   * <p>Initialised one full interval in the past so the first clamp always emits.
+   */
+  private final AtomicLong exclusiveWriteAccountingClampWarnNanos =
+      new AtomicLong(System.nanoTime() - ACCOUNTING_CLAMP_WARN_INTERVAL_NANOS);
 
   /**
    * Amount of exclusive pages are hold by write cache.
@@ -1954,12 +1975,28 @@ public final class WOWCache extends AbstractWriteCache
 
   /**
    * Test-only accessor: how many times the exclusive-write accounting clamp engaged — see
-   * {@link #exclusiveWriteAccountingClamps}. Zero is the expected value on any deterministic,
-   * single-threaded path; a regression test asserts that, which is what keeps the clamp from
-   * silently absorbing a purge that decrements without having removed anything.
+   * {@link #exclusiveWriteAccountingClamps}.
+   *
+   * <p>The expected value is per-scenario, not universally zero. On a path that never drifts the
+   * counter and the set apart, zero is expected, and asserting it is what keeps the clamp from
+   * silently absorbing a purge that decrements without having removed anything (see
+   * {@code deleteFileDoesNotDecrementForPagesThatWereNeverPublishedAsWritersOnly}). A test that
+   * deliberately builds the drift expects exactly as many clamps as keys it orphaned (see
+   * {@code purgeClampsInsteadOfDrivingTheCounterNegativeOnAccountingDrift}). Both live in
+   * {@code WOWCacheShrinkFileTest}.
    */
   public long getExclusiveWriteAccountingClampsForTest() {
     return exclusiveWriteAccountingClamps.sum();
+  }
+
+  /**
+   * Test-only accessor: how many accounting-clamp events emitted a log record rather than being
+   * throttled — see {@link #exclusiveWriteAccountingClampWarnings}. Lets a regression test pin both
+   * arms of the throttle (the first clamp emits; a clamp inside the same interval does not) without
+   * capturing log output.
+   */
+  public long getExclusiveWriteAccountingClampWarningsForTest() {
+    return exclusiveWriteAccountingClampWarnings.sum();
   }
 
   /**
@@ -2346,11 +2383,15 @@ public final class WOWCache extends AbstractWriteCache
     // (AbstractStorage.close), so page releases on other threads can in principle still fire
     // addOnlyWriters/removeOnlyWriters while this runs.
     //
-    // That residual is acceptable because it is not new: two pre-existing assertions on this
-    // same counter (in flushExclusivePagesIfNeeded and in the exclusive-flush task) sample it
-    // on the hot flush path under far more concurrency than this one does. This assertion is
-    // strictly less exposed than both, so it adds no failure mode the file did not already
-    // carry.
+    // That residual is small but it is genuinely a NEW sampling window, not a subset of an
+    // existing one. Two pre-existing assertions on this same counter (in
+    // flushExclusivePagesIfNeeded and in the exclusive-flush task) sample it far more often and
+    // under far more concurrency — but only while flushing is still running, and by the time
+    // control reaches this point flushing has been quiesced, so those two can no longer sample at
+    // all. This assertion therefore covers an instant they never see: rarer than theirs, and not
+    // dominated by them. It is kept because the invariant it checks is the one the clamp exists to
+    // protect, and because a violation here is far cheaper to act on than the silent
+    // back-pressure loss it would otherwise announce much later.
     //
     // It is here rather than inside doRemoveCachePages because an assertion firing in the purge
     // aborts it mid-loop — leaking a PageFrame, orphaning a writeCachePages entry whose listener
@@ -3878,9 +3919,10 @@ public final class WOWCache extends AbstractWriteCache
         exclusiveWriteCacheSize.getAndUpdate(current -> current > 0 ? current - 1 : current);
     if (previous <= 0) {
       exclusiveWriteAccountingClamps.increment();
-      // At most one record per cache instance — see exclusiveWriteAccountingClampWarned. The
-      // counter above still records every occurrence.
-      if (exclusiveWriteAccountingClampWarned.compareAndSet(false, true)) {
+      // Throttled, not one-shot — see exclusiveWriteAccountingClampWarnNanos for why both bounds
+      // matter. The counter above records every occurrence regardless.
+      if (shouldLogAccountingClamp()) {
+        exclusiveWriteAccountingClampWarnings.increment();
         LogManager.instance()
             .warn(
                 this,
@@ -3888,9 +3930,9 @@ public final class WOWCache extends AbstractWriteCache
                     + " counter was already %d; removed the key and left the counter unchanged"
                     + " rather than decrementing below zero. This is the known non-atomic"
                     + " addOnlyWriters/removeOnlyWriters drift and is harmless for durability"
-                    + " (writeCachePages is the source of truth). Further occurrences on this"
-                    + " cache instance are not logged; a growing clamp count is what signals a"
-                    + " real accounting regression.",
+                    + " (writeCachePages is the source of truth). Further occurrences within the"
+                    + " next minute are not logged; a message that keeps reappearing is what"
+                    + " signals a real accounting regression.",
                 (Throwable) null,
                 storageName,
                 pageKey.fileId,
@@ -3898,6 +3940,21 @@ public final class WOWCache extends AbstractWriteCache
                 previous);
       }
     }
+  }
+
+  /**
+   * Throttle gate for the accounting-clamp diagnostic: {@code true} at most once per
+   * {@link #ACCOUNTING_CLAMP_WARN_INTERVAL_NANOS}. The compare-and-set makes the winner unique when
+   * several threads clamp inside the same window, so the bound holds under concurrency and not only
+   * on the single commit-executor thread that runs the purge.
+   */
+  private boolean shouldLogAccountingClamp() {
+    final var now = System.nanoTime();
+    final var last = exclusiveWriteAccountingClampWarnNanos.get();
+    if (now - last < ACCOUNTING_CLAMP_WARN_INTERVAL_NANOS) {
+      return false;
+    }
+    return exclusiveWriteAccountingClampWarnNanos.compareAndSet(last, now);
   }
 
   /**
@@ -4017,7 +4074,11 @@ public final class WOWCache extends AbstractWriteCache
     //     structural blind spot: it builds its CacheEntryImpl with insideCache=false and never
     //     inserts it into the read cache's map, so clearFile can neither see nor freeze it, and
     //     the matching releaseFromRead calls decrementReadersReferrer with no filesLock held.
-    //     That blind spot is NOT demonstrated to be live today. silentLoadForRead has exactly
+    //     That blind spot is NOT demonstrated to be live today — subject to the same interruption
+    //     caveat noted above: the exclusion below is a stateLock argument, so it is independent of
+    //     filesLock, but if the submitter is interrupted out of future.get() then this sweep can
+    //     still be running after its caller returned, and a stateLock-based exclusion says nothing
+    //     about what the interrupted caller's thread does next. silentLoadForRead has exactly
     //     one production caller, DiskStorage.backupPagesWithChanges, and the whole per-page
     //     load/release loop runs under DiskStorage.backup's stateLock.readLock()
     //     (backup :930 acquires, :1000 releases, :979 calls storeBackupDataToStream, which calls

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -396,6 +396,26 @@ public final class WOWCache extends AbstractWriteCache
   private final LongAdder loadOrAddGapFillBranchInvocations = new LongAdder();
 
   /**
+   * Counts how many times {@link #removeExclusiveWritePage} found a key in
+   * {@link #exclusiveWritePages} whose {@link #exclusiveWriteCacheSize} contribution had already
+   * been consumed, and therefore clamped instead of decrementing below zero.
+   *
+   * <p>This is the observable form of the "best-effort" half of the exclusive-write accounting
+   * invariant documented on {@link #removeExclusiveWritePage}. The clamp itself is deliberately
+   * silent as far as behaviour goes — that is the point, it prevents a negative counter from
+   * disabling back-pressure — which means without this counter the only trace would be a WARN
+   * log line, and a regression that made the purge decrement unconditionally would be absorbed
+   * by the clamp and become invisible to tests. Exposed via
+   * {@link #getExclusiveWriteAccountingClampsForTest()} so a regression test can assert the
+   * clamp never engages on the deterministic single-threaded paths.
+   *
+   * <p>A non-zero value in production is not an error: it records the known non-atomic
+   * {@code addOnlyWriters}/{@code removeOnlyWriters} interleaving. A value that grows with load
+   * is a real accounting regression.
+   */
+  private final LongAdder exclusiveWriteAccountingClamps = new LongAdder();
+
+  /**
    * Amount of exclusive pages are hold by write cache.
    */
   private final AtomicLong exclusiveWriteCacheSize = new AtomicLong();
@@ -1918,6 +1938,16 @@ public final class WOWCache extends AbstractWriteCache
   }
 
   /**
+   * Test-only accessor: how many times the exclusive-write accounting clamp engaged — see
+   * {@link #exclusiveWriteAccountingClamps}. Zero is the expected value on any deterministic,
+   * single-threaded path; a regression test asserts that, which is what keeps the clamp from
+   * silently absorbing a purge that decrements without having removed anything.
+   */
+  public long getExclusiveWriteAccountingClampsForTest() {
+    return exclusiveWriteAccountingClamps.sum();
+  }
+
+  /**
    * Test-only accessor: number of times the single-page extend branch of
    * {@link #loadOrAdd} has run to completion (post-allocate, post-sanity-check) since this
    * cache instance was constructed. The regression suite for the original poison-cascade
@@ -2290,6 +2320,25 @@ public final class WOWCache extends AbstractWriteCache
             e, storageName);
       }
     }
+
+    // Quiescent-point invariant check for the exclusive-write accounting. This is the only
+    // place the invariant can be asserted without collateral damage: stopFlush is set, every
+    // triggered ExclusiveFlushTask has completed, and the periodic flush future has returned,
+    // so no flush or purge is in flight. The same assertion inside doRemoveCachePages would
+    // abort the purge mid-loop — leaking a PageFrame, orphaning a writeCachePages entry whose
+    // listener was already nulled, and throwing out of deleteFile/truncateFile after the dirty
+    // pages were dropped but the file was not removed — which is strictly worse than the leak
+    // being fixed, so removeExclusiveWritePage clamps and logs there instead.
+    //
+    // A failure here means some path other than removeExclusiveWritePage (which cannot go
+    // negative by construction) drove the counter below zero; the prime suspect would be the
+    // unconditional decrement in removeOnlyWriters. -ea only; coverage-gate.py excludes
+    // assert lines, so this costs nothing in production.
+    assert exclusiveWriteCacheSize.get() >= 0
+        : "exclusiveWriteCacheSize is negative ("
+            + exclusiveWriteCacheSize.get()
+            + ") at flush shutdown for storage "
+            + storageName;
   }
 
   @Override
@@ -3759,34 +3808,63 @@ public final class WOWCache extends AbstractWriteCache
 
   /**
    * Removes {@code pageKey} from {@link #exclusiveWritePages} and keeps
-   * {@link #exclusiveWriteCacheSize} in step, but only if the key was actually present.
+   * {@link #exclusiveWriteCacheSize} in step, but only if the key was actually present, and
+   * never letting the counter fall below zero.
    *
-   * <p>The conditional shape is load-bearing: {@link #doRemoveCachePages} runs against
-   * caller orderings where the key may or may not have been published into the set yet
-   * (see the call sites there), and an unconditional decrement would drive the counter
-   * negative on the orderings where it has not.
+   * <p>The conditional shape is load-bearing: {@link #doRemoveCachePages} runs against caller
+   * orderings where the key may not have been published into the set at all (see the call
+   * sites there), and an unconditional removal-independent decrement would drive the counter
+   * negative on those orderings.
    *
-   * @return {@code true} if this call is the one that removed the key
+   * <p><b>Guaranteed invariant:</b> this method can never make {@link #exclusiveWriteCacheSize}
+   * negative. That matters more than the leak this whole routine exists to fix, because
+   * {@link #checkCacheOverflow()} enforces writer back-pressure with
+   * {@code while (exclusiveWriteCacheSize.get() > exclusiveWriteCacheMaxSize)} and
+   * {@link #executePeriodicFlush} only flushes exclusive pages when the counter is
+   * {@code >= 0} — so a single negative value disables both back-pressure and the proactive
+   * exclusive flush for the rest of the storage's lifetime, with the symptom (unbounded write
+   * cache growth) surfacing nowhere near the cause.
+   *
+   * <p><b>Best-effort invariant:</b> exact agreement between the counter and the set.
+   * {@link #addOnlyWriters} and {@link #removeOnlyWriters} update the counter and the set as
+   * two separate operations, and {@link CachePointer} invokes them *after* the CAS on its
+   * referrer word without holding any lock that would order them against each other. Two
+   * threads transitioning the same page in opposite directions can therefore land their
+   * callbacks in the order opposite to their CAS order, leaving a key in the set whose counter
+   * contribution has already been consumed. This method then finds a key to remove with
+   * nothing left to decrement; it clamps and logs at WARN rather than going negative. The
+   * non-negativity invariant itself is asserted at a quiescent point instead — see
+   * {@link #stopFlush()} — never here, because an assertion firing inside the purge would
+   * abort it mid-loop and leave a leaked page frame and a listener-less write-cache entry
+   * behind.
    */
-  private boolean removeExclusiveWritePage(final PageKey pageKey) {
+  private void removeExclusiveWritePage(final PageKey pageKey) {
     if (!exclusiveWritePages.remove(pageKey)) {
-      return false;
+      return;
     }
 
-    final var remaining = exclusiveWriteCacheSize.decrementAndGet();
-    // Load-bearing assertion (core surefire runs with -ea): a negative counter is worse
-    // than a leaked one. flushExclusivePagesIfNeeded / flushWriteCacheFromMinLSN compare
-    // the counter against exclusiveWriteCacheMaxSize, so a negative value silently
-    // disables the exclusive-write back-pressure for the rest of the storage's lifetime
-    // and the symptom (unbounded write cache growth) surfaces nowhere near the cause.
-    // Fail loudly here instead if a future caller-ordering change breaks the invariant.
-    // coverage-gate.py excludes assert lines, so this costs nothing in production.
-    assert remaining >= 0
-        : "exclusiveWriteCacheSize went negative ("
-            + remaining
-            + ") while purging "
-            + pageKey;
-    return true;
+    // Clamped decrement. getAndUpdate returns the PREVIOUS value, so previous <= 0 is exactly
+    // the case where the clamp engaged and the counter had already lost this key's
+    // contribution.
+    final var previous =
+        exclusiveWriteCacheSize.getAndUpdate(current -> current > 0 ? current - 1 : current);
+    if (previous <= 0) {
+      exclusiveWriteAccountingClamps.increment();
+      LogManager.instance()
+          .warn(
+              this,
+              "%s: exclusive-write page (%d,%d) was present in exclusiveWritePages while the"
+                  + " counter was already %d; removed the key and left the counter unchanged"
+                  + " rather than decrementing below zero. This is the known non-atomic"
+                  + " addOnlyWriters/removeOnlyWriters drift and is harmless for durability"
+                  + " (writeCachePages is the source of truth), but a repeating message points"
+                  + " at a real accounting regression.",
+              (Throwable) null,
+              storageName,
+              pageKey.fileId,
+              pageKey.pageIndex,
+              previous);
+    }
   }
 
   /**
@@ -3829,14 +3907,19 @@ public final class WOWCache extends AbstractWriteCache
             // eventually latches writers once the leaked count reaches
             // exclusiveWriteCacheMaxSize.
             //
-            // The removal is CONDITIONAL because the two caller orderings differ:
+            // The removal is CONDITIONAL because whether the key is in the set depends on the
+            // caller's ordering AND on whether the page happens to be readers-free right now:
             //   * LockFreeReadCache.closeFile/deleteFile purge the read cache BEFORE this
-            //     write-cache purge, so the page is already readers-free and the key IS in
+            //     write-cache purge, so every page is already readers-free and its key IS in
             //     exclusiveWritePages — this is the leak being fixed;
             //   * LockFreeReadCache.truncateFile/shrinkFile purge the write cache FIRST and
-            //     clear the read cache afterwards, so the page still has readers and the key
-            //     is NOT in the set yet — an unconditional decrement would push the counter
-            //     negative and disable the exclusive-write back-pressure entirely.
+            //     clear the read cache afterwards, so a page that still has a reader has NOT
+            //     been published into the set (its key is absent), while a page whose readers
+            //     were already released has. Both cases occur on these two orderings, so the
+            //     removal must not assume either: an unconditional decrement would push the
+            //     counter negative for the reader-held pages and disable the exclusive-write
+            //     back-pressure entirely. (Both cases are covered by tests in
+            //     WOWCacheShrinkFileTest.)
             // Done inside the page-frame exclusive-lock region so the lock-acquisition
             // ordering documented below is unchanged (set/counter mutations take no lock).
             removeExclusiveWritePage(pageKey);
@@ -3880,15 +3963,29 @@ public final class WOWCache extends AbstractWriteCache
     //     would deadlock against the submitter. Both structures touched are concurrent, and
     //     the per-key group lock would buy nothing because CachePointer fires
     //     addOnlyWriters/removeOnlyWriters without holding it.
+    //     Caveat on that exclusion: it is best-effort under interruption. If the submitter's
+    //     future.get() throws InterruptedException, removeCachedPages / deleteFile rethrow
+    //     without cancelling or awaiting this task, so their finally releases the filesLock
+    //     write lock while the purge — including this sweep — may still be running, and a
+    //     concurrent store() can then proceed. Tracked as its own follow-up item.
     //
-    // KNOWN LIMITATION: this sweep NARROWS the orphan window, it does not close it. On the
-    // truncateFile/shrinkFile ordering the read cache is still populated while the purge
-    // runs, so a concurrent release or eviction (WTinyLFUPolicy.invalidateStampsAndRelease)
-    // can call decrementReadersReferrer -> addOnlyWriters for a page whose listener this
-    // method had not yet nulled and land the key in exclusiveWritePages after the sweep has
-    // already moved past it; that key is still leaked. On the closeFile/deleteFile ordering
-    // the read cache is purged first, so no such concurrent source exists and the sweep is
-    // complete.
+    // KNOWN LIMITATION: this sweep NARROWS the orphan window on every ordering, and closes it
+    // on none. Two residual producers can publish a key into exclusiveWritePages after the
+    // sweep has moved past it, both by way of decrementReadersReferrer -> addOnlyWriters:
+    //   * truncateFile/shrinkFile ordering — the read cache is still populated while the purge
+    //     runs, so an ordinary release or an eviction
+    //     (WTinyLFUPolicy.invalidateStampsAndRelease) can fire the callback for a page whose
+    //     listener this method had not yet nulled.
+    //   * closeFile/deleteFile ordering — eviction IS excluded here (clearFile ran first and
+    //     WTinyLFUPolicy skips dead entries), but LockFreeReadCache.silentLoadForRead builds
+    //     its CacheEntryImpl with insideCache=false and never inserts it into the read cache's
+    //     map, so clearFile can neither see nor freeze it; the matching releaseFromRead then
+    //     calls decrementReadersReferrer with no filesLock held. That is reachable from
+    //     DiskStorage.backupPagesWithChanges, which holds no stateLock across its per-page
+    //     load/release loop.
+    // Closing either window means changing read-cache or backup locking, which is out of scope
+    // here; a leaked key is accounting-only (writeCachePages remains the source of truth for
+    // durability) and is now bounded by the clamp in removeExclusiveWritePage.
     final var orphanCandidates =
         exclusiveWritePages.subSet(
             new PageKey(internalFileId, minPageIndex), true,
@@ -4230,9 +4327,18 @@ public final class WOWCache extends AbstractWriteCache
               flushError.getMessage());
       // Abandon the stamp, as the log message above already claims. Every other flush-path
       // entry point returns immediately after reporting flushError (executeFileFlush,
-      // executeFindDirtySegment, ...); falling through here contradicted the diagnostic and
-      // kept issuing writes into a file whose write cache is already known to be
-      // unflushable, which can lay a blank page on top of data the failed flush left behind.
+      // executeFindDirtySegment, executePeriodicFlush, executeFlush); falling through here
+      // contradicted the method's own diagnostic.
+      //
+      // The write it skips cannot corrupt existing data — the guard below only writes when
+      // getUnderlyingFileSize() <= pagePosition, i.e. strictly at or past end-of-file, so it
+      // appends and never overwrites. What the early return avoids is issuing *new* physical
+      // writes after a write failure has already been latched: this path writes through
+      // file.write directly, bypassing the double-write log and any fsync, and flushError is
+      // monotone and escalates via AbstractStorage.setInError, so the file is on its way to
+      // read-only. Extending it further only widens torn-page exposure for a page no healthy
+      // reader will reach, and recovery re-derives the physical size and re-runs the
+      // idempotent gap-fill stamp anyway.
       return;
     }
 
@@ -4246,10 +4352,15 @@ public final class WOWCache extends AbstractWriteCache
       if (entry == null) {
         // The file disappeared between this task being queued and it running: loadOrAdd's
         // extend / gap-fill branches submit EnsurePageIsValidInFileTask asynchronously, and
-        // deleteFile or replaceFileId (which unregisters both ids while it rebinds them) or a
-        // restore can drop the id in the meantime. Nothing can be stamped — writing now would
-        // either resurrect a deleted file or stamp a page into a file id that has since been
-        // rebound to a different component — so bail out instead of dereferencing null.
+        // the live producer of that window is deleteFile -> executeDeleteFile, which calls
+        // files.remove after the task was queued. (The whole-cache close() also removes every
+        // file, but it sets stopFlush first, so the guard above already covers it. WOWCache
+        // .replaceFileId would unregister both ids while it rebinds them and additionally open
+        // a window where the id is valid but bound to a different file — it has no production
+        // callers today, the only one being commented out in CollectionPositionMapV2, so it is
+        // named here as a hazard to re-check if that code is ever revived, not as a path that
+        // is currently reachable.) Nothing can be stamped for a file that is gone, so bail out
+        // instead of dereferencing null.
         //
         // WARN rather than a silent skip, deliberately asymmetric with the null-entry skips on
         // the fsync paths (fsyncFiles, and the callFsync loop in executeFileFlush): there a

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -3931,13 +3931,14 @@ public final class WOWCache extends AbstractWriteCache
                     + " rather than decrementing below zero. This is the known non-atomic"
                     + " addOnlyWriters/removeOnlyWriters drift and is harmless for durability"
                     + " (writeCachePages is the source of truth). Further occurrences within the"
-                    + " next minute are not logged; a message that keeps reappearing is what"
+                    + " next %d seconds are not logged; a message that keeps reappearing is what"
                     + " signals a real accounting regression.",
                 (Throwable) null,
                 storageName,
                 pageKey.fileId,
                 pageKey.pageIndex,
-                previous);
+                previous,
+                TimeUnit.NANOSECONDS.toSeconds(ACCOUNTING_CLAMP_WARN_INTERVAL_NANOS));
       }
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/ConcurrencyDiagnostics.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/ConcurrencyDiagnostics.java
@@ -1,0 +1,95 @@
+/*
+ *
+ *
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *
+ */
+
+package com.jetbrains.youtrackdb.internal;
+
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+
+/// One shared dialect for the timeout-bounded concurrency tests, colocated with
+/// [JUnitTestListener#appendDiagnostics] because every helper here ends in that report:
+///
+///   - **shared deadlines**: [#deadlineFromNow] / [#remainingMillis], so a test's sequential waits
+///     share ONE budget instead of summing independent bounds past the `@Test(timeout)` (which can
+///     only ever produce a bare `TestTimedOutException` carrying no thread state);
+///   - **dump before cleanup**: [#dumpThreads] / [#assertWithThreadDump], so the stacks are
+///     captured before the caller's `finally` interrupts a stuck thread or releases a latch it is
+///     pinned on.
+///
+/// Deliberately monotonic: deadlines are [System#nanoTime] values, never wall clock. A forward
+/// clock step (NTP, or a Hyper-V guest resyncing after the host suspends it — routine on the
+/// Windows CI VMs) would collapse every remaining-time computation onto the 1 ms clamp and report a
+/// false deadlock; a backward step would push the tail past the `@Test(timeout)` and restore the
+/// very failure mode these helpers exist to remove.
+public final class ConcurrencyDiagnostics {
+
+  private ConcurrencyDiagnostics() {
+  }
+
+  /// A deadline `millis` from now, as a [System#nanoTime] value to be passed to
+  /// [#remainingMillis]. Arm it immediately before the racing starts, so unrelated setup (opening
+  /// sessions, building fixtures) is not charged to the contention budget.
+  public static long deadlineFromNow(final long millis) {
+    return System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(millis);
+  }
+
+  /// Milliseconds remaining until `deadlineNanos`, clamped to at least 1 ms. Every wait derived
+  /// from a shared deadline must go through this clamp: [Thread#join(long)] with `0` waits
+  /// *forever* and with a negative argument throws [IllegalArgumentException], so an expired
+  /// deadline would otherwise turn a bounded wait into an unbounded one (or an unrelated crash).
+  ///
+  /// The subtraction is done in nanos so it stays correct across [System#nanoTime] wraparound.
+  public static long remainingMillis(final long deadlineNanos) {
+    return Math.max(1L, TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime()));
+  }
+
+  /// Appends a `label`-tagged thread dump to the shared diagnostics report (the build directory's
+  /// `deadlock-report.txt`, which CI uploads as an artifact).
+  ///
+  /// Never throws: a caller is always about to report a *different*, real failure, and a dump that
+  /// failed (a full disk, a security manager, an [OutOfMemoryError] while building the dump string)
+  /// must not replace that failure with its own. A dump that cannot be written is reported on
+  /// stderr and otherwise ignored.
+  public static void dumpThreads(final String label) {
+    try {
+      JUnitTestListener.appendDiagnostics(label);
+    } catch (final Throwable dumpFailure) {
+      // Deliberately swallowed - see above. Printed, not rethrown, so the caller's own failure is
+      // the one that reaches the test report.
+      System.err.println("Failed to write thread diagnostics for '" + label + "': " + dumpFailure);
+      System.err.flush();
+    }
+  }
+
+  /// Dumps thread state under `message` and then fails with it. For stalls only: use it where the
+  /// caller's cleanup (an interrupt, a latch release) would unwind the state that explains the
+  /// stall before anyone could read it.
+  public static void failWithThreadDump(final String message) {
+    dumpThreads(message);
+    fail(message);
+  }
+
+  /// [#failWithThreadDump] unless `condition` holds.
+  public static void assertWithThreadDump(final String message, final boolean condition) {
+    if (!condition) {
+      failWithThreadDump(message);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/ConcurrencyDiagnostics.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/ConcurrencyDiagnostics.java
@@ -19,19 +19,16 @@
 
 package com.jetbrains.youtrackdb.internal;
 
-import static org.junit.Assert.fail;
-
 import java.util.concurrent.TimeUnit;
 
-/// One shared dialect for the timeout-bounded concurrency tests, colocated with
+/// The shared deadline-and-dump dialect of the timeout-bounded concurrency tests, colocated with
 /// [JUnitTestListener#appendDiagnostics] because every helper here ends in that report:
 ///
 ///   - **shared deadlines**: [#deadlineFromNow] / [#remainingMillis], so a test's sequential waits
 ///     share ONE budget instead of summing independent bounds past the `@Test(timeout)` (which can
 ///     only ever produce a bare `TestTimedOutException` carrying no thread state);
-///   - **dump before cleanup**: [#dumpThreads] / [#assertWithThreadDump], so the stacks are
-///     captured before the caller's `finally` interrupts a stuck thread or releases a latch it is
-///     pinned on.
+///   - **dump before cleanup**: [#dumpThreads], so the stacks are captured before the caller's
+///     `finally` interrupts a stuck thread or releases a latch it is pinned on.
 ///
 /// Deliberately monotonic: deadlines are [System#nanoTime] values, never wall clock. A forward
 /// clock step (NTP, or a Hyper-V guest resyncing after the host suspends it — routine on the
@@ -75,21 +72,6 @@ public final class ConcurrencyDiagnostics {
       // the one that reaches the test report.
       System.err.println("Failed to write thread diagnostics for '" + label + "': " + dumpFailure);
       System.err.flush();
-    }
-  }
-
-  /// Dumps thread state under `message` and then fails with it. For stalls only: use it where the
-  /// caller's cleanup (an interrupt, a latch release) would unwind the state that explains the
-  /// stall before anyone could read it.
-  public static void failWithThreadDump(final String message) {
-    dumpThreads(message);
-    fail(message);
-  }
-
-  /// [#failWithThreadDump] unless `condition` holds.
-  public static void assertWithThreadDump(final String message, final boolean condition) {
-    if (!condition) {
-      failWithThreadDump(message);
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/JUnitTestListener.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/JUnitTestListener.java
@@ -20,15 +20,16 @@
 package com.jetbrains.youtrackdb.internal;
 
 import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
-import com.jetbrains.youtrackdb.internal.common.log.LogManager;
 import com.jetbrains.youtrackdb.internal.core.YouTrackDBEnginesManager;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
+import java.time.Instant;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
@@ -38,19 +39,31 @@ import org.junit.runner.notification.RunListener;
 ///   - Listens for the JUnit test run finishing and runs the direct memory leaks detector, if no
 ///     tests failed. If leak detector finds some leaks, it triggers [AssertionError] and the
 ///     build is marked as failed. Java assertions (-ea) must be active for this to work.
-///   - Triggers [AssertionError] if [LogManager] is shutdown before test is finished.
-///     We may miss some errors because [LogManager] is shutdown
+///   - Triggers [AssertionError] if the engine's log manager is shutdown before the test is
+///     finished. We may miss some errors because the log manager is shutdown.
 ///   - Runs a watchdog thread that detects deadlocked or stuck tests. If a test exceeds the
 ///     configured timeout, diagnostics are dumped and the JVM is terminated. The timeout is
 ///     configurable via `-Dyoutrackdb.test.deadlock.timeout.minutes` (default: 15).
 ///   - Detects inactivity gaps (e.g. during @After teardown or between test methods) when no
 ///     test is tracked as running. Uses `Runtime.halt(1)` instead of `System.exit(1)` to avoid
 ///     deadlocking in shutdown hooks when threads hold locks that would never be released.
+///   - Exposes [#appendDiagnostics] so a test that detects a stuck thread can contribute its own
+///     labelled thread dump to the same report the watchdog writes.
 public class JUnitTestListener extends RunListener {
 
   private static final long DEFAULT_TIMEOUT_MINUTES = 15;
   private static final long CI_DEFAULT_TIMEOUT_MINUTES = 60;
   private static final long CHECK_INTERVAL_MS = TimeUnit.SECONDS.toMillis(30);
+  /// Serializes every write to the shared diagnostics report. Up to four test classes share one
+  /// forked JVM under parallel class execution, and a test's own dump can race the watchdog's, so
+  /// without this lock (and append mode) the writes truncate or interleave with each other.
+  ///
+  /// A [ReentrantLock] rather than a monitor because the watchdog's halt path must never *block*
+  /// on it: see [#appendReportToFile].
+  private static final ReentrantLock REPORT_LOCK = new ReentrantLock();
+  /// How long the watchdog's last-resort halt path is willing to wait for [#REPORT_LOCK] before it
+  /// gives up on the file and halts anyway.
+  private static final long HALT_PATH_LOCK_TIMEOUT_SECONDS = 5;
 
   private final ConcurrentHashMap<String, Long> runningTests = new ConcurrentHashMap<>();
   private volatile boolean running;
@@ -186,6 +199,50 @@ public class JUnitTestListener extends RunListener {
     watchdogThread.start();
   }
 
+  /// Appends a labelled diagnostics block — a header carrying `label` and a timestamp, the
+  /// deadlocked-thread set when the JVM reports one, and a full thread dump with locked monitors
+  /// and synchronizers — to the shared diagnostics report, and echoes it to `System.err`.
+  ///
+  /// Public entry point for tests that detect a stuck thread: the stack has to be captured BEFORE
+  /// the test interrupts that thread or releases a latch it is pinned on, because both unwind
+  /// exactly the state the dump must show. Writes are append-mode and serialized on
+  /// [#REPORT_LOCK], so a test's dump never erases the watchdog's dump or another test's.
+  public static void appendDiagnostics(String label) {
+    var bean = ManagementFactory.getThreadMXBean();
+
+    var report = new StringBuilder();
+    report.append(blockHeader("DIAGNOSTICS: " + label));
+
+    var deadlocked = bean.findDeadlockedThreads();
+    if (deadlocked != null) {
+      report.append("\n=== DEADLOCKED THREADS ===\n");
+      for (var info : bean.getThreadInfo(deadlocked, true, true)) {
+        report.append(info).append("\n");
+      }
+    }
+
+    report.append("\n=== ALL THREADS ===\n");
+    for (var info : bean.dumpAllThreads(true, true)) {
+      report.append(info).append("\n");
+    }
+
+    var reportStr = report.toString();
+    System.err.println(reportStr);
+    System.err.flush();
+    System.out.flush();
+
+    appendReportToFile(reportStr, false);
+  }
+
+  /// The common first line of every report block: the reason/label, the wall-clock instant, and the
+  /// thread that produced it. Both producers (a test's [#appendDiagnostics] and the watchdog's
+  /// [#dumpDiagnosticsAndHalt]) use it, so blocks in the accumulated report are always
+  /// attributable.
+  private static String blockHeader(String reason) {
+    return "\n=== " + reason + " === (" + Instant.now() + ", reported by thread '"
+        + Thread.currentThread().getName() + "')\n";
+  }
+
   private static void checkAndLogDeadlocks(String testName) {
     var bean = ManagementFactory.getThreadMXBean();
     var deadlocked = bean.findDeadlockedThreads();
@@ -212,7 +269,7 @@ public class JUnitTestListener extends RunListener {
     var now = System.currentTimeMillis();
 
     var report = new StringBuilder();
-    report.append("\n=== ").append(reason).append(" ===\n");
+    report.append(blockHeader(reason));
 
     if (deadlocked != null) {
       report.append("\n=== DEADLOCKED THREADS ===\n");
@@ -244,24 +301,57 @@ public class JUnitTestListener extends RunListener {
     System.err.flush();
     System.out.flush();
 
-    writeReportToFile(reportStr);
+    // Best effort: this is the last-resort halt path, so it must never be blocked by whoever holds
+    // the report lock (a wedged writer, or a test thread stuck mid-dump).
+    appendReportToFile(reportStr, true);
 
     // halt() forces immediate JVM termination without running shutdown hooks.
     Runtime.getRuntime().halt(1);
   }
 
-  private static void writeReportToFile(String report) {
+  /// Appends `report` to the shared diagnostics report file. The file name and location are fixed
+  /// (`${buildDirectory}/deadlock-report.txt`) because the CI artifact upload globs match it by
+  /// name — renaming it would silently stop uploading diagnostics. Append mode plus
+  /// [#REPORT_LOCK] is what lets several producers (the watchdog and individual tests) contribute
+  /// to one report instead of overwriting each other.
+  ///
+  /// `bestEffort` callers (only the watchdog's halt path) never block indefinitely on the lock:
+  /// they wait [#HALT_PATH_LOCK_TIMEOUT_SECONDS] and then fall back to stderr, which the report
+  /// has already been echoed to. Blocking there would let a wedged writer prevent the halt — the
+  /// one action that must always happen.
+  private static void appendReportToFile(String report, boolean bestEffort) {
     var buildDir = System.getProperty("buildDirectory", "./target");
     var reportFile = new File(buildDir, "deadlock-report.txt");
     //noinspection ResultOfMethodCallIgnored
     reportFile.getParentFile().mkdirs();
-    try (var writer = new PrintWriter(new FileWriter(reportFile))) {
+
+    if (bestEffort) {
+      var acquired = false;
+      try {
+        acquired = REPORT_LOCK.tryLock(HALT_PATH_LOCK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      if (!acquired) {
+        System.err.println("Skipping the " + reportFile + " write: the report lock was still held"
+            + " after " + HALT_PATH_LOCK_TIMEOUT_SECONDS + "s. The report above (on stderr) is the"
+            + " only copy; halting now.");
+        System.err.flush();
+        return;
+      }
+    } else {
+      REPORT_LOCK.lock();
+    }
+
+    try (var writer = new PrintWriter(new FileWriter(reportFile, true))) {
       writer.print(report);
       writer.flush();
     } catch (IOException e) {
       System.err.println("Failed to write deadlock report to " + reportFile + ": "
           + e.getMessage());
       System.err.flush();
+    } finally {
+      REPORT_LOCK.unlock();
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
@@ -15,6 +15,8 @@ import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransaction;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -65,13 +67,13 @@ public class MetadataWriteMutexTest extends DbTestBase {
 
   /// LIVENESS: a spawned worker must reach a handshake point — engaging the mutex, publishing its
   /// thread, entering a commit window. Costs milliseconds locally, so only a genuine hang exhausts
-  /// it: a worker that THROWS on the way to its handshake would never count its latch down, which
-  /// is why every such wait goes through [#awaitSignalOrWorkerError] and reports the worker's own
-  /// throwable as soon as it appears instead of waiting this bound out.
+  /// it: a worker that THROWS on the way to its handshake is reported at once instead, since every
+  /// such wait goes through [Worker#awaitSignal] and every worker declares the latches its waiters
+  /// await (see the canonical worker idiom below).
   private static final long HANDSHAKE_SECONDS = 60L;
 
-  /// Poll interval of [#awaitSignalOrWorkerError]. Short enough that a worker failure is reported
-  /// within a fraction of a second rather than after [#HANDSHAKE_SECONDS].
+  /// Poll interval of [Worker#awaitSignal]. Short enough that a worker failure is reported within a
+  /// fraction of a second rather than after [#HANDSHAKE_SECONDS].
   private static final long SIGNAL_POLL_MILLIS = 50L;
 
   /// LIVENESS: once the blocking condition is lifted (permit released, commit window opened) the
@@ -116,18 +118,211 @@ public class MetadataWriteMutexTest extends DbTestBase {
 
   private final List<Thread> spawnedWorkers = new CopyOnWriteArrayList<>();
 
+  // ---------------------------------------------------------------------------------------------
+  // THE CANONICAL WORKER IDIOM — read this before adding a worker to this class.
+  //
+  // Every test here drives its scenario from spawned worker threads, and every one of them needs
+  // the same five guarantees. Hand-rolling them per test is what repeatedly made a worker's failure
+  // vanish, or surface as a 60 s stall blamed on a latch instead of on the throwable behind it.
+  // So there is exactly ONE way to spawn a worker in this class: startWorker(name, body). Never use
+  // `new Thread` directly, and never hand-roll an error holder or a done latch.
+  //
+  //   (a) EVERY resource acquisition happens INSIDE the worker's try. Sessions come from
+  //       self.openSession() / self.openSessionForTest(), called from inside the body, so a throw
+  //       while opening one is recorded exactly like any other failure.
+  //   (b) The worker ALWAYS has an error holder and it is ALWAYS populated: the runner catches
+  //       Throwable around the whole body. There is no path on which a throwable is dropped.
+  //   (c) Latches a waiter awaits are declared with signalling(...) and counted down in the
+  //       runner's finally, so no waiter can stall on a worker that died — and since they are per
+  //       worker, the latch released on the failure path is by construction the one the waiter
+  //       awaits. Waits go through worker.awaitSignal(...), which reports the worker's throwable
+  //       rather than the missing signal.
+  //   (d) Completion is observable: the runner counts a done latch down after the body AND its
+  //       cleanup. The authoritative error read is worker.failIfErrored(...), which ASSERTS that
+  //       completion edge — so no test can read the holder before the worker's own teardown could
+  //       have written to it, which is the defect that let a late close() failure pass green.
+  //   (e) Sessions are closed on every path: worker-owned ones in the runner's finally, and
+  //       test-owned ones there too whenever the worker failed, because a failing test will not
+  //       reach its own close.
+  // ---------------------------------------------------------------------------------------------
+
+  /** The body of a worker started by {@link #startWorker}. It may throw anything. */
+  @FunctionalInterface
+  private interface WorkerBody {
+
+    void run(Worker self) throws Throwable;
+  }
+
   /**
-   * Tracked worker spawn helper. Surefire reuses worker threads across {@code @Test} methods, so any
-   * thread spawned here is registered for a bounded join in the {@code @After} hook. Workers are
-   * daemon so a leaked worker (a stuck mutex acquire that the test cannot unblock) cannot keep the
-   * surefire forked JVM alive.
+   * Starts a tracked worker running {@code body}, with all five guarantees of the canonical worker
+   * idiom above. Surefire reuses threads across {@code @Test} methods, so the thread is registered
+   * for the bounded join in {@code @After}; it is a daemon so a leaked worker (a stuck mutex
+   * acquire the test cannot unblock) cannot keep the forked JVM alive.
    */
-  private Thread spawn(Runnable body, String name) {
-    var t = new Thread(body, name);
-    t.setDaemon(true);
-    spawnedWorkers.add(t);
-    t.start();
-    return t;
+  private Worker startWorker(final String name, final WorkerBody body) {
+    final var worker = new Worker(name);
+    final var thread = new Thread(() -> {
+      try {
+        body.run(worker);
+      } catch (final Throwable t) {
+        // (b): the single sink for every throwable this worker can produce.
+        worker.error.compareAndSet(null, t);
+      } finally {
+        // (e) then (c) then (d), in that order: clean up, release anyone waiting on this worker,
+        // and only then publish completion, so a test observing completion sees the final error.
+        worker.closeSessions();
+        for (final var signal : worker.signals) {
+          signal.countDown();
+        }
+        worker.done.countDown();
+      }
+    }, name);
+    thread.setDaemon(true);
+    // Published before start(), so the body may read self.thread() safely.
+    worker.thread = thread;
+    spawnedWorkers.add(thread);
+    thread.start();
+    return worker;
+  }
+
+  /** A worker started by {@link #startWorker}. See the canonical worker idiom above. */
+  private final class Worker {
+
+    private final String name;
+    private final AtomicReference<Throwable> error = new AtomicReference<>();
+    private final CountDownLatch done = new CountDownLatch(1);
+    private final List<CountDownLatch> signals = new CopyOnWriteArrayList<>();
+    private final List<DatabaseSessionEmbedded> ownedSessions = new CopyOnWriteArrayList<>();
+    private final List<DatabaseSessionEmbedded> testOwnedSessions = new CopyOnWriteArrayList<>();
+    private Thread thread;
+
+    private Worker(final String name) {
+      this.name = name;
+    }
+
+    /**
+     * (c) Declares the latches some waiter awaits on this worker. They are counted down on EVERY
+     * exit path, including a failure before the body would have signalled them, so a waiter can
+     * never stall on a dead worker. Declare a latch here even when the body (or a production hook)
+     * signals it on the happy path — double counting down is a no-op.
+     */
+    Worker signalling(final CountDownLatch... latches) {
+      signals.addAll(Arrays.asList(latches));
+      return this;
+    }
+
+    /** (a)+(e) A session this worker owns: opened inside the body, closed by the runner. */
+    DatabaseSessionEmbedded openSession() {
+      final var opened = openDatabase();
+      ownedSessions.add(opened);
+      return opened;
+    }
+
+    /**
+     * (a)+(e) A session the TEST thread takes over and closes (or tears down) on the happy path.
+     * The runner closes it only if this worker failed, since the test will not reach its own close.
+     */
+    DatabaseSessionEmbedded openSessionForTest() {
+      final var opened = openDatabase();
+      testOwnedSessions.add(opened);
+      return opened;
+    }
+
+    Thread thread() {
+      return thread;
+    }
+
+    boolean isAlive() {
+      return thread.isAlive();
+    }
+
+    /** Whether the body and its cleanup have finished — the (d) completion edge, non-blocking. */
+    boolean isFinished() {
+      return done.getCount() == 0;
+    }
+
+    /**
+     * (c) Waits until {@code signal} fires, and fails as soon as this worker records a throwable
+     * instead.
+     *
+     * <p>Both can be true when this returns: workers signal partway through their body and can fail
+     * afterwards, and the runner's finally signals on the failure path too. When both are set the
+     * throwable wins — a worker that has already failed cannot be in the state the caller wanted to
+     * observe. The {@code seconds} bound applies only to the remaining case, a worker that neither
+     * signals nor fails, i.e. a genuine hang.
+     */
+    void awaitSignal(final CountDownLatch signal, final long seconds, final String message)
+        throws InterruptedException {
+      final var deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds);
+      var fired = signal.await(SIGNAL_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      while (!fired && error.get() == null) {
+        if (System.nanoTime() - deadlineNanos >= 0) {
+          fail(message + " (worker '" + name + "' neither signalled nor failed within " + seconds
+              + "s)");
+        }
+        fired = signal.await(SIGNAL_POLL_MILLIS, TimeUnit.MILLISECONDS);
+      }
+      reportErrorIfAny(message);
+    }
+
+    /**
+     * (d) The completion edge: waits for the body AND its cleanup. Every authoritative read of the
+     * error holder must follow this, because a worker records a failure from its own teardown (a
+     * session close that throws) only just before it counts down.
+     */
+    void awaitDone(final long seconds, final String message) throws InterruptedException {
+      assertTrue(message + " (worker '" + name + "' must finish)",
+          done.await(seconds, TimeUnit.SECONDS));
+      reportErrorIfAny(message);
+    }
+
+    /** A bounded join on the worker thread, for tests that assert on liveness themselves. */
+    void joinBounded(final long millis) throws InterruptedException {
+      thread.join(millis);
+    }
+
+    /**
+     * (d) The authoritative error read: rethrows this worker's throwable as the cause of
+     * {@code message}. Asserts the completion edge first, so a test cannot read the holder while
+     * the worker may still write to it.
+     */
+    void failIfErrored(final String message) {
+      assertTrue("test bug: worker '" + name + "' error read before its completion edge",
+          isFinished());
+      reportErrorIfAny(message);
+    }
+
+    private void reportErrorIfAny(final String message) {
+      final var failure = error.get();
+      if (failure != null) {
+        throw new AssertionError(
+            message + " — worker '" + name + "' failed, which is the root cause",
+            failure);
+      }
+    }
+
+    /** (e) Closes what this worker owns, plus test-owned sessions when the worker failed. */
+    private void closeSessions() {
+      final var toClose = new ArrayList<>(ownedSessions);
+      if (error.get() != null) {
+        toClose.addAll(testOwnedSessions);
+      }
+      for (final var opened : toClose) {
+        try {
+          // Lock-free status probe: isClosed() would take the storage state lock and could block
+          // behind an in-flight commit. Skips sessions the body already closed on purpose.
+          if (opened.getStatus() == DatabaseSessionEmbedded.STATUS.OPEN) {
+            opened.activateOnCurrentThread();
+            opened.close();
+          }
+        } catch (final Throwable cleanupFailure) {
+          // Reported, never rethrown: cleanup must not replace the worker's own failure.
+          System.err.println(
+              "worker '" + name + "' could not close its session: " + cleanupFailure);
+          System.err.flush();
+        }
+      }
+    }
   }
 
   /**
@@ -206,31 +401,6 @@ public class MetadataWriteMutexTest extends DbTestBase {
     return null;
   }
 
-  /**
-   * Awaits {@code signal} for up to {@code seconds}, failing as soon as {@code workerError} records
-   * the signalling worker's own throwable.
-   *
-   * <p>Attribution, not liveness, is the point. These handshake latches are counted down on the
-   * worker's success path, so a worker that throws on its way to the handshake never signals: a
-   * plain bounded await would sit out the whole liveness bound and then report the missing signal
-   * instead of the failure that caused it. The bound is still enforced for the case where the
-   * worker neither signals nor fails (a genuine hang).
-   */
-  private static void awaitSignalOrWorkerError(final CountDownLatch signal,
-      final AtomicReference<Throwable> workerError, final long seconds, final String message)
-      throws InterruptedException {
-    final var deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds);
-    while (!signal.await(SIGNAL_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
-      if (workerError.get() != null) {
-        throw new AssertionError(
-            message + " — the worker failed first, which is the root cause", workerError.get());
-      }
-      if (System.nanoTime() - deadlineNanos >= 0) {
-        fail(message);
-      }
-    }
-  }
-
   @After
   public void joinSpawnedWorkers() throws InterruptedException {
     var leaked = new java.util.ArrayList<String>();
@@ -282,91 +452,63 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var firstMayCommit = new CountDownLatch(1);
     var secondCreatedClass = new AtomicBoolean(false);
     var secondAborted = new AtomicBoolean(false);
-    // One error holder PER worker: with a single shared holder, a first-worker failure surfaced
-    // under a message that named neither worker ("no schema tx should error on contention"), and
-    // whichever worker lost the compareAndSet had its throwable dropped entirely.
-    var firstError = new AtomicReference<Throwable>();
-    var secondError = new AtomicReference<Throwable>();
-    // Counted down in worker 1's own finally, i.e. AFTER its session close. It is the
-    // happens-before edge for the firstError read at the end: the mutex permit is released before
-    // commit() returns, so without this edge the body could read firstError while worker 1 is still
-    // inside first.close(), silently dropping a teardown failure recorded a moment later.
-    var firstDone = new CountDownLatch(1);
     var secondAboutToEngage = new CountDownLatch(1);
-    var secondThreadRef = new AtomicReference<Thread>();
 
     // First session: open a schema tx, engage the mutex by creating a class, then park holding it
     // until the test releases it. Runs on its own thread so its session activation does not collide
     // with the test thread's default session. One collection per class: these classes exist only to
     // drive a schema transaction, and the default eight would create ~16 files apiece.
-    spawn(() -> {
-      try (var first = openDatabase()) {
-        first.activateOnCurrentThread();
-        first.begin();
-        first.getMetadata().getSchema().createClass("FirstSchemaTx", 1);
-        firstHoldsMutex.countDown();
-        firstMayCommit.await();
-        first.commit();
-      } catch (Throwable t) {
-        firstError.compareAndSet(null, t);
-      } finally {
-        // Runs after the try-with-resources close, and the catch above covers that close, so by the
-        // time this fires firstError is final for this worker.
-        firstDone.countDown();
-      }
-    }, "mutex-first-writer");
+    var firstWriter = startWorker("mutex-first-writer", self -> {
+      var first = self.openSession();
+      first.activateOnCurrentThread();
+      first.begin();
+      first.getMetadata().getSchema().createClass("FirstSchemaTx", 1);
+      firstHoldsMutex.countDown();
+      firstMayCommit.await();
+      first.commit();
+    }).signalling(firstHoldsMutex);
 
-    var secondDone = new CountDownLatch(1);
+    // Declared here so the authoritative error read after the try can reach it.
+    Worker secondWriter = null;
     try {
-      // Reports worker 1's own throwable the moment it appears instead of waiting out the liveness
-      // bound and blaming the missing latch — worker 1 counts firstHoldsMutex down only on success.
-      awaitSignalOrWorkerError(firstHoldsMutex, firstError, HANDSHAKE_SECONDS,
+      firstWriter.awaitSignal(firstHoldsMutex, HANDSHAKE_SECONDS,
           "first session must engage the mutex");
 
       // Second session: try to start a schema tx while the first holds the mutex. Its createClass
       // must block on the mutex, so secondCreatedClass stays false until the first releases.
-      spawn(() -> {
-        try (var second = openDatabase()) {
-          second.activateOnCurrentThread();
-          second.begin();
-          try {
-            // Publish this worker's thread and signal that the very next call is the blocking
-            // schema write, so the test can observe this thread park on the permit
-            // deterministically.
-            secondThreadRef.set(Thread.currentThread());
-            secondAboutToEngage.countDown();
-            second.getMetadata().getSchema().createClass("SecondSchemaTx", 1);
-            // No mutex-holder check here on purpose. engage() overwrites the single holder slot
-            // unconditionally, so "the first session no longer holds it" is true the instant THIS
-            // write returns even under a hypothetical two-permit mutex that let both writers run
-            // concurrently - i.e. it cannot fail, and it cannot prove serialization. What does
-            // prove it is below: the park observation and secondCreatedClass staying false while
-            // the first holds the permit both go red against a two-permit regression.
-            secondCreatedClass.set(true);
-            second.commit();
-          } catch (Throwable txError) {
-            secondAborted.set(true);
-            throw txError;
-          }
-        } catch (Throwable t) {
-          secondError.compareAndSet(null, t);
-        } finally {
-          secondDone.countDown();
+      secondWriter = startWorker("mutex-second-writer", self -> {
+        var second = self.openSession();
+        second.activateOnCurrentThread();
+        second.begin();
+        try {
+          // Signal that the very next call is the blocking schema write, so the test can observe
+          // this thread park on the permit deterministically.
+          secondAboutToEngage.countDown();
+          second.getMetadata().getSchema().createClass("SecondSchemaTx", 1);
+          // No mutex-holder check here on purpose. engage() overwrites the single holder slot
+          // unconditionally, so "the first session no longer holds it" is true the instant THIS
+          // write returns even under a hypothetical two-permit mutex that let both writers run
+          // concurrently - i.e. it cannot fail, and it cannot prove serialization. What does
+          // prove it is below: the park observation and secondCreatedClass staying false while
+          // the first holds the permit both go red against a two-permit regression.
+          secondCreatedClass.set(true);
+          second.commit();
+        } catch (Throwable txError) {
+          secondAborted.set(true);
+          throw txError;
         }
-      }, "mutex-second-writer");
+      }).signalling(secondAboutToEngage);
 
       // Wait until the second worker is about to make its blocking schema write, then observe it
       // actually park on the permit (WAITING/TIMED_WAITING, inside the mutex's engage frame) rather
       // than inferring blocking from a sleep. The full-path latch only proves the worker reached
       // the call; the park observation proves the call is parked on the semaphore, so this fails
       // closed if a regression let the second writer through instead of blocking it.
-      awaitSignalOrWorkerError(secondAboutToEngage, secondError, HANDSHAKE_SECONDS,
+      secondWriter.awaitSignal(secondAboutToEngage, HANDSHAKE_SECONDS,
           "the second worker must reach its blocking schema write");
-      var secondThread = secondThreadRef.get();
-      assertNotNull("the second worker thread must have been published", secondThread);
       // Deliberately short: the worker has already announced the next call blocks, so this observes
       // thread-state settling, not host-dependent database work.
-      var observedPark = awaitParkedOnMutex(secondThread, PARK_OBSERVATION_MILLIS);
+      var observedPark = awaitParkedOnMutex(secondWriter.thread(), PARK_OBSERVATION_MILLIS);
       assertTrue("the second schema tx must park on the mutex while the first holds it, observed "
           + observedPark, observedPark.parkedOnMutex());
       assertFalse("the second schema tx must block on the mutex while the first holds it",
@@ -378,8 +520,8 @@ public class MetadataWriteMutexTest extends DbTestBase {
       // says "the unblocked worker must not hang", never "it must be fast". The serialization
       // itself is what the park observation and the secondCreatedClass check above proved.
       firstMayCommit.countDown();
-      assertTrue("the second schema tx must finish after the first releases the mutex",
-          secondDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+      secondWriter.awaitDone(UNBLOCKED_COMPLETION_SECONDS,
+          "the second schema tx must finish after the first releases the mutex");
     } finally {
       // Unconditional: the first worker parks on an unbounded firstMayCommit.await(), so a failed
       // assertion above must still release it — otherwise the @After join reports a leaked worker
@@ -387,22 +529,13 @@ public class MetadataWriteMutexTest extends DbTestBase {
       firstMayCommit.countDown();
     }
 
-    // BEFORE the firstError read below, not after: worker 1 counts firstDone down in its own
-    // finally, i.e. after its session close, so only this await establishes that firstError is
-    // final. Read earlier, a close() that throws right after the read would be silently dropped and
-    // the test would pass. (secondError needs no separate edge: worker 2 counts secondDone down in
-    // its own finally and the body already awaited secondDone above.)
-    assertTrue("the first schema tx worker must finish, including its own session close",
-        firstDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
-
-    if (firstError.get() != null) {
-      throw new AssertionError("the first schema tx must not error on contention",
-          firstError.get());
-    }
-    if (secondError.get() != null) {
-      throw new AssertionError("the second schema tx must not error on contention",
-          secondError.get());
-    }
+    // (d) The completion edge before the authoritative error reads. Worker 1's error holder is only
+    // final once its own session close has run, so reading it earlier would silently drop a close
+    // that throws a moment later. failIfErrored asserts this ordering rather than trusting it.
+    firstWriter.awaitDone(UNBLOCKED_COMPLETION_SECONDS,
+        "the first schema tx worker must finish, including its own session close");
+    firstWriter.failIfErrored("the first schema tx must not error on contention");
+    secondWriter.failIfErrored("the second schema tx must not error on contention");
 
     assertTrue("the second schema tx must have created its class once unblocked",
         secondCreatedClass.get());
@@ -447,34 +580,25 @@ public class MetadataWriteMutexTest extends DbTestBase {
     // from the reload below cannot succeed silently — it would park and wedge the reload.
     var mutexHeld = new CountDownLatch(1);
     var holderMayFinish = new CountDownLatch(1);
-    var holderError = new AtomicReference<Throwable>();
-    spawn(() -> {
-      try (var holder = openDatabase()) {
-        holder.activateOnCurrentThread();
-        holder.begin();
-        // One collection: this class only has to drive a schema transaction so the mutex is held.
-        // (The ReloadRippleParent/Child pair above keeps the default count — the subclass's
-        // collection membership rippling into the indexed superclass IS the subject of this test.)
-        holder.getMetadata().getSchema().createClass("ReloadRippleMutexHolder", 1);
-        mutexHeld.countDown();
-        holderMayFinish.await();
-        holder.rollback();
-      } catch (Throwable t) {
-        holderError.compareAndSet(null, t);
-        mutexHeld.countDown();
-      }
-    }, "reload-ripple-mutex-holder");
+    var holder = startWorker("reload-ripple-mutex-holder", self -> {
+      var holderSession = self.openSession();
+      holderSession.activateOnCurrentThread();
+      holderSession.begin();
+      // One collection: this class only has to drive a schema transaction so the mutex is held.
+      // (The ReloadRippleParent/Child pair above keeps the default count — the subclass's
+      // collection membership rippling into the indexed superclass IS the subject of this test.)
+      holderSession.getMetadata().getSchema().createClass("ReloadRippleMutexHolder", 1);
+      mutexHeld.countDown();
+      holderMayFinish.await();
+      holderSession.rollback();
+    }).signalling(mutexHeld);
 
     try {
-      // Inside the try like the handshake wait's four siblings elsewhere in this class: the holder
-      // parks on an unbounded holderMayFinish.await(), so if THIS wait fails the finally still has
-      // to release it — otherwise the @After join reports a stranded worker instead of the real
-      // cause. This was the last handshake wait in the file left outside its release's try.
-      awaitSignalOrWorkerError(mutexHeld, holderError, HANDSHAKE_SECONDS,
+      // Inside the try because the holder parks on an unbounded holderMayFinish.await(): if THIS
+      // wait fails the finally still has to release it, or the @After join reports a stranded
+      // worker instead of the real cause.
+      holder.awaitSignal(mutexHeld, HANDSHAKE_SECONDS,
           "the holder session must engage the mutex");
-      if (holderError.get() != null) {
-        throw new AssertionError("the mutex-holder session must not error", holderError.get());
-      }
 
       // The reload must complete while the mutex is held: the committed-view rebuild is not a
       // schema write, so its inheritance-rebuild ripples are suppressed by the reload guard
@@ -487,9 +611,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
 
     assertFalse("the reloading session must not hold the mutex after the reload",
         session.getSharedContext().getMetadataWriteMutex().isEngagedBy(session));
-    if (holderError.get() != null) {
-      throw new AssertionError("the mutex-holder session must not error", holderError.get());
-    }
+    // (d) Completion edge before the authoritative read: the holder's rollback and session close
+    // run after it was released above, and either can fail.
+    holder.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the mutex-holder session must finish");
+    holder.failIfErrored("the mutex-holder session must not error");
     // The reload rebuilt the committed view intact.
     assertTrue(session.getMetadata().getSchema().existsClass("ReloadRippleParent"));
     assertTrue(session.getMetadata().getSchema().existsClass("ReloadRippleChild"));
@@ -515,72 +640,51 @@ public class MetadataWriteMutexTest extends DbTestBase {
 
     var mutexHeld = new CountDownLatch(1);
     var schemaTxMayCommit = new CountDownLatch(1);
-    var holderError = new AtomicReference<Throwable>();
 
-    spawn(() -> {
-      try (var holder = openDatabase()) {
-        holder.activateOnCurrentThread();
-        holder.begin();
-        // Engage the mutex via a schema write, then park holding it. One collection: the class only
-        // exists to drive the schema transaction.
-        holder.getMetadata().getSchema().createClass("MutexHolderClass", 1);
-        assertTrue("the schema writer must hold the mutex",
-            holder.getSharedContext().getMetadataWriteMutex().isEngagedBy(holder));
-        mutexHeld.countDown();
-        schemaTxMayCommit.await();
-        holder.rollback();
-      } catch (Throwable t) {
-        holderError.compareAndSet(null, t);
-      } finally {
-        // Unconditional: the isEngagedBy assertion above runs BEFORE the success-path countDown, so
-        // a holder failure there used to leave the body waiting out its whole liveness bound. The
-        // body re-checks holderError immediately after its wait, so an early signal from this arm
-        // cannot let it proceed on a failed holder.
-        mutexHeld.countDown();
-      }
-    }, "mutex-holder");
+    var holder = startWorker("mutex-holder", self -> {
+      var holderSession = self.openSession();
+      holderSession.activateOnCurrentThread();
+      holderSession.begin();
+      // Engage the mutex via a schema write, then park holding it. One collection: the class only
+      // exists to drive the schema transaction.
+      holderSession.getMetadata().getSchema().createClass("MutexHolderClass", 1);
+      assertTrue("the schema writer must hold the mutex",
+          holderSession.getSharedContext().getMetadataWriteMutex().isEngagedBy(holderSession));
+      mutexHeld.countDown();
+      schemaTxMayCommit.await();
+      holderSession.rollback();
+    }).signalling(mutexHeld);
 
-    var dataDone = new CountDownLatch(1);
-    var dataError = new AtomicReference<Throwable>();
     var snapshotReadSawDataClass = new AtomicBoolean(false);
+    Worker dataWorker = null;
     try {
-      awaitSignalOrWorkerError(mutexHeld, holderError, HANDSHAKE_SECONDS,
-          "the schema writer must engage the mutex");
-      if (holderError.get() != null) {
-        throw new AssertionError("the mutex holder must not error", holderError.get());
-      }
+      // The isEngagedBy assertion above runs BEFORE the body's countDown, so a holder failure there
+      // signals only through the runner's finally; awaitSignal reports the throwable either way.
+      holder.awaitSignal(mutexHeld, HANDSHAKE_SECONDS, "the schema writer must engage the mutex");
 
       // On a separate thread (so it does not touch the test session), run a pure-data commit and a
       // snapshot-based schema read while the mutex is held. Both must complete without waiting on
       // the mutex: a regression that made them take it would block until the holder released, which
       // only happens AFTER this wait, so this is a liveness bound on a permanent block — not a
       // performance claim — and is sized for the slowest CI host.
-      spawn(() -> {
-        try (var dataSession = openDatabase()) {
-          dataSession.activateOnCurrentThread();
-          // Pure-data commit: create an entity in an existing class. Touches no schema, so it never
-          // engages the mutex and must not block behind the held permit.
-          dataSession.executeInTx(tx -> {
-            var entity = dataSession.newEntity("DataClass");
-            entity.setProperty("v", 1);
-          });
-          // Snapshot-based schema read: a plain existsClass goes through the immutable snapshot,
-          // which does not take the mutex.
-          snapshotReadSawDataClass.set(
-              dataSession.getMetadata().getSchema().existsClass("DataClass"));
-        } catch (Throwable t) {
-          dataError.compareAndSet(null, t);
-        } finally {
-          dataDone.countDown();
-        }
-      }, "data-writer-and-reader");
+      dataWorker = startWorker("data-writer-and-reader", self -> {
+        var dataSession = self.openSession();
+        dataSession.activateOnCurrentThread();
+        // Pure-data commit: create an entity in an existing class. Touches no schema, so it never
+        // engages the mutex and must not block behind the held permit.
+        dataSession.executeInTx(tx -> {
+          var entity = dataSession.newEntity("DataClass");
+          entity.setProperty("v", 1);
+        });
+        // Snapshot-based schema read: a plain existsClass goes through the immutable snapshot,
+        // which does not take the mutex.
+        snapshotReadSawDataClass.set(
+            dataSession.getMetadata().getSchema().existsClass("DataClass"));
+      });
 
-      assertTrue("a data commit and a snapshot read must complete while the mutex is held — they do"
-          + " not wait on the schema mutex",
-          dataDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
-      if (dataError.get() != null) {
-        throw new AssertionError("the data path must not be blocked by the mutex", dataError.get());
-      }
+      dataWorker.awaitDone(UNBLOCKED_COMPLETION_SECONDS,
+          "a data commit and a snapshot read must complete while the mutex is held — they do not"
+              + " wait on the schema mutex");
       assertTrue("the snapshot-based schema read must have run unblocked",
           snapshotReadSawDataClass.get());
     } finally {
@@ -590,8 +694,11 @@ public class MetadataWriteMutexTest extends DbTestBase {
       schemaTxMayCommit.countDown();
     }
 
-    if (holderError.get() != null) {
-      throw new AssertionError("the mutex holder must not error", holderError.get());
+    // (d) Completion edges before the authoritative reads.
+    holder.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the mutex holder must finish");
+    holder.failIfErrored("the mutex holder must not error");
+    if (dataWorker != null) {
+      dataWorker.failIfErrored("the data path must not be blocked by the mutex");
     }
   }
 
@@ -640,41 +747,35 @@ public class MetadataWriteMutexTest extends DbTestBase {
   public void differentThreadParksUntilRelease() throws InterruptedException {
     var mutex = session.getSharedContext().getMetadataWriteMutex();
     var foreignEngaged = new CountDownLatch(1);
-    var foreignError = new AtomicReference<Throwable>();
     var foreignSession = new AtomicReference<DatabaseSessionEmbedded>();
-    var foreignThreadRef = new AtomicReference<Thread>();
     var foreignAboutToEngage = new CountDownLatch(1);
     var foreignOrdinal = new AtomicLong();
 
     var ownOrdinal = mutex.engage(session);
+    // Declared here so the finally below can read it; assigned before any wait on it.
+    Worker parker = null;
     try {
-      spawn(() -> {
-        var other = openDatabase();
+      // The session is opened INSIDE the body (self.openSessionForTest), so a failure there is
+      // recorded and released like any other; the test thread closes it on the happy path.
+      parker = startWorker("mutex-foreign-parker", self -> {
+        var other = self.openSessionForTest();
         foreignSession.set(other);
-        try {
-          other.activateOnCurrentThread();
-          // Publish this worker's thread and signal that the next call blocks, so the test can
-          // observe this thread park on the permit deterministically.
-          foreignThreadRef.set(Thread.currentThread());
-          foreignAboutToEngage.countDown();
-          // Blocks here until the test thread releases the permit.
-          foreignOrdinal.set(mutex.engage(other));
-          foreignEngaged.countDown();
-        } catch (Throwable t) {
-          foreignError.compareAndSet(null, t);
-          foreignEngaged.countDown();
-        }
-      }, "mutex-foreign-parker");
+        other.activateOnCurrentThread();
+        // Signal that the next call blocks, so the test can observe this thread park on the permit
+        // deterministically.
+        foreignAboutToEngage.countDown();
+        // Blocks here until the test thread releases the permit.
+        foreignOrdinal.set(mutex.engage(other));
+        foreignEngaged.countDown();
+      }).signalling(foreignAboutToEngage, foreignEngaged);
 
       // While the test thread holds the permit, the foreign thread must park on it. Observe the
       // parked thread state deterministically rather than inferring parking from a negative await.
-      awaitSignalOrWorkerError(foreignAboutToEngage, foreignError, HANDSHAKE_SECONDS,
+      parker.awaitSignal(foreignAboutToEngage, HANDSHAKE_SECONDS,
           "the foreign worker must reach its blocking engage");
-      var foreignThread = foreignThreadRef.get();
-      assertNotNull("the foreign worker thread must have been published", foreignThread);
       // Deliberately short: the worker has already announced that its next call is the engage, so
       // this window only has to cover thread-state settling.
-      var observedPark = awaitParkedOnMutex(foreignThread, PARK_OBSERVATION_MILLIS);
+      var observedPark = awaitParkedOnMutex(parker.thread(), PARK_OBSERVATION_MILLIS);
       assertTrue("a foreign thread must park on the held mutex, observed " + observedPark,
           observedPark.parkedOnMutex());
       assertFalse("the foreign engage must not have completed while the permit is held",
@@ -683,11 +784,11 @@ public class MetadataWriteMutexTest extends DbTestBase {
       mutex.releaseFor(session, ownOrdinal);
     }
 
-    assertTrue("the foreign thread must engage once the permit is released",
-        foreignEngaged.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
-    if (foreignError.get() != null) {
-      throw new AssertionError("the foreign engage must succeed after release", foreignError.get());
-    }
+    parker.awaitSignal(foreignEngaged, UNBLOCKED_COMPLETION_SECONDS,
+        "the foreign thread must engage once the permit is released");
+    // (d) Completion edge before the authoritative read.
+    parker.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the foreign worker must finish");
+    parker.failIfErrored("the foreign engage must succeed after release");
     // Release on the foreign thread's behalf and close its session so the @After join is clean.
     var other = foreignSession.get();
     assertNotNull("the foreign session must have been opened", other);
@@ -874,28 +975,19 @@ public class MetadataWriteMutexTest extends DbTestBase {
     // The concurrency consequence: a fresh schema transaction on another thread must engage and
     // commit promptly. If the failed seed had stranded the permit, this worker would park forever on
     // engage and the bounded join below would leave it alive, failing the test.
-    var workerError = new AtomicReference<Throwable>();
-    var worker =
-        spawn(
-            () -> {
-              try (var next = openDatabase()) {
-                next.activateOnCurrentThread();
-                next.begin();
-                next.getMetadata().getSchema().createClass("AfterSeedFailure", 1);
-                next.commit();
-              } catch (Throwable t) {
-                workerError.compareAndSet(null, t);
-              }
-            },
-            "post-seed-failure-writer");
+    var nextWriter = startWorker("post-seed-failure-writer", self -> {
+      var next = self.openSession();
+      next.activateOnCurrentThread();
+      next.begin();
+      next.getMetadata().getSchema().createClass("AfterSeedFailure", 1);
+      next.commit();
+    });
     // LIVENESS: a stranded permit parks this worker forever, so only a hang exhausts the bound.
-    worker.join(WORKER_JOIN_MILLIS);
+    nextWriter.joinBounded(WORKER_JOIN_MILLIS);
     assertFalse("the next schema writer must not be stranded behind a leaked permit",
-        worker.isAlive());
-    if (workerError.get() != null) {
-      throw new AssertionError("the next schema writer must engage and commit after a failed seed",
-          workerError.get());
-    }
+        nextWriter.isAlive());
+    // (d) The join above is the completion edge for this read.
+    nextWriter.failIfErrored("the next schema writer must engage and commit after a failed seed");
   }
 
   /**
@@ -1034,28 +1126,20 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var engaged = new CountDownLatch(1);
     var ownerMayFinish = new CountDownLatch(1);
     var ownerSession = new AtomicReference<DatabaseSessionEmbedded>();
-    var ownerError = new AtomicReference<Throwable>();
-    spawn(() -> {
-      var owner = openDatabase();
+    // The session is opened INSIDE the body; the TEST thread tears it down on the happy path, so
+    // the runner closes it only if this worker failed.
+    var ownerWorker = startWorker("foreign-teardown-owner", self -> {
+      var owner = self.openSessionForTest();
       ownerSession.set(owner);
-      try {
-        owner.activateOnCurrentThread();
-        owner.begin();
-        owner.getMetadata().getSchema().createClass("ForeignTeardownClass", 1);
-        engaged.countDown();
-        ownerMayFinish.await();
-      } catch (Throwable t) {
-        ownerError.compareAndSet(null, t);
-        engaged.countDown();
-      }
-    }, "foreign-teardown-owner");
+      owner.activateOnCurrentThread();
+      owner.begin();
+      owner.getMetadata().getSchema().createClass("ForeignTeardownClass", 1);
+      engaged.countDown();
+      ownerMayFinish.await();
+    }).signalling(engaged);
 
     try {
-      awaitSignalOrWorkerError(engaged, ownerError, HANDSHAKE_SECONDS,
-          "the owner must engage the mutex");
-      if (ownerError.get() != null) {
-        throw new AssertionError("the owner must not error", ownerError.get());
-      }
+      ownerWorker.awaitSignal(engaged, HANDSHAKE_SECONDS, "the owner must engage the mutex");
       var owner = ownerSession.get();
       assertTrue("the owner session must hold the permit", mutex.isEngagedBy(owner));
 
@@ -1071,6 +1155,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
       // must still release it or the @After join reports a leaked worker instead of the real cause.
       ownerMayFinish.countDown();
     }
+
+    // (d) Completion edge before the authoritative read: the owner unparks only once released.
+    ownerWorker.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the owner worker must finish");
+    ownerWorker.failIfErrored("the owner must not error");
 
     session.activateOnCurrentThread();
     // The permit is usable by the next writer.
@@ -1094,44 +1182,35 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var mutex = session.getSharedContext().getMetadataWriteMutex();
     var holderOrdinal = mutex.engage(session); // the permit is held, so the victim's engage parks
     var victimRef = new AtomicReference<DatabaseSessionEmbedded>();
+    // victimThrown captures the engage failure this test is ASSERTING on, caught inside the body so
+    // it never becomes the worker's error; the worker's own holder covers everything else.
     var victimThrown = new AtomicReference<Throwable>();
     var victimReady = new CountDownLatch(1);
-    var victimDone = new CountDownLatch(1);
-    // Distinct from victimThrown, which captures the engage failure this test is ASSERTING on: this
-    // one records a victim that failed on the way there (opening its session, beginning its tx), so
-    // the body reports that instead of waiting out its liveness bound on a signal that never comes.
-    var victimError = new AtomicReference<Throwable>();
-    var worker = spawn(() -> {
+    var victim = startWorker("post-acquire-dekker-victim", self -> {
+      var victimSession = self.openSession();
+      victimRef.set(victimSession);
+      victimSession.activateOnCurrentThread();
+      victimSession.begin();
+      victimReady.countDown();
       try {
-        var victim = openDatabase();
-        victimRef.set(victim);
-        victim.activateOnCurrentThread();
-        victim.begin();
-        victimReady.countDown();
-        try {
-          // Parks in the engage wait; after the holder releases, the acquire succeeds and the
-          // post-acquire re-check sees the mark set below.
-          victim.getMetadata().getSchema().createClass("PostAcquireDekker", 1);
-        } catch (Throwable t) {
-          victimThrown.set(t);
-        } finally {
-          victim.getTransactionInternal().rollbackInternal();
-          victim.clearTeardownIntent();
-          victim.close();
-        }
+        // Parks in the engage wait; after the holder releases, the acquire succeeds and the
+        // post-acquire re-check sees the mark set below.
+        victimSession.getMetadata().getSchema().createClass("PostAcquireDekker", 1);
       } catch (Throwable t) {
-        victimError.compareAndSet(null, t);
+        victimThrown.set(t);
       } finally {
-        victimDone.countDown();
+        victimSession.getTransactionInternal().rollbackInternal();
+        victimSession.clearTeardownIntent();
+        victimSession.close();
       }
-    }, "post-acquire-dekker-victim");
+    }).signalling(victimReady);
 
     try {
-      awaitSignalOrWorkerError(victimReady, victimError, HANDSHAKE_SECONDS,
+      victim.awaitSignal(victimReady, HANDSHAKE_SECONDS,
           "the victim must reach its blocking schema write");
       // Deliberately short: victimReady already proves the victim reached its blocking write, so
       // only thread-state settling is being waited on here.
-      var observedPark = awaitParkedOnMutex(worker, PARK_OBSERVATION_MILLIS);
+      var observedPark = awaitParkedOnMutex(victim.thread(), PARK_OBSERVATION_MILLIS);
       assertTrue("the victim must park on the held permit, observed " + observedPark,
           observedPark.parkedOnMutex());
       // The mark lands while the victim is parked INSIDE the permit wait — past its loop-top
@@ -1141,8 +1220,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
       mutex.releaseFor(session, holderOrdinal);
     }
 
-    assertTrue("the victim must finish",
-        victimDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+    // (d) Completion edge, then the authoritative read: a rollback or close failure in the victim's
+    // own cleanup lands in its holder just before it finishes.
+    victim.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the victim must finish");
+    victim.failIfErrored("the victim's session handling must not error");
     assertNotNull("the marked victim's engage must have failed", victimThrown.get());
     assertTrue("the failure must be the post-acquire self-release branch (message pins the"
         + " 'while engaging' arm, not the loop-top 'while waiting' arm): " + victimThrown.get(),
@@ -1185,35 +1266,31 @@ public class MetadataWriteMutexTest extends DbTestBase {
     });
 
     // firstInListener is counted down by the close listener, so a winner that throws BEFORE its
-    // listener fires would never signal; recording its throwable lets the wait below report that
-    // instead of the missing signal.
-    var firstTeardownError = new AtomicReference<Throwable>();
-    var first = spawn(() -> {
-      try {
-        victim.activateOnCurrentThread();
-        victim.internalClose(false);
-      } catch (Throwable t) {
-        firstTeardownError.compareAndSet(null, t);
-      }
-    }, "teardown-first");
+    // listener fires would never signal it on its own; declaring it here releases the waiter on
+    // that path too, and awaitSignal then reports the throwable rather than the missing signal.
+    var first = startWorker("teardown-first", self -> {
+      victim.activateOnCurrentThread();
+      victim.internalClose(false);
+    }).signalling(firstInListener);
+    Worker second = null;
     try {
       // LIVENESS, not a short bound: the hold clock starts when the winner ENTERS the listener,
       // which is the same moment this wait returns, so time spent reaching the listener consumes no
       // hold time and widening this cannot make the test vacuous.
-      awaitSignalOrWorkerError(firstInListener, firstTeardownError, HANDSHAKE_SECONDS,
+      first.awaitSignal(firstInListener, HANDSHAKE_SECONDS,
           "the first teardown must reach its close listener");
 
       // The second teardown runs while the first is mid-body (status still OPEN): it must no-op on
       // the atomic claim rather than double-running the listeners and the session-count decrement.
-      var second = spawn(() -> {
+      second = startWorker("teardown-second", self -> {
         victim.activateOnCurrentThread();
         victim.internalClose(false);
-      }, "teardown-second");
+      });
       // Deliberately SHORT, and the one bound that must stay under LISTENER_HOLD_SECONDS (asserted
       // at class init): "promptly" means "while the winner is still pinned inside its close
       // listener", and the loser runs one CAS and no I/O, so a slow host cannot need more — only a
       // regression that actually re-ran the teardown body would.
-      second.join(NOOP_TEARDOWN_JOIN_MILLIS);
+      second.joinBounded(NOOP_TEARDOWN_JOIN_MILLIS);
       assertFalse("the losing teardown must no-op promptly", second.isAlive());
     } finally {
       // Unconditional: a failed assertion above must not leave the winning teardown pinned in its
@@ -1221,8 +1298,12 @@ public class MetadataWriteMutexTest extends DbTestBase {
       releaseListener.countDown();
     }
 
-    first.join(WORKER_JOIN_MILLIS);
+    first.joinBounded(WORKER_JOIN_MILLIS);
     assertFalse("the winning teardown must complete", first.isAlive());
+    // (d) Both joins are completion edges: a teardown that threw — the winner late in its body, or
+    // the loser instead of no-opping — used to pass unnoticed here.
+    first.failIfErrored("the winning teardown must not throw");
+    second.failIfErrored("the losing teardown must not throw");
     assertEquals("exactly one full teardown may run (single listener firing, single"
         + " session-count decrement)", 1L, closeListenerFired.get());
 
@@ -1260,42 +1341,31 @@ public class MetadataWriteMutexTest extends DbTestBase {
     // Single-permit proof: engage through one session, then a second engager must PARK rather
     // than acquire a phantom second permit.
     var firstOrdinal = mutex.engage(session);
-    var proberThread = new AtomicReference<Thread>();
     var proberReady = new CountDownLatch(1);
-    var proberError = new AtomicReference<Throwable>();
     var acquired = new CountDownLatch(1);
     var secondOrdinal = new AtomicLong();
     var secondSession = new AtomicReference<DatabaseSessionEmbedded>();
-    spawn(() -> {
-      try {
-        var other = openDatabase();
-        secondSession.set(other);
-        other.activateOnCurrentThread();
-        proberThread.set(Thread.currentThread());
-        // Latch handshake, not a busy-spin the observer runs: opening the session above is real
-        // disk work, and a 60 s Thread.onSpinWait() loop would hot-spin a core inside a fork that
-        // runs four test classes in parallel.
-        proberReady.countDown();
-        secondOrdinal.set(mutex.engage(other));
-        acquired.countDown();
-      } catch (Throwable t) {
-        // Without this the prober's failure was invisible: the observer just waited out its bound.
-        proberError.compareAndSet(null, t);
-        proberReady.countDown();
-      }
-    }, "double-release-prober");
+    // BOTH latches are declared: the test waits on proberReady first and on acquired afterwards, so
+    // a prober that fails inside engage() has to release the second one too - releasing only the
+    // first left the later wait to stall out its whole bound and discard the real error.
+    var prober = startWorker("double-release-prober", self -> {
+      var other = self.openSessionForTest();
+      secondSession.set(other);
+      other.activateOnCurrentThread();
+      // Latch handshake, not a busy-spin the observer runs: opening the session above is real disk
+      // work, and a 60 s Thread.onSpinWait() loop would hot-spin a core inside a fork that runs
+      // four test classes in parallel.
+      proberReady.countDown();
+      secondOrdinal.set(mutex.engage(other));
+      acquired.countDown();
+    }).signalling(proberReady, acquired);
 
     try {
       // LIVENESS: the prober signals only after opening its own session, which is real disk work,
       // so this is sized for the slowest CI host. It returns as soon as the signal lands.
-      awaitSignalOrWorkerError(proberReady, proberError, HANDSHAKE_SECONDS,
-          "the prober must start");
-      if (proberError.get() != null) {
-        throw new AssertionError("the prober must reach its engage", proberError.get());
-      }
-      assertNotNull("the prober must have published its thread", proberThread.get());
+      prober.awaitSignal(proberReady, HANDSHAKE_SECONDS, "the prober must start");
       // Deliberately short: the prober's next call after signalling IS the engage.
-      var observedPark = awaitParkedOnMutex(proberThread.get(), PARK_OBSERVATION_MILLIS);
+      var observedPark = awaitParkedOnMutex(prober.thread(), PARK_OBSERVATION_MILLIS);
       assertTrue("a second engager must park on the single permit (a double release would have"
           + " admitted it immediately), observed " + observedPark,
           observedPark.parkedOnMutex());
@@ -1309,8 +1379,11 @@ public class MetadataWriteMutexTest extends DbTestBase {
       mutex.releaseFor(session, firstOrdinal);
     }
 
-    assertTrue("the prober must acquire after the release",
-        acquired.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+    prober.awaitSignal(acquired, UNBLOCKED_COMPLETION_SECONDS,
+        "the prober must acquire after the release");
+    // (d) Completion edge before the authoritative read.
+    prober.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the prober must finish");
+    prober.failIfErrored("the prober must engage after the release");
     mutex.releaseFor(secondSession.get(), secondOrdinal.get());
     var other = secondSession.get();
     other.activateOnCurrentThread();
@@ -1373,47 +1446,36 @@ public class MetadataWriteMutexTest extends DbTestBase {
     });
 
     var pooledRef = new AtomicReference<DatabaseSessionEmbedded>();
-    var commitError = new AtomicReference<Throwable>();
-    var committed = new CountDownLatch(1);
+    Worker owner = null;
+    Worker poolCloser = null;
     try {
-      spawn(() -> {
-        try {
-          var pooled = pool.acquire();
-          pooledRef.set(pooled);
-          pooled.begin();
-          pooled.getMetadata().getSchema().createClass("PoolSkipClass", 1);
-          pooled.commit();
-        } catch (Throwable t) {
-          commitError.compareAndSet(null, t);
-        } finally {
-          committed.countDown();
-        }
-      }, "pool-skip-owner");
+      // The pooled session belongs to the pool, which pool.close() below tears down, so it is
+      // neither worker- nor test-owned here.
+      owner = startWorker("pool-skip-owner", self -> {
+        var pooled = pool.acquire();
+        pooledRef.set(pooled);
+        pooled.begin();
+        pooled.getMetadata().getSchema().createClass("PoolSkipClass", 1);
+        pooled.commit();
+      }).signalling(inWindow);
 
       // inWindow is signalled by the commit-window hook, so an owner that fails before reaching the
-      // window never signals; this reports the owner's throwable instead of the missing signal.
-      awaitSignalOrWorkerError(inWindow, commitError, HANDSHAKE_SECONDS,
+      // window never signals it on its own; declaring it releases this wait on that path too.
+      owner.awaitSignal(inWindow, HANDSHAKE_SECONDS,
           "the owner must park inside the commit window");
 
       // Pool close while the owner is mid-commit: the skip branch marks and defers. Run it on
       // its own thread with a bounded await so a skip regression (a full teardown that parks on
       // the commit's held locks) FAILS the test instead of hanging the fork — the window latch is
       // still released by the finally below either way.
-      var poolCloseDone = new CountDownLatch(1);
-      spawn(() -> {
-        try {
-          pool.close();
-        } finally {
-          poolCloseDone.countDown();
-        }
-      }, "pool-closer");
+      poolCloser = startWorker("pool-closer", self -> pool.close());
       // LIVENESS despite the "promptly" wording: the regression this catches is a full teardown
       // that parks on the live commit's held locks and therefore NEVER returns, so widening the
       // bound for a slow host does not weaken the check — pool.close() also tears down the pool's
       // other sessions, which is real disk work.
-      assertTrue("pool.close() must return promptly — the skip must neither park on the live"
-          + " commit nor tear it down",
-          poolCloseDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+      poolCloser.awaitDone(UNBLOCKED_COMPLETION_SECONDS,
+          "pool.close() must return promptly — the skip must neither park on the live commit nor"
+              + " tear it down");
       var pooled = pooledRef.get();
       assertNotNull(pooled);
       // Lock-free status probe: isClosed() would take the storage state lock and block behind
@@ -1422,18 +1484,16 @@ public class MetadataWriteMutexTest extends DbTestBase {
           DatabaseSessionEmbedded.STATUS.OPEN, pooled.getStatus());
       assertTrue("the skip must not release the live commit's permit",
           mutex.isEngagedBy(pooled));
-      assertEquals("the commit must still be parked in the window", 1, committed.getCount());
+      assertFalse("the commit must still be parked in the window", owner.isFinished());
     } finally {
       releaseWindow.countDown();
       storage.setCommitWindowTestHook(null);
     }
 
-    assertTrue("the owner's commit must finish",
-        committed.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
-    if (commitError.get() != null) {
-      throw new AssertionError(
-          "the deferred teardown must not disturb the commit outcome", commitError.get());
-    }
+    // (d) Completion edges before the authoritative reads.
+    owner.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the owner's commit must finish");
+    owner.failIfErrored("the deferred teardown must not disturb the commit outcome");
+    poolCloser.failIfErrored("the pool close must not throw");
     var pooled = pooledRef.get();
     // The owner's completer ran the full teardown on the owning thread. (The window is released
     // now, so the lock-taking isClosed() probe is safe again.)
@@ -1460,29 +1520,19 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var engaged = new CountDownLatch(1);
     var ownerMayFinish = new CountDownLatch(1);
     var pooledRef = new AtomicReference<DatabaseSessionEmbedded>();
-    // The owner's throwable used to be swallowed here, leaving the body to fail on a null pooled
-    // session with no hint of why.
-    var ownerError = new AtomicReference<Throwable>();
-    spawn(() -> {
-      try {
-        var pooled = pool.acquire();
-        pooledRef.set(pooled);
-        pooled.begin();
-        pooled.getMetadata().getSchema().createClass("PoolFallThroughClass", 1);
-        engaged.countDown();
-        ownerMayFinish.await();
-      } catch (Throwable t) {
-        ownerError.compareAndSet(null, t);
-        engaged.countDown();
-      }
-    }, "pool-fallthrough-owner");
+    // The pooled session is the pool's to close (pool.close() below); the owner's throwable used to
+    // be swallowed here, leaving the body to fail on a null pooled session with no hint of why.
+    var owner = startWorker("pool-fallthrough-owner", self -> {
+      var pooled = pool.acquire();
+      pooledRef.set(pooled);
+      pooled.begin();
+      pooled.getMetadata().getSchema().createClass("PoolFallThroughClass", 1);
+      engaged.countDown();
+      ownerMayFinish.await();
+    }).signalling(engaged);
 
     try {
-      awaitSignalOrWorkerError(engaged, ownerError, HANDSHAKE_SECONDS,
-          "the owner must engage the mutex");
-      if (ownerError.get() != null) {
-        throw new AssertionError("the pool-fallthrough owner must not error", ownerError.get());
-      }
+      owner.awaitSignal(engaged, HANDSHAKE_SECONDS, "the owner must engage the mutex");
       var pooled = pooledRef.get();
       assertNotNull(pooled);
       assertTrue(mutex.isEngagedBy(pooled));
@@ -1497,6 +1547,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
       // must still release it or the @After join reports a leaked worker instead of the real cause.
       ownerMayFinish.countDown();
     }
+
+    // (d) Completion edge before the authoritative read.
+    owner.awaitDone(UNBLOCKED_COMPLETION_SECONDS, "the pool-fallthrough owner must finish");
+    owner.failIfErrored("the pool-fallthrough owner must not error");
 
     session.activateOnCurrentThread();
     session.executeInTx(
@@ -1558,14 +1612,12 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var thrown = new AtomicReference<Throwable>();
     var flagRestored = new AtomicBoolean(false);
     var waiterStarted = new CountDownLatch(1);
-    // Same reason as the prober in doubleReleaseKeepsSinglePermit: without a holder, a failing
-    // openDatabase() killed this worker silently and the body just waited out its liveness bound.
-    var waiterError = new AtomicReference<Throwable>();
     try {
-      var waiter = spawn(() -> {
-        DatabaseSessionEmbedded other = null;
+      var waiter = startWorker("interrupted-engage-waiter", self -> {
+        // The session is worker-owned: the runner closes it after this body returns, which is why
+        // the interrupt flag is cleared here first (a set flag would disturb that close).
+        var other = self.openSession();
         try {
-          other = openDatabase();
           other.activateOnCurrentThread();
           waiterStarted.countDown();
           try {
@@ -1574,37 +1626,28 @@ public class MetadataWriteMutexTest extends DbTestBase {
             thrown.set(t);
             flagRestored.set(Thread.currentThread().isInterrupted());
           }
-        } catch (Throwable t) {
-          waiterError.compareAndSet(null, t);
         } finally {
-          // Clear the interrupt status before the teardown so the session close is undisturbed.
           Thread.interrupted();
-          if (other != null) {
-            other.activateOnCurrentThread();
-            other.close();
-          }
         }
-      }, "interrupted-engage-waiter");
+      }).signalling(waiterStarted);
 
-      awaitSignalOrWorkerError(waiterStarted, waiterError, HANDSHAKE_SECONDS,
-          "the waiter must start");
+      waiter.awaitSignal(waiterStarted, HANDSHAKE_SECONDS, "the waiter must start");
       // Deliberately short: the waiter's next call after the start latch is the engage itself.
-      var observedPark = awaitParkedOnMutex(waiter, PARK_OBSERVATION_MILLIS);
+      var observedPark = awaitParkedOnMutex(waiter.thread(), PARK_OBSERVATION_MILLIS);
       assertTrue("the waiter must park on the held permit, observed " + observedPark,
           observedPark.parkedOnMutex());
-      waiter.interrupt();
+      waiter.thread().interrupt();
       // LIVENESS: an interruptible waiter exits at once; only a regression back to an
       // uninterruptible park exhausts this bound.
-      waiter.join(WORKER_JOIN_MILLIS);
+      waiter.joinBounded(WORKER_JOIN_MILLIS);
       assertFalse("the interrupted waiter must exit", waiter.isAlive());
+      // (d) The join is the completion edge for this read.
+      waiter.failIfErrored("the waiter's session handling must not error");
       assertNotNull("the interrupted waiter must have thrown", thrown.get());
       assertTrue("the throw must be a DatabaseException naming the wait: " + thrown.get(),
           thrown.get() instanceof DatabaseException
               && thrown.get().getMessage().contains("interrupted while waiting"));
       assertTrue("the interrupt flag must be restored before the throw", flagRestored.get());
-      if (waiterError.get() != null) {
-        throw new AssertionError("the waiter's session handling must not error", waiterError.get());
-      }
     } finally {
       mutex.releaseFor(session, holderOrdinal);
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.internal.core.db;
 
+import static com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics.dumpThreads;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -33,6 +34,13 @@ import org.junit.Test;
  * fails loudly instead of self-deadlocking; a foreign thread parks until release; and a mis-ordered
  * engage (from inside a held shared metadata lock) trips the engage-order assertion.
  *
+ * <p>Classes created here purely to drive a schema transaction are created with ONE collection
+ * ({@code createClass(name, 1)}) instead of the default eight: each collection is its own pair of
+ * files, so the default made every driver class cost ~16 file creations and none of these tests
+ * asserts anything about collection count. The one exception is the {@code ReloadRippleParent} /
+ * {@code ReloadRippleChild} pair, whose collection membership is the subject of the reload-ripple
+ * test and is therefore left on the default path.
+ *
  * <p>The abnormal-termination permit handshake IS exercised here: the widened teardown release
  * pass, the Dekker teardown-intent pair (both deterministic shapes), the stranded-holder
  * re-engage throw, the double-release single-permit proof, the pool-close skip protocol with the
@@ -40,6 +48,66 @@ import org.junit.Test;
  * Only the freezer gate remains a later step and is not exercised here.
  */
 public class MetadataWriteMutexTest extends DbTestBase {
+
+  // ---------------------------------------------------------------------------------------------
+  // Wait budgets. This class carries no @Test(timeout) — the JUnitTestListener watchdog is the
+  // whole-test hang detector — so every bound below exists only to turn a hang into a named
+  // failure. Budget derivation, stated once for all of them: the class costs ~14.5 s locally on
+  // DISK storage (`-Dyoutrackdb.test.env=ci`) and ~1.9 s on MEMORY storage, which is the module
+  // default and what most CI legs run; the Windows disk-storage leg took 121-129 s, i.e. 3.34x
+  // (p50) / 5.01x (p95) / 7.73x (max) the reference host. Every LIVENESS bound is therefore sized
+  // an order of magnitude above its local cost, comfortably past the worst observed factor: a
+  // genuinely stuck mutex acquire still fails the test, a merely slow host never does. The three
+  // SHORT budgets are deliberately NOT scaled — their shortness IS the assertion — and each of
+  // their call sites repeats why.
+  // ---------------------------------------------------------------------------------------------
+
+  /// LIVENESS: a spawned worker must reach a handshake point — engaging the mutex, publishing its
+  /// thread, entering a commit window. Costs milliseconds locally. Note that a worker which THROWS
+  /// before its handshake also exhausts this bound, because these latches are counted down on the
+  /// success path only; the failing worker's own error holder is what names the real cause, so the
+  /// waits that have one consult it (see `twoConcurrentSchemaTransactionsSerializeWithoutAbort`).
+  private static final long HANDSHAKE_SECONDS = 60L;
+
+  /// LIVENESS: once the blocking condition is lifted (permit released, commit window opened) the
+  /// unblocked worker must run its schema write, commit and teardown through to completion. Larger
+  /// than [#HANDSHAKE_SECONDS] because that is real disk work, not a latch flip.
+  private static final long UNBLOCKED_COMPLETION_SECONDS = 90L;
+
+  /// LIVENESS: bounded [Thread#join] for a worker that must already be finishing — its work is
+  /// done, or it was interrupted. In millis to match the join signature.
+  private static final long WORKER_JOIN_MILLIS = 60_000L;
+
+  /// SPIN-OBSERVATION, deliberately SHORT and NOT host-scaled: the window in which a worker that
+  /// has ALREADY announced it is about to block must be observed parked in the mutex. It measures
+  /// thread-state settling (microseconds), never database work, so scaling it with the host would
+  /// only slow down the failure case.
+  private static final long PARK_OBSERVATION_MILLIS = 5_000L;
+
+  /// NO-OP-PROMPTNESS, deliberately NOT host-scaled: the losing teardown must lose the atomic claim
+  /// and return within this bound. It runs one CAS and no I/O.
+  ///
+  /// This is the ONE bound that must stay below [#LISTENER_HOLD_SECONDS]. The hold clock starts
+  /// when the winner enters its close listener, which is also the moment the body's reach wait
+  /// returns — so reaching the listener consumes no hold time, and only what the body does AFTER
+  /// that (spawn the loser, join it for this bound) has to fit inside the hold. Widen this past the
+  /// hold and "promptly" stops meaning "while the winner is still pinned in its listener", i.e. the
+  /// test would pass vacuously.
+  private static final long NOOP_TEARDOWN_JOIN_MILLIS = 5_000L;
+
+  /// How long the winning teardown stays pinned inside its close listener, which is what makes the
+  /// racing-teardown overlap deterministic. It is a backstop against a hang, not a performance
+  /// bound.
+  private static final long LISTENER_HOLD_SECONDS = 10L;
+
+  static {
+    // Enforced rather than merely documented: the units differ (millis vs seconds), so prose alone
+    // was one careless edit away from a vacuously passing racing-teardown test.
+    // Core tests run with -ea, so this fires at class-init time.
+    assert NOOP_TEARDOWN_JOIN_MILLIS < TimeUnit.SECONDS.toMillis(LISTENER_HOLD_SECONDS)
+        : "the losing teardown must be joined while the winner is still pinned in its close"
+            + " listener: NOOP_TEARDOWN_JOIN_MILLIS must stay below LISTENER_HOLD_SECONDS";
+  }
 
   private final List<Thread> spawnedWorkers = new CopyOnWriteArrayList<>();
 
@@ -58,38 +126,111 @@ public class MetadataWriteMutexTest extends DbTestBase {
   }
 
   /**
-   * Spin until {@code worker} settles into a parked state (WAITING/TIMED_WAITING — the states a
-   * thread blocked on {@code Semaphore.acquireUninterruptibly} reports) or the timeout elapses,
-   * returning the last observed state. Used to prove a worker is parked on the mutex permit by
-   * observing its thread state rather than inferring blocking from absence of progress after a sleep,
-   * so the blocking proof fails closed if a regression lets the worker through instead of parking it.
+   * Outcome of a park observation: whether the worker was seen parked INSIDE the metadata-write
+   * mutex's engage wait, plus the last observed thread state and the matched mutex frame, so a
+   * failing assertion says which of the two halves was missing.
    */
-  private static Thread.State awaitThreadParked(Thread worker, long timeoutMillis) {
-    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
-    Thread.State state = worker.getState();
+  private record MutexPark(boolean parkedOnMutex, Thread.State state, String mutexFrame) {
+
+    @Override
+    public String toString() {
+      if (parkedOnMutex) {
+        return "parked in " + mutexFrame + " (thread state " + state + ")";
+      }
+      return "NOT parked on the mutex (thread state " + state + ", no "
+          + MetadataWriteMutex.class.getSimpleName() + ".engage frame on its stack)";
+    }
+  }
+
+  /**
+   * Spin until {@code worker} settles into a parked state (WAITING/TIMED_WAITING — the states a
+   * thread blocked in the mutex's timed {@code tryAcquire} wait reports) INSIDE
+   * {@link MetadataWriteMutex#engage}, or the timeout elapses. Used to prove a worker is parked on
+   * the mutex permit by observing its thread state rather than inferring blocking from absence of
+   * progress after a sleep, so the blocking proof fails closed if a regression lets the worker
+   * through instead of parking it.
+   *
+   * <p>Deliberately NOT named {@code awaitThreadParked} like the state-only helpers in
+   * {@code FreezerGateTest} and {@code ScalableRWLockTest}: this one additionally requires the
+   * mutex-engage frame, and sharing their name for stricter semantics would be the trap. Those
+   * copies are left alone here because they observe different (non-mutex) waits.
+   *
+   * <p>The stack check is the other half of that fail-closed property: a parked STATE alone is also
+   * satisfied by a thread parked for an unrelated reason (a disk read in {@code openDatabase}, a
+   * log flush), under which a mutex that had stopped blocking would still pass. The stack is
+   * sampled only once the state matches, and at a millisecond cadence rather than in the spin:
+   * {@link Thread#getStackTrace()} on a live thread costs a safepoint.
+   */
+  private static MutexPark awaitParkedOnMutex(Thread worker, long timeoutMillis) {
+    var deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+    var state = worker.getState();
     while (System.nanoTime() < deadline) {
       state = worker.getState();
       if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
-        return state;
+        var frame = mutexEngageFrame(worker);
+        if (frame != null) {
+          return new MutexPark(true, state, frame);
+        }
+        // Parked, but not (yet) in the mutex — e.g. still opening its own session. Re-sample the
+        // stack on a millisecond cadence so the walks do not saturate the safepoint.
+        try {
+          Thread.sleep(1L);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return new MutexPark(false, state, null);
+        }
+        continue;
       }
       Thread.onSpinWait();
     }
-    return state;
+    return new MutexPark(false, state, null);
+  }
+
+  /**
+   * The {@link MetadataWriteMutex} engage frame on {@code worker}'s current stack, or {@code null}
+   * when the worker is not inside an engage. Matched on the declaring class plus an {@code engage}
+   * method-name prefix, so a future timed or interruptible engage variant is covered too.
+   */
+  private static String mutexEngageFrame(Thread worker) {
+    for (var frame : worker.getStackTrace()) {
+      if (MetadataWriteMutex.class.getName().equals(frame.getClassName())
+          && frame.getMethodName().startsWith("engage")) {
+        return frame.getClassName() + "." + frame.getMethodName();
+      }
+    }
+    return null;
   }
 
   @After
   public void joinSpawnedWorkers() throws InterruptedException {
     var leaked = new java.util.ArrayList<String>();
     for (var t : spawnedWorkers) {
-      t.join(5_000);
+      // LIVENESS: a worker that has finished its scenario returns immediately; a worker stuck on a
+      // mutex permit (or dying late in its teardown) is what exhausts this bound, so it is sized
+      // for the slowest CI host.
+      t.join(WORKER_JOIN_MILLIS);
       if (t.isAlive()) {
         leaked.add(t.getName());
+      }
+    }
+    if (!leaked.isEmpty()) {
+      // Dump BEFORE the interrupts below, which unwind the stacks that explain the leak. This is
+      // the only diagnosis this class can get: a worker parked in MetadataWriteMutex.engage waits
+      // on a Semaphore, which records no AQS exclusive owner, so the watchdog's detector
+      // (ThreadMXBean.findDeadlockedThreads) provably cannot see it, and the watchdog would only
+      // fire after its own multi-minute timeout anyway.
+      dumpThreads("MetadataWriteMutexTest.joinSpawnedWorkers: workers did not join within "
+          + WORKER_JOIN_MILLIS + "ms: " + leaked);
+    }
+    for (var t : spawnedWorkers) {
+      if (t.isAlive()) {
         t.interrupt();
       }
     }
     spawnedWorkers.clear();
     if (!leaked.isEmpty()) {
-      fail("workers did not join within 5s — likely a stuck mutex acquire: " + leaked);
+      fail("workers did not join within " + WORKER_JOIN_MILLIS
+          + "ms — likely a stuck mutex acquire: " + leaked);
     }
   }
 
@@ -108,80 +249,128 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var firstMayCommit = new CountDownLatch(1);
     var secondCreatedClass = new AtomicBoolean(false);
     var secondAborted = new AtomicBoolean(false);
+    // One error holder PER worker: with a single shared holder, a first-worker failure surfaced
+    // under a message that named neither worker ("no schema tx should error on contention"), and
+    // whichever worker lost the compareAndSet had its throwable dropped entirely.
+    var firstError = new AtomicReference<Throwable>();
     var secondError = new AtomicReference<Throwable>();
+    // Counted down in worker 1's own finally, i.e. AFTER its session close. It is the
+    // happens-before edge for the firstError read at the end: the mutex permit is released before
+    // commit() returns, so without this edge the body could read firstError while worker 1 is still
+    // inside first.close(), silently dropping a teardown failure recorded a moment later.
+    var firstDone = new CountDownLatch(1);
     var secondAboutToEngage = new CountDownLatch(1);
     var secondThreadRef = new AtomicReference<Thread>();
 
     // First session: open a schema tx, engage the mutex by creating a class, then park holding it
     // until the test releases it. Runs on its own thread so its session activation does not collide
-    // with the test thread's default session.
+    // with the test thread's default session. One collection per class: these classes exist only to
+    // drive a schema transaction, and the default eight would create ~16 files apiece.
     spawn(() -> {
       try (var first = openDatabase()) {
         first.activateOnCurrentThread();
         first.begin();
-        first.getMetadata().getSchema().createClass("FirstSchemaTx");
+        first.getMetadata().getSchema().createClass("FirstSchemaTx", 1);
         firstHoldsMutex.countDown();
         firstMayCommit.await();
         first.commit();
       } catch (Throwable t) {
-        secondError.compareAndSet(null, t);
+        firstError.compareAndSet(null, t);
+      } finally {
+        // Runs after the try-with-resources close, and the catch above covers that close, so by the
+        // time this fires firstError is final for this worker.
+        firstDone.countDown();
       }
     }, "mutex-first-writer");
 
-    assertTrue("first session must engage the mutex", firstHoldsMutex.await(5, TimeUnit.SECONDS));
-
-    // Second session: try to start a schema tx while the first holds the mutex. Its createClass must
-    // block on the mutex, so secondCreatedClass stays false until the first releases.
     var secondDone = new CountDownLatch(1);
-    spawn(() -> {
-      try (var second = openDatabase()) {
-        second.activateOnCurrentThread();
-        second.begin();
-        try {
-          // Publish this worker's thread and signal that the very next call is the blocking schema
-          // write, so the test can observe this thread park on the permit deterministically.
-          secondThreadRef.set(Thread.currentThread());
-          secondAboutToEngage.countDown();
-          second.getMetadata().getSchema().createClass("SecondSchemaTx");
-          secondCreatedClass.set(true);
-          second.commit();
-        } catch (Throwable txError) {
-          secondAborted.set(true);
-          throw txError;
+    try {
+      if (!firstHoldsMutex.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS)) {
+        // The handshake can only time out because the first worker died before engaging, so report
+        // ITS failure rather than the latch symptom — that cause used to be swallowed here.
+        if (firstError.get() != null) {
+          throw new AssertionError("the first schema tx failed before engaging the mutex",
+              firstError.get());
         }
-      } catch (Throwable t) {
-        secondError.compareAndSet(null, t);
-      } finally {
-        secondDone.countDown();
+        fail("first session must engage the mutex");
       }
-    }, "mutex-second-writer");
 
-    // Wait until the second worker is about to make its blocking schema write, then observe it
-    // actually park on the permit (WAITING/TIMED_WAITING) rather than inferring blocking from a
-    // sleep. The full-path latch only proves the worker reached the call; the thread-state poll
-    // proves the call is parked on the semaphore, so this fails closed if a regression let the
-    // second writer through instead of blocking it.
-    assertTrue("the second worker must reach its blocking schema write",
-        secondAboutToEngage.await(5, TimeUnit.SECONDS));
-    var secondThread = secondThreadRef.get();
-    assertNotNull("the second worker thread must have been published", secondThread);
-    var parkedState = awaitThreadParked(secondThread, 5_000);
-    assertTrue("the second schema tx must park on the mutex while the first holds it, observed in"
-        + " thread state " + parkedState,
-        parkedState == Thread.State.WAITING || parkedState == Thread.State.TIMED_WAITING);
-    assertFalse("the second schema tx must block on the mutex while the first holds it",
-        secondCreatedClass.get());
-    assertFalse("the second schema tx must not be aborted by contention — it blocks instead",
-        secondAborted.get());
+      // Second session: try to start a schema tx while the first holds the mutex. Its createClass
+      // must block on the mutex, so secondCreatedClass stays false until the first releases.
+      spawn(() -> {
+        try (var second = openDatabase()) {
+          second.activateOnCurrentThread();
+          second.begin();
+          try {
+            // Publish this worker's thread and signal that the very next call is the blocking
+            // schema write, so the test can observe this thread park on the permit
+            // deterministically.
+            secondThreadRef.set(Thread.currentThread());
+            secondAboutToEngage.countDown();
+            second.getMetadata().getSchema().createClass("SecondSchemaTx", 1);
+            // No mutex-holder check here on purpose. engage() overwrites the single holder slot
+            // unconditionally, so "the first session no longer holds it" is true the instant THIS
+            // write returns even under a hypothetical two-permit mutex that let both writers run
+            // concurrently - i.e. it cannot fail, and it cannot prove serialization. What does
+            // prove it is below: the park observation and secondCreatedClass staying false while
+            // the first holds the permit both go red against a two-permit regression.
+            secondCreatedClass.set(true);
+            second.commit();
+          } catch (Throwable txError) {
+            secondAborted.set(true);
+            throw txError;
+          }
+        } catch (Throwable t) {
+          secondError.compareAndSet(null, t);
+        } finally {
+          secondDone.countDown();
+        }
+      }, "mutex-second-writer");
 
-    // Release the first; the second now acquires the mutex and finishes.
-    firstMayCommit.countDown();
-    assertTrue("the second schema tx must finish after the first releases the mutex",
-        secondDone.await(5, TimeUnit.SECONDS));
+      // Wait until the second worker is about to make its blocking schema write, then observe it
+      // actually park on the permit (WAITING/TIMED_WAITING, inside the mutex's engage frame) rather
+      // than inferring blocking from a sleep. The full-path latch only proves the worker reached
+      // the call; the park observation proves the call is parked on the semaphore, so this fails
+      // closed if a regression let the second writer through instead of blocking it.
+      assertTrue("the second worker must reach its blocking schema write",
+          secondAboutToEngage.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      var secondThread = secondThreadRef.get();
+      assertNotNull("the second worker thread must have been published", secondThread);
+      // Deliberately short: the worker has already announced the next call blocks, so this observes
+      // thread-state settling, not host-dependent database work.
+      var observedPark = awaitParkedOnMutex(secondThread, PARK_OBSERVATION_MILLIS);
+      assertTrue("the second schema tx must park on the mutex while the first holds it, observed "
+          + observedPark, observedPark.parkedOnMutex());
+      assertFalse("the second schema tx must block on the mutex while the first holds it",
+          secondCreatedClass.get());
+      assertFalse("the second schema tx must not be aborted by contention — it blocks instead",
+          secondAborted.get());
 
-    if (secondError.get() != null) {
-      throw new AssertionError("no schema tx should error on contention", secondError.get());
+      // Release the first; the second now acquires the mutex and finishes. LIVENESS only: the bound
+      // says "the unblocked worker must not hang", never "it must be fast". The serialization
+      // itself is what the park observation and the secondCreatedClass check above proved.
+      firstMayCommit.countDown();
+      assertTrue("the second schema tx must finish after the first releases the mutex",
+          secondDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+    } finally {
+      // Unconditional: the first worker parks on an unbounded firstMayCommit.await(), so a failed
+      // assertion above must still release it — otherwise the @After join reports a leaked worker
+      // instead of the real cause. countDown() is idempotent, so the in-flow release above stands.
+      firstMayCommit.countDown();
     }
+
+    if (firstError.get() != null) {
+      throw new AssertionError("the first schema tx must not error on contention",
+          firstError.get());
+    }
+    if (secondError.get() != null) {
+      throw new AssertionError("the second schema tx must not error on contention",
+          secondError.get());
+    }
+    // Happens-before edge for the firstError read below (see the firstDone declaration).
+    assertTrue("the first schema tx worker must finish, including its own session close",
+        firstDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+
     assertTrue("the second schema tx must have created its class once unblocked",
         secondCreatedClass.get());
     // Both transactions committed without a contention abort: the first held the mutex to its
@@ -230,7 +419,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
       try (var holder = openDatabase()) {
         holder.activateOnCurrentThread();
         holder.begin();
-        holder.getMetadata().getSchema().createClass("ReloadRippleMutexHolder");
+        // One collection: this class only has to drive a schema transaction so the mutex is held.
+        // (The ReloadRippleParent/Child pair above keeps the default count — the subclass's
+        // collection membership rippling into the indexed superclass IS the subject of this test.)
+        holder.getMetadata().getSchema().createClass("ReloadRippleMutexHolder", 1);
         mutexHeld.countDown();
         holderMayFinish.await();
         holder.rollback();
@@ -239,9 +431,15 @@ public class MetadataWriteMutexTest extends DbTestBase {
         mutexHeld.countDown();
       }
     }, "reload-ripple-mutex-holder");
-    assertTrue("the holder session must engage the mutex", mutexHeld.await(5, TimeUnit.SECONDS));
 
     try {
+      // Inside the try like the handshake wait's four siblings elsewhere in this class: the holder
+      // parks on an unbounded holderMayFinish.await(), so if THIS wait fails the finally still has
+      // to release it — otherwise the @After join reports a stranded worker instead of the real
+      // cause. (Left outside, this was the last site of that shape in the file.)
+      assertTrue("the holder session must engage the mutex",
+          mutexHeld.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+
       // The reload must complete while the mutex is held: the committed-view rebuild is not a
       // schema write, so its inheritance-rebuild ripples are suppressed by the reload guard
       // instead of seeding a tx-local schema state (which would either throw the engage-order
@@ -262,7 +460,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     // A follow-up schema transaction on the reloading session works: the reload guard cleared and
     // the mutex is free again once the holder rolled back.
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("ReloadRippleAfter"));
+        tx -> session.getMetadata().getSchema().createClass("ReloadRippleAfter", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("ReloadRippleAfter"));
   }
 
@@ -275,8 +473,9 @@ public class MetadataWriteMutexTest extends DbTestBase {
    */
   @Test
   public void heldMutexDoesNotBlockDataCommitOrSnapshotRead() throws InterruptedException {
-    // A data class for the concurrent data commit to write into.
-    session.getMetadata().getSchema().createClass("DataClass");
+    // A data class for the concurrent data commit to write into. One collection: the test writes a
+    // single entity and asserts nothing about collection count.
+    session.getMetadata().getSchema().createClass("DataClass", 1);
 
     var mutexHeld = new CountDownLatch(1);
     var schemaTxMayCommit = new CountDownLatch(1);
@@ -286,8 +485,9 @@ public class MetadataWriteMutexTest extends DbTestBase {
       try (var holder = openDatabase()) {
         holder.activateOnCurrentThread();
         holder.begin();
-        // Engage the mutex via a schema write, then park holding it.
-        holder.getMetadata().getSchema().createClass("MutexHolderClass");
+        // Engage the mutex via a schema write, then park holding it. One collection: the class only
+        // exists to drive the schema transaction.
+        holder.getMetadata().getSchema().createClass("MutexHolderClass", 1);
         assertTrue("the schema writer must hold the mutex",
             holder.getSharedContext().getMetadataWriteMutex().isEngagedBy(holder));
         mutexHeld.countDown();
@@ -298,43 +498,53 @@ public class MetadataWriteMutexTest extends DbTestBase {
       }
     }, "mutex-holder");
 
-    assertTrue("the schema writer must engage the mutex", mutexHeld.await(5, TimeUnit.SECONDS));
-
-    // On a separate thread (so it does not touch the test session), run a pure-data commit and a
-    // snapshot-based schema read while the mutex is held. Both must complete promptly.
     var dataDone = new CountDownLatch(1);
     var dataError = new AtomicReference<Throwable>();
     var snapshotReadSawDataClass = new AtomicBoolean(false);
-    spawn(() -> {
-      try (var dataSession = openDatabase()) {
-        dataSession.activateOnCurrentThread();
-        // Pure-data commit: create an entity in an existing class. Touches no schema, so it never
-        // engages the mutex and must not block behind the held permit.
-        dataSession.executeInTx(tx -> {
-          var entity = dataSession.newEntity("DataClass");
-          entity.setProperty("v", 1);
-        });
-        // Snapshot-based schema read: a plain existsClass goes through the immutable snapshot, which
-        // does not take the mutex.
-        snapshotReadSawDataClass.set(
-            dataSession.getMetadata().getSchema().existsClass("DataClass"));
-      } catch (Throwable t) {
-        dataError.compareAndSet(null, t);
-      } finally {
-        dataDone.countDown();
+    try {
+      assertTrue("the schema writer must engage the mutex",
+          mutexHeld.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+
+      // On a separate thread (so it does not touch the test session), run a pure-data commit and a
+      // snapshot-based schema read while the mutex is held. Both must complete without waiting on
+      // the mutex: a regression that made them take it would block until the holder released, which
+      // only happens AFTER this wait, so this is a liveness bound on a permanent block — not a
+      // performance claim — and is sized for the slowest CI host.
+      spawn(() -> {
+        try (var dataSession = openDatabase()) {
+          dataSession.activateOnCurrentThread();
+          // Pure-data commit: create an entity in an existing class. Touches no schema, so it never
+          // engages the mutex and must not block behind the held permit.
+          dataSession.executeInTx(tx -> {
+            var entity = dataSession.newEntity("DataClass");
+            entity.setProperty("v", 1);
+          });
+          // Snapshot-based schema read: a plain existsClass goes through the immutable snapshot,
+          // which does not take the mutex.
+          snapshotReadSawDataClass.set(
+              dataSession.getMetadata().getSchema().existsClass("DataClass"));
+        } catch (Throwable t) {
+          dataError.compareAndSet(null, t);
+        } finally {
+          dataDone.countDown();
+        }
+      }, "data-writer-and-reader");
+
+      assertTrue("a data commit and a snapshot read must complete while the mutex is held — they do"
+          + " not wait on the schema mutex",
+          dataDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+      if (dataError.get() != null) {
+        throw new AssertionError("the data path must not be blocked by the mutex", dataError.get());
       }
-    }, "data-writer-and-reader");
-
-    assertTrue("a data commit and a snapshot read must complete while the mutex is held — they do"
-        + " not wait on the schema mutex",
-        dataDone.await(5, TimeUnit.SECONDS));
-    if (dataError.get() != null) {
-      throw new AssertionError("the data path must not be blocked by the mutex", dataError.get());
+      assertTrue("the snapshot-based schema read must have run unblocked",
+          snapshotReadSawDataClass.get());
+    } finally {
+      // Unconditional: the holder parks on an unbounded schemaTxMayCommit.await(), so any failure
+      // above must still release it or the @After join reports a leaked worker instead of the real
+      // cause.
+      schemaTxMayCommit.countDown();
     }
-    assertTrue("the snapshot-based schema read must have run unblocked",
-        snapshotReadSawDataClass.get());
 
-    schemaTxMayCommit.countDown();
     if (holderError.get() != null) {
       throw new AssertionError("the mutex holder must not error", holderError.get());
     }
@@ -414,13 +624,14 @@ public class MetadataWriteMutexTest extends DbTestBase {
       // While the test thread holds the permit, the foreign thread must park on it. Observe the
       // parked thread state deterministically rather than inferring parking from a negative await.
       assertTrue("the foreign worker must reach its blocking engage",
-          foreignAboutToEngage.await(5, TimeUnit.SECONDS));
+          foreignAboutToEngage.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
       var foreignThread = foreignThreadRef.get();
       assertNotNull("the foreign worker thread must have been published", foreignThread);
-      var parkedState = awaitThreadParked(foreignThread, 5_000);
-      assertTrue("a foreign thread must park on the held mutex, observed in thread state "
-          + parkedState,
-          parkedState == Thread.State.WAITING || parkedState == Thread.State.TIMED_WAITING);
+      // Deliberately short: the worker has already announced that its next call is the engage, so
+      // this window only has to cover thread-state settling.
+      var observedPark = awaitParkedOnMutex(foreignThread, PARK_OBSERVATION_MILLIS);
+      assertTrue("a foreign thread must park on the held mutex, observed " + observedPark,
+          observedPark.parkedOnMutex());
       assertFalse("the foreign engage must not have completed while the permit is held",
           foreignEngaged.getCount() == 0);
     } finally {
@@ -428,7 +639,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     }
 
     assertTrue("the foreign thread must engage once the permit is released",
-        foreignEngaged.await(5, TimeUnit.SECONDS));
+        foreignEngaged.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
     if (foreignError.get() != null) {
       throw new AssertionError("the foreign engage must succeed after release", foreignError.get());
     }
@@ -533,7 +744,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var outer = session;
     outer.begin();
     // First schema write engages the mutex through the production seam (ensureTxSchemaState).
-    outer.getMetadata().getSchema().createClass("OuterTxClass");
+    outer.getMetadata().getSchema().createClass("OuterTxClass", 1);
     assertTrue("the outer schema write must engage the mutex through the production seam",
         outer.getSharedContext().getMetadataWriteMutex().isEngagedBy(outer));
 
@@ -548,7 +759,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
           assertThrows(
               "a same-thread second session's schema write must throw rather than self-deadlock",
               IllegalStateException.class,
-              () -> inner.getMetadata().getSchema().createClass("InnerTxClass"));
+              () -> inner.getMetadata().getSchema().createClass("InnerTxClass", 1));
       assertTrue("the reject must name the same-thread different-session cause: " + ex.getMessage(),
           ex.getMessage() != null && ex.getMessage().contains("different session"));
       inner.rollback();
@@ -625,14 +836,15 @@ public class MetadataWriteMutexTest extends DbTestBase {
               try (var next = openDatabase()) {
                 next.activateOnCurrentThread();
                 next.begin();
-                next.getMetadata().getSchema().createClass("AfterSeedFailure");
+                next.getMetadata().getSchema().createClass("AfterSeedFailure", 1);
                 next.commit();
               } catch (Throwable t) {
                 workerError.compareAndSet(null, t);
               }
             },
             "post-seed-failure-writer");
-    worker.join(5_000);
+    // LIVENESS: a stranded permit parks this worker forever, so only a hang exhausts the bound.
+    worker.join(WORKER_JOIN_MILLIS);
     assertFalse("the next schema writer must not be stranded behind a leaked permit",
         worker.isAlive());
     if (workerError.get() != null) {
@@ -656,7 +868,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var victim = openDatabase();
     victim.activateOnCurrentThread();
     victim.begin();
-    victim.getMetadata().getSchema().createClass("RollbackSkipVictim");
+    victim.getMetadata().getSchema().createClass("RollbackSkipVictim", 1);
     assertTrue("the schema write must engage the mutex", mutex.isEngagedBy(victim));
 
     // Force the state session.rollback()'s isActive gate skips: the teardown then never calls
@@ -675,7 +887,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     // The permit is usable, not merely unrecorded: the next schema transaction proceeds.
     session.activateOnCurrentThread();
     session.executeInTx(
-        tx2 -> session.getMetadata().getSchema().createClass("AfterRollbackSkip"));
+        tx2 -> session.getMetadata().getSchema().createClass("AfterRollbackSkip", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterRollbackSkip"));
   }
 
@@ -704,7 +916,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     victim.registerListener(listener);
     try {
       victim.begin();
-      victim.getMetadata().getSchema().createClass("RollbackThrowVictim");
+      victim.getMetadata().getSchema().createClass("RollbackThrowVictim", 1);
       assertTrue("the schema write must engage the mutex", mutex.isEngagedBy(victim));
       try {
         victim.close();
@@ -726,7 +938,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     }
     // The permit is usable by the next writer.
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterRollbackThrow"));
+        tx -> session.getMetadata().getSchema().createClass("AfterRollbackThrow", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterRollbackThrow"));
   }
 
@@ -746,7 +958,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     marked.markTeardownIntent();
     try {
       try {
-        marked.getMetadata().getSchema().createClass("MarkedSessionClass");
+        marked.getMetadata().getSchema().createClass("MarkedSessionClass", 1);
         fail("a schema write on a teardown-marked session must fail loudly");
       } catch (final DatabaseException expected) {
         assertTrue("the failure must name the closed-while-engaging cause",
@@ -761,7 +973,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     }
     // The permit is genuinely free: the next writer engages and commits.
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterMarkedReject"));
+        tx -> session.getMetadata().getSchema().createClass("AfterMarkedReject", 1));
   }
 
   /**
@@ -784,7 +996,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
       try {
         owner.activateOnCurrentThread();
         owner.begin();
-        owner.getMetadata().getSchema().createClass("ForeignTeardownClass");
+        owner.getMetadata().getSchema().createClass("ForeignTeardownClass", 1);
         engaged.countDown();
         ownerMayFinish.await();
       } catch (Throwable t) {
@@ -793,26 +1005,32 @@ public class MetadataWriteMutexTest extends DbTestBase {
       }
     }, "foreign-teardown-owner");
 
-    assertTrue("the owner must engage the mutex", engaged.await(5, TimeUnit.SECONDS));
-    if (ownerError.get() != null) {
-      throw new AssertionError("the owner must not error", ownerError.get());
+    try {
+      assertTrue("the owner must engage the mutex",
+          engaged.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      if (ownerError.get() != null) {
+        throw new AssertionError("the owner must not error", ownerError.get());
+      }
+      var owner = ownerSession.get();
+      assertTrue("the owner session must hold the permit", mutex.isEngagedBy(owner));
+
+      // Foreign teardown (the pool-close shape): activate the owner's session on THIS thread and
+      // run its own full teardown. The release pass harvests the engage's ordinal and frees the
+      // permit; the (session, ordinal) CAS is the second belt.
+      owner.activateOnCurrentThread();
+      owner.internalClose(false);
+      assertFalse("the foreign teardown must harvest the engaged permit",
+          mutex.isEngagedBy(owner));
+    } finally {
+      // Unconditional: the owner parks on an unbounded ownerMayFinish.await(), so any failure above
+      // must still release it or the @After join reports a leaked worker instead of the real cause.
+      ownerMayFinish.countDown();
     }
-    var owner = ownerSession.get();
-    assertTrue("the owner session must hold the permit", mutex.isEngagedBy(owner));
 
-    // Foreign teardown (the pool-close shape): activate the owner's session on THIS thread and
-    // run its own full teardown. The release pass harvests the engage's ordinal and frees the
-    // permit; the (session, ordinal) CAS is the second belt.
-    owner.activateOnCurrentThread();
-    owner.internalClose(false);
-    assertFalse("the foreign teardown must harvest the engaged permit",
-        mutex.isEngagedBy(owner));
-
-    ownerMayFinish.countDown();
     session.activateOnCurrentThread();
     // The permit is usable by the next writer.
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterForeignTeardown"));
+        tx -> session.getMetadata().getSchema().createClass("AfterForeignTeardown", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterForeignTeardown"));
   }
 
@@ -844,7 +1062,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
         try {
           // Parks in the engage wait; after the holder releases, the acquire succeeds and the
           // post-acquire re-check sees the mark set below.
-          victim.getMetadata().getSchema().createClass("PostAcquireDekker");
+          victim.getMetadata().getSchema().createClass("PostAcquireDekker", 1);
         } catch (Throwable t) {
           victimThrown.set(t);
         } finally {
@@ -858,10 +1076,12 @@ public class MetadataWriteMutexTest extends DbTestBase {
     }, "post-acquire-dekker-victim");
 
     try {
-      assertTrue(victimReady.await(5, TimeUnit.SECONDS));
-      var state = awaitThreadParked(worker, 5_000);
-      assertTrue("the victim must park on the held permit, observed state " + state,
-          state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING);
+      assertTrue(victimReady.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      // Deliberately short: victimReady already proves the victim reached its blocking write, so
+      // only thread-state settling is being waited on here.
+      var observedPark = awaitParkedOnMutex(worker, PARK_OBSERVATION_MILLIS);
+      assertTrue("the victim must park on the held permit, observed " + observedPark,
+          observedPark.parkedOnMutex());
       // The mark lands while the victim is parked INSIDE the permit wait — past its loop-top
       // check — so only the post-acquire re-check can see it.
       victimRef.get().markTeardownIntent();
@@ -869,7 +1089,8 @@ public class MetadataWriteMutexTest extends DbTestBase {
       mutex.releaseFor(session, holderOrdinal);
     }
 
-    assertTrue("the victim must finish", victimDone.await(15, TimeUnit.SECONDS));
+    assertTrue("the victim must finish",
+        victimDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
     assertNotNull("the marked victim's engage must have failed", victimThrown.get());
     assertTrue("the failure must be the post-acquire self-release branch (message pins the"
         + " 'while engaging' arm, not the loop-top 'while waiting' arm): " + victimThrown.get(),
@@ -877,7 +1098,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
             && victimThrown.get().getMessage().contains("while engaging the metadata-write mutex"));
     // The self-release freed the permit: the next writer engages and commits.
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterPostAcquireDekker"));
+        tx -> session.getMetadata().getSchema().createClass("AfterPostAcquireDekker", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterPostAcquireDekker"));
   }
 
@@ -902,7 +1123,9 @@ public class MetadataWriteMutexTest extends DbTestBase {
         closeListenerFired.incrementAndGet();
         firstInListener.countDown();
         try {
-          releaseListener.await(10, TimeUnit.SECONDS);
+          // The overlap window the whole test rests on: the winning teardown stays inside this
+          // listener while the losing one runs. Both bounds below must stay strictly under it.
+          releaseListener.await(LISTENER_HOLD_SECONDS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
@@ -913,20 +1136,32 @@ public class MetadataWriteMutexTest extends DbTestBase {
       victim.activateOnCurrentThread();
       victim.internalClose(false);
     }, "teardown-first");
-    assertTrue("the first teardown must reach its close listener",
-        firstInListener.await(5, TimeUnit.SECONDS));
+    try {
+      // LIVENESS, not a short bound: the hold clock starts when the winner ENTERS the listener,
+      // which is the same moment this wait returns, so time spent reaching the listener consumes no
+      // hold time and widening this cannot make the test vacuous.
+      assertTrue("the first teardown must reach its close listener",
+          firstInListener.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
 
-    // The second teardown runs while the first is mid-body (status still OPEN): it must no-op on
-    // the atomic claim rather than double-running the listeners and the session-count decrement.
-    var second = spawn(() -> {
-      victim.activateOnCurrentThread();
-      victim.internalClose(false);
-    }, "teardown-second");
-    second.join(5_000);
-    assertFalse("the losing teardown must no-op promptly", second.isAlive());
+      // The second teardown runs while the first is mid-body (status still OPEN): it must no-op on
+      // the atomic claim rather than double-running the listeners and the session-count decrement.
+      var second = spawn(() -> {
+        victim.activateOnCurrentThread();
+        victim.internalClose(false);
+      }, "teardown-second");
+      // Deliberately SHORT, and the one bound that must stay under LISTENER_HOLD_SECONDS (asserted
+      // at class init): "promptly" means "while the winner is still pinned inside its close
+      // listener", and the loser runs one CAS and no I/O, so a slow host cannot need more — only a
+      // regression that actually re-ran the teardown body would.
+      second.join(NOOP_TEARDOWN_JOIN_MILLIS);
+      assertFalse("the losing teardown must no-op promptly", second.isAlive());
+    } finally {
+      // Unconditional: a failed assertion above must not leave the winning teardown pinned in its
+      // close listener for the rest of the hold.
+      releaseListener.countDown();
+    }
 
-    releaseListener.countDown();
-    first.join(5_000);
+    first.join(WORKER_JOIN_MILLIS);
     assertFalse("the winning teardown must complete", first.isAlive());
     assertEquals("exactly one full teardown may run (single listener firing, single"
         + " session-count decrement)", 1L, closeListenerFired.get());
@@ -934,7 +1169,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     // The storage session accounting is intact: another session opens, works, and closes.
     session.activateOnCurrentThread();
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterClaimRace"));
+        tx -> session.getMetadata().getSchema().createClass("AfterClaimRace", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterClaimRace"));
   }
 
@@ -950,7 +1185,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
   public void doubleReleaseKeepsSinglePermit() throws InterruptedException {
     var mutex = session.getSharedContext().getMetadataWriteMutex();
     session.begin();
-    session.getMetadata().getSchema().createClass("DoubleReleaseClass");
+    session.getMetadata().getSchema().createClass("DoubleReleaseClass", 1);
     assertTrue(mutex.isEngagedBy(session));
 
     // First releaser (the foreign teardown's pass in miniature): claims the ordinal and releases.
@@ -965,33 +1200,56 @@ public class MetadataWriteMutexTest extends DbTestBase {
     // Single-permit proof: engage through one session, then a second engager must PARK rather
     // than acquire a phantom second permit.
     var firstOrdinal = mutex.engage(session);
-    var parked = new AtomicReference<Thread>();
+    var proberThread = new AtomicReference<Thread>();
+    var proberReady = new CountDownLatch(1);
+    var proberError = new AtomicReference<Throwable>();
     var acquired = new CountDownLatch(1);
     var secondOrdinal = new AtomicLong();
     var secondSession = new AtomicReference<DatabaseSessionEmbedded>();
     spawn(() -> {
-      var other = openDatabase();
-      secondSession.set(other);
-      other.activateOnCurrentThread();
-      parked.set(Thread.currentThread());
-      secondOrdinal.set(mutex.engage(other));
-      acquired.countDown();
+      try {
+        var other = openDatabase();
+        secondSession.set(other);
+        other.activateOnCurrentThread();
+        proberThread.set(Thread.currentThread());
+        // Latch handshake, not a busy-spin the observer runs: opening the session above is real
+        // disk work, and a 60 s Thread.onSpinWait() loop would hot-spin a core inside a fork that
+        // runs four test classes in parallel.
+        proberReady.countDown();
+        secondOrdinal.set(mutex.engage(other));
+        acquired.countDown();
+      } catch (Throwable t) {
+        // Without this the prober's failure was invisible: the observer just waited out its bound.
+        proberError.compareAndSet(null, t);
+        proberReady.countDown();
+      }
     }, "double-release-prober");
 
-    var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-    while (parked.get() == null && System.nanoTime() < deadline) {
-      Thread.onSpinWait();
+    try {
+      // LIVENESS: the prober signals only after opening its own session, which is real disk work,
+      // so this is sized for the slowest CI host. It returns as soon as the signal lands.
+      assertTrue("the prober must start", proberReady.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      if (proberError.get() != null) {
+        throw new AssertionError("the prober must reach its engage", proberError.get());
+      }
+      assertNotNull("the prober must have published its thread", proberThread.get());
+      // Deliberately short: the prober's next call after signalling IS the engage.
+      var observedPark = awaitParkedOnMutex(proberThread.get(), PARK_OBSERVATION_MILLIS);
+      assertTrue("a second engager must park on the single permit (a double release would have"
+          + " admitted it immediately), observed " + observedPark,
+          observedPark.parkedOnMutex());
+      assertFalse("the prober must not have acquired while the permit is held",
+          acquired.getCount() == 0);
+    } finally {
+      // Unconditional, same reason as the latch releases elsewhere in this class: the prober parks
+      // on this permit, so a failed assertion above must still free it. Otherwise the prober is
+      // stranded and the @After join reports "a stuck mutex acquire" on top of — and ahead of — the
+      // real failure.
+      mutex.releaseFor(session, firstOrdinal);
     }
-    assertNotNull("the prober must have started", parked.get());
-    var state = awaitThreadParked(parked.get(), 5_000);
-    assertTrue("a second engager must park on the single permit (a double release would have"
-        + " admitted it immediately), observed state " + state,
-        state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING);
-    assertFalse("the prober must not have acquired while the permit is held",
-        acquired.getCount() == 0);
 
-    mutex.releaseFor(session, firstOrdinal);
-    assertTrue("the prober must acquire after the release", acquired.await(15, TimeUnit.SECONDS));
+    assertTrue("the prober must acquire after the release",
+        acquired.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
     mutex.releaseFor(secondSession.get(), secondOrdinal.get());
     var other = secondSession.get();
     other.activateOnCurrentThread();
@@ -1016,7 +1274,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
         var thrown = assertThrows(
             "a same-session re-engage on a stranded holder must throw, not park",
             IllegalStateException.class,
-            () -> session.getMetadata().getSchema().createClass("StrandedReengage"));
+            () -> session.getMetadata().getSchema().createClass("StrandedReengage", 1));
         assertTrue("the message must name the stranded-holder state: " + thrown.getMessage(),
             thrown.getMessage().contains("already held by this session"));
         assertTrue("the message must name the likely cause: " + thrown.getMessage(),
@@ -1062,7 +1320,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
           var pooled = pool.acquire();
           pooledRef.set(pooled);
           pooled.begin();
-          pooled.getMetadata().getSchema().createClass("PoolSkipClass");
+          pooled.getMetadata().getSchema().createClass("PoolSkipClass", 1);
           pooled.commit();
         } catch (Throwable t) {
           commitError.compareAndSet(null, t);
@@ -1072,7 +1330,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
       }, "pool-skip-owner");
 
       assertTrue("the owner must park inside the commit window",
-          inWindow.await(10, TimeUnit.SECONDS));
+          inWindow.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
 
       // Pool close while the owner is mid-commit: the skip branch marks and defers. Run it on
       // its own thread with a bounded await so a skip regression (a full teardown that parks on
@@ -1086,9 +1344,13 @@ public class MetadataWriteMutexTest extends DbTestBase {
           poolCloseDone.countDown();
         }
       }, "pool-closer");
+      // LIVENESS despite the "promptly" wording: the regression this catches is a full teardown
+      // that parks on the live commit's held locks and therefore NEVER returns, so widening the
+      // bound for a slow host does not weaken the check — pool.close() also tears down the pool's
+      // other sessions, which is real disk work.
       assertTrue("pool.close() must return promptly — the skip must neither park on the live"
           + " commit nor tear it down",
-          poolCloseDone.await(10, TimeUnit.SECONDS));
+          poolCloseDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
       var pooled = pooledRef.get();
       assertNotNull(pooled);
       // Lock-free status probe: isClosed() would take the storage state lock and block behind
@@ -1103,7 +1365,8 @@ public class MetadataWriteMutexTest extends DbTestBase {
       storage.setCommitWindowTestHook(null);
     }
 
-    assertTrue("the owner's commit must finish", committed.await(15, TimeUnit.SECONDS));
+    assertTrue("the owner's commit must finish",
+        committed.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
     if (commitError.get() != null) {
       throw new AssertionError(
           "the deferred teardown must not disturb the commit outcome", commitError.get());
@@ -1119,7 +1382,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     assertTrue("the deferred-teardown commit must be durable",
         session.getMetadata().getSchema().existsClass("PoolSkipClass"));
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterPoolSkip"));
+        tx -> session.getMetadata().getSchema().createClass("AfterPoolSkip", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterPoolSkip"));
   }
 
@@ -1139,7 +1402,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
         var pooled = pool.acquire();
         pooledRef.set(pooled);
         pooled.begin();
-        pooled.getMetadata().getSchema().createClass("PoolFallThroughClass");
+        pooled.getMetadata().getSchema().createClass("PoolFallThroughClass", 1);
         engaged.countDown();
         ownerMayFinish.await();
       } catch (Throwable t) {
@@ -1147,21 +1410,27 @@ public class MetadataWriteMutexTest extends DbTestBase {
       }
     }, "pool-fallthrough-owner");
 
-    assertTrue("the owner must engage the mutex", engaged.await(10, TimeUnit.SECONDS));
-    var pooled = pooledRef.get();
-    assertNotNull(pooled);
-    assertTrue(mutex.isEngagedBy(pooled));
+    try {
+      assertTrue("the owner must engage the mutex",
+          engaged.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      var pooled = pooledRef.get();
+      assertNotNull(pooled);
+      assertTrue(mutex.isEngagedBy(pooled));
 
-    // The tx is idle-open (BEGUN, not COMMITTING): the pool's re-validation falls through to the
-    // full teardown on the pool thread — the one legitimate foreign releaser.
-    pool.close();
-    assertTrue("the pool's full teardown must close the idle session", pooled.isClosed());
-    assertFalse("the pool's full teardown must harvest the permit", mutex.isEngagedBy(pooled));
+      // The tx is idle-open (BEGUN, not COMMITTING): the pool's re-validation falls through to the
+      // full teardown on the pool thread — the one legitimate foreign releaser.
+      pool.close();
+      assertTrue("the pool's full teardown must close the idle session", pooled.isClosed());
+      assertFalse("the pool's full teardown must harvest the permit", mutex.isEngagedBy(pooled));
+    } finally {
+      // Unconditional: the owner parks on an unbounded ownerMayFinish.await(), so any failure above
+      // must still release it or the @After join reports a leaked worker instead of the real cause.
+      ownerMayFinish.countDown();
+    }
 
-    ownerMayFinish.countDown();
     session.activateOnCurrentThread();
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterPoolFallThrough"));
+        tx -> session.getMetadata().getSchema().createClass("AfterPoolFallThrough", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterPoolFallThrough"));
   }
 
@@ -1186,7 +1455,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     victim.registerListener(listener);
     try {
       victim.begin();
-      victim.getMetadata().getSchema().createClass("MaskedOutcomeClass");
+      victim.getMetadata().getSchema().createClass("MaskedOutcomeClass", 1);
       // Simulate the pool skip having marked the session mid-commit.
       victim.markTeardownIntent();
       // Must return normally: the completer's teardown failure is logged, not thrown.
@@ -1239,12 +1508,16 @@ public class MetadataWriteMutexTest extends DbTestBase {
         }
       }, "interrupted-engage-waiter");
 
-      assertTrue("the waiter must start", waiterStarted.await(5, TimeUnit.SECONDS));
-      var state = awaitThreadParked(waiter, 5_000);
-      assertTrue("the waiter must park on the held permit, observed state " + state,
-          state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING);
+      assertTrue("the waiter must start",
+          waiterStarted.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      // Deliberately short: the waiter's next call after the start latch is the engage itself.
+      var observedPark = awaitParkedOnMutex(waiter, PARK_OBSERVATION_MILLIS);
+      assertTrue("the waiter must park on the held permit, observed " + observedPark,
+          observedPark.parkedOnMutex());
       waiter.interrupt();
-      waiter.join(5_000);
+      // LIVENESS: an interruptible waiter exits at once; only a regression back to an
+      // uninterruptible park exhausts this bound.
+      waiter.join(WORKER_JOIN_MILLIS);
       assertFalse("the interrupted waiter must exit", waiter.isAlive());
       assertNotNull("the interrupted waiter must have thrown", thrown.get());
       assertTrue("the throw must be a DatabaseException naming the wait: " + thrown.get(),
@@ -1280,7 +1553,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     session.activateOnCurrentThread();
     // The storage stays usable afterwards.
     session.executeInTx(
-        tx -> session.getMetadata().getSchema().createClass("AfterThrowingPoolClose"));
+        tx -> session.getMetadata().getSchema().createClass("AfterThrowingPoolClose", 1));
     assertTrue(session.getMetadata().getSchema().existsClass("AfterThrowingPoolClose"));
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
@@ -52,22 +52,27 @@ public class MetadataWriteMutexTest extends DbTestBase {
   // ---------------------------------------------------------------------------------------------
   // Wait budgets. This class carries no @Test(timeout) — the JUnitTestListener watchdog is the
   // whole-test hang detector — so every bound below exists only to turn a hang into a named
-  // failure. Budget derivation, stated once for all of them: the class costs ~14.5 s locally on
-  // DISK storage (`-Dyoutrackdb.test.env=ci`) and ~1.9 s on MEMORY storage, which is the module
-  // default and what most CI legs run; the Windows disk-storage leg took 121-129 s, i.e. 3.34x
-  // (p50) / 5.01x (p95) / 7.73x (max) the reference host. Every LIVENESS bound is therefore sized
-  // an order of magnitude above its local cost, comfortably past the worst observed factor: a
-  // genuinely stuck mutex acquire still fails the test, a merely slow host never does. The three
-  // SHORT budgets are deliberately NOT scaled — their shortness IS the assertion — and each of
-  // their call sites repeats why.
+  // failure. Budget derivation, stated once for all of them. Measured cost of the whole class:
+  // ~14.5 s here on DISK storage (`-Dyoutrackdb.test.env=ci`), ~1.9 s on MEMORY storage (the module
+  // default, and what most CI legs run). The Windows disk-storage leg took 121-129 s, i.e. ~8.5x
+  // this host for THIS class; the per-test slowdown distribution measured across the affected tests
+  // was 3.34x (p50) / 5.01x (p95) / 7.73x (max). Every LIVENESS bound below is therefore sized at
+  // least an order of magnitude above the local cost of what it waits for — comfortably past even
+  // the ~8.5x class-level factor — so a genuinely stuck mutex acquire still fails the test while a
+  // merely slow host never does. The SHORT budgets are deliberately NOT scaled: their shortness IS
+  // the assertion, and each of their call sites repeats why.
   // ---------------------------------------------------------------------------------------------
 
   /// LIVENESS: a spawned worker must reach a handshake point — engaging the mutex, publishing its
-  /// thread, entering a commit window. Costs milliseconds locally. Note that a worker which THROWS
-  /// before its handshake also exhausts this bound, because these latches are counted down on the
-  /// success path only; the failing worker's own error holder is what names the real cause, so the
-  /// waits that have one consult it (see `twoConcurrentSchemaTransactionsSerializeWithoutAbort`).
+  /// thread, entering a commit window. Costs milliseconds locally, so only a genuine hang exhausts
+  /// it: a worker that THROWS on the way to its handshake would never count its latch down, which
+  /// is why every such wait goes through [#awaitSignalOrWorkerError] and reports the worker's own
+  /// throwable as soon as it appears instead of waiting this bound out.
   private static final long HANDSHAKE_SECONDS = 60L;
+
+  /// Poll interval of [#awaitSignalOrWorkerError]. Short enough that a worker failure is reported
+  /// within a fraction of a second rather than after [#HANDSHAKE_SECONDS].
+  private static final long SIGNAL_POLL_MILLIS = 50L;
 
   /// LIVENESS: once the blocking condition is lifted (permit released, commit window opened) the
   /// unblocked worker must run its schema write, commit and teardown through to completion. Larger
@@ -150,10 +155,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
    * progress after a sleep, so the blocking proof fails closed if a regression lets the worker
    * through instead of parking it.
    *
-   * <p>Deliberately NOT named {@code awaitThreadParked} like the state-only helpers in
-   * {@code FreezerGateTest} and {@code ScalableRWLockTest}: this one additionally requires the
-   * mutex-engage frame, and sharing their name for stricter semantics would be the trap. Those
-   * copies are left alone here because they observe different (non-mutex) waits.
+   * <p>Deliberately named differently from the state-only siblings elsewhere in the module
+   * ({@code FreezerGateTest.awaitThreadParked}, {@code ScalableRWLockTest.awaitParked}): this one
+   * additionally requires the mutex-engage frame, and reusing a sibling's name for stricter
+   * semantics would be the trap. Those copies are left alone because they observe non-mutex waits.
    *
    * <p>The stack check is the other half of that fail-closed property: a parked STATE alone is also
    * satisfied by a thread parked for an unrelated reason (a disk read in {@code openDatabase}, a
@@ -201,6 +206,31 @@ public class MetadataWriteMutexTest extends DbTestBase {
     return null;
   }
 
+  /**
+   * Awaits {@code signal} for up to {@code seconds}, failing as soon as {@code workerError} records
+   * the signalling worker's own throwable.
+   *
+   * <p>Attribution, not liveness, is the point. These handshake latches are counted down on the
+   * worker's success path, so a worker that throws on its way to the handshake never signals: a
+   * plain bounded await would sit out the whole liveness bound and then report the missing signal
+   * instead of the failure that caused it. The bound is still enforced for the case where the
+   * worker neither signals nor fails (a genuine hang).
+   */
+  private static void awaitSignalOrWorkerError(final CountDownLatch signal,
+      final AtomicReference<Throwable> workerError, final long seconds, final String message)
+      throws InterruptedException {
+    final var deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds);
+    while (!signal.await(SIGNAL_POLL_MILLIS, TimeUnit.MILLISECONDS)) {
+      if (workerError.get() != null) {
+        throw new AssertionError(
+            message + " — the worker failed first, which is the root cause", workerError.get());
+      }
+      if (System.nanoTime() - deadlineNanos >= 0) {
+        fail(message);
+      }
+    }
+  }
+
   @After
   public void joinSpawnedWorkers() throws InterruptedException {
     var leaked = new java.util.ArrayList<String>();
@@ -219,8 +249,11 @@ public class MetadataWriteMutexTest extends DbTestBase {
       // on a Semaphore, which records no AQS exclusive owner, so the watchdog's detector
       // (ThreadMXBean.findDeadlockedThreads) provably cannot see it, and the watchdog would only
       // fire after its own multi-minute timeout anyway.
-      dumpThreads("MetadataWriteMutexTest.joinSpawnedWorkers: workers did not join within "
-          + WORKER_JOIN_MILLIS + "ms: " + leaked);
+      // Labelled with the test whose workers leaked (the TestName rule still holds it during
+      // @After): four test classes share one forked JVM, so a block in the CI report has to name
+      // its own test to be traceable.
+      dumpThreads(getClass().getSimpleName() + "." + name.getMethodName()
+          + ": workers did not join within " + WORKER_JOIN_MILLIS + "ms: " + leaked);
     }
     for (var t : spawnedWorkers) {
       if (t.isAlive()) {
@@ -285,15 +318,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
 
     var secondDone = new CountDownLatch(1);
     try {
-      if (!firstHoldsMutex.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS)) {
-        // The handshake can only time out because the first worker died before engaging, so report
-        // ITS failure rather than the latch symptom — that cause used to be swallowed here.
-        if (firstError.get() != null) {
-          throw new AssertionError("the first schema tx failed before engaging the mutex",
-              firstError.get());
-        }
-        fail("first session must engage the mutex");
-      }
+      // Reports worker 1's own throwable the moment it appears instead of waiting out the liveness
+      // bound and blaming the missing latch — worker 1 counts firstHoldsMutex down only on success.
+      awaitSignalOrWorkerError(firstHoldsMutex, firstError, HANDSHAKE_SECONDS,
+          "first session must engage the mutex");
 
       // Second session: try to start a schema tx while the first holds the mutex. Its createClass
       // must block on the mutex, so secondCreatedClass stays false until the first releases.
@@ -332,8 +360,8 @@ public class MetadataWriteMutexTest extends DbTestBase {
       // than inferring blocking from a sleep. The full-path latch only proves the worker reached
       // the call; the park observation proves the call is parked on the semaphore, so this fails
       // closed if a regression let the second writer through instead of blocking it.
-      assertTrue("the second worker must reach its blocking schema write",
-          secondAboutToEngage.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(secondAboutToEngage, secondError, HANDSHAKE_SECONDS,
+          "the second worker must reach its blocking schema write");
       var secondThread = secondThreadRef.get();
       assertNotNull("the second worker thread must have been published", secondThread);
       // Deliberately short: the worker has already announced the next call blocks, so this observes
@@ -359,6 +387,14 @@ public class MetadataWriteMutexTest extends DbTestBase {
       firstMayCommit.countDown();
     }
 
+    // BEFORE the firstError read below, not after: worker 1 counts firstDone down in its own
+    // finally, i.e. after its session close, so only this await establishes that firstError is
+    // final. Read earlier, a close() that throws right after the read would be silently dropped and
+    // the test would pass. (secondError needs no separate edge: worker 2 counts secondDone down in
+    // its own finally and the body already awaited secondDone above.)
+    assertTrue("the first schema tx worker must finish, including its own session close",
+        firstDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
+
     if (firstError.get() != null) {
       throw new AssertionError("the first schema tx must not error on contention",
           firstError.get());
@@ -367,9 +403,6 @@ public class MetadataWriteMutexTest extends DbTestBase {
       throw new AssertionError("the second schema tx must not error on contention",
           secondError.get());
     }
-    // Happens-before edge for the firstError read below (see the firstDone declaration).
-    assertTrue("the first schema tx worker must finish, including its own session close",
-        firstDone.await(UNBLOCKED_COMPLETION_SECONDS, TimeUnit.SECONDS));
 
     assertTrue("the second schema tx must have created its class once unblocked",
         secondCreatedClass.get());
@@ -436,9 +469,12 @@ public class MetadataWriteMutexTest extends DbTestBase {
       // Inside the try like the handshake wait's four siblings elsewhere in this class: the holder
       // parks on an unbounded holderMayFinish.await(), so if THIS wait fails the finally still has
       // to release it — otherwise the @After join reports a stranded worker instead of the real
-      // cause. (Left outside, this was the last site of that shape in the file.)
-      assertTrue("the holder session must engage the mutex",
-          mutexHeld.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      // cause. This was the last handshake wait in the file left outside its release's try.
+      awaitSignalOrWorkerError(mutexHeld, holderError, HANDSHAKE_SECONDS,
+          "the holder session must engage the mutex");
+      if (holderError.get() != null) {
+        throw new AssertionError("the mutex-holder session must not error", holderError.get());
+      }
 
       // The reload must complete while the mutex is held: the committed-view rebuild is not a
       // schema write, so its inheritance-rebuild ripples are suppressed by the reload guard
@@ -495,6 +531,12 @@ public class MetadataWriteMutexTest extends DbTestBase {
         holder.rollback();
       } catch (Throwable t) {
         holderError.compareAndSet(null, t);
+      } finally {
+        // Unconditional: the isEngagedBy assertion above runs BEFORE the success-path countDown, so
+        // a holder failure there used to leave the body waiting out its whole liveness bound. The
+        // body re-checks holderError immediately after its wait, so an early signal from this arm
+        // cannot let it proceed on a failed holder.
+        mutexHeld.countDown();
       }
     }, "mutex-holder");
 
@@ -502,8 +544,11 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var dataError = new AtomicReference<Throwable>();
     var snapshotReadSawDataClass = new AtomicBoolean(false);
     try {
-      assertTrue("the schema writer must engage the mutex",
-          mutexHeld.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(mutexHeld, holderError, HANDSHAKE_SECONDS,
+          "the schema writer must engage the mutex");
+      if (holderError.get() != null) {
+        throw new AssertionError("the mutex holder must not error", holderError.get());
+      }
 
       // On a separate thread (so it does not touch the test session), run a pure-data commit and a
       // snapshot-based schema read while the mutex is held. Both must complete without waiting on
@@ -623,8 +668,8 @@ public class MetadataWriteMutexTest extends DbTestBase {
 
       // While the test thread holds the permit, the foreign thread must park on it. Observe the
       // parked thread state deterministically rather than inferring parking from a negative await.
-      assertTrue("the foreign worker must reach its blocking engage",
-          foreignAboutToEngage.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(foreignAboutToEngage, foreignError, HANDSHAKE_SECONDS,
+          "the foreign worker must reach its blocking engage");
       var foreignThread = foreignThreadRef.get();
       assertNotNull("the foreign worker thread must have been published", foreignThread);
       // Deliberately short: the worker has already announced that its next call is the engage, so
@@ -1006,8 +1051,8 @@ public class MetadataWriteMutexTest extends DbTestBase {
     }, "foreign-teardown-owner");
 
     try {
-      assertTrue("the owner must engage the mutex",
-          engaged.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(engaged, ownerError, HANDSHAKE_SECONDS,
+          "the owner must engage the mutex");
       if (ownerError.get() != null) {
         throw new AssertionError("the owner must not error", ownerError.get());
       }
@@ -1052,10 +1097,14 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var victimThrown = new AtomicReference<Throwable>();
     var victimReady = new CountDownLatch(1);
     var victimDone = new CountDownLatch(1);
+    // Distinct from victimThrown, which captures the engage failure this test is ASSERTING on: this
+    // one records a victim that failed on the way there (opening its session, beginning its tx), so
+    // the body reports that instead of waiting out its liveness bound on a signal that never comes.
+    var victimError = new AtomicReference<Throwable>();
     var worker = spawn(() -> {
-      var victim = openDatabase();
-      victimRef.set(victim);
       try {
+        var victim = openDatabase();
+        victimRef.set(victim);
         victim.activateOnCurrentThread();
         victim.begin();
         victimReady.countDown();
@@ -1070,13 +1119,16 @@ public class MetadataWriteMutexTest extends DbTestBase {
           victim.clearTeardownIntent();
           victim.close();
         }
+      } catch (Throwable t) {
+        victimError.compareAndSet(null, t);
       } finally {
         victimDone.countDown();
       }
     }, "post-acquire-dekker-victim");
 
     try {
-      assertTrue(victimReady.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(victimReady, victimError, HANDSHAKE_SECONDS,
+          "the victim must reach its blocking schema write");
       // Deliberately short: victimReady already proves the victim reached its blocking write, so
       // only thread-state settling is being waited on here.
       var observedPark = awaitParkedOnMutex(worker, PARK_OBSERVATION_MILLIS);
@@ -1132,16 +1184,24 @@ public class MetadataWriteMutexTest extends DbTestBase {
       }
     });
 
+    // firstInListener is counted down by the close listener, so a winner that throws BEFORE its
+    // listener fires would never signal; recording its throwable lets the wait below report that
+    // instead of the missing signal.
+    var firstTeardownError = new AtomicReference<Throwable>();
     var first = spawn(() -> {
-      victim.activateOnCurrentThread();
-      victim.internalClose(false);
+      try {
+        victim.activateOnCurrentThread();
+        victim.internalClose(false);
+      } catch (Throwable t) {
+        firstTeardownError.compareAndSet(null, t);
+      }
     }, "teardown-first");
     try {
       // LIVENESS, not a short bound: the hold clock starts when the winner ENTERS the listener,
       // which is the same moment this wait returns, so time spent reaching the listener consumes no
       // hold time and widening this cannot make the test vacuous.
-      assertTrue("the first teardown must reach its close listener",
-          firstInListener.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(firstInListener, firstTeardownError, HANDSHAKE_SECONDS,
+          "the first teardown must reach its close listener");
 
       // The second teardown runs while the first is mid-body (status still OPEN): it must no-op on
       // the atomic claim rather than double-running the listeners and the session-count decrement.
@@ -1228,7 +1288,8 @@ public class MetadataWriteMutexTest extends DbTestBase {
     try {
       // LIVENESS: the prober signals only after opening its own session, which is real disk work,
       // so this is sized for the slowest CI host. It returns as soon as the signal lands.
-      assertTrue("the prober must start", proberReady.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(proberReady, proberError, HANDSHAKE_SECONDS,
+          "the prober must start");
       if (proberError.get() != null) {
         throw new AssertionError("the prober must reach its engage", proberError.get());
       }
@@ -1329,8 +1390,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
         }
       }, "pool-skip-owner");
 
-      assertTrue("the owner must park inside the commit window",
-          inWindow.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      // inWindow is signalled by the commit-window hook, so an owner that fails before reaching the
+      // window never signals; this reports the owner's throwable instead of the missing signal.
+      awaitSignalOrWorkerError(inWindow, commitError, HANDSHAKE_SECONDS,
+          "the owner must park inside the commit window");
 
       // Pool close while the owner is mid-commit: the skip branch marks and defers. Run it on
       // its own thread with a bounded await so a skip regression (a full teardown that parks on
@@ -1397,6 +1460,9 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var engaged = new CountDownLatch(1);
     var ownerMayFinish = new CountDownLatch(1);
     var pooledRef = new AtomicReference<DatabaseSessionEmbedded>();
+    // The owner's throwable used to be swallowed here, leaving the body to fail on a null pooled
+    // session with no hint of why.
+    var ownerError = new AtomicReference<Throwable>();
     spawn(() -> {
       try {
         var pooled = pool.acquire();
@@ -1406,13 +1472,17 @@ public class MetadataWriteMutexTest extends DbTestBase {
         engaged.countDown();
         ownerMayFinish.await();
       } catch (Throwable t) {
+        ownerError.compareAndSet(null, t);
         engaged.countDown();
       }
     }, "pool-fallthrough-owner");
 
     try {
-      assertTrue("the owner must engage the mutex",
-          engaged.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(engaged, ownerError, HANDSHAKE_SECONDS,
+          "the owner must engage the mutex");
+      if (ownerError.get() != null) {
+        throw new AssertionError("the pool-fallthrough owner must not error", ownerError.get());
+      }
       var pooled = pooledRef.get();
       assertNotNull(pooled);
       assertTrue(mutex.isEngagedBy(pooled));
@@ -1488,10 +1558,14 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var thrown = new AtomicReference<Throwable>();
     var flagRestored = new AtomicBoolean(false);
     var waiterStarted = new CountDownLatch(1);
+    // Same reason as the prober in doubleReleaseKeepsSinglePermit: without a holder, a failing
+    // openDatabase() killed this worker silently and the body just waited out its liveness bound.
+    var waiterError = new AtomicReference<Throwable>();
     try {
       var waiter = spawn(() -> {
-        var other = openDatabase();
+        DatabaseSessionEmbedded other = null;
         try {
+          other = openDatabase();
           other.activateOnCurrentThread();
           waiterStarted.countDown();
           try {
@@ -1500,16 +1574,20 @@ public class MetadataWriteMutexTest extends DbTestBase {
             thrown.set(t);
             flagRestored.set(Thread.currentThread().isInterrupted());
           }
+        } catch (Throwable t) {
+          waiterError.compareAndSet(null, t);
         } finally {
           // Clear the interrupt status before the teardown so the session close is undisturbed.
           Thread.interrupted();
-          other.activateOnCurrentThread();
-          other.close();
+          if (other != null) {
+            other.activateOnCurrentThread();
+            other.close();
+          }
         }
       }, "interrupted-engage-waiter");
 
-      assertTrue("the waiter must start",
-          waiterStarted.await(HANDSHAKE_SECONDS, TimeUnit.SECONDS));
+      awaitSignalOrWorkerError(waiterStarted, waiterError, HANDSHAKE_SECONDS,
+          "the waiter must start");
       // Deliberately short: the waiter's next call after the start latch is the engage itself.
       var observedPark = awaitParkedOnMutex(waiter, PARK_OBSERVATION_MILLIS);
       assertTrue("the waiter must park on the held permit, observed " + observedPark,
@@ -1524,6 +1602,9 @@ public class MetadataWriteMutexTest extends DbTestBase {
           thrown.get() instanceof DatabaseException
               && thrown.get().getMessage().contains("interrupted while waiting"));
       assertTrue("the interrupt flag must be restored before the throw", flagRestored.get());
+      if (waiterError.get() != null) {
+        throw new AssertionError("the waiter's session handling must not error", waiterError.get());
+      }
     } finally {
       mutex.releaseFor(session, holderOrdinal);
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/db/MetadataWriteMutexTest.java
@@ -4,6 +4,7 @@ import static com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics.dumpThrea
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -16,7 +17,6 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransaction;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -107,13 +107,19 @@ public class MetadataWriteMutexTest extends DbTestBase {
   /// bound.
   private static final long LISTENER_HOLD_SECONDS = 10L;
 
+  /// The slack a bound-ordering invariant must keep, so "below" cannot degrade into "below by a
+  /// millisecond": spawning the loser and scheduling its thread happens inside that slack.
+  private static final long INVARIANT_MARGIN_MILLIS = 2_000L;
+
   static {
     // Enforced rather than merely documented: the units differ (millis vs seconds), so prose alone
     // was one careless edit away from a vacuously passing racing-teardown test.
     // Core tests run with -ea, so this fires at class-init time.
-    assert NOOP_TEARDOWN_JOIN_MILLIS < TimeUnit.SECONDS.toMillis(LISTENER_HOLD_SECONDS)
+    assert NOOP_TEARDOWN_JOIN_MILLIS + INVARIANT_MARGIN_MILLIS
+        <= TimeUnit.SECONDS.toMillis(LISTENER_HOLD_SECONDS)
         : "the losing teardown must be joined while the winner is still pinned in its close"
-            + " listener: NOOP_TEARDOWN_JOIN_MILLIS must stay below LISTENER_HOLD_SECONDS";
+            + " listener: NOOP_TEARDOWN_JOIN_MILLIS must stay below LISTENER_HOLD_SECONDS by at"
+            + " least INVARIANT_MARGIN_MILLIS";
   }
 
   private final List<Thread> spawnedWorkers = new CopyOnWriteArrayList<>();
@@ -131,19 +137,25 @@ public class MetadataWriteMutexTest extends DbTestBase {
   //       self.openSession() / self.openSessionForTest(), called from inside the body, so a throw
   //       while opening one is recorded exactly like any other failure.
   //   (b) The worker ALWAYS has an error holder and it is ALWAYS populated: the runner catches
-  //       Throwable around the whole body. There is no path on which a throwable is dropped.
-  //   (c) Latches a waiter awaits are declared with signalling(...) and counted down in the
-  //       runner's finally, so no waiter can stall on a worker that died — and since they are per
-  //       worker, the latch released on the failure path is by construction the one the waiter
-  //       awaits. Waits go through worker.awaitSignal(...), which reports the worker's throwable
-  //       rather than the missing signal.
+  //       Throwable around the whole body AND around its own cleanup, so no throwable is dropped.
+  //       A cleanup failure that arrives second is attached to the first as a suppressed exception,
+  //       so a failing close() can neither be lost nor displace the body's failure.
+  //   (c) Latches a waiter awaits are passed to startWorker BEFORE the thread starts and counted
+  //       down in the runner's finally, so no waiter can stall on a worker that died — and since
+  //       they are per worker, the latch released on the failure path is by construction the one
+  //       the waiter awaits. Waits go through worker.awaitSignal(...), which reports the worker's
+  //       throwable rather than the missing signal, and which asserts the latch was declared.
   //   (d) Completion is observable: the runner counts a done latch down after the body AND its
-  //       cleanup. The authoritative error read is worker.failIfErrored(...), which ASSERTS that
-  //       completion edge — so no test can read the holder before the worker's own teardown could
-  //       have written to it, which is the defect that let a late close() failure pass green.
+  //       cleanup, unconditionally. The authoritative error read is worker.failIfErrored(...),
+  //       which ASSERTS that completion edge — so no test can read the holder before the worker's
+  //       own teardown could have written to it, the defect that let a late close() failure pass
+  //       green.
   //   (e) Sessions are closed on every path: worker-owned ones in the runner's finally, and
   //       test-owned ones there too whenever the worker failed, because a failing test will not
-  //       reach its own close.
+  //       reach its own close. Sessions borrowed from the shared SessionPool are the exception:
+  //       they belong to the pool and are torn down by the pool.close() those tests perform
+  //       themselves, so closing them from the worker would break the very pool-close protocol
+  //       under test. The two sites that borrow one say so at the borrow.
   // ---------------------------------------------------------------------------------------------
 
   /** The body of a worker started by {@link #startWorker}. It may throw anything. */
@@ -159,22 +171,32 @@ public class MetadataWriteMutexTest extends DbTestBase {
    * for the bounded join in {@code @After}; it is a daemon so a leaked worker (a stuck mutex
    * acquire the test cannot unblock) cannot keep the forked JVM alive.
    */
-  private Worker startWorker(final String name, final WorkerBody body) {
-    final var worker = new Worker(name);
+  private Worker startWorker(final String name, final WorkerBody body,
+      final CountDownLatch... signals) {
+    // (c): the signals are fixed before the thread exists, so a peer can never await a latch this
+    // runner does not yet know to release.
+    final var worker = new Worker(name, signals);
     final var thread = new Thread(() -> {
       try {
         body.run(worker);
       } catch (final Throwable t) {
-        // (b): the single sink for every throwable this worker can produce.
-        worker.error.compareAndSet(null, t);
+        // (b): one sink for every throwable this worker can produce, body or cleanup.
+        worker.recordFailure(t);
       } finally {
-        // (e) then (c) then (d), in that order: clean up, release anyone waiting on this worker,
-        // and only then publish completion, so a test observing completion sees the final error.
-        worker.closeSessions();
-        for (final var signal : worker.signals) {
-          signal.countDown();
+        try {
+          // (e) then (c): clean up, then release anyone waiting on this worker.
+          worker.closeSessions();
+          for (final var signal : worker.signals) {
+            signal.countDown();
+          }
+        } catch (final Throwable cleanupFailure) {
+          worker.recordFailure(cleanupFailure);
+        } finally {
+          // (d) published unconditionally and last: a test blocked on the completion edge must
+          // never hang because cleanup itself failed, and a test that observes completion must see
+          // the final error.
+          worker.done.countDown();
         }
-        worker.done.countDown();
       }
     }, name);
     thread.setDaemon(true);
@@ -191,24 +213,20 @@ public class MetadataWriteMutexTest extends DbTestBase {
     private final String name;
     private final AtomicReference<Throwable> error = new AtomicReference<>();
     private final CountDownLatch done = new CountDownLatch(1);
-    private final List<CountDownLatch> signals = new CopyOnWriteArrayList<>();
+    private final List<CountDownLatch> signals;
     private final List<DatabaseSessionEmbedded> ownedSessions = new CopyOnWriteArrayList<>();
     private final List<DatabaseSessionEmbedded> testOwnedSessions = new CopyOnWriteArrayList<>();
     private Thread thread;
 
-    private Worker(final String name) {
-      this.name = name;
-    }
-
     /**
-     * (c) Declares the latches some waiter awaits on this worker. They are counted down on EVERY
-     * exit path, including a failure before the body would have signalled them, so a waiter can
-     * never stall on a dead worker. Declare a latch here even when the body (or a production hook)
-     * signals it on the happy path — double counting down is a no-op.
+     * @param signals (c) the latches some waiter awaits on this worker. They are counted down on
+     *     EVERY exit path, including a failure before the body would have signalled them, so a
+     *     waiter can never stall on a dead worker. Declare a latch even when the body (or a
+     *     production hook) signals it on the happy path — counting down twice is a no-op.
      */
-    Worker signalling(final CountDownLatch... latches) {
-      signals.addAll(Arrays.asList(latches));
-      return this;
+    private Worker(final String name, final CountDownLatch... signals) {
+      this.name = name;
+      this.signals = List.of(signals);
     }
 
     /** (a)+(e) A session this worker owns: opened inside the body, closed by the runner. */
@@ -242,6 +260,16 @@ public class MetadataWriteMutexTest extends DbTestBase {
     }
 
     /**
+     * A NON-AUTHORITATIVE peek at the error holder: the worker may still write to it. Only for
+     * disambiguating a negative assertion ("this must not have happened yet") from a dead worker,
+     * which would satisfy such an assertion for the wrong reason. The authoritative read is
+     * {@link #failIfErrored}.
+     */
+    Throwable errorSoFar() {
+      return error.get();
+    }
+
+    /**
      * (c) Waits until {@code signal} fires, and fails as soon as this worker records a throwable
      * instead.
      *
@@ -253,6 +281,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
      */
     void awaitSignal(final CountDownLatch signal, final long seconds, final String message)
         throws InterruptedException {
+      // (c) A latch this worker never declared would not be released when it dies, so awaiting one
+      // is a test bug - catch the typo here instead of as a mysterious stall.
+      assertTrue("test bug: worker '" + name + "' does not declare the awaited latch",
+          signals.contains(signal));
       final var deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds);
       var fired = signal.await(SIGNAL_POLL_MILLIS, TimeUnit.MILLISECONDS);
       while (!fired && error.get() == null) {
@@ -271,8 +303,13 @@ public class MetadataWriteMutexTest extends DbTestBase {
      * session close that throws) only just before it counts down.
      */
     void awaitDone(final long seconds, final String message) throws InterruptedException {
-      assertTrue(message + " (worker '" + name + "' must finish)",
-          done.await(seconds, TimeUnit.SECONDS));
+      if (!done.await(seconds, TimeUnit.SECONDS)) {
+        // A worker can record a failure and then hang in its own cleanup. Report the failure first:
+        // it explains the missing completion, whereas the bound alone does not.
+        reportErrorIfAny(message + " (worker '" + name + "' did not finish within " + seconds
+            + "s after failing)");
+        fail(message + " (worker '" + name + "' must finish within " + seconds + "s)");
+      }
       reportErrorIfAny(message);
     }
 
@@ -287,9 +324,28 @@ public class MetadataWriteMutexTest extends DbTestBase {
      * the worker may still write to it.
      */
     void failIfErrored(final String message) {
-      assertTrue("test bug: worker '" + name + "' error read before its completion edge",
-          isFinished());
+      if (!isFinished()) {
+        // Test bug: this read is unordered with respect to the worker's own teardown. Report the
+        // misuse, but carry whatever the worker has recorded so far as the cause, so the guard
+        // cannot hide a genuine failure.
+        throw new AssertionError("test bug: worker '" + name + "' error read before its completion"
+            + " edge (while checking: " + message + ")", error.get());
+      }
       reportErrorIfAny(message);
+    }
+
+    /**
+     * (b) Records {@code failure}, keeping the first one as the primary and attaching any later one
+     * to it as suppressed. Nothing this worker throws — body or cleanup — is ever dropped, and a
+     * cleanup failure never displaces the body failure that probably caused it.
+     */
+    private void recordFailure(final Throwable failure) {
+      if (!error.compareAndSet(null, failure)) {
+        final var primary = error.get();
+        if (primary != failure) {
+          primary.addSuppressed(failure);
+        }
+      }
     }
 
     private void reportErrorIfAny(final String message) {
@@ -301,7 +357,14 @@ public class MetadataWriteMutexTest extends DbTestBase {
       }
     }
 
-    /** (e) Closes what this worker owns, plus test-owned sessions when the worker failed. */
+    /**
+     * (e) Closes what this worker owns, plus test-owned sessions when the worker failed.
+     *
+     * <p>A close that throws is RECORDED, not printed: six of these workers used to close inside a
+     * guarded try-with-resources, where the language captured such a failure (JLS 14.20.3.2), so
+     * swallowing it here would have made a failing close pass green - the exact defect class this
+     * idiom exists to remove.
+     */
     private void closeSessions() {
       final var toClose = new ArrayList<>(ownedSessions);
       if (error.get() != null) {
@@ -316,10 +379,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
             opened.close();
           }
         } catch (final Throwable cleanupFailure) {
-          // Reported, never rethrown: cleanup must not replace the worker's own failure.
-          System.err.println(
-              "worker '" + name + "' could not close its session: " + cleanupFailure);
-          System.err.flush();
+          recordFailure(cleanupFailure);
         }
       }
     }
@@ -466,7 +526,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
       firstHoldsMutex.countDown();
       firstMayCommit.await();
       first.commit();
-    }).signalling(firstHoldsMutex);
+    }, firstHoldsMutex);
 
     // Declared here so the authoritative error read after the try can reach it.
     Worker secondWriter = null;
@@ -497,7 +557,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
           secondAborted.set(true);
           throw txError;
         }
-      }).signalling(secondAboutToEngage);
+      }, secondAboutToEngage);
 
       // Wait until the second worker is about to make its blocking schema write, then observe it
       // actually park on the permit (WAITING/TIMED_WAITING, inside the mutex's engage frame) rather
@@ -591,7 +651,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
       mutexHeld.countDown();
       holderMayFinish.await();
       holderSession.rollback();
-    }).signalling(mutexHeld);
+    }, mutexHeld);
 
     try {
       // Inside the try because the holder parks on an unbounded holderMayFinish.await(): if THIS
@@ -653,7 +713,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
       mutexHeld.countDown();
       schemaTxMayCommit.await();
       holderSession.rollback();
-    }).signalling(mutexHeld);
+    }, mutexHeld);
 
     var snapshotReadSawDataClass = new AtomicBoolean(false);
     Worker dataWorker = null;
@@ -767,7 +827,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
         // Blocks here until the test thread releases the permit.
         foreignOrdinal.set(mutex.engage(other));
         foreignEngaged.countDown();
-      }).signalling(foreignAboutToEngage, foreignEngaged);
+      }, foreignAboutToEngage, foreignEngaged);
 
       // While the test thread holds the permit, the foreign thread must park on it. Observe the
       // parked thread state deterministically rather than inferring parking from a negative await.
@@ -778,8 +838,12 @@ public class MetadataWriteMutexTest extends DbTestBase {
       var observedPark = awaitParkedOnMutex(parker.thread(), PARK_OBSERVATION_MILLIS);
       assertTrue("a foreign thread must park on the held mutex, observed " + observedPark,
           observedPark.parkedOnMutex());
-      assertFalse("the foreign engage must not have completed while the permit is held",
-          foreignEngaged.getCount() == 0);
+      // Probes the ORDINAL, not the latch: foreignEngaged is also released when the worker dies, so
+      // a latch-count assertion here could only ever go red, never distinguish "engage completed
+      // early" (the regression) from "the worker failed". The ordinal is written only by a
+      // successful engage, and 0 is not a valid ordinal (MetadataWriteMutex numbers from 1).
+      assertEquals("the foreign engage must not have completed while the permit is held",
+          0L, foreignOrdinal.get());
     } finally {
       mutex.releaseFor(session, ownOrdinal);
     }
@@ -1136,7 +1200,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
       owner.getMetadata().getSchema().createClass("ForeignTeardownClass", 1);
       engaged.countDown();
       ownerMayFinish.await();
-    }).signalling(engaged);
+    }, engaged);
 
     try {
       ownerWorker.awaitSignal(engaged, HANDSHAKE_SECONDS, "the owner must engage the mutex");
@@ -1203,7 +1267,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
         victimSession.clearTeardownIntent();
         victimSession.close();
       }
-    }).signalling(victimReady);
+    }, victimReady);
 
     try {
       victim.awaitSignal(victimReady, HANDSHAKE_SECONDS,
@@ -1271,7 +1335,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var first = startWorker("teardown-first", self -> {
       victim.activateOnCurrentThread();
       victim.internalClose(false);
-    }).signalling(firstInListener);
+    }, firstInListener);
     Worker second = null;
     try {
       // LIVENESS, not a short bound: the hold clock starts when the winner ENTERS the listener,
@@ -1358,7 +1422,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
       proberReady.countDown();
       secondOrdinal.set(mutex.engage(other));
       acquired.countDown();
-    }).signalling(proberReady, acquired);
+    }, proberReady, acquired);
 
     try {
       // LIVENESS: the prober signals only after opening its own session, which is real disk work,
@@ -1369,8 +1433,10 @@ public class MetadataWriteMutexTest extends DbTestBase {
       assertTrue("a second engager must park on the single permit (a double release would have"
           + " admitted it immediately), observed " + observedPark,
           observedPark.parkedOnMutex());
-      assertFalse("the prober must not have acquired while the permit is held",
-          acquired.getCount() == 0);
+      // Probes the ORDINAL for the same reason as the foreign parker above: `acquired` is released
+      // on the failure path too, while the ordinal is written only by a successful engage.
+      assertEquals("the prober must not have acquired while the permit is held",
+          0L, secondOrdinal.get());
     } finally {
       // Unconditional, same reason as the latch releases elsewhere in this class: the prober parks
       // on this permit, so a failed assertion above must still free it. Otherwise the prober is
@@ -1449,15 +1515,16 @@ public class MetadataWriteMutexTest extends DbTestBase {
     Worker owner = null;
     Worker poolCloser = null;
     try {
-      // The pooled session belongs to the pool, which pool.close() below tears down, so it is
-      // neither worker- nor test-owned here.
       owner = startWorker("pool-skip-owner", self -> {
+        // (e) exemption: a borrowed pool session is the POOL's to close, and pool.close() below is
+        // what this test drives. Closing it from the worker would pre-empt the skip protocol under
+        // test, so it is deliberately neither worker- nor test-owned.
         var pooled = pool.acquire();
         pooledRef.set(pooled);
         pooled.begin();
         pooled.getMetadata().getSchema().createClass("PoolSkipClass", 1);
         pooled.commit();
-      }).signalling(inWindow);
+      }, inWindow);
 
       // inWindow is signalled by the commit-window hook, so an owner that fails before reaching the
       // window never signals it on its own; declaring it releases this wait on that path too.
@@ -1484,6 +1551,11 @@ public class MetadataWriteMutexTest extends DbTestBase {
           DatabaseSessionEmbedded.STATUS.OPEN, pooled.getStatus());
       assertTrue("the skip must not release the live commit's permit",
           mutex.isEngagedBy(pooled));
+      // A worker that DIED also reads "finished" here, so the non-authoritative error peek is what
+      // separates the regression this catches (the commit completed early, i.e. the skip did not
+      // defer) from an owner that simply failed - the latter is reported with its cause by the
+      // awaitDone/failIfErrored pair once the window is released.
+      assertNull("the owner must not have failed inside the commit window", owner.errorSoFar());
       assertFalse("the commit must still be parked in the window", owner.isFinished());
     } finally {
       releaseWindow.countDown();
@@ -1520,16 +1592,16 @@ public class MetadataWriteMutexTest extends DbTestBase {
     var engaged = new CountDownLatch(1);
     var ownerMayFinish = new CountDownLatch(1);
     var pooledRef = new AtomicReference<DatabaseSessionEmbedded>();
-    // The pooled session is the pool's to close (pool.close() below); the owner's throwable used to
-    // be swallowed here, leaving the body to fail on a null pooled session with no hint of why.
     var owner = startWorker("pool-fallthrough-owner", self -> {
+      // (e) exemption, as in poolCloseDuringCommitDefersTeardownToOwner: the borrowed session is
+      // the pool's to close, and the pool.close() below is the teardown this test is about.
       var pooled = pool.acquire();
       pooledRef.set(pooled);
       pooled.begin();
       pooled.getMetadata().getSchema().createClass("PoolFallThroughClass", 1);
       engaged.countDown();
       ownerMayFinish.await();
-    }).signalling(engaged);
+    }, engaged);
 
     try {
       owner.awaitSignal(engaged, HANDSHAKE_SECONDS, "the owner must engage the mutex");
@@ -1629,7 +1701,7 @@ public class MetadataWriteMutexTest extends DbTestBase {
         } finally {
           Thread.interrupted();
         }
-      }).signalling(waiterStarted);
+      }, waiterStarted);
 
       waiter.awaitSignal(waiterStarted, HANDSHAKE_SECONDS, "the waiter must start");
       // Deliberately short: the waiter's next call after the start latch is the engage itself.

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
@@ -1035,18 +1035,38 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     // A @Test(timeout) body runs on a JUnit watchdog thread, not the @Before thread, so the bound
     // session must be re-activated here before its racer thread re-binds it.
     session.activateOnCurrentThread();
-    // Budget derivation. A round is a create+drop of a ONE-collection class. Measured here: ~50 ms
-    // per round on local DISK storage (`-Dyoutrackdb.test.env=ci`), versus ~310 ms at the default 8
-    // collections (each collection is its own pair of files, so the default made a round create and
-    // delete ~40 files); 60 rounds therefore cost ~3-4 s. On MEMORY storage - the module default,
-    // and what most CI legs run - the whole method costs ~0.15 s, so the budget below is sized for
-    // the disk case, which dominates. The Windows disk-storage leg ran the affected tests at 3.34x
-    // (p50) / 5.01x (p95) / 7.73x (max) this host: at the worst observed factor those ~3-4 s become
-    // ~23-31 s, i.e. 20-26% of the 120 s deadline, so the deadline still has ~4x headroom over a
-    // legitimate slow-host run. Worst-case tail: 120 s deadline + 3 x 10 s trailing
-    // grace + ~1 s thread dump + 30 s cleanup joins (3 x 10 s) = ~181 s under the 240 s
-    // @Test(timeout) - which is what keeps a real deadlock a NAMED assertion carrying a thread dump
-    // instead of a bare TestTimedOutException.
+    // Budget derivation, from a measured sweep on local DISK storage (`-Dyoutrackdb.test.env=ci`,
+    // three isolated runs per setting, medians of the surefire method time): 60 rounds -> 4.06 s,
+    // 72 -> 4.54 s, 90 -> 5.46 s, 120 -> 6.65 s, 180 -> 9.31 s. Those fit
+    // methodTime = 1.44 s fixed + 43.7 ms/round to within 1.4% at every point, so cost is LINEAR in
+    // the round count: the fixed part is the two openDatabase() calls plus the fixture, and a round
+    // is one create+drop of a ONE-collection class (44-48 ms measured directly; the default 8
+    // collections cost ~310 ms/round, each being its own file pair). MEMORY storage - the module
+    // default, and what most CI legs run - costs ~0.15 s in-class and ~0.9 s isolated, so the disk
+    // case is what sizes the budget. (In-class disk runs measure ~3.0 s rather than 4.06 s, the JIT
+    // being warm by then; the larger isolated median is used below, being the conservative one.)
+    //
+    // Why 60 and not more: the deadline must absorb the SLOWEST observed host, not the median one.
+    // The Windows disk-storage leg ran these tests at 3.34x (p50) / 5.01x (p95) this host, with a
+    // worst observed cross-leg ratio of 12.96x. Applying 12.96x to the measured medians - itself
+    // conservative, since the method median includes ~1.44 s of fixture work that runs BEFORE the
+    // deadline is armed - projects 60 rounds to 52.6 s, i.e. 44% of the 120 s racer deadline, while
+    // 90 rounds project to 70.8 s (59%) and 180 to 120.6 s (100.5%: past the deadline outright).
+    // Under the rule "projected worst case at or below half the deadline" the ceiling is 72 rounds
+    // ((60 s / 12.96 - 1.44 s) / 43.7 ms = 72.9). Raising 60 -> 72 would buy 20% more interleaving
+    // samples while consuming the whole remaining margin against a factor that is an observed
+    // maximum rather than a bound, so the count stays at 60, and the deadline, the trailing grace
+    // and the @Test(timeout) stay exactly as verified.
+    //
+    // Nothing accumulates per round, so the linear fit is not hiding a compounding term: the
+    // storage's file count is identical (116) at 60, 72, 90, 120 and 180 rounds - collection slots
+    // are reused, not appended - the database grows a flat ~17 KB/round, and the per-round
+    // create+drop cost DEcreases slightly within a run (first 20 rounds 47-50 ms, last 20 rounds
+    // 43-47 ms, JIT warmup), never rises.
+    //
+    // Worst-case tail: 120 s deadline + 3 x 10 s trailing grace + ~1 s thread dump + 30 s cleanup
+    // joins (3 x 10 s) = ~181 s under the 240 s @Test(timeout) - which is what keeps a real
+    // deadlock a NAMED assertion carrying a thread dump instead of a bare TestTimedOutException.
     final var rounds = 60;
     final var raceDeadlineBudgetMillis = 120_000L;
     var barrier = new CyclicBarrier(3);

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
@@ -19,6 +19,9 @@
  */
 package com.jetbrains.youtrackdb.internal.core.metadata.schema;
 
+import static com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics.deadlineFromNow;
+import static com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics.dumpThreads;
+import static com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics.remainingMillis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -47,6 +50,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.io.FileUtils;
 import org.junit.Ignore;
@@ -819,11 +823,24 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * exactly the guarantee under test; an "await the data commit while still holding the write lock"
    * shape would deadlock by construction.
    */
-  @Test(timeout = 60_000)
+  @Test(timeout = 180_000)
   public void dataCommitSerializesBehindHeldSchemaWriteLock() throws Exception {
     // A @Test(timeout) body runs on a JUnit watchdog thread, not the @Before thread, so the bound
     // session must be re-activated here before any use (the session is ThreadLocal-bound).
     session.activateOnCurrentThread();
+    // Budget derivation, same dialect as the sibling race test below. Local cost is ~1-2 s (disk)
+    // and ~1 s (memory, the module default); the Windows disk-storage CI leg was measured at 3.34x
+    // (p50) / 5.01x (p95) / 7.73x (max) the reference host, so 90 s is ~45x the worst observed
+    // cost. Tail: 90 s observer deadline + the 1 s exclusion probe + ~1 s thread dump + 20 s
+    // cleanup joins (2 x 10 s) = ~112 s, and the pinning hook's own 105 s bound cannot extend it
+    // (the body's finally releases the hook as soon as it fails) - all under the 180 s
+    // @Test(timeout).
+    final var waitBudgetMillis = 90_000L;
+    // The in-window hook must outlive the observer's deadline: if both expired together, the pinned
+    // schema commit could unwind WHILE (or before) the diagnostic dump is taken, and the dump would
+    // show the very state we are trying to capture already gone. Strictly later, still far below
+    // the @Test(timeout).
+    final var hookGraceMillis = 15_000L;
     // A pre-existing class for the pure-data commit to insert into (a create would itself be a
     // schema-carry commit; we need the read-lock branch).
     session.executeInTx(tx -> session.getMetadata().getSchema().createClass("DataTarget"));
@@ -834,6 +851,9 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     var dataCommitStarted = new CountDownLatch(1);
     var dataCommitted = new CountDownLatch(1);
     var errors = new AtomicReference<Throwable>();
+    // Holds the shared deadline so the racer threads and the in-window hook - all wired up before
+    // the deadline is armed - can read the same budget the body uses.
+    var deadlineNanos = new AtomicLong();
 
     // The schema transaction runs entirely on its own thread with its own session (the session is
     // ThreadLocal-bound, so the main thread must never share it). The in-window hook latches it inside
@@ -864,9 +884,11 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
             () -> {
               try {
                 dataSession.activateOnCurrentThread();
-                // Bounded: if the schema commit never enters its window (a regression), the data
-                // thread fails fast instead of parking forever and leaking with its session open.
-                if (!schemaInWindow.await(30, TimeUnit.SECONDS)) {
+                // Bounded on the SAME shared deadline as the body's wait for this very event: with
+                // an independent (tighter) bound, this thread died first and the body then failed
+                // on a later, unrelated wait, misattributing the stall.
+                if (!schemaInWindow.await(remainingMillis(deadlineNanos.get()),
+                    TimeUnit.MILLISECONDS)) {
                   throw new AssertionError("the schema commit never entered its window");
                 }
                 dataCommitStarted.countDown();
@@ -885,14 +907,16 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
             "data-commit-thread");
 
     // Pin the schema commit inside its window so the data commit demonstrably contends with the held
-    // write lock. The hook waits with a bound: if the test body never releases (an assertion above
-    // failed before releaseSchema.countDown()), the test-body finally releases it anyway, but the
-    // bound is a second backstop so the schema thread cannot park forever and leak.
+    // write lock. The hook's bound is the shared deadline PLUS hookGraceMillis, so the observer
+    // always fails (and dumps) first: if the test body never releases (an assertion above failed
+    // before releaseSchema.countDown()), the test-body finally releases it anyway, so this bound
+    // is only the last backstop against the schema thread parking forever and leaking.
     storage.setCommitWindowTestHook(
         () -> {
           schemaInWindow.countDown();
           try {
-            if (!releaseSchema.await(50, TimeUnit.SECONDS)) {
+            if (!releaseSchema.await(
+                remainingMillis(deadlineNanos.get()) + hookGraceMillis, TimeUnit.MILLISECONDS)) {
               throw new AssertionError("the schema commit was never released from its window");
             }
           } catch (final InterruptedException ie) {
@@ -900,26 +924,38 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
           }
         });
     try {
+      // ONE shared, monotonic deadline for every open-ended wait of this test - the body's waits
+      // above and below, the data thread's wait for the in-window signal, and (offset by
+      // hookGraceMillis) the pinning hook. Armed here, immediately before the racers start, so the
+      // unrelated openDatabase() cost above is not charged to it. Independent per-wait bounds used
+      // to sum to ~141 s against a 60 s @Test(timeout), so a stall could only ever surface as a
+      // bare TestTimedOutException carrying no thread state.
+      deadlineNanos.set(deadlineFromNow(waitBudgetMillis));
       schemaThread.start();
       dataThread.start();
 
       // Wait until the schema commit is inside its window and the data thread has started its commit.
-      assertTrue("the schema commit must enter its window",
-          schemaInWindow.await(30, TimeUnit.SECONDS));
-      assertTrue("the data thread must start its commit",
-          dataCommitStarted.await(30, TimeUnit.SECONDS));
+      // Every deadline-derived wait dumps thread state before failing, because the finally arm
+      // below releases the pinned commit and interrupts both racers - either action unwinds the
+      // stacks that would explain the stall.
+      assertWithRacerErrors(errors, "the schema commit must enter its window",
+          schemaInWindow.await(remainingMillis(deadlineNanos.get()), TimeUnit.MILLISECONDS));
+      assertWithRacerErrors(errors, "the data thread must start its commit",
+          dataCommitStarted.await(remainingMillis(deadlineNanos.get()), TimeUnit.MILLISECONDS));
 
       // The data commit must NOT have completed yet: it is blocked on the read lock behind the held
-      // write lock. A short bounded wait that times out is the positive signal of exclusion.
+      // write lock. A short bounded wait that times out is the positive signal of exclusion, so
+      // this one wait is deliberately a fixed 1 s and not deadline-derived.
       assertFalse("the data commit must be blocked while the schema write lock is held",
           dataCommitted.await(1, TimeUnit.SECONDS));
 
       // Release the schema commit; both commits must now complete with no deadlock.
       releaseSchema.countDown();
-      schemaThread.join(30_000);
-      assertFalse("the schema commit must finish after release", schemaThread.isAlive());
-      assertTrue("the data commit must complete once the write lock is released",
-          dataCommitted.await(30, TimeUnit.SECONDS));
+      schemaThread.join(remainingMillis(deadlineNanos.get()));
+      assertWithRacerErrors(errors, "the schema commit must finish after release",
+          !schemaThread.isAlive());
+      assertWithRacerErrors(errors, "the data commit must complete once the write lock is released",
+          dataCommitted.await(remainingMillis(deadlineNanos.get()), TimeUnit.MILLISECONDS));
     } finally {
       // Always release the pinned schema commit and clear the hook, then interrupt-and-join both
       // racer threads so neither leaks past the test (each closes its own session in its own
@@ -954,12 +990,29 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * four-lock interleaving. The {@code @Test(timeout)} is the deadlock detector: a lock-order
    * regression hangs and trips the timeout instead of hanging the whole suite.
    */
-  @Test(timeout = 60_000)
+  @Test(timeout = 210_000)
   public void schemaCommitReloadAndIndexLoadRaceWithoutDeadlock() throws Exception {
     // A @Test(timeout) body runs on a JUnit watchdog thread, not the @Before thread, so the bound
     // session must be re-activated here before its racer thread re-binds it.
     session.activateOnCurrentThread();
-    final var rounds = 30;
+    // Budget derivation. A round is a create+drop of a ONE-collection class. Measured here: ~50 ms
+    // per round on local DISK storage (`-Dyoutrackdb.test.env=ci`), versus ~310 ms at the default 8
+    // collections (each collection is its own pair of files, so the default made a round create and
+    // delete ~40 files); 60 rounds therefore cost ~3-4 s. On MEMORY storage - the module default,
+    // and what most CI legs run - the whole method costs ~0.15 s, so the budget below is sized for
+    // the disk case, which dominates. The Windows disk-storage leg was measured at 3.34x (p50) /
+    // 5.01x (p95) / 7.73x (max) the reference host, so even the worst observed factor lands far
+    // inside the 120 s deadline. Tail: 120 s deadline + 3 x 3 s trailing grace + ~1 s thread dump +
+    // 30 s cleanup joins (3 x 10 s) = ~160 s under the 210 s @Test(timeout) - ~24% headroom, which
+    // is what keeps the failure a NAMED assertion carrying a thread dump instead of a bare
+    // TestTimedOutException.
+    final var rounds = 60;
+    final var raceDeadlineBudgetMillis = 120_000L;
+    // Trailing grace per racer, applied only after the shared deadline expires. The joins below are
+    // sequential against ONE deadline, so a racer that finishes just before it would leave the next
+    // racer nothing but the 1 ms clamp and be reported as deadlocked while it is merely finishing
+    // (its session close can take seconds behind an in-flight commit).
+    final var trailingGraceMillis = 3_000L;
     var barrier = new CyclicBarrier(3);
     var error = new AtomicReference<Throwable>();
 
@@ -983,7 +1036,10 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
                 for (var i = 0; i < rounds; i++) {
                   barrier.await(30, TimeUnit.SECONDS);
                   var cls = "Racer" + i;
-                  session.executeInTx(tx -> session.getMetadata().getSchema().createClass(cls));
+                  // One collection per class instead of the default 8: same four-lock commit path
+                  // and the same interleaving under test, at roughly an eighth of the file churn.
+                  session.executeInTx(
+                      tx -> session.getMetadata().getSchema().createClass(cls, 1));
                   session.executeInTx(tx -> session.getMetadata().getSchema().dropClass(cls));
                 }
               } catch (final Throwable t) {
@@ -1035,18 +1091,43 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
             },
             "index-load-racer");
 
+    final var racers = new Thread[] {commitThread, reloadThread, indexThread};
     try {
+      // ONE shared, monotonic deadline for all three joins instead of three independent 55 s
+      // bounds, whose sum exceeded the @Test(timeout) and so guaranteed that a real deadlock could
+      // only ever surface as a bare TestTimedOutException with no thread state. Armed here,
+      // immediately before the racers start, so the (unrelated) openDatabase() cost above is not
+      // charged to it.
+      final var deadlineNanos = deadlineFromNow(raceDeadlineBudgetMillis);
       commitThread.start();
       reloadThread.start();
       indexThread.start();
 
-      commitThread.join(55_000);
-      reloadThread.join(55_000);
-      indexThread.join(55_000);
+      for (final var t : racers) {
+        t.join(remainingMillis(deadlineNanos));
+      }
+      // Trailing grace: whoever the shared deadline starved gets its own small bound, so "still
+      // alive" below means "did not finish even with slack", not "was joined for 1 ms".
+      for (final var t : racers) {
+        if (t.isAlive()) {
+          t.join(trailingGraceMillis);
+        }
+      }
 
-      assertFalse("the schema-commit racer must finish (no deadlock)", commitThread.isAlive());
-      assertFalse("the schema-reload racer must finish (no deadlock)", reloadThread.isAlive());
-      assertFalse("the index-load racer must finish (no deadlock)", indexThread.isAlive());
+      // Deadline breach - name the racers that are still running and dump their stacks BEFORE the
+      // finally arm interrupts them, since an interrupt unwinds exactly the state that shows where
+      // the lock cycle is. A racer that already failed is attached as the cause: it is the likelier
+      // root cause of a peer still sitting on the barrier.
+      final var stillAlive = new ArrayList<String>();
+      for (final var t : racers) {
+        if (t.isAlive()) {
+          stillAlive.add(t.getName());
+        }
+      }
+      assertWithRacerErrors(error,
+          "the racers must finish (no deadlock); still alive after " + raceDeadlineBudgetMillis
+              + " ms plus " + trailingGraceMillis + " ms grace: " + stillAlive,
+          stillAlive.isEmpty());
       if (error.get() != null) {
         throw new AssertionError("a concurrent racer failed", error.get());
       }
@@ -1059,7 +1140,15 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     }
   }
 
-  /** Interrupts each thread and joins it with a bounded wait so a test never leaks a racer thread. */
+  /**
+   * Interrupts each thread and joins it with a bounded wait so a test never leaks a racer thread.
+   * The bound is deliberately generous, because an interrupt is NOT the end of a racer's work: each
+   * racer's own {@code finally} still closes its session, and that close can legitimately block for
+   * seconds on the storage state lock behind an in-flight commit. A racer left unjoined here is
+   * still closing its session when the next test's teardown drops the database, which is a far
+   * worse failure than waiting. Both callers leave 80+ s between their shared wait deadline and
+   * their {@code @Test(timeout)}, so this wait costs nothing they need.
+   */
   private static void interruptAndJoin(final Thread... threads) throws InterruptedException {
     for (final var t : threads) {
       if (t != null) {
@@ -1071,6 +1160,31 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
         t.join(10_000);
       }
     }
+  }
+
+  /**
+   * Fails with {@code message} unless {@code condition} holds, dumping thread state first (see
+   * {@link com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics#failWithThreadDump}) and
+   * attaching whatever a racer thread has already recorded in {@code errors} as the cause.
+   *
+   * <p>The racer's throwable is the real root cause in the common shape: a racer dies, so it never
+   * sends the signal the body is waiting for, and the body then fails on its own bound. Plain
+   * {@code fail()} would discard that throwable entirely, because the {@code errors} check these
+   * tests do at the end is unreachable once an assertion has already thrown.
+   */
+  private static void assertWithRacerErrors(final AtomicReference<Throwable> errors,
+      final String message, final boolean condition) {
+    if (condition) {
+      return;
+    }
+    dumpThreads(message);
+    final var racerError = errors.get();
+    if (racerError != null) {
+      throw new AssertionError(
+          message + " — and a concurrent racer failed first, which is the likely root cause",
+          racerError);
+    }
+    fail(message);
   }
 
   /**

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
@@ -72,6 +72,15 @@ import org.junit.Test;
  */
 public class SchemaCommitReconciliationTest extends DbTestBase {
 
+  /**
+   * Bound for every join that follows the shared wait deadline of the two concurrency tests below:
+   * both the trailing grace those tests give a racer that is merely finishing, and the
+   * post-interrupt join in {@link #interruptAndJoin}. ONE constant because both cover the same
+   * worst case — a racer whose {@code finally} is closing its session, which can block on the
+   * storage state lock behind an in-flight commit.
+   */
+  private static final long CLEANUP_JOIN_MILLIS = 10_000L;
+
   private SchemaShared schemaShared() {
     return session.getSharedContext().getSchema();
   }
@@ -823,18 +832,20 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * exactly the guarantee under test; an "await the data commit while still holding the write lock"
    * shape would deadlock by construction.
    */
-  @Test(timeout = 180_000)
+  @Test(timeout = 210_000)
   public void dataCommitSerializesBehindHeldSchemaWriteLock() throws Exception {
     // A @Test(timeout) body runs on a JUnit watchdog thread, not the @Before thread, so the bound
     // session must be re-activated here before any use (the session is ThreadLocal-bound).
     session.activateOnCurrentThread();
-    // Budget derivation, same dialect as the sibling race test below. Local cost is ~1-2 s (disk)
-    // and ~1 s (memory, the module default); the Windows disk-storage CI leg was measured at 3.34x
-    // (p50) / 5.01x (p95) / 7.73x (max) the reference host, so 90 s is ~45x the worst observed
-    // cost. Tail: 90 s observer deadline + the 1 s exclusion probe + ~1 s thread dump + 20 s
-    // cleanup joins (2 x 10 s) = ~112 s, and the pinning hook's own 105 s bound cannot extend it
-    // (the body's finally releases the hook as soon as it fails) - all under the 180 s
-    // @Test(timeout).
+    // Budget derivation, same dialect as the sibling race test below. Measured cost of this method:
+    // ~1.9 s on DISK storage, ~1.0 s on MEMORY storage (the module default). The Windows
+    // disk-storage leg ran the affected tests at 3.34x (p50) / 5.01x (p95) / 7.73x (max) this host,
+    // so 90 s is ~6x even the worst-case slow-host cost of this method. Worst-case tail: 90 s
+    // observer deadline + 4 x 10 s trailing grace (one per deadline-derived wait, each able to
+    // finish just inside its grace) + the 1 s exclusion probe + ~1 s thread dump + 20 s cleanup
+    // joins (2 x 10 s) = ~152 s, under the 210 s @Test(timeout). The pinning hook's own bound
+    // (deadline + 15 s) cannot extend that: the body's finally releases the hook as soon as it
+    // fails.
     final var waitBudgetMillis = 90_000L;
     // The in-window hook must outlive the observer's deadline: if both expired together, the pinned
     // schema commit could unwind WHILE (or before) the diagnostic dump is taken, and the dump would
@@ -939,9 +950,9 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
       // below releases the pinned commit and interrupts both racers - either action unwinds the
       // stacks that would explain the stall.
       assertWithRacerErrors(errors, "the schema commit must enter its window",
-          schemaInWindow.await(remainingMillis(deadlineNanos.get()), TimeUnit.MILLISECONDS));
+          awaitWithTrailingGrace(schemaInWindow, deadlineNanos.get()));
       assertWithRacerErrors(errors, "the data thread must start its commit",
-          dataCommitStarted.await(remainingMillis(deadlineNanos.get()), TimeUnit.MILLISECONDS));
+          awaitWithTrailingGrace(dataCommitStarted, deadlineNanos.get()));
 
       // The data commit must NOT have completed yet: it is blocked on the read lock behind the held
       // write lock. A short bounded wait that times out is the positive signal of exclusion, so
@@ -952,10 +963,16 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
       // Release the schema commit; both commits must now complete with no deadlock.
       releaseSchema.countDown();
       schemaThread.join(remainingMillis(deadlineNanos.get()));
+      if (schemaThread.isAlive()) {
+        // Trailing grace, for the same reason as the race test's second join pass below: past the
+        // shared deadline remainingMillis() clamps to 1 ms, which would report a thread that is
+        // merely finishing (its finally is closing its session) as a stall.
+        schemaThread.join(CLEANUP_JOIN_MILLIS);
+      }
       assertWithRacerErrors(errors, "the schema commit must finish after release",
           !schemaThread.isAlive());
       assertWithRacerErrors(errors, "the data commit must complete once the write lock is released",
-          dataCommitted.await(remainingMillis(deadlineNanos.get()), TimeUnit.MILLISECONDS));
+          awaitWithTrailingGrace(dataCommitted, deadlineNanos.get()));
     } finally {
       // Always release the pinned schema commit and clear the hook, then interrupt-and-join both
       // racer threads so neither leaks past the test (each closes its own session in its own
@@ -990,7 +1007,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * four-lock interleaving. The {@code @Test(timeout)} is the deadlock detector: a lock-order
    * regression hangs and trips the timeout instead of hanging the whole suite.
    */
-  @Test(timeout = 210_000)
+  @Test(timeout = 240_000)
   public void schemaCommitReloadAndIndexLoadRaceWithoutDeadlock() throws Exception {
     // A @Test(timeout) body runs on a JUnit watchdog thread, not the @Before thread, so the bound
     // session must be re-activated here before its racer thread re-binds it.
@@ -1000,19 +1017,14 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     // collections (each collection is its own pair of files, so the default made a round create and
     // delete ~40 files); 60 rounds therefore cost ~3-4 s. On MEMORY storage - the module default,
     // and what most CI legs run - the whole method costs ~0.15 s, so the budget below is sized for
-    // the disk case, which dominates. The Windows disk-storage leg was measured at 3.34x (p50) /
-    // 5.01x (p95) / 7.73x (max) the reference host, so even the worst observed factor lands far
-    // inside the 120 s deadline. Tail: 120 s deadline + 3 x 3 s trailing grace + ~1 s thread dump +
-    // 30 s cleanup joins (3 x 10 s) = ~160 s under the 210 s @Test(timeout) - ~24% headroom, which
-    // is what keeps the failure a NAMED assertion carrying a thread dump instead of a bare
-    // TestTimedOutException.
+    // the disk case, which dominates. The Windows disk-storage leg ran the affected tests at 3.34x
+    // (p50) / 5.01x (p95) / 7.73x (max) this host, so even the worst-case slow-host cost of this
+    // method is ~4% of the 120 s deadline. Worst-case tail: 120 s deadline + 3 x 10 s trailing
+    // grace + ~1 s thread dump + 30 s cleanup joins (3 x 10 s) = ~181 s under the 240 s
+    // @Test(timeout) - which is what keeps a real deadlock a NAMED assertion carrying a thread dump
+    // instead of a bare TestTimedOutException.
     final var rounds = 60;
     final var raceDeadlineBudgetMillis = 120_000L;
-    // Trailing grace per racer, applied only after the shared deadline expires. The joins below are
-    // sequential against ONE deadline, so a racer that finishes just before it would leave the next
-    // racer nothing but the 1 ms clamp and be reported as deadlocked while it is merely finishing
-    // (its session close can take seconds behind an in-flight commit).
-    final var trailingGraceMillis = 3_000L;
     var barrier = new CyclicBarrier(3);
     var error = new AtomicReference<Throwable>();
 
@@ -1106,11 +1118,13 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
       for (final var t : racers) {
         t.join(remainingMillis(deadlineNanos));
       }
-      // Trailing grace: whoever the shared deadline starved gets its own small bound, so "still
-      // alive" below means "did not finish even with slack", not "was joined for 1 ms".
+      // Trailing grace: whoever the shared deadline starved gets its own bound, so "still alive"
+      // below means "did not finish even with slack", not "was joined for 1 ms". Sized like the
+      // post-interrupt join because it covers the same worst case - a racer whose finally is
+      // closing its session behind an in-flight commit.
       for (final var t : racers) {
         if (t.isAlive()) {
-          t.join(trailingGraceMillis);
+          t.join(CLEANUP_JOIN_MILLIS);
         }
       }
 
@@ -1126,7 +1140,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
       }
       assertWithRacerErrors(error,
           "the racers must finish (no deadlock); still alive after " + raceDeadlineBudgetMillis
-              + " ms plus " + trailingGraceMillis + " ms grace: " + stillAlive,
+              + " ms plus " + CLEANUP_JOIN_MILLIS + " ms grace: " + stillAlive,
           stillAlive.isEmpty());
       if (error.get() != null) {
         throw new AssertionError("a concurrent racer failed", error.get());
@@ -1146,7 +1160,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * racer's own {@code finally} still closes its session, and that close can legitimately block for
    * seconds on the storage state lock behind an in-flight commit. A racer left unjoined here is
    * still closing its session when the next test's teardown drops the database, which is a far
-   * worse failure than waiting. Both callers leave 80+ s between their shared wait deadline and
+   * worse failure than waiting. Both callers leave ~120 s between their shared wait deadline and
    * their {@code @Test(timeout)}, so this wait costs nothing they need.
    */
   private static void interruptAndJoin(final Thread... threads) throws InterruptedException {
@@ -1157,9 +1171,21 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     }
     for (final var t : threads) {
       if (t != null) {
-        t.join(10_000);
+        t.join(CLEANUP_JOIN_MILLIS);
       }
     }
+  }
+
+  /**
+   * Awaits {@code latch} until the shared deadline and, if it has not fired by then, once more for
+   * {@link #CLEANUP_JOIN_MILLIS}. Past the deadline {@link ConcurrencyDiagnostics#remainingMillis}
+   * clamps to 1 ms, so without this trailing grace a wait that follows a slow (but successful)
+   * earlier wait would report a latch that is about to fire as a stall.
+   */
+  private static boolean awaitWithTrailingGrace(final CountDownLatch latch,
+      final long deadlineNanos) throws InterruptedException {
+    return latch.await(remainingMillis(deadlineNanos), TimeUnit.MILLISECONDS)
+        || latch.await(CLEANUP_JOIN_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -1172,12 +1198,16 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * {@code fail()} would discard that throwable entirely, because the {@code errors} check these
    * tests do at the end is unreachable once an assertion has already thrown.
    */
-  private static void assertWithRacerErrors(final AtomicReference<Throwable> errors,
+  private void assertWithRacerErrors(final AtomicReference<Throwable> errors,
       final String message, final boolean condition) {
     if (condition) {
       return;
     }
-    dumpThreads(message);
+    // Label the dump with the test that produced it. The report accumulates blocks from four test
+    // classes sharing one forked JVM, and the recorded producer thread of a @Test(timeout) body is
+    // the uninformative "Time-limited test", so the class and method name are the only way to trace
+    // a block in a CI artifact back to its test.
+    dumpThreads(getClass().getSimpleName() + "." + name.getMethodName() + ": " + message);
     final var racerError = errors.get();
     if (racerError != null) {
       throw new AssertionError(
@@ -1200,8 +1230,10 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * <p>The timeout is the safety net for the regression case: with the guard gone the probes
    * acquire real locks, and any unexpected blocking on the non-interruptible lock acquisitions
    * must surface as a bounded test failure rather than as a silent forked-JVM death — the exact
-   * failure mode the guard exists to eliminate. Sixty seconds matches the sibling stress test
-   * and is ~80x this test's observed runtime, so it cannot flake under CI load.
+   * failure mode the guard exists to eliminate. Sixty seconds is ~80x this deterministic test's
+   * observed runtime, so it cannot flake under CI load. (The stress tests above need far larger
+   * timeouts because their internal wait deadlines, thread dump and cleanup joins must all fit
+   * inside them; this test has no racer to wait on, so it needs none of that headroom.)
    */
   @Test(timeout = 60_000)
   public void schemaLockAcquisitionUnderIndexManagerLockThrowsLockOrderViolation() {
@@ -1271,9 +1303,10 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    * <p>The timeout is load-bearing: if the upgrade guard regresses, the write acquisition below
    * parks forever on the non-interruptible ReentrantReadWriteLock — without a timeout this test
    * would BECOME the silent forked-JVM death it exists to prevent, leaving no surefire failure
-   * record. With it, the regression reports as a bounded, named test failure. Sixty seconds
-   * matches the sibling stress test and is ~80x this test's observed runtime, so it cannot
-   * flake under CI load.
+   * record. With it, the regression reports as a bounded, named test failure. Sixty seconds is
+   * ~80x this deterministic test's observed runtime, so it cannot flake under CI load; unlike the
+   * stress tests above it has no shared wait deadline, dump or cleanup joins to fit inside its
+   * timeout, so it needs no extra headroom.
    */
   @Test(timeout = 60_000)
   public void schemaReadToWriteUpgradeThrowsInsteadOfSelfDeadlocking() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
@@ -81,6 +81,23 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    */
   private static final long CLEANUP_JOIN_MILLIS = 10_000L;
 
+  /**
+   * How much longer than the shared wait deadline the in-window pinning hook of
+   * {@link #dataCommitSerializesBehindHeldSchemaWriteLock} stays pinned. It must exceed
+   * {@link #CLEANUP_JOIN_MILLIS}, because the observer's last wait can run that long past the
+   * deadline before it dumps: if the hook unpinned first, the schema commit would already be
+   * unwinding and the dump would no longer show the state it exists to capture.
+   */
+  private static final long HOOK_GRACE_MILLIS = 15_000L;
+
+  static {
+    // Enforced rather than merely documented, like the listener-hold invariant in
+    // MetadataWriteMutexTest: core tests run with -ea, so this fires at class-init time.
+    assert CLEANUP_JOIN_MILLIS < HOOK_GRACE_MILLIS
+        : "the observer's trailing grace must expire while the schema commit is still pinned:"
+            + " CLEANUP_JOIN_MILLIS must stay below HOOK_GRACE_MILLIS";
+  }
+
   private SchemaShared schemaShared() {
     return session.getSharedContext().getSchema();
   }
@@ -847,11 +864,11 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     // (deadline + 15 s) cannot extend that: the body's finally releases the hook as soon as it
     // fails.
     final var waitBudgetMillis = 90_000L;
-    // The in-window hook must outlive the observer's deadline: if both expired together, the pinned
-    // schema commit could unwind WHILE (or before) the diagnostic dump is taken, and the dump would
-    // show the very state we are trying to capture already gone. Strictly later, still far below
-    // the @Test(timeout).
-    final var hookGraceMillis = 15_000L;
+    // The in-window hook must outlive the observer's deadline AND its trailing grace: if they
+    // expired together, the pinned schema commit could unwind WHILE (or before) the diagnostic dump
+    // is taken, and the dump would show the very state we are trying to capture already gone. The
+    // ordering is asserted at class init (see HOOK_GRACE_MILLIS).
+    final var hookGraceMillis = HOOK_GRACE_MILLIS;
     // A pre-existing class for the pure-data commit to insert into (a create would itself be a
     // schema-carry commit; we need the read-lock branch).
     session.executeInTx(tx -> session.getMetadata().getSchema().createClass("DataTarget"));
@@ -1018,8 +1035,9 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     // delete ~40 files); 60 rounds therefore cost ~3-4 s. On MEMORY storage - the module default,
     // and what most CI legs run - the whole method costs ~0.15 s, so the budget below is sized for
     // the disk case, which dominates. The Windows disk-storage leg ran the affected tests at 3.34x
-    // (p50) / 5.01x (p95) / 7.73x (max) this host, so even the worst-case slow-host cost of this
-    // method is ~4% of the 120 s deadline. Worst-case tail: 120 s deadline + 3 x 10 s trailing
+    // (p50) / 5.01x (p95) / 7.73x (max) this host: at the worst observed factor those ~3-4 s become
+    // ~23-31 s, i.e. 20-26% of the 120 s deadline, so the deadline still has ~4x headroom over a
+    // legitimate slow-host run. Worst-case tail: 120 s deadline + 3 x 10 s trailing
     // grace + ~1 s thread dump + 30 s cleanup joins (3 x 10 s) = ~181 s under the 240 s
     // @Test(timeout) - which is what keeps a real deadlock a NAMED assertion carrying a thread dump
     // instead of a bare TestTimedOutException.
@@ -1190,7 +1208,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
 
   /**
    * Fails with {@code message} unless {@code condition} holds, dumping thread state first (see
-   * {@link com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics#failWithThreadDump}) and
+   * {@link com.jetbrains.youtrackdb.internal.ConcurrencyDiagnostics#dumpThreads}) and
    * attaching whatever a racer thread has already recorded in {@code errors} as the cause.
    *
    * <p>The racer's throwable is the real root cause in the common shape: a racer dies, so it never

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
@@ -35,6 +35,7 @@ import com.jetbrains.youtrackdb.api.YouTrackDB.LocalUserCredential;
 import com.jetbrains.youtrackdb.api.YouTrackDB.PredefinedLocalRole;
 import com.jetbrains.youtrackdb.api.YourTracks;
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.CommandInterruptedException;
@@ -905,8 +906,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
               } catch (final Throwable t) {
                 errors.compareAndSet(null, t);
               } finally {
-                schemaSession.activateOnCurrentThread();
-                schemaSession.close();
+                closeRacerSession(schemaSession, errors);
               }
             },
             "schema-commit-thread");
@@ -935,8 +935,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
               } catch (final Throwable t) {
                 errors.compareAndSet(null, t);
               } finally {
-                dataSession.activateOnCurrentThread();
-                dataSession.close();
+                closeRacerSession(dataSession, errors);
               }
             },
             "data-commit-thread");
@@ -1101,8 +1100,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
                 error.compareAndSet(null, t);
                 barrier.reset();
               } finally {
-                reloadSession.activateOnCurrentThread();
-                reloadSession.close();
+                closeRacerSession(reloadSession, error);
               }
             },
             "schema-reload-racer");
@@ -1122,8 +1120,7 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
                 error.compareAndSet(null, t);
                 barrier.reset();
               } finally {
-                indexSession.activateOnCurrentThread();
-                indexSession.close();
+                closeRacerSession(indexSession, error);
               }
             },
             "index-load-racer");
@@ -1197,6 +1194,37 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
     for (final var t : threads) {
       if (t != null) {
         t.join(CLEANUP_JOIN_MILLIS);
+      }
+    }
+  }
+
+  /**
+   * Closes {@code racerSession} on the calling racer thread, recording a close failure into
+   * {@code errors} instead of letting it escape the racer's {@code finally}.
+   *
+   * <p>An escaping close failure kills the racer thread with an uncaught exception that nothing
+   * records, so the test can still pass — the one path left in this class where a genuine failure
+   * goes green. The first failure stays primary (a close that fails BECAUSE the body failed must
+   * not displace the cause that explains it) and a later one is attached as suppressed, so neither
+   * is lost. The assertions already surface {@code errors}: the deadline-derived waits attach it as
+   * their cause and both tests re-check it at the end.
+   *
+   * <p>This is deliberately narrower than the canonical worker idiom of
+   * {@code MetadataWriteMutexTest}: converting these racers is deferred (their session opens sit
+   * outside the measured budget on purpose, and their peer release is a {@code CyclicBarrier} the
+   * idiom does not model), so only the silent-close path is closed here.
+   */
+  private static void closeRacerSession(final DatabaseSessionEmbedded racerSession,
+      final AtomicReference<Throwable> errors) {
+    try {
+      racerSession.activateOnCurrentThread();
+      racerSession.close();
+    } catch (final Throwable closeFailure) {
+      if (!errors.compareAndSet(null, closeFailure)) {
+        final var primary = errors.get();
+        if (primary != closeFailure) {
+          primary.addSuppressed(closeFailure);
+        }
       }
     }
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaCommitReconciliationTest.java
@@ -90,12 +90,19 @@ public class SchemaCommitReconciliationTest extends DbTestBase {
    */
   private static final long HOOK_GRACE_MILLIS = 15_000L;
 
+  /**
+   * The slack the bound ordering below must keep, so "below" cannot degrade into "below by a
+   * millisecond": taking the thread dump between the two expiries happens inside that slack.
+   */
+  private static final long INVARIANT_MARGIN_MILLIS = 2_000L;
+
   static {
     // Enforced rather than merely documented, like the listener-hold invariant in
     // MetadataWriteMutexTest: core tests run with -ea, so this fires at class-init time.
-    assert CLEANUP_JOIN_MILLIS < HOOK_GRACE_MILLIS
-        : "the observer's trailing grace must expire while the schema commit is still pinned:"
-            + " CLEANUP_JOIN_MILLIS must stay below HOOK_GRACE_MILLIS";
+    assert CLEANUP_JOIN_MILLIS + INVARIANT_MARGIN_MILLIS <= HOOK_GRACE_MILLIS
+        : "the observer's trailing grace must expire while the schema commit is still pinned, with"
+            + " room for the dump: CLEANUP_JOIN_MILLIS + INVARIANT_MARGIN_MILLIS must stay at or"
+            + " below HOOK_GRACE_MILLIS";
   }
 
   private SchemaShared schemaShared() {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheFlushErrorTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheFlushErrorTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -728,8 +729,21 @@ public class WOWCacheFlushErrorTest {
   /**
    * Invokes the private {@code stopFlush()} method via reflection, expecting it
    * to complete without exception.
+   *
+   * <p>{@code exclusiveWriteCacheSize} is installed first because {@code stopFlush} ends with a
+   * quiescent-point invariant assertion that reads it, and a Mockito {@code CALLS_REAL_METHODS}
+   * mock never runs a constructor, so all of {@link WOWCache}'s final fields are {@code null}
+   * here. Without this the real method under test NPEs on that read under {@code -ea} instead of
+   * exercising the shutdown path the tests are about. Installing a real counter (rather than
+   * relaxing the production assertion) also keeps the invariant meaningful: a negative value
+   * seeded by a future test would still fail the assertion.
    */
   private static void invokeStopFlush(WOWCache cache) throws Exception {
+    final Field counterField = findField(cache.getClass(), "exclusiveWriteCacheSize");
+    counterField.setAccessible(true);
+    if (counterField.get(cache) == null) {
+      counterField.set(cache, new AtomicLong());
+    }
     Method method = WOWCache.class.getDeclaredMethod("stopFlush");
     method.setAccessible(true);
     try {
@@ -754,7 +768,7 @@ public class WOWCacheFlushErrorTest {
   // These tests depend on the following WOWCache internal fields (via reflection):
   //   files, filesLock, id, pageSize, storageName, closed,
   //   dirtyPages, localDirtyPages, localDirtyPagesBySegment, writeCachePages,
-  //   flushError, pageIsBrokenListeners
+  //   flushError, pageIsBrokenListeners, exclusiveWriteCacheSize
   // If any of these fields are renamed or removed, update setField() calls here.
   // ---------------------------------------------------------------------------
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheLoadOrAddTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheLoadOrAddTest.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrackdb.internal.core.storage.cache.local;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -1004,5 +1005,111 @@ public class WOWCacheLoadOrAddTest {
           bytesBefore,
           Files.readAllBytes(diskPath));
     }
+  }
+
+  /**
+   * Regression test for the removed-file guard in
+   * {@link WOWCache#writeValidPageInFile(int, int)}.
+   *
+   * <p><b>Scenario.</b> {@code loadOrAdd}'s extend and gap-fill branches submit an
+   * {@link EnsurePageIsValidInFileTask} to the commit executor and return without waiting for
+   * it, so the stamp write is asynchronous with respect to the allocation. If the file is
+   * removed in the interval — {@code deleteFile}, or {@code replaceFileId}, which unregisters
+   * both ids from {@code files} while it rebinds them, or a backup restore — the queued task
+   * runs against a fileId that {@code files.acquire} no longer resolves and returns
+   * {@code null} for. This test drives that state deterministically: allocate and flush page 0
+   * (so the file genuinely exists on disk), delete the file, then invoke
+   * {@code writeValidPageInFile} directly, which is precisely what the queued task would do.
+   *
+   * <p><b>Pre-fix failure mode.</b> There was no null check: the method dereferenced the null
+   * entry at {@code entry.get()} and threw {@link NullPointerException} out of the flush
+   * executor (and would then have called {@code files.release(null)} from the finally block).
+   * The fix logs at WARN and returns.
+   *
+   * <p><b>Assertions.</b> The call must not throw, and it must not resurrect the deleted file
+   * on disk — a stamp write here would recreate a file the storage believes is gone (or, on the
+   * {@code replaceFileId} path, write into a fileId that now belongs to another component).
+   */
+  @Test
+  public void writeValidPageInFileSkipsStampWhenFileWasAlreadyRemoved() throws IOException {
+    final var fileId = wowCache.addFile(FILE_NAME);
+    final var intId = AbstractWriteCache.extractFileId(fileId);
+
+    // Allocate page 0 and drain the executor so the file exists on disk with a stamped page.
+    wowCache.loadOrAdd(fileId, 0L, false).decrementReadersReferrer();
+    wowCache.flush(fileId);
+
+    final var nativeName = wowCache.nativeFileNameById(fileId);
+    assertNotNull("file must have a registered native name", nativeName);
+    final var diskPath = storagePath.resolve(nativeName);
+    assertTrue("the file must exist on disk before the delete", Files.exists(diskPath));
+
+    // Remove the file. This unregisters it from the `files` container, so every subsequent
+    // files.acquire(...) for this id resolves to null.
+    wowCache.deleteFile(fileId);
+    assertFalse("deleteFile must remove the file from disk", Files.exists(diskPath));
+
+    // Stand-in for an EnsurePageIsValidInFileTask that was queued before the delete and runs
+    // after it. Pre-fix this threw NullPointerException from entry.get(); post-fix it logs a
+    // WARN and returns.
+    wowCache.writeValidPageInFile(intId, 0);
+
+    assertFalse(
+        "writeValidPageInFile must not resurrect a file that was already removed",
+        Files.exists(diskPath));
+  }
+
+  /**
+   * Regression test for the missing early return after the {@code flushError} diagnostic in
+   * {@link WOWCache#writeValidPageInFile(int, int)}.
+   *
+   * <p><b>Scenario.</b> Once a background flush has failed, {@code flushError} is set and every
+   * other flush-path entry point ({@code executeFileFlush}, {@code executeFindDirtySegment},
+   * {@code executePeriodicFlush}, {@code executeFlush}) logs and returns immediately — see the
+   * sibling tests in {@code WOWCacheFlushErrorTest}. {@code writeValidPageInFile} logged the
+   * same "can not write valid page in file" diagnostic and then carried on writing anyway,
+   * contradicting its own message and stamping a blank page into a file whose write cache is
+   * already known to be unflushable.
+   *
+   * <p><b>How the state is driven.</b> {@code flushError} is a private field with no setter, so
+   * it is injected by reflection — the same seam {@code WOWCacheFlushErrorTest} uses for the
+   * four sibling guards. The target page index is deliberately past the end of the freshly
+   * created (zero-length) file, so the inner
+   * {@code getUnderlyingFileSize() <= pagePosition} short-circuit does NOT fire and the method
+   * would genuinely attempt the write.
+   *
+   * <p><b>Pre-fix failure mode.</b> Falling through reached {@code AsyncFile.write}, whose
+   * {@code checkPosition} rejects an offset outside the allocated region and throws
+   * {@code StorageException("You are going to access region outside of allocated file
+   * position")} — a RuntimeException that the method's {@code catch (IOException |
+   * InterruptedException)} does not intercept, so it escaped raw to the flush executor. Post-fix
+   * the method returns at the guard and nothing is attempted.
+   *
+   * <p><b>Assertions.</b> The call must not throw and must not have extended the file. The
+   * injected {@code flushError} is cleared in a finally block so the {@code tearDown} teardown
+   * path ({@code wowCache.delete()}) is not perturbed by it.
+   */
+  @Test
+  public void writeValidPageInFileSkipsStampWhenFlushErrorIsRecorded() throws Exception {
+    final var fileId = wowCache.addFile(FILE_NAME);
+    final var intId = AbstractWriteCache.extractFileId(fileId);
+    assertEquals("fresh file must start at 0 pages", 0L, wowCache.getFilledUpTo(fileId));
+
+    final var flushErrorField = WOWCache.class.getDeclaredField("flushError");
+    flushErrorField.setAccessible(true);
+    flushErrorField.set(wowCache, new IOException("injected flush failure"));
+    try {
+      // Page 3 is past the end of the zero-length file, so the underlying-size short-circuit
+      // inside writeValidPageInFile cannot mask the flushError guard: the only thing that can
+      // stop the write here is the early return under test.
+      wowCache.writeValidPageInFile(intId, 3);
+    } finally {
+      flushErrorField.set(wowCache, null);
+    }
+
+    assertEquals(
+        "writeValidPageInFile must not extend the file after a recorded flush error",
+        0L,
+        wowCache.getFilledUpTo(fileId));
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
@@ -61,6 +61,14 @@ public class WOWCacheShrinkFileTest {
   private static final int TEST_SHUTDOWN_TIMEOUT = 10_000;
   private static final long TEST_EXCLUSIVE_WRITE_CACHE_MAX_SIZE = 100L;
 
+  /**
+   * Page count used by the exclusive-write-page accounting tests. Comfortably below
+   * {@link #TEST_EXCLUSIVE_WRITE_CACHE_MAX_SIZE} so no writer-latching flush is triggered
+   * while the test is building its precondition state, and large enough that the shrink test
+   * can split it into a purged range and a surviving range.
+   */
+  private static final int LEAK_TEST_PAGES = 6;
+
   private static final String FILE_NAME = "wowCacheShrinkFileTest.tst";
   private static final String STORAGE_NAME = "WOWCacheShrinkFileTest";
 
@@ -165,18 +173,28 @@ public class WOWCacheShrinkFileTest {
         testFile.delete();
       }
     }
+    // Recursive best-effort wipe, mirroring WOWCacheLoadOrAddTest.cleanUp(). This used to
+    // delete a hand-written list of names (name_id_map.cm, name_id_map_v2.cm) and then call
+    // Files.deleteIfExists(storagePath), which throws DirectoryNotEmptyException on anything
+    // the list misses — name_id_map_v3.cm (the format actually in use) and the WAL segments
+    // among them. On a passing test those are removed by wowCache.delete() /
+    // writeAheadLog.delete() above, so the gap was invisible; but if a test aborts partway
+    // (for example on the -ea exclusive-write-counter assertion) the leftovers make setUp
+    // itself throw for every subsequent run against the same target directory, turning one
+    // real failure into a permanently red class until the directory is wiped by hand.
     if (storagePath != null && Files.exists(storagePath)) {
-      var nameIdMapFile = storagePath.resolve("name_id_map.cm").toFile();
-      if (nameIdMapFile.exists()) {
-        //noinspection ResultOfMethodCallIgnored
-        nameIdMapFile.delete();
+      try (var stream = Files.walk(storagePath)) {
+        stream
+            .sorted(java.util.Comparator.reverseOrder())
+            .forEach(
+                p -> {
+                  try {
+                    Files.deleteIfExists(p);
+                  } catch (IOException e) {
+                    // best-effort cleanup
+                  }
+                });
       }
-      nameIdMapFile = storagePath.resolve("name_id_map_v2.cm").toFile();
-      if (nameIdMapFile.exists()) {
-        //noinspection ResultOfMethodCallIgnored
-        nameIdMapFile.delete();
-      }
-      Files.deleteIfExists(storagePath);
     }
   }
 
@@ -588,5 +606,328 @@ public class WOWCacheShrinkFileTest {
         .isInstanceOf(
             com.jetbrains.youtrackdb.internal.core.exception.StorageException.class)
         .hasMessageContaining("no file entry is open");
+  }
+
+  /**
+   * Regression test for the exclusive-write-page accounting leak in
+   * {@code WOWCache.doRemoveCachePages} — the <b>deleteFile</b> ordering, asserted strictly.
+   *
+   * <p><b>Scenario.</b> Allocate {@code LEAK_TEST_PAGES} pages and install a dirty
+   * {@code writeCachePages} entry for each, then drop the reader reference on every page. That
+   * last step is what publishes each page key into {@code exclusiveWritePages}:
+   * {@code CachePointer.decrementReadersReferrer} fires {@code addOnlyWriters} once a page
+   * reaches {@code readers == 0 && writers > 0}. It reproduces in-process exactly the state the
+   * real orchestration produces on this ordering, where
+   * {@code LockFreeReadCache.deleteFile}/{@code closeFile} purge the READ cache first (dropping
+   * the reader references) and only then call into the write cache. Deleting the file must then
+   * return both the counter and the set to zero.
+   *
+   * <p><b>The bug.</b> {@code doRemoveCachePages} nulls each page's writers listener before
+   * calling {@code decrementWritersReferrer}, deliberately suppressing the
+   * {@code removeOnlyWriters} callback. Before the fix nothing else did the bookkeeping, so
+   * every deleted file's page keys were orphaned in {@code exclusiveWritePages} and
+   * {@code exclusiveWriteCacheSize} never came back down. A permanently non-zero counter pins
+   * the periodic flush task at its 1 ms re-arm interval instead of 25 ms for the whole life of
+   * the storage, and once the leaked count reaches {@code exclusiveWriteCacheMaxSize} it starts
+   * latching writers.
+   *
+   * <p><b>Why the counter and the set are asserted independently, never against each other.</b>
+   * They leak in lockstep — the buggy path skipped both mutations — so
+   * {@code assertThat(counter).isEqualTo(setSize)} held true before the fix as well and proves
+   * nothing. Each is therefore pinned to an absolute expected value: exactly
+   * {@code LEAK_TEST_PAGES} before the delete and exactly zero after it. The set-size assertion
+   * is the one that distinguishes "the counter was decremented" from "the key was actually
+   * removed", which is why {@code getExclusiveWritePagesCountForTest()} exists.
+   *
+   * <p><b>Why background flushing is paused.</b> This cache is built with a 10 ms
+   * {@code pagesFlushInterval}. A periodic flush would write the dirty pages back and remove
+   * their keys through the normal {@code removeOnlyWriters} path, making the non-zero
+   * precondition (and hence the whole test) racy. {@code pauseBackgroundFlush()} additionally
+   * barriers on the commit executor, so any flush already in flight has fully returned before
+   * the test builds its state.
+   */
+  @Test
+  public void deleteFileClearsExclusiveWritePageAccounting() throws IOException {
+    wowCache.pauseBackgroundFlush();
+    try {
+      // Baseline: a fresh cache has no exclusive-write pages at all.
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("fresh cache must report a zero exclusive-write page counter")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("fresh cache must hold an empty exclusive-write page set")
+          .isZero();
+
+      final var fileId = allocateAndOptionallyDirty(LEAK_TEST_PAGES, true);
+
+      // Non-zero precondition. Without this the post-delete zero assertions would pass
+      // vacuously against a cache that never accumulated anything to leak.
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("every dirty reader-free page must be counted in the exclusive-write counter")
+          .isEqualTo(LEAK_TEST_PAGES);
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("every dirty reader-free page must be present in the exclusive-write page set")
+          .isEqualTo(LEAK_TEST_PAGES);
+
+      // deleteFile submits DeleteFileTask to the single-threaded commit executor and blocks on
+      // its future, so doRemoveCachePages has fully run by the time this call returns.
+      wowCache.deleteFile(fileId);
+
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("deleteFile must return the exclusive-write counter to zero (back-pressure and"
+              + " the 25 ms flush re-arm both depend on it reaching zero)")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("deleteFile must actually empty the exclusive-write page set, not merely fix up"
+              + " the counter")
+          .isZero();
+    } finally {
+      wowCache.resumeBackgroundFlush();
+    }
+  }
+
+  /**
+   * Same accounting invariant as {@link #deleteFileClearsExclusiveWritePageAccounting}, on the
+   * <b>closeFile</b> ordering, also asserted strictly.
+   *
+   * <p>{@code close(fileId, flush = false)} reaches {@code doRemoveCachePages} through
+   * {@code removeCachedPages} rather than through {@code DeleteFileTask}, and
+   * {@code LockFreeReadCache.closeFile} likewise purges the read cache before delegating. This
+   * test exists so a future change that fixes (or breaks) only the delete path cannot pass:
+   * both entry points must leave the counter and the set at zero.
+   *
+   * <p>{@code flush = false} is deliberate — with {@code flush = true} the pages would be
+   * written back and unregistered through the ordinary {@code removeOnlyWriters} callback,
+   * which is not the path under test.
+   */
+  @Test
+  public void closeFileWithoutFlushClearsExclusiveWritePageAccounting() throws IOException {
+    wowCache.pauseBackgroundFlush();
+    try {
+      final var fileId = allocateAndOptionallyDirty(LEAK_TEST_PAGES, true);
+
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("non-zero precondition: counter must reflect the dirty reader-free pages")
+          .isEqualTo(LEAK_TEST_PAGES);
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("non-zero precondition: set must hold one key per dirty reader-free page")
+          .isEqualTo(LEAK_TEST_PAGES);
+
+      wowCache.close(fileId, false);
+
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("close(fileId, false) must return the exclusive-write counter to zero")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("close(fileId, false) must actually empty the exclusive-write page set")
+          .isZero();
+    } finally {
+      wowCache.resumeBackgroundFlush();
+    }
+  }
+
+  /**
+   * Accounting behaviour of the range-scoped purge on the <b>shrinkFile</b> ordering —
+   * deliberately asserted only as a <i>direction of improvement</i>, never as a strict
+   * zero-leak claim.
+   *
+   * <p><b>Why not strict.</b> The production comment in {@code doRemoveCachePages} documents a
+   * known, unclosed window on this ordering: {@code LockFreeReadCache.shrinkFile} (and
+   * {@code truncateFile}) purge the write cache FIRST and clear the read cache afterwards, so
+   * the read cache is still live while the purge runs and a concurrent release or eviction can
+   * call {@code decrementReadersReferrer -> addOnlyWriters} and re-publish a key after the
+   * post-loop sweep has already passed it. The in-process shape below happens to be
+   * deterministic (there is no read cache and no eviction thread in this harness), but pinning
+   * an exact post-shrink value here would assert an invariant the production code explicitly
+   * does not promise, and would turn any future eviction-timing change into a spurious
+   * failure. Only the two properties the code does guarantee are asserted.
+   *
+   * <p><b>Property 1 — the purged range is accounted for.</b> The counter and the set must
+   * strictly decrease across the shrink. Before the fix they did not move at all, so this is
+   * the load-bearing half.
+   *
+   * <p><b>Property 2 — the surviving range is NOT over-purged.</b> Neither may drop below the
+   * number of pages the shrink keeps ({@code minPageIndex}). This is the guard against the
+   * whole-file sweep and the unconditional decrement that review rejected: both would run the
+   * counter down past the surviving pages and, on the real ordering, straight into negative
+   * territory, which silently disables the exclusive-write back-pressure altogether.
+   */
+  @Test
+  public void shrinkFileAccountsForThePurgedRangeWithoutOverPurgingTheSurvivors()
+      throws IOException {
+    wowCache.pauseBackgroundFlush();
+    try {
+      final var fileId = allocateAndOptionallyDirty(LEAK_TEST_PAGES, true);
+
+      final long counterBefore = wowCache.getExclusiveWriteCachePagesSize();
+      final int setSizeBefore = wowCache.getExclusiveWritePagesCountForTest();
+      assertThat(counterBefore)
+          .as("non-zero precondition: counter must reflect the dirty reader-free pages")
+          .isEqualTo(LEAK_TEST_PAGES);
+      assertThat(setSizeBefore)
+          .as("non-zero precondition: set must hold one key per dirty reader-free page")
+          .isEqualTo(LEAK_TEST_PAGES);
+
+      // Keep the first SURVIVING_PAGES pages, drop the rest.
+      final int survivingPages = 2;
+      assertThat(wowCache.shrinkFile(fileId, (long) survivingPages * pageSize))
+          .as("a real truncate must return true")
+          .isTrue();
+
+      // Property 1 — the dropped range was accounted for, not orphaned.
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("shrinkFile must account for the purged page range in the counter")
+          .isLessThan(counterBefore);
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("shrinkFile must remove the purged page range from the set")
+          .isLessThan(setSizeBefore);
+
+      // Property 2 — the surviving range below the target was not swept away.
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("the pages below the shrink target must stay counted (a whole-file sweep or an"
+              + " unconditional decrement would drop them and, on the real ordering, drive the"
+              + " counter negative)")
+          .isGreaterThanOrEqualTo(survivingPages);
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("the page keys below the shrink target must stay in the set")
+          .isGreaterThanOrEqualTo(survivingPages);
+    } finally {
+      wowCache.resumeBackgroundFlush();
+    }
+  }
+
+  /**
+   * The <b>conditional</b> half of the accounting fix: a dirty page that still has a reader
+   * must NOT be decremented when its file is purged.
+   *
+   * <p><b>Why this shape matters.</b> A page only enters {@code exclusiveWritePages} once it
+   * becomes writers-only ({@code readers == 0 && writers > 0}). On the
+   * {@code truncateFile}/{@code shrinkFile} ordering the write cache is purged BEFORE the read
+   * cache is cleared, so the pages still have readers and their keys are NOT in the set when
+   * {@code doRemoveCachePages} runs. This test reproduces that in-process by installing a dirty
+   * entry via {@code store} and deliberately holding the reader reference across the delete.
+   *
+   * <p>An unconditional {@code exclusiveWriteCacheSize.decrementAndGet()} in the purge — the
+   * variant review rejected — would take the counter to -1 here. A negative counter is strictly
+   * worse than the leak being fixed: {@code flushExclusivePagesIfNeeded} and
+   * {@code flushWriteCacheFromMinLSN} compare it against {@code exclusiveWriteCacheMaxSize}, so
+   * a negative value disables the exclusive-write back-pressure outright for the rest of the
+   * storage's lifetime. The counter must therefore stay at exactly zero, never go below it.
+   * (The {@code assert remaining >= 0} in the production helper would also trip here under
+   * {@code -ea}, which surefire enables.)
+   */
+  @Test
+  public void deleteFileDoesNotDecrementForPagesThatWereNeverPublishedAsWritersOnly()
+      throws IOException {
+    wowCache.pauseBackgroundFlush();
+    try {
+      final var fileId = wowCache.addFile(FILE_NAME);
+      wowCache.loadOrAdd(fileId, 0L, false).decrementReadersReferrer();
+
+      // Install a dirty writeCachePages entry but KEEP the reader reference, so the page stays
+      // at readers=1/writers=1 and addOnlyWriters never fires for it.
+      final var heldPointer = wowCache.load(fileId, 0L, new ModifiableBoolean(), false);
+      long exclusiveStamp = heldPointer.acquireExclusiveLock();
+      try {
+        var buffer = heldPointer.getBuffer();
+        assert buffer != null;
+        buffer.put(DurablePage.NEXT_FREE_POSITION, (byte) 0x5A);
+      } finally {
+        heldPointer.releaseExclusiveLock(exclusiveStamp);
+      }
+      wowCache.store(fileId, 0L, heldPointer);
+
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("a page that still has a reader must not be counted as exclusive-write")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("a page that still has a reader must not be present in the exclusive-write set")
+          .isZero();
+
+      // The purge walks this dirty entry and must find nothing to remove from the set.
+      wowCache.deleteFile(fileId);
+
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("purging a reader-held dirty page must leave the counter at zero, never negative"
+              + " (a negative counter permanently disables exclusive-write back-pressure)")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("purging a reader-held dirty page must leave the set empty")
+          .isZero();
+
+      // Release the reference the test held so the page frame returns to the pool.
+      heldPointer.decrementReadersReferrer();
+    } finally {
+      wowCache.resumeBackgroundFlush();
+    }
+  }
+
+  /**
+   * The <b>post-loop sweep</b>: page keys that exist ONLY in {@code exclusiveWritePages}, with
+   * no {@code writeCachePages} entry backing them, must still be cleaned up when their file is
+   * purged.
+   *
+   * <p><b>Why such keys exist.</b> {@code flushExclusiveWriteCache} documents the two structures
+   * as only eventually consistent, with {@code writeCachePages} as the source of truth; it even
+   * has a dedicated no-progress break for the case where a key has no entry and the file is too
+   * small to extend. That break is the source of the "no progress in flush cycle" warning this
+   * track eliminates. The purge loop iterates {@code writeCachePages}, so it structurally cannot
+   * see such a key — only the post-loop sweep can.
+   *
+   * <p><b>How the shape is built.</b> {@code addOnlyWriters} is the public {@code WritersListener}
+   * callback the cache installs on every stored page; calling it directly publishes a key into
+   * {@code exclusiveWritePages} and bumps the counter with no {@code writeCachePages} entry —
+   * exactly the orphan shape, built through production API rather than reflection.
+   *
+   * <p><b>Two properties, both load-bearing.</b> The delete must clear the orphans (only the
+   * sweep can), and the shrink must clear ONLY the keys at or above the truncate target. The
+   * second is the regression guard for the range-bound requirement: a whole-file sweep would
+   * also drop the three below-target keys, and on the real ordering that over-purge is what
+   * drives the counter negative. Exact values are asserted here — unlike the CachePointer-backed
+   * shrink test above — because these keys are synthetic: there is no read cache, no
+   * {@code CachePointer} and no listener behind them, so the concurrent-eviction re-publication
+   * that the production known-limitation comment describes cannot occur.
+   */
+  @Test
+  public void purgeSweepsKeysPresentOnlyInTheExclusiveWritePageSet() throws IOException {
+    wowCache.pauseBackgroundFlush();
+    try {
+      final var fileId = allocateAndOptionallyDirty(LEAK_TEST_PAGES, false);
+
+      // Publish LEAK_TEST_PAGES orphan keys: in the set, absent from writeCachePages.
+      for (int i = 0; i < LEAK_TEST_PAGES; i++) {
+        wowCache.addOnlyWriters(fileId, i);
+      }
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("non-zero precondition: every published orphan key must be counted")
+          .isEqualTo(LEAK_TEST_PAGES);
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("non-zero precondition: every published orphan key must be in the set")
+          .isEqualTo(LEAK_TEST_PAGES);
+
+      // Range-bound check first: shrink to 3 pages must sweep keys 3..5 and keep keys 0..2.
+      final int survivingPages = 3;
+      assertThat(wowCache.shrinkFile(fileId, (long) survivingPages * pageSize))
+          .as("a real truncate must return true")
+          .isTrue();
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("the sweep must be range-bound: only keys at or above the truncate target are"
+              + " dropped, so the three below-target keys stay counted")
+          .isEqualTo(survivingPages);
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("the sweep must leave the below-target keys in the set")
+          .isEqualTo(survivingPages);
+
+      // Now delete the file: minPageIndex is 0, so the sweep must clear the remainder.
+      wowCache.deleteFile(fileId);
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("deleting the file must sweep every remaining orphan key from the counter")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("deleting the file must sweep every remaining orphan key from the set")
+          .isZero();
+    } finally {
+      wowCache.resumeBackgroundFlush();
+    }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -1029,12 +1030,19 @@ public class WOWCacheShrinkFileTest {
    * exists precisely so the answer does not matter.
    *
    * <p><b>How the test builds it deterministically.</b> The two callbacks are public
-   * ({@code WritersListener}), so the interleaving's *net outcome* is reproduced exactly by
-   * calling them sequentially in the reverse order on the same key — no reflection, no threads,
-   * no timing. {@code removeOnlyWriters} first (counter to -1, set untouched because the key is
-   * absent), then {@code addOnlyWriters} (counter back to 0, key added). Background flushing is
-   * paused for the whole test so the transient -1 cannot be observed by the flush path's own
-   * pre-existing non-negativity assertion.
+   * ({@code WritersListener}), so the interleaving's *net outcome* is reproduced exactly by calling
+   * them sequentially in the reverse order on the same key — no threads and no timing.
+   * {@code removeOnlyWriters} first (counter to -1, set untouched because the key is absent), then
+   * {@code addOnlyWriters} (counter back to 0, key added). Background flushing is paused for the
+   * whole test so the transient -1 cannot be observed by the flush path's own pre-existing
+   * non-negativity assertion.
+   *
+   * <p>The test also pins both arms of the diagnostic's throttle, since the clamp is the only thing
+   * that emits it. The emitting arm needs nothing special: the throttle timestamp is initialised one
+   * full interval in the past and {@code nanoTime()} is monotonic, so the first clamp on a fresh
+   * cache always emits. The suppressing arm is the one that cannot be left to elapsed real time —
+   * see {@link #forceAccountingClampThrottleWindowOpen()}, the single place this test reaches into
+   * cache internals.
    *
    * <p><b>What must hold afterwards.</b> The purge sweeps the orphan key, and the counter ends at
    * exactly zero — <i>not</i> -1, which is the outcome the clamp exists to prevent and which would
@@ -1044,7 +1052,7 @@ public class WOWCacheShrinkFileTest {
    * no drift was present at all.
    */
   @Test
-  public void purgeClampsInsteadOfDrivingTheCounterNegativeOnAccountingDrift() throws IOException {
+  public void purgeClampsInsteadOfDrivingTheCounterNegativeOnAccountingDrift() throws Exception {
     wowCache.pauseBackgroundFlush();
     try {
       final var fileId = allocateAndOptionallyDirty(1, false);
@@ -1084,9 +1092,21 @@ public class WOWCacheShrinkFileTest {
           .as("throttle arm 1 — the first clamp on a cache instance must emit its diagnostic")
           .isEqualTo(1);
 
-      // Throttle arm 2: a second drift within the same throttle interval must still be counted as
-      // a clamp but must NOT emit a second record. Both arms are pinned deterministically because
-      // the interval is a minute and this runs in microseconds; no clock injection needed.
+      // Throttle arm 2: a clamp that happens while the throttle window is still open must still be
+      // counted, but must NOT emit a second record.
+      //
+      // The window is forced open explicitly rather than by assuming the work below outruns the
+      // clock. That work is not cheap: allocateAndOptionallyDirty's addFile and the deleteFile
+      // after it each finish with writeNameIdEntry(..., sync = true), i.e. a real
+      // nameIdMapHolder.force(true) fsync, plus a file create, a blank-page task and an unlink. On
+      // an I/O-throttled runner that can cumulatively outlast the one-minute throttle interval, at
+      // which point the second clamp legitimately emits and an assertion of 1 fails on correct
+      // code. No assertion on the emitted count can be both flake-free and able to catch a removed
+      // throttle while the gate is time-based — correct code under a long enough stall is
+      // indistinguishable from a throttle that never suppresses — so the clock is taken out of the
+      // comparison instead of merely being given more headroom.
+      forceAccountingClampThrottleWindowOpen();
+
       final var secondFileId = allocateAndOptionallyDirty(1, false);
       wowCache.removeOnlyWriters(secondFileId, 0);
       wowCache.addOnlyWriters(secondFileId, 0);
@@ -1106,5 +1126,35 @@ public class WOWCacheShrinkFileTest {
     } finally {
       wowCache.resumeBackgroundFlush();
     }
+  }
+
+  /**
+   * Makes {@link WOWCache}'s accounting-clamp log throttle behave as though it had just emitted a
+   * record, so the next clamp is suppressed regardless of how much real time passes — which is what
+   * lets the suppression arm of
+   * {@link #purgeClampsInsteadOfDrivingTheCounterNegativeOnAccountingDrift} assert an exact emitted
+   * count without depending on a wall-clock budget.
+   *
+   * <p>It parks the throttle's last-emitted timestamp far ahead of the clock, so the
+   * {@code now - last < interval} test inside {@code shouldLogAccountingClamp} sees a large negative
+   * elapsed time and takes the suppression branch for any {@code now}. The offset is added to a
+   * fresh {@code nanoTime()} reading rather than being written as an absolute constant: that keeps
+   * the difference bounded near {@code -Long.MAX_VALUE / 4} whatever origin the platform's
+   * {@code nanoTime()} uses, so the subtraction cannot overflow into a positive value and silently
+   * re-open the window. {@code nanoTime()} is documented as possibly negative, which is exactly the
+   * case an absolute constant would get wrong.
+   *
+   * <p>Reflection rather than a production seam, deliberately. Reaching into cache internals from a
+   * test is the established pattern in this package — {@code WOWCacheLoadOrAddTest} injects
+   * {@code flushError}, {@code WOWCacheFlushErrorTest} installs an {@code AtomicLong} into
+   * {@code exclusiveWriteCacheSize}, and three more classes here do the same kind of thing — and it
+   * leaves production behaviour byte-for-byte unchanged. A test-only mutator on {@link WOWCache}
+   * would have meant adding public API that no production path calls, to a class that is already
+   * over five thousand lines.
+   */
+  private void forceAccountingClampThrottleWindowOpen() throws Exception {
+    final var field = WOWCache.class.getDeclaredField("exclusiveWriteAccountingClampWarnNanos");
+    field.setAccessible(true);
+    ((AtomicLong) field.get(wowCache)).set(System.nanoTime() + Long.MAX_VALUE / 4);
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
@@ -766,9 +766,21 @@ public class WOWCacheShrinkFileTest {
    * the purge completes inside {@code shrinkFile} (which blocks on the task's future), background
    * flushing is paused, and the one thread that could otherwise re-publish a key — a read-cache
    * release or eviction — does not exist here, because the test drives {@link WOWCache} directly
-   * with no {@code LockFreeReadCache} and no evictor. Bounds instead of exact values were
-   * measurably too weak: a mutant that removes the sweep's range bound and purges the whole file
-   * passed them, and fails these.
+   * with no {@code LockFreeReadCache} and no evictor.
+   *
+   * <p>The exact values are what kill an off-by-one in the purge's range filter. Mutating
+   * {@code pageKey.pageIndex >= minPageIndex} to {@code >} in {@code doRemoveCachePages} leaves the
+   * page at the target index behind, so three keys survive where two should: measured, this test
+   * fails on the assertion below with {@code but was: 3L}. The bounds this replaced — strictly less
+   * than the 6 published keys, and at least the 2 surviving ones — both admit 3, so they passed
+   * that mutant.
+   *
+   * <p>What these assertions do <i>not</i> catch, so that the next reader does not over-trust them:
+   * removing the sweep's range bound (making it whole-file) is inert here, because the sweep skips
+   * any key that still has a {@code writeCachePages} entry and the below-target keys all do.
+   * Measured: that mutant leaves this test green and is caught instead by
+   * {@link #purgeSweepsKeysPresentOnlyInTheExclusiveWritePageSet}, whose keys are synthetic and have
+   * no {@code writeCachePages} entries. The two tests are complementary, not redundant.
    *
    * <p>The exactness is therefore a statement about this harness, <i>not</i> a zero-leak promise
    * for the production shrink ordering. There the read cache is still live while the purge runs,
@@ -1068,6 +1080,29 @@ public class WOWCacheShrinkFileTest {
           .as("the clamp branch must have executed exactly once; a zero here would mean the"
               + " assertions above passed without the drift ever being present")
           .isEqualTo(1);
+      assertThat(wowCache.getExclusiveWriteAccountingClampWarningsForTest())
+          .as("throttle arm 1 — the first clamp on a cache instance must emit its diagnostic")
+          .isEqualTo(1);
+
+      // Throttle arm 2: a second drift within the same throttle interval must still be counted as
+      // a clamp but must NOT emit a second record. Both arms are pinned deterministically because
+      // the interval is a minute and this runs in microseconds; no clock injection needed.
+      final var secondFileId = allocateAndOptionallyDirty(1, false);
+      wowCache.removeOnlyWriters(secondFileId, 0);
+      wowCache.addOnlyWriters(secondFileId, 0);
+      wowCache.deleteFile(secondFileId);
+
+      assertThat(wowCache.getExclusiveWriteAccountingClampsForTest())
+          .as("the second drift must still be counted — the counter is never throttled, which is"
+              + " what keeps a recurring drift measurable")
+          .isEqualTo(2);
+      assertThat(wowCache.getExclusiveWriteAccountingClampWarningsForTest())
+          .as("throttle arm 2 — a clamp inside the same interval must be suppressed, bounding the"
+              + " log volume emitted under the purge's page and group locks")
+          .isEqualTo(1);
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("the clamp must still hold the counter at zero on the second drift")
+          .isZero();
     } finally {
       wowCache.resumeBackgroundFlush();
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
@@ -156,10 +156,18 @@ public class WOWCacheShrinkFileTest {
 
   @After
   public void tearDown() throws IOException {
-    deleteCacheAndDeleteFile();
-    if (bufferPool != null) {
-      bufferPool.clear();
-      bufferPool = null;
+    // deleteCacheAndDeleteFile() now throws when it cannot fully wipe the storage directory, so
+    // the buffer-pool release has to be in a finally: otherwise that throw would skip
+    // bufferPool.clear() and the real failure would arrive alongside an unrelated direct-memory
+    // leak report from the shutdown detector — the same leak-masking shape the held-reader
+    // release in deleteFileDoesNotDecrementForPagesThatWereNeverPublishedAsWritersOnly avoids.
+    try {
+      deleteCacheAndDeleteFile();
+    } finally {
+      if (bufferPool != null) {
+        bufferPool.clear();
+        bufferPool = null;
+      }
     }
   }
 
@@ -750,30 +758,33 @@ public class WOWCacheShrinkFileTest {
   }
 
   /**
-   * Accounting behaviour of the range-scoped purge on the <b>shrinkFile</b> ordering —
-   * deliberately asserted only as a <i>direction of improvement</i>, never as a strict
-   * zero-leak claim.
+   * Accounting behaviour of the range-scoped purge on the <b>shrinkFile</b> ordering: exactly the
+   * page keys at or above the truncate target are dropped, and the ones below it survive.
    *
-   * <p><b>Why not strict.</b> The production comment in {@code doRemoveCachePages} documents a
-   * known, unclosed window on this ordering: {@code LockFreeReadCache.shrinkFile} (and
-   * {@code truncateFile}) purge the write cache FIRST and clear the read cache afterwards, so
-   * the read cache is still live while the purge runs and a concurrent release or eviction can
-   * call {@code decrementReadersReferrer -> addOnlyWriters} and re-publish a key after the
-   * post-loop sweep has already passed it. The in-process shape below happens to be
-   * deterministic (there is no read cache and no eviction thread in this harness), but pinning
-   * an exact post-shrink value here would assert an invariant the production code explicitly
-   * does not promise, and would turn any future eviction-timing change into a spurious
-   * failure. Only the two properties the code does guarantee are asserted.
+   * <p><b>Why exact values are asserted, and what they do NOT claim.</b> The outcome is fully
+   * determined in this harness: all {@code LEAK_TEST_PAGES} keys are published before the shrink,
+   * the purge completes inside {@code shrinkFile} (which blocks on the task's future), background
+   * flushing is paused, and the one thread that could otherwise re-publish a key — a read-cache
+   * release or eviction — does not exist here, because the test drives {@link WOWCache} directly
+   * with no {@code LockFreeReadCache} and no evictor. Bounds instead of exact values were
+   * measurably too weak: a mutant that removes the sweep's range bound and purges the whole file
+   * passed them, and fails these.
    *
-   * <p><b>Property 1 — the purged range is accounted for.</b> The counter and the set must
-   * strictly decrease across the shrink. Before the fix they did not move at all, so this is
-   * the load-bearing half.
+   * <p>The exactness is therefore a statement about this harness, <i>not</i> a zero-leak promise
+   * for the production shrink ordering. There the read cache is still live while the purge runs,
+   * so a concurrent release or eviction can call
+   * {@code decrementReadersReferrer -> addOnlyWriters} and re-publish a key after the post-loop
+   * sweep has passed it — which is exactly why {@code doRemoveCachePages} carries a KNOWN
+   * LIMITATION block for these two orderings.
+   *
+   * <p><b>Property 1 — the purged range is accounted for.</b> The counter and the set must land on
+   * exactly the number of surviving pages. Before the fix they did not move at all.
    *
    * <p><b>Property 2 — the surviving range is NOT over-purged.</b> Neither may drop below the
-   * number of pages the shrink keeps ({@code minPageIndex}). This is the guard against the
-   * whole-file sweep and the unconditional decrement that review rejected: both would run the
-   * counter down past the surviving pages and, on the real ordering, straight into negative
-   * territory, which silently disables the exclusive-write back-pressure altogether.
+   * pages the shrink keeps. This is the guard against the whole-file sweep and the
+   * removal-independent decrement that review rejected: both would run the counter down past the
+   * surviving pages and, on the real ordering, straight into negative territory, which silently
+   * disables the exclusive-write back-pressure altogether.
    */
   @Test
   public void shrinkFileAccountsForThePurgedRangeWithoutOverPurgingTheSurvivors()
@@ -982,6 +993,81 @@ public class WOWCacheShrinkFileTest {
       assertThat(wowCache.getExclusiveWritePagesCountForTest())
           .as("deleting the file must sweep every remaining orphan key from the set")
           .isZero();
+    } finally {
+      wowCache.resumeBackgroundFlush();
+    }
+  }
+
+  /**
+   * The non-negativity <b>clamp</b> in {@code removeExclusiveWritePage}: when the purge finds a key
+   * in {@code exclusiveWritePages} whose {@code exclusiveWriteCacheSize} contribution has already
+   * been consumed, it must remove the key, leave the counter unchanged instead of decrementing it
+   * below zero, and record the event.
+   *
+   * <p><b>Why this state is reachable in production.</b> {@code addOnlyWriters} and
+   * {@code removeOnlyWriters} each mutate the counter and the set as two separate operations, and
+   * {@link com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer} invokes them only
+   * after the CAS on its referrer word, holding no lock that orders one callback against the
+   * other. Two threads transitioning the same page in opposite directions can therefore have
+   * their callbacks interleave in the order opposite to their CAS order: the decrementing thread's
+   * {@code removeOnlyWriters} runs first, so its set removal is a no-op (the key is not there
+   * yet) but its decrement lands, and the incrementing thread's {@code addOnlyWriters} then adds
+   * the key and restores the count. Net result: the key is in the set with no contribution behind
+   * it. Whether that interleaving is actually reachable was disputed between reviewers; the clamp
+   * exists precisely so the answer does not matter.
+   *
+   * <p><b>How the test builds it deterministically.</b> The two callbacks are public
+   * ({@code WritersListener}), so the interleaving's *net outcome* is reproduced exactly by
+   * calling them sequentially in the reverse order on the same key — no reflection, no threads,
+   * no timing. {@code removeOnlyWriters} first (counter to -1, set untouched because the key is
+   * absent), then {@code addOnlyWriters} (counter back to 0, key added). Background flushing is
+   * paused for the whole test so the transient -1 cannot be observed by the flush path's own
+   * pre-existing non-negativity assertion.
+   *
+   * <p><b>What must hold afterwards.</b> The purge sweeps the orphan key, and the counter ends at
+   * exactly zero — <i>not</i> -1, which is the outcome the clamp exists to prevent and which would
+   * permanently disable writer back-pressure in {@code checkCacheOverflow} and the proactive
+   * exclusive flush in {@code executePeriodicFlush}. The clamp counter must read exactly 1, which
+   * is what proves the clamp branch actually executed rather than the assertions passing because
+   * no drift was present at all.
+   */
+  @Test
+  public void purgeClampsInsteadOfDrivingTheCounterNegativeOnAccountingDrift() throws IOException {
+    wowCache.pauseBackgroundFlush();
+    try {
+      final var fileId = allocateAndOptionallyDirty(1, false);
+
+      // Reproduce the net outcome of the opposite-order callback interleaving on page 0.
+      wowCache.removeOnlyWriters(fileId, 0);
+      wowCache.addOnlyWriters(fileId, 0);
+
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("drift precondition: the counter must be back at zero")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("drift precondition: the set must still hold the orphaned key, so the counter and"
+              + " the set disagree — this is the state the clamp has to survive")
+          .isEqualTo(1);
+      assertThat(wowCache.getExclusiveWriteAccountingClampsForTest())
+          .as("no clamp should have engaged while merely building the precondition")
+          .isZero();
+
+      // The purge sweeps the orphan key and finds nothing left to decrement.
+      wowCache.deleteFile(fileId);
+
+      assertThat(wowCache.getExclusiveWriteCachePagesSize())
+          .as("the clamp must leave the counter at zero; -1 here would permanently disable both"
+              + " writer back-pressure (checkCacheOverflow) and the proactive exclusive flush"
+              + " (executePeriodicFlush only flushes while the counter is >= 0)")
+          .isZero();
+      assertThat(wowCache.getExclusiveWritePagesCountForTest())
+          .as("the orphaned key must still be removed from the set — clamping the counter must not"
+              + " mean skipping the cleanup")
+          .isZero();
+      assertThat(wowCache.getExclusiveWriteAccountingClampsForTest())
+          .as("the clamp branch must have executed exactly once; a zero here would mean the"
+              + " assertions above passed without the drift ever being present")
+          .isEqualTo(1);
     } finally {
       wowCache.resumeBackgroundFlush();
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
@@ -26,9 +26,19 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Focused regression tests for {@link WOWCache#shrinkFile(long, long)}.
+ * Regression tests for {@link WOWCache#shrinkFile(long, long)} and for the exclusive-write page
+ * accounting that the file-purge path ({@code doRemoveCachePages}) maintains.
  *
- * <p>The recovery-time orphan-truncation pass uses this primitive to repair the
+ * <p>The class covers two related areas. The original one is {@code shrinkFile} itself, listed
+ * below. The second, added with the accounting-leak fix, is the {@code exclusiveWritePages} /
+ * {@code exclusiveWriteCacheSize} bookkeeping that {@code deleteFile}, {@code close(fileId,false)}
+ * and {@code shrinkFile} all drive through the same purge: those tests live here because this class
+ * already builds a real single-file {@link WOWCache} and has the {@code allocateAndOptionallyDirty}
+ * helper needed to put pages into a deterministic writers-only state. They are named
+ * {@code ...ExclusiveWritePage...} / {@code ...Sweep...} rather than {@code shrinkFile...} so the
+ * split is visible from the test names alone.
+ *
+ * <p>The recovery-time orphan-truncation pass uses the shrink primitive to repair the
  * {@code logical &lt;= physical} invariant on entry-point-equipped storage components after a
  * partial-flush crash. Three load-bearing semantics under test:
  *
@@ -183,6 +193,11 @@ public class WOWCacheShrinkFileTest {
     // itself throw for every subsequent run against the same target directory, turning one
     // real failure into a permanently red class until the directory is wiped by hand.
     if (storagePath != null && Files.exists(storagePath)) {
+      // Collect per-path failures instead of swallowing them. Silently ignoring an IOException
+      // here is what let the original residue problem hide: the wipe appears to succeed, and
+      // the next run fails far away in setUp with a DirectoryNotEmptyException that names no
+      // cause. Anything left behind is reported with the paths that could not be removed.
+      final var undeletable = new java.util.ArrayList<String>();
       try (var stream = Files.walk(storagePath)) {
         stream
             .sorted(java.util.Comparator.reverseOrder())
@@ -191,9 +206,17 @@ public class WOWCacheShrinkFileTest {
                   try {
                     Files.deleteIfExists(p);
                   } catch (IOException e) {
-                    // best-effort cleanup
+                    undeletable.add(p + " (" + e.getClass().getSimpleName() + ": "
+                        + e.getMessage() + ")");
                   }
                 });
+      }
+      if (!undeletable.isEmpty()) {
+        throw new IOException(
+            "Could not fully wipe the test storage directory "
+                + storagePath
+                + "; leftovers will break every subsequent run of this class: "
+                + undeletable);
       }
     }
   }
@@ -768,29 +791,39 @@ public class WOWCacheShrinkFileTest {
           .as("non-zero precondition: set must hold one key per dirty reader-free page")
           .isEqualTo(LEAK_TEST_PAGES);
 
-      // Keep the first SURVIVING_PAGES pages, drop the rest.
+      // Keep the first survivingPages pages, drop the rest.
       final int survivingPages = 2;
       assertThat(wowCache.shrinkFile(fileId, (long) survivingPages * pageSize))
           .as("a real truncate must return true")
           .isTrue();
 
-      // Property 1 — the dropped range was accounted for, not orphaned.
+      // Exact expected value, not a bound. In THIS harness the outcome is fully determined:
+      // all LEAK_TEST_PAGES keys are published before the shrink, the purge runs to completion
+      // inside shrinkFile (which blocks on the task's future), and the only other thread that
+      // could publish a key — a read-cache release or eviction — does not exist here, because
+      // the test drives WOWCache directly with no LockFreeReadCache and no evictor. Asserting
+      // a range instead would let a mutant that purges the wrong number of keys pass.
+      //
+      // This is a claim about the harness, NOT a zero-leak promise for the production shrink
+      // ordering: there the read cache is still live during the purge and a key can be
+      // re-published after the sweep, which is why doRemoveCachePages documents that window as
+      // a known limitation.
+      final int expectedAfterShrink = survivingPages;
       assertThat(wowCache.getExclusiveWriteCachePagesSize())
-          .as("shrinkFile must account for the purged page range in the counter")
-          .isLessThan(counterBefore);
+          .as("shrinkFile must account for exactly the purged page range: %d published pages"
+              + " minus the %d dropped at or above the target",
+              counterBefore, LEAK_TEST_PAGES - survivingPages)
+          .isEqualTo(expectedAfterShrink);
       assertThat(wowCache.getExclusiveWritePagesCountForTest())
-          .as("shrinkFile must remove the purged page range from the set")
-          .isLessThan(setSizeBefore);
-
-      // Property 2 — the surviving range below the target was not swept away.
-      assertThat(wowCache.getExclusiveWriteCachePagesSize())
-          .as("the pages below the shrink target must stay counted (a whole-file sweep or an"
-              + " unconditional decrement would drop them and, on the real ordering, drive the"
-              + " counter negative)")
-          .isGreaterThanOrEqualTo(survivingPages);
-      assertThat(wowCache.getExclusiveWritePagesCountForTest())
-          .as("the page keys below the shrink target must stay in the set")
-          .isGreaterThanOrEqualTo(survivingPages);
+          .as("shrinkFile must remove exactly the purged page range from the set, leaving the"
+              + " %d below-target keys (a whole-file sweep or a removal-independent"
+              + " decrement would drop those too and, on the real ordering, drive the"
+              + " counter negative)",
+              survivingPages)
+          .isEqualTo(expectedAfterShrink);
+      assertThat(setSizeBefore - wowCache.getExclusiveWritePagesCountForTest())
+          .as("exactly the at-or-above-target keys must have been removed")
+          .isEqualTo(LEAK_TEST_PAGES - survivingPages);
     } finally {
       wowCache.resumeBackgroundFlush();
     }
@@ -807,14 +840,26 @@ public class WOWCacheShrinkFileTest {
    * {@code doRemoveCachePages} runs. This test reproduces that in-process by installing a dirty
    * entry via {@code store} and deliberately holding the reader reference across the delete.
    *
-   * <p>An unconditional {@code exclusiveWriteCacheSize.decrementAndGet()} in the purge — the
+   * <p>A removal-independent {@code exclusiveWriteCacheSize.decrementAndGet()} in the purge — the
    * variant review rejected — would take the counter to -1 here. A negative counter is strictly
-   * worse than the leak being fixed: {@code flushExclusivePagesIfNeeded} and
-   * {@code flushWriteCacheFromMinLSN} compare it against {@code exclusiveWriteCacheMaxSize}, so
-   * a negative value disables the exclusive-write back-pressure outright for the rest of the
-   * storage's lifetime. The counter must therefore stay at exactly zero, never go below it.
-   * (The {@code assert remaining >= 0} in the production helper would also trip here under
-   * {@code -ea}, which surefire enables.)
+   * worse than the leak being fixed: {@code checkCacheOverflow} enforces writer back-pressure
+   * with {@code while (exclusiveWriteCacheSize.get() > exclusiveWriteCacheMaxSize)} and
+   * {@code executePeriodicFlush} only flushes exclusive pages while the counter is {@code >= 0},
+   * so one negative value disables both for the rest of the storage's lifetime. The counter must
+   * therefore stay at exactly zero and never go below it.
+   *
+   * <p><b>This test passes against the pre-fix code, by design.</b> Before the fix the purge did
+   * no accounting at all, so the counter also stayed at zero here. It is not a regression test
+   * for the shipped leak (that is {@link #deleteFileClearsExclusiveWritePageAccounting}); it is a
+   * guard against the *rejected alternative implementation* — the removal-independent decrement.
+   *
+   * <p>Detecting that mutant needs the clamp counter, not the value assertions. The production
+   * clamp deliberately prevents the counter going negative, so a purge that decrements without
+   * having removed anything now leaves the counter at zero too — indistinguishable from correct
+   * behaviour by value alone. {@code getExclusiveWriteAccountingClampsForTest()} is the
+   * observable difference: the clamp must never engage on this deterministic single-threaded
+   * path, and it engages exactly once per purged page under the mutant. Verified by mutation:
+   * with the removal guard removed, this test fails on the clamp assertion below.
    */
   @Test
   public void deleteFileDoesNotDecrementForPagesThatWereNeverPublishedAsWritersOnly()
@@ -844,19 +889,30 @@ public class WOWCacheShrinkFileTest {
           .as("a page that still has a reader must not be present in the exclusive-write set")
           .isZero();
 
-      // The purge walks this dirty entry and must find nothing to remove from the set.
-      wowCache.deleteFile(fileId);
+      try {
+        // The purge walks this dirty entry and must find nothing to remove from the set.
+        wowCache.deleteFile(fileId);
 
-      assertThat(wowCache.getExclusiveWriteCachePagesSize())
-          .as("purging a reader-held dirty page must leave the counter at zero, never negative"
-              + " (a negative counter permanently disables exclusive-write back-pressure)")
-          .isZero();
-      assertThat(wowCache.getExclusiveWritePagesCountForTest())
-          .as("purging a reader-held dirty page must leave the set empty")
-          .isZero();
-
-      // Release the reference the test held so the page frame returns to the pool.
-      heldPointer.decrementReadersReferrer();
+        assertThat(wowCache.getExclusiveWriteCachePagesSize())
+            .as("purging a reader-held dirty page must leave the counter at zero, never negative"
+                + " (a negative counter permanently disables exclusive-write back-pressure)")
+            .isZero();
+        assertThat(wowCache.getExclusiveWritePagesCountForTest())
+            .as("purging a reader-held dirty page must leave the set empty")
+            .isZero();
+        assertThat(wowCache.getExclusiveWriteAccountingClampsForTest())
+            .as("the non-negativity clamp must never engage on this deterministic path: engaging"
+                + " means the purge tried to decrement for a key it had not removed, which is"
+                + " the rejected removal-independent-decrement implementation")
+            .isZero();
+      } finally {
+        // Release the reference the test deliberately held, on every path. In a try/finally
+        // rather than trailing the assertions: a failing assertion above would otherwise skip
+        // the release and leak the PageFrame, so the real failure would be followed by an
+        // unrelated direct-memory leak report from the shutdown detector and the diagnosis
+        // would start from the wrong symptom.
+        heldPointer.decrementReadersReferrer();
+      }
     } finally {
       wowCache.resumeBackgroundFlush();
     }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheShrinkFileTest.java
@@ -1056,6 +1056,7 @@ public class WOWCacheShrinkFileTest {
     wowCache.pauseBackgroundFlush();
     try {
       final var fileId = allocateAndOptionallyDirty(1, false);
+      final var throttleNanosBeforeArm1 = accountingClampThrottleNanos().get();
 
       // Reproduce the net outcome of the opposite-order callback interleaving on page 0.
       wowCache.removeOnlyWriters(fileId, 0);
@@ -1091,6 +1092,14 @@ public class WOWCacheShrinkFileTest {
       assertThat(wowCache.getExclusiveWriteAccountingClampWarningsForTest())
           .as("throttle arm 1 — the first clamp on a cache instance must emit its diagnostic")
           .isEqualTo(1);
+      // Emitting is only half the contract: the throttle must also RECORD that it emitted, or it
+      // would emit again on every clamp and the bound would not exist. Compared against the value
+      // read before the drift rather than against System.nanoTime(): the timestamp only moves
+      // forward, so extra elapsed time can never make this fail — only a missing write can.
+      assertThat(accountingClampThrottleNanos().get())
+          .as("throttle arm 1 — emitting must advance the last-emitted timestamp; leaving it at the"
+              + " bootstrap value would re-open the window immediately")
+          .isGreaterThan(throttleNanosBeforeArm1);
 
       // Throttle arm 2: a clamp that happens while the throttle window is still open must still be
       // counted, but must NOT emit a second record.
@@ -1153,8 +1162,13 @@ public class WOWCacheShrinkFileTest {
    * over five thousand lines.
    */
   private void forceAccountingClampThrottleWindowOpen() throws Exception {
+    accountingClampThrottleNanos().set(System.nanoTime() + Long.MAX_VALUE / 4);
+  }
+
+  /** The cache's accounting-clamp throttle timestamp, for the two assertions that inspect it. */
+  private AtomicLong accountingClampThrottleNanos() throws Exception {
     final var field = WOWCache.class.getDeclaredField("exclusiveWriteAccountingClampWarnNanos");
     field.setAccessible(true);
-    ((AtomicLong) field.get(wowCache)).set(System.nanoTime() + Long.MAX_VALUE / 4);
+    return (AtomicLong) field.get(wowCache);
   }
 }


### PR DESCRIPTION
#### Motivation:

The Java CI/CD Integration Tests Pipeline fails on `develop` on Windows only (JDK 21 and 25); every Linux leg is green. Two tests introduced by #1150 fail: the schema-commit/reload/index-load race in `SchemaCommitReconciliationTest` times out in 3 of 3 runs, and the two-concurrent-schema-transaction case in `MetadataWriteMutexTest` fails an assertion in 1 of 3.

Neither is a product defect in the transactional-schema work. Both tests assert absolute wall-clock budgets, while the Windows disk-storage leg is far slower and far more variable than the hardware those budgets were calibrated on: a 596-class cross-leg comparison gives p50 3.34x, p95 5.01x and max 7.73x, and that leg's own wall-clock duration has ranged from 3h44m to 18h12m over the last 30 days. The race test needs only about 5.5x to breach its bounds. Measurement confirms the mechanism: per-round timings are uniform, the committing thread is RUNNABLE inside fsync 81% of sampled time, and no thread waits on any page-cache lock.

A pre-existing defect in the race test compounds this: its three sequential racer joins sum to more than the test's own timeout, so the test can never reach its named assertions nor emit diagnostics — it can only die as a bare timeout carrying no thread state, which is exactly what CI reported.

Investigation also surfaced a real pre-existing accounting leak in `WOWCache`'s exclusive-write-page tracking. It is fixed here because it makes every disk-storage run slower (worst on NTFS) and leaves one CI job one page short of a silent livelock.

#### Planned changes:

**Current state**
- The schema-commit race test created classes with the default collection count, so each round performed roughly forty file creations and deletions, dominated by registry fsyncs. It bounded each of its three racer threads independently, and those bounds together exceeded its own test timeout.
- `MetadataWriteMutexTest` carried about thirty wall-clock bounds of mixed intent — genuine liveness waits, "must not happen" probes, spin-state observations and "must no-op promptly" checks — many of them set to five seconds around full schema transactions.
- `WOWCache` suppressed the writers-listener callback while purging a deleted file's pages, so each deleted page's key was orphaned in the exclusive-write-page set and the exclusive-write-page counter was never decremented. The counter therefore never returned to zero, which pinned the periodic flush task at its shortest re-arm interval for the lifetime of the storage.
- On test timeout the JUnit listener only dumped threads when the JVM reported a monitor deadlock, which never happens for future, latch or spin-lock waits; its report writer truncated a fixed filename and was unsynchronized. The CI diagnostics upload steps collected neither surefire nor failsafe reports.

**What changes**

No product behaviour or API changes. The only production change is internal write-cache accounting: the exclusive-write-page counter and set now return to zero after a file is deleted, restoring the intended flush cadence and back-pressure bound; the counter is also clamped at zero, with a one-time warning logged if it would otherwise underflow. Test-visible behaviour: the two affected tests are now insensitive to host speed while keeping — and in one case strengthening — their detection power. Failure diagnostics: a timing-out race test now emits a thread dump into the report file CI already uploads, so a future occurrence is diagnosable.

**How**
- Reduces the race test's per-round cost by creating single-collection classes through the schema API's existing single-collection creation path, cutting roughly forty files per round to about five, and raises the round count to 60 so detection power increases rather than decreases.
- Replaces the three independent racer joins with a single shared deadline armed when the racers start, clamped so it can never degenerate into an unbounded or invalid wait, with the test timeout set comfortably above the deadline plus dump and cleanup cost so the named assertions and the dump are always reached.
- Classifies every bound in `MetadataWriteMutexTest` by intent and widens only the liveness and performance ones, using several purpose-named constants rather than one; deliberately leaves the spin-observation and "must no-op promptly" bounds short, since widening them would make them vacuous. Splits the shared error holder so a failure in either transaction is attributed correctly, and makes latch releases unconditional so a failing thread never strands its peer; drops the mutex serialisation assertion rather than keeping it, since re-expressing it as a liveness-only check against the mutex's own engagement state proved tautological. Consolidates the test's sixteen spawned workers onto one canonical worker runner, closing a systemic defect where a worker's failure could pass the test green.
- Applies the same shared-deadline treatment to the sibling data-commit-behind-schema-write-lock test, which had the identical bound-sum defect.
- In `WOWCache`, removes the orphaned key and decrements the exclusive-write-page counter only when the removal actually took effect, inside the existing page-frame lock region so the documented lock ordering is preserved, and adds a sweep over the remaining keys of the deleted file while the files registry is exclusively held, because the purge loop iterates the write-cache map and therefore cannot see set-only orphans.
- Hardens the write-cache flush path's handling of a page whose file has already been removed, matching the sibling flush path.
- Gives the JUnit listener a thread-safe, append-only entry point for writing the diagnostics report, so a test's dump and the watchdog's dump can coexist while four test classes share one JVM.
- Extends the CI diagnostics upload steps additively — one of them collected failsafe patterns only, so a blanket replacement would have deleted its sole diagnostics — running them before, not after, the test-results publish step so diagnostics are always attached, letting them run even when a job is killed by its own timeout, and sizing their own step timeouts so the upload itself is never the reason a job is judged hung.

**Key decisions**
- Fixes the budgets and the workload rather than the storage engine. An initial diagnosis attributed the timeout to a page-cache deadlock; measurement refuted it. The latent hazard that diagnosis found is real but is not this failure's cause, and correcting it turned out to require a substantially riskier redesign, so it is deferred, with its analysis recorded below (Out of scope).
- Reduces work before widening bounds. Widening alone was rejected: reconstructing the test's duration on fast and slow legs put it at 145-227 seconds under observed factors, so the widening first proposed would have left residual flakiness.
- Raises the round count to 60, not higher. Holding rounds times duration constant was rejected as unsound: each round is a single barrier rendezvous whose outcome is decided before the commit work begins, so detection power scales with round count alone. The workload reduction plus doubling the round count to 60 cut the race test's method time from 9.50 s to 2.98 s; measurement then showed that pushing further to 90+ rounds is unsafe against the shared racer deadline, so 60 stands as the settled ceiling rather than a provisional value.
- Moves the appendable diagnostics writer into the workload/budget work rather than the cache-accounting work it was originally planned for, because the race test's shared-deadline breach path is the first consumer of a thread dump on timeout and needed the writer available immediately, not after the cache-accounting work landed.
- Drops the mutex-engagement assertion entirely rather than keeping a liveness-only version. A ticket-ordering assertion was already rejected because the mutex is released before the commit call returns, leaving no valid seam; the liveness-only alternative adopted in its place was then found, during code review, to be a tautology that held regardless of whether serialisation actually occurred, so it was removed instead of kept.
- Consolidates the mutex test's spawned workers onto one canonical worker runner. This was not in the original plan; code review found a systemic defect where a worker's failure could pass the test green, so consolidating onto one runner was necessary to make the test's failures trustworthy.
- Does not add a global timeout multiplier. Nothing consumes one today, and the real variable is storage mode times host, which a single flag would mis-scale.
- Fixes the exclusive-write-page leak with a conditional decrement. An unconditional one was rejected: some purge paths clear the write cache before the read cache, so it would drive the counter negative and disable back-pressure entirely.
- Guards the counter with a floor clamp instead of an assertion. An assertion would crash the storage engine in production if some still-unknown path violates the invariant; clamping the counter at zero and logging a one-time warning turns a latent violation into a diagnosable signal instead of a storage-ending failure, while a regression test still enforces the invariant under CI.

**Out of scope** (deferred, all analysed and handed over for issue filing)

Led by the most severe: a latched write-cache flush error leaves dirty-segment detection reporting nothing, so a fuzzy checkpoint or WAL vacuum can advance past segments whose pages exist only in memory — pre-existing, not introduced here, and an unrecoverable data-loss path if triggered. Fourteen further items below were validated against the pushed tree during review and are awaiting YouTrack issue numbers (none assigned yet), in descending severity, followed by the items already noted at design time:
- The asynchronous file layer's close path can deadlock uninterruptibly against its own write-completion callback when a partial write is in flight, invisible to the JVM's built-in deadlock detector.
- Two lost-signal paths in the asynchronous file layer can permanently leak a write-completion permit, hanging that file's sync and close forever with no timeout able to recover it.
- The IO and embedded thread pools pass their constructor arguments in the wrong order, silently collapsing to a single thread on hosts with eleven or more CPUs.
- The write cache's page-store path takes the global files lock while already holding a page-frame lock, the root of a lock-ordering hazard mitigated today one call site at a time rather than at the source.
- Two write-cache flush loops have no progress guard, so a stalled exit condition spins the sole flush thread indefinitely with no diagnostic signal.
- WAL vacuum holds the storage's read lock across an unbounded wait on the flush executor, which can block close, delete and schema DDL storage-wide if that executor stalls.
- Every disk storage shares one JVM-global write-cache flush executor, so a wedge on that single thread stalls flushing for every storage in the process.
- The JUnit 5 test module carries no in-JVM deadlock watchdog, so the CI diagnostics uploads this change adds have nothing to collect for a hang there.
- A concurrency lock's per-method documentation still describes reentrancy counters that do not exist, contradicting its own class-level "not reentrant" note.
- Interrupting the wait for a page-purge task can release the files lock while the purge sweep is still running, orphaning exclusive-write accounting under a narrow, low-frequency race.
- A read-cache load path's exclusion from concurrent purge depends on having exactly one production caller today, an invariant nothing in the code enforces.
- A write-cache bookkeeping map for triggered flush tasks is never pruned, growing without bound and slowing shutdown over a long-running storage's lifetime.
- The exclusive-write accounting-clamp counter this change adds has a throttled log signal but no production metric.
- The schema-commit race test's three racer threads still use hand-rolled error attribution instead of the canonical single-error-holder worker idiom this change introduced for the mutex test.
- The delete-marker registry record is written with its logical and filesystem names transposed relative to create records.
- Batching the registry fsyncs that dominate schema DDL cost, which would cut roughly 120 forces per create-and-drop round to about 42 and directly shorten the Windows leg.
- The undocumented default collection count per class inherited from OrientDB.
- Integration tests never run on Windows and never gate a PR, and the sequential-test category is inert under failsafe.
- The Windows integration leg's duration and variance as a CI-health item.
- A misleading provider-detection comment in the core module's build configuration: manually configured providers always win, so parallel class execution and the custom run listener are in fact honoured.

**Risks & accepted trade-offs**
- Bound sizing rested on a cross-leg factor distribution rather than a Windows measurement of these specific tests, whose true duration had been censored by the bound being fixed; the dedicated Windows `workflow_dispatch` run described under Verification approach closed that gap before this flip, passing on both JDK legs.
- The estimate that CI Linux is about twice local speed under four-way parallel class execution is unmeasured.
- The latent write-cache locking hazard is knowingly left in place (see Out of scope).
- Reducing collections per class narrows each round's window; the round-count increase is the agreed compensation, and the reasoning behind its magnitude was itself adversarially reviewed and corrected.
- Two commits landed after the tree that Windows run validated — a log-message and derived-argument change plus one strengthened test assertion (no control-flow or state change), and the empty final marker commit — and neither was re-run on Windows; accepted given their scope.

Design review: user-approved — 2026-07-29 (v3, supersedes earlier approval)

Adversarial review: passed, 3 rounds, 4 accepted risks — 2026-07-29

**Verification approach**

Both affected test classes were run in a dedicated worktree on disk-backed storage; the race test's method time fell from 9.50 s to 2.98 s at double the round count (60), with measurement showing 90+ rounds unsafe. The write-cache unit tests pass; flush-cycle "no progress" warnings dropped from 204-213 per run to 0; the coverage gate passed at 100% line (42/42) / 93.8% branch coverage on the changed surface; the full core unit suite (19,833 tests, 0 failures, 0 errors, 101 skipped) is green on the production tree; a targeted integration subset (239 tests, 0 failures) is also green. A dedicated Windows `workflow_dispatch` run (https://github.com/JetBrains/youtrackdb/actions/runs/30575078096) confirmed both target tests pass on Windows disk storage: JDK 21 succeeded in 1h31m and JDK 25 in 2h58m, every Linux leg stayed green, and the diagnostics-upload gate itself was green on both Windows legs. Two further commits landed after the tree that run validated — a log-message and derived-argument change plus one strengthened test assertion, and the empty final marker commit — and were not re-run on Windows (see Risks).
