### PR TITLE
[YTDB-1231] Benchmark and speed up transactional schema creation

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/api/config/GlobalConfiguration.java
@@ -220,7 +220,13 @@ public enum GlobalConfiguration {
 
   STORAGE_CALL_FSYNC(
       "youtrackdb.storage.callFsync",
-      "Call fsync during fuzzy checkpoints or WAL writes, true by default",
+      "Call the file synchronization system call in the live storage engine, true by default. "
+          + "A false value removes the durability barriers on the storage hot path. "
+          + "The crash marker and the encryption initialization vector file stay synchronous. "
+          + "After a power loss the database can lose recent data. "
+          + "The file registry can also lose entries. "
+          + "A truncated registry can leave the database unopenable. "
+          + "Use false only for test runs.",
       Boolean.class,
       true),
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -1039,14 +1039,15 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       return;
     }
 
+    var indexedFieldNames = new HashSet<String>(indexedFields);
     Predicate<SecurityResourceProperty> isIndexedProperty =
-        property -> indexedFields.contains(property.getPropertyName());
+        property -> indexedFieldNames.contains(property.getPropertyName());
     var allFilteredProperties = security.getAllFilteredProperties(database);
-    Set<SecurityResourceProperty> potentiallyFilteredProperties;
+    boolean hasPotentiallyFilteredProperties;
     try (var stream = allFilteredProperties.stream()) {
-      potentiallyFilteredProperties = stream.filter(isIndexedProperty).collect(Collectors.toSet());
+      hasPotentiallyFilteredProperties = stream.anyMatch(isIndexedProperty);
     }
-    if (potentiallyFilteredProperties.isEmpty()) {
+    if (!hasPotentiallyFilteredProperties) {
       return;
     }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbedded.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -1038,6 +1039,17 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
       return;
     }
 
+    Predicate<SecurityResourceProperty> isIndexedProperty =
+        property -> indexedFields.contains(property.getPropertyName());
+    var allFilteredProperties = security.getAllFilteredProperties(database);
+    Set<SecurityResourceProperty> potentiallyFilteredProperties;
+    try (var stream = allFilteredProperties.stream()) {
+      potentiallyFilteredProperties = stream.filter(isIndexedProperty).collect(Collectors.toSet());
+    }
+    if (potentiallyFilteredProperties.isEmpty()) {
+      return;
+    }
+
     Set<String> classesToCheck = new HashSet<>();
     classesToCheck.add(indexClass);
     var clazz = database.getMetadata().getImmutableSchemaSnapshot().getClass(indexClass);
@@ -1046,16 +1058,18 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
     }
     clazz.getAllSubclasses().forEach(x -> classesToCheck.add(x.getName()));
     clazz.getAllSuperClasses().forEach(x -> classesToCheck.add(x.getName()));
-    var allFilteredProperties =
-        security.getAllFilteredProperties(database);
 
+    // The pre-filter only avoids class-family resolution when rejection is impossible. Read the
+    // rules again so the slow path makes its decision from the same post-resolution cache state as
+    // before the optimization.
+    allFilteredProperties = security.getAllFilteredProperties(database);
     for (var className : classesToCheck) {
       Set<SecurityResourceProperty> indexedAndFilteredProperties;
       try (var stream = allFilteredProperties.stream()) {
         indexedAndFilteredProperties =
             stream
                 .filter(x -> x.isAllClasses() || className.equals(x.getClassName()))
-                .filter(x -> indexedFields.contains(x.getPropertyName()))
+                .filter(isIndexedProperty)
                 .collect(Collectors.toSet());
       }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaClassImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaClassImpl.java
@@ -23,6 +23,7 @@ import static com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.Sche
 import static com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass.VERTEX_CLASS_NAME;
 
 import com.jetbrains.youtrackdb.api.exception.RecordNotFoundException;
+import com.jetbrains.youtrackdb.internal.common.collection.MultiValue;
 import com.jetbrains.youtrackdb.internal.common.listener.ProgressListener;
 import com.jetbrains.youtrackdb.internal.common.log.LogManager;
 import com.jetbrains.youtrackdb.internal.common.util.CommonConst;
@@ -31,6 +32,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
 import com.jetbrains.youtrackdb.internal.core.exception.SecurityAccessException;
+import com.jetbrains.youtrackdb.internal.core.id.RecordId;
 import com.jetbrains.youtrackdb.internal.core.index.Index;
 import com.jetbrains.youtrackdb.internal.core.index.IndexDefinitionFactory;
 import com.jetbrains.youtrackdb.internal.core.index.IndexException;
@@ -43,6 +45,7 @@ import com.jetbrains.youtrackdb.internal.core.metadata.security.Rule;
 import com.jetbrains.youtrackdb.internal.core.query.Result;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransactionImpl;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
@@ -57,6 +60,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -1296,6 +1300,38 @@ public abstract class SchemaClassImpl {
       final String propertyName,
       final PropertyTypeInternal type,
       SchemaClassImpl linkedClass) {
+    if (hasOnlyTransactionLocalCollections()) {
+      session.executeInTx(transaction -> {
+        final var currentTx = (FrontendTransactionImpl) session.getTransactionInternal();
+        currentTx.preProcessRecordsAndExecuteCallCallbacks();
+
+        forEachTransactionLocalEntity(currentTx, entity -> {
+          final var value = entity.getPropertyInternal(propertyName);
+          if (value == null) {
+            return;
+          }
+
+          final var valueType = PropertyTypeInternal.getTypeByValue(value);
+          if (!type.getCastable().contains(valueType)
+              && (!type.isMultiValue() || MultiValue.getSize(value) != 0)) {
+            throw incompatiblePropertyType(session, propertyName, type);
+          }
+        });
+
+        if (linkedClass != null) {
+          forEachTransactionLocalEntity(
+              currentTx,
+              entity -> checkLinkedValue(
+                  session,
+                  propertyName,
+                  type,
+                  linkedClass,
+                  entity.getPropertyInternal(propertyName)));
+        }
+      });
+      return;
+    }
+
     final var builder = new StringBuilder(256);
     builder.append("select from ");
     builder.append(getEscapedName(name));
@@ -1324,20 +1360,40 @@ public abstract class SchemaClassImpl {
     session.executeInTx(transaction -> {
       try (final var res = session.query(builder.toString())) {
         if (res.hasNext()) {
-          throw new SchemaException(session.getDatabaseName(),
-              "The database contains some schema-less data in the property '"
-                  + name
-                  + "."
-                  + propertyName
-                  + "' that is not compatible with the type "
-                  + type
-                  + ". Fix those records and change the schema again");
+          throw incompatiblePropertyType(session, propertyName, type);
         }
       }
     });
 
     if (linkedClass != null) {
       checkAllLikedObjects(session, propertyName, type, linkedClass);
+    }
+  }
+
+  private boolean hasOnlyTransactionLocalCollections() {
+    // A provisional collection has no storage records. Its records must register transaction
+    // operations, so the transaction walk is the complete scan for this class subtree.
+    for (final var collectionId : polymorphicCollectionIds) {
+      if (!SchemaShared.isProvisionalCollectionId(collectionId)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void forEachTransactionLocalEntity(
+      FrontendTransactionImpl transaction, Consumer<EntityImpl> consumer) {
+    // The polymorphic array already has the ascending order used by class query iteration.
+    for (final var collectionId : polymorphicCollectionIds) {
+      var rid = transaction.getNextRidInCollection(
+          new RecordId(collectionId, Long.MIN_VALUE), 0);
+      while (rid != null) {
+        final var recordEntry = transaction.getRecordEntry(rid);
+        if (recordEntry != null && recordEntry.record instanceof EntityImpl entity) {
+          consumer.accept(entity);
+        }
+        rid = transaction.getNextRidInCollection(rid, 0);
+      }
     }
   }
 
@@ -1365,38 +1421,101 @@ public abstract class SchemaClassImpl {
                   .findFirst()
                   .ifPresent(
                       x -> {
-                        throw new SchemaException(db.getDatabaseName(),
-                            "The database contains some schema-less data in the property '"
-                                + name
-                                + "."
-                                + propertyName
-                                + "' that is not compatible with the type "
-                                + type
-                                + " "
-                                + linkedClass.getName()
-                                + ". Fix those records and change the schema again. "
-                                + x);
+                        throw incompatibleLinkedCollectionType(
+                            db, propertyName, type, linkedClass, x);
                       });
             }
             case EMBEDDED, LINK -> {
               var elem = item.getProperty(propertyName);
               if (!matchesType(db, elem, linkedClass)) {
-                throw new SchemaException(db.getDatabaseName(),
-                    "The database contains some schema-less data in the property '"
-                        + name
-                        + "."
-                        + propertyName
-                        + "' that is not compatible with the type "
-                        + type
-                        + " "
-                        + linkedClass.getName()
-                        + ". Fix those records and change the schema again!");
+                throw incompatibleLinkedScalarType(db, propertyName, type, linkedClass);
               }
             }
           }
         }
       }
     });
+  }
+
+  private void checkLinkedValue(
+      DatabaseSessionEmbedded db,
+      String propertyName,
+      PropertyTypeInternal type,
+      SchemaClassImpl linkedClass,
+      Object value) {
+    if (value == null) {
+      return;
+    }
+
+    switch (type) {
+      case EMBEDDEDLIST, LINKLIST, EMBEDDEDSET, LINKSET -> {
+        Collection<?> embedded = (Collection<?>) value;
+        embedded.stream()
+            .filter(element -> !matchesType(db, element, linkedClass))
+            .findFirst()
+            .ifPresent(
+                element -> {
+                  throw incompatibleLinkedCollectionType(
+                      db, propertyName, type, linkedClass, element);
+                });
+      }
+      case EMBEDDED, LINK -> {
+        if (!matchesType(db, value, linkedClass)) {
+          throw incompatibleLinkedScalarType(db, propertyName, type, linkedClass);
+        }
+      }
+    }
+  }
+
+  private SchemaException incompatiblePropertyType(
+      DatabaseSessionEmbedded db, String propertyName, PropertyTypeInternal type) {
+    return new SchemaException(
+        db.getDatabaseName(),
+        "The database contains some schema-less data in the property '"
+            + name
+            + "."
+            + propertyName
+            + "' that is not compatible with the type "
+            + type
+            + ". Fix those records and change the schema again");
+  }
+
+  private SchemaException incompatibleLinkedCollectionType(
+      DatabaseSessionEmbedded db,
+      String propertyName,
+      PropertyTypeInternal type,
+      SchemaClassImpl linkedClass,
+      Object element) {
+    return new SchemaException(
+        db.getDatabaseName(),
+        "The database contains some schema-less data in the property '"
+            + name
+            + "."
+            + propertyName
+            + "' that is not compatible with the type "
+            + type
+            + " "
+            + linkedClass.getName()
+            + ". Fix those records and change the schema again. "
+            + element);
+  }
+
+  private SchemaException incompatibleLinkedScalarType(
+      DatabaseSessionEmbedded db,
+      String propertyName,
+      PropertyTypeInternal type,
+      SchemaClassImpl linkedClass) {
+    return new SchemaException(
+        db.getDatabaseName(),
+        "The database contains some schema-less data in the property '"
+            + name
+            + "."
+            + propertyName
+            + "' that is not compatible with the type "
+            + type
+            + " "
+            + linkedClass.getName()
+            + ". Fix those records and change the schema again!");
   }
 
   protected static boolean matchesType(DatabaseSessionEmbedded db, Object x,

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaClassImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaClassImpl.java
@@ -1242,6 +1242,25 @@ public abstract class SchemaClassImpl {
   public void fireDatabaseMigration(
       final DatabaseSessionEmbedded database, final String propertyName,
       final PropertyTypeInternal type) {
+    if (hasOnlyTransactionLocalCollections()) {
+      database.executeInTx(transaction -> {
+        final var currentTx = (FrontendTransactionImpl) database.getTransactionInternal();
+        currentTx.preProcessRecordsAndExecuteCallCallbacks();
+
+        forEachTransactionLocalEntity(currentTx, entity -> {
+          final var value = entity.getPropertyInternal(propertyName);
+          if (value == null) {
+            return;
+          }
+
+          final var valueType = PropertyTypeInternal.getTypeByValue(value);
+          if (valueType != type) {
+            entity.setPropertyInternal(propertyName, value, type);
+          }
+        });
+      });
+      return;
+    }
 
     var recordsToUpdate = database.computeInTx(transaction -> {
       try (var result =

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaClassImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/SchemaClassImpl.java
@@ -29,6 +29,7 @@ import com.jetbrains.youtrackdb.internal.common.log.LogManager;
 import com.jetbrains.youtrackdb.internal.common.util.CommonConst;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.Entity;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.Identifiable;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
 import com.jetbrains.youtrackdb.internal.core.exception.SecurityAccessException;
@@ -1331,8 +1332,10 @@ public abstract class SchemaClassImpl {
           }
 
           final var valueType = PropertyTypeInternal.getTypeByValue(value);
+          // SQLMethodSize treats an identifiable scalar as one item, unlike MultiValue.getSize.
+          final var valueSize = value instanceof Identifiable ? 1 : MultiValue.getSize(value);
           if (!type.getCastable().contains(valueType)
-              && (!type.isMultiValue() || MultiValue.getSize(value) != 0)) {
+              && (!type.isMultiValue() || valueSize != 0)) {
             throw incompatiblePropertyType(session, propertyName, type);
           }
         });

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecurityShared.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecurityShared.java
@@ -1761,7 +1761,7 @@ public class SecurityShared implements SecurityInternal {
     if (session.getCurrentUser() == null) {
       result = calculateAllFilteredProperties(session);
       synchronized (this) {
-        filteredProperties = result;
+        filteredProperties = new HashSet<>(result);
       }
 
     } else {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -2463,7 +2463,9 @@ public final class WOWCache extends AbstractWriteCache
               false);
         }
 
-        nameIdMapHolder.force(true);
+        if (callFsync) {
+          nameIdMapHolder.force(true);
+        }
       }
 
       try {
@@ -2899,7 +2901,9 @@ public final class WOWCache extends AbstractWriteCache
       }
     }
 
-    v3NameIdMapHolder.force(true);
+    if (callFsync) {
+      v3NameIdMapHolder.force(true);
+    }
     v3NameIdMapHolder.close();
 
     try {
@@ -3097,7 +3101,8 @@ public final class WOWCache extends AbstractWriteCache
         pageSize,
         logFileDeletion,
         this.executor,
-        storageName);
+        storageName,
+        callFsync);
   }
 
   private static String createInternalFileName(final String fileName, final int fileId) {
@@ -3182,7 +3187,8 @@ public final class WOWCache extends AbstractWriteCache
           final var path =
               storagePath.resolve(idFileNameMap.get(nameIdEntry.getValue().intValue()));
           final var file =
-              new AsyncFile(path, pageSize, logFileDeletion, this.executor, storageName);
+              new AsyncFile(
+                  path, pageSize, logFileDeletion, this.executor, storageName, callFsync);
 
           if (file.exists()) {
             file.open();
@@ -3251,7 +3257,8 @@ public final class WOWCache extends AbstractWriteCache
           final var path =
               storagePath.resolve(idFileNameMap.get(nameIdEntry.getValue().intValue()));
           final var file =
-              new AsyncFile(path, pageSize, logFileDeletion, this.executor, storageName);
+              new AsyncFile(
+                  path, pageSize, logFileDeletion, this.executor, storageName, callFsync);
 
           if (file.exists()) {
             file.open();
@@ -3330,7 +3337,8 @@ public final class WOWCache extends AbstractWriteCache
                   pageSize,
                   logFileDeletion,
                   this.executor,
-                  storageName);
+                  storageName,
+                  callFsync);
 
           if (fileClassic.exists()) {
             fileClassic.open();
@@ -3550,7 +3558,7 @@ public final class WOWCache extends AbstractWriteCache
     //noinspection ResultOfMethodCallIgnored
     nameIdMapHolder.write(serializedRecord);
 
-    if (sync) {
+    if (sync && callFsync) {
       nameIdMapHolder.force(true);
     }
   }
@@ -3854,24 +3862,27 @@ public final class WOWCache extends AbstractWriteCache
   }
 
   private void fsyncFiles() throws java.lang.InterruptedException, IOException {
-    for (int intFileId : idNameMap.keySet()) {
-      if (intFileId >= 0) {
-        final var extFileId = externalFileId(intFileId);
+    if (callFsync) {
+      for (int intFileId : idNameMap.keySet()) {
+        if (intFileId >= 0) {
+          final var extFileId = externalFileId(intFileId);
 
-        final var fileEntry = files.acquire(extFileId);
-        // such thing can happen during db restore
-        if (fileEntry == null) {
-          continue;
-        }
-        try {
-          final var fileClassic = fileEntry.get();
-          fileClassic.synch();
-        } finally {
-          files.release(fileEntry);
+          final var fileEntry = files.acquire(extFileId);
+          // such thing can happen during db restore
+          if (fileEntry == null) {
+            continue;
+          }
+          try {
+            final var fileClassic = fileEntry.get();
+            fileClassic.synch();
+          } finally {
+            files.release(fileEntry);
+          }
         }
       }
     }
 
+    // Truncate even without fsync so that the double-write log does not grow without bound.
     doubleWriteLog.truncate();
   }
 

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCache.java
@@ -2918,7 +2918,8 @@ public final class WOWCache extends AbstractWriteCache
 
   /**
    * Writes the current set of non-durable file IDs to the shadow-copy side file pair.
-   * Write protocol: write shadow → fsync → write primary → fsync.
+   * When fsync is enabled, the write protocol is write shadow → fsync → write primary → fsync.
+   * When fsync is disabled, writes proceed without file synchronization.
    *
    * <p>Format: {@code [4 bytes version][8 bytes xxHash64][4 bytes count][count × 4 bytes fileId]}
    *

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/doublewritelog/DoubleWriteLogGL.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/doublewritelog/DoubleWriteLogGL.java
@@ -86,6 +86,7 @@ public class DoubleWriteLogGL implements DoubleWriteLog {
   private long currentSegment;
 
   private final long maxSegSize;
+  private final boolean callFsync;
 
   private static final LZ4Compressor LZ_4_COMPRESSOR;
   private static final LZ4FastDecompressor LZ_4_DECOMPRESSOR;
@@ -112,12 +113,22 @@ public class DoubleWriteLogGL implements DoubleWriteLog {
   private final Object mutex = new Object();
 
   public DoubleWriteLogGL(final long maxSegSize) {
+    this(maxSegSize, true);
+  }
+
+  public DoubleWriteLogGL(final long maxSegSize, final boolean callFsync) {
     this.maxSegSize = maxSegSize;
+    this.callFsync = callFsync;
   }
 
   public DoubleWriteLogGL(final long maxSegSize, int blockSize) {
+    this(maxSegSize, blockSize, true);
+  }
+
+  public DoubleWriteLogGL(final long maxSegSize, int blockSize, final boolean callFsync) {
     this.maxSegSize = maxSegSize;
     this.blockSize = blockSize;
+    this.callFsync = callFsync;
   }
 
   @Override
@@ -298,7 +309,9 @@ public class DoubleWriteLogGL implements DoubleWriteLog {
         containerBuffer.rewind();
         assert currentFile.size() == segmentPosition;
         var written = IOUtils.writeByteBuffer(containerBuffer, currentFile, segmentPosition);
-        currentFile.force(true);
+        if (callFsync) {
+          currentFile.force(true);
+        }
         diskWriteMeter.record(written);
         segmentPosition += written;
         assert currentFile.size() == segmentPosition;
@@ -354,8 +367,7 @@ public class DoubleWriteLogGL implements DoubleWriteLog {
     }
   }
 
-  @Nullable
-  @Override
+  @Nullable @Override
   public Pointer loadPage(int fileId, int pageIndex, ByteBufferPool bufferPool)
       throws IOException {
     if (!restoreMode) {
@@ -478,8 +490,7 @@ public class DoubleWriteLogGL implements DoubleWriteLog {
                 .toArray(Path[]::new);
       }
 
-      segmentLoop:
-      for (final var segment : segments) {
+      segmentLoop : for (final var segment : segments) {
         try (final var channel = FileChannel.open(segment, StandardOpenOption.READ)) {
           long position = 0;
           var fileSize = channel.size();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
@@ -105,6 +105,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -135,6 +136,7 @@ public class DiskStorage extends AbstractStorage {
   public static final long XX_HASH_SEED = 0xAEF5634;
 
   private static final Logger logger = LoggerFactory.getLogger(DiskStorage.class);
+  private static final AtomicBoolean fsyncWarningLogged = new AtomicBoolean();
 
   private static final String BACKUP_LOCK = "backup.ibl";
 
@@ -685,6 +687,10 @@ public class DiskStorage extends AbstractStorage {
   @Override
   protected void initWalAndDiskCache(final ContextConfiguration contextConfiguration)
       throws IOException, java.lang.InterruptedException {
+    final var callFsync =
+        contextConfiguration.getValueAsBoolean(GlobalConfiguration.STORAGE_CALL_FSYNC);
+    warnIfFsyncDisabled(callFsync);
+
     final var aesKeyEncoded =
         contextConfiguration.getValueAsString(GlobalConfiguration.STORAGE_ENCRYPTION_KEY);
     final var aesKey =
@@ -740,7 +746,7 @@ public class DiskStorage extends AbstractStorage {
             contextConfiguration.getValueAsLong(GlobalConfiguration.WAL_MAX_SIZE) * 1024 * 1024,
             contextConfiguration.getValueAsInteger(GlobalConfiguration.WAL_COMMIT_TIMEOUT),
             contextConfiguration.getValueAsBoolean(GlobalConfiguration.WAL_KEEP_SINGLE_SEGMENT),
-            contextConfiguration.getValueAsBoolean(GlobalConfiguration.STORAGE_CALL_FSYNC),
+            callFsync,
             contextConfiguration.getValueAsBoolean(
                 GlobalConfiguration.STORAGE_PRINT_WAL_PERFORMANCE_STATISTICS),
             contextConfiguration.getValueAsInteger(
@@ -755,9 +761,6 @@ public class DiskStorage extends AbstractStorage {
         (long) (contextConfiguration.getValueAsInteger(GlobalConfiguration.DISK_WRITE_CACHE_PART)
             / 100.0
             * diskCacheSize);
-    final var callFsync =
-        contextConfiguration.getValueAsBoolean(GlobalConfiguration.STORAGE_CALL_FSYNC);
-
     final DoubleWriteLog doubleWriteLog;
     if (contextConfiguration.getValueAsBoolean(
         GlobalConfiguration.STORAGE_USE_DOUBLE_WRITE_LOG)) {
@@ -795,6 +798,17 @@ public class DiskStorage extends AbstractStorage {
     wowCache.addPageIsBrokenListener(this);
 
     writeCache = wowCache;
+  }
+
+  static boolean warnIfFsyncDisabled(final boolean callFsync) {
+    if (callFsync || !fsyncWarningLogged.compareAndSet(false, true)) {
+      return false;
+    }
+
+    logger.warn(
+        "Storage durability barriers are disabled by youtrackdb.storage.callFsync. "
+            + "A power loss can lose data. Use this mode only for tests.");
+    return true;
   }
 
   public static boolean exists(final Path path) {

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorage.java
@@ -755,11 +755,13 @@ public class DiskStorage extends AbstractStorage {
         (long) (contextConfiguration.getValueAsInteger(GlobalConfiguration.DISK_WRITE_CACHE_PART)
             / 100.0
             * diskCacheSize);
+    final var callFsync =
+        contextConfiguration.getValueAsBoolean(GlobalConfiguration.STORAGE_CALL_FSYNC);
 
     final DoubleWriteLog doubleWriteLog;
     if (contextConfiguration.getValueAsBoolean(
         GlobalConfiguration.STORAGE_USE_DOUBLE_WRITE_LOG)) {
-      doubleWriteLog = new DoubleWriteLogGL(doubleWriteLogMaxSegSize);
+      doubleWriteLog = new DoubleWriteLogGL(doubleWriteLogMaxSegSize, callFsync);
     } else {
       doubleWriteLog = new DoubleWriteLogNoOP();
     }
@@ -785,7 +787,7 @@ public class DiskStorage extends AbstractStorage {
                 GlobalConfiguration.STORAGE_CHECKSUM_MODE, ChecksumMode.class),
             iv,
             aesKey,
-            contextConfiguration.getValueAsBoolean(GlobalConfiguration.STORAGE_CALL_FSYNC),
+            callFsync,
             context.getIoExecutor());
 
     wowCache.loadRegisteredFiles();

--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/fs/AsyncFile.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/fs/AsyncFile.java
@@ -43,6 +43,7 @@ public final class AsyncFile implements File {
   private final int pageSize;
   private final ExecutorService executor;
   private final String dbName;
+  private final boolean callFsync;
 
   private final TimeRate diskReadMeter;
   private final TimeRate diskWriteMeter;
@@ -59,11 +60,18 @@ public final class AsyncFile implements File {
   public AsyncFile(
       final Path osFile, final int pageSize, boolean logFileDeletion, ExecutorService executor,
       String dbName) {
+    this(osFile, pageSize, logFileDeletion, executor, dbName, true);
+  }
+
+  public AsyncFile(
+      final Path osFile, final int pageSize, boolean logFileDeletion, ExecutorService executor,
+      String dbName, boolean callFsync) {
     this.osFile = osFile;
     this.pageSize = pageSize;
     this.executor = executor;
     this.logFileDeletion = logFileDeletion;
     this.dbName = dbName;
+    this.callFsync = callFsync;
 
     this.diskReadMeter = YouTrackDBEnginesManager.instance()
         .getMetricsRegistry()
@@ -366,23 +374,26 @@ public final class AsyncFile implements File {
   }
 
   private void doSynch() {
+    // Drain in-flight writes even when fsync is disabled because close relies on this barrier.
     syncSemaphore.acquireUninterruptibly(Integer.MAX_VALUE);
     try {
       synchronized (flushSemaphore) {
         var dirtyCounterValue = dirtyCounter.get();
         if (dirtyCounterValue > 0) {
-          try {
-            fileChannel.force(true);
-          } catch (final IOException e) {
-            LogManager.instance()
-                .warn(
-                    this,
-                    "Error during flush of file %s. Data may be lost in case of power failure",
-                    e,
-                    getName());
-          }
+          if (callFsync) {
+            try {
+              fileChannel.force(true);
+            } catch (final IOException e) {
+              LogManager.instance()
+                  .warn(
+                      this,
+                      "Error during flush of file %s. Data may be lost in case of power failure",
+                      e,
+                      getName());
+            }
 
-          dirtyCounter.addAndGet(-dirtyCounterValue);
+            dirtyCounter.addAndGet(-dirtyCounterValue);
+          }
         }
       }
     } finally {

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -463,6 +463,26 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
   }
 
   /**
+   * A rule on an unrelated class may share an indexed field's name and reach the slow path, but it
+   * must not block composite-index creation after the indexed class family is resolved.
+   */
+  @Test
+  public void compositeIndexAllowsSameNamedFilteredPropertyOnUnrelatedClass() {
+    var unrelatedClassName = "ImeUnrelatedSecurityClass";
+    var unrelated = session.getMetadata().getSchema().createClass(unrelatedClassName);
+    unrelated.createProperty("name", PropertyType.STRING);
+    setFilteredPropertyRule(
+        "unrelatedClassPropertyPolicy",
+        "database.class." + unrelatedClassName + ".name");
+
+    var indexName = CLS + ".compositeUnrelatedClassRule";
+    session.getMetadata().getSchema().getClass(CLS)
+        .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "val", "name");
+
+    assertNotNull(session.getSharedContext().getIndexManager().getIndex(indexName));
+  }
+
+  /**
    * A class-specific rule naming an indexed field still rejects composite creation with the exact
    * pre-optimization exception type and message.
    */

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/index/IndexManagerEmbeddedTest.java
@@ -6,11 +6,25 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.SharedContext;
+import com.jetbrains.youtrackdb.internal.core.metadata.MetadataDefault;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.ImmutableSchema;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import com.jetbrains.youtrackdb.internal.core.metadata.security.SecurityInternal;
+import com.jetbrains.youtrackdb.internal.core.metadata.security.SecurityResourceProperty;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -406,6 +420,284 @@ public class IndexManagerEmbeddedTest extends DbTestBase {
 
     assertNotNull("the rolled-back rename must restore the old-name resolution",
         mgr.getClassIndex(session, CLS, IDX));
+  }
+
+  // -----------------------------------------------------------------------
+  //  Composite-index security checks
+  // -----------------------------------------------------------------------
+
+  /**
+   * A composite index with no filtered-property rules is created successfully. The direct,
+   * narrowly scoped invocation of the security check proves that the check itself never asks for
+   * schema metadata on this fast path; unrelated work in a cold security cache is outside the
+   * assertion.
+   */
+  @Test
+  public void compositeIndexWithoutFilteredPropertiesSkipsSecuritySnapshot() {
+    var indexName = CLS + ".compositeNoRules";
+    session.getMetadata().getSchema().getClass(CLS)
+        .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "val", "name");
+
+    assertNotNull(session.getSharedContext().getIndexManager().getIndex(indexName));
+    assertSecurityCheckSkipsSnapshot(Collections.emptySet());
+  }
+
+  /**
+   * A filtered-property rule for a field outside the composite index does not block creation, and
+   * the security check returns before touching schema metadata after applying its property-name
+   * pre-filter.
+   */
+  @Test
+  public void compositeIndexWithUnrelatedFilteredPropertySkipsSecuritySnapshot() {
+    var cls = session.getMetadata().getSchema().getClass(CLS);
+    cls.createProperty("unindexed", PropertyType.STRING);
+    setFilteredPropertyRule(
+        "unrelatedPropertyPolicy", "database.class." + CLS + ".unindexed");
+
+    var indexName = CLS + ".compositeUnrelatedRule";
+    cls.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "val", "name");
+
+    assertNotNull(session.getSharedContext().getIndexManager().getIndex(indexName));
+    assertSecurityCheckSkipsSnapshot(
+        Set.of(filteredProperty(CLS, "unindexed")));
+  }
+
+  /**
+   * A class-specific rule naming an indexed field still rejects composite creation with the exact
+   * pre-optimization exception type and message.
+   */
+  @Test
+  public void compositeIndexOnFilteredPropertyKeepsExactRejection() {
+    setFilteredPropertyRule(
+        "indexedPropertyPolicy", "database.class." + CLS + ".name");
+
+    var exception = assertThrows(
+        IndexException.class,
+        () -> session.getMetadata().getSchema().getClass(CLS)
+            .createIndex(CLS + ".compositeRejected", SchemaClass.INDEX_TYPE.NOTUNIQUE,
+                "val", "name"));
+
+    assertEquals(expectedSecurityMessage(CLS, "name"), exception.getMessage());
+  }
+
+  /**
+   * A rule attached to a superclass remains effective for a composite index created on its
+   * subclass, proving superclass traversal is unchanged on the slow path.
+   */
+  @Test
+  public void compositeIndexRejectsFilteredPropertyInheritedFromSuperclass() {
+    var schema = session.getMetadata().getSchema();
+    var parent = schema.createClass("ImeSecurityParent");
+    parent.createProperty("secret", PropertyType.STRING);
+    parent.createProperty("other", PropertyType.STRING);
+    var child = schema.createClass("ImeSecurityChild", parent);
+    setFilteredPropertyRule(
+        "superclassPropertyPolicy", "database.class.ImeSecurityParent.secret");
+
+    var exception = assertThrows(
+        IndexException.class,
+        () -> child.createIndex("ImeSecurityChild.compositeRejected",
+            SchemaClass.INDEX_TYPE.NOTUNIQUE, "secret", "other"));
+
+    assertEquals(expectedSecurityMessage("ImeSecurityChild", "secret"), exception.getMessage());
+  }
+
+  /**
+   * A rule attached to a subclass remains effective for a composite index created on its
+   * superclass, proving subclass traversal is unchanged on the slow path.
+   */
+  @Test
+  public void compositeIndexRejectsFilteredPropertyDeclaredBySubclass() {
+    var schema = session.getMetadata().getSchema();
+    var parent = schema.createClass("ImeSecurityBase");
+    parent.createProperty("secret", PropertyType.STRING);
+    parent.createProperty("other", PropertyType.STRING);
+    schema.createClass("ImeSecurityDerived", parent);
+    setFilteredPropertyRule(
+        "subclassPropertyPolicy", "database.class.ImeSecurityDerived.secret");
+
+    var exception = assertThrows(
+        IndexException.class,
+        () -> parent.createIndex("ImeSecurityBase.compositeRejected",
+            SchemaClass.INDEX_TYPE.NOTUNIQUE, "secret", "other"));
+
+    assertEquals(expectedSecurityMessage("ImeSecurityBase", "secret"), exception.getMessage());
+  }
+
+  /**
+   * Property-name matching remains case-sensitive: a rule for {@code Name} is unrelated to an
+   * index on {@code name}, so composite creation succeeds and the fast path skips metadata.
+   */
+  @Test
+  public void compositeIndexPropertyRuleMatchingRemainsCaseSensitive() {
+    setFilteredPropertyRule(
+        "caseSensitivePropertyPolicy", "database.class." + CLS + ".Name");
+
+    var indexName = CLS + ".compositeCaseSensitive";
+    session.getMetadata().getSchema().getClass(CLS)
+        .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "val", "name");
+
+    assertNotNull(session.getSharedContext().getIndexManager().getIndex(indexName));
+    assertSecurityCheckSkipsSnapshot(Set.of(filteredProperty(CLS, "Name")));
+  }
+
+  /**
+   * A wildcard-class filtered-property rule still rejects every class and preserves the exact
+   * exception contract.
+   */
+  @Test
+  public void compositeIndexAllClassesRuleKeepsExactRejection() {
+    setFilteredPropertyRule("allClassesPropertyPolicy", "database.class.*.name");
+
+    var exception = assertThrows(
+        IndexException.class,
+        () -> session.getMetadata().getSchema().getClass(CLS)
+            .createIndex(CLS + ".compositeWildcardRejected",
+                SchemaClass.INDEX_TYPE.NOTUNIQUE, "val", "name"));
+
+    assertEquals(expectedSecurityMessage(CLS, "name"), exception.getMessage());
+  }
+
+  /**
+   * Single-property indexes retain their original unconditional early return even when a rule
+   * names the indexed field; neither filtered rules nor schema metadata are consulted by the
+   * check.
+   */
+  @Test
+  public void singlePropertyIndexSecurityCheckRemainsUnchanged() {
+    setFilteredPropertyRule(
+        "singlePropertyPolicy", "database.class." + CLS + ".name");
+    var indexName = CLS + ".singleFiltered";
+    session.getMetadata().getSchema().getClass(CLS)
+        .createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, "name");
+    assertNotNull(session.getSharedContext().getIndexManager().getIndex(indexName));
+
+    var fixture = securityCheckFixture(Set.of(filteredProperty("Indexed", "first")));
+    when(fixture.definition().getProperties()).thenReturn(List.of("first"));
+    invokeSecurityCheck(fixture.database(), fixture.definition());
+    verify(fixture.security(), never()).getAllFilteredProperties(fixture.database());
+    verify(fixture.database(), never()).getMetadata();
+  }
+
+  /**
+   * When a relevant property rule reaches the slow path but the indexed class is absent, the
+   * existing early return remains in place and no second, decision-making rule read occurs.
+   */
+  @Test
+  public void compositeIndexSecurityCheckKeepsAbsentClassEarlyReturn() {
+    var fixture = securityCheckFixture(Set.of(filteredProperty("Missing", "first")));
+    var metadata = mock(MetadataDefault.class);
+    var schema = mock(ImmutableSchema.class);
+    when(fixture.database().getMetadata()).thenReturn(metadata);
+    when(metadata.getImmutableSchemaSnapshot()).thenReturn(schema);
+    when(schema.getClass("Missing")).thenReturn(null);
+    when(fixture.definition().getClassName()).thenReturn("Missing");
+
+    invokeSecurityCheck(fixture.database(), fixture.definition());
+
+    verify(fixture.security(), times(1)).getAllFilteredProperties(fixture.database());
+    verify(schema).getClass("Missing");
+  }
+
+  /**
+   * The pre-filter is only a necessary-condition check. Once class-family resolution is required,
+   * the post-resolution rule read remains the effective decision point: removing the rule between
+   * the two reads allows creation exactly as the old decision point would.
+   */
+  @Test
+  public void compositeIndexSecuritySlowPathDecidesFromSecondRuleRead() {
+    var fixture = securityCheckFixture(Set.of(filteredProperty("Indexed", "first")));
+    when(fixture.security().getAllFilteredProperties(fixture.database()))
+        .thenReturn(Set.of(filteredProperty("Indexed", "first")), Collections.emptySet());
+    var metadata = mock(MetadataDefault.class);
+    var schema = mock(ImmutableSchema.class);
+    var clazz = mock(SchemaClass.class);
+    when(fixture.database().getMetadata()).thenReturn(metadata);
+    when(metadata.getImmutableSchemaSnapshot()).thenReturn(schema);
+    when(schema.getClass("Indexed")).thenReturn(clazz);
+    when(clazz.getAllSubclasses()).thenReturn(Collections.emptyList());
+    when(clazz.getAllSuperClasses()).thenReturn(Collections.emptyList());
+
+    invokeSecurityCheck(fixture.database(), fixture.definition());
+
+    verify(fixture.security(), times(2)).getAllFilteredProperties(fixture.database());
+  }
+
+  private void setFilteredPropertyRule(String policyName, String resource) {
+    var security = session.getSharedContext().getSecurity();
+    session.begin();
+    var policy = security.createSecurityPolicy(session, policyName);
+    policy.setActive(true);
+    policy.setReadRule("name = 'allowed'");
+    security.saveSecurityPolicy(session, policy);
+    security.setSecurityPolicy(
+        session, security.getRole(session, "reader"), resource, policy);
+    session.commit();
+  }
+
+  private String expectedSecurityMessage(String className, String propertyName) {
+    return "Cannot create index on "
+        + className
+        + "["
+        + propertyName
+        + " because of existing column security rules\r\n\tDB Name=\""
+        + session.getDatabaseName()
+        + "\"";
+  }
+
+  private static void assertSecurityCheckSkipsSnapshot(
+      Set<SecurityResourceProperty> filteredProperties) {
+    var fixture = securityCheckFixture(filteredProperties);
+
+    invokeSecurityCheck(fixture.database(), fixture.definition());
+
+    verify(fixture.database(), never()).getMetadata();
+  }
+
+  private static SecurityCheckFixture securityCheckFixture(
+      Set<SecurityResourceProperty> filteredProperties) {
+    var database = mock(DatabaseSessionEmbedded.class);
+    var sharedContext = mock(SharedContext.class);
+    var security = mock(SecurityInternal.class);
+    var definition = mock(IndexDefinition.class);
+    when(database.getSharedContext()).thenReturn(sharedContext);
+    when(sharedContext.getSecurity()).thenReturn(security);
+    when(security.getAllFilteredProperties(database)).thenReturn(filteredProperties);
+    when(definition.getClassName()).thenReturn("Indexed");
+    when(definition.getProperties()).thenReturn(List.of("first", "second"));
+    return new SecurityCheckFixture(database, security, definition);
+  }
+
+  private static SecurityResourceProperty filteredProperty(
+      String className, String propertyName) {
+    return new SecurityResourceProperty(
+        "database.class." + className + "." + propertyName, className, propertyName);
+  }
+
+  private static void invokeSecurityCheck(
+      DatabaseSessionEmbedded database, IndexDefinition definition) {
+    try {
+      var method = IndexManagerEmbedded.class.getDeclaredMethod(
+          "checkSecurityConstraintsForIndexCreate",
+          DatabaseSessionEmbedded.class,
+          IndexDefinition.class);
+      method.setAccessible(true);
+      method.invoke(null, database, definition);
+    } catch (InvocationTargetException exception) {
+      if (exception.getCause() instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw new AssertionError("Unexpected checked exception from security check",
+          exception.getCause());
+    } catch (ReflectiveOperationException exception) {
+      throw new AssertionError("Cannot invoke composite-index security check", exception);
+    }
+  }
+
+  private record SecurityCheckFixture(
+      DatabaseSessionEmbedded database,
+      SecurityInternal security,
+      IndexDefinition definition) {
   }
 
   // -----------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
@@ -1,0 +1,535 @@
+package com.jetbrains.youtrackdb.internal.core.metadata.schema;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.internal.BaseMemoryInternalDatabase;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.SessionListener;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.DBRecord;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RecordHookAbstract;
+import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
+import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import com.jetbrains.youtrackdb.internal.core.query.ResultSet;
+import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalDatabase {
+
+  private CommandCounter commands;
+
+  @Before
+  public void registerCommandCounter() {
+    commands = new CommandCounter();
+    session.registerListener(commands);
+  }
+
+  @Test
+  public void emptyTransactionCreatedClassUsesFastPath() {
+    session.executeInTx(transaction -> {
+      var schemaClass = session.getMetadata().getSchema().createClass("EmptyFast");
+      commands.reset();
+      schemaClass.createProperty("value", PropertyType.INTEGER);
+      assertEquals(0, commands.get());
+      assertNotNull(schemaClass.getProperty("value"));
+    });
+  }
+
+  @Test
+  public void incompatibleValueMatchesCommittedMessage() {
+    var fastMessage = incompatibleMessage(true, "IncompatibleParity");
+    var queryMessage = incompatibleMessage(false, "IncompatibleParity");
+    assertEquals(queryMessage, fastMessage);
+  }
+
+  @Test
+  public void migratableValueMatchesCommittedResult() {
+    assertEquals(Integer.class, migratedValueClass(true, "MigratableFast"));
+    assertEquals(Integer.class, migratedValueClass(false, "MigratableQuery"));
+  }
+
+  @Test
+  public void linkedCollectionAndScalarMismatchesMatchCommittedMessages() {
+    var target = session.getMetadata().getSchema().createClass("LinkedTarget");
+    assertEquals(
+        linkedMismatchMessage(true, "ListParity", target, true),
+        linkedMismatchMessage(false, "ListParity", target, true));
+    assertEquals(
+        linkedMismatchMessage(true, "ScalarParity", target, false),
+        linkedMismatchMessage(false, "ScalarParity", target, false));
+  }
+
+  @Test
+  public void violatingRecordOrderMatchesWithinCollectionAndAcrossSubtree() {
+    assertEquals(
+        orderedFailure(false, true, "OneCollectionOrder"),
+        orderedFailure(true, true, "OneCollectionOrderFast"));
+    assertEquals(
+        orderedFailure(false, false, "SubtreeOrder"),
+        orderedFailure(true, false, "SubtreeOrderFast"));
+  }
+
+  @Test
+  public void deletedRecordIsIgnoredOnBothPaths() {
+    assertEquals(0, deletedRecordCommands(true, "DeletedFast"));
+    assertTrue(deletedRecordCommands(false, "DeletedQuery") > 0);
+  }
+
+  @Test
+  public void createdThenUpdatedRecordUsesUpdatedValue() {
+    assertUpdatedRecordFails(true, "UpdatedFast");
+    assertUpdatedRecordFails(false, "UpdatedQuery");
+  }
+
+  @Test
+  public void emptyMultivalueIsIgnoredOnBothPaths() {
+    assertEquals(0, emptyListCommands(true, "EmptyListFast"));
+    assertTrue(emptyListCommands(false, "EmptyListQuery") > 0);
+  }
+
+  @Test
+  public void transactionCreatedParentWithCommittedPopulatedSubclassUsesQueryPath() {
+    var schema = session.getMetadata().getSchema();
+    var child = schema.createClass("CommittedPopulatedChild");
+    session.executeInTx(
+        transaction -> session.newEntity(child.getName()).setProperty("value", 1));
+
+    session.executeInTx(transaction -> {
+      var parent = schema.createClass("TransactionParent");
+      child.addSuperClass(parent);
+      commands.reset();
+      parent.createProperty("value", PropertyType.INTEGER);
+      assertTrue(commands.get() > 0);
+    });
+  }
+
+  @Test
+  public void committedEmptyClassUsesQueryPath() {
+    var schemaClass = session.getMetadata().getSchema().createClass("CommittedEmpty");
+    commands.reset();
+    schemaClass.createProperty("value", PropertyType.INTEGER);
+    assertTrue(commands.get() > 0);
+  }
+
+  @Test
+  public void embeddedMapLinkMapAndLinkBagRemainUncheckedOnBothPaths() {
+    for (var type : List.of(
+        PropertyType.EMBEDDEDMAP, PropertyType.LINKMAP, PropertyType.LINKBAG)) {
+      assertUncheckedLinkedType(type, true, "UncheckedFast" + type);
+      assertUncheckedLinkedType(type, false, "UncheckedQuery" + type);
+    }
+  }
+
+  @Test
+  public void callbackRejectionSurfacesDuringPropertyCreation() {
+    var callbackCount = new AtomicInteger();
+    session.registerHook(new RecordHookAbstract() {
+      @Override
+      public void onBeforeRecordCreate(DBRecord record) {
+        if (record instanceof EntityImpl entity
+            && "CallbackRejected".equals(entity.getSchemaClassName())) {
+          callbackCount.incrementAndGet();
+          throw new IllegalStateException("callback rejected pending create");
+        }
+      }
+    });
+
+    session.begin();
+    var schemaClass = session.getMetadata().getSchema().createClass("CallbackRejected");
+    session.newEntity("CallbackRejected").setProperty("value", 1);
+    commands.reset();
+    var error = assertThrows(
+        IllegalStateException.class,
+        () -> schemaClass.createProperty("value", PropertyType.INTEGER));
+    assertEquals("callback rejected pending create", error.getMessage());
+    assertEquals(1, callbackCount.get());
+    assertEquals(0, commands.get());
+    finishRollingBackTransaction();
+  }
+
+  @Test
+  public void failedValidationLeavesEquivalentTransactionStateOnBothPaths() {
+    var fast = transactionOutcomeAfterFailure(true, "RollbackFast");
+    var query = transactionOutcomeAfterFailure(false, "RollbackQuery");
+    assertEquals(query, fast);
+  }
+
+  @Test
+  public void typeFailurePrecedesLinkedClassFailureOnBothPaths() {
+    var target = session.getMetadata().getSchema().createClass("PassOrderTarget");
+    assertEquals(
+        passOrderMessage(true, "PassOrderParity", target),
+        passOrderMessage(false, "PassOrderParity", target));
+  }
+
+  @Test
+  public void committedAbstractClassWithoutDescendantsUsesFastPath() {
+    var schemaClass =
+        session.getMetadata().getSchema().createAbstractClass("CommittedAbstractEmpty");
+    commands.reset();
+    schemaClass.createProperty("value", PropertyType.INTEGER);
+    assertEquals(0, commands.get());
+  }
+
+  @Test
+  public void migrationRewritesMultipleRecordsAcrossCollectionsAndTerminates() {
+    session.executeInTx(transaction -> {
+      var schema = session.getMetadata().getSchema();
+      var parent = schema.createClass("MigrationParent");
+      schema.createClass("MigrationChild", parent);
+      var parentRecord = (EntityImpl) session.newEntity("MigrationParent");
+      var childRecordOne = (EntityImpl) session.newEntity("MigrationChild");
+      var childRecordTwo = (EntityImpl) session.newEntity("MigrationChild");
+      parentRecord.setProperty("value", (short) 1);
+      childRecordOne.setProperty("value", (short) 2);
+      childRecordTwo.setProperty("value", (short) 3);
+
+      commands.reset();
+      parent.createProperty("value", PropertyType.INTEGER);
+
+      assertEquals(0, commands.get());
+      assertEquals(Integer.class, parentRecord.getPropertyInternal("value").getClass());
+      assertEquals(Integer.class, childRecordOne.getPropertyInternal("value").getClass());
+      assertEquals(Integer.class, childRecordTwo.getPropertyInternal("value").getClass());
+    });
+  }
+
+  private void assertUncheckedLinkedType(
+      PropertyType type, boolean fast, String className) {
+    var schema = session.getMetadata().getSchema();
+    var target = schema.createClass(className + "Target");
+    var wrong = type == PropertyType.EMBEDDEDMAP
+        ? schema.createAbstractClass(className + "Wrong")
+        : schema.createClass(className + "Wrong");
+    if (fast) {
+      session.begin();
+      var schemaClass = schema.createClass(className);
+      createUncheckedLinkedRecord(type, className, wrong.getName());
+      commands.reset();
+      schemaClass.createProperty("value", type, target);
+      assertEquals(0, commands.get());
+      session.rollback();
+    } else {
+      var schemaClass = schema.createClass(className);
+      session.executeInTx(
+          transaction -> createUncheckedLinkedRecord(type, className, wrong.getName()));
+      commands.reset();
+      schemaClass.createProperty("value", type, target);
+      assertTrue(commands.get() > 0);
+    }
+  }
+
+  private void createUncheckedLinkedRecord(
+      PropertyType type, String className, String wrongClassName) {
+    var record = (EntityImpl) session.newEntity(className);
+    switch (type) {
+      case EMBEDDEDMAP -> {
+        var values = session.newEmbeddedMap();
+        values.put("wrong", session.newEmbeddedEntity(wrongClassName));
+        record.setEmbeddedMap("value", values);
+      }
+      case LINKMAP -> {
+        var values = session.newLinkMap();
+        values.put("wrong", session.newEntity(wrongClassName));
+        record.setLinkMap("value", values);
+      }
+      case LINKBAG -> {
+        var wrongEntity = session.newEntity(wrongClassName);
+        var values = new LinkBag(session);
+        values.add(wrongEntity.getIdentity());
+        record.setProperty("value", values);
+      }
+      default -> throw new AssertionError("Unexpected type " + type);
+    }
+  }
+
+  private TransactionOutcome transactionOutcomeAfterFailure(boolean fast, String className) {
+    SchemaClass schemaClass;
+    if (fast) {
+      session.begin();
+      schemaClass = session.getMetadata().getSchema().createClass(className);
+    } else {
+      schemaClass = session.getMetadata().getSchema().createClass(className);
+      session.begin();
+    }
+    session.newEntity(className).setProperty("value", "bad");
+    commands.reset();
+    assertThrows(
+        SchemaException.class,
+        () -> schemaClass.createProperty("value", PropertyType.INTEGER));
+    if (fast) {
+      assertEquals(0, commands.get());
+    } else {
+      assertTrue(commands.get() > 0);
+    }
+    var outcome = new TransactionOutcome(
+        session.getTransactionInternal().getStatus().name(),
+        session.getTransactionInternal().isActive());
+    finishRollingBackTransaction();
+    return outcome;
+  }
+
+  private String passOrderMessage(
+      boolean fast, String className, SchemaClass target) {
+    if (fast) {
+      session.begin();
+    }
+    var schemaClass = session.getMetadata().getSchema().createClass(className);
+    Runnable records = () -> {
+      session.newEntity(className).setProperty("value", "type failure");
+      session.newEntity(className).setProperty("value", session.newEntity(className));
+    };
+    if (fast) {
+      records.run();
+    } else {
+      session.executeInTx(transaction -> records.run());
+    }
+    commands.reset();
+    var error = assertThrows(
+        SchemaException.class,
+        () -> schemaClass.createProperty("value", PropertyType.LINK, target));
+    if (fast) {
+      assertEquals(0, commands.get());
+      finishRollingBackTransaction();
+    } else {
+      assertTrue(commands.get() > 0);
+    }
+    assertTrue(error.getMessage().contains("not compatible with the type LINK."));
+    return error.getMessage();
+  }
+
+  private record TransactionOutcome(String status, boolean active) {
+  }
+
+  private String orderedFailure(boolean fast, boolean oneCollection, String className) {
+    var target = session.getMetadata().getSchema().createClass(className + "Target");
+    if (fast) {
+      session.begin();
+    }
+    var schema = session.getMetadata().getSchema();
+    var parent = schema.createClass(className);
+    var child = oneCollection ? null : schema.createClass(className + "Child", parent);
+    Runnable createRecords = () -> {
+      addMarkerRecord(parent.getName(), "first-created");
+      addMarkerRecord(child == null ? parent.getName() : child.getName(), "second-created");
+    };
+    if (fast) {
+      createRecords.run();
+    } else {
+      session.executeInTx(transaction -> createRecords.run());
+    }
+    commands.reset();
+    var error = assertThrows(
+        SchemaException.class,
+        () -> parent.createProperty("value", PropertyType.EMBEDDEDLIST, target));
+    if (fast) {
+      assertEquals(0, commands.get());
+      finishRollingBackTransaction();
+    } else {
+      assertTrue(commands.get() > 0);
+    }
+    return error.getMessage().substring(error.getMessage().lastIndexOf(' ') + 1);
+  }
+
+  private void addMarkerRecord(String className, String marker) {
+    var record = (EntityImpl) session.newEntity(className);
+    var values = session.newEmbeddedList();
+    values.add(marker);
+    record.setEmbeddedList("value", values);
+  }
+
+  private int deletedRecordCommands(boolean fast, String className) {
+    var result = new int[1];
+    if (fast) {
+      session.executeInTx(transaction -> {
+        var schemaClass = session.getMetadata().getSchema().createClass(className);
+        var record = session.newEntity(className);
+        record.setProperty("value", "bad");
+        session.delete(record);
+        commands.reset();
+        schemaClass.createProperty("value", PropertyType.INTEGER);
+        result[0] = commands.get();
+      });
+    } else {
+      var schemaClass = session.getMetadata().getSchema().createClass(className);
+      session.executeInTx(transaction -> {
+        var record = session.newEntity(className);
+        record.setProperty("value", "bad");
+        session.delete(record);
+      });
+      commands.reset();
+      schemaClass.createProperty("value", PropertyType.INTEGER);
+      result[0] = commands.get();
+    }
+    return result[0];
+  }
+
+  private void assertUpdatedRecordFails(boolean fast, String className) {
+    if (fast) {
+      session.begin();
+    }
+    var schemaClass = session.getMetadata().getSchema().createClass(className);
+    Runnable createRecord = () -> {
+      var record = session.newEntity(className);
+      record.setProperty("value", 1);
+      record.setProperty("value", "updated bad value");
+    };
+    if (fast) {
+      createRecord.run();
+    } else {
+      session.executeInTx(transaction -> createRecord.run());
+    }
+    commands.reset();
+    assertThrows(
+        SchemaException.class,
+        () -> schemaClass.createProperty("value", PropertyType.INTEGER));
+    if (fast) {
+      assertEquals(0, commands.get());
+      finishRollingBackTransaction();
+    } else {
+      assertTrue(commands.get() > 0);
+    }
+  }
+
+  private int emptyListCommands(boolean fast, String className) {
+    var result = new int[1];
+    if (fast) {
+      session.executeInTx(transaction -> {
+        var schemaClass = session.getMetadata().getSchema().createClass(className);
+        ((EntityImpl) session.newEntity(className))
+            .setEmbeddedList("value", session.newEmbeddedList());
+        commands.reset();
+        schemaClass.createProperty("value", PropertyType.EMBEDDEDLIST);
+        result[0] = commands.get();
+      });
+    } else {
+      var schemaClass = session.getMetadata().getSchema().createClass(className);
+      session.executeInTx(
+          transaction -> ((EntityImpl) session.newEntity(className))
+              .setEmbeddedList("value", session.newEmbeddedList()));
+      commands.reset();
+      schemaClass.createProperty("value", PropertyType.EMBEDDEDLIST);
+      result[0] = commands.get();
+    }
+    return result[0];
+  }
+
+  private String incompatibleMessage(boolean fast, String className) {
+    if (fast) {
+      session.begin();
+    }
+    var schemaClass = session.getMetadata().getSchema().createClass(className);
+    if (fast) {
+      session.newEntity(className).setProperty("value", "bad");
+    } else {
+      session.executeInTx(
+          transaction -> session.newEntity(className).setProperty("value", "bad"));
+    }
+    commands.reset();
+    var error = assertThrows(
+        SchemaException.class,
+        () -> schemaClass.createProperty("value", PropertyType.INTEGER));
+    assertEquals(fast ? 0 : 1, commands.get());
+    if (fast) {
+      finishRollingBackTransaction();
+    }
+    return error.getMessage();
+  }
+
+  private Class<?> migratedValueClass(boolean fast, String className) {
+    var observedClass = new Class<?>[1];
+    var rid = new RID[1];
+    if (fast) {
+      session.executeInTx(transaction -> {
+        var schemaClass = session.getMetadata().getSchema().createClass(className);
+        var record = (EntityImpl) session.newEntity(className);
+        record.setProperty("value", (short) 42);
+        commands.reset();
+        schemaClass.createProperty("value", PropertyType.INTEGER);
+        assertEquals(0, commands.get());
+        observedClass[0] = record.getPropertyInternal("value").getClass();
+      });
+    } else {
+      var schemaClass = session.getMetadata().getSchema().createClass(className);
+      session.executeInTx(transaction -> {
+        var record = (EntityImpl) session.newEntity(className);
+        record.setProperty("value", (short) 42);
+        rid[0] = record.getIdentity();
+      });
+      commands.reset();
+      schemaClass.createProperty("value", PropertyType.INTEGER);
+      assertTrue(commands.get() > 0);
+      observedClass[0] = session.computeInTx(
+          transaction -> ((EntityImpl) transaction.load(rid[0]))
+              .getPropertyInternal("value").getClass());
+    }
+    return observedClass[0];
+  }
+
+  private String linkedMismatchMessage(
+      boolean fast, String className, SchemaClass target, boolean collection) {
+    if (fast) {
+      session.begin();
+    }
+    var schemaClass = session.getMetadata().getSchema().createClass(className);
+    Runnable createRecord = () -> {
+      var record = (EntityImpl) session.newEntity(className);
+      if (collection) {
+        var values = session.newEmbeddedList();
+        values.add("wrong linked value");
+        record.setEmbeddedList("value", values);
+      } else {
+        record.setProperty("value", session.newEntity(className));
+      }
+    };
+    if (fast) {
+      createRecord.run();
+    } else {
+      session.executeInTx(transaction -> createRecord.run());
+    }
+    commands.reset();
+    var type = collection ? PropertyType.EMBEDDEDLIST : PropertyType.LINK;
+    var error = assertThrows(
+        SchemaException.class,
+        () -> schemaClass.createProperty("value", type, target));
+    if (fast) {
+      assertEquals(0, commands.get());
+      finishRollingBackTransaction();
+    } else {
+      assertTrue(commands.get() > 0);
+    }
+    return error.getMessage();
+  }
+
+  private void finishRollingBackTransaction() {
+    while (session.getTransactionInternal().isActive()) {
+      session.rollback();
+    }
+  }
+
+  private static final class CommandCounter implements SessionListener {
+
+    private final AtomicInteger count = new AtomicInteger();
+
+    @Override
+    public void onCommandStart(DatabaseSessionEmbedded database, ResultSet resultSet) {
+      count.incrementAndGet();
+    }
+
+    int get() {
+      return count.get();
+    }
+
+    void reset() {
+      count.set(0);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
@@ -22,6 +22,7 @@ import com.jetbrains.youtrackdb.internal.core.metadata.security.Role;
 import com.jetbrains.youtrackdb.internal.core.metadata.security.Rule;
 import com.jetbrains.youtrackdb.internal.core.query.ResultSet;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrackdb.internal.core.sql.executor.InternalExecutionPlan;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -871,14 +872,16 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
   private static final class CommandCounter implements SessionListener {
 
     private final AtomicInteger count = new AtomicInteger();
-    private final List<String> executionPlans = new ArrayList<>();
+    private final List<String> statements = new ArrayList<>();
 
     @Override
     public void onCommandStart(DatabaseSessionEmbedded database, ResultSet resultSet) {
       count.incrementAndGet();
-      var executionPlan = resultSet.getExecutionPlan();
-      if (executionPlan != null) {
-        executionPlans.add(executionPlan.prettyPrint(0, 2));
+      if (resultSet.getExecutionPlan() instanceof InternalExecutionPlan executionPlan) {
+        var statement = executionPlan.getStatement();
+        if (statement != null) {
+          statements.add(statement);
+        }
       }
     }
 
@@ -887,15 +890,16 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     }
 
     void assertQueriedClass(String className) {
-      var fetchStep = "+ FETCH FROM CLASS " + className + "\n";
+      var validationPrefix = "select from `" + className + "` where `value`.type() not in [";
       assertTrue(
-          "Expected a query plan containing " + fetchStep + " but got " + executionPlans,
-          executionPlans.stream().anyMatch(plan -> plan.contains(fetchStep)));
+          "Expected validation query starting with " + validationPrefix + " but got " + statements,
+          statements.stream().anyMatch(statement -> statement.startsWith(validationPrefix)
+              && statement.contains("] and `value` is not null ")));
     }
 
     void reset() {
       count.set(0);
-      executionPlans.clear();
+      statements.clear();
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
@@ -13,6 +13,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.DBRecord;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RecordHookAbstract;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
+import com.jetbrains.youtrackdb.internal.core.exception.CommandSQLParsingException;
 import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
 import com.jetbrains.youtrackdb.internal.core.exception.SecurityAccessException;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -21,6 +22,7 @@ import com.jetbrains.youtrackdb.internal.core.metadata.security.Role;
 import com.jetbrains.youtrackdb.internal.core.metadata.security.Rule;
 import com.jetbrains.youtrackdb.internal.core.query.ResultSet;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Before;
@@ -84,7 +86,8 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
   @Test
   public void deletedRecordIsIgnoredOnBothPaths() {
     assertEquals(0, deletedRecordCommands(true, "DeletedFast"));
-    assertTrue(deletedRecordCommands(false, "DeletedQuery") > 0);
+    deletedRecordCommands(false, "DeletedQuery");
+    commands.assertQueriedClass("DeletedQuery");
   }
 
   @Test
@@ -96,7 +99,34 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
   @Test
   public void emptyMultivalueIsIgnoredOnBothPaths() {
     assertEquals(0, emptyListCommands(true, "EmptyListFast"));
-    assertTrue(emptyListCommands(false, "EmptyListQuery") > 0);
+    emptyListCommands(false, "EmptyListQuery");
+    commands.assertQueriedClass("EmptyListQuery");
+  }
+
+  @Test
+  public void identifiableScalarIsNotTreatedAsAnEmptyMultivalue() {
+    var schema = session.getMetadata().getSchema();
+    schema.createClass("StoredValue");
+    var storedRid = session.computeInTx(
+        transaction -> session.newEntity("StoredValue").getIdentity());
+
+    var committedClass = schema.createClass("IdentifiableScalarQuery");
+    session.executeInTx(transaction -> session.newEntity(committedClass.getName())
+        .setProperty("value", session.loadEntity(storedRid)));
+    var queryError = assertThrows(
+        SchemaException.class,
+        () -> committedClass.createProperty("value", PropertyType.EMBEDDEDLIST));
+
+    session.begin();
+    var fastClass = schema.createClass("IdentifiableScalarFast");
+    session.newEntity(fastClass.getName()).setProperty("value", session.loadEntity(storedRid));
+    var fastError = assertThrows(
+        SchemaException.class,
+        () -> fastClass.createProperty("value", PropertyType.EMBEDDEDLIST));
+    assertEquals(
+        queryError.getMessage().replace("IdentifiableScalarQuery", "IdentifiableScalarFast"),
+        fastError.getMessage());
+    finishRollingBackTransaction();
   }
 
   @Test
@@ -111,7 +141,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       child.addSuperClass(parent);
       commands.reset();
       parent.createProperty("value", PropertyType.INTEGER);
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass("TransactionParent");
     });
   }
 
@@ -120,7 +150,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     var schemaClass = session.getMetadata().getSchema().createClass("CommittedEmpty");
     commands.reset();
     schemaClass.createProperty("value", PropertyType.INTEGER);
-    assertTrue(commands.get() > 0);
+    commands.assertQueriedClass("CommittedEmpty");
   }
 
   @Test
@@ -199,7 +229,8 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     session.executeInTx(
         transaction -> session.newEntity(committed.getName()).setProperty(propertyName, 1));
     commands.reset();
-    assertThrows(Exception.class,
+    assertThrows(
+        CommandSQLParsingException.class,
         () -> committed.createProperty(propertyName, PropertyType.INTEGER));
   }
 
@@ -227,7 +258,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     commands.reset();
     committedClass.createProperty("value", PropertyType.LINK, linkedClass);
     var queryCycles = cycleCount.get();
-    assertTrue(commands.get() > 0);
+    commands.assertQueriedClass("CycleCommittedClass");
 
     assertEquals(2, queryCycles - fastCycles);
   }
