### PR TITLE
Upgrade slate to 0.5.1 and enable per-action model routing

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -3,5 +3,9 @@
   "defaultModel": "claude-opus-5",
   "defaultThinkingLevel": "xhigh",
   "hideThinkingBlock": true,
-  "packages": ["npm:ytdb-slate@0.4.0", "npm:pi-smart-fetch@0.3.17", "npm:pi-web-search@1.3.1"]
+  "packages": [
+    "npm:ytdb-slate@0.5.1",
+    "npm:pi-smart-fetch@0.3.17",
+    "npm:pi-web-search@1.3.1"
+  ]
 }

--- a/.pi/slate.json
+++ b/.pi/slate.json
@@ -6,13 +6,20 @@
   "workerExtensions": ["^npm:pi-smart-fetch(@|$)", "^npm:pi-web-search(@|$)"],
   "doctrineExtraPath": "docs-internal/agents/slate-doctrine-extra.md",
   "reviewPerspectivesPath": "docs-internal/agents/review-perspectives.md",
+  "episodeModel": "anthropic/claude-sonnet-5",
+  "router": {
+    "models": [
+      "anthropic/claude-opus-5",
+      "anthropic/claude-sonnet-5",
+      "openai/gpt-5.6-sol",
+      "openai/gpt-5.6-luna"
+    ],
+    "allowUnmeasuredEffort": false
+  },
   "modelFailover": {
-    "anthropic/claude-sonnet-5": "openai/gpt-5.6-luna",
-    "openai/gpt-5.6-luna": "anthropic/claude-sonnet-5",
-    "anthropic/claude-opus-4-8": "openai/gpt-5.6-terra",
-    "openai/gpt-5.6-terra": "anthropic/claude-opus-4-8",
-    "anthropic/claude-fable-5": "openai/gpt-5.6-sol",
     "anthropic/claude-opus-5": "openai/gpt-5.6-sol",
-    "openai/gpt-5.6-sol": "anthropic/claude-opus-5"
+    "anthropic/claude-sonnet-5": "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-sol": "anthropic/claude-opus-5",
+    "openai/gpt-5.6-luna": "anthropic/claude-opus-5"
   }
 }

--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -8,7 +8,7 @@ product documentation lives in the [user documentation index](../docs/README.md)
 
 | Document | Description |
 |---|---|
-| [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, umbrella-PR peer-review policy, package pin-bump rule |
+| [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, umbrella-PR peer-review policy, action-level model-routing and failover configuration, package pin-bump rule |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, web tools, codebase tips |
 | [Architecture Decision Records](adr/) | Archive of Architecture Decision Records, plus historical/sunset workflow research logs |

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -15,8 +15,8 @@ code review → mandatory user review → marker commit), and the change-size sc
 and pr-publishing.md — umbrella draft PR before implementation, description rules,
 ready-for-review flip, user-performed merge (draft-PR publishing is enabled for this repo).
 YTDB deltas — the `develop` base branch, issue-prefix/PR-template conventions, the
-umbrella-PR peer-review policy, and the package pin-bump rule — live in
-`docs-internal/dev-workflow/track-development.md`.
+umbrella-PR peer-review policy, the action-level model-routing setup, and the package
+pin-bump rule — live in `docs-internal/dev-workflow/track-development.md`.
 
 This flow covers **all files in the repository**, including `.pi/` configuration, prompts,
 and docs — not only Java/product sources. There is no "harness tooling" exemption: editing a

--- a/docs-internal/agents/slate-doctrine-extra.md
+++ b/docs-internal/agents/slate-doctrine-extra.md
@@ -16,3 +16,20 @@ itself, for changes of any size:
    description in sync (pr-publishing.md § After the flip).
 3. Peer review supplements, never replaces, the mandatory per-track
    user review (track-workflow.md § Peer review).
+
+## Model routing
+
+1. Always name both `model` and `effort`, or neither. Naming one alone
+   takes the other from a default you did not choose.
+2. Name neither only for bulk mechanical work: the dispatch then rides
+   the thread's base, which is sized for nothing else.
+3. Gate and verification actions MUST name both, on a level the live
+   routing table marks measured for that model, and MUST NOT be sized
+   down to the cheapest model that looks like it would clear them:
+   adversarial review, agent code review, the design-review and
+   PR-description statements, the ready-for-review flip, Maven
+   build/test/coverage runs, commits and pushes, and any change to
+   storage, WAL, index, transaction or crash-recovery code.
+
+Rationale, model-list maintenance and the machine-local prerequisite:
+`docs-internal/dev-workflow/track-development.md` § Model routing.

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -10,8 +10,9 @@ demand:
   mandatory user review → marker commit), marker-commit mechanics, and the change-size
   scaling table.
 - **pr-publishing.md** — umbrella draft PR mechanics: creation before implementation,
