### PR TITLE
Move test and coverage verification from every commit to track end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Storage engine, Gremlin integration, RID format, generated code pipeline, and th
 
 Role-specific rules live in two documents, keyed by the kind of activity you are about to do:
 
-- **Planning work, choosing verification scope, PR / branch work, reviewing changes for workflow or review discipline, doc-sync duties** → read `docs-internal/agents/orchestrator-guidelines.md` (track-based workflow, test policy, pre-commit verification rules, git conventions, documentation sync).
+- **Planning work, choosing verification scope, PR / branch work, reviewing changes for workflow or review discipline, doc-sync duties** → read `docs-internal/agents/orchestrator-guidelines.md` (track-based workflow, test policy, verification scope, git conventions, documentation sync).
 - **Writing, editing, or reviewing code (style and test rules), running builds / tests / formatting, committing, using web tools, hands-on codebase navigation** → read `docs-internal/agents/thread-guidelines.md` (build commands, code style, testing, committing, codebase tips).
 
 The slate extension — installed from the `ytdb-slate` npm package pinned in `.pi/settings.json` — injects these documents automatically per role (orchestrator vs worker thread). The package also ships the generic track-based workflow protocol (track-workflow.md, pr-publishing.md), cited by absolute path in the orchestrator doctrine; YTDB-specific workflow deltas live in `docs-internal/dev-workflow/track-development.md`. Any agent whose prompt does not already include the relevant document must read it on demand before doing that kind of work.

--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -8,7 +8,8 @@ product documentation lives in the [user documentation index](../docs/README.md)
 
 | Document | Description |
 |---|---|