@@ -349,7 +380,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       committedClass.createProperty("value", PropertyType.INTEGER);
       assertNotNull("S1 old path skips the hidden record", committedClass.getProperty("value"));
     }
-    assertTrue(commands.get() > 0);
+    commands.assertQueriedClass(className);
     finishRollingBackTransaction();
   }
 
@@ -381,7 +412,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     installReadPolicy(className, false, "PredicateMigrationQueryPolicy");
     commands.reset();
     committedClass.createProperty("value", PropertyType.INTEGER);
-    assertTrue(commands.get() > 0);
+    commands.assertQueriedClass(className);
     assertEquals("S5 old path omits the hidden record", Short.class,
         committedRecord.getPropertyInternal("value").getClass());
     finishRollingBackTransaction();
@@ -409,7 +440,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     installReadPolicy(className, true, "PredicateFilterQueryPolicy");
     commands.reset();
     committedClass.createProperty("value", PropertyType.INTEGER);
-    assertTrue(commands.get() > 0);
+    commands.assertQueriedClass(className);
     assertNotNull("S11 old path installs filter state", committedRecord.propertyAccess);
     assertTrue("S11 old filter hides the protected property",
         !committedRecord.checkPropertyAccess("value"));
@@ -456,7 +487,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       readerQueryClass.createProperty("value", PropertyType.INTEGER);
       assertNotNull(readerQueryClass.getProperty("value"));
     }
-    assertTrue(commands.get() > 0);
+    commands.assertQueriedClass(queryName);
   }
 
   private void assertGrantHiddenMigrationDifference(
@@ -492,7 +523,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     } else {
       readerQueryClass.createProperty("value", PropertyType.INTEGER);
     }
-    assertTrue(commands.get() > 0);
+    commands.assertQueriedClass(queryName);
     reOpen(adminUser, adminPassword);
     var queryValueClass = session.computeInTx(
         transaction -> ((EntityImpl) transaction.load(queryRid[0]))
@@ -545,7 +576,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
           transaction -> createUncheckedLinkedRecord(type, className, wrong.getName()));
       commands.reset();
       schemaClass.createProperty("value", type, target);
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass(className);
     }
   }
 
@@ -590,7 +621,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     if (fast) {
       assertEquals(0, commands.get());
     } else {
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass(className);
     }
     var outcome = new TransactionOutcome(
         session.getTransactionInternal().getStatus().name(),
@@ -622,7 +653,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       assertEquals(0, commands.get());
       finishRollingBackTransaction();
     } else {
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass(className);
     }
     assertTrue(error.getMessage().contains("not compatible with the type LINK."));
     return error.getMessage();
@@ -656,7 +687,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       assertEquals(0, commands.get());
       finishRollingBackTransaction();
     } else {
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass(className);
     }
     return error.getMessage().substring(error.getMessage().lastIndexOf(' ') + 1);
   }
@@ -717,7 +748,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       assertEquals(0, commands.get());
       finishRollingBackTransaction();
     } else {
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass(className);
     }
   }
 
@@ -788,7 +819,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       });
       commands.reset();
       schemaClass.createProperty("value", PropertyType.INTEGER);
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass(className);
       observedClass[0] = session.computeInTx(
           transaction -> ((EntityImpl) transaction.load(rid[0]))
               .getPropertyInternal("value").getClass());
@@ -826,7 +857,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       assertEquals(0, commands.get());
       finishRollingBackTransaction();
     } else {
-      assertTrue(commands.get() > 0);
+      commands.assertQueriedClass(className);
     }
     return error.getMessage();
   }
@@ -840,18 +871,31 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
   private static final class CommandCounter implements SessionListener {
 
     private final AtomicInteger count = new AtomicInteger();
+    private final List<String> executionPlans = new ArrayList<>();
 
     @Override
     public void onCommandStart(DatabaseSessionEmbedded database, ResultSet resultSet) {
       count.incrementAndGet();
+      var executionPlan = resultSet.getExecutionPlan();
+      if (executionPlan != null) {
+        executionPlans.add(executionPlan.prettyPrint(0, 2));
+      }
     }
 
     int get() {
       return count.get();
     }
 
+    void assertQueriedClass(String className) {
+      var fetchStep = "+ FETCH FROM CLASS " + className + "\n";
+      assertTrue(
+          "Expected a query plan containing " + fetchStep + " but got " + executionPlans,
+          executionPlans.stream().anyMatch(plan -> plan.contains(fetchStep)));
+    }
+
     void reset() {
       count.set(0);
+      executionPlans.clear();
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrackdb.internal.core.metadata.schema;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -13,6 +14,7 @@ import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RecordHookAbstract;
 import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
+import com.jetbrains.youtrackdb.internal.core.exception.SecurityAccessException;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.metadata.security.Role;
@@ -122,13 +124,31 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
   }
 
   @Test
+  public void predicateSecurityRebuiltMidTransactionRevealsDifferences() {
+    // S1: a record hidden by a class read policy is validated on the fast path.
+    assertPredicateHiddenValidationDifference(false, "PredicateRecordHidden");
+
+    // S4: validation reports the hidden bad value before migration tries to convert it.
+    assertPredicateHiddenValidationDifference(true, "PredicatePropertyHidden");
+
+    // S5 and S11 cover migration and retained-instance filter state, respectively.
+    assertPredicateHiddenMigrationAndInstanceDifferences();
+  }
+
+  @Test
   public void classGrantDeniedRecordNowFailsPropertyCreation() {
     assertGrantHiddenValidationDifference(Rule.ResourceGeneric.CLASS);
   }
 
   @Test
+  public void collectionGrantDenialThrowsOnlyOnQueryValidationPath() {
+    assertGrantHiddenValidationDifference(Rule.ResourceGeneric.COLLECTION);
+  }
+
+  @Test
   public void grantDeniedRecordNowMigrates() {
     assertGrantHiddenMigrationDifference(Rule.ResourceGeneric.CLASS);
+    assertGrantHiddenMigrationDifference(Rule.ResourceGeneric.COLLECTION);
   }
 
   @Test
@@ -295,6 +315,117 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     });
   }
 
+  private void assertPredicateHiddenValidationDifference(
+      boolean propertyPolicy, String className) {
+    session.begin();
+    var schemaClass = session.getMetadata().getSchema().createClass(className);
+    var record = (EntityImpl) session.newEntity(className);
+    record.setProperty("marker", "hidden");
+    record.setProperty("value", "bad");
+    installReadPolicy(className, propertyPolicy, className + "FastPolicy");
+    commands.reset();
+    var error = assertThrows(
+        SchemaException.class,
+        () -> schemaClass.createProperty("value", PropertyType.INTEGER));
+    assertTrue((propertyPolicy ? "S4" : "S1"),
+        error.getMessage().contains(className + ".value"));
+    assertEquals(0, commands.get());
+    finishRollingBackTransaction();
+
+    var committedClass = session.getMetadata().getSchema().createClass(className);
+    session.executeInTx(transaction -> {
+      var committedRecord = session.newEntity(className);
+      committedRecord.setProperty("marker", "hidden");
+      committedRecord.setProperty("value", "bad");
+    });
+    session.begin();
+    installReadPolicy(className, propertyPolicy, className + "QueryPolicy");
+    commands.reset();
+    if (propertyPolicy) {
+      assertThrows("S4 old path reaches low-level migration conversion",
+          NumberFormatException.class,
+          () -> committedClass.createProperty("value", PropertyType.INTEGER));
+    } else {
+      committedClass.createProperty("value", PropertyType.INTEGER);
+      assertNotNull("S1 old path skips the hidden record", committedClass.getProperty("value"));
+    }
+    assertTrue(commands.get() > 0);
+    finishRollingBackTransaction();
+  }
+
+  private void assertPredicateHiddenMigrationAndInstanceDifferences() {
+    assertClassPredicateMigrationDifference();
+    assertPropertyPredicateFilterStateDifference();
+  }
+
+  private void assertClassPredicateMigrationDifference() {
+    var className = "PredicateMigration";
+    session.begin();
+    var schemaClass = session.getMetadata().getSchema().createClass(className);
+    var record = (EntityImpl) session.newEntity(className);
+    record.setProperty("marker", "hidden");
+    record.setProperty("value", (short) 7);
+    installReadPolicy(className, false, "PredicateMigrationFastPolicy");
+    commands.reset();
+    schemaClass.createProperty("value", PropertyType.INTEGER);
+    assertEquals(0, commands.get());
+    assertEquals("S5 fast path migrates the hidden record", Integer.class,
+        record.getPropertyInternal("value").getClass());
+    finishRollingBackTransaction();
+
+    var committedClass = session.getMetadata().getSchema().createClass(className);
+    session.begin();
+    var committedRecord = (EntityImpl) session.newEntity(className);
+    committedRecord.setProperty("marker", "hidden");
+    committedRecord.setProperty("value", (short) 7);
+    installReadPolicy(className, false, "PredicateMigrationQueryPolicy");
+    commands.reset();
+    committedClass.createProperty("value", PropertyType.INTEGER);
+    assertTrue(commands.get() > 0);
+    assertEquals("S5 old path omits the hidden record", Short.class,
+        committedRecord.getPropertyInternal("value").getClass());
+    finishRollingBackTransaction();
+  }
+
+  private void assertPropertyPredicateFilterStateDifference() {
+    var className = "PredicateFilterState";
+    session.begin();
+    var schemaClass = session.getMetadata().getSchema().createClass(className);
+    var record = (EntityImpl) session.newEntity(className);
+    record.setProperty("marker", "hidden");
+    record.setProperty("value", 7);
+    installReadPolicy(className, true, "PredicateFilterFastPolicy");
+    commands.reset();
+    schemaClass.createProperty("value", PropertyType.INTEGER);
+    assertEquals(0, commands.get());
+    assertNull("S11 fast path leaves filter state unchanged", record.propertyAccess);
+    finishRollingBackTransaction();
+
+    var committedClass = session.getMetadata().getSchema().createClass(className);
+    session.begin();
+    var committedRecord = (EntityImpl) session.newEntity(className);
+    committedRecord.setProperty("marker", "hidden");
+    committedRecord.setProperty("value", 7);
+    installReadPolicy(className, true, "PredicateFilterQueryPolicy");
+    commands.reset();
+    committedClass.createProperty("value", PropertyType.INTEGER);
+    assertTrue(commands.get() > 0);
+    assertNotNull("S11 old path installs filter state", committedRecord.propertyAccess);
+    assertTrue("S11 old filter hides the protected property",
+        !committedRecord.checkPropertyAccess("value"));
+    finishRollingBackTransaction();
+  }
+
+  private void installReadPolicy(String className, boolean propertyPolicy, String policyName) {
+    var security = session.getSharedContext().getSecurity();
+    var policy = security.createSecurityPolicy(session, policyName);
+    policy.setActive(true);
+    policy.setReadRule("marker = 'visible'");
+    security.saveSecurityPolicy(session, policy);
+    var resource = "database.class." + className + (propertyPolicy ? ".value" : "");
+    security.setSecurityPolicy(session, security.getRole(session, "admin"), resource, policy);
+  }
+
   private void assertGrantHiddenValidationDifference(
       Rule.ResourceGeneric resourceGeneric) {
     var suffix = resourceGeneric == Rule.ResourceGeneric.CLASS ? "Class" : "Collection";
@@ -305,6 +436,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
         transaction -> session.newEntity(queryName).setProperty("value", "bad"));
     prepareReaderForGrantTest(resourceGeneric, fastName, queryName);
     queryClass = session.getMetadata().getSchema().getClass(queryName);
+    var readerQueryClass = queryClass;
 
     session.begin();
     var fastClass = session.getMetadata().getSchema().createClass(fastName);
@@ -317,9 +449,14 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     finishRollingBackTransaction();
 
     commands.reset();
-    queryClass.createProperty("value", PropertyType.INTEGER);
+    if (resourceGeneric == Rule.ResourceGeneric.COLLECTION) {
+      assertThrows(SecurityAccessException.class,
+          () -> readerQueryClass.createProperty("value", PropertyType.INTEGER));
+    } else {
+      readerQueryClass.createProperty("value", PropertyType.INTEGER);
+      assertNotNull(readerQueryClass.getProperty("value"));
+    }
     assertTrue(commands.get() > 0);
-    assertNotNull(queryClass.getProperty("value"));
   }
 
   private void assertGrantHiddenMigrationDifference(
@@ -336,6 +473,7 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     });
     prepareReaderForGrantTest(resourceGeneric, fastName, queryName);
     queryClass = session.getMetadata().getSchema().getClass(queryName);
+    var readerQueryClass = queryClass;
 
     session.begin();
     var fastClass = session.getMetadata().getSchema().createClass(fastName);
@@ -348,7 +486,12 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
     session.rollback();
 
     commands.reset();
-    queryClass.createProperty("value", PropertyType.INTEGER);
+    if (resourceGeneric == Rule.ResourceGeneric.COLLECTION) {
+      assertThrows(SecurityAccessException.class,
+          () -> readerQueryClass.createProperty("value", PropertyType.INTEGER));
+    } else {
+      readerQueryClass.createProperty("value", PropertyType.INTEGER);
+    }
     assertTrue(commands.get() > 0);
     reOpen(adminUser, adminPassword);
     var queryValueClass = session.computeInTx(

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/schema/ProvisionalClassInMemorySchemaCheckTest.java
@@ -15,6 +15,8 @@ import com.jetbrains.youtrackdb.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrackdb.internal.core.exception.SchemaException;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import com.jetbrains.youtrackdb.internal.core.metadata.security.Role;
+import com.jetbrains.youtrackdb.internal.core.metadata.security.Rule;
 import com.jetbrains.youtrackdb.internal.core.query.ResultSet;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
 import java.util.List;
@@ -120,6 +122,97 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
   }
 
   @Test