-  description rules (Motivation, Planned changes, Tracks), ready-for-review flip checklist,
-  user-performed merge.
+  description rules (Motivation, Planned changes, Tracks, plus the 16,384-UTF-8-byte body
+  target and the size exception that must carry measurements), ready-for-review flip
+  checklist, user-performed merge.
 
 This document carries ONLY the YTDB-specific deltas layered on that baseline. Draft-PR
 publishing is ENABLED for this repository (`workflow.draftPRs` in `.pi/slate.json`), so
@@ -31,7 +32,18 @@ targets it, and track 01's base is the merge-base with it.
   `docs-internal/agents/orchestrator-guidelines.md` § Git Conventions.
 - The PR description follows the repository template at `.github/pull_request_template.md`,
   which instantiates the generic description rules owned by pr-publishing.md (Motivation,
-  Planned changes with its subsections and hard guards, Tracks).
+  Planned changes with its subsections and hard guards, Tracks). What the template does NOT
+  carry, and pr-publishing.md § Description rules still requires: keep the description body
+  at or below 16,384 UTF-8 bytes (a target, not a gate — measure the GitHub API `body`
+  string, never a formatted `git log %b`), and when it runs over, record a size exception in
+  Risks & accepted trade-offs carrying the measurements — the overrun, every top-level
+  section's byte count, and the before-count of anything condensed. Measure at the
+  ready-for-review flip, after every post-flip description change, and again at the final
+  handoff for merge (pr-publishing.md § After the flip); YTDB's per-push title/description
+  sync, per the bullet above, is what makes those points recur.
+- The template has no Open questions subsection, so open questions carried over from the
+  research log live in Risks & accepted trade-offs — which is also where the flip checklist
+  wants each remaining one resolved, or its user-approved deferral recorded.
 
 ## Peer review
 
@@ -48,6 +60,139 @@ Per-track implementation (step 1 of the generic track loop) follows YTDB's test 
 pre-commit verification rules in `docs-internal/agents/orchestrator-guidelines.md`; the
 exact command lines are in `docs-internal/agents/thread-guidelines.md`.
 
