### PR TITLE
Update ytdb-slate to 0.9.0, enable six Slate settings and reconcile the doctrine they falsified

### DIFF
--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -4,7 +4,7 @@
   "defaultThinkingLevel": "xhigh",
   "hideThinkingBlock": true,
   "packages": [
-    "npm:ytdb-slate@0.5.1",
+    "npm:ytdb-slate@0.9.0",
     "npm:pi-smart-fetch@0.3.17",
     "npm:pi-web-search@1.3.1"
   ]

--- a/.pi/slate.json
+++ b/.pi/slate.json
@@ -14,7 +14,16 @@
       "openai/gpt-5.6-sol",
       "openai/gpt-5.6-luna"
     ],
-    "allowUnmeasuredEffort": false
+    "allowUnmeasuredEffort": true,
+    "showWarnings": true
+  },
+  "writing": {
+    "check": true,
+    "remind": true
+  },
+  "threadChoice": {
+    "report": true,
+    "act": true
   },
   "modelFailover": {
     "anthropic/claude-opus-5": "openai/gpt-5.6-sol",

--- a/docs-internal/agents/slate-doctrine-extra.md
+++ b/docs-internal/agents/slate-doctrine-extra.md
@@ -24,9 +24,10 @@ itself, for changes of any size:
 2. Name neither only for bulk mechanical work: the dispatch then rides
    the thread's base, which is sized for nothing else.
 3. Gate and verification actions MUST name both, on a level the live
-   routing table marks measured for that model — Slate now warns about
-   an unmeasured level instead of refusing it — and MUST NOT be sized
-   down to the cheapest model that looks like it would clear them:
+   routing table marks measured for that model — this project
+   configures the router to warn about an unmeasured level rather
+   than refuse it — and MUST NOT be sized down to the cheapest model
+   that looks like it would clear them:
    adversarial review, agent code review, the design-review and
    PR-description statements, the ready-for-review flip, all Maven
    test/coverage verification runs (including end-of-track and post-flip

--- a/docs-internal/agents/slate-doctrine-extra.md
+++ b/docs-internal/agents/slate-doctrine-extra.md
@@ -24,7 +24,8 @@ itself, for changes of any size:
 2. Name neither only for bulk mechanical work: the dispatch then rides
    the thread's base, which is sized for nothing else.
 3. Gate and verification actions MUST name both, on a level the live
-   routing table marks measured for that model, and MUST NOT be sized
+   routing table marks measured for that model — Slate now warns about
+   an unmeasured level instead of refusing it — and MUST NOT be sized
    down to the cheapest model that looks like it would clear them:
    adversarial review, agent code review, the design-review and
    PR-description statements, the ready-for-review flip, all Maven

--- a/docs-internal/agents/slate-doctrine-extra.md
+++ b/docs-internal/agents/slate-doctrine-extra.md
@@ -24,15 +24,15 @@ itself, for changes of any size:
 2. Name neither only for bulk mechanical work: the dispatch then rides
    the thread's base, which is sized for nothing else.
 3. Gate and verification actions MUST name both, on a level the live
-   routing table marks measured for that model — this project
-   configures the router to warn about an unmeasured level rather
-   than refuse it — and MUST NOT be sized down to the cheapest model
-   that looks like it would clear them:
-   adversarial review, agent code review, the design-review and
-   PR-description statements, the ready-for-review flip, all Maven
-   test/coverage verification runs (including end-of-track and post-flip
-   runs), commits and pushes, and any change to storage, WAL, index,
-   transaction or crash-recovery code.
+   routing table marks measured for that model: adversarial review,
+   agent code review, the design-review and PR-description
+   statements, the ready-for-review flip, all Maven test/coverage
+   verification runs (including end-of-track and post-flip runs),
+   commits and pushes, and any change to storage, WAL, index,
+   transaction or crash-recovery code. Those actions MUST NOT be
+   sized down to the cheapest model that looks like it would clear
+   them. This project configures the router to warn about an
+   unmeasured level rather than refuse it.
 
 Rationale, model-list maintenance and the machine-local prerequisite:
 `docs-internal/dev-workflow/track-development.md` § Model routing.

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -259,15 +259,18 @@ model-routing.md owns which warning is which.
 
 **Effort policy.** `router.allowUnmeasuredEffort` is `true`. Slate therefore warns about an
 explicit level that sits on the model's ladder but carries no capability measurement, rather
-than refusing it: the dispatch runs, a ⚠ notice calls the result unevidenced, and Slate marks
-the episode header `(unmeasured level)`. The guards judge only a level the dispatch NAMES:
-omit `effort` and the router derives a measured level instead. One path escapes that rule. A
-failover retry names no level, so it can land on an unevidenced level, and it leaves no
-marker behind — What failover ignores records the case. Two nearby refusals come from
-elsewhere and stand whatever this key says: a level off the model's ladder, and one the
-provider rejects outright. One rule alone keeps a review or a gate action on a measured
-level: the Model routing rule in `docs-internal/agents/slate-doctrine-extra.md`. The package
-states it as doctrine only, not a code-enforced guard.
+than refusing it. The dispatch runs. A ⚠ notice calls the result unevidenced. Slate marks the
+episode header `(unmeasured level)`. The guards judge whichever level the action ends up on,
+named by the dispatch or not, and only a named one can fail them. A dispatch that omits
+`effort` leaves the router a measured level by construction: it derives the routed model's
+lowest measured level, or re-validates the thread's stored base level and re-derives it when
+that level no longer reads measured. One path escapes that rule. A failover retry names no
+level, so it can land on an unevidenced level, and it leaves no marker behind — What failover
+ignores records the case. Two nearby refusals come from elsewhere and stand whatever this
+key says: a level off the model's ladder, and one the provider rejects outright. One rule
+alone keeps a review or a gate action on a measured level: the Model routing rule in
+`docs-internal/agents/slate-doctrine-extra.md`. The package states it as doctrine only, not
+a code-enforced guard.
 
 **Unsized dispatches.** A dispatch that names neither `model` nor `effort` runs on the
 thread's base. For a NEW thread that base is `openai/gpt-5.6-luna@medium` — the cheapest
@@ -350,17 +353,16 @@ configuration-fault line, a hidden-warnings summary line, or a non-zero exit is 
 too.
 
 **Authority.** The routing table Slate renders into the doctrine each turn is the single
-authority on per-model guidance, prices and measured levels; do not restate it under
-`docs-internal/`. Four restatements here are deliberate. Each records a project decision
-that a reader cannot follow without the fact it rests on: the profile markers the candidate
-list cites to justify every inclusion and exclusion, the base model-and-level pairs under
-Unsized dispatches, the accepted residual under What failover ignores, and the dated price
-step this paragraph names next. Those four are the only restatements here, and every pin
-bump re-checks them. The figures drift: prices are dated schedules (`claude-sonnet-5`'s step
-up 50% on 2026-09-01, which changes the table's numbers but not its order, since
-`nonPreferred` sorts that model last on both sides of the step), and measured levels,
-route-for/avoid-for guidance and the profiled model set itself change whenever the package
-is republished.
+authority on per-model guidance, prices and measured levels. Leave every such fact in that
+table. This section restates it in exactly four deliberate places, each recording a project
+decision that a reader cannot follow without the fact it rests on: the profile markers the
+candidate list cites to justify every inclusion and exclusion, the base model-and-level pairs
+under Unsized dispatches, the accepted residual under What failover ignores, and the dated
+price step this paragraph names next. Every pin bump re-checks those four. The figures
+drift: prices are dated schedules (`claude-sonnet-5`'s step up 50% on 2026-09-01, which
+changes the table's numbers but not its order, since `nonPreferred` sorts that model last on
+both sides of the step), and measured levels, route-for/avoid-for guidance and the profiled
+model set itself change whenever the package is republished.
 
 ## Package pin bumps
 
@@ -373,6 +375,6 @@ written against.
 Last reconciled against **ytdb-slate 0.9.0**: track-workflow.md, pr-publishing.md,
 model-routing.md, model-failover.md, review-rules.md, writing-guidance.md,
 thread-cache-cost.md and context-budget.md. Those are the package documents these deltas
-rest on, re-read against the six `.pi/slate.json` switches this change turned on across
-`router`, `writing` and `threadChoice`. The list deliberately omits design-principles.md,
-because no delta here rests on it.
+rest on. This reconciliation read each of them against the six `.pi/slate.json` switches
+that this change turned on across `router`, `writing` and `threadChoice`. The list
+deliberately omits design-principles.md, because no delta here rests on it.

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -260,17 +260,15 @@ model-routing.md owns which warning is which.
 **Effort policy.** `router.allowUnmeasuredEffort` is `true`. Slate therefore warns about an
 explicit level that sits on the model's ladder but carries no capability measurement, rather
 than refusing it. The dispatch runs. A ⚠ notice calls the result unevidenced. Slate marks the
-episode header `(unmeasured level)`. The guards judge whichever level the action ends up on,
-named by the dispatch or not, and only a named one can fail them. A dispatch that omits
-`effort` leaves the router a measured level by construction: it derives the routed model's
-lowest measured level, or re-validates the thread's stored base level and re-derives it when
-that level no longer reads measured. One path escapes that rule. A failover retry names no
-level, so it can land on an unevidenced level, and it leaves no marker behind — What failover
-ignores records the case. Two nearby refusals come from elsewhere and stand whatever this
-key says: a level off the model's ladder, and one the provider rejects outright. One rule
-alone keeps a review or a gate action on a measured level: the Model routing rule in
-`docs-internal/agents/slate-doctrine-extra.md`. The package states it as doctrine only, not
-a code-enforced guard.
+episode header `(unmeasured level)`. Only a level the dispatch names can draw that notice or
+a refusal. Every model on this project's candidate list carries measured levels, so a
+dispatch that omits `effort` gets one of them. A failover retry is the exception. It names no
+level, so it can land on an unevidenced one. The episode header then carries no marker to say
+so. What failover ignores records that case. Two nearby refusals come from elsewhere and
+stand whatever this key says: a level off the model's ladder, and one the provider rejects
+outright. One rule alone keeps a review or a gate action on a measured level: the Model
+routing rule in `docs-internal/agents/slate-doctrine-extra.md`. The package states it as
+doctrine only, not a code-enforced guard.
 
 **Unsized dispatches.** A dispatch that names neither `model` nor `effort` runs on the
 thread's base. For a NEW thread that base is `openai/gpt-5.6-luna@medium` — the cheapest
@@ -358,11 +356,13 @@ table. This section restates it in exactly four deliberate places, each recordin
 decision that a reader cannot follow without the fact it rests on: the profile markers the
 candidate list cites to justify every inclusion and exclusion, the base model-and-level pairs
 under Unsized dispatches, the accepted residual under What failover ignores, and the dated
-price step this paragraph names next. Every pin bump re-checks those four. The figures
-drift: prices are dated schedules (`claude-sonnet-5`'s step up 50% on 2026-09-01, which
-changes the table's numbers but not its order, since `nonPreferred` sorts that model last on
-both sides of the step), and measured levels, route-for/avoid-for guidance and the profiled
-model set itself change whenever the package is republished.
+price step this paragraph names next. Every pin bump re-checks those four. A pin bump also
+re-checks the Effort policy claim that every listed model carries measured levels. A new
+list entry or a refreshed profile table can falsify it. The figures drift: prices are dated
+schedules (`claude-sonnet-5`'s step up 50% on 2026-09-01, which changes the table's numbers
+but not its order, since `nonPreferred` sorts that model last on both sides of the step), and
+measured levels, route-for/avoid-for guidance and the profiled model set itself change
+whenever the package is republished.
 
 ## Package pin bumps
 

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -242,23 +242,29 @@ model.
 
 **When warnings appear.** Only config-SHAPE checks run at session start: a `router` value
 that is not an object, an unknown key under it, a non-array `models`, a malformed entry, a
-non-boolean `allowUnmeasuredEffort`. Candidate resolution — profile lookup, registry and
+non-boolean `allowUnmeasuredEffort` or `showWarnings`, and — since this project now enables
+it too — a malformed `writing` object, an unknown key under it, or a non-boolean value
+inside it. `threadChoice` is the exception: its shape is read at the first continuation
+dispatch rather than at session start, so a fault in it reaches that dispatch's warnings and
+never the acceptance check below. Candidate resolution — profile lookup, registry and
 credential checks, effort-ladder readability, failover coverage — is memoized and runs at
 the FIRST consultation instead: the doctrine build in orchestrator mode, or the first
 dispatch outside it. A session that builds no doctrine and dispatches nothing emits none of
-those warnings, which is what the acceptance check below has to work around.
+those warnings, which is what the acceptance check below has to work around. Resolution
+warnings now carry a class, and only one of the two is gated: a configuration fault always
+reaches the user — a candidate with no `modelFailover` entry is one — while
+`router.showWarnings: true` is what reveals the model data notes. The package's
+model-routing.md owns which warning is which.
 
-**Effort policy.** `router.allowUnmeasuredEffort` is `false`, so an explicit level that sits
-on the model's ladder but carries no capability measurement is refused rather than warned
-about. Only a level the dispatch NAMES can be refused: omit `effort` and the router derives
-the model's lowest measured level, which by construction clears the guard. What the setting
-costs, per model: `off`, `low`, `high` and `xhigh` on `gpt-5.6-luna`; `off` and `low` on
-`gpt-5.6-sol`; `off` and `minimal` on `claude-opus-5`; `minimal`, `low` and `medium` on
-`claude-sonnet-5`. Of those, the ones this project would otherwise have reached for are
-`luna@high` and `luna@xhigh` (escalating luna instead of routing to sol) and `sol@low`. Two
-nearby refusals come from elsewhere and stand whatever this key says: `minimal` is off-ladder
-on both `gpt-5.6` models, and `off` on `claude-sonnet-5` is rejected outright by the
-provider — which is why `off` is absent from that model's list above.
+**Effort policy.** `router.allowUnmeasuredEffort` is `true`, so an explicit level that sits
+on the model's ladder but carries no capability measurement is warned about rather than
+refused: the dispatch runs, a ⚠ notice says the result is unevidenced, and the episode
+header is marked `(unmeasured level)`. Only a level the dispatch NAMES can be unevidenced —
+omit `effort` and the router derives the model's lowest measured level. Two nearby refusals
+come from elsewhere and stand whatever this key says: a level off the model's ladder, and
+one the provider rejects outright. Nothing therefore keeps a review or a gate action on a
+measured level except the rule in `docs-internal/agents/slate-doctrine-extra.md` § Model
+routing, which the package states as doctrine only, not a code-enforced guard.
 
 **Unsized dispatches.** A dispatch that names neither `model` nor `effort` runs on the
 thread's base. For a NEW thread that base is `openai/gpt-5.6-luna@medium` — the cheapest
@@ -291,11 +297,10 @@ compressor), `gpt-5.6-sol → claude-opus-5`, `gpt-5.6-luna → claude-opus-5`.
 **What failover ignores.** A failover switch bypasses the list and effort guards entirely —
 the package's deliberate carve-out, since a model that just failed is worse than an unlisted
 one that works — and it requests no level, so pi re-applies the session's current level to
-the fallback model. `allowUnmeasuredEffort: false` therefore does not constrain the retry, and
-the episode header drops its `(unmeasured level)` marker whenever the model changed
-mid-action, so an unmeasured retry level leaves no trace there either. Each pair above retries
-on a level its target has a measurement at, with one accepted residual: `claude-opus-5@low`
-retries as `gpt-5.6-sol@low`, and sol carries no measurement at `low`.
+the fallback model. The episode header drops its `(unmeasured level)` marker whenever the
+model changed mid-action, so an unmeasured retry level leaves no trace there either. Each
+pair above retries on a level its target has a measurement at, with one accepted residual:
+`claude-opus-5@low` retries as `gpt-5.6-sol@low`, and sol carries no measurement at `low`.
 
 **Machine-local prerequisite.** Routing here assumes a per-developer, untracked
 `~/.pi/agent/models.json` that raises the registry context window of the `gpt-5.6-*` models
@@ -329,22 +334,25 @@ repo-side: `models.json` is a user-global pi file, not project config.
 orchestrator-mode auto-seed is gated to TUI sessions, so a print-mode run builds no doctrine,
 never consults the resolver, and emits ZERO router warnings however broken the list is. Turn
 the mode on in the same session instead — `pi -p "/slate on" "hi"`, which runs the command
-first and the prompt second — and the warnings reach stderr. A healthy configuration prints
-exactly four, one per routable model, each reporting unknown routing-critical data and that
-routing decisions for that model are provisional. Anything beyond those four is a finding:
-context-window-divergence or long-context-billing lines mean the `models.json` override is
-missing, a failover-coverage line means a candidate lost its `modelFailover` entry, a
-"no benchmark data" or "not in pi's model registry" line means a spec is misspelled, and an
-`allowUnmeasuredEffort` line means the key is no longer a boolean.
+first and the prompt second — and the warnings reach stderr. A healthy configuration emits
+one general note about untraced research-table data, then one model-data note per model in
+the candidate list above, naming those models and in that order, with zero
+configuration-fault lines. Read the ids, not just the count: a note missing, one too many,
+one naming a model the list does not, or the set arriving in another order is a finding —
+that is what a silently dropped or swapped candidate looks like. The notes are visible
+because `router.showWarnings` is `true`; there is no hidden-warnings summary line. Per-model
+fact counts are deliberately not specified because package model data can change. A
+configuration-fault line, a hidden-warnings summary line, or a non-zero exit is a finding
+too.
 
 **Authority.** The routing table Slate renders into the doctrine each turn is the single
 authority on per-model guidance, prices and measured levels; do not restate it under
-`docs-internal/`. The effort-policy enumeration above is the one deliberate exception — it
-explains a project setting rather than the table — and it is re-checked at every pin bump.
-The figures drift: prices are dated schedules (`claude-sonnet-5`'s step up 50% on 2026-09-01,
-which changes the table's numbers but not its order, since `nonPreferred` sorts that model
-last on both sides of the step), and measured levels, route-for/avoid-for guidance and the
-profiled model set itself change whenever the package is republished.
+`docs-internal/`. Nothing here claims an exception to that: the effort-policy paragraph
+above names this project's setting and what follows from it, never the table's per-model
+levels. The figures drift: prices are dated schedules (`claude-sonnet-5`'s step up 50% on
+2026-09-01, which changes the table's numbers but not its order, since `nonPreferred` sorts
+that model last on both sides of the step), and measured levels, route-for/avoid-for
+guidance and the profiled model set itself change whenever the package is republished.
 
 ## Package pin bumps
 
@@ -354,5 +362,7 @@ document and `docs-internal/agents/slate-doctrine-extra.md` against the NEW pack
 fix any skew: the deltas here are valid only relative to the package version they were
 written against.
 
-Last reconciled against **ytdb-slate 0.5.1**: track-workflow.md, pr-publishing.md,
-model-routing.md and model-failover.md — the package documents these deltas actually rest on.
+Last reconciled against **ytdb-slate 0.9.0**: track-workflow.md, pr-publishing.md,
+model-routing.md, model-failover.md, review-rules.md, writing-guidance.md and
+thread-cache-cost.md — the package documents these deltas and the four enabled
+`.pi/slate.json` features actually rest on.

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -240,31 +240,34 @@ that still routes — read the warnings, or the typo passes for a working config
 entry drops, the router turns OFF entirely and dispatches fall back to the host session's
 model.
 
-**When warnings appear.** Only config-SHAPE checks run at session start: a `router` value
-that is not an object, an unknown key under it, a non-array `models`, a malformed entry, a
-non-boolean `allowUnmeasuredEffort` or `showWarnings`, and — since this project now enables
-it too — a malformed `writing` object, an unknown key under it, or a non-boolean value
-inside it. `threadChoice` is the exception: its shape is read at the first continuation
-dispatch rather than at session start, so a fault in it reaches that dispatch's warnings and
-never the acceptance check below. Candidate resolution — profile lookup, registry and
+**When warnings appear.** Only config-SHAPE checks run at session start. On the `router`
+side those are a value that is not an object, an unknown key under it, a non-array `models`,
+a malformed entry, and a non-boolean `allowUnmeasuredEffort` or `showWarnings`. This project
+enables `writing` too, which adds a malformed `writing` object, an unknown key under it, a
+non-boolean `check` or `remind`, and a `remindPercent` that is not a finite number in
+(0, 100]. `threadChoice` is the exception: Slate reads its shape at the first continuation
+dispatch, not at session start. A fault there reaches that dispatch's warnings, and the
+acceptance check below never sees it. Candidate resolution — profile lookup, registry and
 credential checks, effort-ladder readability, failover coverage — is memoized and runs at
 the FIRST consultation instead: the doctrine build in orchestrator mode, or the first
 dispatch outside it. A session that builds no doctrine and dispatches nothing emits none of
 those warnings, which is what the acceptance check below has to work around. Resolution
-warnings now carry a class, and only one of the two is gated: a configuration fault always
-reaches the user — a candidate with no `modelFailover` entry is one — while
-`router.showWarnings: true` is what reveals the model data notes. The package's
+warnings now carry a class, and Slate gates only one of the two. A configuration fault
+always reaches the user, and a candidate with no `modelFailover` entry is one.
+`router.showWarnings: true` is what reveals the model data notes, and the package's
 model-routing.md owns which warning is which.
 
-**Effort policy.** `router.allowUnmeasuredEffort` is `true`, so an explicit level that sits
-on the model's ladder but carries no capability measurement is warned about rather than
-refused: the dispatch runs, a ⚠ notice says the result is unevidenced, and the episode
-header is marked `(unmeasured level)`. Only a level the dispatch NAMES can be unevidenced —
-omit `effort` and the router derives the model's lowest measured level. Two nearby refusals
-come from elsewhere and stand whatever this key says: a level off the model's ladder, and
-one the provider rejects outright. Nothing therefore keeps a review or a gate action on a
-measured level except the rule in `docs-internal/agents/slate-doctrine-extra.md` § Model
-routing, which the package states as doctrine only, not a code-enforced guard.
+**Effort policy.** `router.allowUnmeasuredEffort` is `true`. Slate therefore warns about an
+explicit level that sits on the model's ladder but carries no capability measurement, rather
+than refusing it: the dispatch runs, a ⚠ notice calls the result unevidenced, and Slate marks
+the episode header `(unmeasured level)`. The guards judge only a level the dispatch NAMES:
+omit `effort` and the router derives a measured level instead. One path escapes that rule. A
+failover retry names no level, so it can land on an unevidenced level, and it leaves no
+marker behind — What failover ignores records the case. Two nearby refusals come from
+elsewhere and stand whatever this key says: a level off the model's ladder, and one the
+provider rejects outright. One rule alone keeps a review or a gate action on a measured
+level: the Model routing rule in `docs-internal/agents/slate-doctrine-extra.md`. The package
+states it as doctrine only, not a code-enforced guard.
 
 **Unsized dispatches.** A dispatch that names neither `model` nor `effort` runs on the
 thread's base. For a NEW thread that base is `openai/gpt-5.6-luna@medium` — the cheapest
@@ -336,23 +339,28 @@ never consults the resolver, and emits ZERO router warnings however broken the l
 the mode on in the same session instead — `pi -p "/slate on" "hi"`, which runs the command
 first and the prompt second — and the warnings reach stderr. A healthy configuration emits
 one general note about untraced research-table data, then one model-data note per model in
-the candidate list above, naming those models and in that order, with zero
-configuration-fault lines. Read the ids, not just the count: a note missing, one too many,
-one naming a model the list does not, or the set arriving in another order is a finding —
-that is what a silently dropped or swapped candidate looks like. The notes are visible
-because `router.showWarnings` is `true`; there is no hidden-warnings summary line. Per-model
-fact counts are deliberately not specified because package model data can change. A
+the candidate list above. Those notes name those models, in that order, and no
+configuration-fault line appears. Match each note's model id against that list, position by
+position, rather than counting notes. A missing note, an extra one, a note naming a model
+the list does not, or ids in a different order: each is a finding, and each is what a
+silently dropped or swapped candidate looks like. The notes are visible because
+`router.showWarnings` is `true`. No hidden-warnings summary line appears. This check
+deliberately omits per-model fact counts, because package model data can change. A
 configuration-fault line, a hidden-warnings summary line, or a non-zero exit is a finding
 too.
 
 **Authority.** The routing table Slate renders into the doctrine each turn is the single
 authority on per-model guidance, prices and measured levels; do not restate it under
-`docs-internal/`. Nothing here claims an exception to that: the effort-policy paragraph
-above names this project's setting and what follows from it, never the table's per-model
-levels. The figures drift: prices are dated schedules (`claude-sonnet-5`'s step up 50% on
-2026-09-01, which changes the table's numbers but not its order, since `nonPreferred` sorts
-that model last on both sides of the step), and measured levels, route-for/avoid-for
-guidance and the profiled model set itself change whenever the package is republished.
+`docs-internal/`. Four restatements here are deliberate. Each records a project decision
+that a reader cannot follow without the fact it rests on: the profile markers the candidate
+list cites to justify every inclusion and exclusion, the base model-and-level pairs under
+Unsized dispatches, the accepted residual under What failover ignores, and the dated price
+step this paragraph names next. Those four are the only restatements here, and every pin
+bump re-checks them. The figures drift: prices are dated schedules (`claude-sonnet-5`'s step
+up 50% on 2026-09-01, which changes the table's numbers but not its order, since
+`nonPreferred` sorts that model last on both sides of the step), and measured levels,
+route-for/avoid-for guidance and the profiled model set itself change whenever the package
+is republished.
 
 ## Package pin bumps
 
@@ -363,6 +371,8 @@ fix any skew: the deltas here are valid only relative to the package version the
 written against.
 
 Last reconciled against **ytdb-slate 0.9.0**: track-workflow.md, pr-publishing.md,
-model-routing.md, model-failover.md, review-rules.md, writing-guidance.md and
-thread-cache-cost.md — the package documents these deltas and the four enabled
-`.pi/slate.json` features actually rest on.
+model-routing.md, model-failover.md, review-rules.md, writing-guidance.md,
+thread-cache-cost.md and context-budget.md. Those are the package documents these deltas
+rest on, re-read against the six `.pi/slate.json` switches this change turned on across
+`router`, `writing` and `threadChoice`. The list deliberately omits design-principles.md,
+because no delta here rests on it.


### PR DESCRIPTION
#### Motivation:

The project pinned the ytdb-slate agent-workflow package at 0.5.1 while 0.9.0 was published. Four minor versions of drift left the project's own doctrine asserting package behaviour that no longer held. The project also wanted six Slate capabilities that were switched off: prose checking, its reminder cadence, the thread-choice planner in both reporting and acting modes, router warning visibility, and permission to dispatch an unmeasured effort level. The project's pin-bump rule treats a version bump as a tracked change, and it requires reconciling local doctrine against the new package documents. The upgrade and the doctrine repair are therefore one unit of work.

#### Planned changes:

**Current state**

The Slate package sat at 0.5.1. The project's Slate configuration refused an unmeasured effort level, and it carried no writing or thread-choice configuration. The internal track-development doctrine claimed that the router refuses an unmeasured level rather than warning about it. Its acceptance check expected the router to emit exactly four warnings at startup. The YTDB doctrine extension justified its measured-level requirement on that refusal. The reconciliation marker recorded 0.5.1 as the last version the doctrine was checked against, and it listed four package documents.

**What changes**

The pin moves to 0.9.0. Six settings switch on across three configuration objects: the router now shows warnings and allows an unmeasured effort level, prose checking and its reminders are enabled, and the thread-choice planner both reports and acts. Every future session sees the effects. A prose-rules sentence joins every worker preamble. Periodic hidden writing reminders reach the orchestrator. The thread-choice planner may restart a thread, which obliges a fresh-context argument on every continuation dispatch. Router model-data notes stay visible instead of collapsing into a hidden count. An unmeasured effort level now produces a warning instead of a refusal. Local doctrine no longer asserts superseded package behaviour.

**How**

The configuration edits are the whole functional change. The rest is doctrine reconciliation, which the pin-bump rule requires. The track-development doctrine's routing section had its effort policy and failover prose corrected, its acceptance check rebuilt around an observed run, and its reconciliation marker advanced to 0.9.0 with the package's current document set. The YTDB doctrine extension keeps its measured-level requirement, and that requirement now stands on its own authority.

Reconciliation corrected and deleted rather than mirrored. The package alone documents what 0.9.0 newly owns: the thread-choice and fresh-context mechanics, the reviewer and adversarial thread types, and the review-time writing checker. The routing section's standing Authority clause makes the package's routing table the single authority, and a local copy would recreate the drift this rule exists to prevent.

**Key decisions**

The acceptance check records an observed run rather than a predicted one. Research offered a derived estimate, and the change rejected it. An expected value nobody observed cannot detect the drift the check exists to catch. The measured run also contradicted the plan: a healthy configuration emits five notes, not the four the doctrine had claimed.

Router warning visibility is switched on rather than left at the new default, which hides model-data notes. The alternative was rewriting the acceptance check around a hidden-warning summary line, and that would have discarded the detail that makes the check useful.

The acceptance check describes the shape of a healthy run and ties each expected note to the candidate list by identity and position. It deliberately omits per-model fact counts, because those drift with package data and would fail a healthy configuration. An earlier draft described structure alone, and review found that a silently dropped or swapped model would still have passed it.

The routing section keeps four per-model facts that the package table also holds. Deleting them was considered and rejected: each one is the evidence for a project decision recorded elsewhere in the section, so deleting them would delete the reasoning. The Authority clause now names them as deliberate, and the pin-bump hook re-checks them.

The effort-policy paragraph describes no router internals. Three review rounds failed on that paragraph, each time on a claim about internal mechanics. The paragraph now makes two scoped claims that the project can verify, and the package documents the mechanics.

**Out of scope**

The reminder percentage keeps the package default. The project declares no new writing convention, and the mechanical thresholds the checker applies stay unadopted. Prose that predates this change stays as it is. The upstream gaps found during the work stay unreported here. Review filed twelve suggestion reports in the repository's local issue folder, which version control ignores; each one stands alone, and the user decides which become issues.

**Risks & accepted trade-offs**

Installing 0.9.0 mid-session replaced the package documents that worker threads cite while the running extension stayed at 0.5.1. This change was therefore reviewed under 0.5.1 mechanics, without the new thread types or the review-time writing checker. The user reviewed this trade-off, approved the track, and waived a peer review on the ready PR.

Prose checking and reminders change behaviour for every future session in this repository. That is the intent.

Version control ignores the local package tree, so the committed diff carries the pin string alone. A stale checkout can disagree with the pin until someone reinstalls it.

The review corrected a premise the agent stated wrongly. It first graded writing findings as advisory, on the belief that the project declares no writing convention. The project does declare one, and it governs every prose surface in the repository. Re-grading against its real rules turned six matches into genuine violations, and this change fixes them.

Design review: user-approved — 2026-08-07
Adversarial review: skipped with explicit user consent, medium-tier change — 2026-08-07

**Verification approach**

A live 0.9.0 install ran the router acceptance check six times across the work, and the observed output went into the doctrine. Static verification traced all six settings from configuration to effect site in the installed extension. Two review perspectives and three gate iterations examined the change; the gate confirmed the acceptance-check paragraph stayed byte-identical through every fix by hashing it. A repository sweep confirmed that no stale reference to the old version or the superseded refusal behaviour survives.