+  public void classGrantDeniedRecordNowFailsPropertyCreation() {
+    assertGrantHiddenValidationDifference(Rule.ResourceGeneric.CLASS);
+  }
+
+  @Test
+  public void grantDeniedRecordNowMigrates() {
+    assertGrantHiddenMigrationDifference(Rule.ResourceGeneric.CLASS);
+  }
+
+  @Test
+  public void readHooksDoNotObserveInternalSchemaChecks() {
+    var readCount = new AtomicInteger();
+    session.registerHook(new RecordHookAbstract() {
+      @Override
+      public void onRecordRead(DBRecord record) {
+        readCount.incrementAndGet();
+      }
+    });
+
+    session.executeInTx(transaction -> {
+      var schemaClass = session.getMetadata().getSchema().createClass("NoReadHooksFast");
+      session.newEntity(schemaClass.getName()).setProperty("value", 1);
+      commands.reset();
+      schemaClass.createProperty("value", PropertyType.INTEGER);
+      assertEquals(0, readCount.get());
+      assertEquals(0, commands.get());
+    });
+  }
+
+  @Test
+  public void noCommandStartsOnFastPath() {
+    session.executeInTx(transaction -> {
+      var schemaClass = session.getMetadata().getSchema().createClass("NoCommandsFast");
+      session.newEntity(schemaClass.getName()).setProperty("value", 1);
+      commands.reset();
+      schemaClass.createProperty("value", PropertyType.INTEGER);
+      assertEquals(0, commands.get());
+      assertTrue(session.getActiveQueries().isEmpty());
+    });
+  }
+
+  @Test
+  public void backslashSuffixedPropertyNameSucceedsOnFastPath() {
+    var propertyName = "broken\\";
+    session.executeInTx(transaction -> {
+      var schemaClass = session.getMetadata().getSchema().createClass("EscapedNameFast");
+      session.newEntity(schemaClass.getName()).setProperty(propertyName, 1);
+      commands.reset();
+      schemaClass.createProperty(propertyName, PropertyType.INTEGER);
+      assertEquals(0, commands.get());
+      assertNotNull(schemaClass.getProperty(propertyName));
+    });
+
+    var committed = session.getMetadata().getSchema().createClass("EscapedNameQuery");
+    session.executeInTx(
+        transaction -> session.newEntity(committed.getName()).setProperty(propertyName, 1));
+    commands.reset();
+    assertThrows(Exception.class,
+        () -> committed.createProperty(propertyName, PropertyType.INTEGER));
+  }
+
+  @Test
+  public void abstractClassOutsideTransactionRunsFewerTransactionCycles() {
+    var cycleCount = new AtomicInteger();
+    session.registerListener(new SessionListener() {
+      @Override
+      public void onBeforeTxBegin(
+          com.jetbrains.youtrackdb.internal.core.tx.Transaction transaction) {
+        cycleCount.incrementAndGet();
+      }
+    });
+    var linkedClass = session.getMetadata().getSchema().createClass("CycleLinkedClass");
+    var schemaClass =
+        session.getMetadata().getSchema().createAbstractClass("CycleAbstractClass");
+    cycleCount.set(0);
+    commands.reset();
+    schemaClass.createProperty("value", PropertyType.LINK, linkedClass);
+    var fastCycles = cycleCount.get();
+    assertEquals(0, commands.get());
+
+    var committedClass = session.getMetadata().getSchema().createClass("CycleCommittedClass");
+    cycleCount.set(0);
+    commands.reset();
+    committedClass.createProperty("value", PropertyType.LINK, linkedClass);
+    var queryCycles = cycleCount.get();
+    assertTrue(commands.get() > 0);
+
+    assertEquals(2, queryCycles - fastCycles);
+  }
+
+  @Test
   public void embeddedMapLinkMapAndLinkBagRemainUncheckedOnBothPaths() {
     for (var type : List.of(
         PropertyType.EMBEDDEDMAP, PropertyType.LINKMAP, PropertyType.LINKBAG)) {
@@ -200,6 +293,92 @@ public class ProvisionalClassInMemorySchemaCheckTest extends BaseMemoryInternalD
       assertEquals(Integer.class, childRecordOne.getPropertyInternal("value").getClass());
       assertEquals(Integer.class, childRecordTwo.getPropertyInternal("value").getClass());
     });