+## Model routing
+
+Action-level model routing is ENABLED for this repository (`router` in `.pi/slate.json`).
+The mechanics — guards, resolution, effort ladders, per-model profile data — are owned by
+the package's model-routing.md; this section records only the choices this project made and
+what follows from them.
+
+**The candidate list.** Four models are routable: `anthropic/claude-opus-5`,
+`anthropic/claude-sonnet-5`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-luna`.
+`openai/gpt-5.6-terra` is excluded: its shipped profile marks it never-auto-select with no
+defensible routing niche, and every routable model adds a row to the routing table Slate
+renders into the orchestrator doctrine on EVERY turn, so listing a model no action should
+land on spends context every turn and buys nothing. `anthropic/claude-sonnet-5` is listed
+despite carrying the same never-auto-select marker, solely for the one niche its profile
+names: only if sol is unavailable, at `high`. `anthropic/claude-fable-5` is excluded on two
+counts: never-auto-select, and it has no zero-data-retention option.
+
+**Maintaining the list.** The routable set is CLOSED to the nine models the package ships
+profiles for — project-supplied profiles do not exist — so adding a model takes a ytdb-slate
+release, not a config edit. Write canonical `provider/id` specs only: the profile table's
+alias spellings resolve a profile but are not routable specs, since pi's registry decides
+what can be dispatched and most aliases are absent from it. A spec that differs by one
+character is dropped as unprofiled or as unknown to the registry, leaving a three-model list
+that still routes — read the warnings, or the typo passes for a working config. If every
+entry drops, the router turns OFF entirely and dispatches fall back to the host session's
+model.
+
+**When warnings appear.** Only config-SHAPE checks run at session start: a `router` value
+that is not an object, an unknown key under it, a non-array `models`, a malformed entry, a
+non-boolean `allowUnmeasuredEffort`. Candidate resolution — profile lookup, registry and
+credential checks, effort-ladder readability, failover coverage — is memoized and runs at
+the FIRST consultation instead: the doctrine build in orchestrator mode, or the first
+dispatch outside it. A session that builds no doctrine and dispatches nothing emits none of
+those warnings, which is what the acceptance check below has to work around.
+
+**Effort policy.** `router.allowUnmeasuredEffort` is `false`, so an explicit level that sits
+on the model's ladder but carries no capability measurement is refused rather than warned
+about. Only a level the dispatch NAMES can be refused: omit `effort` and the router derives
+the model's lowest measured level, which by construction clears the guard. What the setting
+costs, per model: `off`, `low`, `high` and `xhigh` on `gpt-5.6-luna`; `off` and `low` on
+`gpt-5.6-sol`; `off` and `minimal` on `claude-opus-5`; `minimal`, `low` and `medium` on
+`claude-sonnet-5`. Of those, the ones this project would otherwise have reached for are
+`luna@high` and `luna@xhigh` (escalating luna instead of routing to sol) and `sol@low`. Two
+nearby refusals come from elsewhere and stand whatever this key says: `minimal` is off-ladder
+on both `gpt-5.6` models, and `off` on `claude-sonnet-5` is rejected outright by the
+provider — which is why `off` is absent from that model's list above.
+
+**Unsized dispatches.** A dispatch that names neither `model` nor `effort` runs on the
+thread's base. For a NEW thread that base is `openai/gpt-5.6-luna@medium` — the cheapest
+preferred candidate at its lowest measured level. A thread that predates the router is the
+exception worth knowing: when its stored pre-router pin is itself a listed model, the router
+keeps that pin as the base and derives that model's own lowest measured level, silently and
+with no warning — a thread pinned to `claude-opus-5` bases to `claude-opus-5@low`. Only a
+base that is absent or off-list is re-seeded, and a re-seed does warn. Either way the router
+lowers the pre-router floor of `claude-opus-5@xhigh` (`.pi/settings.json`), and no candidate
+list restores it: even a list of `claude-opus-5` and `openai/gpt-5.6-sol` alone bases a new
+thread to `claude-opus-5@low`. The compensating discipline is the Model routing rule in
+`docs-internal/agents/slate-doctrine-extra.md`, which Slate does not enforce in code — name
+both arguments on every action that needs more than the base.
+
+**Episode compression.** `episodeModel` is pinned to `anthropic/claude-sonnet-5`. Left
+unpinned it resolves from registry state — the newest available Anthropic Sonnet, by numeric
+version comparison — so a future model release could move compression onto a model the
+failover map does not cover, without saying so. The pin keeps that answer stable.
+
+**The failover map.** `modelFailover` covers three consumers, and Slate checks only the
+first: the router's candidates (an uncovered candidate produces one aggregate warning at the
+first consultation), the orchestrator's own session model (`defaultModel` in
+`.pi/settings.json`, today `claude-opus-5`), and the pinned `episodeModel`. Nothing warns
+about the last two, and dropping a model from `router.models` does not end its need for cover
+while it is still one of them. The current pairing keeps every route cross-provider, so one
+provider's outage cannot take out both sides of a pair: `claude-opus-5 → gpt-5.6-sol` (which
+also covers the orchestrator session), `claude-sonnet-5 → gpt-5.6-sol` (also the episode
+compressor), `gpt-5.6-sol → claude-opus-5`, `gpt-5.6-luna → claude-opus-5`.
+
+**What failover ignores.** A failover switch bypasses the list and effort guards entirely —
+the package's deliberate carve-out, since a model that just failed is worse than an unlisted
+one that works — and it requests no level, so pi re-applies the session's current level to
+the fallback model. `allowUnmeasuredEffort: false` therefore does not constrain the retry, and
+the episode header drops its `(unmeasured level)` marker whenever the model changed
+mid-action, so an unmeasured retry level leaves no trace there either. Each pair above retries
+on a level its target has a measurement at, with one accepted residual: `claude-opus-5@low`
+retries as `gpt-5.6-sol@low`, and sol carries no measurement at `low`.
+
+**Machine-local prerequisite.** Routing here assumes a per-developer, untracked
+`~/.pi/agent/models.json` that raises the registry context window of the `gpt-5.6-*` models
+to 1,050,000. pi documents this exact override in its own `docs/models.md` § Per-model
+Overrides (installed with the `@earendil-works/pi-coding-agent` package), including the
+warning that above 272K total input the whole request bills at GPT-5.6's long-context rates:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "modelOverrides": {
+        "gpt-5.6-sol": { "contextWindow": 1050000 },
+        "gpt-5.6-luna": { "contextWindow": 1050000 }
+      }
+    }
+  }
+}
+```
+
+Slate's profile records 1,050,000 for those models while the base registry reports 272,000,
+and the window guard judges against the REGISTRY figure. A developer without the override
+sees three extra warnings per session — a context-window divergence for `gpt-5.6-luna`, one
+for `gpt-5.6-sol`, and one aggregate line noting that the registry window equals those
+models' own long-context billing threshold — and the guard then treats both GPT models as
+narrower than `claude-opus-5` (1,000,000), so a long thread is substituted off them onto an
+Anthropic candidate rather than the reverse. The override is deliberately not reproduced
+repo-side: `models.json` is a user-global pi file, not project config.
+
+**Acceptance check.** Router health is invisible to a bare `pi -p "<prompt>"`: the
+orchestrator-mode auto-seed is gated to TUI sessions, so a print-mode run builds no doctrine,
+never consults the resolver, and emits ZERO router warnings however broken the list is. Turn
+the mode on in the same session instead — `pi -p "/slate on" "hi"`, which runs the command
+first and the prompt second — and the warnings reach stderr. A healthy configuration prints
+exactly four, one per routable model, each reporting unknown routing-critical data and that
+routing decisions for that model are provisional. Anything beyond those four is a finding:
+context-window-divergence or long-context-billing lines mean the `models.json` override is
+missing, a failover-coverage line means a candidate lost its `modelFailover` entry, a
+"no benchmark data" or "not in pi's model registry" line means a spec is misspelled, and an
+`allowUnmeasuredEffort` line means the key is no longer a boolean.
+
+**Authority.** The routing table Slate renders into the doctrine each turn is the single
+authority on per-model guidance, prices and measured levels; do not restate it under
+`docs-internal/`. The effort-policy enumeration above is the one deliberate exception — it
+explains a project setting rather than the table — and it is re-checked at every pin bump.
+The figures drift: prices are dated schedules (`claude-sonnet-5`'s step up 50% on 2026-09-01,
+which changes the table's numbers but not its order, since `nonPreferred` sorts that model
+last on both sides of the step), and measured levels, route-for/avoid-for guidance and the
+profiled model set itself change whenever the package is republished.
+
 ## Package pin bumps
 
 Changing the `ytdb-slate` version pin in `.pi/settings.json` is a tracked change like any
