### PR TITLE
Make integration tests mandatory on pull requests and scope thread runs to affected tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,12 @@
 
 If this PR is related to an issue, prefix the title with the issue number (e.g., `YTDB-123: Imperative summary under 50 chars`).
 
-Integration tests run on every pull request that is ready for review.
+Integration tests run once a pull request from a branch in this repository is ready for review.
+Pull requests from forks do not run integration tests.
+A maintainer runs the integration tests before merging.
 Add `[no-it-tests]` to the title to skip that run.
 Use the tag only when the change cannot affect integration tests.
-A pull request that changes only Markdown files skips the run automatically.
-A documentation-only change needs no tag.
+A pull request that changes only Markdown files skips the run automatically, so a documentation-only change needs no tag.
 
 #### Motivation:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,12 @@
 
 If this PR is related to an issue, prefix the title with the issue number (e.g., `YTDB-123: Imperative summary under 50 chars`).
 
+Integration tests run as a blocking check on every pull request that is ready for review.
+Add `[no-it-tests]` to the title to skip that check.
+Use the tag only when the change cannot affect integration tests.
+A pull request with only Markdown file changes skips the check automatically.
+Documentation-only changes do not need the tag.
+
 #### Motivation:
 
 Explain WHY this change was made — the problem, context, and trade-offs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,6 @@ Two title tags change which checks run:
 Integration test run conditions:
 
 - Integration tests run unless the pull request is a draft.
-- Integration tests do not run for a draft pull request.
 - Integration tests do not run when the pull request branch lives in a fork.
 - Integration tests do not run when every changed file is a Markdown file.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,11 @@
 
 If this PR is related to an issue, prefix the title with the issue number (e.g., `YTDB-123: Imperative summary under 50 chars`).
 
-Integration tests run as a blocking check on every pull request that is ready for review.
-Add `[no-it-tests]` to the title to skip that check.
+Integration tests run on every pull request that is ready for review.
+Add `[no-it-tests]` to the title to skip that run.
 Use the tag only when the change cannot affect integration tests.
-A pull request with only Markdown file changes skips the check automatically.
-Documentation-only changes do not need the tag.
+A pull request that changes only Markdown files skips the run automatically.
+A documentation-only change needs no tag.
 
 #### Motivation:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,9 @@ Two title tags change which checks run:
 
 - `[no-it-tests]` skips the integration test run. Use it only when the change cannot affect integration tests.
 - `[no-test-number-check]` skips the test count gate. Use it only for an intentional test refactoring that does not reduce coverage.
+
+Integration test run conditions:
+
 - Integration tests run when a pull request becomes ready for review.
 - Integration tests do not run for a draft pull request.
 - Integration tests do not run when the pull request branch lives in a fork.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,14 @@
 
 If this PR is related to an issue, prefix the title with the issue number (e.g., `YTDB-123: Imperative summary under 50 chars`).
 
-Integration tests run once a pull request from a branch in this repository is ready for review.
-Pull requests from forks do not run integration tests.
-A maintainer runs the integration tests before merging.
-Add `[no-it-tests]` to the title to skip that run.
-Use the tag only when the change cannot affect integration tests.
-A pull request that changes only Markdown files skips the run automatically, so a documentation-only change needs no tag.
+Two title tags change which checks run:
+
+- `[no-it-tests]` skips the integration test run. Use it only when the change cannot affect integration tests.
+- `[no-test-number-check]` skips the test count gate. Use it only for an intentional test refactoring that does not reduce coverage.
+- Integration tests run when a pull request becomes ready for review.
+- Integration tests do not run for a draft pull request.
+- Integration tests do not run when the pull request branch lives in a fork.
+- Integration tests do not run when every changed file is a Markdown file.
 
 #### Motivation:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Two title tags change which checks run:
 
 Integration test run conditions:
 
-- Integration tests run when a pull request becomes ready for review.
+- Integration tests run unless the pull request is a draft.
 - Integration tests do not run for a draft pull request.
 - Integration tests do not run when the pull request branch lives in a fork.
 - Integration tests do not run when every changed file is a Markdown file.

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -822,8 +822,8 @@ jobs:
   # ------------------------------------------------------------------
   # GATE JOB: CI STATUS
   # Always runs — reports success when build is skipped or all jobs pass.
-  # Configure this and `integration-status` from the pull request (PR) workflow named
-  # `PR Integration Tests` as required status checks in branch protection.
+  # Branch protection requires two status checks: the job `ci-status` in this
+  # workflow, and the job `integration-status` in the `PR Integration Tests` workflow.
   # ------------------------------------------------------------------
   ci-status:
     name: CI Status

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -822,8 +822,8 @@ jobs:
   # ------------------------------------------------------------------
   # GATE JOB: CI STATUS
   # Always runs — reports success when build is skipped or all jobs pass.
-  # Branch protection requires two status checks: the job `ci-status` in this
-  # workflow, and the job `integration-status` in the `PR Integration Tests` workflow.
+  # This workflow contributes `CI Status` to branch protection.
+  # Other workflows contribute checks such as `integration-status` and `check-merges`.
   # ------------------------------------------------------------------
   ci-status:
     name: CI Status

--- a/.github/workflows/maven-pipeline.yml
+++ b/.github/workflows/maven-pipeline.yml
@@ -822,7 +822,8 @@ jobs:
   # ------------------------------------------------------------------
   # GATE JOB: CI STATUS
   # Always runs — reports success when build is skipped or all jobs pass.
-  # Configure this as the single required status check in branch protection.
+  # Configure this and `integration-status` from the pull request (PR) workflow named
+  # `PR Integration Tests` as required status checks in branch protection.
   # ------------------------------------------------------------------
   ci-status:
     name: CI Status

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,4 +1,5 @@
-# Configure integration-status as the required status check in branch protection.
+# Configure this and `ci-status` from the `Java CI/CD Pipeline` workflow
+# as required status checks in branch protection.
 name: PR Integration Tests
 
 on:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -220,13 +220,16 @@ jobs:
           fi
 
           if [[ "$INTEGRATION_RESULT" == "skipped" ]]; then