+  }
+
+  private void assertGrantHiddenValidationDifference(
+      Rule.ResourceGeneric resourceGeneric) {
+    var suffix = resourceGeneric == Rule.ResourceGeneric.CLASS ? "Class" : "Collection";
+    var fastName = "GrantValidationFast" + suffix;
+    var queryName = "GrantValidationQuery" + suffix;
+    var queryClass = session.getMetadata().getSchema().createClass(queryName);
+    session.executeInTx(
+        transaction -> session.newEntity(queryName).setProperty("value", "bad"));
+    prepareReaderForGrantTest(resourceGeneric, fastName, queryName);
+    queryClass = session.getMetadata().getSchema().getClass(queryName);
+
+    session.begin();
+    var fastClass = session.getMetadata().getSchema().createClass(fastName);
+    session.newEntity(fastName).setProperty("value", "bad");
+    commands.reset();
+    assertThrows(
+        SchemaException.class,
+        () -> fastClass.createProperty("value", PropertyType.INTEGER));
+    assertEquals(0, commands.get());
+    finishRollingBackTransaction();
+
+    commands.reset();
+    queryClass.createProperty("value", PropertyType.INTEGER);
+    assertTrue(commands.get() > 0);
+    assertNotNull(queryClass.getProperty("value"));
+  }
+
+  private void assertGrantHiddenMigrationDifference(
+      Rule.ResourceGeneric resourceGeneric) {
+    var suffix = resourceGeneric == Rule.ResourceGeneric.CLASS ? "Class" : "Collection";
+    var fastName = "GrantMigrationFast" + suffix;
+    var queryName = "GrantMigrationQuery" + suffix;
+    var queryClass = session.getMetadata().getSchema().createClass(queryName);
+    var queryRid = new RID[1];
+    session.executeInTx(transaction -> {
+      var queryRecord = (EntityImpl) session.newEntity(queryName);
+      queryRecord.setProperty("value", (short) 1);
+      queryRid[0] = queryRecord.getIdentity();
+    });
+    prepareReaderForGrantTest(resourceGeneric, fastName, queryName);
+    queryClass = session.getMetadata().getSchema().getClass(queryName);
+
+    session.begin();
+    var fastClass = session.getMetadata().getSchema().createClass(fastName);
+    var fastRecord = (EntityImpl) session.newEntity(fastName);
+    fastRecord.setProperty("value", (short) 1);
+    commands.reset();
+    fastClass.createProperty("value", PropertyType.INTEGER);
+    assertEquals(0, commands.get());
+    assertEquals(Integer.class, fastRecord.getPropertyInternal("value").getClass());
+    session.rollback();
+
+    commands.reset();
+    queryClass.createProperty("value", PropertyType.INTEGER);
+    assertTrue(commands.get() > 0);
+    reOpen(adminUser, adminPassword);
+    var queryValueClass = session.computeInTx(
+        transaction -> ((EntityImpl) transaction.load(queryRid[0]))
+            .getPropertyInternal("value").getClass());
+    assertEquals(Short.class, queryValueClass);
+  }
+
+  private void prepareReaderForGrantTest(
+      Rule.ResourceGeneric resourceGeneric, String fastName, String queryName) {
+    session.begin();
+    var role = session.getMetadata().getSecurity().getRole(readerUser);
+    role.grant(session, Rule.ResourceGeneric.SCHEMA, null, Role.PERMISSION_ALL);
+    role.grant(session, Rule.ResourceGeneric.CLASS, null, Role.PERMISSION_ALL);
+    role.grant(session, Rule.ResourceGeneric.COLLECTION, null, Role.PERMISSION_ALL);
+    var allowedWrites = Role.PERMISSION_CREATE | Role.PERMISSION_UPDATE | Role.PERMISSION_DELETE;
+    role.grant(session, Rule.ResourceGeneric.COLLECTION, "internal", Role.PERMISSION_ALL);
+    if (resourceGeneric == Rule.ResourceGeneric.CLASS) {
+      role.grant(session, resourceGeneric, fastName, Role.PERMISSION_NONE);
+      role.grant(session, resourceGeneric, fastName, allowedWrites);
+      role.grant(session, resourceGeneric, queryName, Role.PERMISSION_NONE);
+      role.grant(session, resourceGeneric, queryName, allowedWrites);
+    } else {
+      role.grant(session, resourceGeneric, null, Role.PERMISSION_NONE);
+      role.grant(session, resourceGeneric, null, allowedWrites);
+    }
+    role.save(session);
+    session.commit();
+    reOpen(readerUser, readerPassword);
+    registerCommandCounter();
   }
 
   private void assertUncheckedLinkedType(

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecuritySharedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecuritySharedTest.java
@@ -2,7 +2,9 @@ package com.jetbrains.youtrackdb.internal.core.metadata.security;
 
 import com.jetbrains.youtrackdb.internal.DbTestBase;
 import com.jetbrains.youtrackdb.internal.core.record.impl.EntityImpl;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -159,6 +161,26 @@ public class SecuritySharedTest extends DbTestBase {
     Assert.assertFalse(
         "calculateAllFilteredProperties must not leak an implicit transaction",
         session.isTxActive());
+  }
+
+  /**
+   * Verifies that an immutable empty result from filtered-property calculation is cached as a
+   * mutable defensive copy, so the later in-place refresh can clear and repopulate it.
+   */
+  @Test
+  public void testImmutableEmptyFilteredPropertiesCanBeRefreshedInPlace() {
+    var security = new EmptyFilteredPropertiesSecurity();
+    var user = session.getCurrentUser();
+
+    try {
+      session.setUser(null);
+      security.updateAllFilteredProperties(session);
+    } finally {
+      session.setUser(user);
+    }
+
+    security.updateAllFilteredPropertiesInternal(session);
+    Assert.assertTrue(security.getAllFilteredProperties(session).isEmpty());
   }
 
   /**
@@ -348,5 +370,18 @@ public class SecuritySharedTest extends DbTestBase {
 
     Assert.assertTrue("version must increase after incrementVersion",
         versionAfter > versionBefore);
+  }
+
+  private static final class EmptyFilteredPropertiesSecurity extends SecurityShared {
+
+    private EmptyFilteredPropertiesSecurity() {
+      super(null);
+    }
+
+    @Override
+    protected Set<SecurityResourceProperty> calculateAllFilteredProperties(
+        com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded database) {
+      return Collections.emptySet();
+    }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecuritySharedTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/metadata/security/SecuritySharedTest.java
@@ -164,12 +164,12 @@ public class SecuritySharedTest extends DbTestBase {
   }
 
   /**
-   * Verifies that an immutable empty result from filtered-property calculation is cached as a
-   * mutable defensive copy, so the later in-place refresh can clear and repopulate it.
+   * Verifies that an immutable empty result from the initial filtered-property calculation is
+   * cached as a mutable defensive copy, so a later in-place refresh can add calculated content.
    */
   @Test
   public void testImmutableEmptyFilteredPropertiesCanBeRefreshedInPlace() {
-    var security = new EmptyFilteredPropertiesSecurity();
+    var security = new InitiallyEmptyFilteredPropertiesSecurity();
     var user = session.getCurrentUser();
 
     try {
@@ -180,7 +180,9 @@ public class SecuritySharedTest extends DbTestBase {
     }
 
     security.updateAllFilteredPropertiesInternal(session);
-    Assert.assertTrue(security.getAllFilteredProperties(session).isEmpty());
+    Assert.assertEquals(
+        Collections.singleton(SecurityResourceProperty.ALL_PROPERTIES),
+        security.getAllFilteredProperties(session));
   }
 
   /**
@@ -372,16 +374,21 @@ public class SecuritySharedTest extends DbTestBase {
         versionAfter > versionBefore);
   }
 
-  private static final class EmptyFilteredPropertiesSecurity extends SecurityShared {
+  private static final class InitiallyEmptyFilteredPropertiesSecurity extends SecurityShared {
 
-    private EmptyFilteredPropertiesSecurity() {
+    private int calculationCount;
+
+    private InitiallyEmptyFilteredPropertiesSecurity() {
       super(null);
     }
 
     @Override
     protected Set<SecurityResourceProperty> calculateAllFilteredProperties(
         com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded database) {
-      return Collections.emptySet();
+      if (calculationCount++ == 0) {
+        return Collections.emptySet();
+      }
+      return Collections.singleton(SecurityResourceProperty.ALL_PROPERTIES);
     }
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheNonDurableFileTrackingTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/WOWCacheNonDurableFileTrackingTest.java
@@ -7,9 +7,15 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
 import com.jetbrains.youtrackdb.internal.SequentialTest;
@@ -22,6 +28,7 @@ import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import com.jetbrains.youtrackdb.internal.core.storage.ChecksumMode;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.CachePointer;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.chm.LockFreeReadCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.local.doublewritelog.DoubleWriteLog;
 import com.jetbrains.youtrackdb.internal.core.storage.cache.local.doublewritelog.DoubleWriteLogNoOP;
 import com.jetbrains.youtrackdb.internal.core.storage.fs.File;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.base.DurablePage;
@@ -30,11 +37,15 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.c
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -44,6 +55,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.MockedStatic;
 
 /**
  * Tests the in-memory non-durable file tracking in WOWCache: addFile with nonDurable flag,
@@ -445,6 +457,220 @@ public class WOWCacheNonDurableFileTrackingTest {
     assertFalse(wowCache.isNonDurable(existingId));
   }
 
+  /**
+   * Registry mutations skip every channel force when the cache disables fsync.
+   */
+  @Test
+  public void testRegistryMutationsDoNotForceWhenFsyncIsDisabled() throws Exception {
+    assertRegistryMutationForces(false);
+  }
+
+  /**
+   * Registry mutations retain their channel force when the cache enables fsync.
+   */
+  @Test
+  public void testRegistryMutationsForceWhenFsyncIsEnabled() throws Exception {
+    assertRegistryMutationForces(true);
+  }
+
+  private void assertRegistryMutationForces(boolean callFsync) throws Exception {
+    wowCache.delete();
+    createNewCache(callFsync);
+
+    final Field registryPathField = WOWCache.class.getDeclaredField("nameIdMapHolderPath");
+    registryPathField.setAccessible(true);
+    final var registryPath = (Path) registryPathField.get(wowCache);
+
+    final var channels = new ArrayList<FileChannel>();
+    for (var i = 0; i < 4; i++) {
+      channels.add(
+          spy(
+              FileChannel.open(
+                  registryPath, StandardOpenOption.READ, StandardOpenOption.WRITE)));
+    }
+
+    final var nextChannel = new java.util.concurrent.atomic.AtomicInteger();
+    try (MockedStatic<FileChannel> mockedChannels =
+        mockStatic(FileChannel.class, CALLS_REAL_METHODS)) {
+      mockedChannels
+          .when(
+              () -> FileChannel.open(
+                  registryPath, StandardOpenOption.READ, StandardOpenOption.WRITE))
+          .thenAnswer(invocation -> channels.get(nextChannel.getAndIncrement()));
+
+      final var fileId = wowCache.addFile("forceRegistry.tst");
+      wowCache.renameFile(fileId, "forceRegistryRenamed.tst");
+      wowCache.deleteFile(fileId);
+    }
+
+    assertEquals("add, rename twice, and delete must open four registry channels", 4,
+        nextChannel.get());
+    if (callFsync) {
+      final var forceCount =
+          channels.stream()
+              .flatMap(channel -> mockingDetails(channel).getInvocations().stream())
+              .filter(invocation -> invocation.getMethod().getName().equals("force"))
+              .count();
+      assertEquals("add, rename, and delete must each force their durable registry entry", 3,
+          forceCount);
+    } else {
+      for (final var channel : channels) {
+        assertEquals(
+            "disabled fsync must suppress every registry force invocation",
+            0,
+            countInvocations(channel, "force"));
+      }
+    }
+  }
+
+  /** Clean close suppresses the rewritten registry force when fsync is disabled. */
+  @Test
+  public void testCleanCloseRegistryRewriteSkipsForceWhenFsyncIsDisabled() throws Exception {
+    assertCleanCloseRegistryForces(false, 0);
+  }
+
+  /** Clean close retains the rewritten registry force when fsync is enabled. */
+  @Test
+  public void testCleanCloseRegistryRewriteForcesWhenFsyncIsEnabled() throws Exception {
+    assertCleanCloseRegistryForces(true, 1);
+  }
+
+  private void assertCleanCloseRegistryForces(boolean callFsync, long expectedForces)
+      throws Exception {
+    wowCache.delete();
+    createNewCache(callFsync);
+    wowCache.addFile("closeForceProbe.tst");
+
+    final var backupPath = storagePath.resolve("name_id_map_v2_backup.cm");
+    final var channel =
+        spy(
+            FileChannel.open(
+                backupPath,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE));
+    try (MockedStatic<FileChannel> mockedChannels =
+        mockStatic(FileChannel.class, CALLS_REAL_METHODS)) {
+      mockedChannels
+          .when(
+              () -> FileChannel.open(
+                  backupPath,
+                  StandardOpenOption.CREATE,
+                  StandardOpenOption.READ,
+                  StandardOpenOption.WRITE))
+          .thenReturn(channel);
+      wowCache.close();
+      wowCache = null;
+    }
+
+    assertEquals(
+        "clean-close registry force count must follow callFsync",
+        expectedForces,
+        countInvocations(channel, "force"));
+  }
+
+  /** V3 migration suppresses its registry force when fsync is disabled. */
+  @Test
+  public void testV3MigrationSkipsForceWhenFsyncIsDisabled() throws Exception {
+    assertV3MigrationForces(false, 0);
+  }
+
+  /** V3 migration retains its registry force when fsync is enabled. */
+  @Test
+  public void testV3MigrationForcesWhenFsyncIsEnabled() throws Exception {
+    assertV3MigrationForces(true, 1);
+  }
+
+  private void assertV3MigrationForces(boolean callFsync, long expectedForces) throws Exception {
+    wowCache.delete();
+    createNewCache(callFsync);
+
+    Files.deleteIfExists(storagePath.resolve("name_id_map_v3.cm"));
+    final var temporaryPath = storagePath.resolve("name_id_map_v3_t.cm");
+    final var channel = new java.util.concurrent.atomic.AtomicReference<FileChannel>();
+    try (MockedStatic<FileChannel> mockedChannels =
+        mockStatic(FileChannel.class, CALLS_REAL_METHODS)) {
+      mockedChannels
+          .when(
+              () -> FileChannel.open(
+                  temporaryPath,
+                  StandardOpenOption.CREATE,
+                  StandardOpenOption.WRITE,
+                  StandardOpenOption.READ))
+          .thenAnswer(
+              invocation -> {
+                final var realChannel =
+                    temporaryPath
+                        .getFileSystem()
+                        .provider()
+                        .newFileChannel(
+                            temporaryPath,
+                            java.util.Set.of(
+                                StandardOpenOption.CREATE,
+                                StandardOpenOption.WRITE,
+                                StandardOpenOption.READ));
+                final var channelSpy = spy(realChannel);
+                channel.set(channelSpy);
+                return channelSpy;
+              });
+      invokeFsyncFilesOrMigration(wowCache, "storedNameIdMapToV3");
+    }
+
+    assertNotNull("migration must open its temporary registry channel", channel.get());
+    assertEquals(
+        "V3 migration force count must follow callFsync",
+        expectedForces,
+        countInvocations(channel.get(), "force"));
+  }
+
+  /** fsyncFiles skips per-file synchronization but still truncates the DWL when disabled. */
+  @Test
+  public void testFsyncFilesSkipsFilesButTruncatesDwlWhenFsyncIsDisabled() throws Exception {
+    assertFsyncFilesBehavior(false);
+  }
+
+  /** fsyncFiles synchronizes files and truncates the DWL when fsync is enabled. */
+  @Test
+  public void testFsyncFilesSynchronizesFilesAndTruncatesDwlWhenFsyncIsEnabled()
+      throws Exception {
+    assertFsyncFilesBehavior(true);
+  }
+
+  private void assertFsyncFilesBehavior(boolean callFsync) throws Exception {
+    wowCache.delete();
+    final var doubleWriteLog = mock(DoubleWriteLog.class);
+    createNewCache(callFsync, doubleWriteLog);
+
+    final var fileId = wowCache.addFile("fsyncFilesProbe.tst");
+    final var realFile = files.remove(fileId);
+    realFile.close();
+    final var file = mock(File.class);
+    when(file.isOpen()).thenReturn(true);
+    files.add(fileId, file);
+
+    invokeFsyncFilesOrMigration(wowCache, "fsyncFiles");
+
+    if (callFsync) {
+      verify(file).synch();
+    } else {
+      verify(file, never()).synch();
+    }
+    verify(doubleWriteLog).truncate();
+  }
+
+  private static void invokeFsyncFilesOrMigration(WOWCache cache, String methodName)
+      throws Exception {
+    final Method method = WOWCache.class.getDeclaredMethod(methodName);
+    method.setAccessible(true);
+    method.invoke(cache);
+  }
+
+  private static long countInvocations(Object mock, String methodName) {
+    return mockingDetails(mock).getInvocations().stream()
+        .filter(invocation -> invocation.getMethod().getName().equals(methodName))
+        .count();
+  }
+
   // --- Side file persistence tests ---
 
   /**
@@ -461,6 +687,14 @@ public class WOWCacheNonDurableFileTrackingTest {
    * the old cache (e.g., to corrupt side files before reopening) call this directly.
    */
   private void createNewCache() throws Exception {
+    createNewCache(false);
+  }
+
+  private void createNewCache(boolean callFsync) throws Exception {
+    createNewCache(callFsync, new DoubleWriteLogNoOP());
+  }
+
+  private void createNewCache(boolean callFsync, DoubleWriteLog doubleWriteLog) throws Exception {
     writeAheadLog.close();
     writeAheadLog =
         new CASDiskWriteAheadLog(
@@ -491,7 +725,7 @@ public class WOWCacheNonDurableFileTrackingTest {
             false,
             bufferPool,
             writeAheadLog,
-            new DoubleWriteLogNoOP(),
+            doubleWriteLog,
             PAGES_FLUSH_INTERVAL,
             SHUTDOWN_TIMEOUT,
             EXCLUSIVE_WRITE_CACHE_MAX_SIZE,
@@ -503,7 +737,7 @@ public class WOWCacheNonDurableFileTrackingTest {
             ChecksumMode.StoreAndVerify,
             null,
             null,
-            false,
+            callFsync,
             Executors.newCachedThreadPool());
     wowCache.loadRegisteredFiles();
   }

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/doublewritelog/DoubleWriteLogGLTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/cache/local/doublewritelog/DoubleWriteLogGLTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.verify;
 
 import com.jetbrains.youtrackdb.internal.common.directmemory.ByteBufferPool;
 import com.jetbrains.youtrackdb.internal.common.directmemory.Pointer;
@@ -14,8 +18,10 @@ import com.jetbrains.youtrackdb.internal.core.config.ContextConfiguration;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -140,6 +146,94 @@ public class DoubleWriteLogGLTest {
   @Test
   public void testExtensionConstant() {
     assertEquals(".dwl", DoubleWriteLogGL.EXTENSION);
+  }
+
+  /**
+   * A write skips the segment force when fsync is disabled.
+   */
+  @Test
+  public void testWriteSkipsForceWhenFsyncIsDisabled() throws Exception {
+    final var dwl = new DoubleWriteLogGL(MAX_SEG_SIZE, BLOCK_SIZE, false);
+    dwl.open("s", ContextConfiguration.DOUBLE_WRITE_LOG_DEFAULT_NAME, testDirectory, PAGE_SIZE);
+    try {
+      final var channel = installCurrentFileSpy(dwl);
+      final var buffer = ByteBuffer.allocate(PAGE_SIZE).order(ByteOrder.nativeOrder());
+      randomPage(buffer);
+
+      dwl.write(
+          new ArrayList<>(Collections.singleton(buffer)),
+          IntArrayList.of(1),
+          IntArrayList.of(0));
+
+      final var forceCount =
+          mockingDetails(channel).getInvocations().stream()
+              .filter(invocation -> invocation.getMethod().getName().equals("force"))
+              .count();
+      assertEquals("disabled fsync must suppress every force invocation", 0, forceCount);
+    } finally {
+      dwl.close();
+    }
+  }
+
+  /**
+   * A write retains the segment force when fsync is enabled.
+   */
+  @Test
+  public void testWriteForcesWhenFsyncIsEnabled() throws Exception {
+    final var dwl = new DoubleWriteLogGL(MAX_SEG_SIZE, BLOCK_SIZE, true);
+    dwl.open("s", ContextConfiguration.DOUBLE_WRITE_LOG_DEFAULT_NAME, testDirectory, PAGE_SIZE);
+    try {
+      final var channel = installCurrentFileSpy(dwl);
+      final var buffer = ByteBuffer.allocate(PAGE_SIZE).order(ByteOrder.nativeOrder());
+      randomPage(buffer);
+
+      dwl.write(
+          new ArrayList<>(Collections.singleton(buffer)),
+          IntArrayList.of(1),
+          IntArrayList.of(0));
+
+      verify(channel).force(true);
+    } finally {
+      dwl.close();
+    }
+  }
+
+  /**
+   * Disabling fsync does not prevent rollover tail segments from being truncated.
+   */
+  @Test
+  public void testTruncateAfterRolloverStillRunsWhenFsyncIsDisabled() throws IOException {
+    final var dwl = new DoubleWriteLogGL(MAX_SEG_SIZE, BLOCK_SIZE, false);
+    dwl.open("s", ContextConfiguration.DOUBLE_WRITE_LOG_DEFAULT_NAME, testDirectory, PAGE_SIZE);
+    try {
+      final var buffer = ByteBuffer.allocate(PAGE_SIZE).order(ByteOrder.nativeOrder());
+      randomPage(buffer);
+      dwl.write(
+          new ArrayList<>(Collections.singleton(buffer)),
+          IntArrayList.of(1),
+          IntArrayList.of(0));
+      randomPage(buffer);
+      assertTrue(
+          dwl.write(
+              new ArrayList<>(Collections.singleton(buffer)),
+              IntArrayList.of(1),
+              IntArrayList.of(1)));
+
+      dwl.truncate();
+
+      assertEquals("truncate must remove the rollover tail", 1, listDwlFiles().size());
+    } finally {
+      dwl.close();
+    }
+  }
+
+  private static FileChannel installCurrentFileSpy(DoubleWriteLogGL dwl) throws Exception {
+    final Field field = DoubleWriteLogGL.class.getDeclaredField("currentFile");
+    field.setAccessible(true);
+    final var channel = (FileChannel) field.get(dwl);
+    final var spy = mock(FileChannel.class, delegatesTo(channel));
+    field.set(dwl, spy);
+    return spy;
   }
 
   // -------------------------------------------------------------------------

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageFsyncWarningTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/DiskStorageFsyncWarningTest.java
@@ -1,0 +1,122 @@
+package com.jetbrains.youtrackdb.internal.core.storage.disk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/** Verifies that disabled storage durability logs only one warning per JVM. */
+@Category(SequentialTest.class)
+public class DiskStorageFsyncWarningTest extends DbTestBase {
+
+  private static final String WARNING_MESSAGE =
+      "Storage durability barriers are disabled by youtrackdb.storage.callFsync. "
+          + "A power loss can lose data. Use this mode only for tests.";
+
+  private Object previousCallFsync;
+  private AtomicBoolean warningState;
+  private boolean previousWarningState;
+  private Logger rootLogger;
+  private CapturingHandler capturingHandler;
+  private Level previousLevel;
+
+  @Override
+  protected DatabaseType calculateDbType() {
+    return DatabaseType.DISK;
+  }
+
+  @Before
+  @Override
+  public void beforeTest() throws Exception {
+    previousCallFsync = GlobalConfiguration.STORAGE_CALL_FSYNC.getValue();
+    GlobalConfiguration.STORAGE_CALL_FSYNC.setValue(false);
+    warningState = warningState();
+    previousWarningState = warningState.get();
+    warningState.set(false);
+    rootLogger = Logger.getLogger("");
+    capturingHandler = new CapturingHandler();
+    previousLevel = rootLogger.getLevel();
+    rootLogger.addHandler(capturingHandler);
+    rootLogger.setLevel(Level.ALL);
+    super.beforeTest();
+  }
+
+  @After
+  @Override
+  public void afterTest() {
+    try {
+      super.afterTest();
+    } finally {
+      rootLogger.removeHandler(capturingHandler);
+      rootLogger.setLevel(previousLevel);
+      warningState.set(previousWarningState);
+      GlobalConfiguration.STORAGE_CALL_FSYNC.setValue(previousCallFsync);
+    }
+  }
+
+  /** A disk storage open emits the warning, and a second disabled open emits no duplicate. */
+  @Test
+  public void disabledFsyncWarningIsEmittedOnceThroughStorageOpen() {
+    assertTrue(warningState.get());
+    reopenStorage();
+
+    assertEquals(1, warningRecords().size());
+    assertEquals(WARNING_MESSAGE, warningRecords().get(0).getMessage());
+    assertFalse(DiskStorage.warnIfFsyncDisabled(false));
+  }
+
+  private void reopenStorage() {
+    session.close();
+    pool.close();
+    youTrackDB.close();
+
+    youTrackDB = createContext();
+    pool = youTrackDB.cachedPool(databaseName, adminUser, adminPassword);
+    session = openDatabase();
+  }
+
+  private List<LogRecord> warningRecords() {
+    return capturingHandler.records.stream()
+        .filter(record -> record.getLevel().intValue() >= Level.WARNING.intValue())
+        .toList();
+  }
+
+  private static AtomicBoolean warningState() throws Exception {
+    final Field warningField = DiskStorage.class.getDeclaredField("fsyncWarningLogged");
+    warningField.setAccessible(true);
+    return (AtomicBoolean) warningField.get(null);
+  }
+
+  private static final class CapturingHandler extends Handler {
+    private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(final LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/FsyncSuppressedRoundTripTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/disk/FsyncSuppressedRoundTripTest.java
@@ -1,0 +1,231 @@
+package com.jetbrains.youtrackdb.internal.core.storage.disk;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.DbTestBase;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
+import com.jetbrains.youtrackdb.internal.common.collection.closabledictionary.ClosableLinkedContainer;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.local.WOWCache;
+import com.jetbrains.youtrackdb.internal.core.storage.cache.local.doublewritelog.DoubleWriteLogGL;
+import com.jetbrains.youtrackdb.internal.core.storage.fs.AsyncFile;
+import com.jetbrains.youtrackdb.internal.core.storage.fs.File;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import java.lang.reflect.Field;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.MockedStatic;
+
+/** Clean-close disk round trips for durable and fsync-suppressed storage modes. */
+@Category(SequentialTest.class)
+public class FsyncSuppressedRoundTripTest extends DbTestBase {
+
+  private Object previousCallFsync;
+
+  @Override
+  protected DatabaseType calculateDbType() {
+    return DatabaseType.DISK;
+  }
+
+  @Before
+  @Override
+  public void beforeTest() throws Exception {
+    previousCallFsync = GlobalConfiguration.STORAGE_CALL_FSYNC.getValue();
+    GlobalConfiguration.STORAGE_CALL_FSYNC.setValue(
+        !name.getMethodName().contains("WithoutFsync"));
+    super.beforeTest();
+  }
+
+  @After
+  @Override
+  public void afterTest() {
+    try {
+      super.afterTest();
+    } finally {
+      GlobalConfiguration.STORAGE_CALL_FSYNC.setValue(previousCallFsync);
+    }
+  }
+
+  /**
+   * Schema, indexes, and file registry mappings survive a clean close without fsync.
+   */
+  @Test
+  public void testCleanCloseReopenWithoutFsyncPreservesSchemaAndRegistry() {
+    assertFalse(readCallFsync(session));
+    assertProductionWiringFsyncMode(session, false, "productionWiringProbe.tst");
+    createScenario(session);
+
+    reopenStorage();
+
+    assertProductionWiringFsyncMode(session, false, "productionWiringProbe.tst");
+    assertScenario(session);
+    final var storage = (AbstractStorage) session.getStorage();
+    assertFalse("clean reopen must not run WAL recovery", storage.wereDataRestoredAfterOpen());
+    assertRegistryMappings(storage);
+  }
+
+  /**
+   * The same round trip keeps durable mode enabled while preserving schema and registry data.
+   */
+  @Test
+  public void testCleanCloseReopenWithFsyncKeepsDurableMode() {
+    assertTrue(readCallFsync(session));
+    assertProductionWiringFsyncMode(session, true, "durableProductionWiringProbe.tst");
+    createScenarioAndAssertRegistryForce(session);
+
+    reopenStorage();
+
+    assertProductionWiringFsyncMode(session, true, "durableProductionWiringProbe.tst");
+    assertScenario(session);
+    final var storage = (AbstractStorage) session.getStorage();
+    assertFalse("durable clean reopen must not run WAL recovery",
+        storage.wereDataRestoredAfterOpen());
+    assertRegistryMappings(storage);
+  }
+
+  private void reopenStorage() {
+    session.close();
+    pool.close();
+    youTrackDB.close();
+
+    youTrackDB = createContext();
+    pool = youTrackDB.cachedPool(databaseName, adminUser, adminPassword);
+    session = openDatabase();
+  }
+
+  private static void assertProductionWiringFsyncMode(
+      DatabaseSessionEmbedded database, boolean expectedFsync, String fileName) {
+    try {
+      final var writeCache = (WOWCache) database.getStorage().getWriteCache();
+      var fileId = writeCache.fileIdByName(fileName);
+      if (fileId < 0) {
+        fileId = writeCache.addFile(fileName);
+      }
+
+      final Field filesField = WOWCache.class.getDeclaredField("files");
+      filesField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      final var liveFiles =
+          (ClosableLinkedContainer<Long, File>) filesField.get(writeCache);
+      final var fileEntry = liveFiles.acquire(fileId);
+      assertNotNull("production-created file must be registered", fileEntry);
+      try {
+        assertTrue("production wiring must create AsyncFile", fileEntry.get() instanceof AsyncFile);
+        final Field fileFsyncField = AsyncFile.class.getDeclaredField("callFsync");
+        fileFsyncField.setAccessible(true);
+        assertEquals(
+            "live AsyncFile must inherit the configured fsync mode",
+            expectedFsync,
+            fileFsyncField.getBoolean(fileEntry.get()));
+      } finally {
+        liveFiles.release(fileEntry);
+      }
+
+      final Field doubleWriteLogField = WOWCache.class.getDeclaredField("doubleWriteLog");
+      doubleWriteLogField.setAccessible(true);
+      final var doubleWriteLog = doubleWriteLogField.get(writeCache);
+      assertTrue("production wiring must create DoubleWriteLogGL",
+          doubleWriteLog instanceof DoubleWriteLogGL);
+      final Field dwlFsyncField = DoubleWriteLogGL.class.getDeclaredField("callFsync");
+      dwlFsyncField.setAccessible(true);
+      assertEquals(
+          "live double-write log must inherit the configured fsync mode",
+          expectedFsync,
+          dwlFsyncField.getBoolean(doubleWriteLog));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("Interrupted while inspecting production fsync wiring", e);
+    } catch (ReflectiveOperationException | java.io.IOException e) {
+      throw new AssertionError("Cannot inspect production fsync wiring", e);
+    }
+  }
+
+  private static void createScenarioAndAssertRegistryForce(DatabaseSessionEmbedded database) {
+    try {
+      final var writeCache = (WOWCache) database.getStorage().getWriteCache();
+      final Field pathField = WOWCache.class.getDeclaredField("nameIdMapHolderPath");
+      pathField.setAccessible(true);
+      final var registryPath = (Path) pathField.get(writeCache);
+      final var channel =
+          spy(
+              FileChannel.open(
+                  registryPath, StandardOpenOption.READ, StandardOpenOption.WRITE));
+
+      try (MockedStatic<FileChannel> mockedChannels =
+          mockStatic(FileChannel.class, CALLS_REAL_METHODS)) {
+        mockedChannels
+            .when(
+                () -> FileChannel.open(
+                    registryPath, StandardOpenOption.READ, StandardOpenOption.WRITE))
+            .thenReturn(channel);
+        writeCache.addFile("durableForceProbe.tst");
+      }
+      verify(channel).force(true);
+      createScenario(database);
+    } catch (ReflectiveOperationException | java.io.IOException e) {
+      throw new AssertionError("Cannot observe durable registry forces", e);
+    }
+  }
+
+  private static void createScenario(DatabaseSessionEmbedded database) {
+    for (var i = 0; i < 3; i++) {
+      final var className = "FsyncRoundTrip" + i;
+      final var propertyName = "value" + i;
+      final var indexName = className + "." + propertyName;
+      final var schemaClass = database.getMetadata().getSchema().createClass(className);
+      schemaClass.createProperty(propertyName, PropertyType.STRING);
+      schemaClass.createIndex(indexName, SchemaClass.INDEX_TYPE.NOTUNIQUE, propertyName);
+    }
+  }
+
+  private static void assertScenario(DatabaseSessionEmbedded database) {
+    final var schema = database.getMetadata().getSchema();
+    for (var i = 0; i < 3; i++) {
+      final var className = "FsyncRoundTrip" + i;
+      final var propertyName = "value" + i;
+      final var indexName = className + "." + propertyName;
+      final var schemaClass = schema.getClass(className);
+      assertNotNull("class must survive reopen", schemaClass);
+      assertNotNull("property must survive reopen", schemaClass.getProperty(propertyName));
+      assertTrue("index must survive reopen", schema.getIndexes().contains(indexName));
+    }
+  }
+
+  private static void assertRegistryMappings(AbstractStorage storage) {
+    final var writeCache = storage.getWriteCache();
+    final var registeredFiles = writeCache.files();
+    assertFalse("disk storage must register files", registeredFiles.isEmpty());
+    for (final var fileName : registeredFiles.keySet()) {
+      assertTrue("every registry name must map to a file id",
+          writeCache.fileIdByName(fileName) >= 0);
+    }
+  }
+
+  private static boolean readCallFsync(DatabaseSessionEmbedded database) {
+    try {
+      final var writeCache = database.getStorage().getWriteCache();
+      assertTrue("disk storage must use WOWCache", writeCache instanceof WOWCache);
+      final Field field = WOWCache.class.getDeclaredField("callFsync");
+      field.setAccessible(true);
+      return field.getBoolean(writeCache);
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Cannot inspect WOWCache fsync mode", e);
+    }
+  }
+}

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/fs/AsyncFileTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/fs/AsyncFileTest.java
@@ -1,11 +1,22 @@
 package com.jetbrains.youtrackdb.internal.core.storage.fs;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.verify;
+
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
 import com.jetbrains.youtrackdb.internal.common.util.RawPairLongObject;
 import com.jetbrains.youtrackdb.internal.core.exception.StorageException;
 import java.io.File;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -13,8 +24,12 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -801,6 +816,163 @@ public class AsyncFileTest {
     } finally {
       file.close();
     }
+  }
+
+  /**
+   * A dirty non-durable file closes without forcing, remains readable, and closes its channel.
+   */
+  @Test
+  public void testCloseSkipsForceWhenFsyncIsDisabled() throws Exception {
+    final var data = new byte[] {1, 2, 3, 4};
+    final var file = new AsyncFile(buildDirectoryPath, 1, false, executor, STORAGE_NAME, false);
+    file.create();
+    final var channel = installDelegatingChannelSpy(file);
+    file.allocateSpace(data.length);
+    file.write(0, ByteBuffer.wrap(data));
+
+    file.close();
+
+    Assert.assertEquals(
+        "disabled fsync must suppress every force invocation",
+        0,
+        countInvocations(channel, "force"));
+    verify(channel).close();
+    Assert.assertFalse(file.isOpen());
+
+    final var reopened =
+        new AsyncFile(buildDirectoryPath, 1, false, executor, STORAGE_NAME, false);
+    reopened.open();
+    final var result = ByteBuffer.allocate(data.length);
+    reopened.read(0, result, true);
+    Assert.assertArrayEquals(data, result.array());
+    reopened.close();
+  }
+
+  /**
+   * The explicit durable mode forces a dirty file before closing its channel.
+   */
+  @Test
+  public void testCloseForcesWhenFsyncIsEnabled() throws Exception {
+    final var file = new AsyncFile(buildDirectoryPath, 1, false, executor, STORAGE_NAME, true);
+    file.create();
+    final var channel = installDelegatingChannelSpy(file);
+    file.allocateSpace(1);
+    file.write(0, ByteBuffer.wrap(new byte[] {1}));
+
+    file.close();
+
+    verify(channel).force(true);
+    verify(channel).close();
+  }
+
+  /**
+   * The legacy five-argument constructor keeps durable forcing enabled.
+   */
+  @Test
+  public void testLegacyConstructorDefaultsToFsyncEnabled() throws Exception {
+    final var file = new AsyncFile(buildDirectoryPath, 1, false, executor, STORAGE_NAME);
+    file.create();
+    final var channel = installDelegatingChannelSpy(file);
+    file.allocateSpace(1);
+    file.write(0, ByteBuffer.wrap(new byte[] {1}));
+
+    file.close();
+
+    verify(channel).force(true);
+  }
+
+  /**
+   * Closing without fsync still waits for an asynchronous write completion callback.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  @Test
+  public void testCloseWithoutFsyncDrainsInFlightWrite() throws Exception {
+    final var file = new AsyncFile(buildDirectoryPath, 1, false, executor, STORAGE_NAME, false);
+    file.create();
+    final var realChannel = getChannel(file);
+    realChannel.close();
+
+    final var channel = mock(AsynchronousFileChannel.class);
+    final var handler = new AtomicReference<CompletionHandler<Integer, Object>>();
+    final var attachment = new AtomicReference<Object>();
+    final var writtenBuffer = new AtomicReference<ByteBuffer>();
+    doAnswer(
+        invocation -> {
+          writtenBuffer.set(invocation.getArgument(0));
+          attachment.set(invocation.getArgument(2));
+          handler.set(invocation.getArgument(3));
+          return null;
+        })
+        .when(channel)
+        .write(any(ByteBuffer.class), anyLong(), any(), any(CompletionHandler.class));
+    setChannel(file, channel);
+
+    file.allocateSpace(1);
+    file.write(
+        List.of(new RawPairLongObject<>(0L, ByteBuffer.wrap(new byte[] {42}))));
+    final var closeStarted = new CountDownLatch(1);
+    final var closingThread = new AtomicReference<Thread>();
+    final var closeFuture =
+        executor.submit(
+            () -> {
+              closingThread.set(Thread.currentThread());
+              closeStarted.countDown();
+              file.close();
+            });
+    Assert.assertTrue("close task must start", closeStarted.await(5, TimeUnit.SECONDS));
+    awaitSemaphoreWait(closingThread.get());
+    Assert.assertFalse("close must remain blocked before the write callback", closeFuture.isDone());
+
+    writtenBuffer.get().position(writtenBuffer.get().limit());
+    handler.get().completed(1, attachment.get());
+
+    closeFuture.get(5, TimeUnit.SECONDS);
+    verify(channel).close();
+    Assert.assertFalse(file.isOpen());
+  }
+
+  private static void awaitSemaphoreWait(Thread thread) {
+    final var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    while (System.nanoTime() < deadline) {
+      final var waitingInSemaphore =
+          java.util.Arrays.stream(thread.getStackTrace())
+              .anyMatch(
+                  frame -> frame.getClassName().equals("java.util.concurrent.Semaphore")
+                      && frame.getMethodName().equals("acquireUninterruptibly"));
+      if (thread.getState() == Thread.State.WAITING && waitingInSemaphore) {
+        return;
+      }
+      LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+    }
+    Assert.fail("close thread did not block in Semaphore.acquireUninterruptibly");
+  }
+
+  private static long countInvocations(Object mock, String methodName) {
+    return mockingDetails(mock).getInvocations().stream()
+        .filter(invocation -> invocation.getMethod().getName().equals(methodName))
+        .count();
+  }
+
+  private static AsynchronousFileChannel installDelegatingChannelSpy(AsyncFile file)
+      throws Exception {
+    final var realChannel = getChannel(file);
+    final var channel =
+        mock(AsynchronousFileChannel.class, delegatesTo(realChannel));
+    setChannel(file, channel);
+    return channel;
+  }
+
+  private static AsynchronousFileChannel getChannel(AsyncFile file) throws Exception {
+    final Field field = AsyncFile.class.getDeclaredField("fileChannel");
+    field.setAccessible(true);
+    return (AsynchronousFileChannel) field.get(file);
+  }
+
+  private static void setChannel(AsyncFile file, AsynchronousFileChannel channel)
+      throws Exception {
+    final Field field = AsyncFile.class.getDeclaredField("fileChannel");
+    field.setAccessible(true);
+    field.set(file, channel);
   }
 
   @Test

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageStartupMetadataTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/StorageStartupMetadataTest.java
@@ -2,7 +2,14 @@ package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.SequentialTest;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -16,6 +23,8 @@ import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.MockedStatic;
 
 /**
  * Unit tests for {@link StorageStartupMetadata}. The metadata file persists a dirty flag,
@@ -29,6 +38,7 @@ import org.junit.Test;
  * <p>Per project rules every temp path includes a UUID suffix so concurrent surefire forks
  * do not collide, and tests delete on @After (no JVM-shutdown cleanup).
  */
+@Category(SequentialTest.class)
 public class StorageStartupMetadataTest {
 
   private Path tmpDir;
@@ -55,6 +65,67 @@ public class StorageStartupMetadataTest {
           }
         });
       }
+    }
+  }
+
+  /**
+   * Disabling storage fsync does not remove synchronous open options from startup metadata.
+   */
+  @Test
+  public void testCreateKeepsSyncOptionWhenStorageFsyncIsDisabled() throws IOException {
+    final var previousFsync = GlobalConfiguration.STORAGE_CALL_FSYNC.getValue();
+    final var previousFileLock = GlobalConfiguration.FILE_LOCK.getValue();
+    GlobalConfiguration.STORAGE_CALL_FSYNC.setValue(false);
+    GlobalConfiguration.FILE_LOCK.setValue(false);
+    try (MockedStatic<FileChannel> channels = mockStatic(FileChannel.class)) {
+      final var channel = mock(FileChannel.class);
+      when(channel.write(any(ByteBuffer.class), anyLong()))
+          .thenAnswer(
+              invocation -> {
+                final ByteBuffer buffer = invocation.getArgument(0);
+                final var remaining = buffer.remaining();
+                buffer.position(buffer.limit());
+                return remaining;
+              });
+      channels
+          .when(
+              () -> FileChannel.open(
+                  filePath,
+                  StandardOpenOption.READ,
+                  StandardOpenOption.CREATE,
+                  StandardOpenOption.WRITE,
+                  StandardOpenOption.SYNC))
+          .thenReturn(channel);
+      channels
+          .when(
+              () -> FileChannel.open(
+                  backupPath,
+                  StandardOpenOption.READ,
+                  StandardOpenOption.CREATE_NEW,
+                  StandardOpenOption.WRITE,
+                  StandardOpenOption.SYNC))
+          .thenReturn(channel);
+
+      final var metadata = new StorageStartupMetadata(filePath, backupPath);
+      metadata.create("sync-option-test");
+
+      channels.verify(
+          () -> FileChannel.open(
+              filePath,
+              StandardOpenOption.READ,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.WRITE,
+              StandardOpenOption.SYNC));
+      channels.verify(
+          () -> FileChannel.open(
+              backupPath,
+              StandardOpenOption.READ,
+              StandardOpenOption.CREATE_NEW,
+              StandardOpenOption.WRITE,
+              StandardOpenOption.SYNC));
+    } finally {
+      GlobalConfiguration.STORAGE_CALL_FSYNC.setValue(previousFsync);
+      GlobalConfiguration.FILE_LOCK.setValue(previousFileLock);
     }
   }
 

--- a/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLogCloseTest.java
+++ b/core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/impl/local/paginated/wal/cas/CASDiskWriteAheadLogCloseTest.java
@@ -1,7 +1,9 @@
 package com.jetbrains.youtrackdb.internal.core.storage.impl.local.paginated.wal.cas;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.when;
 
 import com.jetbrains.youtrackdb.internal.common.io.FileUtils;
@@ -302,8 +304,12 @@ public class CASDiskWriteAheadLogCloseTest {
 
     wal.close();
 
-    // force() should NOT be called when callFsync=false
-    org.mockito.Mockito.verify(mockFile, org.mockito.Mockito.never()).force(true);
+    // No force variant should be called when callFsync=false.
+    final var forceCount =
+        mockingDetails(mockFile).getInvocations().stream()
+            .filter(invocation -> invocation.getMethod().getName().equals("force"))
+            .count();
+    assertEquals("disabled fsync must suppress every WAL force invocation", 0, forceCount);
     org.mockito.Mockito.verify(mockFile).close();
   }
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -220,6 +220,7 @@
         <bench.resultFile></bench.resultFile>
         <bench.manifestFile></bench.manifestFile>
         <bench.verify></bench.verify>
+        <bench.durabilityBarrier></bench.durabilityBarrier>
         <bench.label></bench.label>
       </properties>
       <build>
@@ -240,7 +241,7 @@
                   <classpathScope>test</classpathScope>
                   <!-- exec-maven-plugin tokenizes this itself and expands %classpath. There is no
                        shell interpolation, so metacharacters are passed to java as data. -->
-                  <commandlineArgs>-da -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED ${bench.jvmBaseArgs} ${bench.jvmAddArgs} -classpath "${project.build.testOutputDirectory}${path.separator}%classpath" "-Dbench.classes=${bench.classes}" "-Dbench.properties=${bench.properties}" "-Dbench.indexes=${bench.indexes}" "-Dbench.policy=${bench.policy}" "-Dbench.batchSize=${bench.batchSize}" "-Dbench.propertyPath=${bench.propertyPath}" "-Dbench.phase=${bench.phase}" "-Dbench.uniquePropertyNames=${bench.uniquePropertyNames}" "-Dbench.dbPath=${bench.dbPath}" "-Dbench.dbName=${bench.dbName}" "-Dbench.resultFile=${bench.resultFile}" "-Dbench.manifestFile=${bench.manifestFile}" "-Dbench.verify=${bench.verify}" "-Dbench.label=${bench.label}" ${bench.mainClass}</commandlineArgs>
+                  <commandlineArgs>-da -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED ${bench.jvmBaseArgs} ${bench.jvmAddArgs} -classpath "${project.build.testOutputDirectory}${path.separator}%classpath" "-Dbench.classes=${bench.classes}" "-Dbench.properties=${bench.properties}" "-Dbench.indexes=${bench.indexes}" "-Dbench.policy=${bench.policy}" "-Dbench.batchSize=${bench.batchSize}" "-Dbench.propertyPath=${bench.propertyPath}" "-Dbench.phase=${bench.phase}" "-Dbench.uniquePropertyNames=${bench.uniquePropertyNames}" "-Dbench.dbPath=${bench.dbPath}" "-Dbench.dbName=${bench.dbName}" "-Dbench.resultFile=${bench.resultFile}" "-Dbench.manifestFile=${bench.manifestFile}" "-Dbench.verify=${bench.verify}" "-Dbench.durabilityBarrier=${bench.durabilityBarrier}" "-Dbench.label=${bench.label}" ${bench.mainClass}</commandlineArgs>
                 </configuration>
               </execution>
             </executions>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -210,6 +210,10 @@
         <bench.classes></bench.classes>
         <bench.properties></bench.properties>
         <bench.indexes></bench.indexes>
+        <bench.singleIndexes></bench.singleIndexes>
+        <bench.compositeIndexes></bench.compositeIndexes>
+        <bench.compositeIndexWidth></bench.compositeIndexWidth>
+        <bench.securityFilter></bench.securityFilter>
         <bench.policy></bench.policy>
         <bench.batchSize></bench.batchSize>
         <bench.propertyPath></bench.propertyPath>
@@ -241,7 +245,7 @@
                   <classpathScope>test</classpathScope>
                   <!-- exec-maven-plugin tokenizes this itself and expands %classpath. There is no
                        shell interpolation, so metacharacters are passed to java as data. -->
-                  <commandlineArgs>-da -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED ${bench.jvmBaseArgs} ${bench.jvmAddArgs} -classpath "${project.build.testOutputDirectory}${path.separator}%classpath" "-Dbench.classes=${bench.classes}" "-Dbench.properties=${bench.properties}" "-Dbench.indexes=${bench.indexes}" "-Dbench.policy=${bench.policy}" "-Dbench.batchSize=${bench.batchSize}" "-Dbench.propertyPath=${bench.propertyPath}" "-Dbench.phase=${bench.phase}" "-Dbench.uniquePropertyNames=${bench.uniquePropertyNames}" "-Dbench.dbPath=${bench.dbPath}" "-Dbench.dbName=${bench.dbName}" "-Dbench.resultFile=${bench.resultFile}" "-Dbench.manifestFile=${bench.manifestFile}" "-Dbench.verify=${bench.verify}" "-Dbench.durabilityBarrier=${bench.durabilityBarrier}" "-Dbench.label=${bench.label}" ${bench.mainClass}</commandlineArgs>
+                  <commandlineArgs>-da -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED ${bench.jvmBaseArgs} ${bench.jvmAddArgs} -classpath "${project.build.testOutputDirectory}${path.separator}%classpath" "-Dbench.classes=${bench.classes}" "-Dbench.properties=${bench.properties}" "-Dbench.indexes=${bench.indexes}" "-Dbench.singleIndexes=${bench.singleIndexes}" "-Dbench.compositeIndexes=${bench.compositeIndexes}" "-Dbench.compositeIndexWidth=${bench.compositeIndexWidth}" "-Dbench.securityFilter=${bench.securityFilter}" "-Dbench.policy=${bench.policy}" "-Dbench.batchSize=${bench.batchSize}" "-Dbench.propertyPath=${bench.propertyPath}" "-Dbench.phase=${bench.phase}" "-Dbench.uniquePropertyNames=${bench.uniquePropertyNames}" "-Dbench.dbPath=${bench.dbPath}" "-Dbench.dbName=${bench.dbName}" "-Dbench.resultFile=${bench.resultFile}" "-Dbench.manifestFile=${bench.manifestFile}" "-Dbench.verify=${bench.verify}" "-Dbench.durabilityBarrier=${bench.durabilityBarrier}" "-Dbench.label=${bench.label}" ${bench.mainClass}</commandlineArgs>
                 </configuration>
               </execution>
             </executions>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -194,4 +194,59 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Forked, platform-independent schema benchmark runner. jvmBaseArgs is replaceable;
+         jvmAddArgs is appended and is the appropriate place for profiler agents. -->
+    <profile>
+      <id>bench</id>
+      <properties>
+        <bench.mainClass>com.jetbrains.youtrackdb.benchmarks.SchemaCreationBenchmark
+        </bench.mainClass>
+        <bench.jvmBaseArgs>-Xms4g -Xmx4g</bench.jvmBaseArgs>
+        <bench.jvmAddArgs></bench.jvmAddArgs>
+        <!-- Empty workload values are forwarded deliberately. The harness treats empty as unset,
+             preserving entry-point-specific defaults while explicit Maven -D values still win. -->
+        <bench.classes></bench.classes>
+        <bench.properties></bench.properties>
+        <bench.indexes></bench.indexes>
+        <bench.policy></bench.policy>
+        <bench.batchSize></bench.batchSize>
+        <bench.propertyPath></bench.propertyPath>
+        <bench.phase></bench.phase>
+        <bench.uniquePropertyNames></bench.uniquePropertyNames>
+        <bench.dbPath></bench.dbPath>
+        <bench.dbName></bench.dbName>
+        <bench.resultFile></bench.resultFile>
+        <bench.manifestFile></bench.manifestFile>
+        <bench.verify></bench.verify>
+        <bench.label></bench.label>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.6.3</version>
+            <executions>
+              <execution>
+                <id>run-schema-benchmark</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>${java.home}/bin/java</executable>
+                  <classpathScope>test</classpathScope>
+                  <!-- exec-maven-plugin tokenizes this itself and expands %classpath. There is no
+                       shell interpolation, so metacharacters are passed to java as data. -->
+                  <commandlineArgs>-da -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints --add-opens jdk.unsupported/sun.misc=ALL-UNNAMED ${bench.jvmBaseArgs} ${bench.jvmAddArgs} -classpath "${project.build.testOutputDirectory}${path.separator}%classpath" "-Dbench.classes=${bench.classes}" "-Dbench.properties=${bench.properties}" "-Dbench.indexes=${bench.indexes}" "-Dbench.policy=${bench.policy}" "-Dbench.batchSize=${bench.batchSize}" "-Dbench.propertyPath=${bench.propertyPath}" "-Dbench.phase=${bench.phase}" "-Dbench.uniquePropertyNames=${bench.uniquePropertyNames}" "-Dbench.dbPath=${bench.dbPath}" "-Dbench.dbName=${bench.dbName}" "-Dbench.resultFile=${bench.resultFile}" "-Dbench.manifestFile=${bench.manifestFile}" "-Dbench.verify=${bench.verify}" "-Dbench.label=${bench.label}" ${bench.mainClass}</commandlineArgs>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
@@ -125,8 +125,14 @@ import java.util.stream.Collectors;
  *
  * <p>The schema-work time is the latency a user feels while the schema is created. This number
  * matches the reported complaint. The barrier time and the shutdown time show where deferred work
- * lands. Their sum with the schema-work time shows whether a policy removes work or only moves it.
- * No single number is the answer. A conclusion must name which of the three it uses and why.
+ * lands. {@code totalNs} contains the schema-work time and the barrier time. It does not contain
+ * the shutdown time. Their sum with the shutdown time shows whether a policy removes work or only
+ * moves it. No single number is the answer. A conclusion must name which of the three it uses and
+ * why.
+ *
+ * <p>The harness measures shutdown once per run. It repeats that value on every phase row in the
+ * run. Deduplicate shutdown by {@code runId} before summing rows, or the sum counts shutdown more
+ * than once.
  *
  * <p>Turn verification off for every profiling run. Otherwise the profile includes manifest work,
  * database reopen, proof-record insertion, and index lookup. Use one profiler event per run. Run
@@ -148,7 +154,7 @@ public final class SchemaCreationWorkload {
       "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
           + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,"
           + "shutdownNs,schemaWorkMs,durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,"
-          + "unsafePropertyCreations,verificationRan,jvmArgs,"
+          + "unsafePropertyCreations,verificationState,jvmArgs,"
           + "assertionsEnabled,storageCallFsync,storageFullCheckpointAfterCreate,"
           + "osOpenFileSoftLimit,osOpenFileHardLimit,resolvedOpenFilesLimit,gitCommit,gitDirty,"
           + "coreImplementationVersion,coreBuildNumber,coreBuildVersion,coreCodeSource,javaVersion,"
@@ -245,10 +251,14 @@ public final class SchemaCreationWorkload {
     }
 
     var manifest = Optional.<String>empty();
-    var verificationRan = false;
-    if (closeFailure == null && config.verify) {
-      manifest = Optional.of(verify(config));
-      verificationRan = true;
+    var verificationState = VerificationState.NOT_REQUESTED;
+    if (config.verify) {
+      if (closeFailure == null) {
+        manifest = Optional.of(verify(config));
+        verificationState = VerificationState.COMPLETED;
+      } else {
+        verificationState = VerificationState.SKIPPED_CLOSE_FAILED;
+      }
     }
     var runtimeEnvironment = captureRuntimeEnvironment();
     var detailFile = detailFile(config.resultFile);
@@ -258,7 +268,7 @@ public final class SchemaCreationWorkload {
           runId,
           result,
           shutdownNs,
-          verificationRan,
+          verificationState,
           storageEnvironment,
           runtimeEnvironment);
       appendTimingDetails(detailFile, runId, result);
@@ -273,7 +283,8 @@ public final class SchemaCreationWorkload {
         config.manifestFile,
         detailFile,
         shutdownNs,
-        verificationRan && config.phase.runsB());
+        verificationState,
+        verificationState == VerificationState.COMPLETED && config.phase.runsB());
   }
 
   private PhaseResult runPhase(
@@ -312,10 +323,12 @@ public final class SchemaCreationWorkload {
     // all storage data and the WAL, then unfreezes writes. Disabling it preserves the natural flow
     // in which deferred work may land in the next phase or in the measured shutdown.
     var durabilityBarrierNs = 0L;
+    var durabilityBarrierRan = false;
     if (config.durabilityBarrier) {
       var durabilityStart = System.nanoTime();
       session.getStorage().synch();
       durabilityBarrierNs = System.nanoTime() - durabilityStart;
+      durabilityBarrierRan = true;
     }
     var totalNs = schemaWorkNs + durabilityBarrierNs;
     System.out.printf(
@@ -328,7 +341,7 @@ public final class SchemaCreationWorkload {
         phase,
         schemaWorkNs,
         durabilityBarrierNs,
-        config.durabilityBarrier,
+        durabilityBarrierRan,
         totalNs,
         transactionCount,
         counters.unsafePropertyCreations,
@@ -523,7 +536,7 @@ public final class SchemaCreationWorkload {
       String runId,
       PhaseResult result,
       long shutdownNs,
-      boolean verificationRan,
+      VerificationState verificationState,
       StorageEnvironment storage,
       RuntimeEnvironment runtime) throws IOException {
     var values = List.of(
@@ -549,7 +562,7 @@ public final class SchemaCreationWorkload {
         Long.toString(TimeUnit.NANOSECONDS.toMillis(shutdownNs)),
         Integer.toString(result.topLevelTransactions),
         Integer.toString(result.unsafePropertyCreations),
-        Boolean.toString(verificationRan),
+        verificationState.name(),
         runtime.jvmArgs,
         Boolean.toString(runtime.assertionsEnabled),
         Boolean.toString(storage.callFsync),
@@ -839,6 +852,10 @@ public final class SchemaCreationWorkload {
     SAFE, UNSAFE
   }
 
+  public enum VerificationState {
+    NOT_REQUESTED, COMPLETED, SKIPPED_CLOSE_FAILED
+  }
+
   public enum Phase {
     A, B, AB;
 
@@ -896,6 +913,7 @@ public final class SchemaCreationWorkload {
       Path manifestFile,
       Path detailFile,
       long shutdownNs,
+      VerificationState verificationState,
       boolean functionalIndexProofRan) {
   }
 

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
@@ -23,6 +23,7 @@ import com.jetbrains.youtrackdb.internal.core.YouTrackDBConstants;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.SessionListener;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.index.CompositeKey;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
@@ -43,6 +44,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -70,8 +72,21 @@ import java.util.stream.Collectors;
  *       agents here.</td></tr>
  *   <tr><td>{@code bench.classes}</td><td>{@code 100}</td><td>Sets the class count.</td></tr>
  *   <tr><td>{@code bench.properties}</td><td>{@code 20}</td><td>Sets the properties per class.</td></tr>
- *   <tr><td>{@code bench.indexes}</td><td>{@code 20}</td><td>Sets the indexes per class. This value
- *       must not exceed {@code bench.properties}.</td></tr>
+ *   <tr><td>{@code bench.indexes}</td><td>{@code 20}</td><td>Sets the single-property indexes per
+ *       class. This keeps its original meaning. It must not exceed {@code bench.properties}.</td></tr>
+ *   <tr><td>{@code bench.singleIndexes}</td><td>{@code 20} (effective)</td><td>Aliases
+ *       {@code bench.indexes}. When set, it takes precedence; if both names are set, they must
+ *       have the same value or setup
+ *       fails. Thus an existing command using only {@code bench.indexes} does exactly the same
+ *       work as before.</td></tr>
+ *   <tr><td>{@code bench.compositeIndexes}</td><td>{@code 0}</td><td>Sets the genuinely composite
+ *       indexes per class.</td></tr>
+ *   <tr><td>{@code bench.compositeIndexWidth}</td><td>{@code 2}</td><td>Sets the number of distinct,
+ *       stably ordered properties in every composite index. The width must be at least two.</td></tr>
+ *   <tr><td>{@code bench.securityFilter}</td><td>{@code NONE}</td><td>Selects {@code NONE} or
+ *       {@code UNRELATED}. {@code UNRELATED} installs property-level security rules on properties
+ *       that no index covers, making the composite-index security check measurable without
+ *       rejecting index creation.</td></tr>
  *   <tr><td>{@code bench.policy}</td><td>{@code NONE} for {@code SchemaCreationBenchmark}; {@code
  *       ALL} for {@code TxSchemaCreationBenchmark}</td><td>Selects the transaction policy.</td></tr>
  *   <tr><td>{@code bench.batchSize}</td><td>{@code 50}</td><td>Sets the classes per {@code BATCH}
@@ -100,7 +115,12 @@ import java.util.stream.Collectors;
  *
  * <p>An explicitly set value wins. Otherwise the entry point's default applies. Otherwise the
  * built-in default applies. An empty value counts as not set. The Maven profile forwards empty
- * values so that each entry point keeps its own defaults.
+ * values so that each entry point keeps its own defaults. For the index-count alias specifically,
+ * {@code bench.singleIndexes} takes precedence when present, while a simultaneously present
+ * {@code bench.indexes} must agree; contradictory values fail fast.
+ *
+ * <p>This harness is a manual performance tool run through the Maven {@code bench} profile. It is
+ * not a continuous-integration regression gate.
  *
  * <p>Use these commands exactly. The {@code -am} flag builds the upstream modules and prevents a
  * stale core jar from entering the run.
@@ -116,6 +136,17 @@ import java.util.stream.Collectors;
  *
  * <p>One phase:
  * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.phase=A verify}</pre>
+ *
+ * <p>The canonical composite-index qualification run uses 100 classes, 10 width-two composite
+ * indexes per class, no single-property indexes, {@code UNRELATED} security filtering, the
+ * {@code ALL} policy (one transaction per phase), verification, and a dedicated result file:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.mainClass=com.jetbrains.youtrackdb.benchmarks.TxSchemaCreationBenchmark -Dbench.classes=100 -Dbench.properties=20 -Dbench.indexes=0 -Dbench.compositeIndexes=10 -Dbench.compositeIndexWidth=2 -Dbench.securityFilter=UNRELATED -Dbench.policy=ALL -Dbench.phase=AB -Dbench.verify=true -Dbench.resultFile=target/benchmark-results/schema-creation-composite.csv verify}</pre>
+ * Composite runs are a NEW baseline stratum and must never be compared against the existing
+ * 62-run matrix.
+ *
+ * <p>There is deliberately no colliding-policy mode. Binding a policy over an already indexed
+ * property fails during setup with a different exception, which could be misread as proof that
+ * the composite-index creation check worked.
  *
  * <p>One sampling profile:
  * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.verify=false -Dbench.jvmAddArgs="-agentpath:/path/to/libasyncProfiler.so=start,event=cpu,file=cpu.jfr" verify}</pre>
@@ -138,9 +169,16 @@ import java.util.stream.Collectors;
  * run. Deduplicate shutdown by {@code runId} before summing rows, or the sum counts shutdown more
  * than once.
  *
+ * <p>Both CSV outputs carry schema version {@code 2}. Before appending, the harness requires the
+ * existing header to exactly match the header for this run; use a new file when the schema changes.
+ *
  * <p>Turn verification off for every profiling run. Otherwise the profile includes manifest work,
  * database reopen, proof-record insertion, and index lookup. Use one profiler event per run. Run
  * sampling and instrumentation separately. Never report an instrumentation run as a timing.
+ *
+ * <p>When counting immutable-schema construction, count every construction in the total,
+ * independent of which caller triggered it. An ancestor-scoped count can read zero while the work
+ * merely moved to another caller.
  *
  * <p>Measure phase A for every policy and property-path pair. The property path does not affect
  * phase B. Run phase B once per transaction policy. The non-transactional index path pays listener
@@ -154,18 +192,22 @@ public final class SchemaCreationWorkload {
   private static final String USER = "admin";
   private static final String PASSWORD = "admin";
   private static final String CLASS_PREFIX = "TestClass";
+  private static final String COMPOSITE_INDEX_PREFIX = "TestCompositeIndex";
+  private static final String UNRELATED_SECURITY_PROPERTY = "SecurityUnrelatedProperty";
+  private static final String UNRELATED_SECURITY_POLICY = "SchemaBenchmarkUnrelatedPolicy";
+  private static final String CSV_SCHEMA_VERSION = "2";
   private static final String CSV_HEADER =
-      "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
-          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,"
-          + "shutdownNs,schemaWorkMs,durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,"
-          + "unsafePropertyCreations,verificationState,jvmArgs,"
-          + "assertionsEnabled,storageCallFsync,storageFullCheckpointAfterCreate,"
-          + "osOpenFileSoftLimit,osOpenFileHardLimit,resolvedOpenFilesLimit,gitCommit,gitDirty,"
-          + "coreImplementationVersion,coreBuildNumber,coreBuildVersion,coreCodeSource,javaVersion,"
-          + "osName,garbageCollectors,"
-          + "hostName,availableProcessors,maxHeapBytes,effectiveDatabasePath";
+      "schemaVersion,timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,"
+          + "indexes,compositeIndexes,compositeIndexWidth,securityFilter,uniquePropertyNames,"
+          + "schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,shutdownNs,schemaWorkMs,"
+          + "durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,unsafePropertyCreations,"
+          + "verificationState,jvmArgs,assertionsEnabled,storageCallFsync,"
+          + "storageFullCheckpointAfterCreate,osOpenFileSoftLimit,osOpenFileHardLimit,"
+          + "resolvedOpenFilesLimit,gitCommit,gitDirty,coreImplementationVersion,coreBuildNumber,"
+          + "coreBuildVersion,coreCodeSource,javaVersion,osName,garbageCollectors,hostName,"
+          + "availableProcessors,maxHeapBytes,effectiveDatabasePath";
   private static final String DETAIL_HEADER =
-      "runId,phase,completedClasses,cumulativeSchemaWorkNs";
+      "schemaVersion,runId,phase,completedClasses,cumulativeSchemaWorkNs";
 
   private SchemaCreationWorkload() {
   }
@@ -192,6 +234,8 @@ public final class SchemaCreationWorkload {
 
   static RunResult run(Configuration configuration, SessionListener listener) throws IOException {
     configuration.validate();
+    requireCompatibleHeader(configuration.resultFile, CSV_HEADER);
+    requireCompatibleHeader(detailFile(configuration.resultFile), DETAIL_HEADER);
     return new SchemaCreationWorkload().runInternal(configuration, listener);
   }
 
@@ -237,6 +281,7 @@ public final class SchemaCreationWorkload {
         phaseResults.add(runPhase(config, session, Phase.A, this::createClassAndProperties));
       }
       if (config.phase.runsB()) {
+        installSecurityFilters(config, session);
         phaseResults.add(runPhase(config, session, Phase.B, this::createIndexes));
       }
     } catch (Throwable failure) {
@@ -259,7 +304,9 @@ public final class SchemaCreationWorkload {
     if (config.verify) {
       if (closeFailure == null) {
         manifest = Optional.of(verify(config));
-        verificationState = VerificationState.COMPLETED;
+        verificationState = config.compositeIndexes > 0 && config.phase.runsB()
+            ? VerificationState.COMPLETED_COMPOSITE_INDEX_PROOF
+            : VerificationState.COMPLETED;
       } else {
         verificationState = VerificationState.SKIPPED_CLOSE_FAILED;
       }
@@ -414,6 +461,34 @@ public final class SchemaCreationWorkload {
     return unsafePropertyCreations;
   }
 
+  private void installSecurityFilters(
+      Configuration config, DatabaseSessionEmbedded session) {
+    if (config.securityFilter == SecurityFilter.NONE) {
+      return;
+    }
+
+    session.begin();
+    try {
+      var security = session.getSharedContext().getSecurity();
+      var policy = security.createSecurityPolicy(session, UNRELATED_SECURITY_POLICY);
+      policy.setActive(true);
+      policy.setReadRule("false");
+      security.saveSecurityPolicy(session, policy);
+      var reader = security.getRole(session, "reader");
+      for (var classIndex = 0; classIndex < config.classes; classIndex++) {
+        // The synthetic resource does not name a schema property, so it cannot accidentally
+        // collide with either index family as benchmark dimensions change.
+        var resource = "database.class." + className(classIndex) + "."
+            + UNRELATED_SECURITY_PROPERTY;
+        security.setSecurityPolicy(session, reader, resource, policy);
+      }
+      session.commit();
+    } catch (Throwable failure) {
+      session.rollback();
+      throw failure;
+    }
+  }
+
   private int createIndexes(
       Configuration config, DatabaseSessionEmbedded session, int classIndex) {
     var schemaClass = session.getSchema().getClass(className(classIndex));
@@ -421,15 +496,29 @@ public final class SchemaCreationWorkload {
       throw new IllegalStateException("Missing class for phase B: " + className(classIndex));
     }
     for (var index = 0; index < config.indexes; index++) {
-      var propertyName = propertyName(config, classIndex, index);
-      if (!schemaClass.existsProperty(propertyName)) {
-        throw new IllegalStateException(
-            "Missing property for phase B: " + className(classIndex) + "." + propertyName);
+      var property = propertyName(config, classIndex, index);
+      requireProperty(schemaClass, property);
+      schemaClass.createIndex(
+          indexName(classIndex, index), SchemaClass.INDEX_TYPE.UNIQUE, property);
+    }
+    for (var index = 0; index < config.compositeIndexes; index++) {
+      var properties = compositeProperties(config, classIndex, index);
+      for (var property : properties) {
+        requireProperty(schemaClass, property);
       }
       schemaClass.createIndex(
-          indexName(classIndex, index), SchemaClass.INDEX_TYPE.UNIQUE, propertyName);
+          compositeIndexName(classIndex, index),
+          SchemaClass.INDEX_TYPE.UNIQUE,
+          properties.toArray(String[]::new));
     }
     return 0;
+  }
+
+  private static void requireProperty(SchemaClass schemaClass, String property) {
+    if (!schemaClass.existsProperty(property)) {
+      throw new IllegalStateException(
+          "Missing property for phase B: " + schemaClass.getName() + "." + property);
+    }
   }
 
   private String verify(Configuration config) throws IOException {
@@ -496,12 +585,14 @@ public final class SchemaCreationWorkload {
         + ": one manifest ended early");
   }
 
-  private void proveIndexes(Configuration config, DatabaseSessionEmbedded session) {
+  static void proveIndexes(Configuration config, DatabaseSessionEmbedded session) {
+    verifyIndexDefinitions(config, session);
+
     session.begin();
     try {
       for (var classIndex = 0; classIndex < config.classes; classIndex++) {
         var entity = session.newEntity(className(classIndex));
-        for (var propertyIndex = 0; propertyIndex < config.indexes; propertyIndex++) {
+        for (var propertyIndex : indexedPropertyIndexes(config)) {
           entity.setProperty(
               propertyName(config, classIndex, propertyIndex),
               indexedValue(classIndex, propertyIndex));
@@ -516,22 +607,67 @@ public final class SchemaCreationWorkload {
     for (var classIndex = 0; classIndex < config.classes; classIndex++) {
       for (var indexNumber = 0; indexNumber < config.indexes; indexNumber++) {
         var name = indexName(classIndex, indexNumber);
-        var index = session.getSharedContext().getIndexManager().getIndex(session, name);
-        if (index == null) {
-          throw new IllegalStateException("Index manager cannot find " + name);
-        }
-        if (index.getIndexId() < 0) {
-          throw new IllegalStateException("Index has no real identifier: " + name);
-        }
-        if (((AbstractStorage) session.getStorage()).loadIndexEngine(name) < 0) {
-          throw new IllegalStateException("Storage cannot load index engine: " + name);
-        }
-        var value = indexedValue(classIndex, indexNumber);
-        var found = session.computeInTx(tx -> index.getRids(session, value).findAny().isPresent());
-        if (!found) {
-          throw new IllegalStateException("Index " + name + " cannot find inserted value " + value);
-        }
+        proveIndexLookup(
+            session, name, indexedValue(classIndex, indexNumber));
       }
+      for (var indexNumber = 0; indexNumber < config.compositeIndexes; indexNumber++) {
+        var name = compositeIndexName(classIndex, indexNumber);
+        var values = new ArrayList<String>(config.compositeIndexWidth);
+        for (var propertyIndex : compositePropertyIndexes(config, indexNumber)) {
+          values.add(indexedValue(classIndex, propertyIndex));
+        }
+        proveIndexLookup(session, name, new CompositeKey(values));
+      }
+    }
+  }
+
+  private static void verifyIndexDefinitions(
+      Configuration config, DatabaseSessionEmbedded session) {
+    for (var classIndex = 0; classIndex < config.classes; classIndex++) {
+      for (var indexNumber = 0; indexNumber < config.indexes; indexNumber++) {
+        requireIndexFields(
+            session,
+            indexName(classIndex, indexNumber),
+            List.of(propertyName(config, classIndex, indexNumber)));
+      }
+      for (var indexNumber = 0; indexNumber < config.compositeIndexes; indexNumber++) {
+        requireIndexFields(
+            session,
+            compositeIndexName(classIndex, indexNumber),
+            compositeProperties(config, classIndex, indexNumber));
+      }
+    }
+  }
+
+  private static void requireIndexFields(
+      DatabaseSessionEmbedded session, String name, List<String> expectedFields) {
+    var index = session.getSharedContext().getIndexManager().getIndex(session, name);
+    if (index == null) {
+      throw new IllegalStateException("Index manager cannot find " + name);
+    }
+    var actualFields = index.getDefinition().getFieldsToIndex();
+    if (!expectedFields.equals(actualFields)) {
+      throw new IllegalStateException(
+          "Index " + name + " has fields " + actualFields + " (width " + actualFields.size()
+              + "), expected " + expectedFields + " (width " + expectedFields.size() + ")");
+    }
+  }
+
+  private static void proveIndexLookup(
+      DatabaseSessionEmbedded session, String name, Object key) {
+    var index = session.getSharedContext().getIndexManager().getIndex(session, name);
+    if (index == null) {
+      throw new IllegalStateException("Index manager cannot find " + name);
+    }
+    if (index.getIndexId() < 0) {
+      throw new IllegalStateException("Index has no real identifier: " + name);
+    }
+    if (((AbstractStorage) session.getStorage()).loadIndexEngine(name) < 0) {
+      throw new IllegalStateException("Storage cannot load index engine: " + name);
+    }
+    var found = session.computeInTx(tx -> index.getRids(session, key).findAny().isPresent());
+    if (!found) {
+      throw new IllegalStateException("Index " + name + " cannot find inserted key " + key);
     }
   }
 
@@ -544,6 +680,7 @@ public final class SchemaCreationWorkload {
       StorageEnvironment storage,
       RuntimeEnvironment runtime) throws IOException {
     var values = List.of(
+        CSV_SCHEMA_VERSION,
         Instant.now().toString(),
         runId,
         config.label,
@@ -554,6 +691,9 @@ public final class SchemaCreationWorkload {
         Integer.toString(config.classes),
         Integer.toString(config.properties),
         Integer.toString(config.indexes),
+        Integer.toString(config.compositeIndexes),
+        Integer.toString(config.compositeIndexWidth),
+        config.securityFilter.name(),
         Boolean.toString(config.uniquePropertyNames),
         Long.toString(result.schemaWorkNs),
         Long.toString(result.durabilityBarrierNs),
@@ -594,6 +734,7 @@ public final class SchemaCreationWorkload {
       throws IOException {
     for (var detail : result.timingDetails) {
       appendRow(detailFile, DETAIL_HEADER, List.of(
+          CSV_SCHEMA_VERSION,
           runId,
           result.phase.name(),
           Integer.toString(detail.completedClasses),
@@ -603,6 +744,7 @@ public final class SchemaCreationWorkload {
 
   private static void appendRow(Path file, String header, List<String> values) throws IOException {
     createParentDirectories(file);
+    requireCompatibleHeader(file, header);
     var newFile = Files.notExists(file) || Files.size(file) == 0;
     try (var writer = Files.newBufferedWriter(
         file, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
@@ -613,6 +755,21 @@ public final class SchemaCreationWorkload {
       writer
           .write(values.stream().map(SchemaCreationWorkload::csv).collect(Collectors.joining(",")));
       writer.newLine();
+    }
+  }
+
+  static void requireCompatibleHeader(Path file, String expectedHeader) throws IOException {
+    if (Files.notExists(file) || Files.size(file) == 0) {
+      return;
+    }
+    String existingHeader;
+    try (var reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+      existingHeader = reader.readLine();
+    }
+    if (!expectedHeader.equals(existingHeader)) {
+      throw new IOException(
+          "Cannot append to " + file + ": existing header <" + existingHeader
+              + "> does not match this run's header <" + expectedHeader + ">");
     }
   }
 
@@ -844,6 +1001,43 @@ public final class SchemaCreationWorkload {
     return "TestIndex_" + classIndex + "_" + indexNumber;
   }
 
+  private static String compositeIndexName(int classIndex, int indexNumber) {
+    return COMPOSITE_INDEX_PREFIX + "_" + classIndex + "_" + indexNumber;
+  }
+
+  private static List<String> compositeProperties(
+      Configuration config, int classIndex, int indexNumber) {
+    return compositePropertyIndexes(config, indexNumber).stream()
+        .map(propertyIndex -> propertyName(config, classIndex, propertyIndex))
+        .toList();
+  }
+
+  private static List<Integer> compositePropertyIndexes(
+      Configuration config, int indexNumber) {
+    var firstProperty = (int) (((long) indexNumber * config.compositeIndexWidth)
+        % config.properties);
+    var properties = new ArrayList<Integer>(config.compositeIndexWidth);
+    for (var offset = 0; offset < config.compositeIndexWidth; offset++) {
+      properties.add((firstProperty + offset) % config.properties);
+    }
+    return properties;
+  }
+
+  private static List<Integer> indexedPropertyIndexes(Configuration config) {
+    var indexed = new ArrayList<Integer>();
+    for (var propertyIndex = 0; propertyIndex < config.indexes; propertyIndex++) {
+      indexed.add(propertyIndex);
+    }
+    for (var indexNumber = 0; indexNumber < config.compositeIndexes; indexNumber++) {
+      for (var propertyIndex : compositePropertyIndexes(config, indexNumber)) {
+        if (!indexed.contains(propertyIndex)) {
+          indexed.add(propertyIndex);
+        }
+      }
+    }
+    return indexed;
+  }
+
   private static String indexedValue(int classIndex, int propertyIndex) {
     return "value_" + classIndex + "_" + propertyIndex;
   }
@@ -856,8 +1050,12 @@ public final class SchemaCreationWorkload {
     SAFE, UNSAFE
   }
 
+  public enum SecurityFilter {
+    NONE, UNRELATED
+  }
+
   public enum VerificationState {
-    NOT_REQUESTED, COMPLETED, SKIPPED_CLOSE_FAILED
+    NOT_REQUESTED, COMPLETED, COMPLETED_COMPOSITE_INDEX_PROOF, SKIPPED_CLOSE_FAILED
   }
 
   public enum Phase {
@@ -957,6 +1155,9 @@ public final class SchemaCreationWorkload {
       int classes,
       int properties,
       int indexes,
+      int compositeIndexes,
+      int compositeIndexWidth,
+      SecurityFilter securityFilter,
       Policy policy,
       int batchSize,
       PropertyPath propertyPath,
@@ -970,27 +1171,46 @@ public final class SchemaCreationWorkload {
       boolean durabilityBarrier,
       String label) {
 
-    private static Configuration fromSystemProperties(
+    static Configuration fromSystemProperties(
         Policy defaultPolicy, PropertyPath defaultPropertyPath) {
+      return fromProperties(System::getProperty, defaultPolicy, defaultPropertyPath);
+    }
+
+    static Configuration fromProperties(
+        Function<String, String> properties,
+        Policy defaultPolicy,
+        PropertyPath defaultPropertyPath) {
       return new Configuration(
-          integer("bench.classes", 100),
-          integer("bench.properties", 20),
-          integer("bench.indexes", 20),
-          enumeration("bench.policy", defaultPolicy, Policy.class),
-          integer("bench.batchSize", 50),
-          enumeration("bench.propertyPath", defaultPropertyPath, PropertyPath.class),
-          enumeration("bench.phase", Phase.AB, Phase.class),
-          Boolean.parseBoolean(systemProperty("bench.uniquePropertyNames", "true")),
+          integer(properties, "bench.classes", 100),
+          integer(properties, "bench.properties", 20),
+          singleIndexes(properties),
+          integer(properties, "bench.compositeIndexes", 0),
+          integer(properties, "bench.compositeIndexWidth", 2),
+          enumeration(properties, "bench.securityFilter", SecurityFilter.NONE,
+              SecurityFilter.class),
+          enumeration(properties, "bench.policy", defaultPolicy, Policy.class),
+          integer(properties, "bench.batchSize", 50),
+          enumeration(properties, "bench.propertyPath", defaultPropertyPath, PropertyPath.class),
+          enumeration(properties, "bench.phase", Phase.AB, Phase.class),
+          Boolean.parseBoolean(systemProperty(
+              properties, "bench.uniquePropertyNames", "true")),
           Path.of(systemProperty(
-              "bench.dbPath", "./target/databases/benchmarks/schemaCreationBenchmark")),
-          systemProperty("bench.dbName", "schemaBenchmark"),
+              properties,
+              "bench.dbPath",
+              "./target/databases/benchmarks/schemaCreationBenchmark")),
+          systemProperty(properties, "bench.dbName", "schemaBenchmark"),
           Path.of(systemProperty(
-              "bench.resultFile", "target/benchmark-results/schema-creation.csv")),
+              properties,
+              "bench.resultFile",
+              "target/benchmark-results/schema-creation.csv")),
           Path.of(systemProperty(
-              "bench.manifestFile", "target/benchmark-results/manifest.txt")),
-          Boolean.parseBoolean(systemProperty("bench.verify", "true")),
-          Boolean.parseBoolean(systemProperty("bench.durabilityBarrier", "true")),
-          systemProperty("bench.label", ""));
+              properties,
+              "bench.manifestFile",
+              "target/benchmark-results/manifest.txt")),
+          Boolean.parseBoolean(systemProperty(properties, "bench.verify", "true")),
+          Boolean.parseBoolean(systemProperty(
+              properties, "bench.durabilityBarrier", "true")),
+          systemProperty(properties, "bench.label", ""));
     }
 
     private void validate() {
@@ -1004,24 +1224,62 @@ public final class SchemaCreationWorkload {
         throw new IllegalArgumentException(
             "bench.indexes must be between zero and bench.properties");
       }
+      if (compositeIndexes < 0) {
+        throw new IllegalArgumentException("bench.compositeIndexes must not be negative");
+      }
+      if (compositeIndexWidth < 2) {
+        throw new IllegalArgumentException("bench.compositeIndexWidth must be at least two");
+      }
+      if (compositeIndexes > 0 && compositeIndexWidth > properties) {
+        throw new IllegalArgumentException(
+            "bench.compositeIndexWidth must not exceed bench.properties when composite indexes "
+                + "are requested");
+      }
       if (batchSize <= 0) {
         throw new IllegalArgumentException("bench.batchSize must be positive");
       }
     }
 
-    private static int integer(String name, int defaultValue) {
-      return Integer.parseInt(systemProperty(name, Integer.toString(defaultValue)));
+    private static int singleIndexes(Function<String, String> properties) {
+      var legacy = explicitProperty(properties, "bench.indexes");
+      var alias = explicitProperty(properties, "bench.singleIndexes");
+      if (alias.isPresent()) {
+        var aliasValue = Integer.parseInt(alias.orElseThrow());
+        if (legacy.isPresent()) {
+          var legacyValue = Integer.parseInt(legacy.orElseThrow());
+          if (legacyValue != aliasValue) {
+            throw new IllegalArgumentException(
+                "bench.singleIndexes=" + aliasValue + " contradicts bench.indexes="
+                    + legacyValue);
+          }
+        }
+        return aliasValue;
+      }
+      return legacy.map(Integer::parseInt).orElse(20);
+    }
+
+    private static int integer(
+        Function<String, String> properties, String name, int defaultValue) {
+      return Integer.parseInt(
+          systemProperty(properties, name, Integer.toString(defaultValue)));
     }
 
     private static <E extends Enum<E>> E enumeration(
-        String name, E defaultValue, Class<E> type) {
+        Function<String, String> properties, String name, E defaultValue, Class<E> type) {
       return Enum.valueOf(
-          type, systemProperty(name, defaultValue.name()).toUpperCase(Locale.ROOT));
+          type,
+          systemProperty(properties, name, defaultValue.name()).toUpperCase(Locale.ROOT));
     }
 
-    private static String systemProperty(String name, String defaultValue) {
-      var value = System.getProperty(name);
-      return value == null || value.isBlank() ? defaultValue : value;
+    private static Optional<String> explicitProperty(
+        Function<String, String> properties, String name) {
+      var value = properties.apply(name);
+      return value == null || value.isBlank() ? Optional.empty() : Optional.of(value);
+    }
+
+    private static String systemProperty(
+        Function<String, String> properties, String name, String defaultValue) {
+      return explicitProperty(properties, name).orElse(defaultValue);
     }
   }
 

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
@@ -92,6 +92,9 @@ import java.util.stream.Collectors;
  *       target/benchmark-results/manifest.txt}</td><td>Sets the canonical manifest file.</td></tr>
  *   <tr><td>{@code bench.verify}</td><td>{@code true}</td><td>Verifies persistence. It also proves
  *       indexes after phase B.</td></tr>
+ *   <tr><td>{@code bench.durabilityBarrier}</td><td>{@code true}</td><td>Synchronizes storage after
+ *       each phase when true. When false, deferred work may land in the next phase or at
+ *       shutdown.</td></tr>
  *   <tr><td>{@code bench.label}</td><td>empty</td><td>Sets the free-text result label.</td></tr>
  * </table>
  *
@@ -120,8 +123,10 @@ import java.util.stream.Collectors;
  * <p>One instrumentation count:
  * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.verify=false -Dbench.jvmAddArgs="-agentpath:/path/to/libasyncProfiler.so=start,event=alloc,interval=0,file=alloc.jfr" verify}</pre>
  *
- * <p>Compare {@code totalNs}. It adds schema work to the durability barrier. Never compare {@code
- * schemaWorkNs} alone. Transactional work can remain pending until storage synchronization.
+ * <p>The schema-work time is the latency a user feels while the schema is created. This number
+ * matches the reported complaint. The barrier time and the shutdown time show where deferred work
+ * lands. Their sum with the schema-work time shows whether a policy removes work or only moves it.
+ * No single number is the answer. A conclusion must name which of the three it uses and why.
  *
  * <p>Turn verification off for every profiling run. Otherwise the profile includes manifest work,
  * database reopen, proof-record insertion, and index lookup. Use one profiler event per run. Run
@@ -141,9 +146,9 @@ public final class SchemaCreationWorkload {
   private static final String CLASS_PREFIX = "TestClass";
   private static final String CSV_HEADER =
       "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
-          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,totalNs,schemaWorkMs,"
-          + "durabilityBarrierMs,totalMs,topLevelTransactions,unsafePropertyCreations,"
-          + "verificationRan,jvmArgs,"
+          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,"
+          + "shutdownNs,schemaWorkMs,durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,"
+          + "unsafePropertyCreations,verificationRan,jvmArgs,"
           + "assertionsEnabled,storageCallFsync,storageFullCheckpointAfterCreate,"
           + "osOpenFileSoftLimit,osOpenFileHardLimit,resolvedOpenFilesLimit,gitCommit,gitDirty,"
           + "coreImplementationVersion,coreBuildNumber,coreBuildVersion,coreCodeSource,javaVersion,"
@@ -196,8 +201,14 @@ public final class SchemaCreationWorkload {
   private RunResult runInternal(Configuration config, SessionListener listener) throws IOException {
     var runId = UUID.randomUUID().toString();
     var phaseResults = new ArrayList<PhaseResult>();
-    StorageEnvironment storageEnvironment;
-    try (var manager = manager(config.dbPath)) {
+    StorageEnvironment storageEnvironment = null;
+    YouTrackDBImpl manager = null;
+    DatabaseSessionEmbedded session = null;
+    Throwable workFailure = null;
+    Throwable closeFailure = null;
+    long shutdownNs;
+    try {
+      manager = manager(config.dbPath);
       if (config.phase != Phase.B) {
         if (manager.exists(config.dbName)) {
           manager.drop(config.dbName);
@@ -207,27 +218,53 @@ public final class SchemaCreationWorkload {
         throw new IllegalStateException("Phase B requires existing database " + config.dbName);
       }
 
-      try (var session = manager.open(config.dbName, USER, PASSWORD)) {
-        if (listener != null) {
-          session.registerListener(listener);
-        }
-        storageEnvironment = captureStorageEnvironment(session);
-        if (config.phase.runsA()) {
-          phaseResults.add(
-              runPhase(config, session, Phase.A, this::createClassAndProperties));
-        }
-        if (config.phase.runsB()) {
-          phaseResults.add(runPhase(config, session, Phase.B, this::createIndexes));
-        }
+      session = manager.open(config.dbName, USER, PASSWORD);
+      if (listener != null) {
+        session.registerListener(listener);
       }
+      storageEnvironment = captureStorageEnvironment(session);
+      if (config.phase.runsA()) {
+        phaseResults.add(runPhase(config, session, Phase.A, this::createClassAndProperties));
+      }
+      if (config.phase.runsB()) {
+        phaseResults.add(runPhase(config, session, Phase.B, this::createIndexes));
+      }
+    } catch (Throwable failure) {
+      workFailure = failure;
+    } finally {
+      var shutdownStart = System.nanoTime();
+      closeFailure = closeFirstSessionAndManager(session, manager);
+      shutdownNs = System.nanoTime() - shutdownStart;
     }
 
-    var manifest = config.verify ? Optional.of(verify(config)) : Optional.<String>empty();
+    if (workFailure != null) {
+      if (closeFailure != null) {
+        workFailure.addSuppressed(closeFailure);
+      }
+      rethrow(workFailure);
+    }
+
+    var manifest = Optional.<String>empty();
+    var verificationRan = false;
+    if (closeFailure == null && config.verify) {
+      manifest = Optional.of(verify(config));
+      verificationRan = true;
+    }
     var runtimeEnvironment = captureRuntimeEnvironment();
     var detailFile = detailFile(config.resultFile);
     for (var result : phaseResults) {
-      appendCsv(config, runId, result, storageEnvironment, runtimeEnvironment);
+      appendCsv(
+          config,
+          runId,
+          result,
+          shutdownNs,
+          verificationRan,
+          storageEnvironment,
+          runtimeEnvironment);
       appendTimingDetails(detailFile, runId, result);
+    }
+    if (closeFailure != null) {
+      rethrow(closeFailure);
     }
     return new RunResult(
         runId,
@@ -235,7 +272,8 @@ public final class SchemaCreationWorkload {
         manifest,
         config.manifestFile,
         detailFile,
-        config.verify && config.phase.runsB());
+        shutdownNs,
+        verificationRan && config.phase.runsB());
   }
 
   private PhaseResult runPhase(
@@ -271,11 +309,14 @@ public final class SchemaCreationWorkload {
     }
 
     // AbstractStorage.synch() freezes writes, flushes index engines and dirty histograms, flushes
-    // all storage data and the WAL, then unfreezes writes. This is the durability work that would
-    // otherwise be deferred until storage shutdown and hidden from the mode comparison.
-    var durabilityStart = System.nanoTime();
-    session.getStorage().synch();
-    var durabilityBarrierNs = System.nanoTime() - durabilityStart;
+    // all storage data and the WAL, then unfreezes writes. Disabling it preserves the natural flow
+    // in which deferred work may land in the next phase or in the measured shutdown.
+    var durabilityBarrierNs = 0L;
+    if (config.durabilityBarrier) {
+      var durabilityStart = System.nanoTime();
+      session.getStorage().synch();
+      durabilityBarrierNs = System.nanoTime() - durabilityStart;
+    }
     var totalNs = schemaWorkNs + durabilityBarrierNs;
     System.out.printf(
         "Finished phase %s: schema %,d ms, durability %,d ms, total %,d ms%n",
@@ -287,6 +328,7 @@ public final class SchemaCreationWorkload {
         phase,
         schemaWorkNs,
         durabilityBarrierNs,
+        config.durabilityBarrier,
         totalNs,
         transactionCount,
         counters.unsafePropertyCreations,
@@ -480,6 +522,8 @@ public final class SchemaCreationWorkload {
       Configuration config,
       String runId,
       PhaseResult result,
+      long shutdownNs,
+      boolean verificationRan,
       StorageEnvironment storage,
       RuntimeEnvironment runtime) throws IOException {
     var values = List.of(
@@ -496,13 +540,16 @@ public final class SchemaCreationWorkload {
         Boolean.toString(config.uniquePropertyNames),
         Long.toString(result.schemaWorkNs),
         Long.toString(result.durabilityBarrierNs),
+        Boolean.toString(result.durabilityBarrierRan),
         Long.toString(result.totalNs),
+        Long.toString(shutdownNs),
         Long.toString(TimeUnit.NANOSECONDS.toMillis(result.schemaWorkNs)),
         Long.toString(TimeUnit.NANOSECONDS.toMillis(result.durabilityBarrierNs)),
         Long.toString(TimeUnit.NANOSECONDS.toMillis(result.totalNs)),
+        Long.toString(TimeUnit.NANOSECONDS.toMillis(shutdownNs)),
         Integer.toString(result.topLevelTransactions),
         Integer.toString(result.unsafePropertyCreations),
-        Boolean.toString(config.verify),
+        Boolean.toString(verificationRan),
         runtime.jvmArgs,
         Boolean.toString(runtime.assertionsEnabled),
         Boolean.toString(storage.callFsync),
@@ -721,6 +768,43 @@ public final class SchemaCreationWorkload {
     return (YouTrackDBImpl) YourTracks.instance(databasePath.toString());
   }
 
+  private static Throwable closeFirstSessionAndManager(
+      DatabaseSessionEmbedded session, YouTrackDBImpl manager) {
+    Throwable failure = null;
+    if (session != null) {
+      try {
+        session.close();
+      } catch (Throwable closeFailure) {
+        failure = closeFailure;
+      }
+    }
+    if (manager != null) {
+      try {
+        manager.close();
+      } catch (Throwable closeFailure) {
+        if (failure == null) {
+          failure = closeFailure;
+        } else {
+          failure.addSuppressed(closeFailure);
+        }
+      }
+    }
+    return failure;
+  }
+
+  private static void rethrow(Throwable failure) throws IOException {
+    if (failure instanceof IOException ioFailure) {
+      throw ioFailure;
+    }
+    if (failure instanceof RuntimeException runtimeFailure) {
+      throw runtimeFailure;
+    }
+    if (failure instanceof Error error) {
+      throw error;
+    }
+    throw new IOException("Benchmark failed", failure);
+  }
+
   private static void createParentDirectories(Path file) throws IOException {
     var parent = file.toAbsolutePath().getParent();
     if (parent != null) {
@@ -786,6 +870,7 @@ public final class SchemaCreationWorkload {
       Phase phase,
       long schemaWorkNs,
       long durabilityBarrierNs,
+      boolean durabilityBarrierRan,
       long totalNs,
       int topLevelTransactions,
       int unsafePropertyCreations,
@@ -810,6 +895,7 @@ public final class SchemaCreationWorkload {
       Optional<String> manifestText,
       Path manifestFile,
       Path detailFile,
+      long shutdownNs,
       boolean functionalIndexProofRan) {
   }
 
@@ -859,6 +945,7 @@ public final class SchemaCreationWorkload {
       Path resultFile,
       Path manifestFile,
       boolean verify,
+      boolean durabilityBarrier,
       String label) {
 
     private static Configuration fromSystemProperties(
@@ -880,6 +967,7 @@ public final class SchemaCreationWorkload {
           Path.of(systemProperty(
               "bench.manifestFile", "target/benchmark-results/manifest.txt")),
           Boolean.parseBoolean(systemProperty("bench.verify", "true")),
+          Boolean.parseBoolean(systemProperty("bench.durabilityBarrier", "true")),
           systemProperty("bench.label", ""));
     }
 

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
@@ -120,8 +120,12 @@ import java.util.stream.Collectors;
  * <p>One sampling profile:
  * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.verify=false -Dbench.jvmAddArgs="-agentpath:/path/to/libasyncProfiler.so=start,event=cpu,file=cpu.jfr" verify}</pre>
  *
- * <p>One instrumentation count:
- * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.verify=false -Dbench.jvmAddArgs="-agentpath:/path/to/libasyncProfiler.so=start,event=alloc,interval=0,file=alloc.jfr" verify}</pre>
+ * <p>One instrumentation count for the selective schema-serialization overload:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.mainClass=com.jetbrains.youtrackdb.benchmarks.TxSchemaCreationBenchmark -Dbench.verify=false -Dbench.jvmAddArgs="-agentpath:/path/to/libasyncProfiler.so=start,event=com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaShared.toStream(Lcom/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded;Ljava/util/Set;Z)Lcom/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl;,file=schema-serialization.html" verify}</pre>
+ *
+ * <p>{@code SchemaShared.toStream} has two overloads. An event that ends at the method name counts
+ * entries to both. Append the JVM method descriptor to select one overload; the command above uses
+ * {@code (Lcom/jetbrains/youtrackdb/internal/core/db/DatabaseSessionEmbedded;Ljava/util/Set;Z)Lcom/jetbrains/youtrackdb/internal/core/record/impl/EntityImpl;} to select the three-argument overload.
  *
  * <p>The schema-work time is the latency a user feels while the schema is created. This number
  * matches the reported complaint. The barrier time and the shutdown time show where deferred work

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
@@ -32,6 +32,7 @@ import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -141,8 +142,14 @@ import java.util.stream.Collectors;
  * indexes per class, no single-property indexes, {@code UNRELATED} security filtering, the
  * {@code ALL} policy (one transaction per phase), verification, and a dedicated result file:
  * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.mainClass=com.jetbrains.youtrackdb.benchmarks.TxSchemaCreationBenchmark -Dbench.classes=100 -Dbench.properties=20 -Dbench.indexes=0 -Dbench.compositeIndexes=10 -Dbench.compositeIndexWidth=2 -Dbench.securityFilter=UNRELATED -Dbench.policy=ALL -Dbench.phase=AB -Dbench.verify=true -Dbench.resultFile=target/benchmark-results/schema-creation-composite.csv verify}</pre>
- * Composite runs are a NEW baseline stratum and must never be compared against the existing
- * 62-run matrix.
+ * Composite or security-filtered runs are a NEW baseline stratum and must never be compared
+ * against the existing 62-run matrix. The harness rejects attempts to mix that stratum with plain
+ * single-property runs in one result file.
+ *
+ * <p>Qualification requires a paired control with the same composite configuration and {@code
+ * bench.securityFilter=NONE}. Repeat both {@code NONE} and {@code UNRELATED} runs; one timing
+ * cannot distinguish security-check cost from run-to-run noise. Both arms belong to the same new
+ * stratum and may share its dedicated result file.
  *
  * <p>There is deliberately no colliding-policy mode. Binding a policy over an already indexed
  * property fails during setup with a different exception, which could be misread as proof that
@@ -179,6 +186,15 @@ import java.util.stream.Collectors;
  * <p>When counting immutable-schema construction, count every construction in the total,
  * independent of which caller triggered it. An ancestor-scoped count can read zero while the work
  * merely moved to another caller.
+ *
+ * <p>Do not count {@code IndexManagerEmbedded.checkSecurityConstraintsForIndexCreate} to prove the
+ * composite security path. The method is entered for single-property indexes too; its early return
+ * is inside the method, and independent profiling measured nine entries against nine. At this
+ * revision, the discriminating event is {@code
+ * com.jetbrains.youtrackdb.internal.core.index.IndexManagerEmbedded.lambda$checkSecurityConstraintsForIndexCreate$12(Ljava/util/List;Lcom/jetbrains/youtrackdb/internal/core/metadata/security/SecurityResourceProperty;)Z},
+ * which measured four entries for composite indexes and zero for the single-property control.
+ * Reconfirm the synthetic method name and descriptor with {@code javap -p -s} after product-code
+ * changes because compiler-generated lambda numbering can move.
  *
  * <p>Measure phase A for every policy and property-path pair. The property path does not affect
  * phase B. Run phase B once per transaction policy. The non-transactional index path pays listener
@@ -234,7 +250,7 @@ public final class SchemaCreationWorkload {
 
   static RunResult run(Configuration configuration, SessionListener listener) throws IOException {
     configuration.validate();
-    requireCompatibleHeader(configuration.resultFile, CSV_HEADER);
+    requireCompatibleResultFile(configuration.resultFile, configuration);
     requireCompatibleHeader(detailFile(configuration.resultFile), DETAIL_HEADER);
     return new SchemaCreationWorkload().runInternal(configuration, listener);
   }
@@ -281,7 +297,7 @@ public final class SchemaCreationWorkload {
         phaseResults.add(runPhase(config, session, Phase.A, this::createClassAndProperties));
       }
       if (config.phase.runsB()) {
-        installSecurityFilters(config, session);
+        prepareSecurityFilters(config, session);
         phaseResults.add(runPhase(config, session, Phase.B, this::createIndexes));
       }
     } catch (Throwable failure) {
@@ -335,7 +351,7 @@ public final class SchemaCreationWorkload {
         detailFile,
         shutdownNs,
         verificationState,
-        verificationState == VerificationState.COMPLETED && config.phase.runsB());
+        verificationState.functionalIndexProofCompleted() && config.phase.runsB());
   }
 
   private PhaseResult runPhase(
@@ -461,20 +477,36 @@ public final class SchemaCreationWorkload {
     return unsafePropertyCreations;
   }
 
-  private void installSecurityFilters(
+  private void prepareSecurityFilters(
       Configuration config, DatabaseSessionEmbedded session) {
+    var existingFilters = benchmarkSecurityFilters(session);
+    if (!existingFilters.isEmpty()) {
+      throw new IllegalStateException(
+          "bench.securityFilter=" + config.securityFilter
+              + " requires a clean property-security state for the benchmark classes, but found "
+              + existingFilters);
+    }
     if (config.securityFilter == SecurityFilter.NONE) {
       return;
     }
 
+    var security = session.getSharedContext().getSecurity();
+    if (security.getSecurityPolicy(session, UNRELATED_SECURITY_POLICY) != null) {
+      throw new IllegalStateException(
+          "bench.securityFilter=UNRELATED cannot install policy " + UNRELATED_SECURITY_POLICY
+              + " because it already exists");
+    }
     session.begin();
     try {
-      var security = session.getSharedContext().getSecurity();
       var policy = security.createSecurityPolicy(session, UNRELATED_SECURITY_POLICY);
       policy.setActive(true);
       policy.setReadRule("false");
       security.saveSecurityPolicy(session, policy);
       var reader = security.getRole(session, "reader");
+      if (reader == null) {
+        throw new IllegalStateException(
+            "bench.securityFilter=UNRELATED requires the reader security role");
+      }
       for (var classIndex = 0; classIndex < config.classes; classIndex++) {
         // The synthetic resource does not name a schema property, so it cannot accidentally
         // collide with either index family as benchmark dimensions change.
@@ -487,6 +519,26 @@ public final class SchemaCreationWorkload {
       session.rollback();
       throw failure;
     }
+
+    var installedFilters = benchmarkSecurityFilters(session);
+    for (var classIndex = 0; classIndex < config.classes; classIndex++) {
+      var expected = className(classIndex) + "." + UNRELATED_SECURITY_PROPERTY;
+      if (!installedFilters.contains(expected)) {
+        throw new IllegalStateException(
+            "bench.securityFilter=UNRELATED did not install expected rule " + expected
+                + " before phase B; observed " + installedFilters);
+      }
+    }
+  }
+
+  private static List<String> benchmarkSecurityFilters(DatabaseSessionEmbedded session) {
+    return session.getSharedContext().getSecurity().getAllFilteredProperties(session).stream()
+        .filter(resource -> resource.isAllClasses()
+            || resource.getClassName().startsWith(CLASS_PREFIX))
+        .map(resource -> (resource.isAllClasses() ? "*" : resource.getClassName()) + "."
+            + resource.getPropertyName())
+        .sorted()
+        .toList();
   }
 
   private int createIndexes(
@@ -679,6 +731,7 @@ public final class SchemaCreationWorkload {
       VerificationState verificationState,
       StorageEnvironment storage,
       RuntimeEnvironment runtime) throws IOException {
+    requireCompatibleResultFile(config.resultFile, config);
     var values = List.of(
         CSV_SCHEMA_VERSION,
         Instant.now().toString(),
@@ -742,19 +795,65 @@ public final class SchemaCreationWorkload {
     }
   }
 
-  private static void appendRow(Path file, String header, List<String> values) throws IOException {
+  static void appendRow(Path file, String header, List<String> values) throws IOException {
     createParentDirectories(file);
     requireCompatibleHeader(file, header);
     var newFile = Files.notExists(file) || Files.size(file) == 0;
+    var separatorRequired = !newFile && !endsWithLineSeparator(file);
     try (var writer = Files.newBufferedWriter(
         file, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
       if (newFile) {
         writer.write(header);
         writer.newLine();
+      } else if (separatorRequired) {
+        writer.newLine();
       }
       writer
           .write(values.stream().map(SchemaCreationWorkload::csv).collect(Collectors.joining(",")));
       writer.newLine();
+    }
+  }
+
+  private static boolean endsWithLineSeparator(Path file) throws IOException {
+    var lastByte = ByteBuffer.allocate(1);
+    try (var channel = Files.newByteChannel(file, StandardOpenOption.READ)) {
+      channel.position(channel.size() - 1);
+      channel.read(lastByte);
+    }
+    var value = lastByte.array()[0];
+    return value == '\n' || value == '\r';
+  }
+
+  private static void requireCompatibleResultFile(Path file, Configuration config)
+      throws IOException {
+    requireCompatibleHeader(file, CSV_HEADER);
+    if (Files.notExists(file) || Files.size(file) == 0) {
+      return;
+    }
+
+    var incoming = ResultStratum.from(config.compositeIndexes, config.securityFilter.name());
+    var rows = Files.readAllLines(file, StandardCharsets.UTF_8);
+    var columns = List.of(CSV_HEADER.split(",", -1));
+    var compositeColumn = columns.indexOf("compositeIndexes");
+    var securityColumn = columns.indexOf("securityFilter");
+    for (var line = 1; line < rows.size(); line++) {
+      if (rows.get(line).isBlank()) {
+        continue;
+      }
+      var values = parseCsvRow(file, line + 1, rows.get(line));
+      if (values.size() != columns.size()) {
+        throw new IOException(
+            "Cannot append to " + file + ": row " + (line + 1) + " has " + values.size()
+                + " values but header has " + columns.size());
+      }
+      var existing = ResultStratum.from(
+          values.get(compositeColumn), values.get(securityColumn), file, line + 1);
+      if (incoming.extended != existing.extended) {
+        throw new IOException(
+            "Cannot append run with " + incoming.description() + " to " + file + ": row "
+                + (line + 1) + " has " + existing.description()
+                + "; plain single-property and composite-or-security-filtered strata must not mix");
+      }
     }
   }
 
@@ -771,6 +870,35 @@ public final class SchemaCreationWorkload {
           "Cannot append to " + file + ": existing header <" + existingHeader
               + "> does not match this run's header <" + expectedHeader + ">");
     }
+  }
+
+  private static List<String> parseCsvRow(Path file, int lineNumber, String row)
+      throws IOException {
+    var values = new ArrayList<String>();
+    var value = new StringBuilder();
+    var quoted = false;
+    for (var index = 0; index < row.length(); index++) {
+      var character = row.charAt(index);
+      if (character == '"') {
+        if (quoted && index + 1 < row.length() && row.charAt(index + 1) == '"') {
+          value.append('"');
+          index++;
+        } else {
+          quoted = !quoted;
+        }
+      } else if (character == ',' && !quoted) {
+        values.add(value.toString());
+        value.setLength(0);
+      } else {
+        value.append(character);
+      }
+    }
+    if (quoted) {
+      throw new IOException(
+          "Cannot append to " + file + ": row " + lineNumber + " has an unterminated quote");
+    }
+    values.add(value.toString());
+    return values;
   }
 
   private static StorageEnvironment captureStorageEnvironment(DatabaseSessionEmbedded session) {
@@ -1055,7 +1183,11 @@ public final class SchemaCreationWorkload {
   }
 
   public enum VerificationState {
-    NOT_REQUESTED, COMPLETED, COMPLETED_COMPOSITE_INDEX_PROOF, SKIPPED_CLOSE_FAILED
+    NOT_REQUESTED, COMPLETED, COMPLETED_COMPOSITE_INDEX_PROOF, SKIPPED_CLOSE_FAILED;
+
+    private boolean functionalIndexProofCompleted() {
+      return this == COMPLETED || this == COMPLETED_COMPOSITE_INDEX_PROOF;
+    }
   }
 
   public enum Phase {
@@ -1123,6 +1255,52 @@ public final class SchemaCreationWorkload {
   }
 
   private record StorageEnvironment(boolean callFsync, boolean fullCheckpointAfterCreate) {
+  }
+
+  private record ResultStratum(
+      boolean extended, String compositeIndexes, String securityFilter) {
+
+    private static ResultStratum from(int compositeIndexes, String securityFilter) {
+      return new ResultStratum(
+          compositeIndexes > 0 || !SecurityFilter.NONE.name().equals(securityFilter),
+          Integer.toString(compositeIndexes),
+          securityFilter);
+    }
+
+    private static ResultStratum from(
+        String compositeIndexes, String securityFilter, Path file, int lineNumber)
+        throws IOException {
+      final int parsedCompositeIndexes;
+      try {
+        parsedCompositeIndexes = Integer.parseInt(compositeIndexes);
+      } catch (NumberFormatException failure) {
+        throw new IOException(
+            "Cannot append to " + file + ": row " + lineNumber
+                + " has invalid compositeIndexes=" + compositeIndexes,
+            failure);
+      }
+      if (parsedCompositeIndexes < 0) {
+        throw new IOException(
+            "Cannot append to " + file + ": row " + lineNumber
+                + " has invalid compositeIndexes=" + compositeIndexes);
+      }
+      try {
+        SecurityFilter.valueOf(securityFilter);
+      } catch (IllegalArgumentException failure) {
+        throw new IOException(
+            "Cannot append to " + file + ": row " + lineNumber
+                + " has invalid securityFilter=" + securityFilter,
+            failure);
+      }
+      return from(parsedCompositeIndexes, securityFilter);
+    }
+
+    private String description() {
+      var name = extended ? "composite-or-security-filtered stratum"
+          : "plain single-property stratum";
+      return "compositeIndexes=" + compositeIndexes + ", securityFilter=" + securityFilter
+          + " (" + name + ")";
+    }
   }
 
   private record GitIdentity(String commit, String dirty) {
@@ -1218,22 +1396,27 @@ public final class SchemaCreationWorkload {
         throw new IllegalArgumentException("bench.classes must be positive");
       }
       if (properties < 0) {
-        throw new IllegalArgumentException("bench.properties must not be negative");
+        throw new IllegalArgumentException(
+            "bench.properties must not be negative: " + properties);
       }
       if (indexes < 0 || indexes > properties) {
         throw new IllegalArgumentException(
-            "bench.indexes must be between zero and bench.properties");
+            "bench.indexes=" + indexes + " must be between zero and bench.properties="
+                + properties);
       }
       if (compositeIndexes < 0) {
-        throw new IllegalArgumentException("bench.compositeIndexes must not be negative");
+        throw new IllegalArgumentException(
+            "bench.compositeIndexes must not be negative: " + compositeIndexes);
       }
       if (compositeIndexWidth < 2) {
-        throw new IllegalArgumentException("bench.compositeIndexWidth must be at least two");
+        throw new IllegalArgumentException(
+            "bench.compositeIndexWidth must be at least two: " + compositeIndexWidth);
       }
       if (compositeIndexes > 0 && compositeIndexWidth > properties) {
         throw new IllegalArgumentException(
-            "bench.compositeIndexWidth must not exceed bench.properties when composite indexes "
-                + "are requested");
+            "bench.compositeIndexWidth=" + compositeIndexWidth
+                + " must not exceed bench.properties=" + properties
+                + " when bench.compositeIndexes=" + compositeIndexes + " is requested");
       }
       if (batchSize <= 0) {
         throw new IllegalArgumentException("bench.batchSize must be positive");

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkload.java
@@ -1,0 +1,945 @@
+/*
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.youtrackdb.benchmarks;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.api.config.GlobalConfiguration;
+import com.jetbrains.youtrackdb.internal.common.jnr.Native;
+import com.jetbrains.youtrackdb.internal.core.YouTrackDBConstants;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.SessionListener;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.PropertyTypeInternal;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.SchemaClassInternal;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Shared workload for measuring schema creation.
+ *
+ * <p>The mode combines {@code bench.policy} with {@code bench.propertyPath}. The policies are
+ * {@code NONE}, {@code PER_CLASS}, {@code BATCH}, and {@code ALL}. The property paths are {@code
+ * SAFE} and {@code UNSAFE}. {@code UNSAFE} skips the persistent-type check and the migration query.
+ * It is a measurement control, not a product option.
+ *
+ * <p>Phase A creates classes and properties. Phase B creates indexes. The phases never share a
+ * transaction. The harness checks for an active transaction at both boundaries of every phase.
+ *
+ * <table>
+ *   <caption>Benchmark properties</caption>
+ *   <tr><th>Property</th><th>Built-in default</th><th>Meaning</th></tr>
+ *   <tr><td>{@code bench.mainClass}</td><td>{@code SchemaCreationBenchmark}</td><td>Selects the
+ *       entry point. Use {@code com.jetbrains.youtrackdb.benchmarks.SchemaCreationBenchmark} for
+ *       the non-transactional entry point. Use {@code
+ *       com.jetbrains.youtrackdb.benchmarks.TxSchemaCreationBenchmark} for the transactional entry
+ *       point.</td></tr>
+ *   <tr><td>{@code bench.jvmBaseArgs}</td><td>{@code -Xms4g -Xmx4g}</td><td>Replaces the base JVM
+ *       arguments.</td></tr>
+ *   <tr><td>{@code bench.jvmAddArgs}</td><td>empty</td><td>Appends JVM arguments. Put profiler
+ *       agents here.</td></tr>
+ *   <tr><td>{@code bench.classes}</td><td>{@code 100}</td><td>Sets the class count.</td></tr>
+ *   <tr><td>{@code bench.properties}</td><td>{@code 20}</td><td>Sets the properties per class.</td></tr>
+ *   <tr><td>{@code bench.indexes}</td><td>{@code 20}</td><td>Sets the indexes per class. This value
+ *       must not exceed {@code bench.properties}.</td></tr>
+ *   <tr><td>{@code bench.policy}</td><td>{@code NONE} for {@code SchemaCreationBenchmark}; {@code
+ *       ALL} for {@code TxSchemaCreationBenchmark}</td><td>Selects the transaction policy.</td></tr>
+ *   <tr><td>{@code bench.batchSize}</td><td>{@code 50}</td><td>Sets the classes per {@code BATCH}
+ *       transaction.</td></tr>
+ *   <tr><td>{@code bench.propertyPath}</td><td>{@code SAFE} for both entry points</td><td>Selects
+ *       {@code SAFE} or {@code UNSAFE} property creation.</td></tr>
+ *   <tr><td>{@code bench.phase}</td><td>{@code AB}</td><td>Selects phase {@code A}, {@code B}, or
+ *       {@code AB}.</td></tr>
+ *   <tr><td>{@code bench.uniquePropertyNames}</td><td>{@code true}</td><td>Uses class-qualified
+ *       property names when true.</td></tr>
+ *   <tr><td>{@code bench.dbPath}</td><td>{@code
+ *       ./target/databases/benchmarks/schemaCreationBenchmark}</td><td>Sets the database-manager
+ *       directory.</td></tr>
+ *   <tr><td>{@code bench.dbName}</td><td>{@code schemaBenchmark}</td><td>Sets the database name.</td></tr>
+ *   <tr><td>{@code bench.resultFile}</td><td>{@code
+ *       target/benchmark-results/schema-creation.csv}</td><td>Sets the appended result file.</td></tr>
+ *   <tr><td>{@code bench.manifestFile}</td><td>{@code
+ *       target/benchmark-results/manifest.txt}</td><td>Sets the canonical manifest file.</td></tr>
+ *   <tr><td>{@code bench.verify}</td><td>{@code true}</td><td>Verifies persistence. It also proves
+ *       indexes after phase B.</td></tr>
+ *   <tr><td>{@code bench.label}</td><td>empty</td><td>Sets the free-text result label.</td></tr>
+ * </table>
+ *
+ * <p>An explicitly set value wins. Otherwise the entry point's default applies. Otherwise the
+ * built-in default applies. An empty value counts as not set. The Maven profile forwards empty
+ * values so that each entry point keeps its own defaults.
+ *
+ * <p>Use these commands exactly. The {@code -am} flag builds the upstream modules and prevents a
+ * stale core jar from entering the run.
+ *
+ * <p>Plain non-transactional timing:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests verify}</pre>
+ *
+ * <p>Plain transactional timing:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.mainClass=com.jetbrains.youtrackdb.benchmarks.TxSchemaCreationBenchmark verify}</pre>
+ *
+ * <p>One scale-sweep point:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.classes=200 -Dbench.label=n200 verify}</pre>
+ *
+ * <p>One phase:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.phase=A verify}</pre>
+ *
+ * <p>One sampling profile:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.verify=false -Dbench.jvmAddArgs="-agentpath:/path/to/libasyncProfiler.so=start,event=cpu,file=cpu.jfr" verify}</pre>
+ *
+ * <p>One instrumentation count:
+ * <pre>{@code ./mvnw -pl tests -am -Pbench -DskipTests -Dbench.verify=false -Dbench.jvmAddArgs="-agentpath:/path/to/libasyncProfiler.so=start,event=alloc,interval=0,file=alloc.jfr" verify}</pre>
+ *
+ * <p>Compare {@code totalNs}. It adds schema work to the durability barrier. Never compare {@code
+ * schemaWorkNs} alone. Transactional work can remain pending until storage synchronization.
+ *
+ * <p>Turn verification off for every profiling run. Otherwise the profile includes manifest work,
+ * database reopen, proof-record insertion, and index lookup. Use one profiler event per run. Run
+ * sampling and instrumentation separately. Never report an instrumentation run as a timing.
+ *
+ * <p>Measure phase A for every policy and property-path pair. The property path does not affect
+ * phase B. Run phase B once per transaction policy. The non-transactional index path pays listener
+ * overhead that the transactional path does not.
+ *
+ * <p>Flush the operating-system page cache between sweep points when the environment permits it.
+ * Otherwise wait until input-output settles. Dirty pages from one point can affect the next point.
+ */
+public final class SchemaCreationWorkload {
+
+  private static final String USER = "admin";
+  private static final String PASSWORD = "admin";
+  private static final String CLASS_PREFIX = "TestClass";
+  private static final String CSV_HEADER =
+      "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
+          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,totalNs,schemaWorkMs,"
+          + "durabilityBarrierMs,totalMs,topLevelTransactions,unsafePropertyCreations,"
+          + "verificationRan,jvmArgs,"
+          + "assertionsEnabled,storageCallFsync,storageFullCheckpointAfterCreate,"
+          + "osOpenFileSoftLimit,osOpenFileHardLimit,resolvedOpenFilesLimit,gitCommit,gitDirty,"
+          + "coreImplementationVersion,coreBuildNumber,coreBuildVersion,coreCodeSource,javaVersion,"
+          + "osName,garbageCollectors,"
+          + "hostName,availableProcessors,maxHeapBytes,effectiveDatabasePath";
+  private static final String DETAIL_HEADER =
+      "runId,phase,completedClasses,cumulativeSchemaWorkNs";
+
+  private SchemaCreationWorkload() {
+  }
+
+  public static void runMain(Policy defaultPolicy, PropertyPath defaultPropertyPath) {
+    try {
+      run(Configuration.fromSystemProperties(defaultPolicy, defaultPropertyPath));
+    } catch (Throwable failure) {
+      failure.printStackTrace();
+      System.exit(1);
+    }
+  }
+
+  /**
+   * Runs one explicitly configured workload without changing global system properties. Runtime,
+   * operating-system, process, and build metadata are still observed for the result files; missing
+   * environmental values are recorded with explicit markers and never fail a completed workload.
+   *
+   * @return phase timings and, when verification is enabled, the canonical manifest
+   */
+  public static RunResult run(Configuration configuration) throws IOException {
+    return run(configuration, null);
+  }
+
+  static RunResult run(Configuration configuration, SessionListener listener) throws IOException {
+    configuration.validate();
+    return new SchemaCreationWorkload().runInternal(configuration, listener);
+  }
+
+  static PhaseResult runPhaseForTesting(
+      Configuration configuration, DatabaseSessionEmbedded session, Phase phase) {
+    if (phase == Phase.AB) {
+      throw new IllegalArgumentException("A test phase must be A or B");
+    }
+    var workload = new SchemaCreationWorkload();
+    return workload.runPhase(
+        configuration,
+        session,
+        phase,
+        phase == Phase.A ? workload::createClassAndProperties : workload::createIndexes);
+  }
+
+  private RunResult runInternal(Configuration config, SessionListener listener) throws IOException {
+    var runId = UUID.randomUUID().toString();
+    var phaseResults = new ArrayList<PhaseResult>();
+    StorageEnvironment storageEnvironment;
+    try (var manager = manager(config.dbPath)) {
+      if (config.phase != Phase.B) {
+        if (manager.exists(config.dbName)) {
+          manager.drop(config.dbName);
+        }
+        manager.create(config.dbName, DatabaseType.DISK, USER, PASSWORD, USER);
+      } else if (!manager.exists(config.dbName)) {
+        throw new IllegalStateException("Phase B requires existing database " + config.dbName);
+      }
+
+      try (var session = manager.open(config.dbName, USER, PASSWORD)) {
+        if (listener != null) {
+          session.registerListener(listener);
+        }
+        storageEnvironment = captureStorageEnvironment(session);
+        if (config.phase.runsA()) {
+          phaseResults.add(
+              runPhase(config, session, Phase.A, this::createClassAndProperties));
+        }
+        if (config.phase.runsB()) {
+          phaseResults.add(runPhase(config, session, Phase.B, this::createIndexes));
+        }
+      }
+    }
+
+    var manifest = config.verify ? Optional.of(verify(config)) : Optional.<String>empty();
+    var runtimeEnvironment = captureRuntimeEnvironment();
+    var detailFile = detailFile(config.resultFile);
+    for (var result : phaseResults) {
+      appendCsv(config, runId, result, storageEnvironment, runtimeEnvironment);
+      appendTimingDetails(detailFile, runId, result);
+    }
+    return new RunResult(
+        runId,
+        List.copyOf(phaseResults),
+        manifest,
+        config.manifestFile,
+        detailFile,
+        config.verify && config.phase.runsB());
+  }
+
+  private PhaseResult runPhase(
+      Configuration config, DatabaseSessionEmbedded session, Phase phase,
+      ClassOperation operation) {
+    requireNoActiveTransaction(session, phase, "start");
+    if (config.policy == Policy.BATCH && config.batchSize >= config.classes) {
+      System.err.printf(
+          "WARNING: BATCH size %,d is not smaller than %,d classes; phase %s is equivalent to ALL.%n",
+          config.batchSize, config.classes, phase);
+    }
+    System.out.printf("Starting phase %s: %,d classes%n", phase, config.classes);
+    var progress = new Progress(config.classes, phase);
+    var details = new ArrayList<TimingDetail>();
+    var counters = new PhaseCounters();
+    var start = System.nanoTime();
+    var transactionCount = executePolicy(config, session, classIndex -> {
+      counters.unsafePropertyCreations += operation.run(config, session, classIndex);
+      var completed = classIndex + 1;
+      if (progress.completed(completed)) {
+        details.add(new TimingDetail(completed, System.nanoTime() - start));
+      }
+    });
+    var schemaWorkNs = System.nanoTime() - start;
+    requireNoActiveTransaction(session, phase, "end");
+    var finalDetail = new TimingDetail(config.classes, schemaWorkNs);
+    if (details.isEmpty() || details.getLast().completedClasses != config.classes) {
+      details.add(finalDetail);
+    } else {
+      // The callback for the final class runs before its enclosing transaction commits. Replace
+      // that sample so the final cumulative point exactly matches the complete schema-work timer.
+      details.set(details.size() - 1, finalDetail);
+    }
+
+    // AbstractStorage.synch() freezes writes, flushes index engines and dirty histograms, flushes
+    // all storage data and the WAL, then unfreezes writes. This is the durability work that would
+    // otherwise be deferred until storage shutdown and hidden from the mode comparison.
+    var durabilityStart = System.nanoTime();
+    session.getStorage().synch();
+    var durabilityBarrierNs = System.nanoTime() - durabilityStart;
+    var totalNs = schemaWorkNs + durabilityBarrierNs;
+    System.out.printf(
+        "Finished phase %s: schema %,d ms, durability %,d ms, total %,d ms%n",
+        phase,
+        TimeUnit.NANOSECONDS.toMillis(schemaWorkNs),
+        TimeUnit.NANOSECONDS.toMillis(durabilityBarrierNs),
+        TimeUnit.NANOSECONDS.toMillis(totalNs));
+    return new PhaseResult(
+        phase,
+        schemaWorkNs,
+        durabilityBarrierNs,
+        totalNs,
+        transactionCount,
+        counters.unsafePropertyCreations,
+        List.copyOf(details));
+  }
+
+  private static void requireNoActiveTransaction(
+      DatabaseSessionEmbedded session, Phase phase, String boundary) {
+    if (session.getTransactionInternal().isActive()) {
+      throw new IllegalStateException(
+          "Phase " + phase + " must have no active transaction at its " + boundary);
+    }
+  }
+
+  private int executePolicy(
+      Configuration config, DatabaseSessionEmbedded session, ClassIndexOperation operation) {
+    if (config.policy == Policy.NONE) {
+      for (var classIndex = 0; classIndex < config.classes; classIndex++) {
+        operation.run(classIndex);
+      }
+      return 0;
+    }
+
+    var groupSize = switch (config.policy) {
+      case PER_CLASS -> 1;
+      case BATCH -> config.batchSize;
+      case ALL -> config.classes;
+      case NONE -> throw new IllegalStateException("NONE was handled above");
+    };
+    var transactions = 0;
+    for (var first = 0; first < config.classes; first += groupSize) {
+      var end = Math.min(config.classes, first + groupSize);
+      session.begin();
+      try {
+        for (var classIndex = first; classIndex < end; classIndex++) {
+          operation.run(classIndex);
+        }
+        session.commit();
+        transactions++;
+      } catch (Throwable failure) {
+        session.rollback();
+        throw failure;
+      }
+    }
+    return transactions;
+  }
+
+  private int createClassAndProperties(
+      Configuration config, DatabaseSessionEmbedded session, int classIndex) {
+    var schemaClass = session.getSchema().createClass(className(classIndex));
+    var unsafePropertyCreations = 0;
+    for (var propertyIndex = 0; propertyIndex < config.properties; propertyIndex++) {
+      var propertyName = propertyName(config, classIndex, propertyIndex);
+      if (config.propertyPath == PropertyPath.SAFE) {
+        schemaClass.createProperty(propertyName, PropertyType.STRING);
+      } else {
+        ((SchemaClassInternal) schemaClass)
+            .createProperty(
+                propertyName,
+                PropertyTypeInternal.convertFromPublicType(PropertyType.STRING),
+                (PropertyTypeInternal) null,
+                true);
+        unsafePropertyCreations++;
+      }
+    }
+    return unsafePropertyCreations;
+  }
+
+  private int createIndexes(
+      Configuration config, DatabaseSessionEmbedded session, int classIndex) {
+    var schemaClass = session.getSchema().getClass(className(classIndex));
+    if (schemaClass == null) {
+      throw new IllegalStateException("Missing class for phase B: " + className(classIndex));
+    }
+    for (var index = 0; index < config.indexes; index++) {
+      var propertyName = propertyName(config, classIndex, index);
+      if (!schemaClass.existsProperty(propertyName)) {
+        throw new IllegalStateException(
+            "Missing property for phase B: " + className(classIndex) + "." + propertyName);
+      }
+      schemaClass.createIndex(
+          indexName(classIndex, index), SchemaClass.INDEX_TYPE.UNIQUE, propertyName);
+    }
+    return 0;
+  }
+
+  private String verify(Configuration config) throws IOException {
+    String beforeRestart;
+    try (var manager = manager(config.dbPath);
+        var session = manager.open(config.dbName, USER, PASSWORD)) {
+      beforeRestart = buildManifest(session);
+    }
+
+    String afterRestart;
+    try (var manager = manager(config.dbPath);
+        var session = manager.open(config.dbName, USER, PASSWORD)) {
+      afterRestart = buildManifest(session);
+      requireEqualManifests(beforeRestart, afterRestart);
+      if (config.phase.runsB()) {
+        proveIndexes(config, session);
+      }
+    }
+
+    var manifestFile = config.manifestFile;
+    createParentDirectories(manifestFile);
+    Files.writeString(manifestFile, afterRestart, StandardCharsets.UTF_8);
+    return afterRestart;
+  }
+
+  private String buildManifest(DatabaseSessionEmbedded session) {
+    var classes = session.getSchema().getClasses().stream()
+        .filter(schemaClass -> schemaClass.getName().startsWith(CLASS_PREFIX))
+        .sorted(Comparator.comparing(SchemaClass::getName))
+        .toList();
+    var indexes = session.getSharedContext().getIndexManager().getIndexes(session);
+    var manifest = new StringBuilder();
+    for (var schemaClass : classes) {
+      manifest.append("class ").append(schemaClass.getName()).append('\n');
+      schemaClass.getProperties().stream()
+          .sorted(Comparator.comparing(property -> property.getName()))
+          .forEach(property -> manifest.append("  property ").append(property.getName())
+              .append(" type=").append(property.getType()).append('\n'));
+      indexes.stream()
+          .filter(index -> index.getDefinition() != null)
+          .filter(index -> schemaClass.getName().equals(index.getDefinition().getClassName()))
+          .sorted(Comparator.comparing(index -> index.getName()))
+          .forEach(index -> manifest.append("  index ").append(index.getName())
+              .append(" type=").append(index.getType()).append(" fields=")
+              .append(String.join(",", index.getDefinition().getFieldsToIndex())).append('\n'));
+    }
+    return manifest.toString();
+  }
+
+  static void requireEqualManifests(String expected, String actual) {
+    if (expected.equals(actual)) {
+      return;
+    }
+    var expectedLines = expected.lines().toList();
+    var actualLines = actual.lines().toList();
+    var commonSize = Math.min(expectedLines.size(), actualLines.size());
+    for (var line = 0; line < commonSize; line++) {
+      if (!expectedLines.get(line).equals(actualLines.get(line))) {
+        throw new IllegalStateException("Manifest differs at line " + (line + 1) + ": expected <"
+            + expectedLines.get(line) + "> but was <" + actualLines.get(line) + ">");
+      }
+    }
+    throw new IllegalStateException("Manifest differs at line " + (commonSize + 1)
+        + ": one manifest ended early");
+  }
+
+  private void proveIndexes(Configuration config, DatabaseSessionEmbedded session) {
+    session.begin();
+    try {
+      for (var classIndex = 0; classIndex < config.classes; classIndex++) {
+        var entity = session.newEntity(className(classIndex));
+        for (var propertyIndex = 0; propertyIndex < config.indexes; propertyIndex++) {
+          entity.setProperty(
+              propertyName(config, classIndex, propertyIndex),
+              indexedValue(classIndex, propertyIndex));
+        }
+      }
+      session.commit();
+    } catch (Throwable failure) {
+      session.rollback();
+      throw failure;
+    }
+
+    for (var classIndex = 0; classIndex < config.classes; classIndex++) {
+      for (var indexNumber = 0; indexNumber < config.indexes; indexNumber++) {
+        var name = indexName(classIndex, indexNumber);
+        var index = session.getSharedContext().getIndexManager().getIndex(session, name);
+        if (index == null) {
+          throw new IllegalStateException("Index manager cannot find " + name);
+        }
+        if (index.getIndexId() < 0) {
+          throw new IllegalStateException("Index has no real identifier: " + name);
+        }
+        if (((AbstractStorage) session.getStorage()).loadIndexEngine(name) < 0) {
+          throw new IllegalStateException("Storage cannot load index engine: " + name);
+        }
+        var value = indexedValue(classIndex, indexNumber);
+        var found = session.computeInTx(tx -> index.getRids(session, value).findAny().isPresent());
+        if (!found) {
+          throw new IllegalStateException("Index " + name + " cannot find inserted value " + value);
+        }
+      }
+    }
+  }
+
+  private void appendCsv(
+      Configuration config,
+      String runId,
+      PhaseResult result,
+      StorageEnvironment storage,
+      RuntimeEnvironment runtime) throws IOException {
+    var values = List.of(
+        Instant.now().toString(),
+        runId,
+        config.label,
+        config.policy.name(),
+        Integer.toString(config.batchSize),
+        config.propertyPath.name(),
+        result.phase.name(),
+        Integer.toString(config.classes),
+        Integer.toString(config.properties),
+        Integer.toString(config.indexes),
+        Boolean.toString(config.uniquePropertyNames),
+        Long.toString(result.schemaWorkNs),
+        Long.toString(result.durabilityBarrierNs),
+        Long.toString(result.totalNs),
+        Long.toString(TimeUnit.NANOSECONDS.toMillis(result.schemaWorkNs)),
+        Long.toString(TimeUnit.NANOSECONDS.toMillis(result.durabilityBarrierNs)),
+        Long.toString(TimeUnit.NANOSECONDS.toMillis(result.totalNs)),
+        Integer.toString(result.topLevelTransactions),
+        Integer.toString(result.unsafePropertyCreations),
+        Boolean.toString(config.verify),
+        runtime.jvmArgs,
+        Boolean.toString(runtime.assertionsEnabled),
+        Boolean.toString(storage.callFsync),
+        Boolean.toString(storage.fullCheckpointAfterCreate),
+        runtime.openFileLimits.soft,
+        runtime.openFileLimits.hard,
+        runtime.resolvedOpenFilesLimit,
+        runtime.git.commit,
+        runtime.git.dirty,
+        runtime.coreImplementationVersion,
+        runtime.coreBuildNumber,
+        runtime.coreBuildVersion,
+        runtime.coreCodeSource,
+        runtime.javaVersion,
+        runtime.osName,
+        runtime.garbageCollectors,
+        runtime.hostName,
+        Integer.toString(runtime.availableProcessors),
+        Long.toString(runtime.maxHeapBytes),
+        config.dbPath.toAbsolutePath().normalize().resolve(config.dbName).toString());
+    appendRow(config.resultFile, CSV_HEADER, values);
+  }
+
+  private void appendTimingDetails(Path detailFile, String runId, PhaseResult result)
+      throws IOException {
+    for (var detail : result.timingDetails) {
+      appendRow(detailFile, DETAIL_HEADER, List.of(
+          runId,
+          result.phase.name(),
+          Integer.toString(detail.completedClasses),
+          Long.toString(detail.cumulativeSchemaWorkNs)));
+    }
+  }
+
+  private static void appendRow(Path file, String header, List<String> values) throws IOException {
+    createParentDirectories(file);
+    var newFile = Files.notExists(file) || Files.size(file) == 0;
+    try (var writer = Files.newBufferedWriter(
+        file, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
+      if (newFile) {
+        writer.write(header);
+        writer.newLine();
+      }
+      writer
+          .write(values.stream().map(SchemaCreationWorkload::csv).collect(Collectors.joining(",")));
+      writer.newLine();
+    }
+  }
+
+  private static StorageEnvironment captureStorageEnvironment(DatabaseSessionEmbedded session) {
+    var context = session.getStorage().getContextConfiguration();
+    return new StorageEnvironment(
+        context.getValueAsBoolean(GlobalConfiguration.STORAGE_CALL_FSYNC),
+        context.getValueAsBoolean(GlobalConfiguration.STORAGE_MAKE_FULL_CHECKPOINT_AFTER_CREATE));
+  }
+
+  private static RuntimeEnvironment captureRuntimeEnvironment() {
+    var limits = readOpenFileLimits();
+    var implementationVersion = coreImplementationVersion();
+    var codeSourceLocation = coreCodeSource();
+    var garbageCollectors = ManagementFactory.getGarbageCollectorMXBeans().stream()
+        .map(collector -> collector.getName())
+        .sorted()
+        .collect(Collectors.joining(";"));
+    return new RuntimeEnvironment(
+        String.join(" ", ManagementFactory.getRuntimeMXBean().getInputArguments()),
+        assertionsEnabled(),
+        limits,
+        resolvedOpenFilesLimit(),
+        readGitIdentity(),
+        implementationVersion,
+        coreBuildNumber(),
+        coreBuildVersion(),
+        codeSourceLocation,
+        safeSystemProperty("java.version"),
+        safeSystemProperty("os.name"),
+        valueOrMarker(garbageCollectors, "unavailable:no-garbage-collector"),
+        hostName(),
+        Runtime.getRuntime().availableProcessors(),
+        Runtime.getRuntime().maxMemory());
+  }
+
+  private static String resolvedOpenFilesLimit() {
+    var configured = GlobalConfiguration.OPEN_FILES_LIMIT.getValueAsInteger();
+    if (configured > 0) {
+      return Integer.toString(configured);
+    }
+    // Call the same resolver and use the same constants as EngineLocalPaginated. The prefix makes
+    // clear that this is a repeated derivation from OS limits, not an accessor on the live engine.
+    var resolved = Native.instance().getOpenFilesLimit(false, 256 * 1024, 512);
+    return "derived:" + resolved;
+  }
+
+  private static OpenFileLimits readOpenFileLimits() {
+    var limitsFile = Path.of("/proc/self/limits");
+    if (!Files.isRegularFile(limitsFile)) {
+      return new OpenFileLimits("unknown", "unknown");
+    }
+    try {
+      for (var line : Files.readAllLines(limitsFile, StandardCharsets.UTF_8)) {
+        if (line.startsWith("Max open files")) {
+          var fields = line.trim().split("\\s+");
+          return fields.length >= 5
+              ? new OpenFileLimits(fields[3], fields[4])
+              : new OpenFileLimits("unknown", "unknown");
+        }
+      }
+    } catch (IOException ignored) {
+      // Environmental metadata must not prevent the benchmark result from being recorded.
+    }
+    return new OpenFileLimits("unknown", "unknown");
+  }
+
+  private static GitIdentity readGitIdentity() {
+    var commit = runCommand("git", "rev-parse", "--short=12", "HEAD");
+    var status = runCommand("git", "status", "--porcelain", "--untracked-files=no");
+    var dirty = status.startsWith("unavailable:") ? status : Boolean.toString(!status.isBlank());
+    return new GitIdentity(commit.isBlank() ? "unavailable:empty-commit" : commit, dirty);
+  }
+
+  private static String runCommand(String... command) {
+    try {
+      var process = new ProcessBuilder(command).redirectErrorStream(true).start();
+      if (!process.waitFor(5, TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        return "unavailable:command-timeout";
+      }
+      var output =
+          new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+      return process.exitValue() == 0
+          ? output
+          : "unavailable:command-exit-" + process.exitValue() + ":" + output;
+    } catch (IOException failure) {
+      return "unavailable:command-io-" + failure.getClass().getSimpleName();
+    } catch (InterruptedException failure) {
+      Thread.currentThread().interrupt();
+      return "unavailable:command-interrupted";
+    }
+  }
+
+  private static String hostName() {
+    try {
+      return valueOrMarker(InetAddress.getLocalHost().getHostName(), "unavailable:no-host-name");
+    } catch (Exception failure) {
+      return "unavailable:host-" + failure.getClass().getSimpleName();
+    }
+  }
+
+  private static String coreImplementationVersion() {
+    try {
+      var corePackage = YourTracks.class.getPackage();
+      return corePackage == null
+          ? "unavailable:no-package"
+          : valueOrMarker(
+              corePackage.getImplementationVersion(), "unavailable:no-package-version");
+    } catch (RuntimeException failure) {
+      return "unavailable:package-" + failure.getClass().getSimpleName();
+    }
+  }
+
+  private static String coreBuildNumber() {
+    try {
+      return valueOrMarker(
+          YouTrackDBConstants.getBuildNumber(), "unavailable:no-core-build-number");
+    } catch (RuntimeException failure) {
+      return "unavailable:core-build-number-" + failure.getClass().getSimpleName();
+    }
+  }
+
+  private static String coreBuildVersion() {
+    try {
+      return valueOrMarker(
+          YouTrackDBConstants.getVersion(), "unavailable:no-core-build-version");
+    } catch (RuntimeException failure) {
+      return "unavailable:core-build-version-" + failure.getClass().getSimpleName();
+    }
+  }
+
+  private static String coreCodeSource() {
+    try {
+      var protectionDomain = YourTracks.class.getProtectionDomain();
+      var codeSource = protectionDomain == null ? null : protectionDomain.getCodeSource();
+      return codeSource == null || codeSource.getLocation() == null
+          ? "unavailable:no-code-source"
+          : codeSource.getLocation().toExternalForm();
+    } catch (RuntimeException failure) {
+      return "unavailable:code-source-" + failure.getClass().getSimpleName();
+    }
+  }
+
+  private static String safeSystemProperty(String name) {
+    try {
+      return valueOrMarker(System.getProperty(name), "unavailable:missing-" + name);
+    } catch (SecurityException failure) {
+      return "unavailable:property-security-" + name;
+    }
+  }
+
+  private static String valueOrMarker(String value, String marker) {
+    return value == null || value.isBlank() ? marker : value;
+  }
+
+  private static boolean assertionsEnabled() {
+    return SchemaCreationWorkload.class.desiredAssertionStatus();
+  }
+
+  private static Path detailFile(Path resultFile) {
+    return resultFile.resolveSibling(resultFile.getFileName() + ".detail.csv");
+  }
+
+  private static String csv(String value) {
+    return '"' + value.replace("\"", "\"\"") + '"';
+  }
+
+  private static YouTrackDBImpl manager(Path databasePath) {
+    return (YouTrackDBImpl) YourTracks.instance(databasePath.toString());
+  }
+
+  private static void createParentDirectories(Path file) throws IOException {
+    var parent = file.toAbsolutePath().getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+  }
+
+  private static String className(int classIndex) {
+    return CLASS_PREFIX + classIndex;
+  }
+
+  private static String propertyName(
+      Configuration config, int classIndex, int propertyIndex) {
+    return config.uniquePropertyNames
+        ? className(classIndex) + "Prop" + propertyIndex
+        : "TestProperty" + propertyIndex;
+  }
+
+  private static String indexName(int classIndex, int indexNumber) {
+    return "TestIndex_" + classIndex + "_" + indexNumber;
+  }
+
+  private static String indexedValue(int classIndex, int propertyIndex) {
+    return "value_" + classIndex + "_" + propertyIndex;
+  }
+
+  public enum Policy {
+    NONE, PER_CLASS, BATCH, ALL
+  }
+
+  public enum PropertyPath {
+    SAFE, UNSAFE
+  }
+
+  public enum Phase {
+    A, B, AB;
+
+    private boolean runsA() {
+      return this == A || this == AB;
+    }
+
+    private boolean runsB() {
+      return this == B || this == AB;
+    }
+  }
+
+  @FunctionalInterface
+  private interface ClassOperation {
+
+    int run(Configuration config, DatabaseSessionEmbedded session, int classIndex);
+  }
+
+  @FunctionalInterface
+  private interface ClassIndexOperation {
+
+    void run(int classIndex);
+  }
+
+  public record TimingDetail(int completedClasses, long cumulativeSchemaWorkNs) {
+  }
+
+  public record PhaseResult(
+      Phase phase,
+      long schemaWorkNs,
+      long durabilityBarrierNs,
+      long totalNs,
+      int topLevelTransactions,
+      int unsafePropertyCreations,
+      List<TimingDetail> timingDetails) {
+
+    public long schemaWorkMs() {
+      return TimeUnit.NANOSECONDS.toMillis(schemaWorkNs);
+    }
+
+    public long durabilityBarrierMs() {
+      return TimeUnit.NANOSECONDS.toMillis(durabilityBarrierNs);
+    }
+
+    public long totalMs() {
+      return TimeUnit.NANOSECONDS.toMillis(totalNs);
+    }
+  }
+
+  public record RunResult(
+      String runId,
+      List<PhaseResult> phases,
+      Optional<String> manifestText,
+      Path manifestFile,
+      Path detailFile,
+      boolean functionalIndexProofRan) {
+  }
+
+  private record OpenFileLimits(String soft, String hard) {
+  }
+
+  private record StorageEnvironment(boolean callFsync, boolean fullCheckpointAfterCreate) {
+  }
+
+  private record GitIdentity(String commit, String dirty) {
+  }
+
+  private record RuntimeEnvironment(
+      String jvmArgs,
+      boolean assertionsEnabled,
+      OpenFileLimits openFileLimits,
+      String resolvedOpenFilesLimit,
+      GitIdentity git,
+      String coreImplementationVersion,
+      String coreBuildNumber,
+      String coreBuildVersion,
+      String coreCodeSource,
+      String javaVersion,
+      String osName,
+      String garbageCollectors,
+      String hostName,
+      int availableProcessors,
+      long maxHeapBytes) {
+  }
+
+  private static final class PhaseCounters {
+
+    private int unsafePropertyCreations;
+  }
+
+  public record Configuration(
+      int classes,
+      int properties,
+      int indexes,
+      Policy policy,
+      int batchSize,
+      PropertyPath propertyPath,
+      Phase phase,
+      boolean uniquePropertyNames,
+      Path dbPath,
+      String dbName,
+      Path resultFile,
+      Path manifestFile,
+      boolean verify,
+      String label) {
+
+    private static Configuration fromSystemProperties(
+        Policy defaultPolicy, PropertyPath defaultPropertyPath) {
+      return new Configuration(
+          integer("bench.classes", 100),
+          integer("bench.properties", 20),
+          integer("bench.indexes", 20),
+          enumeration("bench.policy", defaultPolicy, Policy.class),
+          integer("bench.batchSize", 50),
+          enumeration("bench.propertyPath", defaultPropertyPath, PropertyPath.class),
+          enumeration("bench.phase", Phase.AB, Phase.class),
+          Boolean.parseBoolean(systemProperty("bench.uniquePropertyNames", "true")),
+          Path.of(systemProperty(
+              "bench.dbPath", "./target/databases/benchmarks/schemaCreationBenchmark")),
+          systemProperty("bench.dbName", "schemaBenchmark"),
+          Path.of(systemProperty(
+              "bench.resultFile", "target/benchmark-results/schema-creation.csv")),
+          Path.of(systemProperty(
+              "bench.manifestFile", "target/benchmark-results/manifest.txt")),
+          Boolean.parseBoolean(systemProperty("bench.verify", "true")),
+          systemProperty("bench.label", ""));
+    }
+
+    private void validate() {
+      if (classes <= 0) {
+        throw new IllegalArgumentException("bench.classes must be positive");
+      }
+      if (properties < 0) {
+        throw new IllegalArgumentException("bench.properties must not be negative");
+      }
+      if (indexes < 0 || indexes > properties) {
+        throw new IllegalArgumentException(
+            "bench.indexes must be between zero and bench.properties");
+      }
+      if (batchSize <= 0) {
+        throw new IllegalArgumentException("bench.batchSize must be positive");
+      }
+    }
+
+    private static int integer(String name, int defaultValue) {
+      return Integer.parseInt(systemProperty(name, Integer.toString(defaultValue)));
+    }
+
+    private static <E extends Enum<E>> E enumeration(
+        String name, E defaultValue, Class<E> type) {
+      return Enum.valueOf(
+          type, systemProperty(name, defaultValue.name()).toUpperCase(Locale.ROOT));
+    }
+
+    private static String systemProperty(String name, String defaultValue) {
+      var value = System.getProperty(name);
+      return value == null || value.isBlank() ? defaultValue : value;
+    }
+  }
+
+  private static final class Progress {
+
+    private final int total;
+    private final Phase phase;
+    private final int interval;
+    private int next;
+
+    private Progress(int total, Phase phase) {
+      this.total = total;
+      this.phase = phase;
+      interval = Math.max(1, (int) Math.ceil(total / 10.0));
+      next = interval;
+    }
+
+    private boolean completed(int count) {
+      if (count < next && count < total) {
+        return false;
+      }
+      if (count < total) {
+        System.out.printf("Phase %s progress: %,d of %,d classes%n", phase, count, total);
+      }
+      while (next <= count) {
+        next += interval;
+      }
+      return true;
+    }
+  }
+}

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
@@ -57,9 +57,9 @@ public class SchemaCreationWorkloadTest {
 
   private static final String CSV_HEADER =
       "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
-          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,totalNs,schemaWorkMs,"
-          + "durabilityBarrierMs,totalMs,topLevelTransactions,unsafePropertyCreations,"
-          + "verificationRan,jvmArgs,assertionsEnabled,storageCallFsync,"
+          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,"
+          + "shutdownNs,schemaWorkMs,durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,"
+          + "unsafePropertyCreations,verificationRan,jvmArgs,assertionsEnabled,storageCallFsync,"
           + "storageFullCheckpointAfterCreate,osOpenFileSoftLimit,osOpenFileHardLimit,"
           + "resolvedOpenFilesLimit,gitCommit,gitDirty,coreImplementationVersion,coreBuildNumber,"
           + "coreBuildVersion,coreCodeSource,javaVersion,osName,garbageCollectors,hostName,"
@@ -104,6 +104,17 @@ public class SchemaCreationWorkloadTest {
     completedRuns.add(runCase("per-class-unsafe", Policy.PER_CLASS, 50,
         PropertyPath.UNSAFE, 3, 9));
     completedRuns.add(runCase("all-unsafe", Policy.ALL, 50, PropertyPath.UNSAFE, 1, 9));
+    var barrierOff =
+        runCase("all-safe-no-barrier", Policy.ALL, 50, PropertyPath.SAFE, 1, 0, false);
+    completedRuns.add(barrierOff);
+    for (var phaseResult : barrierOff.phases()) {
+      assertFalse(phaseResult.durabilityBarrierRan());
+      assertEquals(0, phaseResult.durabilityBarrierNs());
+    }
+    var barrierOffRows = Files.readAllLines(
+        temporaryDirectory.resolve("all-safe-no-barrier/results.csv"), StandardCharsets.UTF_8);
+    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 12).equals("0")));
+    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 13).equals("false")));
 
     var splitDirectory = temporaryDirectory.resolve("split");
     var splitCsv = splitDirectory.resolve("results.csv");
@@ -280,6 +291,24 @@ public class SchemaCreationWorkloadTest {
       PropertyPath propertyPath,
       int expectedTransactions,
       int expectedUnsafeProperties) throws IOException {
+    return runCase(
+        name,
+        policy,
+        batchSize,
+        propertyPath,
+        expectedTransactions,
+        expectedUnsafeProperties,
+        true);
+  }
+
+  private RunResult runCase(
+      String name,
+      Policy policy,
+      int batchSize,
+      PropertyPath propertyPath,
+      int expectedTransactions,
+      int expectedUnsafeProperties,
+      boolean durabilityBarrier) throws IOException {
     var directory = temporaryDirectory.resolve(name);
     var csv = directory.resolve("results.csv");
     var result = SchemaCreationWorkload.run(configuration(
@@ -293,7 +322,8 @@ public class SchemaCreationWorkloadTest {
         Phase.AB,
         3,
         3,
-        3));
+        3,
+        durabilityBarrier));
     assertEquals(2, result.phases().size(), "AB must report one result for each phase");
     assertPhase(result, Phase.A, expectedTransactions, expectedUnsafeProperties);
     assertPhase(result, Phase.B, expectedTransactions, 0);
@@ -347,6 +377,34 @@ public class SchemaCreationWorkloadTest {
       int classes,
       int properties,
       int indexes) {
+    return configuration(
+        databasePath,
+        databaseName,
+        csv,
+        manifest,
+        policy,
+        batchSize,
+        propertyPath,
+        phase,
+        classes,
+        properties,
+        indexes,
+        true);
+  }
+
+  private static Configuration configuration(
+      Path databasePath,
+      String databaseName,
+      Path csv,
+      Path manifest,
+      Policy policy,
+      int batchSize,
+      PropertyPath propertyPath,
+      Phase phase,
+      int classes,
+      int properties,
+      int indexes,
+      boolean durabilityBarrier) {
     return new Configuration(
         classes,
         properties,
@@ -361,6 +419,7 @@ public class SchemaCreationWorkloadTest {
         csv,
         manifest,
         true,
+        durabilityBarrier,
         "smoke");
   }
 
@@ -371,7 +430,7 @@ public class SchemaCreationWorkloadTest {
     assertEquals(expectedDataRows + 1, lines.size(), "CSV must contain one row per phase");
     assertEquals(1, lines.stream().filter(CSV_HEADER::equals).count(),
         "CSV header must occur exactly once");
-    assertTrue(lines.stream().skip(1).allMatch(line -> csvField(line, 19).equals("true")),
+    assertTrue(lines.stream().skip(1).allMatch(line -> csvField(line, 22).equals("true")),
         "verified runs must record verificationRan=true");
 
     var details = Files.readAllLines(result.detailFile(), StandardCharsets.UTF_8);

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
@@ -358,7 +358,7 @@ public class SchemaCreationWorkloadTest {
   }
 
   @Test
-  void appendGuardHandlesLateMismatchMissingNewlineAndEmptyFiles() throws IOException {
+  void preAppendHeaderGuardRejectsMismatchIntroducedAfterPreflight() throws IOException {
     var lateMismatch = temporaryDirectory.resolve("late-header-mismatch.csv");
     Files.writeString(lateMismatch, CSV_HEADER + "\n", StandardCharsets.UTF_8);
     var mismatch = assertThrows(IOException.class,
@@ -366,7 +366,54 @@ public class SchemaCreationWorkloadTest {
             lateMismatch, "changed-after-preflight", List.of("value")));
     assertTrue(mismatch.getMessage().contains(CSV_HEADER));
     assertTrue(mismatch.getMessage().contains("changed-after-preflight"));
+  }
 
+  @Test
+  void preExistingEmptyResultFileReceivesHeaderAndRows() throws IOException {
+    var directory = temporaryDirectory.resolve("empty-result-file");
+    Files.createDirectories(directory);
+    var emptyResult = directory.resolve("results.csv");
+    Files.createFile(emptyResult);
+    var result = SchemaCreationWorkload.run(configuration(
+        directory.resolve("database"),
+        "empty_result_file",
+        emptyResult,
+        directory.resolve("manifest.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.AB,
+        1,
+        1,
+        1));
+    assertCsvAndDetails(result, emptyResult, 2, 2);
+  }
+
+  @Test
+  void preExistingEmptyDetailFileReceivesHeaderAndRows() throws IOException {
+    var directory = temporaryDirectory.resolve("empty-detail-file");
+    Files.createDirectories(directory);
+    var resultFile = directory.resolve("results.csv");
+    var emptyDetail = directory.resolve("results.csv.detail.csv");
+    Files.writeString(resultFile, CSV_HEADER + "\n", StandardCharsets.UTF_8);
+    Files.createFile(emptyDetail);
+    var result = SchemaCreationWorkload.run(configuration(
+        directory.resolve("database"),
+        "empty_detail_file",
+        resultFile,
+        directory.resolve("manifest.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.AB,
+        1,
+        1,
+        1));
+    assertCsvAndDetails(result, resultFile, 2, 2);
+  }
+
+  @Test
+  void appendAfterUnterminatedLastLineKeepsRecordsSeparate() throws IOException {
     var missingNewline = temporaryDirectory.resolve("missing-newline.csv");
     Files.writeString(
         missingNewline, CSV_HEADER + "\n\"existing\"", StandardCharsets.UTF_8);
@@ -376,26 +423,6 @@ public class SchemaCreationWorkloadTest {
         "append must add a separator after an unterminated existing record");
     assertEquals("\"existing\"", separatedLines.get(1));
     assertEquals("\"next\"", separatedLines.get(2));
-
-    var emptyDirectory = temporaryDirectory.resolve("empty-output-files");
-    Files.createDirectories(emptyDirectory);
-    var emptyResult = emptyDirectory.resolve("results.csv");
-    var emptyDetail = emptyDirectory.resolve("results.csv.detail.csv");
-    Files.createFile(emptyResult);
-    Files.createFile(emptyDetail);
-    var result = SchemaCreationWorkload.run(configuration(
-        emptyDirectory.resolve("database"),
-        "empty_output_files",
-        emptyResult,
-        emptyDirectory.resolve("manifest.txt"),
-        Policy.ALL,
-        1,
-        PropertyPath.SAFE,
-        Phase.AB,
-        1,
-        1,
-        1));
-    assertCsvAndDetails(result, emptyResult, 2, 2);
   }
 
   @Test

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
@@ -59,7 +59,7 @@ public class SchemaCreationWorkloadTest {
       "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
           + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,"
           + "shutdownNs,schemaWorkMs,durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,"
-          + "unsafePropertyCreations,verificationRan,jvmArgs,assertionsEnabled,storageCallFsync,"
+          + "unsafePropertyCreations,verificationState,jvmArgs,assertionsEnabled,storageCallFsync,"
           + "storageFullCheckpointAfterCreate,osOpenFileSoftLimit,osOpenFileHardLimit,"
           + "resolvedOpenFilesLimit,gitCommit,gitDirty,coreImplementationVersion,coreBuildNumber,"
           + "coreBuildVersion,coreCodeSource,javaVersion,osName,garbageCollectors,hostName,"
@@ -327,6 +327,16 @@ public class SchemaCreationWorkloadTest {
     assertEquals(2, result.phases().size(), "AB must report one result for each phase");
     assertPhase(result, Phase.A, expectedTransactions, expectedUnsafeProperties);
     assertPhase(result, Phase.B, expectedTransactions, 0);
+    for (var phaseResult : result.phases()) {
+      assertEquals(durabilityBarrier, phaseResult.durabilityBarrierRan());
+      if (durabilityBarrier) {
+        assertTrue(phaseResult.durabilityBarrierNs() > 0,
+            "an executed barrier must have a positive duration");
+      } else {
+        assertEquals(0, phaseResult.durabilityBarrierNs());
+      }
+    }
+    assertTrue(result.shutdownNs() > 0, "shutdown must have a positive duration");
     assertCsvAndDetails(result, csv, 2, 6);
     return result;
   }
@@ -430,8 +440,26 @@ public class SchemaCreationWorkloadTest {
     assertEquals(expectedDataRows + 1, lines.size(), "CSV must contain one row per phase");
     assertEquals(1, lines.stream().filter(CSV_HEADER::equals).count(),
         "CSV header must occur exactly once");
-    assertTrue(lines.stream().skip(1).allMatch(line -> csvField(line, 22).equals("true")),
-        "verified runs must record verificationRan=true");
+    assertTrue(lines.stream().skip(1)
+        .allMatch(line -> csvField(line, 22).equals("COMPLETED")),
+        "verified runs must record verificationState=COMPLETED");
+    assertTrue(result.shutdownNs() > 0, "the returned shutdown time must be positive");
+    for (var line : lines.stream()
+        .skip(1)
+        .filter(row -> csvField(row, 1).equals(result.runId()))
+        .toList()) {
+      var phase = Phase.valueOf(csvField(line, 6));
+      var phaseResult = result.phases().stream()
+          .filter(candidate -> candidate.phase() == phase)
+          .findFirst()
+          .orElseThrow();
+      assertEquals(phaseResult.durabilityBarrierNs(), Long.parseLong(csvField(line, 12)));
+      assertEquals(
+          phaseResult.durabilityBarrierRan(), Boolean.parseBoolean(csvField(line, 13)));
+      assertEquals(result.shutdownNs(), Long.parseLong(csvField(line, 15)));
+      assertTrue(Long.parseLong(csvField(line, 15)) > 0,
+          "the CSV shutdown time must be positive");
+    }
 
     var details = Files.readAllLines(result.detailFile(), StandardCharsets.UTF_8);
     assertEquals(DETAIL_HEADER, details.getFirst());

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
@@ -29,10 +29,14 @@ import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.Phase;
 import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.Policy;
 import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.PropertyPath;
 import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.RunResult;
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.SecurityFilter;
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.VerificationState;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
 import com.jetbrains.youtrackdb.internal.core.db.SessionListener;
 import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
 import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.PropertyType;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
 import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransaction;
 import com.jetbrains.youtrackdb.internal.core.tx.Transaction;
@@ -42,6 +46,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
@@ -56,17 +61,17 @@ import org.junit.jupiter.api.io.TempDir;
 public class SchemaCreationWorkloadTest {
 
   private static final String CSV_HEADER =
-      "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
-          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,"
-          + "shutdownNs,schemaWorkMs,durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,"
-          + "unsafePropertyCreations,verificationState,jvmArgs,assertionsEnabled,storageCallFsync,"
+      "schemaVersion,timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,"
+          + "indexes,compositeIndexes,compositeIndexWidth,securityFilter,uniquePropertyNames,"
+          + "schemaWorkNs,durabilityBarrierNs,durabilityBarrierRan,totalNs,shutdownNs,schemaWorkMs,"
+          + "durabilityBarrierMs,totalMs,shutdownMs,topLevelTransactions,unsafePropertyCreations,"
+          + "verificationState,jvmArgs,assertionsEnabled,storageCallFsync,"
           + "storageFullCheckpointAfterCreate,osOpenFileSoftLimit,osOpenFileHardLimit,"
           + "resolvedOpenFilesLimit,gitCommit,gitDirty,coreImplementationVersion,coreBuildNumber,"
           + "coreBuildVersion,coreCodeSource,javaVersion,osName,garbageCollectors,hostName,"
-          + "availableProcessors,maxHeapBytes,"
-          + "effectiveDatabasePath";
+          + "availableProcessors,maxHeapBytes,effectiveDatabasePath";
   private static final String DETAIL_HEADER =
-      "runId,phase,completedClasses,cumulativeSchemaWorkNs";
+      "schemaVersion,runId,phase,completedClasses,cumulativeSchemaWorkNs";
   private static final String EXPECTED_MANIFEST = """
       class TestClass0
         property TestClass0Prop0 type=STRING
@@ -113,8 +118,8 @@ public class SchemaCreationWorkloadTest {
     }
     var barrierOffRows = Files.readAllLines(
         temporaryDirectory.resolve("all-safe-no-barrier/results.csv"), StandardCharsets.UTF_8);
-    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 12).equals("0")));
-    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 13).equals("false")));
+    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 16).equals("0")));
+    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 17).equals("false")));
 
     var splitDirectory = temporaryDirectory.resolve("split");
     var splitCsv = splitDirectory.resolve("results.csv");
@@ -213,6 +218,161 @@ public class SchemaCreationWorkloadTest {
   }
 
   @Test
+  void compositeIndexesUseStableDistinctFieldsAtWidthsTwoAndThree() throws IOException {
+    var widthTwo = runCompositeCase(
+        "composite-width-two", 1, 6, 0, 2, 2, SecurityFilter.NONE);
+    var widthTwoManifest = widthTwo.manifestText().orElseThrow();
+    assertTrue(widthTwoManifest.contains(
+        "index TestCompositeIndex_0_0 type=UNIQUE fields=TestClass0Prop0,TestClass0Prop1"));
+    assertTrue(widthTwoManifest.contains(
+        "index TestCompositeIndex_0_1 type=UNIQUE fields=TestClass0Prop2,TestClass0Prop3"));
+    assertEquals(
+        VerificationState.COMPLETED_COMPOSITE_INDEX_PROOF, widthTwo.verificationState());
+
+    var widthThree = runCompositeCase(
+        "composite-width-three", 1, 6, 0, 2, 3, SecurityFilter.NONE);
+    var widthThreeManifest = widthThree.manifestText().orElseThrow();
+    assertTrue(widthThreeManifest.contains(
+        "index TestCompositeIndex_0_0 type=UNIQUE fields=TestClass0Prop0,TestClass0Prop1,"
+            + "TestClass0Prop2"));
+    assertTrue(widthThreeManifest.contains(
+        "index TestCompositeIndex_0_1 type=UNIQUE fields=TestClass0Prop3,TestClass0Prop4,"
+            + "TestClass0Prop5"));
+  }
+
+  @Test
+  void compositeAndSingleIndexesCanBeMeasuredTogether() throws IOException {
+    var result = runCompositeCase(
+        "mixed-indexes", 1, 4, 2, 1, 2, SecurityFilter.NONE);
+    var manifest = result.manifestText().orElseThrow();
+    assertTrue(manifest.contains("index TestIndex_0_0 type=UNIQUE fields=TestClass0Prop0"));
+    assertTrue(manifest.contains("index TestIndex_0_1 type=UNIQUE fields=TestClass0Prop1"));
+    assertTrue(manifest.contains(
+        "index TestCompositeIndex_0_0 type=UNIQUE fields=TestClass0Prop0,TestClass0Prop1"));
+  }
+
+  @Test
+  void absentNewOptionsPreserveTheLegacyWorkloadShape() throws IOException {
+    var defaults = Configuration.fromProperties(
+        name -> null, Policy.NONE, PropertyPath.SAFE);
+    assertEquals(100, defaults.classes());
+    assertEquals(20, defaults.properties());
+    assertEquals(20, defaults.indexes());
+    assertEquals(0, defaults.compositeIndexes());
+    assertEquals(2, defaults.compositeIndexWidth());
+    assertEquals(SecurityFilter.NONE, defaults.securityFilter());
+
+    var legacy = runCustomCase("legacy-default-options", 1, 3, 3);
+    var expected = EXPECTED_MANIFEST.lines()
+        .takeWhile(line -> !line.equals("class TestClass1"))
+        .collect(java.util.stream.Collectors.joining("\n", "", "\n"));
+    assertEquals(expected, legacy.manifestText().orElseThrow(),
+        "omitting every new option must preserve the legacy manifest byte for byte");
+  }
+
+  @Test
+  void verificationRejectsCompositeIndexesWithWrongFieldsOrWidth() {
+    assertMalformedCompositeRejected(
+        "wrong-composite-fields",
+        List.of("TestClass0Prop0", "TestClass0Prop2"),
+        "expected [TestClass0Prop0, TestClass0Prop1] (width 2)");
+    assertMalformedCompositeRejected(
+        "wrong-composite-width",
+        List.of("TestClass0Prop0", "TestClass0Prop1", "TestClass0Prop2"),
+        "width 3");
+  }
+
+  @Test
+  void incompatibleResultAndDetailHeadersAreRejectedBeforeWorkStarts() throws IOException {
+    var resultDirectory = temporaryDirectory.resolve("bad-result-header");
+    var resultFile = resultDirectory.resolve("results.csv");
+    Files.createDirectories(resultDirectory);
+    Files.writeString(resultFile, "legacy-result-header\n", StandardCharsets.UTF_8);
+    var resultFailure = assertThrows(IOException.class,
+        () -> SchemaCreationWorkload.run(configuration(
+            resultDirectory.resolve("database"),
+            "bad_result_header",
+            resultFile,
+            resultDirectory.resolve("manifest.txt"),
+            Policy.ALL,
+            1,
+            PropertyPath.SAFE,
+            Phase.AB,
+            1,
+            1,
+            1)));
+    assertTrue(resultFailure.getMessage().contains("legacy-result-header"));
+    assertTrue(resultFailure.getMessage().contains(CSV_HEADER));
+    assertFalse(Files.exists(resultDirectory.resolve("database")),
+        "header validation must happen before database work");
+
+    var detailDirectory = temporaryDirectory.resolve("bad-detail-header");
+    var detailResult = detailDirectory.resolve("results.csv");
+    var detailFile = detailResult.resolveSibling(detailResult.getFileName() + ".detail.csv");
+    Files.createDirectories(detailDirectory);
+    Files.writeString(detailResult, CSV_HEADER + "\n", StandardCharsets.UTF_8);
+    Files.writeString(detailFile, "legacy-detail-header\n", StandardCharsets.UTF_8);
+    var detailFailure = assertThrows(IOException.class,
+        () -> SchemaCreationWorkload.run(configuration(
+            detailDirectory.resolve("database"),
+            "bad_detail_header",
+            detailResult,
+            detailDirectory.resolve("manifest.txt"),
+            Policy.ALL,
+            1,
+            PropertyPath.SAFE,
+            Phase.AB,
+            1,
+            1,
+            1)));
+    assertTrue(detailFailure.getMessage().contains("legacy-detail-header"));
+    assertTrue(detailFailure.getMessage().contains(DETAIL_HEADER));
+  }
+
+  @Test
+  void unrelatedSecurityRulesReachCompositeCheckWithoutBlockingCreation() throws IOException {
+    var result = runCompositeCase(
+        "unrelated-security", 2, 4, 1, 1, 2, SecurityFilter.UNRELATED);
+    assertEquals(
+        VerificationState.COMPLETED_COMPOSITE_INDEX_PROOF, result.verificationState());
+
+    var databasePath = temporaryDirectory.resolve("unrelated-security/database");
+    try (var manager = (YouTrackDBImpl) YourTracks.instance(databasePath.toString());
+        var session = manager.open("unrelated_security", "admin", "admin")) {
+      var filtered = session.getSharedContext().getSecurity().getAllFilteredProperties(session);
+      for (var classIndex = 0; classIndex < 2; classIndex++) {
+        var className = "TestClass" + classIndex;
+        assertTrue(filtered.stream().anyMatch(resource -> className.equals(resource.getClassName())
+            && "SecurityUnrelatedProperty".equals(resource.getPropertyName())));
+        var coveredFields =
+            session.getSharedContext().getIndexManager().getIndexes(session).stream()
+                .filter(index -> index.getDefinition() != null)
+                .filter(index -> className.equals(index.getDefinition().getClassName()))
+                .flatMap(index -> index.getDefinition().getFieldsToIndex().stream())
+                .toList();
+        assertFalse(coveredFields.contains("SecurityUnrelatedProperty"));
+      }
+    }
+  }
+
+  @Test
+  void singleIndexAliasHasExplicitPrecedenceAndRejectsContradictions() {
+    assertEquals(20, parsedConfiguration(Map.of()).indexes());
+    assertEquals(7, parsedConfiguration(Map.of("bench.indexes", "7")).indexes());
+    assertEquals(6, parsedConfiguration(Map.of("bench.singleIndexes", "6")).indexes());
+    assertEquals(5, parsedConfiguration(Map.of(
+        "bench.indexes", "5", "bench.singleIndexes", "5")).indexes());
+    assertEquals(4, parsedConfiguration(Map.of(
+        "bench.indexes", "", "bench.singleIndexes", "4")).indexes());
+
+    var contradiction = assertThrows(IllegalArgumentException.class,
+        () -> parsedConfiguration(Map.of(
+            "bench.indexes", "3", "bench.singleIndexes", "4")));
+    assertTrue(contradiction.getMessage().contains("bench.singleIndexes=4"));
+    assertTrue(contradiction.getMessage().contains("bench.indexes=3"));
+  }
+
+  @Test
   void invalidAndMissingInputsFailInsteadOfContinuing() {
     var missing = configuration(
         temporaryDirectory.resolve("missing/database"),
@@ -245,6 +405,72 @@ public class SchemaCreationWorkloadTest {
     var mismatch = assertThrows(IllegalStateException.class,
         () -> SchemaCreationWorkload.requireEqualManifests("class Expected\n", "class Actual\n"));
     assertTrue(mismatch.getMessage().contains("Manifest differs at line 1"));
+  }
+
+  private RunResult runCompositeCase(
+      String name,
+      int classes,
+      int properties,
+      int indexes,
+      int compositeIndexes,
+      int compositeIndexWidth,
+      SecurityFilter securityFilter) throws IOException {
+    var directory = temporaryDirectory.resolve(name);
+    var resultFile = directory.resolve("results.csv");
+    var result = SchemaCreationWorkload.run(configurationWithIndexes(
+        directory.resolve("database"),
+        name.replace('-', '_'),
+        resultFile,
+        directory.resolve("manifest.txt"),
+        Phase.AB,
+        classes,
+        properties,
+        indexes,
+        compositeIndexes,
+        compositeIndexWidth,
+        securityFilter));
+    assertPhase(result, Phase.A, 1, 0);
+    assertPhase(result, Phase.B, 1, 0);
+    assertCsvAndDetails(result, resultFile, 2, classes * 2);
+    return result;
+  }
+
+  private void assertMalformedCompositeRejected(
+      String name, List<String> actualFields, String expectedMessage) {
+    var directory = temporaryDirectory.resolve(name);
+    var databaseName = name.replace('-', '_');
+    try (var manager = (YouTrackDBImpl) YourTracks.instance(directory.toString())) {
+      manager.create(databaseName, DatabaseType.DISK, "admin", "admin", "admin");
+      try (var session = manager.open(databaseName, "admin", "admin")) {
+        var schemaClass = session.getSchema().createClass("TestClass0");
+        for (var propertyIndex = 0; propertyIndex < 3; propertyIndex++) {
+          schemaClass.createProperty("TestClass0Prop" + propertyIndex, PropertyType.STRING);
+        }
+        schemaClass.createIndex(
+            "TestCompositeIndex_0_0",
+            SchemaClass.INDEX_TYPE.UNIQUE,
+            actualFields.toArray(String[]::new));
+        var config = configurationWithIndexes(
+            directory,
+            databaseName,
+            temporaryDirectory.resolve(name + ".csv"),
+            temporaryDirectory.resolve(name + ".txt"),
+            Phase.B,
+            1,
+            3,
+            0,
+            1,
+            2,
+            SecurityFilter.NONE);
+        var failure = assertThrows(IllegalStateException.class,
+            () -> SchemaCreationWorkload.proveIndexes(config, session));
+        assertTrue(failure.getMessage().contains(expectedMessage), failure.getMessage());
+      }
+    }
+  }
+
+  private static Configuration parsedConfiguration(Map<String, String> values) {
+    return Configuration.fromProperties(values::get, Policy.NONE, PropertyPath.SAFE);
   }
 
   private void assertObservedCommits(
@@ -375,6 +601,39 @@ public class SchemaCreationWorkloadTest {
         phaseResult.totalNs());
   }
 
+  private static Configuration configurationWithIndexes(
+      Path databasePath,
+      String databaseName,
+      Path csv,
+      Path manifest,
+      Phase phase,
+      int classes,
+      int properties,
+      int indexes,
+      int compositeIndexes,
+      int compositeIndexWidth,
+      SecurityFilter securityFilter) {
+    return new Configuration(
+        classes,
+        properties,
+        indexes,
+        compositeIndexes,
+        compositeIndexWidth,
+        securityFilter,
+        Policy.ALL,
+        classes,
+        PropertyPath.SAFE,
+        phase,
+        true,
+        databasePath,
+        databaseName,
+        csv,
+        manifest,
+        true,
+        true,
+        "smoke");
+  }
+
   private static Configuration configuration(
       Path databasePath,
       String databaseName,
@@ -419,6 +678,9 @@ public class SchemaCreationWorkloadTest {
         classes,
         properties,
         indexes,
+        0,
+        2,
+        SecurityFilter.NONE,
         policy,
         batchSize,
         propertyPath,
@@ -440,30 +702,34 @@ public class SchemaCreationWorkloadTest {
     assertEquals(expectedDataRows + 1, lines.size(), "CSV must contain one row per phase");
     assertEquals(1, lines.stream().filter(CSV_HEADER::equals).count(),
         "CSV header must occur exactly once");
+    assertTrue(lines.stream().skip(1).allMatch(line -> csvField(line, 0).equals("2")),
+        "every result row must identify CSV schema version 2");
     assertTrue(lines.stream().skip(1)
-        .allMatch(line -> csvField(line, 22).equals("COMPLETED")),
-        "verified runs must record verificationState=COMPLETED");
+        .allMatch(line -> csvField(line, 26).equals(result.verificationState().name())),
+        "verified runs must record their exact verification state");
     assertTrue(result.shutdownNs() > 0, "the returned shutdown time must be positive");
     for (var line : lines.stream()
         .skip(1)
-        .filter(row -> csvField(row, 1).equals(result.runId()))
+        .filter(row -> csvField(row, 2).equals(result.runId()))
         .toList()) {
-      var phase = Phase.valueOf(csvField(line, 6));
+      var phase = Phase.valueOf(csvField(line, 7));
       var phaseResult = result.phases().stream()
           .filter(candidate -> candidate.phase() == phase)
           .findFirst()
           .orElseThrow();
-      assertEquals(phaseResult.durabilityBarrierNs(), Long.parseLong(csvField(line, 12)));
+      assertEquals(phaseResult.durabilityBarrierNs(), Long.parseLong(csvField(line, 16)));
       assertEquals(
-          phaseResult.durabilityBarrierRan(), Boolean.parseBoolean(csvField(line, 13)));
-      assertEquals(result.shutdownNs(), Long.parseLong(csvField(line, 15)));
-      assertTrue(Long.parseLong(csvField(line, 15)) > 0,
+          phaseResult.durabilityBarrierRan(), Boolean.parseBoolean(csvField(line, 17)));
+      assertEquals(result.shutdownNs(), Long.parseLong(csvField(line, 19)));
+      assertTrue(Long.parseLong(csvField(line, 19)) > 0,
           "the CSV shutdown time must be positive");
     }
 
     var details = Files.readAllLines(result.detailFile(), StandardCharsets.UTF_8);
     assertEquals(DETAIL_HEADER, details.getFirst());
     assertEquals(expectedDetailRows + 1, details.size());
+    assertTrue(details.stream().skip(1).allMatch(line -> csvField(line, 0).equals("2")),
+        "every detail row must identify CSV schema version 2");
     var currentRunDetailRows = result.phases().stream()
         .mapToInt(phase -> phase.timingDetails().size())
         .sum();

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
@@ -46,6 +46,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -118,8 +119,10 @@ public class SchemaCreationWorkloadTest {
     }
     var barrierOffRows = Files.readAllLines(
         temporaryDirectory.resolve("all-safe-no-barrier/results.csv"), StandardCharsets.UTF_8);
-    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 16).equals("0")));
-    assertTrue(barrierOffRows.stream().skip(1).allMatch(row -> csvField(row, 17).equals("false")));
+    assertTrue(barrierOffRows.stream().skip(1)
+        .allMatch(row -> csvValue(CSV_HEADER, row, "durabilityBarrierNs").equals("0")));
+    assertTrue(barrierOffRows.stream().skip(1)
+        .allMatch(row -> csvValue(CSV_HEADER, row, "durabilityBarrierRan").equals("false")));
 
     var splitDirectory = temporaryDirectory.resolve("split");
     var splitCsv = splitDirectory.resolve("results.csv");
@@ -228,6 +231,8 @@ public class SchemaCreationWorkloadTest {
         "index TestCompositeIndex_0_1 type=UNIQUE fields=TestClass0Prop2,TestClass0Prop3"));
     assertEquals(
         VerificationState.COMPLETED_COMPOSITE_INDEX_PROOF, widthTwo.verificationState());
+    assertTrue(widthTwo.functionalIndexProofRan(),
+        "composite verification must report that its functional proof ran");
 
     var widthThree = runCompositeCase(
         "composite-width-three", 1, 6, 0, 2, 3, SecurityFilter.NONE);
@@ -262,12 +267,35 @@ public class SchemaCreationWorkloadTest {
     assertEquals(2, defaults.compositeIndexWidth());
     assertEquals(SecurityFilter.NONE, defaults.securityFilter());
 
-    var legacy = runCustomCase("legacy-default-options", 1, 3, 3);
+    var directory = temporaryDirectory.resolve("legacy-default-options");
+    var legacyProperties = new LinkedHashMap<String, String>();
+    legacyProperties.put("bench.classes", "1");
+    legacyProperties.put("bench.properties", "3");
+    legacyProperties.put("bench.indexes", "3");
+    legacyProperties.put("bench.policy", "ALL");
+    legacyProperties.put("bench.batchSize", "1");
+    legacyProperties.put("bench.propertyPath", "SAFE");
+    legacyProperties.put("bench.phase", "AB");
+    legacyProperties.put("bench.uniquePropertyNames", "true");
+    legacyProperties.put("bench.dbPath", directory.resolve("database").toString());
+    legacyProperties.put("bench.dbName", "legacy_default_options");
+    legacyProperties.put("bench.resultFile", directory.resolve("results.csv").toString());
+    legacyProperties.put("bench.manifestFile", directory.resolve("manifest.txt").toString());
+    legacyProperties.put("bench.verify", "true");
+    legacyProperties.put("bench.durabilityBarrier", "true");
+    legacyProperties.put("bench.label", "legacy");
+    var parsedLegacy = Configuration.fromProperties(
+        legacyProperties::get, Policy.NONE, PropertyPath.SAFE);
+    assertEquals(0, parsedLegacy.compositeIndexes());
+    assertEquals(2, parsedLegacy.compositeIndexWidth());
+    assertEquals(SecurityFilter.NONE, parsedLegacy.securityFilter());
+
+    var legacy = SchemaCreationWorkload.run(parsedLegacy);
     var expected = EXPECTED_MANIFEST.lines()
         .takeWhile(line -> !line.equals("class TestClass1"))
         .collect(java.util.stream.Collectors.joining("\n", "", "\n"));
     assertEquals(expected, legacy.manifestText().orElseThrow(),
-        "omitting every new option must preserve the legacy manifest byte for byte");
+        "the parsed legacy command must preserve its manifest byte for byte");
   }
 
   @Test
@@ -330,13 +358,223 @@ public class SchemaCreationWorkloadTest {
   }
 
   @Test
-  void unrelatedSecurityRulesReachCompositeCheckWithoutBlockingCreation() throws IOException {
-    var result = runCompositeCase(
-        "unrelated-security", 2, 4, 1, 1, 2, SecurityFilter.UNRELATED);
+  void appendGuardHandlesLateMismatchMissingNewlineAndEmptyFiles() throws IOException {
+    var lateMismatch = temporaryDirectory.resolve("late-header-mismatch.csv");
+    Files.writeString(lateMismatch, CSV_HEADER + "\n", StandardCharsets.UTF_8);
+    var mismatch = assertThrows(IOException.class,
+        () -> SchemaCreationWorkload.appendRow(
+            lateMismatch, "changed-after-preflight", List.of("value")));
+    assertTrue(mismatch.getMessage().contains(CSV_HEADER));
+    assertTrue(mismatch.getMessage().contains("changed-after-preflight"));
+
+    var missingNewline = temporaryDirectory.resolve("missing-newline.csv");
+    Files.writeString(
+        missingNewline, CSV_HEADER + "\n\"existing\"", StandardCharsets.UTF_8);
+    SchemaCreationWorkload.appendRow(missingNewline, CSV_HEADER, List.of("next"));
+    var separatedLines = Files.readAllLines(missingNewline, StandardCharsets.UTF_8);
+    assertEquals(3, separatedLines.size(),
+        "append must add a separator after an unterminated existing record");
+    assertEquals("\"existing\"", separatedLines.get(1));
+    assertEquals("\"next\"", separatedLines.get(2));
+
+    var emptyDirectory = temporaryDirectory.resolve("empty-output-files");
+    Files.createDirectories(emptyDirectory);
+    var emptyResult = emptyDirectory.resolve("results.csv");
+    var emptyDetail = emptyDirectory.resolve("results.csv.detail.csv");
+    Files.createFile(emptyResult);
+    Files.createFile(emptyDetail);
+    var result = SchemaCreationWorkload.run(configuration(
+        emptyDirectory.resolve("database"),
+        "empty_output_files",
+        emptyResult,
+        emptyDirectory.resolve("manifest.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.AB,
+        1,
+        1,
+        1));
+    assertCsvAndDetails(result, emptyResult, 2, 2);
+  }
+
+  @Test
+  void resultFilesRejectCrossStratumAppendsButAllowSameStratumSweeps() throws IOException {
+    var plainDirectory = temporaryDirectory.resolve("plain-stratum");
+    var plainResult = plainDirectory.resolve("results.csv");
+    SchemaCreationWorkload.run(configuration(
+        plainDirectory.resolve("database-one"),
+        "plain_one",
+        plainResult,
+        plainDirectory.resolve("manifest-one.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.AB,
+        1,
+        2,
+        1));
+    SchemaCreationWorkload.run(configuration(
+        plainDirectory.resolve("database-two"),
+        "plain_two",
+        plainResult,
+        plainDirectory.resolve("manifest-two.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.AB,
+        1,
+        2,
+        2));
+    assertEquals(5, Files.readAllLines(plainResult, StandardCharsets.UTF_8).size(),
+        "plain sweeps must append within their stratum");
+
+    var mixedDirectory = temporaryDirectory.resolve("mixed-stratum-attempt");
+    var mixedConfig = configurationWithIndexes(
+        mixedDirectory.resolve("database"),
+        "mixed_stratum_attempt",
+        plainResult,
+        mixedDirectory.resolve("manifest.txt"),
+        Phase.AB,
+        1,
+        2,
+        0,
+        1,
+        2,
+        SecurityFilter.NONE);
+    var mixedFailure = assertThrows(IOException.class,
+        () -> SchemaCreationWorkload.run(mixedConfig));
+    assertTrue(mixedFailure.getMessage().contains(plainResult.toString()));
+    assertTrue(mixedFailure.getMessage().contains("compositeIndexes=1"));
+    assertTrue(mixedFailure.getMessage().contains("securityFilter=NONE"));
+    assertTrue(mixedFailure.getMessage().contains("compositeIndexes=0"));
+    assertFalse(Files.exists(mixedDirectory.resolve("database")),
+        "stratum validation must reject the run before database work");
+
+    var extendedDirectory = temporaryDirectory.resolve("extended-stratum");
+    var extendedResult = extendedDirectory.resolve("results.csv");
+    SchemaCreationWorkload.run(configurationWithIndexes(
+        extendedDirectory.resolve("database-control"),
+        "extended_control",
+        extendedResult,
+        extendedDirectory.resolve("manifest-control.txt"),
+        Phase.AB,
+        1,
+        2,
+        0,
+        1,
+        2,
+        SecurityFilter.NONE));
+    SchemaCreationWorkload.run(configurationWithIndexes(
+        extendedDirectory.resolve("database-filtered"),
+        "extended_filtered",
+        extendedResult,
+        extendedDirectory.resolve("manifest-filtered.txt"),
+        Phase.AB,
+        1,
+        2,
+        0,
+        1,
+        2,
+        SecurityFilter.UNRELATED));
+    assertEquals(5, Files.readAllLines(extendedResult, StandardCharsets.UTF_8).size(),
+        "paired composite control and filtered runs must share the new stratum");
+  }
+
+  @Test
+  void noneSecurityModeRejectsFiltersPersistedByAnEarlierRun() throws IOException {
+    var filtered = runCompositeCase(
+        "persisted-filter-source", 1, 2, 0, 1, 2, SecurityFilter.UNRELATED);
+    var retryResult = temporaryDirectory.resolve("persisted-filter-retry/results.csv");
+    var retry = configuration(
+        temporaryDirectory.resolve("persisted-filter-source/database"),
+        "persisted_filter_source",
+        retryResult,
+        temporaryDirectory.resolve("persisted-filter-retry/manifest.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.B,
+        1,
+        2,
+        0);
+    var failure = assertThrows(IllegalStateException.class,
+        () -> SchemaCreationWorkload.run(retry));
+    assertTrue(failure.getMessage().contains("bench.securityFilter=NONE"));
+    assertTrue(failure.getMessage().contains("TestClass0.SecurityUnrelatedProperty"));
+    assertFalse(Files.exists(retryResult),
+        "a misleading NONE result row must not be written");
+    assertEquals(VerificationState.COMPLETED_COMPOSITE_INDEX_PROOF,
+        filtered.verificationState());
+  }
+
+  @Test
+  void unrelatedSecurityModeRequiresTheReaderRole() throws IOException {
+    var directory = temporaryDirectory.resolve("missing-reader-role");
+    var resultFile = directory.resolve("results.csv");
+    var phaseA = configurationWithIndexes(
+        directory.resolve("database"),
+        "missing_reader_role",
+        resultFile,
+        directory.resolve("manifest-a.txt"),
+        Phase.A,
+        1,
+        2,
+        0,
+        1,
+        2,
+        SecurityFilter.UNRELATED);
+    SchemaCreationWorkload.run(phaseA);
+    try (var manager = (YouTrackDBImpl) YourTracks.instance(
+        directory.resolve("database").toString());
+        var session = manager.open("missing_reader_role", "admin", "admin")) {
+      assertTrue(session.getSharedContext().getSecurity().dropRole(session, "reader"));
+    }
+
+    var phaseB = configurationWithIndexes(
+        directory.resolve("database"),
+        "missing_reader_role",
+        resultFile,
+        directory.resolve("manifest-b.txt"),
+        Phase.B,
+        1,
+        2,
+        0,
+        1,
+        2,
+        SecurityFilter.UNRELATED);
+    var failure = assertThrows(IllegalStateException.class,
+        () -> SchemaCreationWorkload.run(phaseB));
+    assertTrue(failure.getMessage().contains(
+        "bench.securityFilter=UNRELATED requires the reader security role"));
+  }
+
+  @Test
+  void unrelatedSecurityRulesAreInstalledBeforeCompositeIndexCommit() throws IOException {
+    var directory = temporaryDirectory.resolve("unrelated-security");
+    var resultFile = directory.resolve("results.csv");
+    var configuration = configurationWithIndexes(
+        directory.resolve("database"),
+        "unrelated_security",
+        resultFile,
+        directory.resolve("manifest.txt"),
+        Phase.AB,
+        2,
+        4,
+        1,
+        1,
+        2,
+        SecurityFilter.UNRELATED);
+    var orderingListener = new SecurityOrderingListener();
+    var result = SchemaCreationWorkload.run(configuration, orderingListener);
     assertEquals(
         VerificationState.COMPLETED_COMPOSITE_INDEX_PROOF, result.verificationState());
+    assertTrue(result.functionalIndexProofRan());
+    assertTrue(orderingListener.filtersPresentBeforeIndexCommit,
+        "property security filters must be visible before the phase-B schema commit");
+    assertCsvAndDetails(result, resultFile, 2, 4, 1, 2, SecurityFilter.UNRELATED);
 
-    var databasePath = temporaryDirectory.resolve("unrelated-security/database");
+    var databasePath = directory.resolve("database");
     try (var manager = (YouTrackDBImpl) YourTracks.instance(databasePath.toString());
         var session = manager.open("unrelated_security", "admin", "admin")) {
       var filtered = session.getSharedContext().getSecurity().getAllFilteredProperties(session);
@@ -370,6 +608,44 @@ public class SchemaCreationWorkloadTest {
             "bench.indexes", "3", "bench.singleIndexes", "4")));
     assertTrue(contradiction.getMessage().contains("bench.singleIndexes=4"));
     assertTrue(contradiction.getMessage().contains("bench.indexes=3"));
+  }
+
+  @Test
+  void compositeValidationRejectsEveryNonCompositeBoundary() throws IOException {
+    assertInvalidCompositeConfiguration(
+        "negative-composite-count", 2, 0, -1, 2,
+        "bench.compositeIndexes must not be negative: -1");
+    assertInvalidCompositeConfiguration(
+        "zero-composite-width", 2, 0, 1, 0,
+        "bench.compositeIndexWidth must be at least two: 0");
+    assertInvalidCompositeConfiguration(
+        "single-composite-width", 2, 0, 1, 1,
+        "bench.compositeIndexWidth must be at least two: 1");
+    assertInvalidCompositeConfiguration(
+        "width-exceeds-properties", 2, 0, 1, 3,
+        "bench.compositeIndexWidth=3 must not exceed bench.properties=2");
+    assertInvalidCompositeConfiguration(
+        "zero-properties-single-index", 0, 1, 0, 2,
+        "bench.indexes=1 must be between zero and bench.properties=0");
+    assertInvalidCompositeConfiguration(
+        "zero-properties-composite-index", 0, 0, 1, 2,
+        "bench.compositeIndexWidth=2 must not exceed bench.properties=0");
+
+    var zeroPropertiesDirectory = temporaryDirectory.resolve("zero-properties-no-indexes");
+    var validZero = SchemaCreationWorkload.run(configurationWithIndexes(
+        zeroPropertiesDirectory.resolve("database"),
+        "zero_properties_no_indexes",
+        zeroPropertiesDirectory.resolve("results.csv"),
+        zeroPropertiesDirectory.resolve("manifest.txt"),
+        Phase.AB,
+        1,
+        0,
+        0,
+        0,
+        2,
+        SecurityFilter.NONE));
+    assertFalse(validZero.manifestText().orElseThrow().contains("property"));
+    assertFalse(validZero.manifestText().orElseThrow().contains("index"));
   }
 
   @Test
@@ -407,6 +683,33 @@ public class SchemaCreationWorkloadTest {
     assertTrue(mismatch.getMessage().contains("Manifest differs at line 1"));
   }
 
+  private void assertInvalidCompositeConfiguration(
+      String name,
+      int properties,
+      int indexes,
+      int compositeIndexes,
+      int compositeIndexWidth,
+      String expectedMessage) {
+    var directory = temporaryDirectory.resolve(name);
+    var invalid = configurationWithIndexes(
+        directory.resolve("database"),
+        name.replace('-', '_'),
+        directory.resolve("results.csv"),
+        directory.resolve("manifest.txt"),
+        Phase.AB,
+        1,
+        properties,
+        indexes,
+        compositeIndexes,
+        compositeIndexWidth,
+        SecurityFilter.NONE);
+    var failure = assertThrows(IllegalArgumentException.class,
+        () -> SchemaCreationWorkload.run(invalid));
+    assertTrue(failure.getMessage().contains(expectedMessage), failure.getMessage());
+    assertFalse(Files.exists(directory.resolve("database")),
+        "invalid dimensions must fail before database work");
+  }
+
   private RunResult runCompositeCase(
       String name,
       int classes,
@@ -431,7 +734,16 @@ public class SchemaCreationWorkloadTest {
         securityFilter));
     assertPhase(result, Phase.A, 1, 0);
     assertPhase(result, Phase.B, 1, 0);
-    assertCsvAndDetails(result, resultFile, 2, classes * 2);
+    assertTrue(result.functionalIndexProofRan(),
+        "verified phase B must report its functional index proof");
+    assertCsvAndDetails(
+        result,
+        resultFile,
+        2,
+        classes * 2,
+        compositeIndexes,
+        compositeIndexWidth,
+        securityFilter);
     return result;
   }
 
@@ -697,49 +1009,121 @@ public class SchemaCreationWorkloadTest {
 
   private static void assertCsvAndDetails(
       RunResult result, Path csv, int expectedDataRows, int expectedDetailRows) throws IOException {
+    assertCsvAndDetails(
+        result,
+        csv,
+        expectedDataRows,
+        expectedDetailRows,
+        0,
+        2,
+        SecurityFilter.NONE);
+  }
+
+  private static void assertCsvAndDetails(
+      RunResult result,
+      Path csv,
+      int expectedDataRows,
+      int expectedDetailRows,
+      int expectedCompositeIndexes,
+      int expectedCompositeIndexWidth,
+      SecurityFilter expectedSecurityFilter) throws IOException {
     var lines = Files.readAllLines(csv, StandardCharsets.UTF_8);
     assertEquals(CSV_HEADER, lines.getFirst(), "CSV header must be written exactly once");
     assertEquals(expectedDataRows + 1, lines.size(), "CSV must contain one row per phase");
     assertEquals(1, lines.stream().filter(CSV_HEADER::equals).count(),
         "CSV header must occur exactly once");
-    assertTrue(lines.stream().skip(1).allMatch(line -> csvField(line, 0).equals("2")),
+    var records = lines.stream().skip(1)
+        .map(line -> csvRecord(CSV_HEADER, line))
+        .toList();
+    assertTrue(records.stream().allMatch(record -> record.get("schemaVersion").equals("2")),
         "every result row must identify CSV schema version 2");
-    assertTrue(lines.stream().skip(1)
-        .allMatch(line -> csvField(line, 26).equals(result.verificationState().name())),
+    assertTrue(records.stream().allMatch(record -> record.get("compositeIndexes").equals(
+        Integer.toString(expectedCompositeIndexes))),
+        "every result row must record the requested composite-index count");
+    assertTrue(records.stream().allMatch(record -> record.get("compositeIndexWidth").equals(
+        Integer.toString(expectedCompositeIndexWidth))),
+        "every result row must record the requested composite-index width");
+    assertTrue(records.stream().allMatch(record -> record.get("securityFilter").equals(
+        expectedSecurityFilter.name())),
+        "every result row must record the requested security-filter mode");
+    assertTrue(records.stream().allMatch(record -> record.get("verificationState").equals(
+        result.verificationState().name())),
         "verified runs must record their exact verification state");
     assertTrue(result.shutdownNs() > 0, "the returned shutdown time must be positive");
-    for (var line : lines.stream()
-        .skip(1)
-        .filter(row -> csvField(row, 2).equals(result.runId()))
+    for (var record : records.stream()
+        .filter(row -> row.get("runId").equals(result.runId()))
         .toList()) {
-      var phase = Phase.valueOf(csvField(line, 7));
+      var phase = Phase.valueOf(record.get("phase"));
       var phaseResult = result.phases().stream()
           .filter(candidate -> candidate.phase() == phase)
           .findFirst()
           .orElseThrow();
-      assertEquals(phaseResult.durabilityBarrierNs(), Long.parseLong(csvField(line, 16)));
       assertEquals(
-          phaseResult.durabilityBarrierRan(), Boolean.parseBoolean(csvField(line, 17)));
-      assertEquals(result.shutdownNs(), Long.parseLong(csvField(line, 19)));
-      assertTrue(Long.parseLong(csvField(line, 19)) > 0,
+          phaseResult.durabilityBarrierNs(),
+          Long.parseLong(record.get("durabilityBarrierNs")));
+      assertEquals(
+          phaseResult.durabilityBarrierRan(),
+          Boolean.parseBoolean(record.get("durabilityBarrierRan")));
+      assertEquals(result.shutdownNs(), Long.parseLong(record.get("shutdownNs")));
+      assertTrue(Long.parseLong(record.get("shutdownNs")) > 0,
           "the CSV shutdown time must be positive");
     }
 
     var details = Files.readAllLines(result.detailFile(), StandardCharsets.UTF_8);
     assertEquals(DETAIL_HEADER, details.getFirst());
     assertEquals(expectedDetailRows + 1, details.size());
-    assertTrue(details.stream().skip(1).allMatch(line -> csvField(line, 0).equals("2")),
+    var detailRecords = details.stream().skip(1)
+        .map(line -> csvRecord(DETAIL_HEADER, line))
+        .toList();
+    assertTrue(detailRecords.stream().allMatch(record -> record.get("schemaVersion").equals("2")),
         "every detail row must identify CSV schema version 2");
     var currentRunDetailRows = result.phases().stream()
         .mapToInt(phase -> phase.timingDetails().size())
         .sum();
-    assertEquals(currentRunDetailRows,
-        details.stream().skip(1).filter(line -> line.contains(result.runId())).count());
+    assertEquals(
+        currentRunDetailRows,
+        detailRecords.stream().filter(record -> record.get("runId").equals(result.runId()))
+            .count());
   }
 
-  private static String csvField(String row, int index) {
-    var fields = row.substring(1, row.length() - 1).split("\"[,]\"", -1);
-    return fields[index].replace("\"\"", "\"");
+  private static String csvValue(String header, String row, String column) {
+    return csvRecord(header, row).get(column);
+  }
+
+  private static Map<String, String> csvRecord(String header, String row) {
+    var columns = List.of(header.split(",", -1));
+    var values = parseCsvValues(row);
+    assertEquals(columns.size(), values.size(), "CSV row must match its header");
+    var record = new LinkedHashMap<String, String>();
+    for (var index = 0; index < columns.size(); index++) {
+      record.put(columns.get(index), values.get(index));
+    }
+    return record;
+  }
+
+  private static List<String> parseCsvValues(String row) {
+    var values = new ArrayList<String>();
+    var value = new StringBuilder();
+    var quoted = false;
+    for (var index = 0; index < row.length(); index++) {
+      var character = row.charAt(index);
+      if (character == '"') {
+        if (quoted && index + 1 < row.length() && row.charAt(index + 1) == '"') {
+          value.append('"');
+          index++;
+        } else {
+          quoted = !quoted;
+        }
+      } else if (character == ',' && !quoted) {
+        values.add(value.toString());
+        value.setLength(0);
+      } else {
+        value.append(character);
+      }
+    }
+    assertFalse(quoted, "CSV row must not contain an unterminated quote");
+    values.add(value.toString());
+    return values;
   }
 
   private static void assertIndexesUsableIndependently(
@@ -759,6 +1143,28 @@ public class SchemaCreationWorkloadTest {
               tx -> index.getRids(session, value).findAny().isPresent());
           assertTrue(found, "index must find the independently queried proof value");
         }
+      }
+    }
+  }
+
+  private static final class SecurityOrderingListener implements SessionListener {
+
+    private int schemaCommits;
+    private boolean filtersPresentBeforeIndexCommit;
+
+    @Override
+    public void onBeforeTxCommit(Transaction transaction) {
+      if (!(transaction instanceof FrontendTransaction frontend)
+          || frontend.getCustomData(DatabaseSessionEmbedded.TX_SCHEMA_STATE_KEY) == null) {
+        return;
+      }
+      schemaCommits++;
+      if (schemaCommits == 2) {
+        filtersPresentBeforeIndexCommit =
+            frontend.getDatabaseSession().getSharedContext().getSecurity()
+                .getAllFilteredProperties(frontend.getDatabaseSession()).stream()
+                .anyMatch(resource -> "TestClass0".equals(resource.getClassName())
+                    && "SecurityUnrelatedProperty".equals(resource.getPropertyName()));
       }
     }
   }

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/SchemaCreationWorkloadTest.java
@@ -1,0 +1,441 @@
+/*
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jetbrains.youtrackdb.benchmarks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.jetbrains.youtrackdb.api.DatabaseType;
+import com.jetbrains.youtrackdb.api.YourTracks;
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.Configuration;
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.Phase;
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.Policy;
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.PropertyPath;
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkload.RunResult;
+import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.db.SessionListener;
+import com.jetbrains.youtrackdb.internal.core.db.YouTrackDBImpl;
+import com.jetbrains.youtrackdb.internal.core.db.record.record.RID;
+import com.jetbrains.youtrackdb.internal.core.storage.impl.local.AbstractStorage;
+import com.jetbrains.youtrackdb.internal.core.tx.FrontendTransaction;
+import com.jetbrains.youtrackdb.internal.core.tx.Transaction;
+import com.jetbrains.youtrackdb.junit.SuiteLifecycleExtension;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that every benchmark mode produces the same persistent schema and exposes its actual
+ * transaction and unsafe-property paths.
+ */
+@ExtendWith(SuiteLifecycleExtension.class)
+public class SchemaCreationWorkloadTest {
+
+  private static final String CSV_HEADER =
+      "timestamp,runId,label,policy,batchSize,propertyPath,phase,classes,properties,indexes,"
+          + "uniquePropertyNames,schemaWorkNs,durabilityBarrierNs,totalNs,schemaWorkMs,"
+          + "durabilityBarrierMs,totalMs,topLevelTransactions,unsafePropertyCreations,"
+          + "verificationRan,jvmArgs,assertionsEnabled,storageCallFsync,"
+          + "storageFullCheckpointAfterCreate,osOpenFileSoftLimit,osOpenFileHardLimit,"
+          + "resolvedOpenFilesLimit,gitCommit,gitDirty,coreImplementationVersion,coreBuildNumber,"
+          + "coreBuildVersion,coreCodeSource,javaVersion,osName,garbageCollectors,hostName,"
+          + "availableProcessors,maxHeapBytes,"
+          + "effectiveDatabasePath";
+  private static final String DETAIL_HEADER =
+      "runId,phase,completedClasses,cumulativeSchemaWorkNs";
+  private static final String EXPECTED_MANIFEST = """
+      class TestClass0
+        property TestClass0Prop0 type=STRING
+        property TestClass0Prop1 type=STRING
+        property TestClass0Prop2 type=STRING
+        index TestIndex_0_0 type=UNIQUE fields=TestClass0Prop0
+        index TestIndex_0_1 type=UNIQUE fields=TestClass0Prop1
+        index TestIndex_0_2 type=UNIQUE fields=TestClass0Prop2
+      class TestClass1
+        property TestClass1Prop0 type=STRING
+        property TestClass1Prop1 type=STRING
+        property TestClass1Prop2 type=STRING
+        index TestIndex_1_0 type=UNIQUE fields=TestClass1Prop0
+        index TestIndex_1_1 type=UNIQUE fields=TestClass1Prop1
+        index TestIndex_1_2 type=UNIQUE fields=TestClass1Prop2
+      class TestClass2
+        property TestClass2Prop0 type=STRING
+        property TestClass2Prop1 type=STRING
+        property TestClass2Prop2 type=STRING
+        index TestIndex_2_0 type=UNIQUE fields=TestClass2Prop0
+        index TestIndex_2_1 type=UNIQUE fields=TestClass2Prop1
+        index TestIndex_2_2 type=UNIQUE fields=TestClass2Prop2
+      """;
+
+  @TempDir
+  Path temporaryDirectory;
+
+  @Test
+  void allModesAndSplitPhasesCreateIdenticalVerifiedSchemas() throws IOException {
+    var completedRuns = new ArrayList<RunResult>();
+    completedRuns.add(runCase("none-safe", Policy.NONE, 50, PropertyPath.SAFE, 0, 0));
+    completedRuns.add(runCase("per-class-safe", Policy.PER_CLASS, 50, PropertyPath.SAFE, 3, 0));
+    completedRuns.add(runCase("batch-safe", Policy.BATCH, 2, PropertyPath.SAFE, 2, 0));
+    completedRuns.add(runCase("all-safe", Policy.ALL, 50, PropertyPath.SAFE, 1, 0));
+    completedRuns.add(runCase("per-class-unsafe", Policy.PER_CLASS, 50,
+        PropertyPath.UNSAFE, 3, 9));
+    completedRuns.add(runCase("all-unsafe", Policy.ALL, 50, PropertyPath.UNSAFE, 1, 9));
+
+    var splitDirectory = temporaryDirectory.resolve("split");
+    var splitCsv = splitDirectory.resolve("results.csv");
+    var phaseAConfig = configuration(
+        splitDirectory.resolve("database"),
+        "splitDatabase",
+        splitCsv,
+        splitDirectory.resolve("manifest-a.txt"),
+        Policy.ALL,
+        50,
+        PropertyPath.SAFE,
+        Phase.A,
+        3,
+        3,
+        3);
+    var phaseA = SchemaCreationWorkload.run(phaseAConfig);
+    assertEquals(1, phaseA.phases().size(), "phase A must report exactly one result");
+    assertPhase(phaseA, Phase.A, 1, 0);
+    assertFalse(phaseA.functionalIndexProofRan(), "phase A must not insert index-proof records");
+
+    var phaseBConfig = configuration(
+        splitDirectory.resolve("database"),
+        "splitDatabase",
+        splitCsv,
+        splitDirectory.resolve("manifest-b.txt"),
+        Policy.ALL,
+        50,
+        PropertyPath.SAFE,
+        Phase.B,
+        3,
+        3,
+        3);
+    var phaseB = SchemaCreationWorkload.run(phaseBConfig);
+    assertPhase(phaseB, Phase.B, 1, 0);
+    assertCsvAndDetails(phaseB, splitCsv, 2, 6);
+
+    for (var result : completedRuns) {
+      assertManifestsEqual(EXPECTED_MANIFEST, result.manifestText().orElseThrow());
+      assertEquals(result.manifestText().orElseThrow(),
+          Files.readString(result.manifestFile(), StandardCharsets.UTF_8));
+    }
+    assertManifestsEqual(EXPECTED_MANIFEST, phaseB.manifestText().orElseThrow());
+    assertIndexesUsableIndependently(
+        temporaryDirectory.resolve("all-safe/database"), "all_safe", 3, 3);
+  }
+
+  @Test
+  void databaseListenerObservesIndependentCommitsForEveryPolicyAndPhase() throws IOException {
+    assertObservedCommits("observed-none", Policy.NONE, 2, 0);
+    assertObservedCommits("observed-per-class", Policy.PER_CLASS, 2, 3);
+    assertObservedCommits("observed-batch", Policy.BATCH, 2, 2);
+    assertObservedCommits("observed-all", Policy.ALL, 2, 1);
+  }
+
+  @Test
+  void phaseGuardRejectsAnAlreadyActiveTransaction() {
+    var directory = temporaryDirectory.resolve("active-transaction-guard");
+    try (var manager = (YouTrackDBImpl) YourTracks.instance(directory.toString())) {
+      manager.create("guardDatabase", DatabaseType.DISK, "admin", "admin", "admin");
+      try (var session = manager.open("guardDatabase", "admin", "admin")) {
+        session.begin();
+        var config = configuration(
+            directory,
+            "guardDatabase",
+            temporaryDirectory.resolve("guard/results.csv"),
+            temporaryDirectory.resolve("guard/manifest.txt"),
+            Policy.ALL,
+            1,
+            PropertyPath.SAFE,
+            Phase.A,
+            1,
+            1,
+            0);
+        var failure = assertThrows(IllegalStateException.class,
+            () -> SchemaCreationWorkload.runPhaseForTesting(config, session, Phase.A));
+        assertTrue(failure.getMessage().contains("no active transaction at its start"));
+        session.rollback();
+      }
+    }
+  }
+
+  @Test
+  void lowerAndZeroIndexCountsPreservePropertyToIndexMapping() throws IOException {
+    var lower = runCustomCase("lower-index-count", 2, 3, 2);
+    var lowerManifest = lower.manifestText().orElseThrow();
+    assertTrue(lowerManifest.contains("property TestClass0Prop2 type=STRING"));
+    assertTrue(lowerManifest.contains("index TestIndex_0_1 type=UNIQUE fields=TestClass0Prop1"));
+    assertFalse(lowerManifest.contains("TestIndex_0_2"));
+    assertIndexesUsableIndependently(
+        temporaryDirectory.resolve("lower-index-count/database"), "lower_index_count", 2, 2);
+
+    var zero = runCustomCase("zero-index-count", 2, 3, 0);
+    var zeroManifest = zero.manifestText().orElseThrow();
+    assertTrue(zeroManifest.contains("property TestClass0Prop2 type=STRING"));
+    assertFalse(zeroManifest.contains("  index "));
+  }
+
+  @Test
+  void invalidAndMissingInputsFailInsteadOfContinuing() {
+    var missing = configuration(
+        temporaryDirectory.resolve("missing/database"),
+        "doesNotExist",
+        temporaryDirectory.resolve("missing/results.csv"),
+        temporaryDirectory.resolve("missing/manifest.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.B,
+        1,
+        1,
+        1);
+    assertThrows(IllegalStateException.class, () -> SchemaCreationWorkload.run(missing));
+
+    var invalid = configuration(
+        temporaryDirectory.resolve("invalid/database"),
+        "invalid",
+        temporaryDirectory.resolve("invalid/results.csv"),
+        temporaryDirectory.resolve("invalid/manifest.txt"),
+        Policy.ALL,
+        1,
+        PropertyPath.SAFE,
+        Phase.A,
+        0,
+        1,
+        1);
+    assertThrows(IllegalArgumentException.class, () -> SchemaCreationWorkload.run(invalid));
+
+    var mismatch = assertThrows(IllegalStateException.class,
+        () -> SchemaCreationWorkload.requireEqualManifests("class Expected\n", "class Actual\n"));
+    assertTrue(mismatch.getMessage().contains("Manifest differs at line 1"));
+  }
+
+  private void assertObservedCommits(
+      String name, Policy policy, int batchSize, int expectedCommits) throws IOException {
+    var directory = temporaryDirectory.resolve(name);
+    var csv = directory.resolve("results.csv");
+    var phaseAListener = new SchemaCommitListener();
+    SchemaCreationWorkload.run(configuration(
+        directory.resolve("database"),
+        name.replace('-', '_'),
+        csv,
+        directory.resolve("manifest-a.txt"),
+        policy,
+        batchSize,
+        PropertyPath.SAFE,
+        Phase.A,
+        3,
+        1,
+        1), phaseAListener);
+    assertEquals(expectedCommits, phaseAListener.commits,
+        "database listener must observe phase-A top-level schema commits for " + policy);
+
+    var phaseBListener = new SchemaCommitListener();
+    SchemaCreationWorkload.run(configuration(
+        directory.resolve("database"),
+        name.replace('-', '_'),
+        csv,
+        directory.resolve("manifest-b.txt"),
+        policy,
+        batchSize,
+        PropertyPath.SAFE,
+        Phase.B,
+        3,
+        1,
+        1), phaseBListener);
+    assertEquals(expectedCommits, phaseBListener.commits,
+        "database listener must observe phase-B top-level schema commits for " + policy);
+  }
+
+  private RunResult runCase(
+      String name,
+      Policy policy,
+      int batchSize,
+      PropertyPath propertyPath,
+      int expectedTransactions,
+      int expectedUnsafeProperties) throws IOException {
+    var directory = temporaryDirectory.resolve(name);
+    var csv = directory.resolve("results.csv");
+    var result = SchemaCreationWorkload.run(configuration(
+        directory.resolve("database"),
+        name.replace('-', '_'),
+        csv,
+        directory.resolve("manifest.txt"),
+        policy,
+        batchSize,
+        propertyPath,
+        Phase.AB,
+        3,
+        3,
+        3));
+    assertEquals(2, result.phases().size(), "AB must report one result for each phase");
+    assertPhase(result, Phase.A, expectedTransactions, expectedUnsafeProperties);
+    assertPhase(result, Phase.B, expectedTransactions, 0);
+    assertCsvAndDetails(result, csv, 2, 6);
+    return result;
+  }
+
+  private RunResult runCustomCase(String name, int classes, int properties, int indexes)
+      throws IOException {
+    var directory = temporaryDirectory.resolve(name);
+    var csv = directory.resolve("results.csv");
+    var result = SchemaCreationWorkload.run(configuration(
+        directory.resolve("database"),
+        name.replace('-', '_'),
+        csv,
+        directory.resolve("manifest.txt"),
+        Policy.ALL,
+        classes,
+        PropertyPath.SAFE,
+        Phase.AB,
+        classes,
+        properties,
+        indexes));
+    assertPhase(result, Phase.A, 1, 0);
+    assertPhase(result, Phase.B, 1, 0);
+    assertCsvAndDetails(result, csv, 2, classes * 2);
+    return result;
+  }
+
+  private static void assertPhase(
+      RunResult result, Phase phase, int transactions, int unsafeProperties) {
+    var phaseResult = result.phases().stream()
+        .filter(candidate -> candidate.phase() == phase)
+        .findFirst()
+        .orElseThrow();
+    assertEquals(transactions, phaseResult.topLevelTransactions());
+    assertEquals(unsafeProperties, phaseResult.unsafePropertyCreations());
+    assertEquals(phaseResult.schemaWorkNs() + phaseResult.durabilityBarrierNs(),
+        phaseResult.totalNs());
+  }
+
+  private static Configuration configuration(
+      Path databasePath,
+      String databaseName,
+      Path csv,
+      Path manifest,
+      Policy policy,
+      int batchSize,
+      PropertyPath propertyPath,
+      Phase phase,
+      int classes,
+      int properties,
+      int indexes) {
+    return new Configuration(
+        classes,
+        properties,
+        indexes,
+        policy,
+        batchSize,
+        propertyPath,
+        phase,
+        true,
+        databasePath,
+        databaseName,
+        csv,
+        manifest,
+        true,
+        "smoke");
+  }
+
+  private static void assertCsvAndDetails(
+      RunResult result, Path csv, int expectedDataRows, int expectedDetailRows) throws IOException {
+    var lines = Files.readAllLines(csv, StandardCharsets.UTF_8);
+    assertEquals(CSV_HEADER, lines.getFirst(), "CSV header must be written exactly once");
+    assertEquals(expectedDataRows + 1, lines.size(), "CSV must contain one row per phase");
+    assertEquals(1, lines.stream().filter(CSV_HEADER::equals).count(),
+        "CSV header must occur exactly once");
+    assertTrue(lines.stream().skip(1).allMatch(line -> csvField(line, 19).equals("true")),
+        "verified runs must record verificationRan=true");
+
+    var details = Files.readAllLines(result.detailFile(), StandardCharsets.UTF_8);
+    assertEquals(DETAIL_HEADER, details.getFirst());
+    assertEquals(expectedDetailRows + 1, details.size());
+    var currentRunDetailRows = result.phases().stream()
+        .mapToInt(phase -> phase.timingDetails().size())
+        .sum();
+    assertEquals(currentRunDetailRows,
+        details.stream().skip(1).filter(line -> line.contains(result.runId())).count());
+  }
+
+  private static String csvField(String row, int index) {
+    var fields = row.substring(1, row.length() - 1).split("\"[,]\"", -1);
+    return fields[index].replace("\"\"", "\"");
+  }
+
+  private static void assertIndexesUsableIndependently(
+      Path databasePath, String databaseName, int classes, int indexes) {
+    try (var manager = (YouTrackDBImpl) YourTracks.instance(databasePath.toString());
+        var session = manager.open(databaseName, "admin", "admin")) {
+      for (var classIndex = 0; classIndex < classes; classIndex++) {
+        for (var indexNumber = 0; indexNumber < indexes; indexNumber++) {
+          var indexName = "TestIndex_" + classIndex + "_" + indexNumber;
+          var index = session.getSharedContext().getIndexManager().getIndex(session, indexName);
+          assertNotNull(index, "index manager must publish " + indexName);
+          assertTrue(index.getIndexId() >= 0, "index must have a real engine id");
+          assertTrue(((AbstractStorage) session.getStorage()).loadIndexEngine(indexName) >= 0,
+              "storage must load the index engine");
+          var value = "value_" + classIndex + "_" + indexNumber;
+          var found = session.computeInTx(
+              tx -> index.getRids(session, value).findAny().isPresent());
+          assertTrue(found, "index must find the independently queried proof value");
+        }
+      }
+    }
+  }
+
+  private static final class SchemaCommitListener implements SessionListener {
+
+    private int commits;
+
+    @Override
+    public void onAfterTxCommit(Transaction transaction, @Nullable Map<RID, RID> ridMapping) {
+      if (transaction instanceof FrontendTransaction frontend
+          && frontend.getCustomData(DatabaseSessionEmbedded.TX_SCHEMA_STATE_KEY) != null) {
+        commits++;
+      }
+    }
+  }
+
+  private static void assertManifestsEqual(String expected, String actual) {
+    if (expected.equals(actual)) {
+      return;
+    }
+    var expectedLines = expected.lines().toList();
+    var actualLines = actual.lines().toList();
+    var commonLines = Math.min(expectedLines.size(), actualLines.size());
+    for (var line = 0; line < commonLines; line++) {
+      if (!expectedLines.get(line).equals(actualLines.get(line))) {
+        fail("Manifest differs at line " + (line + 1) + ": expected <" + expectedLines.get(line)
+            + "> but was <" + actualLines.get(line) + ">");
+      }
+    }
+    fail("Manifest differs at line " + (commonLines + 1) + ": one manifest ended early");
+  }
+}

--- a/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/TxSchemaCreationBenchmark.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/benchmarks/TxSchemaCreationBenchmark.java
@@ -15,10 +15,10 @@
  */
 package com.jetbrains.youtrackdb.benchmarks;
 
-public class SchemaCreationBenchmark {
+public class TxSchemaCreationBenchmark {
 
   public static void main(String[] args) {
     SchemaCreationWorkload.runMain(
-        SchemaCreationWorkload.Policy.NONE, SchemaCreationWorkload.PropertyPath.SAFE);
+        SchemaCreationWorkload.Policy.ALL, SchemaCreationWorkload.PropertyPath.SAFE);
   }
 }

--- a/tests/src/test/java/com/jetbrains/youtrackdb/junit/EmbeddedTestSuite.java
+++ b/tests/src/test/java/com/jetbrains/youtrackdb/junit/EmbeddedTestSuite.java
@@ -1,5 +1,6 @@
 package com.jetbrains.youtrackdb.junit;
 
+import com.jetbrains.youtrackdb.benchmarks.SchemaCreationWorkloadTest;
 import com.jetbrains.youtrackdb.junit.hooks.HookOnIndexedMapTest;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
@@ -13,6 +14,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectClasses({
     SmokeTest.class,
+    SchemaCreationWorkloadTest.class,
     // DbCreation
     DbCreationTest.class,
     DbListenerTest.class,


### PR DESCRIPTION
#### Motivation:

Transactional schema support aims to make schema changes faster. The user still reports slow schema creation.

The repository had one non-transactional benchmark. It had no Maven run wiring and no machine-readable result. We could not compare transaction policies or identify bottlenecks safely.

The benchmark established the main paths before product optimization began.

#### Planned changes:

**Current state**

Transactional schema changes avoid repeated full-schema saves. The original benchmark still found high costs in disk synchronization, snapshot rebuilding, and property integrity checks.

Two internal integrity checks ran a database query for every property creation. Query planning rebuilt schema snapshots and applied user-facing read behavior to internal integrity work.

**What shipped**

The benchmark work added one parameterized schema workload with transactional and non-transactional entry points. The workload records machine-readable timing, environment, durability, and loaded-build data.

The composite-index extension added composite indexes and an unrelated security-filter mode. Versioned results and stratum guards prevent invalid comparisons with single-property baselines.

The durability work made the existing fast mode cover every live-storage barrier that can safely skip synchronization. Startup crash detection and write draining remain durable. Double-write truncation remains unconditional to prevent unbounded growth.

Fast-mode documentation now states the durability cost. Disk storage also warns once per Java virtual machine when fast mode is active.

The integrity work replaced both queries when the target holds no committed records. The checks walk records pending in the current transaction and perform validation and migration in memory.

The gain applies when one transaction creates a class and its records. Test runs get faster. A production schema upgrade does not get faster.

The change is not behaviour preserving. Thirteen behavioural differences are specified and tested.

**How**

The benchmark separates transaction policy from property behavior. It measures schema work, optional durability barriers, shutdown work, and inclusive time.

Measurements use clean dedicated hosts, five scales, raw scaling ratios, and profiler-at-start runs. Measurement remains evidence rather than a delivery unit.

Each verified run checks its own manifest after restart. Index runs prove index shape with a write and read. Profiling and counting use separate runs.

The integrity path requires an empty target or provisional collections only. It flushes pending callbacks before walking target collections and records in ascending order.

Validation keeps type checks and linked-class checks in separate passes. Migration updates records in place. Targets with committed concrete data retain the query path.

Operation authorization, unsafe bypasses, rollback scope, callback timing, error text, and committed-data behavior remain unchanged, except for the specified differences.

**Key decisions**

| Chosen | Rejected | Reason |
|---|---|---|
| One shared benchmark workload | Copied entry points | Shared behavior prevents drift. |
| Plain Java entry points | A microbenchmark framework | The workload is long, stateful, and restart-sensitive. |
| Explicit transaction and property modes | A flat mode list | Independent modes expose each behavior clearly. |
| Per-run restart checks and index proofs | Counts alone | Counts cannot prove persistence or index shape. |
| Separate sampling and counting | Combined profiling | Counting changes timing by orders of magnitude. |
| One existing durability setting | A second fast-mode setting | False already accepts lost crash durability. |
| Durable startup metadata | Gating every synchronization | A crash must remain detectable after restart. |
| One provisional-data condition | Security, hook, or size conditions | Provisional collections prove that committed records are unreachable. |
| Ordered target scans | Whole-transaction scans | Target scans bound cost and preserve deterministic error order. |
| Internal record access | User-facing reads | User-facing reads recreate the filtering defects. |
| Two validation passes | One merged pass | Separate passes preserve the winning error. |
| One transaction wrapper per check | Removing wrappers | One wrapper preserves rollback scope. |

**Delivered evidence**

At 1,000 classes, one transaction reduced safe schema time from 2,985.474 seconds to 383.781 seconds. Inclusive time fell from 2,996.258 seconds to 427.666 seconds.

The same workload reduced no-validation schema time from 2,992.228 seconds to 304.424 seconds. Non-transactional growth remained superlinear, while transactional growth stayed near-linear.

Profiles supported repeated schema saving as a major non-transactional cost. They also supported repeated snapshot invalidation during index and safe property creation.

The first hypothesis was supported. Non-transactional property creation repeatedly serializes the schema.

The second hypothesis was weakened. Schema copies occur per transaction, but per-class scaling remains near-linear.

The third hypothesis was structurally supported. Schema-carrying commits perform serialization and snapshot lifecycle passes.

The fourth hypothesis was supported at two sites. Index changes and safe property creation both trigger repeated snapshot rebuilding.

The composite-index extension reduced phase work by 75.4 percent. Full schema work fell 49.5 percent. End-to-end time fell 42.6 percent.

The reported production case still has only an estimated 35.8 percent end-to-end reduction. No post-change measurement of that workload exists.

Disk synchronization consumed 54.5 percent of the reported run. One live-storage barrier ignored the fast durability setting and cost 166.2 seconds.

Profile arithmetic estimates that the delivered fast mode removes about 369 seconds from that 609-second run. Production durability still requires a separate batching design.

The integrity work used same-host before and after measurements. Safe-over-unsafe schema-work ratios fell beyond the measured noise envelope at every tested scale.

Snapshot construction fell from 36.4 percent to 0.23 percent of processor samples. Snapshot reuse was therefore abandoned.

**Out of scope**

- Faster production schema upgrades on classes committed earlier.
- General repair of integrity defects on the committed-data query path.
- Snapshot reuse, because profiling removed its measured premise.
- Property-name migration, query-name escaping, missing linked-map checks, and unconditional migration for unchanged types.
- Startup crash-marker gating, no-operation double-write logging, and durable file-registry batching.
- Populated-class index creation, wider benchmark shapes, and continuous benchmark execution.

**Risks & accepted trade-offs**

| # | Risk or trade-off | Disposition |
|---|---|---|
| R1 | Timing contains wall-clock noise. | Dedicated hosts, repeats, and a measured noise envelope bound claims. |
| R2 | Large runs are slow and memory-heavy. | Reduced scales and time limits bound runs. No measured run exhausted memory. |
| R3 | Hardware and caches affect storage timing. | Host, storage, heap, and open-file limits accompany results. |
| R4 | Benchmark execution uses a locally managed plugin version. | The version matches existing repository use. |
| R5 | A benchmark can be wrong without changing product code. | Unit tests, restart checks, and index proofs cover it. |
| R6 | Results cover new classes only. | Accepted. Populated-class results require separate work. |
| R7 | Counting distorts timing. | Counting never supplies timing claims. |
| R8 | Stale product code can invalidate results. | Commands build dependencies and record loaded-build identity. |
| R9 | Composite results form a separate stratum. | Version checks reject mixed result files. |
| R10 | The reported production result remains an estimate. | The description labels it as an estimate. |
| R11 | Some security rules retain the composite-index slow path. | Accepted. The optimization cannot help those cases. |
| R12 | File synchronization dominates the production remainder. | Any production change needs recovery design and crash tests. |
| R13 | Fast durability mode can lose committed data after a crash. | Accepted only for test runs. Startup crash detection remains durable. |
| R14 | Internal filtering changes can turn property creation success into failure. | Accepted. Tests and the behavior record pin the change. |
| R15 | Read hooks and query listeners stop observing internal integrity reads. | Accepted. Tests pin the new result. |
| R16 | Integrity defects remain on the committed-data path. | Accepted. A separate follow-up owns that path. |
| R17 | Large pending record sets can make direct scans expensive. | Target-subtree scans bound the work. Measurements cover approved scales. |
| R18 | Removing nested queries changes transaction and timeout observations. | One wrapper remains. Specified tests pin observable changes. |
| R19 | Names that break generated query text can succeed only on the direct path. | Accepted pending the separate escaping fix. |
| R20 | A caller no longer receives an undocumented property-filter mutation. | Accepted and specified as a behavior change. |
| R21 | Empty committed abstract classes can use the direct path. | Accepted. Such classes hold no records. Tests cover observable differences. |
| R22 | An extra snapshot-pin assertion might appear necessary. | Rejected. Existing snapshot clearing already reports the structural violation. |
| R23 | A release note file might be required. | Resolved. The repository has no release note file convention. |
| R24 | A caller-chosen property name can influence an internal query predicate on the unchanged path. | Filed separately at priority zero. The current change neither causes nor fixes the defect. |
| R25 | Four claimed behavioral differences were incorrect. | One was withdrawn. Three now describe errors instead of silent success. The design was corrected after each test. |
| R26 | Snapshot reuse lost its measured premise. | Abandoned. Its target fell from 36.4 percent to 0.23 percent after both queries disappeared. |
| R27 | Two additional integrity defects remain outside this change. | Separate reports cover stale policy protection and validation-migration visibility disagreement. |
| R28 | Production schema upgrade speed remains unmeasured and unaddressed. | Deferred. The original request included deployment speed, but the delivered path only covers pending transaction records. |
| R29 | Property type migration runs when the requested type already matches. | A separate issue note records the candidate. Nobody has measured its potential saving. |

A security policy can silently fail to protect a class created after the policy was installed. Validation and migration can also disagree about visible records.

**Release note disposition**

The repository carries no release note file convention. Release notes are generated at release time from commit history.

The commit history and this description carry the behavior change.

**Review outcomes**

The initial design review received user approval on 2026-08-05. Two adversarial rounds produced 25 findings, including seven blockers and one refuted finding.

The measurement publication review corrected three blockers and five major findings. Durability gating used four focused review passes. Durability documentation used two.

The composite-index extension received design approval on 2026-08-06. Four adversarial perspectives found 24 non-blocking issues. Code review, execution review, and user review completed.

The integrity work used five review perspectives. Reviews covered the baseline, security, performance, test structure, and concurrency. The concurrency review returned no findings.

One blocker and two test-quality findings were fixed and verified. Seven suggestions remain separate follow-up work.

Four security claims failed systematic testing. One claimed difference does not exist. Three old paths raise errors instead of succeeding silently.

The corrected specified-difference suite passed. User review approved the delivered work.

**Verification approach**

The unit suite ran 7,345 tests with zero failures. The new test class contains 25 tests.

Coverage reached 92.2 percent line and 88.4 percent branch.

The integration gate set was empty. Both required searches ran instead of relying on an assumption.

Same-host ratios moved from 1.224, 1.325, 1.390, and 1.508 to 0.917, 1.026, 0.994, and 1.049.

Those points represent 50, 100, 200, and 400 classes. The measured noise envelope was 0.122.

Processor samples for immutable schema snapshot construction fell from 36.4 percent to 0.23 percent.

The specified-difference suite is the correctness gate. The ratio never acts as the correctness gate. A path that skipped checks could show the same ratio.

**Suggestions**

- **SE-1 — Linked-collection mismatch errors:** Redact or authorize internally read values before an error exposes them.
- **SE-2 — Pending-record transaction walk:** Assert or filter each record's membership in the target class.
- **SE-3 — Unchanged query path:** Escape property-name delimiters before placing caller-chosen names in predicates.
- **PF-1 — Fast-path condition:** Inspect the final sorted collection identifier instead of scanning the full array.
- **TS1 — Predicate-security tests:** Flatten nested setup helpers so each test shows the behavior it proves.
- **TQ52 — Read-hook regression test:** Add a committed query-path contrast to prove why the hook is absent.
- **TQ53 — Command-count tests:** Assert validation or migration results alongside command activity.

Size check: body is 14,042 UTF-8 bytes, 2,342 below the target. Sections are Planned changes 13,650 and Motivation 392 bytes. Before final condensation, Planned changes was 13,246 bytes.