@@ -55,3 +200,6 @@ other — it takes the full workflow. In addition, whoever bumps the pin MUST re
 document and `docs-internal/agents/slate-doctrine-extra.md` against the NEW package docs and
 fix any skew: the deltas here are valid only relative to the package version they were
 written against.
+
+Last reconciled against **ytdb-slate 0.5.1**: track-workflow.md, pr-publishing.md,
+model-routing.md and model-failover.md — the package documents these deltas actually rest on.


### PR DESCRIPTION
#### PR Title:
Upgrade slate to 0.5.1 and enable per-action model routing

#### Motivation:
The project pins `ytdb-slate` at 0.4.0. Release 0.5.1 adds an opt-in per-action model router: each dispatched worker action can carry its own model and effort level, sized to the task, instead of every action inheriting the session's single model. This change takes 0.5.1 and turns the router on with an explicit, project-chosen model list, so that bulk mechanical work stops running on the most expensive model at maximum thinking effort while workflow gates keep a model and effort level backed by traced capability evidence. 0.5.1 also carries workflow-document updates that this project's pin-bump rule requires us to reconcile against.

#### Planned changes:

**Current state.** Every worker thread runs the session default — `anthropic/claude-opus-5` at `xhigh` thinking — whether the action is a one-line grep or an architecture decision. Slate's project configuration sets orchestrator mode, draft-PR publishing, prompt documents, worker extensions, a doctrine extra and review perspectives, plus a seven-entry `modelFailover` map that still spans models the project no longer uses (`claude-opus-4-8`, `claude-fable-5`, `gpt-5.6-terra`). The episode compressor is unpinned and resolves from registry state.

**What changes.**