-            if [[ "$SKIP_REASON" == "draft" ]]; then
-              echo "Integration tests have not run yet because the pull request is a draft."
-              exit 1
-            fi
-
-            echo "Integration tests were skipped by the decision job. Reason: $SKIP_REASON."
-            exit 0
+            case "$SKIP_REASON" in
+              merge-group|fork|no-it-tests|markdown-only)
+                echo "Integration tests were skipped by the decision job. Reason: $SKIP_REASON."
+                exit 0
+                ;;
+              *)
+                echo "Integration tests were skipped with an unrecognised reason. Received: '$SKIP_REASON'."
+                exit 1
+                ;;
+            esac
           fi
 
           echo "Integration tests did not succeed. Result: $INTEGRATION_RESULT."

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -45,8 +45,8 @@ jobs:
             "head_sha": "$HEAD_SHA",
             "status": "in_progress",
             "output": {
-              "title": "Integration tests are running",
-              "summary": "Integration tests are running. This check will update when they finish."
+              "title": "Integration test result is pending",
+              "summary": "The integration test result is pending. This check will update when the workflow finishes."
             }
           }
           EOF

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
           # Use a three-dot diff to inspect only changes introduced by this pull request.
-          CHANGED_FILES=$(git diff --name-only "$PR_BASE_SHA...HEAD")
+          CHANGED_FILES=$(git diff --no-renames --name-only "$PR_BASE_SHA...HEAD")
 
           if [[ -n "$CHANGED_FILES" ]]; then
             ONLY_MARKDOWN=true
@@ -92,6 +92,15 @@ jobs:
         env:
           MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
           MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+
+      - name: Verify Integration Test Reports
+        if: success()
+        run: |
+          if ! find . -path '*/target/failsafe-reports/TEST-*.xml' -type f -print -quit \
+              | grep -q .; then
+            echo "::error::No Failsafe integration test report was produced."
+            exit 1
+          fi
 
       - name: Print VMLens Data Race Report
         if: always()
@@ -146,6 +155,7 @@ jobs:
             **/target/surefire-reports/TEST-*.xml
             **/target/failsafe-reports/TEST-*.xml
           action_fail: true