-| [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, umbrella-PR peer-review policy, track verification protocol, action-level model-routing and failover configuration, package pin-bump rule |
+| [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, umbrella-PR peer-review policy, track verification gates, action-level model-routing and failover configuration, package pin-bump rule |
+| [Coverage Verification](dev-workflow/coverage-verification.md) | On-demand coverage procedure — command sequence, report-set assertion, result diagnosis, and local-versus-CI differences |
 | [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, web tools, codebase tips |
 | [Architecture Decision Records](adr/) | Archive of Architecture Decision Records, plus historical/sunset workflow research logs |

--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -8,7 +8,7 @@ product documentation lives in the [user documentation index](../docs/README.md)
 
 | Document | Description |
 |---|---|
-| [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, umbrella-PR peer-review policy, action-level model-routing and failover configuration, package pin-bump rule |
-| [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, pre-commit verification scope, git/PR conventions, documentation sync |
+| [Track-Based Development](dev-workflow/track-development.md) | YTDB deltas on the generic track-based workflow (the baseline ships with the ytdb-slate package as track-workflow.md and pr-publishing.md) — `develop` base branch, issue-prefix/PR-template conventions, umbrella-PR peer-review policy, track verification protocol, action-level model-routing and failover configuration, package pin-bump rule |
+| [Orchestrator Guidelines](agents/orchestrator-guidelines.md) | Planning and delivery rules for the orchestrator role — track workflow, test policy, verification scope, git/PR conventions, documentation sync |
 | [Worker Thread Guidelines](agents/thread-guidelines.md) | Hands-on engineering rules for worker threads — build commands, code style, Spotless, testing, committing, web tools, codebase tips |
 | [Architecture Decision Records](adr/) | Archive of Architecture Decision Records, plus historical/sunset workflow research logs |

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -34,8 +34,9 @@ How and when verification runs is defined in
 
 ## Verification Gates
 
-Mid-track commits run `./mvnw -pl <modules> -am -amd test-compile` over the compile-gate set. At
-the end of a track's implementation, before its agent code review, full verification runs at every
+Mid-track commits run `./mvnw -pl <modules with changed files> -am -amd test-compile` over the
+compile-gate set. At the end of a track's implementation, before its agent code review, full
+verification runs at every
 tier: unit tests for the test-gate set, integration tests under the decision rules below, and
 coverage at the 85% line / 70% branch thresholds. The complete protocol — including module
 selection, exceptions, coverage measurement, and re-run rules — is in

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -34,11 +34,11 @@ How and when verification runs is defined in
 
 ## Verification Gates
 
-Mid-track commits require `./mvnw -pl <affected modules> -am test-compile`. At the end of a
-track's implementation, before its agent code review, full verification runs at every tier:
-affected-module unit tests, integration tests under the decision rules below, and coverage
-at the 85% line / 70% branch thresholds. The complete protocol — including module selection,
-exceptions, coverage measurement, and re-run rules — is in
+Mid-track commits run `./mvnw -pl <modules> -am -amd test-compile` over the compile-gate set. At
+the end of a track's implementation, before its agent code review, full verification runs at every
+tier: unit tests for the test-gate set, integration tests under the decision rules below, and
+coverage at the 85% line / 70% branch thresholds. The complete protocol — including module
+selection, exceptions, coverage measurement, and re-run rules — is in
 `docs-internal/dev-workflow/track-development.md` § Verification integration.
 
 Run related integration tests (`-P ci-integration-tests`) when a change touches areas covered by

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -29,8 +29,8 @@ prompt, config, or doc is a repository change and takes the same gates.
 - Prefer adding tests to **existing test classes** when the change fits their scope. Only create new test classes when there is no suitable existing one.
 - **Coverage target**: 85% line coverage and 70% branch coverage for new/changed code.
 
-How and when verification runs is defined in
-`docs-internal/dev-workflow/track-development.md` § Verification integration.
+How to run and diagnose coverage verification is defined in
+`docs-internal/dev-workflow/coverage-verification.md`.
 
 ## Verification Gates
 
@@ -38,8 +38,8 @@ Mid-track commits run `./mvnw -pl <modules with changed files> -am -amd test-com
 compile-gate set. At the end of a track's implementation, before its agent code review, full
 verification runs at every
 tier: unit tests for the test-gate set, integration tests under the decision rules below, and
-coverage at the 85% line / 70% branch thresholds. The complete protocol — including module
-selection, exceptions, coverage measurement, and re-run rules — is in
+coverage at the 85% line / 70% branch thresholds. The complete gate protocol — including module
+selection, exceptions, and re-run rules — is in
 `docs-internal/dev-workflow/track-development.md` § Verification integration.
 
 Run related integration tests (`-P ci-integration-tests`) when a change touches areas covered by

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -32,7 +32,7 @@ prompt, config, or doc is a repository change and takes the same gates.
 How and when verification runs is defined in
 `docs-internal/dev-workflow/track-development.md` § Verification integration.
 
-## Pre-Commit Verification
+## Verification Gates
 
 Mid-track commits require `./mvnw -pl <affected modules> -am test-compile`. At the end of a
 track's implementation, before its agent code review, full verification runs at every tier:
@@ -41,8 +41,9 @@ at the 85% line / 70% branch thresholds. The complete protocol — including mod
 exceptions, coverage measurement, and re-run rules — is in
 `docs-internal/dev-workflow/track-development.md` § Verification integration.
 
-Run integration tests (`-P ci-integration-tests`) when a change touches storage, WAL, index,
-Gremlin integration, or transaction handling.
+Run related integration tests (`-P ci-integration-tests`) when a change touches areas covered by
+integration tests; storage, WAL, index, Gremlin integration, and transaction handling are examples.
+If in doubt, run the full unit test suite.
 
 ### Serial Test Execution (Scheduling Invariant)
 

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -27,31 +27,22 @@ prompt, config, or doc is a repository change and takes the same gates.
 - **All code changes must have associated tests** that cover the new or modified behavior.
 - **All bug fixes must include a regression test** reproducing the bug, unless one already exists.
 - Prefer adding tests to **existing test classes** when the change fits their scope. Only create new test classes when there is no suitable existing one.
-- **Coverage target**: 85% line coverage and 70% branch coverage for new/changed code (enforced by CI coverage gate).
-- **Coverage verification**: Always check coverage with the `.github/scripts/coverage-gate.py` script instead of computing it by hand — the exact invocation and the reason manual arithmetic gives wrong results are in `docs-internal/agents/thread-guidelines.md`.
+- **Coverage target**: 85% line coverage and 70% branch coverage for new/changed code.
+
+How and when verification runs is defined in
+`docs-internal/dev-workflow/track-development.md` § Verification integration.
 
 ## Pre-Commit Verification
 
-**Every task MUST be verified before committing.** The decision rules are below; the exact
-`./mvnw` command lines are in `docs-internal/agents/thread-guidelines.md`.
+Mid-track commits require `./mvnw -pl <affected modules> -am test-compile`. At the end of a
+track's implementation, before its agent code review, full verification runs at every tier:
+affected-module unit tests, integration tests under the decision rules below, and coverage
+at the 85% line / 70% branch thresholds. The complete protocol — including module selection,
+exceptions, coverage measurement, and re-run rules — is in
+`docs-internal/dev-workflow/track-development.md` § Verification integration.
 
-1. **Run unit tests** for the affected module(s) before committing. If unsure which modules are
-   affected, run the full unit test suite.
-2. **Run related integration tests** (`-P ci-integration-tests`) if the change touches areas
-   covered by integration tests.
-3. **Check coverage of changed code** by running tests with the `coverage` profile and verifying
-   coverage locally with `.github/scripts/coverage-gate.py` against the thresholds in
-   [Test Policy](#test-policy) above. If coverage is below the threshold, add or improve tests
-   for uncovered lines before committing.
-4. **Do not commit if tests fail.** Fix the failures first, then re-run the tests.
-5. **Determining which tests to run:**
-   - Changes to `core` module: always run the `core` unit tests
-   - Changes to `server` module: run the `server` unit tests
-   - Changes to storage, WAL, or index code: also run integration tests
-   - Changes to Gremlin integration or transaction handling: also run integration tests
-   - Changes to `embedded` module: run the `embedded` unit tests (includes Cucumber feature tests)
-   - Changes to `tests` module: run the `tests` module unit tests
-   - If in doubt, run the full unit test suite
+Run integration tests (`-P ci-integration-tests`) when a change touches storage, WAL, index,
+Gremlin integration, or transaction handling.
 
 ### Serial Test Execution (Scheduling Invariant)
 
@@ -70,7 +61,11 @@ dispatch a build there while another build or test run is in progress.
 - `main` - Used for delivery of artifacts once all tests on `develop` have passed (auto-merged from develop nightly after integration tests pass)
 
 ### Commit Messages
-- Commit-message format and rules live in `docs-internal/agents/thread-guidelines.md` § Committing — workers execute the commits, so supply the intended message (or point at that section) when dispatching a commit task.
+- Commit-message format and rules live in `docs-internal/agents/thread-guidelines.md`
+  § Committing — workers execute the commits, so supply the intended message (or point at that
+  section) when dispatching a commit task. Never commit over a red result actually observed;
+  running tests mid-track is not required. See
+  `docs-internal/dev-workflow/track-development.md` § Verification integration.
 
 ### Force Pushing
 - **Always use `--force-with-lease`** instead of `--force` when force pushing. This prevents accidentally overwriting commits pushed by others since your last fetch.

--- a/docs-internal/agents/slate-doctrine-extra.md
+++ b/docs-internal/agents/slate-doctrine-extra.md
@@ -27,8 +27,8 @@ itself, for changes of any size:
    routing table marks measured for that model, and MUST NOT be sized
    down to the cheapest model that looks like it would clear them:
    adversarial review, agent code review, the design-review and
-   PR-description statements, the ready-for-review flip, Maven
-   build/test/coverage runs, commits and pushes, and any change to
+   PR-description statements, the ready-for-review flip, end-of-track Maven
+   test/coverage runs, commits and pushes, and any change to
    storage, WAL, index, transaction or crash-recovery code.
 
 Rationale, model-list maintenance and the machine-local prerequisite:

--- a/docs-internal/agents/slate-doctrine-extra.md
+++ b/docs-internal/agents/slate-doctrine-extra.md
@@ -27,9 +27,10 @@ itself, for changes of any size:
    routing table marks measured for that model, and MUST NOT be sized
    down to the cheapest model that looks like it would clear them:
    adversarial review, agent code review, the design-review and
-   PR-description statements, the ready-for-review flip, end-of-track Maven
-   test/coverage runs, commits and pushes, and any change to
-   storage, WAL, index, transaction or crash-recovery code.
+   PR-description statements, the ready-for-review flip, all Maven
+   test/coverage verification runs (including end-of-track and post-flip
+   runs), commits and pushes, and any change to storage, WAL, index,
+   transaction or crash-recovery code.
 
 Rationale, model-list maintenance and the machine-local prerequisite:
 `docs-internal/dev-workflow/track-development.md` § Model routing.

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -86,7 +86,7 @@ Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless) 
 
 ### Test Authorship
 
-- **All code changes must have associated tests** that cover the new or modified behavior; bug fixes must include a regression test reproducing the bug, unless one already exists. Tests for a track's code must exist by that track's agent code review; substantial test work may be its own task within the same track, completed before that review.
+- **All code changes must have associated tests** that cover the new or modified behavior; bug fixes must include a regression test reproducing the bug, unless one already exists.
 - Prefer adding tests to **existing test classes** when the change fits their scope; only create new test classes when there is no suitable existing one.
 - Coverage target for new/changed code: 85% line / 70% branch — verify with `coverage-gate.py` (see [Coverage Verification](#coverage-verification) below).
 
@@ -103,11 +103,17 @@ For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDB
 
 ### Coverage Verification
 
-Coverage is verified at the end of the track's implementation, not per commit. Always use `coverage-gate.py` rather than hand arithmetic: its `assert`-line exclusions avoid JaCoCo's phantom uncovered branches and unreachable failure-message lines. For the mandatory hygiene procedure (`.coverage/reports` removal, the report-set assertion, and when a "skip" is not a pass), see `docs-internal/dev-workflow/track-development.md` § Verification integration.
+Always use `coverage-gate.py`, not hand arithmetic. Before running it, read
+`docs-internal/dev-workflow/track-development.md` § Verification integration for the mandatory
+procedure.
 
 ## Committing
 
-- **Never commit over a red result you actually observed.** Running tests mid-track is not required; a mid-track commit requires only that the affected modules compile through `./mvnw -pl <module>[,<module>] -am test-compile` (or the `embedded` shading exception above). Report which gate command you ran and its outcome.
+- **Never commit over a red result you actually observed.** Running tests mid-track is not
+  required. Before a mid-track commit, read
+  `docs-internal/dev-workflow/track-development.md` § Verification integration to select modules
+  and apply gate exceptions. Changes with no Java files or module content require no Maven gate;
+  otherwise run the applicable gate above. Report the command and outcome when a gate runs.
 - The YTDB issue number is carried in the PR title only (auto-prefixed from the branch name by `.github/workflows/pr-title-prefix.yml`). Individual commit subjects do not need it — the squash-merge takes its message from the PR title and description.
 - **Format**:
   ```

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -19,15 +19,15 @@ Planning, verification-scope, and PR rules live in `docs-internal/agents/orchest
 # Run integration tests (separate from PR pipeline, used by nightly CI)
 ./mvnw clean verify -P ci-integration-tests
 
-# Run integration tests for the affected module(s)
+# Run integration tests for the test-gate set
 ./mvnw -pl core clean verify -P ci-integration-tests
 
-# If changes span multiple modules, test all affected ones
+# If the test-gate set spans multiple modules, test them all
 ./mvnw -pl core,server clean test
 
-# Mid-track commit gates (-am is mandatory; use package when embedded shading is affected)
-./mvnw -pl <module>[,<module>] -am test-compile
-./mvnw -pl embedded -am package
+# Mid-track compile gate (read Verification integration to select the compile-gate set)
+./mvnw -pl <modules with changed files> -am -amd test-compile
+./mvnw -pl embedded -am -amd package -DskipTests
 
 # Build with Docker images (requires Docker)
 ./mvnw clean package -P docker-images
@@ -111,9 +111,10 @@ procedure.
 
 - **Never commit over a red result you actually observed.** Running tests mid-track is not
   required. Before a mid-track commit, read
-  `docs-internal/dev-workflow/track-development.md` § Verification integration to select modules
-  and apply gate exceptions. Changes with no Java files or module content require no Maven gate;
-  otherwise run the applicable gate above. Report the command and outcome when a gate runs.
+  `docs-internal/dev-workflow/track-development.md` § Verification integration to select the
+  compile-gate set and apply exceptions. Changes with no Java files or module content require no
+  Maven gate; otherwise run the applicable gate above. Report the command and outcome when a gate
+  runs.
 - The YTDB issue number is carried in the PR title only (auto-prefixed from the branch name by `.github/workflows/pr-title-prefix.yml`). Individual commit subjects do not need it — the squash-merge takes its message from the PR title and description.
 - **Format**:
   ```

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -19,7 +19,7 @@ Planning, verification-scope, and PR rules live in `docs-internal/agents/orchest
 # Run integration tests (separate from PR pipeline, used by nightly CI)
 ./mvnw clean verify -P ci-integration-tests
 
-# Run integration tests for the test-gate set
+# Run integration tests for one module
 ./mvnw -pl core clean verify -P ci-integration-tests
 
 # If the test-gate set spans multiple modules, test them all

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -25,6 +25,10 @@ Planning, verification-scope, and PR rules live in `docs-internal/agents/orchest
 # If changes span multiple modules, test all affected ones
 ./mvnw -pl core,server clean test
 
+# Mid-track commit gates (-am is mandatory; use package when embedded shading is affected)
+./mvnw -pl <module>[,<module>] -am test-compile
+./mvnw -pl embedded -am package
+
 # Build with Docker images (requires Docker)
 ./mvnw clean package -P docker-images
 
@@ -82,13 +86,13 @@ Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless) 
 
 ### Test Authorship
 
-- **All code changes must have associated tests** that cover the new or modified behavior; bug fixes must include a regression test reproducing the bug, unless one already exists.
+- **All code changes must have associated tests** that cover the new or modified behavior; bug fixes must include a regression test reproducing the bug, unless one already exists. Tests for a track's code must exist by that track's agent code review; substantial test work may be its own task within the same track, completed before that review.
 - Prefer adding tests to **existing test classes** when the change fits their scope; only create new test classes when there is no suitable existing one.
 - Coverage target for new/changed code: 85% line / 70% branch — verify with `coverage-gate.py` (see [Coverage Verification](#coverage-verification) below).
 
 ### Test Execution
 
-**NEVER run multiple test processes simultaneously in the same worktree/directory.** Always wait for one `./mvnw test` or `./mvnw verify` invocation to finish before starting another in the same working directory. Running tests in parallel within the same worktree causes classloading errors, database file locking conflicts, and false test failures. This applies to all test execution — unit tests, integration tests, and coverage runs. Tests in separate worktrees/directories do not conflict. The rule extends to any concurrent Maven invocations in the same worktree — wait for a running build to complete before starting another build or test run there.
+**NEVER run multiple test processes simultaneously in the same worktree/directory.** Always wait for one `./mvnw test` or `./mvnw verify` invocation to finish before starting another in the same working directory. Running tests in parallel within the same worktree causes classloading errors, database file locking conflicts, and false test failures. This applies to all test execution — unit tests, integration tests, and coverage runs. Tests in separate worktrees/directories do not conflict. The rule extends to any concurrent Maven invocations in the same worktree — wait for a running build to complete before starting another build or test run there. Running tests mid-track is not required.
 
 ### Test Modules at a Glance
 - **Unit tests**: `./mvnw -pl <module> clean test`. Core/server use JUnit 4 (`surefire-junit47` runner); the `tests` module uses JUnit 5 with `EmbeddedTestSuite` (shared DB, fixed class/method order via `@SelectClasses` / `@Order`).
@@ -99,23 +103,11 @@ For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDB
 
 ### Coverage Verification
 
-Always use the `coverage-gate.py` script (invocation below) to check coverage instead of computing it by hand. The script contains special-case logic — for example, it excludes Java `assert` statement lines (including multi-line continuations) from both line and branch coverage calculations, because JaCoCo reports phantom uncovered branches and unreachable failure-message lines for asserts. Manual arithmetic will not account for these exclusions and will give incorrect results.
-
-```bash
-# Run unit tests with coverage collection
-./mvnw clean package -P coverage
-
-# Check coverage of changed lines against thresholds (85% line, 70% branch)
-python3 .github/scripts/coverage-gate.py \
-  --line-threshold 85 \
-  --branch-threshold 70 \
-  --compare-branch origin/develop \
-  --coverage-dir .coverage/reports
-```
+Coverage is verified at the end of the track's implementation, not per commit. Always use `coverage-gate.py` rather than hand arithmetic: its `assert`-line exclusions avoid JaCoCo's phantom uncovered branches and unreachable failure-message lines. For the mandatory hygiene procedure (`.coverage/reports` removal, the report-set assertion, and when a "skip" is not a pass), see `docs-internal/dev-workflow/track-development.md` § Verification integration.
 
 ## Committing
 
-- **Never commit if tests fail.** Fix the failures first, then re-run the tests.
+- **Never commit over a red result you actually observed.** Running tests mid-track is not required; a mid-track commit requires only that the affected modules compile through `./mvnw -pl <module>[,<module>] -am test-compile` (or the `embedded` shading exception above). Report which gate command you ran and its outcome.
 - The YTDB issue number is carried in the PR title only (auto-prefixed from the branch name by `.github/workflows/pr-title-prefix.yml`). Individual commit subjects do not need it — the squash-merge takes its message from the PR title and description.
 - **Format**:
   ```

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -104,8 +104,7 @@ For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDB
 ### Coverage Verification
 
 Always use `coverage-gate.py`, not hand arithmetic. Before running it, read
-`docs-internal/dev-workflow/track-development.md` § Verification integration for the mandatory
-procedure.
+`docs-internal/dev-workflow/coverage-verification.md` for the mandatory procedure.
 
 ## Committing
 

--- a/docs-internal/dev-workflow/coverage-verification.md
+++ b/docs-internal/dev-workflow/coverage-verification.md
@@ -1,0 +1,114 @@
+# Coverage Verification
+
+Read this when you are about to produce a coverage number, or when a coverage result needs
+diagnosing. Which gate runs when, the module sets, and the re-run rule are in
+`docs-internal/dev-workflow/track-development.md` § Verification integration.
+
+## The run
+
+The **coverage set** is the modules containing changed Java files — neither the compile-gate
+set nor the test-gate set. Run these steps in order:
+
+```bash
+# 1. Mandatory: mvn clean does NOT remove this directory.
+rm -rf .coverage/reports
+
+# 2. Build the coverage set - modules with changed Java files - with -am.
+./mvnw -pl <modules with changed Java files> -am clean package -P coverage
+
+# 3. Gate the changed lines against the thresholds.
+python3 .github/scripts/coverage-gate.py \
+  --line-threshold 85 \
+  --branch-threshold 70 \
+  --compare-branch origin/develop \
+  --coverage-dir .coverage/reports
+
+# 4. Assert the report set (see below).
+ls .coverage/reports
+```
+
+Step 1 is mandatory because `.coverage/reports` sits at the repository root, outside every
+module's `target/`, so `mvn clean` never removes it, and stale reports merge into fresh ones
+on a max-covered-wins basis — an invisible upward bias.
+
+## Is the number real?
+
+A skip counts as a pass **only** when the change genuinely has no changed Java files. Check
+that with the same diff the script uses — `--diff-filter=ACM` is part of the check:
+
+```bash
+git diff origin/develop...HEAD --name-only --diff-filter=ACM -- '*.java'
+```
+
+Without the filter the check also lists deleted files, so a deletion-only change looks like
+coverage applies while the script, which filters ACM, has nothing to measure — a loop with no
+exit.
+
+Empty output — a real pass. Non-empty output together with any of the five outputs below — the
+*measurement* failed; investigate it, do not record a green gate. Paths 1 and 2 are skip lines
+and print no PASSED line at all; paths 3–5 look like passes. These are the script's exact
+stdout strings, to be matched against real output:
+
+1. `No changed Java files found. Skipping coverage gate.` — the only legitimate skip, and only
+   if the diff above is empty too. Otherwise the compare branch or the filter is wrong.
+2. `No JaCoCo XML files found. Skipping coverage gate.` — the *entire* coverage directory has
+   no `**/jacoco.xml`; nothing was measured (markdown report: the one `:warning:` case).
+3. `Line coverage: PASSED — no coverable lines in diff` — line total was zero (markdown:
+   `## Line Coverage: :white_check_mark: No coverable lines in diff`).
+4. `Branch coverage: PASSED — no branches in changed lines` — branch total was zero (markdown:
+   `## Branch Coverage: :white_check_mark: No branches in changed lines`).
+5. Paths 3 and 4 together, followed by
+   `PASSED: All coverage meets thresholds (85% line, 70% branch)` and exit 0 — a wholly
+   vacuous green.
+
+Paths 3–5 are also how a missing per-module report surfaces: the script never names a missing
+module — it prints `Found N JaCoCo report(s)` and `Checking coverage for M changed file(s)`,
+then reports PASSED over whatever those M files matched, including nothing. A PASSED line is
+therefore not evidence that the diff was measured; only the report-set assertion is. Hardening
+the script against these paths is deferred follow-up work; until then this protocol is the only
+guard.
+
+## The report-set assertion (step 4)
+
+Report directories are named by **artifactId**, not by module directory: the root `pom.xml`'s
+`coverage` profile writes `.coverage/reports/${project.artifactId}` (unit tests) and
+`.coverage/reports/${project.artifactId}-it` (integration tests, so only when the run reaches
+those phases). Every artifactId is `youtrackdb-<directory name>`, so `core` reports under
+`.coverage/reports/youtrackdb-core`. Derive it rather than guess:
+
+```bash
+./mvnw -q -pl <module dir> help:evaluate -Dexpression=project.artifactId -DforceStdout
+```
+
+`.coverage/reports` must contain a `youtrackdb-<module>` directory for every coverage-set
+module that **has test sources of its own** (`src/test`). The condition is `src/test`-gated
+because a module without tests produces no execution data, so the JaCoCo report goal is
+skipped and no directory is ever written — as of this writing `driver`, `console` and
+`test-commons`; confirm with `ls -d <module>/src/test` instead of trusting that list. Which
+reason applies decides whether a missing directory is a defect:
+
+- **Missing, module has no `src/test`** — expected. A module's report covers only its own
+  classes, so its changed lines are outside the measurement in CI too; say so when reporting
+  the gate rather than presenting the percentage as covering the whole diff. Those lines are
+  guarded by the test-gate modules' tests.
+- **Missing, module has `src/test`** — a measurement defect: the module was left out of `-pl`,
+  its tests were skipped, or the build never reached `prepare-package`, where the report goal
+  is bound. Its changed lines are silently dropped from the denominator, so fix the selection
+  or the build and re-run — a percentage that clears the thresholds is still wrong.
+
+`Found N JaCoCo report(s)` **above** the expected count is normal, not a symptom: `-am` builds
+the upstream modules too and each of those with test sources writes its own report, so a change
+confined to `server` yields three. A surplus cannot be stale either, because step 1 emptied the
+directory. Only a deficit is a defect.
+
+## Local runs versus CI
+
+CI measures coverage in one leg of `.github/workflows/maven-pipeline.yml` (`test-linux`, x86,
+JDK 21): a full-reactor `./mvnw clean package -P docker-images,coverage` with
+`-Dmaven.test.failure.ignore=true -Dyoutrackdb.test.env=ci`, whose reports a separate
+`coverage-gate` job feeds to this script against `origin/<PR base branch>` on non-draft PRs.
+CI therefore counts modules your `-pl` never built (larger denominator — what the report-set
+assertion guards), covers disk-storage paths rather than in-memory ones, and reports a number
+even when tests fail. CI is authoritative; the local run is a prediction that makes it
+unsurprising. Do not substitute the CI command locally — a full-reactor coverage build is
+priced in hours.

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -56,27 +56,16 @@ owned by track-workflow.md § Peer review.
 
 ## Verification integration
 
-This section owns the *mechanics* of verification inside a track: which command gates a
-commit, how the module sets are computed, when the expensive gate re-runs, and how coverage
-is measured. The always-injected `docs-internal/agents/orchestrator-guidelines.md` and
-`docs-internal/agents/thread-guidelines.md` carry only the short rule plus a pointer here,
-per AGENTS.md § Load Guidance Documents on Demand. Ownership is split rather than duplicated.
-The rules below are owned elsewhere, and this section cites them instead of redefining them —
-where a command line needs one of their values, such as the 85/70 flags in the coverage
-invocation, it reproduces the owner's value rather than setting its own: the 85%/70%
-thresholds and the test-authorship obligation (orchestrator-guidelines § Test Policy), the
-integration-test decision rules and the serial-test-execution scheduling invariant
-(orchestrator-guidelines § Verification Gates), and the raw build-command catalogue
-(thread-guidelines § Build Commands). Read those for the rules they own; read this for how a
-gate is executed.
+This section is the gate reference for work inside a track: which command gates a commit, how
+the module sets are computed, which gate runs when, and when a gate must be re-run. The
+coverage measurement procedure — how to produce a coverage number, and how to tell a real pass
+from a vacuous one — is in `docs-internal/dev-workflow/coverage-verification.md`.
 
-Verification is attached to distinct events, not to every commit. Intermediate commits
-inside a track never reach `develop` — one PR is one squashed commit — so a per-commit unit
-test and coverage rule buys latency on every step and protects nothing that survives the
-merge. The cheap gate runs on every commit. The expensive gate runs at least once per track,
-before that track's agent code review, and again before the track's closing event whenever
-anything but prose landed in between — the re-run rule below decides. It is a per-track gate
-rather than a per-commit one, but not a strictly once-per-track one either.
+Intermediate commits inside a track never reach `develop`, since one PR is one squashed commit,
+so a per-commit unit-test and coverage rule buys latency on every step and protects nothing
+that survives the merge. The cheap gate therefore runs on every commit, while the expensive
+gate runs at least once per track — before that track's agent code review — and again before
+the track's closing event whenever anything but prose landed in between.
 
 ### Mid-track commit gate
 
@@ -86,331 +75,143 @@ A commit inside a track requires exactly this to pass:
 ./mvnw -pl <modules with changed files> -am -amd test-compile
 ```
 
-No unit tests, no integration tests, no coverage. `test-compile` is the floor rather than
-`compile` because it compiles test sources — under bare `compile`, test code rots silently
-for the length of a track — and because it still triggers Spotless (bound at
-`process-sources`) and all source generation.
+No unit tests, no integration tests, no coverage. `test-compile` rather than `compile` because
+it compiles test sources — under bare `compile` test code rots silently for the length of a
+track — and because it still triggers Spotless and all source generation.
 
-**`-am` is mandatory, not stylistic.** Without it a `-pl` build resolves sibling modules
-from the local repository instead of the working tree. This was observed, not theorized: a
-plain `-pl <modules> test-compile` picked up an installed snapshot of a sibling module that
-was one commit behind HEAD and roughly two hours stale, and reported green over code that
-did not compile against the tree. `-am` was separately verified to protect the
-annotation-processor resolution channel as well — with the processor deliberately broken,
-the reactor build used the freshly built processor rather than the installed jar. It costs
-nothing worth optimizing: about 40s with versus 48s without on `core`.
+**`-am` is mandatory.** Without it a `-pl` build resolves siblings from the local repository
+instead of the working tree, so a stale installed snapshot can report green over code that does
+not compile against the tree.
 
-**`-amd` is what reaches downstream consumers.** `-am` (`--also-make`) adds the *upstream*
-dependencies of the named modules; `-amd` (`--also-make-dependents`) adds the *downstream*
-modules that depend on them. They select opposite directions of the dependency graph, so
-neither substitutes for the other, and the compile gate needs both: `-am` so siblings are
-built from the working tree instead of resolved from the local repository, `-amd` so a
-consumer that no longer compiles against a changed API is not invisible. On a widely
-consumed module such as `core` this expands to a near-reactor-wide `test-compile`; that
-expansion is the intent of the gate, not an accident of the flag. Enumerating consumers by
-hand in `-pl` instead is allowed, but then the completeness of the downstream set is yours
-to justify.
+**`-amd` is mandatory too, and is not interchangeable with `-am`.** `-am` (`--also-make`) adds
+upstream dependencies; `-amd` (`--also-make-dependents`) adds the downstream modules that
+depend on the named ones, which are otherwise never compiled against the change. On a widely
+consumed module such as `core` this expands to a near-reactor-wide `test-compile`; that is the
+intended price of the gate.
 
-**Shading exception.** A change that affects the `embedded` module's shaded artifact
-replaces the phase in the command above, because shading binds to the `package` phase and
-`test-compile` never exercises it:
+**Shading exception.** A change affecting the `embedded` module's shaded artifact replaces the
+phase, because shading binds to `package` and `test-compile` never exercises it:
 
 ```bash
 ./mvnw -pl embedded -am -amd package -DskipTests
 ```
 
-`-DskipTests` is not optional here — it is what keeps this variant consistent with "no unit
-tests at the mid-track gate". A bare `package` runs surefire, including the Cucumber suites
-configured in `embedded`, turning a compile gate into a full test run. Do not reach for
-`-Dmaven.test.skip=true` instead: it also skips test *compilation*, which is exactly what
-`test-compile` was chosen to protect.
+`-DskipTests` is required: a bare `package` runs surefire, including `embedded`'s Cucumber
+suites, turning the compile gate into a full test run. Not `-Dmaven.test.skip=true`, which also
+skips test compilation.
 
-**Build files that belong to no module.** The root `pom.xml`, `.mvn/jvm.config`, and
-`project-config/eclipse-formatter.xml` affect every module and live in none, so module
-selection has nothing to name. Their compile gate is reactor-wide — no `-pl`, so no `-am` or
-`-amd` either:
+**Build files that belong to no module.** The root `pom.xml`, `.mvn/jvm.config` and
+`project-config/eclipse-formatter.xml` affect every module and live in none, so `-pl` has
+nothing to name. Their compile gate is reactor-wide:
 
 ```bash
 ./mvnw test-compile
 ```
 
-**No-Maven changes.** A change with no Java files and no module content — documentation,
-`.pi/` configuration, prompts — carries no Maven gate at all. There is nothing for
-`test-compile` to say about it.
+**No-Maven changes.** A change with no Java files and no module content — documentation, `.pi/`
+configuration, prompts — carries no Maven gate at all.
 
 ### Two module sets: compile gate vs test gates
 
-Module selection is not one set. The compile gate and the test gates need different
-ones, and carrying the compile-gate definition into a test gate silently converts it into a
-reactor-wide test run — the exact cost this protocol exists to avoid. Both names below —
-**compile-gate set** and **test-gate set** — are the terms the injected guideline documents
-use as well, so a short rule stated there in terms of either set resolves to the definition
-here.
+Module selection is not one set, and carrying the compile-gate definition into a test gate
+silently converts that gate into a reactor-wide test run. Both names below are the terms the
+injected guideline documents use as well.
 
-**Compile-gate set** — the modules containing changed files **plus their downstream
-consumers in the reactor**, which is what `-am -amd` expresses. This set is deliberately
-wide: building dependents is cheap at `test-compile` and it is the only thing that catches
-an API break in a consumer. Do not narrow it. A green `-pl core -am test-compile` says
-nothing about whether `server` still compiles.
+**Compile-gate set** — the modules containing changed files **plus their downstream consumers
+in the reactor**, which is what `-am -amd` expresses. Deliberately wide, and not to be
+narrowed: a green `-pl core -am test-compile` says nothing about whether `server` still
+compiles.
 
-**Test-gate set** — the modules containing changed files, plus any downstream module whose
-own tests exercise the changed behavior. There is no automatic `-amd` fan-out here: a
-dependent that merely compiles against a changed API is already covered by the compile gate,
-and re-running its suites costs tens of minutes for no new signal. This is the set the
-end-of-track gate below and § After the flip mean by the test-gate modules. When the changed
-behavior does reach a dependent's tests, name that dependent in `-pl` explicitly rather than
-switching the run to `-amd`.
+**Test-gate set** — the modules containing changed files, plus any downstream module whose own
+tests exercise the changed behavior. No automatic `-amd` fan-out here: a dependent that merely
+compiles against a changed API is already covered by the compile gate, and re-running its
+suites costs tens of minutes for no new signal. When the changed behavior does reach a
+dependent's tests, name that dependent in `-pl` explicitly.
 
-For the build files that belong to no module, the compile-gate set is the whole reactor (as
-above) and the test-gate set is the modules whose behavior the change can actually alter — a
-dependency-version bump in the root `pom.xml` means the modules consuming that dependency —
-falling back to the whole reactor when the change cannot be bounded that way.
+For build files belonging to no module, the compile-gate set is the whole reactor and the
+test-gate set is the modules whose behavior the change can actually alter — a dependency-version
+bump in the root `pom.xml` means that dependency's consumers — falling back to the whole reactor
+when it cannot be bounded that way.
 
-Both sets are read off the reactor order, which Maven resolves from the dependency graph (it
-is not the module order listed in the root `pom.xml`):
+Both sets are read off the reactor order, which Maven resolves from the dependency graph, not
+from the module order listed in the root `pom.xml`:
 
 > youtrackdb-parent → test-commons → gremlin-annotations → core → driver → server → tests
 > → embedded → examples → console → docker-tests → jmh-ldbc
 
-Everything to the right of a changed module is a candidate consumer; only those that
-actually depend on it are consumers. `-amd` computes that for you at the compile gate; read
-the order when you need to predict what `-amd` will pull in, or to bound a test-gate set by
-hand.
+Everything to the right of a changed module is a candidate consumer; `-amd` computes the actual
+ones at the compile gate, and the order is what lets you bound a test-gate set by hand.
 
 ### End-of-track gate
 
-At the end of each track's implementation, and **before** that track's agent code review,
-the full verification runs:
+At the end of each track's implementation, and **before** that track's agent code review, the
+full verification runs:
 
 1. **Unit tests** for the test-gate modules, green.
 2. **Integration tests** (`-P ci-integration-tests`) when the change touches areas covered by
-   integration tests. That trigger is owned by orchestrator-guidelines § Verification Gates
-   and is deliberately general, not a closed list of areas — read it there rather than
-   working from an enumeration here.
+   integration tests. That trigger is owned by orchestrator-guidelines § Verification Gates and
+   is deliberately general, not a closed list of areas — read it there.
 3. **The coverage gate** over the changed lines, at the thresholds owned by
-   orchestrator-guidelines § Test Policy, run by the procedure below.
+   orchestrator-guidelines § Test Policy. **Read
+   `docs-internal/dev-workflow/coverage-verification.md` and follow it before producing the
+   number.** A coverage result produced without that procedure is not a gate result and must
+   not be reported as one: its report-set assertion is what separates a measured pass from a
+   vacuous one, and nothing in this section can tell them apart.
 
-The placement matters in both directions. Gating only at the track's closing event (below)
-would have reviewers reviewing unverified code; gating only before the review would let
-review-fix commits land unverified. Both holes are closed by the pre-review gate plus the
-re-run rule below.
+Gating only at the track's closing event would have reviewers reviewing unverified code; gating
+only before the review would let review-fix commits land unverified. Both holes are closed by
+this pre-review placement plus the re-run rule below.
 
-**This applies at every tier, including single-track changes.** A single-track change has
-no marker commit, but it still runs the gate before its agent code review — not merely
-before the ready-for-review flip. Exempting the most common tier would reinstate exactly
-the defect the pre-review placement exists to remove.
+**This applies at every tier, including single-track changes.** A single-track change has no
+marker commit, but it still runs the gate before its agent code review, not merely before the
+ready-for-review flip.
 
 ### Re-running the gate before the track's closing event
 
-Every track has a **closing event**: the marker commit for a track inside a multi-track
-change, and the ready-for-review flip for a single-track change, which has no marker commit.
+Every track has a **closing event**: the marker commit for a track inside a multi-track change,
+and the ready-for-review flip for a single-track change, which has no marker commit. Keying the
+obligation to the closing event is what keeps the single-track tier — the most common one — from
+having no trigger at all.
 
-The gate must be re-run before the track's closing event **unless every commit landed since
-the gate is provably outcome-neutral — documentation or comments only.**
-
-The obligation is keyed to the closing event rather than to the marker commit on purpose. A
-marker-commit trigger leaves single-track changes — the most common tier — with no trigger
-at all, while review-fix commits, the very commits this rule exists to catch, are as common
-there as anywhere else.
-
-This is deliberately an exclusion rule, not an allowlist of "safe" paths. Stating it as
-"re-run unless nothing but prose changed" covers build-affecting files by construction:
-module POMs, `.mvn/jvm.config`, and formatter configuration all change the outcome of a
-build without being source files, and none of them has to be remembered and listed. If you
-cannot show that the only thing that changed was prose, re-run.
+The gate must be re-run before the closing event **unless every commit landed since the gate is
+provably outcome-neutral — documentation or comments only.** It is an exclusion rule rather than
+an allowlist of safe paths, so build-affecting non-source files (module POMs, `.mvn/jvm.config`,
+formatter configuration) are covered by construction. If you cannot show that the only thing
+that changed was prose, re-run.
 
 **Approval reopening.** The approval in question is the MANDATORY user review of the track
-(`.pi/npm/node_modules/ytdb-slate/docs/track-workflow.md` § Track loop, step 4) — there is
-no separate "gate approval" event to look for. Any commit that lands after that review has
-approved the track reopens it for those commits, before the closing event. A marker commit
-never certifies code the user has not seen, and the same holds for the ready-for-review flip
-of a single-track change.
-
-### Coverage measurement procedure
-
-Run it as a sequence, in this order. The set built here is a third set, distinct from the two
-above: the **coverage set** is the modules containing changed Java files — no downstream
-fan-out (unlike the compile-gate set) and no judgment call about which suites exercise the
-change (unlike the test-gate set).
-
-```bash
-# 1. Mandatory: mvn clean does NOT remove this directory.
-rm -rf .coverage/reports
-
-# 2. Build the coverage set - modules with changed Java files - with -am.
-./mvnw -pl <modules with changed Java files> -am clean package -P coverage
-
-# 3. Gate the changed lines against the thresholds.
-python3 .github/scripts/coverage-gate.py \
-  --line-threshold 85 \
-  --branch-threshold 70 \
-  --compare-branch origin/develop \
-  --coverage-dir .coverage/reports
-
-# 4. Assert the report set (see below).
-ls .coverage/reports
-```
-
-**Why step 1 is mandatory.** `.coverage/reports` sits at the repository root, outside every
-module's `target/`, and no clean-plugin fileset covers it — `mvn clean` leaves it in place.
-Stale reports merge into fresh ones on a max-covered-wins basis, so a line covered by
-yesterday's run counts as covered today. Leaving the directory in place biases coverage
-upward and the bias is invisible in the output.
-
-**Report directories are named by artifactId, not by module directory.** The `coverage`
-profile in the root `pom.xml` writes the unit-test report to
-`.coverage/reports/${project.artifactId}` and the integration-test report to
-`.coverage/reports/${project.artifactId}-it`. Every module's artifactId is
-`youtrackdb-<directory name>`, so the `core` directory reports under
-`.coverage/reports/youtrackdb-core`, not `.coverage/reports/core`. When in doubt, derive it
-instead of guessing:
-
-```bash
-./mvnw -q -pl <module dir> help:evaluate -Dexpression=project.artifactId -DforceStdout
-```
-
-The `-it` directories appear only when the run reaches the integration-test phases, so a
-local `package` run produces the plain directories only.
-
-**Step 4, the report-set assertion.** `.coverage/reports` must contain a
-`youtrackdb-<module>` directory for every module of the coverage set that **has test sources
-of its own** (`src/test`). A module with no `src/test` never produces execution data, so the
-JaCoCo report goal is skipped and no directory is ever written — as of this writing that is
-`driver`, `console` and `test-commons`; check with `ls -d <module>/src/test` rather than
-trusting the list. Demanding a directory for those modules is unsatisfiable, so the assertion
-turns on which of the two reasons for a missing report applies:
-
-- **Missing, and the module has no `src/test`** — expected, not a defect. A module's JaCoCo
-  report only covers that module's own classes, so its changed lines are outside the
-  measurement in CI too. Say so when reporting the gate instead of presenting the printed
-  percentage as covering the whole diff; what guards those lines is the test-gate modules'
-  tests, not the coverage gate.
-- **Missing, and the module has `src/test`** — a defect in the measurement. The module was
-  left out of `-pl`, its tests were skipped, or the build never reached `prepare-package`
-  (the phase the report goal is bound to). Its changed lines are silently dropped from the
-  denominator and the gate prints a confident number computed over a subset of the diff. Fix
-  the module selection or the build and re-run: a percentage that clears the thresholds is
-  still wrong.
-
-Cross-check the count while you are there, but read it in one direction only. The script
-prints `Found N JaCoCo report(s)`, where N counts the `jacoco.xml` files it globbed — one per
-report directory. N **larger** than the expected report set is normal rather than a symptom:
-`-am` builds the upstream modules too, and every upstream module that has test sources writes
-its own report. A change confined to `server` builds `gremlin-annotations` and `core` on the
-way there, so three reports appear where the coverage set names one. Nor can the surplus be
-stale, since step 1 emptied the directory before the run. The direction that matters is the
-other one: N below the expected count, or `ls` showing no directory for a coverage-set module
-that has `src/test`, is the missing-report defect above.
-
-Always use `coverage-gate.py` rather than computing coverage by hand; the reason manual
-arithmetic gives wrong answers (the JaCoCo `assert`-statement trap) is in
-thread-guidelines § Coverage Verification.
-
-**Local and CI coverage runs are not the same run.** CI collects coverage in the `test-linux`
-x86 / JDK 21 leg of `.github/workflows/maven-pipeline.yml`, from a **full-reactor**
-`./mvnw clean package -P docker-images,coverage` carrying
-`-Dmaven.test.failure.ignore=true -Dyoutrackdb.test.env=ci`; that leg uploads
-`.coverage/reports/` as an artifact and a separate `coverage-gate` job runs this same script
-against `origin/<PR base branch>`, on non-draft PRs only. Three consequences for a locally
-green run:
-
-- CI has reports for every module with tests, so changed lines that your `-pl` selection
-  never reported locally are counted there. A local pass can flip to a CI failure purely
-  through denominator size — which is exactly what the report-set assertion guards.
-- CI runs disk storage (`-Dyoutrackdb.test.env=ci`) while the local default is in-memory, so
-  different code paths are exercised and per-line coverage differs in both directions.
-- CI measures coverage even when tests fail (`-Dmaven.test.failure.ignore=true`), so a red
-  test leg still produces a coverage number.
-
-The CI gate is authoritative — it is what blocks the PR. The local procedure is a prediction
-whose job is to make the CI result unsurprising; do not replace it with the CI command, since
-a full-reactor coverage build is priced in hours and that price is why the per-module
-procedure exists.
-
-### When a coverage "skip" is a pass
-
-A skip counts as a pass **only** when the change genuinely has no changed Java files. Verify
-that with the same diff the script itself uses — `--diff-filter=ACM` is part of the check,
-not decoration:
-
-```bash
-git diff origin/develop...HEAD --name-only --diff-filter=ACM -- '*.java'
-```
-
-Without `--diff-filter=ACM` the check also lists **deleted** Java files. A deletion-only
-change then looks like "coverage applies", while the script's own diff — which passes
-`--diff-filter=ACM` in `get_changed_lines` — comes back empty, so the run takes path 1 below
-and prints a skip. The unfiltered check says Java changed, the rule below says a skip on a
-Java change is a failed measurement, and there is nothing left to fix: a loop with no exit.
-Matching the filter removes it — a deletion-only change legitimately has nothing to measure.
-
-Empty output — a real pass. Non-empty output plus a skip — the *measurement* failed and must
-be investigated, not recorded as a green gate. Five paths print something reassuring without
-measuring anything. These are the strings the script actually writes to stdout, so real
-output can be mapped onto them literally:
-
-1. `No changed Java files found. Skipping coverage gate.` — a **skip line**: the script
-   returns immediately, printing no PASSED line at all. The only legitimate skip, and only
-   when the diff above is also empty. On a change that does touch Java it means the compare
-   branch or the diff filter is wrong.
-2. `No JaCoCo XML files found. Skipping coverage gate.` — also a **skip line** with no PASSED
-   line. It fires only when the *entire* coverage directory contains no `**/jacoco.xml`;
-   nothing was measured. In the markdown report this is the single `:warning:` case rather
-   than a check mark.
-3. `Line coverage: PASSED — no coverable lines in diff` — a **PASSED-style line**: the line
-   total was zero, so the threshold was vacuously satisfied. Markdown counterpart:
-   `## Line Coverage: :white_check_mark: No coverable lines in diff`.
-4. `Branch coverage: PASSED — no branches in changed lines` — a **PASSED-style line**: the
-   branch total was zero. Markdown counterpart:
-   `## Branch Coverage: :white_check_mark: No branches in changed lines`.
-5. Both of the two lines above, followed by
-   `PASSED: All coverage meets thresholds (85% line, 70% branch)` and exit 0 — an entirely
-   vacuous green.
-
-Paths 3–5 are also how a *per-module* missing report surfaces: the script never names a
-missing module. It prints `Found N JaCoCo report(s)` and `Checking coverage for M changed
-file(s)`, matches those M files against whatever XML it found, and then reports PASSED over
-whatever matched — including nothing. A PASSED line is therefore not evidence that the diff
-was measured; only the report-set assertion above is.
-
-Once the `--diff-filter=ACM` diff above is non-empty, every one of the five outputs — path 1
-included — is a measurement failure until proven otherwise. Hardening the script against
-these paths is deferred follow-up work; until then this protocol is the only guard.
+(`.pi/npm/node_modules/ytdb-slate/docs/track-workflow.md` § Track loop, step 4); this workflow
+has no separate "gate approval" event. Any commit landing after that review reopens it for those
+commits, before the closing event — neither a marker commit nor a ready-for-review flip ever
+certifies code the user has not seen.
 
 ### Deferred test authorship
 
 When test work for a track is substantial enough to be split out, it becomes **its own task
-within the same track**, landing before that track's agent code review. Promoting it to a
-track of its own requires explicit user approval. It cannot be deferred to a follow-up issue
-or PR: the CI coverage gate hard-fails a ready PR with no bypass, so the debt cannot leave
-this PR.
+within the same track**, landing before that track's agent code review. Promoting it to a track
+of its own requires explicit user approval. It cannot be deferred to a follow-up issue or PR:
+the CI coverage gate hard-fails a ready PR with no bypass, so the debt cannot leave this PR.
 
 ### Committing, and landing red
 
-**Never commit over a red result you actually observed.** Running unit tests mid-track is
-not required; committing on top of a build or test run you watched fail is forbidden. To
-keep the rule checkable rather than aspirational, the agent reports which gate command it
-ran and what the outcome was — the command line and its result, not an assurance.
-
-**Landing red is the one carve-out from that prohibition**, and it is not one the agent may
-take on its own. It requires explicit user approval, recorded in the PR's Risks & accepted
-trade-offs, naming the failing tests and the track that will fix them. With that record in
-place the track may close over precisely the named red result. Everything else stays
-under the prohibition — any red result not named in that record still blocks the commit.
+Never commit over a red result you actually observed. **Landing red is the one carve-out**, and
+not one the agent may take on its own: it requires explicit user approval, recorded in the PR's
+Risks & accepted trade-offs, naming the failing tests and the track that will fix them. The
+track may then close over precisely the named red result; any red result not named there still
+blocks the commit.
 
 ### After the flip
 
-Any post-flip commit that touches code runs the test-gate modules' tests before being
-pushed. Once the PR is non-draft, CI enforces on every push regardless — including the coverage
-gate, which runs only on non-draft PRs and so re-engages automatically at the
-ready-for-review flip. During the draft phase there is no CI at all, which is why the
-end-of-track gate is the only verification signal that exists while a track is being
-implemented.
+Any post-flip commit that touches code runs the test-gate modules' tests before being pushed.
+Once the PR is non-draft CI enforces on every push regardless, including the coverage gate,
+which runs only on non-draft PRs and so re-engages at the flip. During the draft phase there is
+no CI at all, which is why the end-of-track gate is the only verification signal a track has
+while it is being implemented.
 
 ### Encouraged, never required
 
-Running the single closest test class mid-track for a risky change. It is cheap, it catches
-the obvious break early, and no gate depends on it.
+Running the single closest test class mid-track for a risky change. It is cheap, it catches the
+obvious break early, and no gate depends on it.
 
 ## Model routing
 

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -56,28 +56,32 @@ owned by track-workflow.md § Peer review.
 
 ## Verification integration
 
-This section is the authoritative verification protocol for work inside a track. The
-always-injected `docs-internal/agents/orchestrator-guidelines.md` and
+This section owns the *mechanics* of verification inside a track: which command gates a
+commit, how the module sets are computed, when the expensive gate re-runs, and how coverage
+is measured. The always-injected `docs-internal/agents/orchestrator-guidelines.md` and
 `docs-internal/agents/thread-guidelines.md` carry only the short rule plus a pointer here,
-per AGENTS.md § Load Guidance Documents on Demand — so everything an agent needs to execute
-a gate is below, not there. What stays owned elsewhere: the 85%/70% thresholds and the
-test-authorship obligation (orchestrator-guidelines § Test Policy), the integration-test
-decision rules and the serial-test-execution scheduling invariant
+per AGENTS.md § Load Guidance Documents on Demand. Ownership is split rather than
+duplicated — these rules stay where they are and are not restated below: the 85%/70%
+thresholds and the test-authorship obligation (orchestrator-guidelines § Test Policy), the
+integration-test decision rules and the serial-test-execution scheduling invariant
 (orchestrator-guidelines § Pre-Commit Verification), and the raw build-command catalogue
-(thread-guidelines § Build Commands).
+(thread-guidelines § Build Commands). Read those for the rules they own; read this for how a
+gate is executed.
 
-Verification is attached to two distinct events, not to every commit. Intermediate commits
+Verification is attached to distinct events, not to every commit. Intermediate commits
 inside a track never reach `develop` — one PR is one squashed commit — so a per-commit unit
 test and coverage rule buys latency on every step and protects nothing that survives the
-merge. The cheap gate runs on every commit; the expensive gate runs once per track, at the
-point where its result is actually read.
+merge. The cheap gate runs on every commit. The expensive gate runs at least once per track,
+before that track's agent code review, and again before the track's closing event whenever
+anything but prose landed in between — the re-run rule below decides. It is a per-track gate
+rather than a per-commit one, but not a strictly once-per-track one either.
 
 ### Mid-track commit gate
 
 A commit inside a track requires exactly this to pass:
 
 ```bash
-./mvnw -pl <affected modules> -am test-compile
+./mvnw -pl <modules with changed files> -am -amd test-compile
 ```
 
 No unit tests, no integration tests, no coverage. `test-compile` is the floor rather than
@@ -94,57 +98,115 @@ annotation-processor resolution channel as well — with the processor deliberat
 the reactor build used the freshly built processor rather than the installed jar. It costs
 nothing worth optimizing: about 40s with versus 48s without on `core`.
 
-**Shading exception.** A change that affects the `embedded` module's shaded artifact uses
-`./mvnw -pl embedded -am package` instead, because shading binds to the `package` phase and
-`test-compile` never exercises it.
+**`-amd` is what reaches downstream consumers.** `-am` (`--also-make`) adds the *upstream*
+dependencies of the named modules; `-amd` (`--also-make-dependents`) adds the *downstream*
+modules that depend on them. They select opposite directions of the dependency graph, so
+neither substitutes for the other, and the compile gate needs both: `-am` so siblings are
+built from the working tree instead of resolved from the local repository, `-amd` so a
+consumer that no longer compiles against a changed API is not invisible. On a widely
+consumed module such as `core` this expands to a near-reactor-wide `test-compile`; that
+expansion is the intent of the gate, not an accident of the flag. Enumerating consumers by
+hand in `-pl` instead is allowed, but then the completeness of the downstream set is yours
+to justify.
+
+**Shading exception.** A change that affects the `embedded` module's shaded artifact
+replaces the phase in the command above, because shading binds to the `package` phase and
+`test-compile` never exercises it:
+
+```bash
+./mvnw -pl embedded -am -amd package -DskipTests
+```
+
+`-DskipTests` is not optional here — it is what keeps this variant consistent with "no unit
+tests at the mid-track gate". A bare `package` runs surefire, including the Cucumber suites
+configured in `embedded`, turning a compile gate into a full test run. Do not reach for
+`-Dmaven.test.skip=true` instead: it also skips test *compilation*, which is exactly what
+`test-compile` was chosen to protect.
+
+**Build files that belong to no module.** The root `pom.xml`, `.mvn/jvm.config`, and
+`project-config/eclipse-formatter.xml` affect every module and live in none, so module
+selection has nothing to name. Their compile gate is reactor-wide — no `-pl`, so no `-am` or
+`-amd` either:
+
+```bash
+./mvnw test-compile
+```
 
 **No-Maven changes.** A change with no Java files and no module content — documentation,
 `.pi/` configuration, prompts — carries no Maven gate at all. There is nothing for
 `test-compile` to say about it.
 
-### What "affected modules" means
+### Two module sets: compile gate vs test gates
 
-Affected modules are the modules containing changed files **plus their downstream consumers
-in the reactor**. `-am` builds upstream dependencies only, so a downstream module that no
-longer compiles against the change is invisible unless it is named in `-pl`. A change to a
-widely consumed API surface therefore uses a reactor-wide `test-compile` rather than an
-enumeration.
+"Affected modules" is not a single set. The compile gate and the test gates need different
+ones, and carrying the compile-gate definition into a test gate silently converts it into a
+reactor-wide test run — the exact cost this protocol exists to avoid.
 
-Downstream consumers are read off the reactor order, which Maven resolves from the
-dependency graph (it is not the module order listed in the root `pom.xml`):
+**Compile-gate set** — the modules containing changed files **plus their downstream
+consumers in the reactor**, which is what `-am -amd` expresses. This set is deliberately
+wide: building dependents is cheap at `test-compile` and it is the only thing that catches
+an API break in a consumer. Do not narrow it. A green `-pl core -am test-compile` says
+nothing about whether `server` still compiles.
+
+**Test-gate set** — the modules containing changed files, plus any downstream module whose
+own tests exercise the changed behavior. There is no automatic `-amd` fan-out here: a
+dependent that merely compiles against a changed API is already covered by the compile gate,
+and re-running its suites costs tens of minutes for no new signal. This is the set the
+end-of-track gate below and § After the flip call the test-gate modules, and the set the
+short "affected modules" phrasing in the guideline documents refers to. When the changed
+behavior does reach a dependent's tests, name that dependent in `-pl` explicitly rather than
+switching the run to `-amd`.
+
+For the build files that belong to no module, the compile-gate set is the whole reactor (as
+above) and the test-gate set is the modules whose behavior the change can actually alter — a
+dependency-version bump in the root `pom.xml` means the modules consuming that dependency —
+falling back to the whole reactor when the change cannot be bounded that way.
+
+Both sets are read off the reactor order, which Maven resolves from the dependency graph (it
+is not the module order listed in the root `pom.xml`):
 
 > youtrackdb-parent → test-commons → gremlin-annotations → core → driver → server → tests
 > → embedded → examples → console → docker-tests → jmh-ldbc
 
-Everything to the right of a changed module is a candidate consumer; include those that
-actually depend on it.
+Everything to the right of a changed module is a candidate consumer; only those that
+actually depend on it are consumers. `-amd` computes that for you at the compile gate; read
+the order when you need to predict what `-amd` will pull in, or to bound a test-gate set by
+hand.
 
 ### End-of-track gate
 
 At the end of each track's implementation, and **before** that track's agent code review,
 the full verification runs:
 
-1. **Unit tests** for the affected modules, green.
+1. **Unit tests** for the test-gate modules, green.
 2. **Integration tests** (`-P ci-integration-tests`) where the change hits areas the
    integration-test decision rules in orchestrator-guidelines § Pre-Commit Verification
    name — storage, WAL, index, Gremlin integration, transaction handling.
 3. **The coverage gate** at 85% line / 70% branch over the changed lines, run by the
    procedure below.
 
-The placement matters in both directions. Gating only at the marker commit would have
-reviewers reviewing unverified code; gating only before the review would let review-fix
-commits land unverified. Both holes are closed by the pre-review gate plus the re-run rule
-below.
+The placement matters in both directions. Gating only at the track's closing event (below)
+would have reviewers reviewing unverified code; gating only before the review would let
+review-fix commits land unverified. Both holes are closed by the pre-review gate plus the
+re-run rule below.
 
 **This applies at every tier, including single-track changes.** A single-track change has
 no marker commit, but it still runs the gate before its agent code review — not merely
 before the ready-for-review flip. Exempting the most common tier would reinstate exactly
 the defect the pre-review placement exists to remove.
 
-### Re-running the gate before the marker commit
+### Re-running the gate before the track's closing event
 
-The gate must be re-run before the track's marker commit **unless every commit landed since
+Every track has a **closing event**: the marker commit for a track inside a multi-track
+change, and the ready-for-review flip for a single-track change, which has no marker commit.
+
+The gate must be re-run before the track's closing event **unless every commit landed since
 the gate is provably outcome-neutral — documentation or comments only.**
+
+The obligation is keyed to the closing event rather than to the marker commit on purpose. A
+marker-commit trigger leaves single-track changes — the most common tier — with no trigger
+at all, while review-fix commits, the very commits this rule exists to catch, are as common
+there as anywhere else.
 
 This is deliberately an exclusion rule, not an allowlist of "safe" paths. Stating it as
 "re-run unless nothing but prose changed" covers build-affecting files by construction:
@@ -152,9 +214,12 @@ module POMs, `.mvn/jvm.config`, and formatter configuration all change the outco
 build without being source files, and none of them has to be remembered and listed. If you
 cannot show that the only thing that changed was prose, re-run.
 
-**Approval reopening.** Any commit that lands after the user has approved the track's gate
-result reopens the user review for those commits, before the marker commit is made. A
-marker commit never certifies code the user has not seen.
+**Approval reopening.** The approval in question is the MANDATORY user review of the track
+(`.pi/npm/node_modules/ytdb-slate/docs/track-workflow.md` § Track loop, step 4) — there is
+no separate "gate approval" event to look for. Any commit that lands after that review has
+approved the track reopens it for those commits, before the closing event. A marker commit
+never certifies code the user has not seen, and the same holds for the ready-for-review flip
+of a single-track change.
 
 ### Coverage measurement procedure
 
@@ -232,13 +297,16 @@ not required; committing on top of a build or test run you watched fail is forbi
 keep the rule checkable rather than aspirational, the agent reports which gate command it
 ran and what the outcome was — the command line and its result, not an assurance.
 
-**Landing red** is possible only with explicit user approval, recorded in the PR's Risks &
-accepted trade-offs, naming the failing tests and the track that will fix them.
+**Landing red is the one carve-out from that prohibition**, and it is not one the agent may
+take on its own. It requires explicit user approval, recorded in the PR's Risks & accepted
+trade-offs, naming the failing tests and the track that will fix them. With that record in
+place the track may close over precisely the named red result. Everything else stays
+under the prohibition — any red result not named in that record still blocks the commit.
 
 ### After the flip
 
-Any post-flip commit that touches code runs the affected-module tests before being pushed.
-Once the PR is non-draft, CI enforces on every push regardless — including the coverage
+Any post-flip commit that touches code runs the test-gate modules' tests before being
+pushed. Once the PR is non-draft, CI enforces on every push regardless — including the coverage
 gate, which runs only on non-draft PRs and so re-engages automatically at the
 ready-for-review flip. During the draft phase there is no CI at all, which is why the
 end-of-track gate is the only verification signal that exists while a track is being

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -64,7 +64,7 @@ per AGENTS.md § Load Guidance Documents on Demand. Ownership is split rather th
 duplicated — these rules stay where they are and are not restated below: the 85%/70%
 thresholds and the test-authorship obligation (orchestrator-guidelines § Test Policy), the
 integration-test decision rules and the serial-test-execution scheduling invariant
-(orchestrator-guidelines § Pre-Commit Verification), and the raw build-command catalogue
+(orchestrator-guidelines § Verification Gates), and the raw build-command catalogue
 (thread-guidelines § Build Commands). Read those for the rules they own; read this for how a
 gate is executed.
 
@@ -180,7 +180,7 @@ the full verification runs:
 
 1. **Unit tests** for the test-gate modules, green.
 2. **Integration tests** (`-P ci-integration-tests`) where the change hits areas the
-   integration-test decision rules in orchestrator-guidelines § Pre-Commit Verification
+   integration-test decision rules in orchestrator-guidelines § Verification Gates
    name — storage, WAL, index, Gremlin integration, transaction handling.
 3. **The coverage gate** at 85% line / 70% branch over the changed lines, run by the
    procedure below.
@@ -223,13 +223,16 @@ of a single-track change.
 
 ### Coverage measurement procedure
 
-Run it as a sequence, in this order:
+Run it as a sequence, in this order. The set built here is a third set, distinct from the two
+above: the **coverage set** is the modules containing changed Java files — no downstream
+fan-out (unlike the compile-gate set) and no judgment call about which suites exercise the
+change (unlike the test-gate set).
 
 ```bash
 # 1. Mandatory: mvn clean does NOT remove this directory.
 rm -rf .coverage/reports
 
-# 2. Build the modules containing changed Java files, with -am.
+# 2. Build the coverage set - modules with changed Java files - with -am.
 ./mvnw -pl <modules with changed Java files> -am clean package -P coverage
 
 # 3. Gate the changed lines against the thresholds.
@@ -249,38 +252,120 @@ Stale reports merge into fresh ones on a max-covered-wins basis, so a line cover
 yesterday's run counts as covered today. Leaving the directory in place biases coverage
 upward and the bias is invisible in the output.
 
-**Step 4, the report-set assertion.** `.coverage/reports` must contain a report directory
-for **every** module with changed Java files. Changed files in an unreported module are
-silently dropped from the coverage denominator: the gate reports a confident number
-computed over a subset of the diff. If a module is missing, the measurement is wrong even
-when the printed percentage clears the thresholds — fix the module selection and re-run.
+**Report directories are named by artifactId, not by module directory.** The `coverage`
+profile in the root `pom.xml` writes the unit-test report to
+`.coverage/reports/${project.artifactId}` and the integration-test report to
+`.coverage/reports/${project.artifactId}-it`. Every module's artifactId is
+`youtrackdb-<directory name>`, so the `core` directory reports under
+`.coverage/reports/youtrackdb-core`, not `.coverage/reports/core`. When in doubt, derive it
+instead of guessing:
+
+```bash
+./mvnw -q -pl <module dir> help:evaluate -Dexpression=project.artifactId -DforceStdout
+```
+
+The `-it` directories appear only when the run reaches the integration-test phases, so a
+local `package` run produces the plain directories only.
+
+**Step 4, the report-set assertion.** `.coverage/reports` must contain a
+`youtrackdb-<module>` directory for every module of the coverage set that **has test sources
+of its own** (`src/test`). A module with no `src/test` never produces execution data, so the
+JaCoCo report goal is skipped and no directory is ever written — as of this writing that is
+`driver`, `console` and `test-commons`; check with `ls -d <module>/src/test` rather than
+trusting the list. Demanding a directory for those modules is unsatisfiable, so the assertion
+turns on which of the two reasons for a missing report applies:
+
+- **Missing, and the module has no `src/test`** — expected, not a defect. A module's JaCoCo
+  report only covers that module's own classes, so its changed lines are outside the
+  measurement in CI too. Say so when reporting the gate instead of presenting the printed
+  percentage as covering the whole diff; what guards those lines is the test-gate modules'
+  tests, not the coverage gate.
+- **Missing, and the module has `src/test`** — a defect in the measurement. The module was
+  left out of `-pl`, its tests were skipped, or the build never reached `prepare-package`
+  (the phase the report goal is bound to). Its changed lines are silently dropped from the
+  denominator and the gate prints a confident number computed over a subset of the diff. Fix
+  the module selection or the build and re-run: a percentage that clears the thresholds is
+  still wrong.
+
+Cross-check the count while you are there. The script prints `Found N JaCoCo report(s)`,
+where N counts the `jacoco.xml` files it globbed — one per report directory — so N below the
+size of the expected report set means a report is missing, and N above it means stale
+directories survived step 1.
 
 Always use `coverage-gate.py` rather than computing coverage by hand; the reason manual
 arithmetic gives wrong answers (the JaCoCo `assert`-statement trap) is in
 thread-guidelines § Coverage Verification.
 
+**Local and CI coverage runs are not the same run.** CI collects coverage in the `test-linux`
+x86 / JDK 21 leg of `.github/workflows/maven-pipeline.yml`, from a **full-reactor**
+`./mvnw clean package -P docker-images,coverage` carrying
+`-Dmaven.test.failure.ignore=true -Dyoutrackdb.test.env=ci`; that leg uploads
+`.coverage/reports/` as an artifact and a separate `coverage-gate` job runs this same script
+against `origin/<PR base branch>`, on non-draft PRs only. Three consequences for a locally
+green run:
+
+- CI has reports for every module with tests, so changed lines that your `-pl` selection
+  never reported locally are counted there. A local pass can flip to a CI failure purely
+  through denominator size — which is exactly what the report-set assertion guards.
+- CI runs disk storage (`-Dyoutrackdb.test.env=ci`) while the local default is in-memory, so
+  different code paths are exercised and per-line coverage differs in both directions.
+- CI measures coverage even when tests fail (`-Dmaven.test.failure.ignore=true`), so a red
+  test leg still produces a coverage number.
+
+The CI gate is authoritative — it is what blocks the PR. The local procedure is a prediction
+whose job is to make the CI result unsurprising; do not replace it with the CI command, since
+a full-reactor coverage build is priced in hours and that price is why the per-module
+procedure exists.
+
 ### When a coverage "skip" is a pass
 
-A skip counts as a pass **only** when the change genuinely has no changed Java files.
-Verify that, do not assume it:
+A skip counts as a pass **only** when the change genuinely has no changed Java files. Verify
+that with the same diff the script itself uses — `--diff-filter=ACM` is part of the check,
+not decoration:
 
 ```bash
-git diff origin/develop...HEAD --name-only -- '*.java'
+git diff origin/develop...HEAD --name-only --diff-filter=ACM -- '*.java'
 ```
 
+Without `--diff-filter=ACM` the check also lists **deleted** Java files. A deletion-only
+change then looks like "coverage applies", while the script's own diff — which passes
+`--diff-filter=ACM` in `get_changed_lines` — comes back empty, so the run takes path 1 below
+and prints a skip. The unfiltered check says Java changed, the rule below says a skip on a
+Java change is a failed measurement, and there is nothing left to fix: a loop with no exit.
+Matching the filter removes it — a deletion-only change legitimately has nothing to measure.
+
 Empty output — a real pass. Non-empty output plus a skip — the *measurement* failed and must
-be investigated, not recorded as a green gate. The script has five paths that print
-something reassuring without measuring anything, and all five look like success:
+be investigated, not recorded as a green gate. Five paths print something reassuring without
+measuring anything. These are the strings the script actually writes to stdout, so real
+output can be mapped onto them literally:
 
-1. **No changed Java files** — the only legitimate skip.
-2. **No JaCoCo report found** for a module, so its changed lines are not counted.
-3. **Zero coverable lines in the diff** ("no coverable lines in diff").
-4. **Zero branches in the changed lines** ("no branches in changed lines").
-5. **Both zero** — line and branch checks each vacuously satisfied.
+1. `No changed Java files found. Skipping coverage gate.` — a **skip line**: the script
+   returns immediately, printing no PASSED line at all. The only legitimate skip, and only
+   when the diff above is also empty. On a change that does touch Java it means the compare
+   branch or the diff filter is wrong.
+2. `No JaCoCo XML files found. Skipping coverage gate.` — also a **skip line** with no PASSED
+   line. It fires only when the *entire* coverage directory contains no `**/jacoco.xml`;
+   nothing was measured. In the markdown report this is the single `:warning:` case rather
+   than a check mark.
+3. `Line coverage: PASSED — no coverable lines in diff` — a **PASSED-style line**: the line
+   total was zero, so the threshold was vacuously satisfied. Markdown counterpart:
+   `## Line Coverage: :white_check_mark: No coverable lines in diff`.
+4. `Branch coverage: PASSED — no branches in changed lines` — a **PASSED-style line**: the
+   branch total was zero. Markdown counterpart:
+   `## Branch Coverage: :white_check_mark: No branches in changed lines`.
+5. Both of the two lines above, followed by
+   `PASSED: All coverage meets thresholds (85% line, 70% branch)` and exit 0 — an entirely
+   vacuous green.
 
-"Skipping coverage gate" on a change that touches Java is finding number 2, 3, 4 or 5 until
-proven otherwise. Hardening the script against these paths is deferred follow-up work; until
-then this protocol is the only guard.
+Paths 3–5 are also how a *per-module* missing report surfaces: the script never names a
+missing module. It prints `Found N JaCoCo report(s)` and `Checking coverage for M changed
+file(s)`, matches those M files against whatever XML it found, and then reports PASSED over
+whatever matched — including nothing. A PASSED line is therefore not evidence that the diff
+was measured; only the report-set assertion above is.
+
+Once the `--diff-filter=ACM` diff above is non-empty, every one of the five outputs — path 1
+included — is a measurement failure until proven otherwise. Hardening the script against
+these paths is deferred follow-up work; until then this protocol is the only guard.
 
 ### Deferred test authorship
 

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -56,9 +56,198 @@ owned by track-workflow.md § Peer review.
 
 ## Verification integration
 
-Per-track implementation (step 1 of the generic track loop) follows YTDB's test policy and
-pre-commit verification rules in `docs-internal/agents/orchestrator-guidelines.md`; the
-exact command lines are in `docs-internal/agents/thread-guidelines.md`.
+This section is the authoritative verification protocol for work inside a track. The
+always-injected `docs-internal/agents/orchestrator-guidelines.md` and
+`docs-internal/agents/thread-guidelines.md` carry only the short rule plus a pointer here,
+per AGENTS.md § Load Guidance Documents on Demand — so everything an agent needs to execute
+a gate is below, not there. What stays owned elsewhere: the 85%/70% thresholds and the
+test-authorship obligation (orchestrator-guidelines § Test Policy), the integration-test
+decision rules and the serial-test-execution scheduling invariant
+(orchestrator-guidelines § Pre-Commit Verification), and the raw build-command catalogue
+(thread-guidelines § Build Commands).
+
+Verification is attached to two distinct events, not to every commit. Intermediate commits
+inside a track never reach `develop` — one PR is one squashed commit — so a per-commit unit
+test and coverage rule buys latency on every step and protects nothing that survives the
+merge. The cheap gate runs on every commit; the expensive gate runs once per track, at the
+point where its result is actually read.
+
+### Mid-track commit gate
+
+A commit inside a track requires exactly this to pass:
+
+```bash
+./mvnw -pl <affected modules> -am test-compile
+```
+
+No unit tests, no integration tests, no coverage. `test-compile` is the floor rather than
+`compile` because it compiles test sources — under bare `compile`, test code rots silently
+for the length of a track — and because it still triggers Spotless (bound at
+`process-sources`) and all source generation.
+
+**`-am` is mandatory, not stylistic.** Without it a `-pl` build resolves sibling modules
+from the local repository instead of the working tree. This was observed, not theorized: a
+plain `-pl <modules> test-compile` picked up an installed snapshot of a sibling module that
+was one commit behind HEAD and roughly two hours stale, and reported green over code that
+did not compile against the tree. `-am` was separately verified to protect the
+annotation-processor resolution channel as well — with the processor deliberately broken,
+the reactor build used the freshly built processor rather than the installed jar. It costs
+nothing worth optimizing: about 40s with versus 48s without on `core`.
+
+**Shading exception.** A change that affects the `embedded` module's shaded artifact uses
+`./mvnw -pl embedded -am package` instead, because shading binds to the `package` phase and
+`test-compile` never exercises it.
+
+**No-Maven changes.** A change with no Java files and no module content — documentation,
+`.pi/` configuration, prompts — carries no Maven gate at all. There is nothing for
+`test-compile` to say about it.
+
+### What "affected modules" means
+
+Affected modules are the modules containing changed files **plus their downstream consumers
+in the reactor**. `-am` builds upstream dependencies only, so a downstream module that no
+longer compiles against the change is invisible unless it is named in `-pl`. A change to a
+widely consumed API surface therefore uses a reactor-wide `test-compile` rather than an
+enumeration.
+
+Downstream consumers are read off the reactor order, which Maven resolves from the
+dependency graph (it is not the module order listed in the root `pom.xml`):
+
+> youtrackdb-parent → test-commons → gremlin-annotations → core → driver → server → tests
+> → embedded → examples → console → docker-tests → jmh-ldbc
+
+Everything to the right of a changed module is a candidate consumer; include those that
+actually depend on it.
+
+### End-of-track gate
+
+At the end of each track's implementation, and **before** that track's agent code review,
+the full verification runs:
+
+1. **Unit tests** for the affected modules, green.
+2. **Integration tests** (`-P ci-integration-tests`) where the change hits areas the
+   integration-test decision rules in orchestrator-guidelines § Pre-Commit Verification
+   name — storage, WAL, index, Gremlin integration, transaction handling.
+3. **The coverage gate** at 85% line / 70% branch over the changed lines, run by the
+   procedure below.
+
+The placement matters in both directions. Gating only at the marker commit would have
+reviewers reviewing unverified code; gating only before the review would let review-fix
+commits land unverified. Both holes are closed by the pre-review gate plus the re-run rule
+below.
+
+**This applies at every tier, including single-track changes.** A single-track change has
+no marker commit, but it still runs the gate before its agent code review — not merely
+before the ready-for-review flip. Exempting the most common tier would reinstate exactly
+the defect the pre-review placement exists to remove.
+
+### Re-running the gate before the marker commit
+
+The gate must be re-run before the track's marker commit **unless every commit landed since
+the gate is provably outcome-neutral — documentation or comments only.**
+
+This is deliberately an exclusion rule, not an allowlist of "safe" paths. Stating it as
+"re-run unless nothing but prose changed" covers build-affecting files by construction:
+module POMs, `.mvn/jvm.config`, and formatter configuration all change the outcome of a
+build without being source files, and none of them has to be remembered and listed. If you
+cannot show that the only thing that changed was prose, re-run.
+
+**Approval reopening.** Any commit that lands after the user has approved the track's gate
+result reopens the user review for those commits, before the marker commit is made. A
+marker commit never certifies code the user has not seen.
+
+### Coverage measurement procedure
+
+Run it as a sequence, in this order:
+
+```bash
+# 1. Mandatory: mvn clean does NOT remove this directory.
+rm -rf .coverage/reports
+
+# 2. Build the modules containing changed Java files, with -am.
+./mvnw -pl <modules with changed Java files> -am clean package -P coverage
+
+# 3. Gate the changed lines against the thresholds.
+python3 .github/scripts/coverage-gate.py \
+  --line-threshold 85 \
+  --branch-threshold 70 \
+  --compare-branch origin/develop \
+  --coverage-dir .coverage/reports
+
+# 4. Assert the report set (see below).
+ls .coverage/reports
+```
+
+**Why step 1 is mandatory.** `.coverage/reports` sits at the repository root, outside every
+module's `target/`, and no clean-plugin fileset covers it — `mvn clean` leaves it in place.
+Stale reports merge into fresh ones on a max-covered-wins basis, so a line covered by
+yesterday's run counts as covered today. Leaving the directory in place biases coverage
+upward and the bias is invisible in the output.
+
+**Step 4, the report-set assertion.** `.coverage/reports` must contain a report directory
+for **every** module with changed Java files. Changed files in an unreported module are
+silently dropped from the coverage denominator: the gate reports a confident number
+computed over a subset of the diff. If a module is missing, the measurement is wrong even
+when the printed percentage clears the thresholds — fix the module selection and re-run.
+
+Always use `coverage-gate.py` rather than computing coverage by hand; the reason manual
+arithmetic gives wrong answers (the JaCoCo `assert`-statement trap) is in
+thread-guidelines § Coverage Verification.
+
+### When a coverage "skip" is a pass
+
+A skip counts as a pass **only** when the change genuinely has no changed Java files.
+Verify that, do not assume it:
+
+```bash
+git diff origin/develop...HEAD --name-only -- '*.java'
+```
+
+Empty output — a real pass. Non-empty output plus a skip — the *measurement* failed and must
+be investigated, not recorded as a green gate. The script has five paths that print
+something reassuring without measuring anything, and all five look like success:
+
+1. **No changed Java files** — the only legitimate skip.
+2. **No JaCoCo report found** for a module, so its changed lines are not counted.
+3. **Zero coverable lines in the diff** ("no coverable lines in diff").
+4. **Zero branches in the changed lines** ("no branches in changed lines").
+5. **Both zero** — line and branch checks each vacuously satisfied.
+
+"Skipping coverage gate" on a change that touches Java is finding number 2, 3, 4 or 5 until
+proven otherwise. Hardening the script against these paths is deferred follow-up work; until
+then this protocol is the only guard.
+
+### Deferred test authorship
+
+When test work for a track is substantial enough to be split out, it becomes **its own task
+within the same track**, landing before that track's agent code review. Promoting it to a
+track of its own requires explicit user approval. It cannot be deferred to a follow-up issue
+or PR: the CI coverage gate hard-fails a ready PR with no bypass, so the debt cannot leave
+this PR.
+
+### Committing, and landing red
+
+**Never commit over a red result you actually observed.** Running unit tests mid-track is
+not required; committing on top of a build or test run you watched fail is forbidden. To
+keep the rule checkable rather than aspirational, the agent reports which gate command it
+ran and what the outcome was — the command line and its result, not an assurance.
+
+**Landing red** is possible only with explicit user approval, recorded in the PR's Risks &
+accepted trade-offs, naming the failing tests and the track that will fix them.
+
+### After the flip
+
+Any post-flip commit that touches code runs the affected-module tests before being pushed.
+Once the PR is non-draft, CI enforces on every push regardless — including the coverage
+gate, which runs only on non-draft PRs and so re-engages automatically at the
+ready-for-review flip. During the draft phase there is no CI at all, which is why the
+end-of-track gate is the only verification signal that exists while a track is being
+implemented.
+
+### Encouraged, never required
+
+Running the single closest test class mid-track for a risky change. It is cheap, it catches
+the obvious break early, and no gate depends on it.
 
 ## Model routing
 

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -60,8 +60,10 @@ This section owns the *mechanics* of verification inside a track: which command 
 commit, how the module sets are computed, when the expensive gate re-runs, and how coverage
 is measured. The always-injected `docs-internal/agents/orchestrator-guidelines.md` and
 `docs-internal/agents/thread-guidelines.md` carry only the short rule plus a pointer here,
-per AGENTS.md § Load Guidance Documents on Demand. Ownership is split rather than
-duplicated — these rules stay where they are and are not restated below: the 85%/70%
+per AGENTS.md § Load Guidance Documents on Demand. Ownership is split rather than duplicated.
+The rules below are owned elsewhere, and this section cites them instead of redefining them —
+where a command line needs one of their values, such as the 85/70 flags in the coverage
+invocation, it reproduces the owner's value rather than setting its own: the 85%/70%
 thresholds and the test-authorship obligation (orchestrator-guidelines § Test Policy), the
 integration-test decision rules and the serial-test-execution scheduling invariant
 (orchestrator-guidelines § Verification Gates), and the raw build-command catalogue
@@ -138,9 +140,12 @@ selection has nothing to name. Their compile gate is reactor-wide — no `-pl`, 
 
 ### Two module sets: compile gate vs test gates
 
-"Affected modules" is not a single set. The compile gate and the test gates need different
+Module selection is not one set. The compile gate and the test gates need different
 ones, and carrying the compile-gate definition into a test gate silently converts it into a
-reactor-wide test run — the exact cost this protocol exists to avoid.
+reactor-wide test run — the exact cost this protocol exists to avoid. Both names below —
+**compile-gate set** and **test-gate set** — are the terms the injected guideline documents
+use as well, so a short rule stated there in terms of either set resolves to the definition
+here.
 
 **Compile-gate set** — the modules containing changed files **plus their downstream
 consumers in the reactor**, which is what `-am -amd` expresses. This set is deliberately
@@ -152,8 +157,7 @@ nothing about whether `server` still compiles.
 own tests exercise the changed behavior. There is no automatic `-amd` fan-out here: a
 dependent that merely compiles against a changed API is already covered by the compile gate,
 and re-running its suites costs tens of minutes for no new signal. This is the set the
-end-of-track gate below and § After the flip call the test-gate modules, and the set the
-short "affected modules" phrasing in the guideline documents refers to. When the changed
+end-of-track gate below and § After the flip mean by the test-gate modules. When the changed
 behavior does reach a dependent's tests, name that dependent in `-pl` explicitly rather than
 switching the run to `-amd`.
 
@@ -179,11 +183,12 @@ At the end of each track's implementation, and **before** that track's agent cod
 the full verification runs:
 
 1. **Unit tests** for the test-gate modules, green.
-2. **Integration tests** (`-P ci-integration-tests`) where the change hits areas the
-   integration-test decision rules in orchestrator-guidelines § Verification Gates
-   name — storage, WAL, index, Gremlin integration, transaction handling.
-3. **The coverage gate** at 85% line / 70% branch over the changed lines, run by the
-   procedure below.
+2. **Integration tests** (`-P ci-integration-tests`) when the change touches areas covered by
+   integration tests. That trigger is owned by orchestrator-guidelines § Verification Gates
+   and is deliberately general, not a closed list of areas — read it there rather than
+   working from an enumeration here.
+3. **The coverage gate** over the changed lines, at the thresholds owned by
+   orchestrator-guidelines § Test Policy, run by the procedure below.
 
 The placement matters in both directions. Gating only at the track's closing event (below)
 would have reviewers reviewing unverified code; gating only before the review would let
@@ -287,10 +292,15 @@ turns on which of the two reasons for a missing report applies:
   the module selection or the build and re-run: a percentage that clears the thresholds is
   still wrong.
 
-Cross-check the count while you are there. The script prints `Found N JaCoCo report(s)`,
-where N counts the `jacoco.xml` files it globbed — one per report directory — so N below the
-size of the expected report set means a report is missing, and N above it means stale
-directories survived step 1.
+Cross-check the count while you are there, but read it in one direction only. The script
+prints `Found N JaCoCo report(s)`, where N counts the `jacoco.xml` files it globbed — one per
+report directory. N **larger** than the expected report set is normal rather than a symptom:
+`-am` builds the upstream modules too, and every upstream module that has test sources writes
+its own report. A change confined to `server` builds `gremlin-annotations` and `core` on the
+way there, so three reports appear where the coverage set names one. Nor can the surplus be
+stale, since step 1 emptied the directory before the run. The direction that matters is the
+other one: N below the expected count, or `ls` showing no directory for a coverage-set module
+that has `src/test`, is the missing-report defect above.
 
 Always use `coverage-gate.py` rather than computing coverage by hand; the reason manual
 arithmetic gives wrong answers (the JaCoCo `assert`-statement trap) is in


### PR DESCRIPTION
#### Motivation:

The workflow demanded full verification — affected-module unit tests plus the changed-lines coverage
gate — on **every** commit inside a track. That cost buys nothing durable: one PR becomes one squashed
commit on `develop`, so intermediate commits never reach the default branch and no bisect there can
land on one.

The price is measurable. `./mvnw -pl core -am test-compile` completes in about 40 seconds, while
`./mvnw -pl core test` did **not** finish within a 900-second timeout — a ~40-second gate replaced
by one exceeding 15 minutes, on every commit of every track, to protect commits discarded at merge.
Expensive and unenforced, it was also the kind of rule agents silently skip. Moving verification to
the end of a track's implementation, before review, makes it cheap enough to follow and explicit
enough to check.

#### Planned changes:

**Current state**

The pi/Slate documentation set states the verification obligation as a per-commit rule ("never
commit if tests fail"), coupled to test authorship and the 85% line / 70% branch coverage gate. No
document defines a track-level verification event, so verification is diffuse: every commit is
nominally gated and nothing in particular is. The vendored `ytdb-slate` package imposes no test or
coverage rule of its own, delegating to "the project's own engineering guidelines", so this is a
project-side documentation change with no package bump.

**What changes**

- **Mid-track commit gate.** A commit requires `./mvnw -pl <modules with changed files> -am -amd
  test-compile`. No unit tests, no integration tests, no coverage.
- **Module selection is two named sets.** The **compile-gate set** — changed modules plus their
  upstream *and* downstream reactor neighbours — is deliberately wide. The **test-gate set** —
  changed modules plus only dependents whose own tests exercise the changed behavior — is narrow and
  named explicitly rather than by fan-out. The end-of-track gate and the post-flip rule mean the
  test-gate set.
- **Shading exception.** A change affecting the `embedded` module's shaded artifact runs `-pl
  embedded -am -amd package -DskipTests`, since shading binds to `package`; the skip keeps the gate
  test-free, a bare `package` running surefire including `embedded`'s ~1900 Cucumber scenarios.
- **Build files belonging to no module** (root POM, Maven JVM configuration, formatter config) affect
  every module and live in none, so their compile gate is reactor-wide; a change with no Java files or
  module content carries no Maven gate at all.
- **End-of-track gate.** At the end of each track's implementation and **before** its agent code
  review: unit tests for the test-gate set green, integration tests per the existing decision rules,
  and the coverage gate at 85%/70%. This holds at **every** tier — a single-track change runs it
  before its agent code review too, not merely before the flip.
- **Re-run before the track's closing event** — the marker commit in a multi-track change, the
  ready-for-review flip in a single-track change, which has no marker. It re-runs unless every commit
  since is provably outcome-neutral: documentation or comments only. Being an *exclusion* rule rather
  than a source-path allowlist, it covers build-affecting non-source files by construction.
- **Approval reopening.** Any commit landing after the mandatory per-track user review has approved
  the track reopens that review for those commits, before the closing event: neither a marker commit
  nor a flip certifies code the user has not seen.
- **Commit rule.** "Never commit if tests fail" becomes "never commit over a red result you actually
  observed": running tests mid-track is not required, but committing on top of a run you watched fail
  is forbidden. The agent reports the gate command and outcome, so the rule is checkable.
- **Landing red** is the single carve-out, and not one the agent takes alone: it needs explicit user
  approval recorded in Risks & accepted trade-offs, naming the failing tests and the track that will
  fix them. Any red not named there still blocks the commit.
- **Deferred test authorship.** Substantial test work becomes its own task **within the same track**,
  landing before that track's agent code review; promoting it to its own track needs user approval.
- **Post-flip.** Any post-flip commit touching code runs the test-gate set's tests before being
  pushed; once the PR is non-draft, CI enforces on every push anyway. Running the single closest test
  class mid-track stays encouraged, never required.

**How**

- **Two documents, split by reading moment.** The first draft put the whole protocol in
  `docs-internal/dev-workflow/track-development.md` § Verification integration: 21,148 B, read
  ~19–21 times per multi-track change though on-demand, of which a reader looking up one command
  needed ~5,600 B — and an audit found only 619 B had relocated from the injected guidelines, the
  rest newly authored, ~two-thirds of it justification prose. It was split by *when* a reader needs
  it. § Verification integration is now the **gate reference** — gate commands, the two module
  sets, which gate runs when, the closing-event re-run rule, deferred test authorship, landing red —
  at **8,617 B**; `docs-internal/dev-workflow/coverage-verification.md` is a **new 6,228 B document**
  read only when a coverage number is produced or diagnosed.
- **Neither document is the single home.** The gate reference owns *when, and with what command*, a
  gate runs; the coverage document owns *how a number is produced and judged*; each points at the
  other for the rest. The end-of-track gate carries a hard stop into the coverage document: a result
  produced without following it is **not a gate result and must not be reported as one**. The
  always-injected guidelines keep only the short rule, a pointer, and the rules they own — thresholds,
  test authorship, the integration-test trigger, the serial-test invariant, the build-command
  catalogue — cited by the on-demand documents rather than restated, per AGENTS.md § Load Guidance
  Documents on Demand.
- **Measured outcome.** The injected surface shrank rather than grew, against `origin/develop`: 12,510
  → 11,961 B for the orchestrator role, 12,319 → 12,235 B for the worker role. Across the seven
  documents touched the corpus is 6,164 B smaller than this branch's pre-split state, and the
  per-commit-lookup read cost fell 59.3%.
- **What the coverage document specifies.** A third set — the **coverage set**, the modules with
  changed Java files, no fan-out — is built under the `coverage` profile after removing
  `.coverage/reports`, which `mvn clean` never touches and whose stale reports merge in
  max-covered-wins as an invisible upward bias. Two checks follow. The **report-set assertion**
  requires a report for every coverage-set module that has test sources (modules without tests never
  write one); a report missing from a module that does have tests is a measurement defect whose lines
  silently leave the denominator. Only a deficit is a defect — a surplus is normal, `-am` also
  building upstream modules that have tests. The **skip rule**: a skip is a pass only when the change
  genuinely has no changed Java files, checked with the same filtered diff the script uses, an
  unfiltered check deadlocking on a deletion-only change; the five vacuous outcomes, quoted verbatim,
  otherwise mean the *measurement* failed. CI's run differs (full reactor, disk storage, failures
  ignored, PR base) and is authoritative; the local run is a prediction, no substitute for the CI
  command, which is priced in hours.
- **Elsewhere.** The orchestrator guidelines' § Pre-Commit Verification becomes § Verification Gates,
  no longer describing a pre-commit rule; the docs-internal index gains a row for the coverage
  document; the doctrine's model-routing list now names all Maven test/coverage runs, end-of-track and
  post-flip included, so routine compile gates are not routed as full verification; and two rules a
  condensation pass had dropped — the general integration-test trigger and the "if in doubt, run the
  full suite" fallback — are restored, the trigger a general clause with examples rather than the
  closed list it had become.

**Key decisions**

1. **`test-compile`, not `compile`.** Bare `compile` rejected: it skips test sources, so test code
   rots silently for a whole track. `test-compile` is a superset and still triggers Spotless and all
   source generation.
2. **`-am` mandatory.** Plain `-pl <modules> test-compile` rejected on evidence: it resolved a
   sibling from the local repository — a snapshot one commit behind HEAD, ~2h stale — reporting green
   over code that did not compile against the tree. `-am` was separately verified to protect the
   annotation-processor channel: with the processor deliberately broken, the reactor used the freshly
   built one, not the installed jar. Cost is negligible (~40s versus ~48s on `core`).
3. **`-amd` mandatory too**, added during implementation. `-am` builds upstream only, so a consumer
   that no longer compiles against a changed API was never built — the same false green in the opposite
   direction, a green `-pl core -am test-compile` saying nothing about `server`. Near-reactor-wide
   expansion on a widely consumed module is the intended price, not an accident.
4. **Two module sets, not one phrase.** A single "affected modules" notion rejected: the compile gate
   needs a wide set, the test gates a narrow one, and carrying the wide definition into a test gate
   silently produces the reactor-wide test run this change exists to avoid.
5. **Split by reading moment.** One protocol document rejected after user review of its context cost
   — on-demand is not cheap, and a document consulted repeatedly for one-command answers pays its
   full size each time. Trimming content rejected as it would cost rules and evidence; folding
   coverage into the injected guidelines rejected as it would grow the per-prompt surface.
6. **End gate before the agent code review, at every tier.** Gating only at the closing event
   rejected — reviewers would review unverified code; gating only before review rejected —
   review-fix commits could land unverified; exempting single-track changes rejected as that
   reinstates the defect for the commonest tier.
7. **Re-run keyed to the closing event, not the marker commit.** Marker-only keying rejected:
   single-track changes have no marker and would get no trigger, though review-fix commits are as common
   there as anywhere.
8. **Per-module coverage build with a conditioned report-set assertion.** Full-reactor `-P coverage`
   rejected as priced in hours and so likely to be silently skipped — an unfollowed rule protects
   nothing. An unconditioned assertion rejected as unsatisfiable for modules without tests; a
   surplus-report heuristic rejected as it fires on every normal `-am` run, deficits alone mattering.
9. **Deferred test work is a task in the same track.** A dedicated test track by default rejected per
   the user's direction; deferral to a follow-up issue or PR rejected because the CI coverage gate
   hard-fails a ready PR with no bypass, so the debt cannot leave this PR.
10. **Coverage stays a per-track-end gate.** A change-level-only gate rejected once test authorship was
    confirmed to stay in-track, which makes per-track coverage coherent.
11. **Hygiene documented, not enforced in code.** Hardening the gate script so a missing report or an
    unreported changed module hard-fails rejected here: it adds CI blast radius and test work to a
    documentation change. Deferred.
12. **No CI changes.** Touching CI rejected as unnecessary — the coverage gate runs only on non-draft
    PRs, so it never fires during implementation and re-engages at the flip. Per-push gating rejected
    too: pushes are frequent and the end-of-track gate covers the push that matters.
13. **Scope limited to the pi/Slate documentation set.** Extending to the Claude Code stack rejected
    per the user's direction; see Out of scope.

**Out of scope**

- The separately maintained Claude Code stack (its root instruction file and workflow documents),
  which keeps requiring per-commit testing; the skew is known and accepted. One stray citation of the
  old rule in the archived ADR material is likewise left alone.
- Hardening the coverage-gate script against its five vacuous-pass paths — no changed Java files, no
  report found, zero coverable lines, zero branches, both zero. Recorded as follow-up work.
- Pre-existing Spotless drift in the Gremlin DSL annotation processor source, found while verifying
  decision 2. Unrelated; recorded as follow-up work.
- The 85%/70% thresholds, the test-authorship obligation, the serial-test invariant and all CI
  workflow definitions are unchanged.

**Risks & accepted trade-offs**

- **Draft PRs run zero CI**, so throughout implementation the local end-of-track gate is the only
  verification signal. Accepted — already true today; the change makes that gate explicit and
  reportable rather than nominal.
- **Intra-track bisect becomes unreliable**: breakage surfaces at track end and may have to be traced
  through several compile-only commits. Accepted — those commits are squashed away and were never
  bisectable from `develop`.
- **The gate script's vacuous-pass paths survive**, guarded only by protocol: the report-set
  assertion, the report removal, the filtered skip check, the verbatim strings — weaker than a check.
  Accepted, hardening deferred.
- **Documentation skew with the out-of-scope Claude Code stack**, which still requires per-commit
  testing. Accepted; reconciliation deferred to the user.
- **Per-track coverage figures are cumulative** over the branch diff, so a later track's number
  includes earlier tracks' lines — pre-existing measurement behavior.
- **The compile gate is wide by construction**: with `-amd`, a change to a widely consumed module
  compiles most of the reactor at every commit. Accepted deliberately — the alternative is an
  invisible consumer break, and `test-compile` absorbs the fan-out cheaply.
- **A second on-demand document to keep in sync**: the two point at each other for what they do not
  own, and such cross-references drift. Accepted as the cheaper failure mode, mitigated by each opening
  with what it owns and where the rest lives.
- **Review record.** Four non-code perspectives — instruction completeness, internal consistency,
  context budget, writing style — produced 28 findings, of which the 3 blockers and the should-fix set
  were fixed. Two independent gate threads then verified those fixes, catching two protocol defects
  and four stale description claims, all corrected here; layered peer review was waived by the user.
- **Corpus figure not reconciled.** An earlier −6,303 B whole-corpus estimate could not be reproduced;
  the published −6,164 B is the reproducible measurement, stated with its file set and baseline. User
  disposition: the measured figure stands, the discrepancy not pursued.
- **One document grew.** The doctrine extension gained 58 B — the only file on either injected surface
  to grow — because the model-routing list had to name the new verification runs. User disposition:
  accepted; both role surfaces are still net smaller.
- **A dropped escape hatch stays dropped.** The pre-split clause permitting hand-enumeration of `-pl`
  consumers, with a duty to justify the set's completeness, was removed: `-amd` computes the
  downstream set, making the hatch unnecessary and its justification duty unenforceable. User
  disposition: confirmed, not to be restored.

Design review: user-approved — 2026-08-06
Adversarial review: passed, 2 rounds, 4 accepted risks — 2026-08-06

**Verification approach**

Documentation-only change with no Java files and no module content, so by its own new rules it
carries no Maven gate: verification is the reviews recorded above plus the mandatory user review. Its
empirical claims — the stale-sibling false green, the annotation-processor channel, the missing-report
behavior of modules without tests — were each verified with real Maven runs.