- The `ytdb-slate` pin moves from 0.4.0 to 0.5.1.
- `router.models` declares a closed candidate list of four: `anthropic/claude-opus-5`, `anthropic/claude-sonnet-5`, `openai/gpt-5.6-sol`, `openai/gpt-5.6-luna`. Any model outside the list becomes undispatchable — an explicit off-list model is refused, not warned about.
- `router.allowUnmeasuredEffort` is `false`: an explicitly named effort level with no traced capability measurement is refused rather than warned about. It cannot affect a dispatch that omits effort, because a derived level is measured by construction.
- A dispatch that names no model runs on the thread's base — the cheapest preferred candidate, `openai/gpt-5.6-luna`, at its lowest measured level, `medium`. This replaces the previous `claude-opus-5@xhigh` floor for unsized actions.
- `episodeModel` is pinned to `anthropic/claude-sonnet-5` — the model it already resolves to — so episode compression cannot drift onto a model outside the failover map when the registry gains a newer Sonnet.
- `modelFailover` shrinks from seven entries to four, sending both Anthropic models to `openai/gpt-5.6-sol` and both OpenAI models to `anthropic/claude-opus-5`. Every pair crosses providers, so a single-provider outage is covered in both directions.
- The orchestrator doctrine gains a short project routing policy through the doctrine-extra document; the fuller rationale lands in the project's track-development document.
- The internal documentation index and the orchestrator guidelines both gain a pointer to the new routing policy, so a reader arriving from either entry point finds it.

**Key decisions.**

- *Target 0.5.1, the latest release.* Rejected: staying on 0.4.0 (no router at all) and 0.5.0 (superseded).
- *`allowUnmeasuredEffort: false`.* Refusals reach only an explicitly passed effort argument, so the setting costs nothing on unsized work while forcing every deliberate escalation onto traced evidence. It refuses eleven of twenty-six ladder combinations, of which only `luna@high`, `luna@xhigh` and `sol@low` are levels this project would plausibly reach for. Rejected: `true` (warnings only), whose first-round rationale — that `false` would hard-refuse cheap dispatches — was factually wrong.
- *Four models, not the five originally proposed.* `openai/gpt-5.6-terra` is excluded: its shipped profile marks it never-auto-select with no defensible routing niche, so listing it would only add a row to the routing table rendered into the doctrine on every turn. `anthropic/claude-sonnet-5` is included despite also being never-auto-select, solely for its "only if sol unavailable at high effort" niche.
- *Accept the lower floor for unsized dispatches, and write the discipline into doctrine.* The router seeds a new thread's base to the cheapest preferred candidate and derives the lowest measured level, so enabling it necessarily drops the implicit floor; no model list restores the old default, since even a list of `claude-opus-5` and `gpt-5.6-sol` alone bases to `claude-opus-5@low`. Per-action sizing is the point of the router, so the floor is accepted and the discipline becomes a doctrine rule: always name both `model` and `effort`, or neither, and never size a gate or verification action down to the cheapest model that looks like it would clear it. Both arguments, on a measured level, are mandatory for adversarial review, agent code review, the design-review and PR-description statements, the ready-for-review flip, Maven build/test/coverage runs, commits and pushes, and any change to storage, WAL, index, transaction or crash-recovery code. Rejected: a three-model list for a `claude-opus-5@low` floor at roughly five times the input price and minus a model the project asked for; and not enabling the router at all.
- *The doctrine rule restates nothing the live routing table already renders.* Slate injects per-model routing guidance, prices and measured levels into the doctrine every turn, so the project rule carries only project obligations plus a pointer to the rationale. Rejected: a self-contained project routing table, which would duplicate live data and drift — `claude-sonnet-5`'s price steps up 50% on 2026-09-01.
- *Trim the failover map because the dropped entries are dead configuration, not lost protection.* With the router on, no Slate site can reach an off-list model: worker threads are bounded by the list, the orchestrator runs `claude-opus-5`, and the compressor is now pinned to `claude-sonnet-5`. Rejected: keeping all seven entries.
- *Leave the `.claude` tree untouched.* Its web-tools reference now understates when a worker's model-scoped tool set is re-synced — the trigger is any route-driven model switch, not only a failover — and its status-line pricing table names two of the dropped models. The project is retiring that tooling, so correcting documentation on its way out would add review surface for no durable benefit. Rejected: correcting it as part of this change. Decided after the draft PR was opened.
- *Pair the failover map for measured coverage on the retry, not symmetrically.* A failover switch bypasses the router's list and effort guards and re-applies the session's current effort level to the target model, so `allowUnmeasuredEffort` does not constrain it and the episode header suppresses the unmeasured marker on a model switch. Symmetric pairing — each model with its own tier partner — landed three of four retries on a level with no capability measurement for the target, `claude-sonnet-5@high` retrying as `gpt-5.6-luna@high` among them. Routing both Anthropic models to `gpt-5.6-sol` and both OpenAI models to `claude-opus-5` keeps every pair cross-provider and leaves one measured gap, `claude-opus-5@low` retrying as `gpt-5.6-sol@low`. Found by review after the draft PR was opened.