+          action_fail_on_inconclusive: true
           large_files: true
           comment_mode: off
           compare_to_earlier_commit: false

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -3,14 +3,15 @@ name: PR Integration Tests
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review, edited ]
+  merge_group:
+    types: [ checks_requested ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   decide:
@@ -22,14 +23,32 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Decide Whether to Run Integration Tests
         id: decision
         env:
+          CURRENT_REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           PR_DRAFT: ${{ github.event.pull_request.draft }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          if [[ "$EVENT_NAME" == "merge_group" ]]; then
+            echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "The pull request head already ran the full integration test suite."
+            echo "The nightly pipeline still covers develop after the merge."
+            exit 0
+          fi
+
+          if [[ "$HEAD_REPOSITORY" != "$CURRENT_REPOSITORY" ]]; then
+            echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "Fork pull request detected. Untrusted code must not run on a self-hosted runner."
+            echo "The private Maven mirror rejects fork builds, so this run could never pass."
+            exit 0
+          fi
+
           if [[ "$PR_DRAFT" == "true" ]]; then
             echo "run_its=false" >> "$GITHUB_OUTPUT"
             echo "Pull request is a draft. Integration tests will be skipped."
@@ -67,13 +86,17 @@ jobs:
   integration-tests:
     needs: decide
     if: needs.decide.outputs.run_its == 'true'
+    permissions:
+      contents: read
+      checks: write
     runs-on: [ self-hosted, type-cpx42, image-x86-system-ubuntu-24.04, in-nbg1-fsn1-hel1 ]
-    timeout-minutes: 600
+    timeout-minutes: 360
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,0 +1,152 @@
+name: PR Integration Tests
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review, edited ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      run_its: ${{ steps.decision.outputs.run_its }}
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Decide Whether to Run Integration Tests
+        id: decision
+        env:
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [[ "$PR_DRAFT" == "true" ]]; then
+            echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "Pull request is a draft. Integration tests will be skipped."
+            exit 0
+          fi
+
+          if [[ "$PR_TITLE" == *"[no-it-tests]"* ]]; then
+            echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "PR title contains [no-it-tests]. Integration tests will be skipped."
+            exit 0
+          fi
+
+          # Use a three-dot diff to inspect only changes introduced by this pull request.
+          CHANGED_FILES=$(git diff --name-only "$PR_BASE_SHA...HEAD")
+
+          if [[ -n "$CHANGED_FILES" ]]; then
+            ONLY_MARKDOWN=true
+            while IFS= read -r file; do
+              if [[ "$file" != *.md ]]; then
+                ONLY_MARKDOWN=false
+                break
+              fi
+            done <<< "$CHANGED_FILES"
+
+            if [[ "$ONLY_MARKDOWN" == "true" ]]; then
+              echo "run_its=false" >> "$GITHUB_OUTPUT"
+              echo "Every changed file ends in .md. Integration tests will be skipped."
+              exit 0
+            fi
+          fi
+
+          echo "run_its=true" >> "$GITHUB_OUTPUT"
+          echo "Integration tests will run."
+
+  integration-tests:
+    needs: decide
+    if: needs.decide.outputs.run_its == 'true'
+    runs-on: [ self-hosted, type-cpx42, image-x86-system-ubuntu-24.04, in-nbg1-fsn1-hel1 ]
+    timeout-minutes: 600
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          architecture: x64
+          overwrite-settings: false
+
+      - name: Run Maven Test
+        id: tests
+        run: >-
+          ./mvnw -s .github/workflows/settings.xml clean verify -B
+          -Dmaven.test.failure.ignore=true -P ci-integration-tests -P docker-images
+          -Ddocker.platforms=linux/amd64
+        env:
+          MAVEN_MIRROR_USERNAME: ${{ secrets.MAVEN_MIRROR_USERNAME }}
+          MAVEN_MIRROR_PASSWORD: ${{ secrets.MAVEN_MIRROR_PASSWORD }}
+
+      - name: Print VMLens Data Race Report
+        if: always()
+        run: |
+          REPORT_DIR="core/target/vmlens-report"
+          if [ -d "$REPORT_DIR" ]; then
+            echo "::group::VMLens Data Race Report"
+            echo "Report files:"
+            find "$REPORT_DIR" -type f | sort
+            echo ""
+            for f in "$REPORT_DIR"/*.html; do
+              [ -f "$f" ] || continue
+              echo "=== $(basename "$f") ==="
+              sed 's/<[^>]*>//g; s/&nbsp;/ /g; s/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g' "$f" \
+                | sed '/^[[:space:]]*$/d'
+              echo ""
+            done
+            echo "::endgroup::"
+          else
+            echo "No VMLens report directory found at $REPORT_DIR"
+          fi
+
+      - name: Upload VMLens Report
+        uses: actions/upload-artifact@v7
+        if: "!cancelled()"
+        with:
+          name: vmlens-report-pr-integration-jdk21-temurin
+          path: 'core/target/vmlens-report/'
+          if-no-files-found: ignore
+          retention-days: 30
+
+      # Upload diagnostics before publishing results so timeout evidence gets priority.
+      - name: Upload Test Diagnostics
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: test-diagnostics-pr-integration-jdk21-temurin-attempt${{ github.run_attempt }}
+          path: |
+            **/target/deadlock-report.txt
+            **/target/surefire-reports/*.dumpstream
+            **/target/surefire-reports/*.dump
+            **/target/failsafe-reports/*.dumpstream
+            **/target/failsafe-reports/*.dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            **/target/surefire-reports/TEST-*.xml
+            **/target/failsafe-reports/TEST-*.xml
+          action_fail: true
+          large_files: true
+          comment_mode: off
+          compare_to_earlier_commit: false
+          check_name: Integration Tests Results (Linux x86, JDK 21 - temurin)

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -19,6 +19,9 @@ permissions:
 
 jobs:
   decide:
+    permissions:
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     outputs:
       run_its: ${{ steps.decision.outputs.run_its }}
@@ -93,6 +96,28 @@ jobs:
           echo "run_its=true" >> "$GITHUB_OUTPUT"
           echo "skip_reason=" >> "$GITHUB_OUTPUT"
           echo "Integration tests will run."
+
+      - name: Mark Integration Tests as Running
+        if: steps.decision.outputs.run_its == 'true'
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api --method POST "repos/$GH_REPO/check-runs" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --input - <<EOF
+          {
+            "name": "integration-status",
+            "head_sha": "$HEAD_SHA",
+            "status": "in_progress",
+            "output": {
+              "title": "Integration tests are running",
+              "summary": "Integration tests are running. This check will update when they finish."
+            }
+          }
+          EOF
 
   integration-tests:
     needs: decide

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -250,6 +250,10 @@ jobs:
                 echo "Integration tests were skipped by the decision job. Reason: $SKIP_REASON."
                 exit 0
                 ;;
+              draft)
+                echo "Integration tests have not run yet because the pull request is a draft. They will run when it becomes ready for review."
+                exit 1
+                ;;
               *)
                 echo "Integration tests were skipped with an unrecognised reason. Received: '$SKIP_REASON'."
                 exit 1

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_its: ${{ steps.decision.outputs.run_its }}
+      skip_reason: ${{ steps.decision.outputs.skip_reason }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v7
@@ -41,6 +42,7 @@ jobs:
         run: |
           if [[ "$EVENT_NAME" == "merge_group" ]]; then
             echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=merge-group" >> "$GITHUB_OUTPUT"
             echo "The pull request head already ran the full integration test suite."
             echo "The nightly pipeline still covers develop after the merge."
             exit 0
@@ -48,6 +50,7 @@ jobs:
 
           if [[ "$HEAD_REPOSITORY" != "$CURRENT_REPOSITORY" ]]; then
             echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=fork" >> "$GITHUB_OUTPUT"
             echo "Fork pull request detected. Untrusted code must not run on a self-hosted runner."
             echo "The private Maven mirror rejects fork builds, so this run could never pass."
             exit 0
@@ -55,12 +58,14 @@ jobs:
 
           if [[ "$PR_DRAFT" == "true" ]]; then
             echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=draft" >> "$GITHUB_OUTPUT"
             echo "Pull request is a draft. Integration tests will be skipped."
             exit 0
           fi
 
           if [[ "$PR_TITLE" == *"[no-it-tests]"* ]]; then
             echo "run_its=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=no-it-tests" >> "$GITHUB_OUTPUT"
             echo "PR title contains [no-it-tests]. Integration tests will be skipped."
             exit 0
           fi
@@ -79,12 +84,14 @@ jobs:
 
             if [[ "$ONLY_MARKDOWN" == "true" ]]; then
               echo "run_its=false" >> "$GITHUB_OUTPUT"
+              echo "skip_reason=markdown-only" >> "$GITHUB_OUTPUT"
               echo "Every changed file ends in .md. Integration tests will be skipped."
               exit 0
             fi
           fi
 
           echo "run_its=true" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=" >> "$GITHUB_OUTPUT"
           echo "Integration tests will run."
 
   integration-tests:
@@ -200,6 +207,7 @@ jobs:
         env:
           DECIDE_RESULT: ${{ needs.decide.result }}
           INTEGRATION_RESULT: ${{ needs.integration-tests.result }}
+          SKIP_REASON: ${{ needs.decide.outputs.skip_reason }}
         run: |
           if [[ "$DECIDE_RESULT" != "success" ]]; then
             echo "The decision job did not succeed. Result: $DECIDE_RESULT."
@@ -212,7 +220,12 @@ jobs:
           fi
 
           if [[ "$INTEGRATION_RESULT" == "skipped" ]]; then
-            echo "Integration tests were skipped by the decision job."
+            if [[ "$SKIP_REASON" == "draft" ]]; then
+              echo "Integration tests have not run yet because the pull request is a draft."
+              exit 1
+            fi
+
+            echo "Integration tests were skipped by the decision job. Reason: $SKIP_REASON."
             exit 0
           fi
 

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,3 +1,4 @@
+# Configure integration-status as the required status check in branch protection.
 name: PR Integration Tests
 
 on:
@@ -90,7 +91,8 @@ jobs:
       contents: read
       checks: write
     runs-on: [ self-hosted, type-cpx42, image-x86-system-ubuntu-24.04, in-nbg1-fsn1-hel1 ]
-    timeout-minutes: 360
+    # Lower caps can terminate legitimate long-running integration tests.
+    timeout-minutes: 600
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v7
@@ -182,4 +184,34 @@ jobs:
           large_files: true
           comment_mode: off
           compare_to_earlier_commit: false
-          check_name: Integration Tests Results (Linux x86, JDK 21 - temurin)
+          check_name: PR Integration Test Results (Linux x86, JDK 21 - temurin)
+
+  integration-status:
+    if: always()
+    needs: [ decide, integration-tests ]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Integration Test Results
+        env:
+          DECIDE_RESULT: ${{ needs.decide.result }}
+          INTEGRATION_RESULT: ${{ needs.integration-tests.result }}
+        run: |
+          if [[ "$DECIDE_RESULT" != "success" ]]; then
+            echo "The decision job did not succeed. Result: $DECIDE_RESULT."
+            exit 1
+          fi
+
+          if [[ "$INTEGRATION_RESULT" == "success" ]]; then
+            echo "Integration tests passed."
+            exit 0
+          fi
+
+          if [[ "$INTEGRATION_RESULT" == "skipped" ]]; then
+            echo "Integration tests were skipped by the decision job."
+            exit 0
+          fi
+
+          echo "Integration tests did not succeed. Result: $INTEGRATION_RESULT."
+          exit 1

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,5 +1,6 @@
-# Configure this and `ci-status` from the `Java CI/CD Pipeline` workflow
-# as required status checks in branch protection.
+# Branch protection requires two status checks: the job `integration-status` in
+# this workflow, and the job `ci-status` in the `Java CI/CD Pipeline` workflow.
+# Never require `integration-tests` instead. A failed `decide` job would then pass unnoticed.
 name: PR Integration Tests
 
 on:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -27,6 +27,30 @@ jobs:
       run_its: ${{ steps.decision.outputs.run_its }}
       skip_reason: ${{ steps.decision.outputs.skip_reason }}
     steps:
+      - name: Mark Integration Tests as Running
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api --method POST "repos/$GH_REPO/check-runs" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --input - <<EOF
+          {
+            "name": "integration-status",
+            "head_sha": "$HEAD_SHA",
+            "status": "in_progress",
+            "output": {
+              "title": "Integration tests are running",
+              "summary": "Integration tests are running. This check will update when they finish."
+            }
+          }
+          EOF
+
       - name: Checkout Source Code
         uses: actions/checkout@v7
         with:
@@ -96,28 +120,6 @@ jobs:
           echo "run_its=true" >> "$GITHUB_OUTPUT"
           echo "skip_reason=" >> "$GITHUB_OUTPUT"
           echo "Integration tests will run."
-
-      - name: Mark Integration Tests as Running
-        if: steps.decision.outputs.run_its == 'true'
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          gh api --method POST "repos/$GH_REPO/check-runs" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            --input - <<EOF
-          {
-            "name": "integration-status",
-            "head_sha": "$HEAD_SHA",
-            "status": "in_progress",
-            "output": {
-              "title": "Integration tests are running",
-              "summary": "Integration tests are running. This check will update when they finish."
-            }
-          }
-          EOF
 
   integration-tests:
     needs: decide

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -1,6 +1,7 @@
-# Branch protection requires two status checks: the job `integration-status` in
-# this workflow, and the job `ci-status` in the `Java CI/CD Pipeline` workflow.
-# Never require `integration-tests` instead. A failed `decide` job would then pass unnoticed.
+# This workflow contributes `integration-status` to branch protection.
+# Other workflows contribute checks such as `CI Status` and `check-merges`.
+# Never require `integration-tests` instead of `integration-status`.
+# A failed `decide` job would then pass unnoticed.
 name: PR Integration Tests
 
 on:

--- a/docs-internal/agents/orchestrator-guidelines.md
+++ b/docs-internal/agents/orchestrator-guidelines.md
@@ -35,15 +35,14 @@ How to run and diagnose coverage verification is defined in
 ## Verification Gates
 
 Mid-track commits run `./mvnw -pl <modules with changed files> -am -amd test-compile` over the
-compile-gate set. At the end of a track's implementation, before its agent code review, full
-verification runs at every
-tier: unit tests for the test-gate set, integration tests under the decision rules below, and
-coverage at the 85% line / 70% branch thresholds. The complete gate protocol — including module
-selection, exceptions, and re-run rules — is in
-`docs-internal/dev-workflow/track-development.md` § Verification integration.
+compile-gate set. At each tier, full verification runs after track implementation and before
+agent code review. It covers unit tests for the test-gate set, integration tests for the
+integration-gate set, and coverage at the 85% line / 70% branch thresholds. The complete gate
+protocol is in `docs-internal/dev-workflow/track-development.md` § Verification integration.
 
-Run related integration tests (`-P ci-integration-tests`) when a change touches areas covered by
-integration tests; storage, WAL, index, Gremlin integration, and transaction handling are examples.
+Dispatch the integration-gate set defined in that protocol. The full integration suite is no
+longer a local gate. The pull request pipeline runs it instead. Follow
+`docs-internal/agents/thread-guidelines.md` for command syntax.
 If in doubt, run the full unit test suite.
 
 ### Serial Test Execution (Scheduling Invariant)
@@ -84,6 +83,7 @@ dispatch a build there while another build or test run is in progress.
 - **Must use the PR template** at `.github/pull_request_template.md`. Every PR must include the Motivation section explaining WHY the change was made.
 - **Keep the PR title and description in sync with follow-up commits** — the squash-merge builds the commit message from them, not from individual commit messages, so stale text ships to `develop`'s history; sync rules owned by pr-publishing.md § Keeping the PR in sync.
 - **Test count gate bypass**: Add `[no-test-number-check]` to the PR title to skip the test count gate. Use this only for intentional test refactorings that restructure or consolidate tests without reducing coverage.
+- **Integration test bypass**: Add `[no-it-tests]` to the pull request title to skip the pipeline's integration tests. Use this only when the change cannot affect integration tests. Pull requests whose branches live in forks do not run integration tests.
 - **Planned changes & Tracks sections**: The PR template includes "Planned changes" and "Tracks" sections, mandatory for non-trivial changes. The umbrella draft PR's description is kept in sync as work proceeds — description rules in pr-publishing.md (ytdb-slate package); YTDB template deltas in `docs-internal/dev-workflow/track-development.md`.
 - **Peer review** is optional and, when the user wants it, runs directly on the ready umbrella PR at the ready-for-review flip — no separate review branches or PRs are created; see `docs-internal/agents/slate-doctrine-extra.md`.
 

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -16,11 +16,13 @@ Planning, verification-scope, and PR rules live in `docs-internal/agents/orchest
 # Full build with unit tests on disk storage (as CI does)
 ./mvnw clean package -Dyoutrackdb.test.env=ci
 
-# Run integration tests (separate from PR pipeline, used by nightly CI)
-./mvnw clean verify -P ci-integration-tests
+# Run one or several affected integration test classes
+./mvnw -pl core clean verify -P ci-integration-tests \
+  -Dit.test='BTreeTestIT,FreeSpaceMapTestIT'
 
-# Run integration tests for one module
-./mvnw -pl core clean verify -P ci-integration-tests
+# Run integration tests with dependencies built by Maven
+./mvnw -pl core -am clean verify -P ci-integration-tests \
+  -Dit.test='BTreeTestIT' -Dfailsafe.failIfNoSpecifiedTests=false
 
 # If the test-gate set spans multiple modules, test them all
 ./mvnw -pl core,server clean test
@@ -96,7 +98,10 @@ Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless) 
 
 ### Test Modules at a Glance
 - **Unit tests**: `./mvnw -pl <module> clean test`. Core/server use JUnit 4 (`surefire-junit47` runner); the `tests` module uses JUnit 5 with `EmbeddedTestSuite` (shared DB, fixed class/method order via `@SelectClasses` / `@Order`).
-- **Integration tests**: `./mvnw clean verify -P ci-integration-tests` (uses failsafe in `core` and `server`).
+- **Integration test selection**: Integration classes use Failsafe's default `*IT.java` naming pattern. Select affected classes with a comma-separated `-Dit.test='SomeIT,OtherIT'` list. Patterns such as `-Dit.test='*Histogram*IT'` select several classes. Use `-Dit.test='SomeIT#someMethod'` for one method.
+- **Module scope**: Add `-pl <module>` to limit the run. Failsafe uses `-Dit.test=`. Surefire uses `-Dtest=`, which does not select integration tests.
+- **Dependency builds**: Adding `-am` propagates the selector to upstream modules. Those modules fail when no test matches. Add `-Dfailsafe.failIfNoSpecifiedTests=false` to prevent that failure.
+- **Full integration suite**: Do not run the full suite locally. The pull request pipeline runs it. If affected classes are unclear, escalate verification to that run.
 - **Test utilities**: `test-commons` provides `TestBuilder`, `TestFactory`, `ConcurrentTestHelper`.
 
 For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDBC and legacy JMH benchmarks, and the per-test JVM properties (`bufferSize`, `createDefaultUsers`, `checksumMode`, `directMemory.trackMode`): see `.claude/docs/testing-details.md`.

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -16,13 +16,14 @@ Planning, verification-scope, and PR rules live in `docs-internal/agents/orchest
 # Full build with unit tests on disk storage (as CI does)
 ./mvnw clean package -Dyoutrackdb.test.env=ci
 
-# Run one or several affected integration test classes
-./mvnw -pl core clean verify -P ci-integration-tests \
-  -Dit.test='BTreeTestIT,FreeSpaceMapTestIT'
+# Run an affected integration test method without unit tests
+./mvnw -pl core test-compile failsafe:integration-test failsafe:verify \
+  -P ci-integration-tests -Dit.test='FreeSpaceMapTestIT#findSinglePage'
 
 # Run integration tests with dependencies built by Maven
-./mvnw -pl core -am clean verify -P ci-integration-tests \
-  -Dit.test='BTreeTestIT' -Dfailsafe.failIfNoSpecifiedTests=false
+./mvnw -pl core -am test-compile failsafe:integration-test failsafe:verify \
+  -P ci-integration-tests -Dit.test='FreeSpaceMapTestIT#findSinglePage' \
+  -Dfailsafe.failIfNoSpecifiedTests=false
 
 # If the test-gate set spans multiple modules, test them all
 ./mvnw -pl core,server clean test
@@ -98,10 +99,10 @@ Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless) 
 
 ### Test Modules at a Glance
 - **Unit tests**: `./mvnw -pl <module> clean test`. Core/server use JUnit 4 (`surefire-junit47` runner); the `tests` module uses JUnit 5 with `EmbeddedTestSuite` (shared DB, fixed class/method order via `@SelectClasses` / `@Order`).
-- **Integration test selection**: Integration classes use Failsafe's default `*IT.java` naming pattern. Select affected classes with a comma-separated `-Dit.test='SomeIT,OtherIT'` list. Patterns such as `-Dit.test='*Histogram*IT'` select several classes. Use `-Dit.test='SomeIT#someMethod'` for one method.
+- **Integration test selection**: Integration classes use Failsafe's default `*IT.java` naming pattern. Select affected classes with a comma-separated `-Dit.test='SomeIT,OtherIT'` list. Patterns such as `-Dit.test='*Histogram*IT'` select several classes. Use `-Dit.test='SomeIT#someMethod'` for one method. Run `test-compile` before direct Failsafe goals because a clean checkout has no compiled test classes. Keep `failsafe:verify`, which makes integration failures fail the build.
 - **Module scope**: Add `-pl <module>` to limit the run. Failsafe uses `-Dit.test=`. Surefire uses `-Dtest=`, which does not select integration tests.
 - **Dependency builds**: Adding `-am` propagates the selector to upstream modules. Those modules fail when no test matches. Add `-Dfailsafe.failIfNoSpecifiedTests=false` to prevent that failure.
-- **Full integration suite**: Do not run the full suite locally. The pull request pipeline runs it. If affected classes are unclear, escalate verification to that run.
+- **Full integration suite**: Do not run the full suite locally. The pipeline runs it after the pull request becomes ready for review. If affected classes are unclear, report that uncertainty so the orchestrator can choose the verification path.
 - **Test utilities**: `test-commons` provides `TestBuilder`, `TestFactory`, `ConcurrentTestHelper`.
 
 For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDBC and legacy JMH benchmarks, and the per-test JVM properties (`bufferSize`, `createDefaultUsers`, `checksumMode`, `directMemory.trackMode`): see `.claude/docs/testing-details.md`.