**Out of scope.**

- Reproducing the machine-local context-window override for the `gpt-5.6` family repo-side, or making router behaviour reproducible across developer machines.
- The `.claude` documentation and script tree in its entirety, including its status-line pricing table and its web-tools reference. The project is retiring that tooling, so its stale statements about model failover and about model-scoped tool re-syncing are deliberately left uncorrected.
- Any change to worker tools, concurrency, or the context budget.

**Risks & accepted trade-offs.**

- Slate reads its configuration and package version once at session start, so nothing takes effect until pi is restarted.
- The always-loaded orchestrator doctrine grows by a four-row routing table plus the project routing rule, on every turn.
- Unsized dispatches run at a lower quality floor than before. The mitigation is a doctrine rule, which Slate does not enforce in code — the shipped documentation is explicit that the measured-level obligation for gate actions is doctrine-only.
- `allowUnmeasuredEffort: false` removes `luna@high`, `luna@xhigh`, `sol@low`, and `off` on `claude-opus-5`, `gpt-5.6-luna` and `gpt-5.6-sol`; `off` on `claude-sonnet-5` is refused by the provider outright, independent of this setting.
- The `gpt-5.6` family's context window depends on an untracked machine-local override (1,050,000 against the base registry's 272,000). With it in place those models are the widest listed candidates, so a thread approaching a one-million-token context can be substituted down to `gpt-5.6-luna`, whose profile advises against deep retrieval above 256K. Open question resolved: reproducing the override repo-side, or making routing behaviour reproducible across developer machines, is user-approved as out of scope; it is documented as a per-developer prerequisite in `docs-internal/dev-workflow/track-development.md` § Model routing.
- Window substitution with an explicitly passed effort soft-drops to the session's opening level rather than re-deriving, so a very large thread can still produce an unmeasured `luna@xhigh` dispatch despite `allowUnmeasuredEffort: false`. Low probability, accepted.
- `claude-opus-4-8`, `claude-fable-5` and `gpt-5.6-terra` become undispatchable. If a developer manually switches the session model to an unlisted model, it has no failover cover.
- `modelFailover` now serves two uncoupled purposes: router-candidate coverage, which Slate checks and warns about, and orchestrator plus compressor coverage, which it does not.
- Expect four provisional-routing-data warnings, one per routable model, at the first doctrine build rather than at session start — Slate resolves the router lazily, so only config-shape checks run at startup.
- The base `gpt-5.6-luna@medium` applies to newly created threads. A thread that already exists and whose stored pre-router pin is itself a listed model keeps that pin and bases to that model's own lowest measured level, silently and with no re-seed warning.
- The model profile table is static and frozen in the package, measured as of 2026-07-29; new models require a package release, not a configuration change.
- No YouTrack issue exists for this change, so the title carries no issue prefix. The title-prefix workflow skips silently when the branch name has no issue number.
- The failover carve-out is a second path on which an unmeasured effort level can run despite `allowUnmeasuredEffort: false`, since a failover switch bypasses the effort guards. One such case remains after pairing for coverage: `claude-opus-5@low` retrying as `gpt-5.6-sol@low`.

Design review: user-approved — 2026-08-03 (refreshed after the effort-policy reversal)
Adversarial review: round 1 — 1 blocker, 5 major, 6 minor; triaged with the user (1 reverse, 2 strengthen, 1 partially rejected, rest accepted-as-risk). Round 2 — no blocker, 2 major, 7 minor; triaged with the user (2 strengthen, 1 addition, rest accepted-as-risk or documented). No decision reversed in round 2, so no third round. Passed, 4 accepted risks — 2026-08-03

**Verification approach.** No Maven gate covers this change — configuration and documentation files trigger no build, test or coverage job. Verification is a fresh-session smoke check, which must enable orchestrator mode explicitly: a bare headless prompt emits no router warnings whatever the router's health, because orchestrator-mode auto-seeding is gated to interactive sessions. With it enabled, the clean result is four provisional-routing-data warnings, one per routable model, and no window-divergence, long-context-billing, failover-coverage, unprofiled-spec or invalid-setting warnings, with a new thread reporting its base as `openai/gpt-5.6-luna@medium`.