--- a/docs-internal/agents/thread-guidelines.md
+++ b/docs-internal/agents/thread-guidelines.md
@@ -102,7 +102,7 @@ Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless) 
 - **Integration test selection**: Integration classes use Failsafe's default `*IT.java` naming pattern. Select affected classes with a comma-separated `-Dit.test='SomeIT,OtherIT'` list. Patterns such as `-Dit.test='*Histogram*IT'` select several classes. Use `-Dit.test='SomeIT#someMethod'` for one method. Run `test-compile` before direct Failsafe goals because a clean checkout has no compiled test classes. Keep `failsafe:verify`, which makes integration failures fail the build.
 - **Module scope**: Add `-pl <module>` to limit the run. Failsafe uses `-Dit.test=`. Surefire uses `-Dtest=`, which does not select integration tests.
 - **Dependency builds**: Adding `-am` propagates the selector to upstream modules. Those modules fail when no test matches. Add `-Dfailsafe.failIfNoSpecifiedTests=false` to prevent that failure.
-- **Full integration suite**: Do not run the full suite locally. The pipeline runs it after the pull request becomes ready for review. If affected classes are unclear, report that uncertainty so the orchestrator can choose the verification path.
+- **Full integration suite**: Do not run the full suite locally. Integration tests run unless the pull request is a draft. If affected classes are unclear, report that uncertainty so the orchestrator can choose the verification path.
 - **Test utilities**: `test-commons` provides `TestBuilder`, `TestFactory`, `ConcurrentTestHelper`.
 
 For TinkerPop Cucumber feature-test details (~1900 scenarios), Docker tests, LDBC and legacy JMH benchmarks, and the per-test JVM properties (`bufferSize`, `createDefaultUsers`, `checksumMode`, `directMemory.trackMode`): see `.claude/docs/testing-details.md`.

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -57,7 +57,7 @@ owned by track-workflow.md § Peer review.
 ## Verification integration
 
 This section is the gate reference for work inside a track: which command gates a commit, how
-the module sets are computed, which gate runs when, and when a gate must be re-run. The
+the verification sets are computed, which gate runs when, and when a gate must be re-run. The
 coverage measurement procedure — how to produce a coverage number, and how to tell a real pass
 from a vacuous one — is in `docs-internal/dev-workflow/coverage-verification.md`.
 
@@ -111,11 +111,11 @@ nothing to name. Their compile gate is reactor-wide:
 **No-Maven changes.** A change with no Java files and no module content — documentation, `.pi/`
 configuration, prompts — carries no Maven gate at all.
 
-### Two module sets: compile gate vs test gates
+### Three gate sets: compile, test, and integration
 
-Module selection is not one set, and carrying the compile-gate definition into a test gate
-silently converts that gate into a reactor-wide test run. Both names below are the terms the
-injected guideline documents use as well.
+Verification scope is not one set. Carrying the compile-gate definition into a test gate
+silently converts that gate into a reactor-wide test run. The three names below distinguish
+each scope.
 
 **Compile-gate set** — the modules containing changed files **plus their downstream consumers
 in the reactor**, which is what `-am -amd` expresses. Deliberately wide, and not to be
@@ -128,13 +128,21 @@ compiles against a changed API is already covered by the compile gate, and re-ru
 suites costs tens of minutes for no new signal. When the changed behavior does reach a
 dependent's tests, name that dependent in `-pl` explicitly.
 
+**Integration-gate set** — the integration test classes covering the subsystems touched by the
+changed files. This set names classes, not modules, because module scope alone still runs the
+whole module suite.
+
+Derive the integration-gate set in two steps. Map each changed file to its subsystem. Then map
+that subsystem to its covering integration test classes. Existing coverage includes storage,
+write-ahead log (WAL), index, Gremlin integration, and transaction handling.
+
 For build files belonging to no module, the compile-gate set is the whole reactor and the
 test-gate set is the modules whose behavior the change can actually alter — a dependency-version
 bump in the root `pom.xml` means that dependency's consumers — falling back to the whole reactor
 when it cannot be bounded that way.
 
-Both sets are read off the reactor order, which Maven resolves from the dependency graph, not
-from the module order listed in the root `pom.xml`:
+The two module sets are read off the reactor order, which Maven resolves from the dependency
+graph, not from the module order listed in the root `pom.xml`:
 
 > youtrackdb-parent → test-commons → gremlin-annotations → core → driver → server → tests
 > → embedded → examples → console → docker-tests → jmh-ldbc
@@ -148,15 +156,24 @@ At the end of each track's implementation, and **before** that track's agent cod
 full verification runs:
 
 1. **Unit tests** for the test-gate modules, green.
-2. **Integration tests** (`-P ci-integration-tests`) when the change touches areas covered by
-   integration tests. That trigger is owned by orchestrator-guidelines § Verification Gates and
-   is deliberately general, not a closed list of areas — read it there.
+2. **Integration tests** for the integration-gate set, green. Follow
+   `docs-internal/agents/thread-guidelines.md` for command syntax. If the set cannot be
+   determined, escalate verification to the pull request pipeline. Do not substitute the full
+   local suite.
 3. **The coverage gate** over the changed lines, at the thresholds owned by
    orchestrator-guidelines § Test Policy. **Read
    `docs-internal/dev-workflow/coverage-verification.md` and follow it before producing the
    number.** A coverage result produced without that procedure is not a gate result and must
    not be reported as one: its report-set assertion is what separates a measured pass from a
    vacuous one, and nothing in this section can tell them apart.
+
+The full local integration suite is no longer a gate at any tier. It takes about five hours,
+and the pull request pipeline now covers it. The pipeline runs the full suite for every pull
+request whose branch lives in this repository.
+
+A title tag is a bracketed keyword in the pull request title. The `[no-it-tests]` title tag means
+no integration tests and skips that pipeline run. Use it only when the change cannot affect
+integration tests.
 
 Gating only at the track's closing event would have reviewers reviewing unverified code; gating
 only before the review would let review-fix commits land unverified. Both holes are closed by

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -132,16 +132,61 @@ dependent's tests, name that dependent in `-pl` explicitly.
 changed files. This set names classes, not modules, because module scope alone still runs the
 whole module suite.
 
-Derive the integration-gate set in two steps. Map each changed file to its subsystem. Then map
-that subsystem to its covering integration test classes. Existing coverage includes storage,
-write-ahead log (WAL), index, Gremlin integration, and transaction handling.
+Derive the integration-gate set with two searches for each changed main source file. Use this
+process for storage, write-ahead log (WAL), index, Gremlin integration, transaction handling,
+and any other subsystem.
+
+First, search by package proximity. These commands search the same package in the same module:
+
+```bash
+changed='<module>/src/main/java/<package>/<Class>.java'
+module=${changed%%/*}
+package_path=${changed#*/src/main/java/}
+package_path=${package_path%/*}
+find "$module/src/test/java/$package_path" -type f -name '*IT.java' -print | sort
+```
+
+If this returns nothing, remove one trailing segment with
+`package_path=${package_path%/*}` and repeat the `find` command.
+
+Second, search integration test sources for references to the changed class's simple name:
+
+```bash
+simple_name=$(basename "$changed" .java)
+grep -Rlw --include='*IT.java' -- "$simple_name" "$module/src/test/java" | sort
+```
+
+Combine and deduplicate both result sets. Review each candidate and include every class that
+exercises the changed behavior.
+
+For example, use `FreeSpaceMap.java` as the changed file:
+
+```bash
+changed='core/src/main/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMap.java'
+```
+
+The package search returns:
+
+```text
+core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMapTestIT.java
+core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/LocalPaginatedCollectionV2TestIT.java
+```
+
+The reference search returns:
+
+```text
+core/src/test/java/com/jetbrains/youtrackdb/internal/core/storage/collection/v2/FreeSpaceMapTestIT.java
+```
+
+When both searches return nothing, report the commands and empty results. Do not run the full
+suite. Do not silently assume that integration coverage is absent.
 
 For build files belonging to no module, the compile-gate set is the whole reactor and the
 test-gate set is the modules whose behavior the change can actually alter — a dependency-version
 bump in the root `pom.xml` means that dependency's consumers — falling back to the whole reactor
 when it cannot be bounded that way.
 
-The two module sets are read off the reactor order, which Maven resolves from the dependency
+The reactor order determines the two module sets. Maven resolves this order from the dependency
 graph, not from the module order listed in the root `pom.xml`:
 
 > youtrackdb-parent → test-commons → gremlin-annotations → core → driver → server → tests
@@ -157,9 +202,9 @@ full verification runs:
 
 1. **Unit tests** for the test-gate modules, green.
 2. **Integration tests** for the integration-gate set, green. Follow
-   `docs-internal/agents/thread-guidelines.md` for command syntax. If the set cannot be
-   determined, escalate verification to the pull request pipeline. Do not substitute the full
-   local suite.
+   `docs-internal/agents/thread-guidelines.md` for command syntax. If the set remains uncertain,
+   record the searches and results in the thread report. The orchestrator then chooses the
+   verification path.
 3. **The coverage gate** over the changed lines, at the thresholds owned by
    orchestrator-guidelines § Test Policy. **Read
    `docs-internal/dev-workflow/coverage-verification.md` and follow it before producing the
@@ -167,9 +212,10 @@ full verification runs:
    not be reported as one: its report-set assertion is what separates a measured pass from a
    vacuous one, and nothing in this section can tell them apart.
 
-The full local integration suite is no longer a gate at any tier. It takes about five hours,
-and the pull request pipeline now covers it. The pipeline runs the full suite for every pull
-request whose branch lives in this repository.
+The full local integration suite is no longer a gate at any tier. It takes about five hours.
+The pipeline starts the full suite after the pull request becomes ready for review. Integration
+tests do not run while the pull request is a draft. Worker threads do most work during the draft
+phase. The pipeline skips integration tests for a pull request whose branch lives in a fork.
 
 A title tag is a bracketed keyword in the pull request title. The `[no-it-tests]` title tag means
 no integration tests and skips that pipeline run. Use it only when the change cannot affect

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -132,9 +132,18 @@ dependent's tests, name that dependent in `-pl` explicitly.
 changed files. This set names classes, not modules, because module scope alone still runs the
 whole module suite.
 
-Derive the integration-gate set with two searches for each changed main source file. Use this
-process for storage, write-ahead log (WAL), index, Gremlin integration, transaction handling,
-and any other subsystem.
+The two searches below apply only to main source files inside a module with a package path.
+Do not pass other changed files to them. Report each other path and its potential effect for an
+orchestrator decision.
+
+Other files include a build file such as `pom.xml`, anything under `.mvn/`, a Maven wrapper, a
+workflow file, or a documentation file. A root build file can change behavior in every module.
+No local integration subset is trustworthy for that case. The thread reports the situation,
+and the pull request run covers it after the pull request becomes ready for review.
+
+Derive the integration-gate set with two searches for each applicable file. Use this process
+for storage, write-ahead log (WAL), index, Gremlin integration, transaction handling, and any
+other subsystem.
 
 First, search by package proximity. These commands search the same package in the same module:
 
@@ -143,17 +152,20 @@ changed='<module>/src/main/java/<package>/<Class>.java'
 module=${changed%%/*}
 package_path=${changed#*/src/main/java/}
 package_path=${package_path%/*}
-find "$module/src/test/java/$package_path" -type f -name '*IT.java' -print | sort
+test_root="$module/src/test/java"
+[ ! -d "$test_root/$package_path" ] ||
+  find "$test_root/$package_path" -type f -name '*IT.java' -print | sort
 ```
 
 If this returns nothing, remove one trailing segment with
-`package_path=${package_path%/*}` and repeat the `find` command.
+`package_path=${package_path%/*}` and repeat the guarded `find` command.
 
 Second, search integration test sources for references to the changed class's simple name:
 
 ```bash
 simple_name=$(basename "$changed" .java)
-grep -Rlw --include='*IT.java' -- "$simple_name" "$module/src/test/java" | sort
+[ ! -d "$test_root" ] ||
+  grep -Rlw --include='*IT.java' -- "$simple_name" "$test_root" | sort
 ```
 
 Combine and deduplicate both result sets. Review each candidate and include every class that

--- a/docs-internal/dev-workflow/track-development.md
+++ b/docs-internal/dev-workflow/track-development.md
@@ -132,14 +132,17 @@ dependent's tests, name that dependent in `-pl` explicitly.
 changed files. This set names classes, not modules, because module scope alone still runs the
 whole module suite.
 
+A changed or added integration test class always belongs to the integration-gate set before any
+search runs.
+
 The two searches below apply only to main source files inside a module with a package path.
 Do not pass other changed files to them. Report each other path and its potential effect for an
 orchestrator decision.
 
 Other files include a build file such as `pom.xml`, anything under `.mvn/`, a Maven wrapper, a
 workflow file, or a documentation file. A root build file can change behavior in every module.
-No local integration subset is trustworthy for that case. The thread reports the situation,
-and the pull request run covers it after the pull request becomes ready for review.
+No local integration subset is trustworthy for that case. The thread reports the situation for
+pull request verification.
 
 Derive the integration-gate set with two searches for each applicable file. Use this process
 for storage, write-ahead log (WAL), index, Gremlin integration, transaction handling, and any
@@ -225,9 +228,9 @@ full verification runs:
    vacuous one, and nothing in this section can tell them apart.
 
 The full local integration suite is no longer a gate at any tier. It takes about five hours.
-The pipeline starts the full suite after the pull request becomes ready for review. Integration
-tests do not run while the pull request is a draft. Worker threads do most work during the draft
-phase. The pipeline skips integration tests for a pull request whose branch lives in a fork.
+Integration tests run unless the pull request is a draft. Worker threads do most work during the
+draft phase. The pipeline skips integration tests for a pull request whose branch lives in a
+fork.
 
 A title tag is a bracketed keyword in the pull request title. The `[no-it-tests]` title tag means
 no integration tests and skips that pipeline run. Use it only when the change cannot affect


### PR DESCRIPTION
#### Motivation:

Integration tests take about five hours on a developer machine. Running them locally destroys developer productivity, so developers skip them. The full suite runs only at night. A broken integration test is therefore found long after the change that broke it landed.

This change moves the full integration suite onto the pull request, where continuous integration hardware runs it. This change also narrows what an agent worker thread runs locally, from the whole suite down to the tests the change affects.

#### Planned changes:

**Current state**

The pull request pipeline runs unit tests only. Every pipeline leg stops at the Maven `package` phase, so the Failsafe plugin never executes. Integration tests run only in the nightly pipeline. That pipeline fires on a schedule, on a push to `develop`, and by manual dispatch. Only the self-hosted x86 Linux runner executes Failsafe, and that run takes about two hours and fifty-five minutes.

Agent guidance offers two integration test commands only: the whole Maven reactor, or one whole module. No document names a way to select individual integration test classes.

**What changes**

A pull request that is not a draft, and whose branch lives in this repository, now runs the full integration suite. An author who judges the suite irrelevant adds the title tag `[no-it-tests]`. A title tag is a bracketed keyword inside the pull request title. The run is then skipped rather than failed.

Agent worker threads stop running the full integration suite. Each thread runs only the integration test classes that the change affects, selected by class name.

**How**

A new workflow named `PR Integration Tests` carries the check. A cheap decision job gates an expensive job. The decision job skips the integration run in five cases: a merge queue event, a pull request from a fork, a draft pull request, a title carrying `[no-it-tests]`, and a change whose files are all Markdown files.

A third job named `integration-status` aggregates the outcome. That job is the check to require in branch protection. The aggregation job fails when the decision job did not succeed. The aggregation job passes only when the integration job succeeded or was legitimately skipped. GitHub counts a skipped job as a passing required check, so an unaggregated result would let a failed decision job pass unnoticed.

The workflow listens for the `edited` pull request event, so adding or removing the title tag takes effect at once. The concurrency group cancels a superseded run, so adding the title tag frees the runner within seconds.

The existing pipeline keeps its own `CI Status` check. Only its branch protection comment changed.

Agent guidance gains an integration-gate set, beside the existing compile-gate set and test-gate set. The new set lists integration test classes rather than modules. A thread derives the set with two searches: package proximity, and a reference search for the changed class names. Guidance documents the Failsafe class selector and drops the previous full-suite commands.

**Key decisions**

1. Title tag detection copies the existing `[no-test-number-check]` implementation exactly. One pattern serves both title tags, so a reader learns the pattern once.
2. The title tag produces a skipped job rather than a step that reports success. A skipped job is visible in the pull request checks list.
3. The integration check lives in its own workflow file rather than inside the existing pipeline. Rejected: a job inside the existing pipeline. That choice would need the `edited` trigger on the whole pipeline, so every description edit would cancel and restart unit tests, coverage, and the test count gate.
4. No guard suppresses work on an `edited` event that leaves the title unchanged. GitHub treats a skipped job as a passing required status check. Such a guard would therefore let a description edit turn a failed check green on the same commit.
5. A separate aggregation job holds the required check. Rejected: requiring the integration job directly. A failed decision job would then leave the integration job skipped, which reads as success.
6. Fork pull requests skip the run. Untrusted code must not execute on the self-hosted runner. The private Maven mirror also rejects a fork, so the run could never pass.
7. The merge queue receives the trigger but does not re-run the suite. The pull request head already ran it, and the nightly pipeline still covers `develop` after the merge. Rejected: a full re-run in the queue, which would add about three hours to every merge.
8. The heavy job runs one leg only: Java 21 on x86 Linux. Rejected: mirroring the nightly matrix, which costs four times as much, because only that leg runs Failsafe.
9. Worker threads invoke the Failsafe goals directly rather than the `verify` lifecycle. Maven runs unit tests before integration tests in `verify`, and the class selector filters Failsafe only. A measured single-method run through `verify` exceeded 600 seconds without starting an integration test. The same selection through the Failsafe goals took 47 seconds.
10. Guidance for Claude Code stays out of this change, because the user is retiring that guidance.
11. A draft pull request produces a FAILING integration status. Rejected: a passing status, which the first implementation used. A draft skip is provisional, because the suite runs later when the pull request becomes ready for review. GitHub matches a required status check by the newest check run of that name. A stale draft-era pass would therefore satisfy the requirement for the hours during which the real suite is still running. A draft cannot be merged, so a failing status costs nothing there. The four final skip reasons still pass: a fork pull request, a Markdown-only change, the title tag, and a merge queue event.
12. The decision job publishes a pending integration status check as its first step, before any checkout. Rejected: publishing nothing until the aggregation job finishes. GitHub matches a required status check by the newest check run of that name, so a green from an earlier run stayed newest for the hours an honest run needed. A skip reason can change without a new commit, because the workflow listens for title edits. The pending check makes the newest result unsatisfied within seconds of any such change. The step is skipped for a fork pull request, whose token cannot write checks, and for a merge queue event, which carries no pull request.

**Out of scope**

Changing the nightly pipeline. Changing which tests belong to the integration suite. Adding a Maven profile for a test subset. Adding workflow linting.

**Risks & accepted trade-offs**

- Branch protection needs a manual change. This change cannot register its own required check. An administrator must add the context `integration-status` to the ruleset. The change has no effect until that happens. The existing contexts `CI Status` and `check-merges` stay. Do not require `integration-tests`, because a failed decision job would then pass unnoticed.
- The integration status stays red for the whole draft phase of a pull request. That is intentional, and it is the only safe reading while the suite has not run.
- Feedback slows down. An author waits about three hours for a green pull request. Accepted, because the alternative is finding the same failure a day later on `develop`.
- A title edit that does not add the title tag restarts the integration run and resets the clock. Accepted, because GitHub decides cancellation before any job can read the new title.
- The `[no-it-tests]` title tag relies on author judgement. No check verifies that its use is justified. Accepted, because the existing `[no-test-number-check]` title tag works the same way.
- Fork pull requests get no integration coverage on the pull request. A maintainer needs another route before merging one.
- The self-hosted runner pool gains load. The user reports ample Hetzner capacity, so the load is accepted.
- A cancelled run can leave the pending integration status check in progress. The required check then blocks until a later run publishes a result. Blocking is the safe outcome, and the next run resolves it.
- Nothing restricts who may apply the `[no-it-tests]` title tag. Any contributor with write access can bypass the suite, and the title edit is the only record. Accepted, because the existing `[no-test-number-check]` title tag works the same way.
- Design review: user-approved — 2026-08-07
- Adversarial review: skipped by user decision — 2026-08-07. Runner capacity was the only risk trigger, and the user withdrew it.

**Verification approach**

No workflow linting exists in this repository. Every workflow file was therefore parsed, and every gating expression was traced by hand against each event. A reviewer extracted the aggregation job's shell logic and re-derived its full truth table, covering all 112 combinations of the two job results and the seven skip reason values, including the empty value and an unknown value. Only the eleven correct rows pass. Only the correct rows pass. Only the two correct combinations exit zero. The documented worker command was run against the real build. That run took 47 seconds, executed no unit tests, and a deliberately failing test proved the failure path. The documented search commands were run and reproduce their stated output. This pull request then exercises the new workflow against itself.

#### Tracks:

N/A (single-track)


